### PR TITLE
Add env example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,25 @@
+# Example environment configuration for DevSynth
+# Copy this file to .env and adjust values as needed.
+
+# Basic settings
+DEVSYNTH_ENV=development
+DEVSYNTH_LOG_LEVEL=DEBUG
+DEVSYNTH_MEMORY_STORE=chromadb
+DEVSYNTH_LLM_PROVIDER=openai
+DEVSYNTH_PROVIDER=openai
+
+# Database configuration
+DEVSYNTH_CHROMADB_HOST=chromadb
+DEVSYNTH_CHROMADB_PORT=8000
+
+# LLM settings
+DEVSYNTH_OPENAI_MODEL=gpt-4
+DEVSYNTH_MAX_WORKERS=4
+
+# API keys
+OPENAI_API_KEY=
+DEVSYNTH_OPENAI_API_KEY=
+SERPER_API_KEY=
+LM_STUDIO_ENDPOINT=http://127.0.0.1:1234
+DEVSYNTH_CONFIG_PATH=~/.devsynth/config.yaml
+DEVSYNTH_MEMORY_PATH=~/.devsynth/memory

--- a/docs/technical_reference/configuration_reference.md
+++ b/docs/technical_reference/configuration_reference.md
@@ -115,8 +115,15 @@ DevSynth uses the following environment variables for configuration:
 
 | Variable | Description | Default |
 |----------|-------------|---------|
+| `DEVSYNTH_ENV` | Deployment environment | development |
 | `DEVSYNTH_PROVIDER` | Default LLM provider | openai |
+| `DEVSYNTH_LLM_PROVIDER` | LLM provider override | openai |
+| `DEVSYNTH_MEMORY_STORE` | Memory store to use | chromadb |
+| `DEVSYNTH_CHROMADB_HOST` | ChromaDB host | chromadb |
+| `DEVSYNTH_CHROMADB_PORT` | ChromaDB port | 8000 |
+| `DEVSYNTH_OPENAI_API_KEY` | OpenAI API key (config override) | None |
 | `OPENAI_API_KEY` | OpenAI API key | None |
+| `DEVSYNTH_OPENAI_MODEL` | OpenAI model to use | gpt-4 |
 | `OPENAI_MODEL` | OpenAI model to use | gpt-4 |
 | `LM_STUDIO_ENDPOINT` | LM Studio API endpoint | http://127.0.0.1:1234 |
 | `SERPER_API_KEY` | Serper API key for web searches | None |


### PR DESCRIPTION
## Summary
- provide a `.env.example` with common environment variables
- document additional variables in the configuration reference

## Testing
- `poetry run pytest -q` *(fails: AttributeError: Mock object has no attribute 'retrieve_with_edrr_phase')*

------
https://chatgpt.com/codex/tasks/task_e_6845ff71a6308333ba561f8fcab540a9