### PR TITLE
Add dialectical reasoning flag docs

### DIFF
--- a/docs/architecture/dialectical_reasoning.md
+++ b/docs/architecture/dialectical_reasoning.md
@@ -435,6 +435,31 @@ response = await chat_service.send_message(
 )
 ```
 
+## Dialectical Reasoning Flag
+
+The behavior of agents is controlled by the `features.dialectical_reasoning` flag
+in `.devsynth/project.yaml`. When this flag is set to `true`, agents automatically
+perform thesis/antithesis/synthesis cycles during tasks such as requirement
+analysis or design discussions. Disabling the flag reverts agents to simpler
+critique without the full dialectical loop.
+
+### Customizing Depth and Cycle Frequency
+
+You can adjust how many reasoning cycles run and how deep each cycle recurses by
+adding optional settings under `dialectical_reasoning`:
+
+```yaml
+features:
+  dialectical_reasoning: true
+dialectical_reasoning:
+  cycles: 1  # number of reasoning passes
+  depth: 2   # recursion depth for nested reasoning
+```
+
+Keep these values low at first to minimize resource usage. The [Progressive
+Feature Setup guide](../user_guides/progressive_setup.md#enabling-dialectical-reasoning)
+explains how to gradually increase reasoning depth as your project grows.
+
 ## Performance and Scalability Considerations
 
 - **Caching**: Cache reasoning results for similar requirements and changes

--- a/docs/user_guides/progressive_setup.md
+++ b/docs/user_guides/progressive_setup.md
@@ -45,6 +45,8 @@ This guide describes how to install DevSynth with minimal features and progressi
 
    This sets `features.dialectical_reasoning: true` in the configuration file. See [docs/configuration.md](../configuration.md) for a full description of feature flags.
 
+   For details on how this flag changes agent behavior and how to tune reasoning depth, see [Dialectical Reasoning Flag](../architecture/dialectical_reasoning.md#dialectical-reasoning-flag).
+
 2. Run your workflows as usual. When dialectical reasoning is enabled, agents will perform critique and synthesis steps automatically.
 
 ## Enabling Property-Based Tests


### PR DESCRIPTION
## Summary
- document how the `dialectical_reasoning` flag affects agents
- show how to tune reasoning depth
- reference the new section in the progressive setup guide

## Testing
- `poetry run pytest -q` *(fails: TypeError in coordinator and missing step definitions)*

------
https://chatgpt.com/codex/tasks/task_e_68471fdac9d88333be5b115dfc2d7bc6