### PR TITLE
Add adapter and provider tests

### DIFF
--- a/tests/unit/adapters/providers/test_provider_factory.py
+++ b/tests/unit/adapters/providers/test_provider_factory.py
@@ -1,0 +1,47 @@
+import pytest
+from devsynth.adapters.provider_system import (
+    ProviderFactory,
+    ProviderType,
+    LMStudioProvider,
+    OpenAIProvider,
+)
+
+
+def _config_without_openai_key():
+    return {
+        "default_provider": "openai",
+        "openai": {"api_key": None, "model": "gpt-4", "base_url": "https://api.openai.com/v1"},
+        "lm_studio": {"endpoint": "http://localhost:1234", "model": "default"},
+    }
+
+
+def _config_with_openai_key():
+    return {
+        "default_provider": "openai",
+        "openai": {"api_key": "test", "model": "gpt-4", "base_url": "https://api.openai.com/v1"},
+        "lm_studio": {"endpoint": "http://localhost:1234", "model": "default"},
+    }
+
+
+def test_create_provider_fallbacks_to_lmstudio(monkeypatch):
+    monkeypatch.setattr(
+        "devsynth.adapters.provider_system.get_provider_config", _config_without_openai_key
+    )
+    provider = ProviderFactory.create_provider(ProviderType.OPENAI.value)
+    assert isinstance(provider, LMStudioProvider)
+
+
+def test_create_provider_default_with_missing_key(monkeypatch):
+    monkeypatch.setattr(
+        "devsynth.adapters.provider_system.get_provider_config", _config_without_openai_key
+    )
+    provider = ProviderFactory.create_provider()
+    assert isinstance(provider, LMStudioProvider)
+
+
+def test_create_provider_openai(monkeypatch):
+    monkeypatch.setattr(
+        "devsynth.adapters.provider_system.get_provider_config", _config_with_openai_key
+    )
+    provider = ProviderFactory.create_provider(ProviderType.OPENAI.value)
+    assert isinstance(provider, OpenAIProvider)

--- a/tests/unit/adapters/test_chromadb_memory_store.py
+++ b/tests/unit/adapters/test_chromadb_memory_store.py
@@ -87,8 +87,15 @@ class TestChromaDBMemoryStore:
         # Create a unique instance ID for this test
         instance_id = f"test_{request.node.name}_{uuid.uuid4().hex}"
 
-        # Patch the chromadb_client_context to return our mock client
-        with patch('devsynth.adapters.chromadb_memory_store.chromadb_client_context') as mock_context:
+        # Patch the chromadb client context and the default embedding function to avoid network calls
+        class DummyEmbedder:
+            def __call__(self, text):
+                if isinstance(text, str):
+                    return [0.1, 0.2, 0.3, 0.4, 0.5]
+                return [[0.1, 0.2, 0.3, 0.4, 0.5] for _ in text]
+
+        with patch('devsynth.adapters.chromadb_memory_store.chromadb_client_context') as mock_context, \
+             patch('devsynth.adapters.chromadb_memory_store.embedding_functions.DefaultEmbeddingFunction', DummyEmbedder):
             # Configure the mock context manager to yield our mock client
             mock_context.return_value.__enter__.return_value = mock_client
 
@@ -161,8 +168,15 @@ class TestChromaDBMemoryStore:
         # Create a unique instance ID for this test
         instance_id = f"test_fallback_{request.node.name}_{uuid.uuid4().hex}"
 
-        # Patch the chromadb_client_context to return our mock client
-        with patch('devsynth.adapters.chromadb_memory_store.chromadb_client_context') as mock_context:
+        class DummyEmbedder:
+            def __call__(self, text):
+                if isinstance(text, str):
+                    return [0.1, 0.2, 0.3, 0.4, 0.5]
+                return [[0.1, 0.2, 0.3, 0.4, 0.5] for _ in text]
+
+        # Patch the chromadb_client_context to return our mock client and the default embedder
+        with patch('devsynth.adapters.chromadb_memory_store.chromadb_client_context') as mock_context, \
+             patch('devsynth.adapters.chromadb_memory_store.embedding_functions.DefaultEmbeddingFunction', DummyEmbedder):
             # Configure the mock context manager to yield our mock client
             mock_context.return_value.__enter__.return_value = mock_client
 


### PR DESCRIPTION
## Summary
- extend MemorySystemAdapter tests to cover rdflib and in-memory stores
- mock default embedder in ChromaDBMemoryStore tests for hermeticity
- add ProviderFactory tests verifying LM Studio fallback when OpenAI key missing

## Testing
- `pytest tests/unit/adapters -q`

------
https://chatgpt.com/codex/tasks/task_e_68465a9e73348333932fadd01a32e9f9