### PR TITLE
Add dev extras note for tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,29 @@ You can install DevSynth in a few different ways:
 
 For more on Docker deployment, see the [Deployment Guide](docs/deployment/deployment_guide.md).
 
+## Running Tests
+
+Before running the test suite, install DevSynth with its development dependencies.
+You can use `pip` in editable mode:
+
+```bash
+pip install -e .[dev]
+```
+
+Or install using Poetry, which also sets up the dev extras:
+
+```bash
+poetry install
+```
+
+Once installed, execute the tests with:
+
+```bash
+pytest
+```
+
+See [docs/developer_guides/testing.md](docs/developer_guides/testing.md) for detailed testing guidance.
+
 ## Documentation Structure
 
 The documentation is organized for clarity and ease of navigation, following a comprehensive structure. Key directories:

--- a/docs/developer_guides/testing.md
+++ b/docs/developer_guides/testing.md
@@ -248,6 +248,19 @@ The ChromaDB tests use fixtures for isolation and provider integration:
 
 ## Running Tests
 
+Before executing tests, install DevSynth with its development extras so that all
+test dependencies are available. Use either:
+
+```bash
+pip install -e .[dev]
+```
+
+or
+
+```bash
+poetry install
+```
+
 ### Running All Tests
 
 ```bash


### PR DESCRIPTION
## Summary
- document installing dev dependencies to run tests
- explain running tests in README

## Testing
- `poetry run pytest -v` *(fails: 28 failed, 38 passed)*

------
https://chatgpt.com/codex/tasks/task_e_6846799f718883339f0d624aa9e805fa