### PR TITLE
Add edrr-cycle CLI command

### DIFF
--- a/src/devsynth/adapters/cli/argparse_adapter.py
+++ b/src/devsynth/adapters/cli/argparse_adapter.py
@@ -51,6 +51,7 @@ def show_help():
     console.print(f"  run          Execute the generated code")
     console.print(f"  config       Configure DevSynth settings")
     console.print(f"  ingest       Ingest a project into DevSynth using project configuration")
+    console.print(f"  edrr-cycle   Run an EDRR cycle from a manifest file")
     console.print(f"  webapp       Generate a web application")
     console.print(f"  dbschema     Generate a database schema")
     console.print(f"  apispec      Generate an API specification")
@@ -169,6 +170,10 @@ def parse_args(args: List[str]) -> argparse.Namespace:
     ingest_parser.add_argument("--verbose", action="store_true", help="Provide verbose output")
     ingest_parser.add_argument("--validate-only", action="store_true", help="Only validate the project configuration without performing ingestion")
 
+    # edrr-cycle command
+    edrr_cycle_parser = subparsers.add_parser("edrr-cycle", help="Run an EDRR cycle from a manifest")
+    edrr_cycle_parser.add_argument("--manifest", default="manifest.yaml", help="Path to the manifest file")
+
     # requirements command
     requirements_parser = subparsers.add_parser("requirements", help="Manage requirements with dialectical reasoning")
     requirements_parser.add_argument("--action", help="Action to perform (list, show, create, update, delete, changes, approve-change, reject-change, chat, sessions, continue-chat, evaluate-change, assess-impact)")
@@ -236,6 +241,9 @@ def run_cli():
             generate_docs_cmd(args.path, args.output_dir)
         elif args.command == "ingest":
             ingest_cmd(args.manifest, args.dry_run, args.verbose, args.validate_only)
+        elif args.command == "edrr-cycle":
+            from devsynth.application.cli.commands.edrr_cycle_cmd import edrr_cycle_cmd
+            edrr_cycle_cmd(args.manifest)
         elif args.command == "requirements":
             # Import the LLM service for the dialectical reasoner
             from devsynth.adapters.llm.lmstudio_provider import LMStudioProvider

--- a/src/devsynth/application/cli/__init__.py
+++ b/src/devsynth/application/cli/__init__.py
@@ -16,8 +16,9 @@ from .cli_commands import (
 
 # Import commands from the commands directory
 from .commands.analyze_code_cmd import analyze_code_cmd
+from .commands.edrr_cycle_cmd import edrr_cycle_cmd
 
 __all__ = [
     "init_cmd", "spec_cmd", "test_cmd", "code_cmd", "run_cmd", "config_cmd",
-    "analyze_cmd", "webapp_cmd", "dbschema_cmd", "adaptive_cmd", "analyze_code_cmd"
+    "analyze_cmd", "webapp_cmd", "dbschema_cmd", "adaptive_cmd", "analyze_code_cmd", "edrr_cycle_cmd"
 ]

--- a/src/devsynth/application/cli/commands/edrr_cycle_cmd.py
+++ b/src/devsynth/application/cli/commands/edrr_cycle_cmd.py
@@ -1,0 +1,65 @@
+from pathlib import Path
+from rich.console import Console
+
+from devsynth.application.memory.memory_manager import MemoryManager
+from devsynth.application.memory.adapters.tinydb_memory_adapter import TinyDBMemoryAdapter
+from devsynth.domain.models.wsde import WSDETeam
+from devsynth.application.code_analysis.analyzer import CodeAnalyzer
+from devsynth.application.code_analysis.ast_transformer import AstTransformer
+from devsynth.application.prompts.prompt_manager import PromptManager
+from devsynth.application.documentation.documentation_manager import DocumentationManager
+from devsynth.application.edrr.coordinator import EDRRCoordinator
+from devsynth.methodology.base import Phase
+from devsynth.logging_setup import DevSynthLogger
+from devsynth.exceptions import DevSynthError
+
+logger = DevSynthLogger(__name__)
+
+
+def edrr_cycle_cmd(manifest: str) -> None:
+    """Run an EDRR cycle from a manifest file."""
+    console = Console()
+    try:
+        manifest_path = Path(manifest)
+        if not manifest_path.exists():
+            console.print(f"[red]Manifest file not found:[/red] {manifest_path}")
+            return
+
+        console.print("[bold]Starting EDRR cycle[/bold]")
+        memory_adapter = TinyDBMemoryAdapter()
+        memory_manager = MemoryManager(adapters={"tinydb": memory_adapter})
+        wsde_team = WSDETeam()
+        code_analyzer = CodeAnalyzer()
+        ast_transformer = AstTransformer()
+        prompt_manager = PromptManager()
+        documentation_manager = DocumentationManager(memory_manager)
+
+        coordinator = EDRRCoordinator(
+            memory_manager=memory_manager,
+            wsde_team=wsde_team,
+            code_analyzer=code_analyzer,
+            ast_transformer=ast_transformer,
+            prompt_manager=prompt_manager,
+            documentation_manager=documentation_manager,
+        )
+
+        coordinator.start_cycle_from_manifest(manifest_path, is_file=True)
+
+        for phase in [Phase.EXPAND, Phase.DIFFERENTIATE, Phase.REFINE, Phase.RETROSPECT]:
+            coordinator.progress_to_phase(phase)
+
+        result_id = memory_manager.store_with_edrr_phase(
+            coordinator.results,
+            "EDRR_CYCLE_RESULTS",
+            Phase.RETROSPECT.value,
+            {"cycle_id": coordinator.cycle_id},
+        )
+
+        console.print(
+            f"[green]EDRR cycle completed.[/green] Results stored with id {result_id}"
+        )
+    except DevSynthError as err:
+        console.print(f"[red]Error:[/red] {err}")
+    except Exception as exc:
+        console.print(f"[red]Unexpected error:[/red] {exc}")
+        logger.error(f"Unexpected error running EDRR cycle: {exc}")


### PR DESCRIPTION
## Summary
- add `edrr_cycle_cmd` to run an EDRR cycle from a manifest
- expose the new command through CLI initialization and argument parsing

## Testing
- `pip install pytest-bdd responses`
- `pip install psutil`
- `pytest -q` *(fails: ModuleNotFoundError and StepDefinitionNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_684521a3cec483339b98975ed833f4c3