### PR TITLE
Add project.yaml template and document reference

### DIFF
--- a/docs/getting_started/quick_start_guide.md
+++ b/docs/getting_started/quick_start_guide.md
@@ -65,6 +65,10 @@ cd my-first-project
 
 This command creates a new project directory with the necessary structure for DevSynth to work with.
 
+DevSynth generates a `.devsynth/project.yaml` file during initialization. You
+can use the [templates/project.yaml](../../templates/project.yaml) file as a
+minimal example configuration.
+
 ### Step 2: Define Your Requirements
 
 Create a file named `requirements.md` in your project directory with your project requirements:

--- a/templates/project.yaml
+++ b/templates/project.yaml
@@ -1,0 +1,32 @@
+projectName: example-project
+version: 0.1.0
+lastUpdated: 2025-05-25T12:00:00
+structure:
+  type: single_package
+  primaryLanguage: python
+  directories:
+    source: ["src"]
+    tests: ["tests"]
+    docs: ["docs"]
+  entryPoints: ["src/main.py"]
+  ignore: ["**/__pycache__/**", "**/.git/**", "**/venv/**", "**/.env"]
+keyArtifacts:
+  docs:
+    - path: README.md
+      purpose: Project overview and getting started guide
+methodology:
+  type: sprint
+  settings:
+    sprintDuration: 14
+    reviewFrequency: 7
+resources:
+  global:
+    configDir: ~/.devsynth/config
+    cacheDir: ~/.devsynth/cache
+    logsDir: ~/.devsynth/logs
+    memoryDir: ~/.devsynth/memory
+  project:
+    configDir: .devsynth
+    cacheDir: .devsynth/cache
+    logsDir: .devsynth/logs
+    memoryDir: .devsynth/memory


### PR DESCRIPTION
## Summary
- add `templates/project.yaml` with a minimal example manifest
- update quick start guide to mention the new template

## Testing
- `poetry run pytest` *(fails: EnhancedChromaDBStore, LMStudioProvider, TokenTracker tests)*

------
https://chatgpt.com/codex/tasks/task_e_6846799bc21c8333bebbf2c2502d6da6