### PR TITLE
Add pip extras and update docs/CI

### DIFF
--- a/.github/workflows/validate_documentation.yml
+++ b/.github/workflows/validate_documentation.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Install Python dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install pyyaml markdown-link-check
+          pip install .[docs] pyyaml markdown-link-check
           
       - name: Set up Node.js
         uses: actions/setup-node@v3
@@ -61,7 +61,6 @@ jobs:
           
       - name: Validate MkDocs configuration
         run: |
-          pip install mkdocs mkdocs-material
           mkdocs build --strict
           
       - name: Summary

--- a/.github/workflows/validate_metadata.yml
+++ b/.github/workflows/validate_metadata.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install pyyaml
+          pip install .[docs] pyyaml
           
       - name: Validate Markdown metadata
         run: |

--- a/.github/workflows/verify_code_examples.yml
+++ b/.github/workflows/verify_code_examples.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          # No additional dependencies needed for basic Python syntax checking
+          pip install .[docs]
           
       - name: Set up Node.js
         uses: actions/setup-node@v3

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,6 +42,11 @@ cd devsynth
 # Install dependencies
 poetry install
 
+# Alternatively, install with pip or pipx using extras
+pip install .[dev]
+# or
+pipx install --editable .[dev]
+
 # Activate virtual environment
 poetry shell
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,6 +56,29 @@ mkdocs-typer2 = "*"
 mkdocs-literate-nav = "*"
 mkdocs-section-index = "*"
 
+[tool.poetry.extras]
+dev = [
+    "responses",
+    "pytest",
+    "pytest-bdd",
+    "pytest-cov",
+    "pytest-mock",
+    "pytest-xdist",
+    "black",
+    "pre-commit",
+    "psutil",
+]
+docs = [
+    "mkdocs",
+    "mkdocs-material",
+    "mkdocstrings-python",
+    "mkdocs-gen-files",
+    "mkdocs-include-markdown-plugin",
+    "mkdocs-typer2",
+    "mkdocs-literate-nav",
+    "mkdocs-section-index",
+]
+
 [tool.poetry.scripts]
 devsynth = "devsynth.adapters.cli:run_cli"
 


### PR DESCRIPTION
## Summary
- expose dev and docs extras in `pyproject.toml`
- document installing extras via pip/pipx
- install extras in docs validation workflows

## Testing
- `poetry run pytest tests/` *(fails: 110 failed, 630 passed, 10 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_684602ec6a2c83338273691aa154f0b9