### PR TITLE
Add pipx installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,12 +45,15 @@ DevSynth is governed by a comprehensive set of SDLC policies and documentation a
 
 Full documentation is available in the [docs/](docs/index.md) directory and online at [DevSynth Docs](docs/index.md). Key sections:
 - [Quick Start Guide](docs/getting_started/quick_start_guide.md)
+- [Installation Guide](docs/getting_started/installation.md) *(includes pipx instructions)*
 - [User Guide](docs/user_guides/user_guide.md)
 - [Architecture Overview](docs/architecture/overview.md)
 - [Project Analysis](docs/analysis/executive_summary.md)
 - [Implementation Status](docs/implementation/feature_status_matrix.md)
 - [Requirements Traceability Matrix](docs/requirements_traceability.md)
 - [SDLC Policies](docs/policies/index.md)
+
+Installation instructions, including how to use **pipx**, are provided in the [Installation Guide](docs/getting_started/installation.md) and the [Quick Start Guide](docs/getting_started/quick_start_guide.md).
 
 ## Documentation Structure
 

--- a/docs/getting_started/installation.md
+++ b/docs/getting_started/installation.md
@@ -27,10 +27,21 @@ This guide provides step-by-step instructions for installing DevSynth in various
 pip install devsynth
 ```
 
+### Install with pipx
+
+```bash
+pipx install devsynth
+```
+
 ## Install from Source
 ```bash
 git clone https://github.com/ravenoak/devsynth.git
 cd devsynth
+
+# Install in an isolated environment
+pipx install --editable .
+
+# Or use Poetry
 poetry install
 poetry shell
 ```

--- a/docs/getting_started/quick_start_guide.md
+++ b/docs/getting_started/quick_start_guide.md
@@ -29,6 +29,12 @@ Before you begin, ensure you have the following installed:
 ```bash
 pip install devsynth
 ```
+### Install with pipx
+
+```bash
+pipx install devsynth
+```
+
 
 ### Install from Source
 
@@ -37,7 +43,10 @@ pip install devsynth
 git clone https://github.com/ravenoak/devsynth.git
 cd devsynth
 
-# Install using Poetry
+# Install in an isolated environment
+pipx install --editable .
+
+# Or use Poetry
 poetry install
 
 # Activate the virtual environment


### PR DESCRIPTION
## Summary
- document pipx installation steps in the installation and quick start docs
- link to the installation docs from the README

## Testing
- `poetry run pytest tests/` *(fails: KeyError in pytest tmp_path fixture)*

------
https://chatgpt.com/codex/tasks/task_e_6845ffa13b64833388587d14fc7b1e5e