### PR TITLE
Add security utilities and configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Recursive EDRR framework implementation
 - Documentation cleansing and organization
 - Behavior-driven tests for the EDRR coordinator
+- Basic security utilities for authentication, authorization, and input sanitization
 
 ### Changed
 - Moved development documents to appropriate locations in the docs/ directory

--- a/docs/developer_guides/secure_coding.md
+++ b/docs/developer_guides/secure_coding.md
@@ -172,6 +172,16 @@ For all API endpoints:
 - Implement rate limiting to prevent abuse
 - Set appropriate security headers
 
+### Security Utilities
+
+DevSynth includes helper modules for common security tasks:
+
+- `security.authentication` provides Argon2-based password hashing and simple authentication helpers.
+- `security.authorization` offers role-based access control checks.
+- `security.sanitization` contains input sanitization utilities.
+
+Use these modules when implementing features that require authentication, authorization, or input validation.
+
 ### Dependency Management
 
 For managing dependencies:

--- a/docs/implementation/feature_status_matrix.md
+++ b/docs/implementation/feature_status_matrix.md
@@ -61,7 +61,7 @@ Each feature is scored on two dimensions:
 | Docker Containerization | Fully Implemented (100%) | 4 | 3 | None | | Dockerfile and Compose provided |
 | Configuration Management | Partially Implemented (70%) | 4 | 3 | None | | Environment-specific templates available |
 | Deployment Automation | Partially Implemented (50%) | 3 | 3 | Docker | | Basic Docker Compose workflows |
-| Security Framework | Documented Only (0%) | 4 | 4 | None | | Planned for Month 3 implementation |
+| Security Framework | Partially Implemented (20%) | 4 | 4 | None | | Basic authentication, authorization, and sanitization utilities added |
 | Dependency Management | Partially Implemented (30%) | 3 | 2 | None | | Basic management implemented, optimization pending |
 
 ## Current Limitations and Workarounds

--- a/docs/requirements_traceability.md
+++ b/docs/requirements_traceability.md
@@ -68,5 +68,8 @@ This matrix links requirements to design, code modules, and tests, ensuring bidi
 | FR-58 | Peer review mechanism for agent outputs | [WSDE Interaction Specification](specifications/wsde_interaction_specification.md) | src/devsynth/application/collaboration/peer_review.py | tests/behavior/features/wsde_message_passing_peer_review.feature | Implemented |
 | FR-59 | Advanced query patterns across memory stores | [Hybrid Memory Architecture](specifications/hybrid_memory_architecture.md) | src/devsynth/application/memory/query_router.py | tests/behavior/features/hybrid_memory_query_patterns.feature | Planned |
 | FR-60 | Synchronization between memory stores | [Hybrid Memory Architecture](specifications/hybrid_memory_architecture.md) | src/devsynth/application/memory/sync_manager.py | tests/behavior/features/hybrid_memory_query_patterns.feature | Planned |
+| FR-61 | Authentication utilities with Argon2 hashing | [Secure Coding Guidelines](developer_guides/secure_coding.md) | src/devsynth/security/authentication.py | tests/unit/security/test_authentication.py | Implemented |
+| FR-62 | Role-based authorization checks | [Security and Privacy Framework](analysis/critical_recommendations.md#5-security-and-privacy-framework-high) | src/devsynth/security/authorization.py | tests/unit/security/test_authorization.py | Implemented |
+| FR-63 | Input sanitization utilities | [Secure Coding Guidelines](developer_guides/secure_coding.md) | src/devsynth/security/sanitization.py | tests/unit/security/test_sanitization.py | Implemented |
 
 _Last updated: May 31, 2025_

--- a/poetry.lock
+++ b/poetry.lock
@@ -190,6 +190,65 @@ test = ["anyio[trio]", "blockbuster (>=1.5.23)", "coverage[toml] (>=7)", "except
 trio = ["trio (>=0.26.1)"]
 
 [[package]]
+name = "argon2-cffi"
+version = "23.1.0"
+description = "Argon2 for Python"
+optional = false
+python-versions = ">=3.7"
+groups = ["main"]
+files = [
+    {file = "argon2_cffi-23.1.0-py3-none-any.whl", hash = "sha256:c670642b78ba29641818ab2e68bd4e6a78ba53b7eff7b4c3815ae16abf91c7ea"},
+    {file = "argon2_cffi-23.1.0.tar.gz", hash = "sha256:879c3e79a2729ce768ebb7d36d4609e3a78a4ca2ec3a9f12286ca057e3d0db08"},
+]
+
+[package.dependencies]
+argon2-cffi-bindings = "*"
+
+[package.extras]
+dev = ["argon2-cffi[tests,typing]", "tox (>4)"]
+docs = ["furo", "myst-parser", "sphinx", "sphinx-copybutton", "sphinx-notfound-page"]
+tests = ["hypothesis", "pytest"]
+typing = ["mypy"]
+
+[[package]]
+name = "argon2-cffi-bindings"
+version = "21.2.0"
+description = "Low-level CFFI bindings for Argon2"
+optional = false
+python-versions = ">=3.6"
+groups = ["main"]
+files = [
+    {file = "argon2-cffi-bindings-21.2.0.tar.gz", hash = "sha256:bb89ceffa6c791807d1305ceb77dbfacc5aa499891d2c55661c6459651fc39e3"},
+    {file = "argon2_cffi_bindings-21.2.0-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:ccb949252cb2ab3a08c02024acb77cfb179492d5701c7cbdbfd776124d4d2367"},
+    {file = "argon2_cffi_bindings-21.2.0-cp36-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9524464572e12979364b7d600abf96181d3541da11e23ddf565a32e70bd4dc0d"},
+    {file = "argon2_cffi_bindings-21.2.0-cp36-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b746dba803a79238e925d9046a63aa26bf86ab2a2fe74ce6b009a1c3f5c8f2ae"},
+    {file = "argon2_cffi_bindings-21.2.0-cp36-abi3-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:58ed19212051f49a523abb1dbe954337dc82d947fb6e5a0da60f7c8471a8476c"},
+    {file = "argon2_cffi_bindings-21.2.0-cp36-abi3-musllinux_1_1_aarch64.whl", hash = "sha256:bd46088725ef7f58b5a1ef7ca06647ebaf0eb4baff7d1d0d177c6cc8744abd86"},
+    {file = "argon2_cffi_bindings-21.2.0-cp36-abi3-musllinux_1_1_i686.whl", hash = "sha256:8cd69c07dd875537a824deec19f978e0f2078fdda07fd5c42ac29668dda5f40f"},
+    {file = "argon2_cffi_bindings-21.2.0-cp36-abi3-musllinux_1_1_x86_64.whl", hash = "sha256:f1152ac548bd5b8bcecfb0b0371f082037e47128653df2e8ba6e914d384f3c3e"},
+    {file = "argon2_cffi_bindings-21.2.0-cp36-abi3-win32.whl", hash = "sha256:603ca0aba86b1349b147cab91ae970c63118a0f30444d4bc80355937c950c082"},
+    {file = "argon2_cffi_bindings-21.2.0-cp36-abi3-win_amd64.whl", hash = "sha256:b2ef1c30440dbbcba7a5dc3e319408b59676e2e039e2ae11a8775ecf482b192f"},
+    {file = "argon2_cffi_bindings-21.2.0-cp38-abi3-macosx_10_9_universal2.whl", hash = "sha256:e415e3f62c8d124ee16018e491a009937f8cf7ebf5eb430ffc5de21b900dad93"},
+    {file = "argon2_cffi_bindings-21.2.0-pp37-pypy37_pp73-macosx_10_9_x86_64.whl", hash = "sha256:3e385d1c39c520c08b53d63300c3ecc28622f076f4c2b0e6d7e796e9f6502194"},
+    {file = "argon2_cffi_bindings-21.2.0-pp37-pypy37_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2c3e3cc67fdb7d82c4718f19b4e7a87123caf8a93fde7e23cf66ac0337d3cb3f"},
+    {file = "argon2_cffi_bindings-21.2.0-pp37-pypy37_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6a22ad9800121b71099d0fb0a65323810a15f2e292f2ba450810a7316e128ee5"},
+    {file = "argon2_cffi_bindings-21.2.0-pp37-pypy37_pp73-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:f9f8b450ed0547e3d473fdc8612083fd08dd2120d6ac8f73828df9b7d45bb351"},
+    {file = "argon2_cffi_bindings-21.2.0-pp37-pypy37_pp73-win_amd64.whl", hash = "sha256:93f9bf70084f97245ba10ee36575f0c3f1e7d7724d67d8e5b08e61787c320ed7"},
+    {file = "argon2_cffi_bindings-21.2.0-pp38-pypy38_pp73-macosx_10_9_x86_64.whl", hash = "sha256:3b9ef65804859d335dc6b31582cad2c5166f0c3e7975f324d9ffaa34ee7e6583"},
+    {file = "argon2_cffi_bindings-21.2.0-pp38-pypy38_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d4966ef5848d820776f5f562a7d45fdd70c2f330c961d0d745b784034bd9f48d"},
+    {file = "argon2_cffi_bindings-21.2.0-pp38-pypy38_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:20ef543a89dee4db46a1a6e206cd015360e5a75822f76df533845c3cbaf72670"},
+    {file = "argon2_cffi_bindings-21.2.0-pp38-pypy38_pp73-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:ed2937d286e2ad0cc79a7087d3c272832865f779430e0cc2b4f3718d3159b0cb"},
+    {file = "argon2_cffi_bindings-21.2.0-pp38-pypy38_pp73-win_amd64.whl", hash = "sha256:5e00316dabdaea0b2dd82d141cc66889ced0cdcbfa599e8b471cf22c620c329a"},
+]
+
+[package.dependencies]
+cffi = ">=1.0.1"
+
+[package.extras]
+dev = ["cogapp", "pre-commit", "pytest", "wheel"]
+tests = ["pytest"]
+
+[[package]]
 name = "asgiref"
 version = "3.8.1"
 description = "ASGI specs, helper code, and adapters"
@@ -474,7 +533,6 @@ description = "Foreign Function Interface for Python calling C code."
 optional = false
 python-versions = ">=3.8"
 groups = ["main"]
-markers = "platform_python_implementation == \"PyPy\""
 files = [
     {file = "cffi-1.17.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:df8b1c11f177bc2313ec4b2d46baec87a5f3e71fc8b45dab2ee7cae86d9aba14"},
     {file = "cffi-1.17.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:8f2cdc858323644ab277e9bb925ad72ae0e67f69e804f4898c070998d50b1a67"},
@@ -4202,7 +4260,6 @@ description = "C parser in Python"
 optional = false
 python-versions = ">=3.8"
 groups = ["main"]
-markers = "platform_python_implementation == \"PyPy\""
 files = [
     {file = "pycparser-2.22-py3-none-any.whl", hash = "sha256:c3702b6d3dd8c7abc1afa565d7e63d53a1d0bd86cdc24edd75470f4de499cfcc"},
     {file = "pycparser-2.22.tar.gz", hash = "sha256:491c8be9c040f5390f5bf44a5b07752bd07f56edf992381b05c701439eec10f6"},
@@ -6413,4 +6470,4 @@ docs = []
 [metadata]
 lock-version = "2.1"
 python-versions = "<3.13,>=3.11"
-content-hash = "4ffa2a4a51530b8b1c61542adc285985ac7052fdf090eadfea781cc89cbace8b"
+content-hash = "d5993f889abcc02c5c45bc344b0ce4112c2459937513e94a9d36c66aa5d97096"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ faiss-cpu = "^1.11.0"
 rdflib = "^7.1.4"
 astor = "^0.8.1"
 diskcache = "^5.6.3"
+argon2-cffi = "^23.1.0"
 
 [tool.poetry.group.dev.dependencies]
 responses = "^0.25.7"

--- a/src/devsynth/config/settings.py
+++ b/src/devsynth/config/settings.py
@@ -30,7 +30,7 @@ def is_devsynth_managed_project(project_dir: str = None) -> bool:
         bool: True if the project is managed by DevSynth, False otherwise.
     """
     if project_dir is None:
-        project_dir = os.environ.get('DEVSYNTH_PROJECT_DIR') or os.getcwd()
+        project_dir = os.environ.get("DEVSYNTH_PROJECT_DIR") or os.getcwd()
 
     # Check for .devsynth/project.yaml
     project_config_path = os.path.join(project_dir, ".devsynth", "project.yaml")
@@ -94,14 +94,27 @@ class Settings(BaseSettings):
         """
         # Map test-expected keys to actual attribute names
         key_mapping = {
-            'llm_provider': lambda s: os.environ.get("DEVSYNTH_LLM_PROVIDER", "lmstudio"),
-            'llm_api_base': lambda s: os.environ.get("DEVSYNTH_LLM_API_BASE", "http://localhost:1234/v1"),
-            'llm_model': lambda s: os.environ.get("DEVSYNTH_LLM_MODEL", "gpt-3.5-turbo"),
-            'llm_temperature': lambda s: float(os.environ.get("DEVSYNTH_LLM_TEMPERATURE", "0.7")),
-            'llm_auto_select_model': lambda s: os.environ.get("DEVSYNTH_LLM_AUTO_SELECT_MODEL", "true").lower() in ["true", "1", "yes"],
-            'serper_api_key': lambda s: os.environ.get("SERPER_API_KEY", None),
-            'memory_store_type': lambda s: os.environ.get("DEVSYNTH_MEMORY_STORE", "memory"),
-            'openai_api_key': lambda s: os.environ.get("OPENAI_API_KEY", None),
+            "llm_provider": lambda s: os.environ.get(
+                "DEVSYNTH_LLM_PROVIDER", "lmstudio"
+            ),
+            "llm_api_base": lambda s: os.environ.get(
+                "DEVSYNTH_LLM_API_BASE", "http://localhost:1234/v1"
+            ),
+            "llm_model": lambda s: os.environ.get(
+                "DEVSYNTH_LLM_MODEL", "gpt-3.5-turbo"
+            ),
+            "llm_temperature": lambda s: float(
+                os.environ.get("DEVSYNTH_LLM_TEMPERATURE", "0.7")
+            ),
+            "llm_auto_select_model": lambda s: os.environ.get(
+                "DEVSYNTH_LLM_AUTO_SELECT_MODEL", "true"
+            ).lower()
+            in ["true", "1", "yes"],
+            "serper_api_key": lambda s: os.environ.get("SERPER_API_KEY", None),
+            "memory_store_type": lambda s: os.environ.get(
+                "DEVSYNTH_MEMORY_STORE", "memory"
+            ),
+            "openai_api_key": lambda s: os.environ.get("OPENAI_API_KEY", None),
         }
 
         # Check if we have a mapping for this key
@@ -122,30 +135,62 @@ class Settings(BaseSettings):
             return getattr(self, key)
         except AttributeError:
             raise KeyError(f"Setting '{key}' not found")
+
     # Memory system settings
-    memory_store_type: str = Field(default="memory", json_schema_extra={"env": "DEVSYNTH_MEMORY_STORE"})
-    memory_file_path: str = Field(
-        default=None,
-        json_schema_extra={"env": "DEVSYNTH_MEMORY_PATH"}
+    memory_store_type: str = Field(
+        default="memory", json_schema_extra={"env": "DEVSYNTH_MEMORY_STORE"}
     )
-    max_context_size: int = Field(default=1000, json_schema_extra={"env": "DEVSYNTH_MAX_CONTEXT_SIZE"})
-    context_expiration_days: int = Field(default=7, json_schema_extra={"env": "DEVSYNTH_CONTEXT_EXPIRATION_DAYS"})
+    memory_file_path: str = Field(
+        default=None, json_schema_extra={"env": "DEVSYNTH_MEMORY_PATH"}
+    )
+    max_context_size: int = Field(
+        default=1000, json_schema_extra={"env": "DEVSYNTH_MAX_CONTEXT_SIZE"}
+    )
+    context_expiration_days: int = Field(
+        default=7, json_schema_extra={"env": "DEVSYNTH_CONTEXT_EXPIRATION_DAYS"}
+    )
 
     # Vector store settings
-    vector_store_enabled: bool = Field(default=True, json_schema_extra={"env": "DEVSYNTH_VECTOR_STORE_ENABLED"})
-    chromadb_collection_name: str = Field(default="devsynth_vectors", json_schema_extra={"env": "DEVSYNTH_CHROMADB_COLLECTION"})
-    chromadb_distance_func: str = Field(default="cosine", json_schema_extra={"env": "DEVSYNTH_CHROMADB_DISTANCE_FUNC"})
+    vector_store_enabled: bool = Field(
+        default=True, json_schema_extra={"env": "DEVSYNTH_VECTOR_STORE_ENABLED"}
+    )
+    chromadb_collection_name: str = Field(
+        default="devsynth_vectors",
+        json_schema_extra={"env": "DEVSYNTH_CHROMADB_COLLECTION"},
+    )
+    chromadb_distance_func: str = Field(
+        default="cosine", json_schema_extra={"env": "DEVSYNTH_CHROMADB_DISTANCE_FUNC"}
+    )
 
     # Path settings
     log_dir: str = Field(default=None, json_schema_extra={"env": "DEVSYNTH_LOG_DIR"})
-    project_dir: str = Field(default=None, json_schema_extra={"env": "DEVSYNTH_PROJECT_DIR"})
+    project_dir: str = Field(
+        default=None, json_schema_extra={"env": "DEVSYNTH_PROJECT_DIR"}
+    )
 
     # LLM provider settings
-    provider_type: str = Field(default="openai", json_schema_extra={"env": "DEVSYNTH_PROVIDER_TYPE"})
-    openai_api_key: Optional[str] = Field(default=None, json_schema_extra={"env": "OPENAI_API_KEY"})
-    lm_studio_endpoint: Optional[str] = Field(default=None, json_schema_extra={"env": "LM_STUDIO_ENDPOINT"})
+    provider_type: str = Field(
+        default="openai", json_schema_extra={"env": "DEVSYNTH_PROVIDER_TYPE"}
+    )
+    openai_api_key: Optional[str] = Field(
+        default=None, json_schema_extra={"env": "OPENAI_API_KEY"}
+    )
+    lm_studio_endpoint: Optional[str] = Field(
+        default=None, json_schema_extra={"env": "LM_STUDIO_ENDPOINT"}
+    )
 
-    @field_validator('memory_file_path', mode='before')
+    # Security feature toggles
+    authentication_enabled: bool = Field(
+        default=True, json_schema_extra={"env": "DEVSYNTH_AUTHENTICATION_ENABLED"}
+    )
+    authorization_enabled: bool = Field(
+        default=True, json_schema_extra={"env": "DEVSYNTH_AUTHORIZATION_ENABLED"}
+    )
+    sanitization_enabled: bool = Field(
+        default=True, json_schema_extra={"env": "DEVSYNTH_SANITIZATION_ENABLED"}
+    )
+
+    @field_validator("memory_file_path", mode="before")
     def set_default_memory_path(cls, v, info):
         """
         Set default memory path if not specified.
@@ -157,24 +202,42 @@ class Settings(BaseSettings):
             return v
 
         # Check if we're in a test environment with file operations disabled
-        no_file_logging = os.environ.get("DEVSYNTH_NO_FILE_LOGGING", "0").lower() in ("1", "true", "yes")
+        no_file_logging = os.environ.get("DEVSYNTH_NO_FILE_LOGGING", "0").lower() in (
+            "1",
+            "true",
+            "yes",
+        )
 
         # Get project directory from values or environment
-        project_dir = values.get('project_dir') or os.environ.get('DEVSYNTH_PROJECT_DIR') or os.getcwd()
+        project_dir = (
+            values.get("project_dir")
+            or os.environ.get("DEVSYNTH_PROJECT_DIR")
+            or os.getcwd()
+        )
 
         # Check if this is a DevSynth-managed project
         if is_devsynth_managed_project(project_dir):
             # Check for project-level config
             project_config_path = os.path.join(project_dir, ".devsynth", "project.yaml")
-            config_path = project_config_path if os.path.exists(project_config_path) else None
+            config_path = (
+                project_config_path if os.path.exists(project_config_path) else None
+            )
 
             if config_path:
                 try:
                     import yaml
-                    with open(config_path, 'r') as f:
+
+                    with open(config_path, "r") as f:
                         config = yaml.safe_load(f)
-                        if config and 'resources' in config and 'project' in config['resources'] and 'memoryDir' in config['resources']['project']:
-                            return os.path.join(project_dir, config['resources']['project']['memoryDir'])
+                        if (
+                            config
+                            and "resources" in config
+                            and "project" in config["resources"]
+                            and "memoryDir" in config["resources"]["project"]
+                        ):
+                            return os.path.join(
+                                project_dir, config["resources"]["project"]["memoryDir"]
+                            )
                 except Exception as e:
                     # Log error but continue with default path
                     logger.error(f"Error reading project config: {e}")
@@ -185,9 +248,13 @@ class Settings(BaseSettings):
 
         # For non-DevSynth-managed projects, use global config
         # Use project_dir for global config if DEVSYNTH_PROJECT_DIR is set (for test isolation)
-        if os.environ.get('DEVSYNTH_PROJECT_DIR'):
-            global_config_dir = os.path.join(os.environ.get('DEVSYNTH_PROJECT_DIR'), ".devsynth", "config")
-            logger.debug(f"Using test environment global config dir: {global_config_dir}")
+        if os.environ.get("DEVSYNTH_PROJECT_DIR"):
+            global_config_dir = os.path.join(
+                os.environ.get("DEVSYNTH_PROJECT_DIR"), ".devsynth", "config"
+            )
+            logger.debug(
+                f"Using test environment global config dir: {global_config_dir}"
+            )
         else:
             # In test environments with file operations disabled, avoid using home directory
             if no_file_logging:
@@ -201,11 +268,21 @@ class Settings(BaseSettings):
         if os.path.exists(global_config_path):
             try:
                 import yaml
-                with open(global_config_path, 'r') as f:
+
+                with open(global_config_path, "r") as f:
                     config = yaml.safe_load(f)
-                    if config and 'resources' in config and 'global' in config['resources'] and 'memoryDir' in config['resources']['global']:
-                        memory_path = os.path.expanduser(config['resources']['global']['memoryDir'])
-                        logger.debug(f"Using memory path from global config: {memory_path}")
+                    if (
+                        config
+                        and "resources" in config
+                        and "global" in config["resources"]
+                        and "memoryDir" in config["resources"]["global"]
+                    ):
+                        memory_path = os.path.expanduser(
+                            config["resources"]["global"]["memoryDir"]
+                        )
+                        logger.debug(
+                            f"Using memory path from global config: {memory_path}"
+                        )
                         return memory_path
             except Exception as e:
                 # Log error but continue with default path
@@ -219,7 +296,7 @@ class Settings(BaseSettings):
 
         return os.path.expanduser("~/.devsynth/memory")
 
-    @field_validator('log_dir', mode='before')
+    @field_validator("log_dir", mode="before")
     def set_default_log_dir(cls, v, info):
         """
         Set default log directory if not specified.
@@ -231,24 +308,42 @@ class Settings(BaseSettings):
             return v
 
         # Check if we're in a test environment with file operations disabled
-        no_file_logging = os.environ.get("DEVSYNTH_NO_FILE_LOGGING", "0").lower() in ("1", "true", "yes")
+        no_file_logging = os.environ.get("DEVSYNTH_NO_FILE_LOGGING", "0").lower() in (
+            "1",
+            "true",
+            "yes",
+        )
 
         # Get project directory from values or environment
-        project_dir = values.get('project_dir') or os.environ.get('DEVSYNTH_PROJECT_DIR') or os.getcwd()
+        project_dir = (
+            values.get("project_dir")
+            or os.environ.get("DEVSYNTH_PROJECT_DIR")
+            or os.getcwd()
+        )
 
         # Check if this is a DevSynth-managed project
         if is_devsynth_managed_project(project_dir):
             # Check for project-level config
             project_config_path = os.path.join(project_dir, ".devsynth", "project.yaml")
-            config_path = project_config_path if os.path.exists(project_config_path) else None
+            config_path = (
+                project_config_path if os.path.exists(project_config_path) else None
+            )
 
             if config_path:
                 try:
                     import yaml
-                    with open(config_path, 'r') as f:
+
+                    with open(config_path, "r") as f:
                         config = yaml.safe_load(f)
-                        if config and 'resources' in config and 'project' in config['resources'] and 'logsDir' in config['resources']['project']:
-                            return os.path.join(project_dir, config['resources']['project']['logsDir'])
+                        if (
+                            config
+                            and "resources" in config
+                            and "project" in config["resources"]
+                            and "logsDir" in config["resources"]["project"]
+                        ):
+                            return os.path.join(
+                                project_dir, config["resources"]["project"]["logsDir"]
+                            )
                 except Exception as e:
                     # Log error but continue with default path
                     logger.error(f"Error reading project config: {e}")
@@ -259,9 +354,13 @@ class Settings(BaseSettings):
 
         # For non-DevSynth-managed projects, use global config
         # Use project_dir for global config if DEVSYNTH_PROJECT_DIR is set (for test isolation)
-        if os.environ.get('DEVSYNTH_PROJECT_DIR'):
-            global_config_dir = os.path.join(os.environ.get('DEVSYNTH_PROJECT_DIR'), ".devsynth", "config")
-            logger.debug(f"Using test environment global config dir for logs: {global_config_dir}")
+        if os.environ.get("DEVSYNTH_PROJECT_DIR"):
+            global_config_dir = os.path.join(
+                os.environ.get("DEVSYNTH_PROJECT_DIR"), ".devsynth", "config"
+            )
+            logger.debug(
+                f"Using test environment global config dir for logs: {global_config_dir}"
+            )
         else:
             # In test environments with file operations disabled, avoid using home directory
             if no_file_logging:
@@ -269,16 +368,26 @@ class Settings(BaseSettings):
                 return os.path.join(project_dir, ".devsynth", "logs")
 
             global_config_dir = os.path.expanduser("~/.devsynth/config")
-            logger.debug(f"Using user home global config dir for logs: {global_config_dir}")
+            logger.debug(
+                f"Using user home global config dir for logs: {global_config_dir}"
+            )
 
         global_config_path = os.path.join(global_config_dir, "global_config.yaml")
         if os.path.exists(global_config_path):
             try:
                 import yaml
-                with open(global_config_path, 'r') as f:
+
+                with open(global_config_path, "r") as f:
                     config = yaml.safe_load(f)
-                    if config and 'resources' in config and 'global' in config['resources'] and 'logsDir' in config['resources']['global']:
-                        logs_path = os.path.expanduser(config['resources']['global']['logsDir'])
+                    if (
+                        config
+                        and "resources" in config
+                        and "global" in config["resources"]
+                        and "logsDir" in config["resources"]["global"]
+                    ):
+                        logs_path = os.path.expanduser(
+                            config["resources"]["global"]["logsDir"]
+                        )
                         logger.debug(f"Using logs path from global config: {logs_path}")
                         return logs_path
             except Exception as e:
@@ -293,7 +402,7 @@ class Settings(BaseSettings):
 
         return os.path.expanduser("~/.devsynth/logs")
 
-    @field_validator('project_dir', mode='before')
+    @field_validator("project_dir", mode="before")
     def set_default_project_dir(cls, v, info):
         """
         Set default project directory if not specified.
@@ -304,7 +413,7 @@ class Settings(BaseSettings):
             return v
 
         # Check environment variable first
-        env_project_dir = os.environ.get('DEVSYNTH_PROJECT_DIR')
+        env_project_dir = os.environ.get("DEVSYNTH_PROJECT_DIR")
         if env_project_dir:
             return env_project_dir
 
@@ -312,16 +421,16 @@ class Settings(BaseSettings):
         return os.getcwd()
 
     model_config = SettingsConfigDict(
-        env_file=".env",
-        case_sensitive=False,
-        extra="ignore"
+        env_file=".env", case_sensitive=False, extra="ignore"
     )
+
 
 # Global settings instance for singleton pattern
 _settings_instance = None
 
 # Initialize settings for module-level access
 _settings = Settings()
+
 
 def get_settings(reload: bool = False, **kwargs) -> Settings:
     """
@@ -354,6 +463,7 @@ def get_settings(reload: bool = False, **kwargs) -> Settings:
 
     return _settings_instance
 
+
 def ensure_path_exists(path: str, create: bool = True) -> str:
     """
     Ensure the specified path exists.
@@ -371,11 +481,17 @@ def ensure_path_exists(path: str, create: bool = True) -> str:
     """
     # Check if we're in a test environment
     in_test_env = os.environ.get("DEVSYNTH_PROJECT_DIR") is not None
-    no_file_logging = os.environ.get("DEVSYNTH_NO_FILE_LOGGING", "0").lower() in ("1", "true", "yes")
+    no_file_logging = os.environ.get("DEVSYNTH_NO_FILE_LOGGING", "0").lower() in (
+        "1",
+        "true",
+        "yes",
+    )
 
     # Debug logging
     print(f"ensure_path_exists called with path={path}, create={create}")
-    print(f"in_test_env={in_test_env}, DEVSYNTH_PROJECT_DIR={os.environ.get('DEVSYNTH_PROJECT_DIR')}")
+    print(
+        f"in_test_env={in_test_env}, DEVSYNTH_PROJECT_DIR={os.environ.get('DEVSYNTH_PROJECT_DIR')}"
+    )
 
     # If we're in a test environment with DEVSYNTH_PROJECT_DIR set, ensure paths are within the test directory
     if in_test_env:
@@ -384,7 +500,9 @@ def ensure_path_exists(path: str, create: bool = True) -> str:
 
         print(f"test_project_dir={test_project_dir}, path_obj={path_obj}")
         print(f"path_obj.is_absolute()={path_obj.is_absolute()}")
-        print(f"str(path_obj).startswith(test_project_dir)={str(path_obj).startswith(test_project_dir)}")
+        print(
+            f"str(path_obj).startswith(test_project_dir)={str(path_obj).startswith(test_project_dir)}"
+        )
 
         # If the path is absolute and not within the test project directory,
         # redirect it to be within the test project directory
@@ -402,7 +520,9 @@ def ensure_path_exists(path: str, create: bool = True) -> str:
                 relative_path = str(path_obj.relative_to(path_obj.anchor))
                 new_path = os.path.join(test_project_dir, relative_path)
                 print(f"Redirecting absolute path {path} to test path {new_path}")
-                logger.debug(f"Redirecting absolute path {path} to test path {new_path}")
+                logger.debug(
+                    f"Redirecting absolute path {path} to test path {new_path}"
+                )
                 path = new_path
 
     # Only create directories if explicitly requested and not in a test environment with file operations disabled
@@ -438,7 +558,7 @@ def get_llm_settings(reload: bool = False, **kwargs) -> Dict[str, Any]:
         "model": settings["llm_model"],
         "max_tokens": int(os.environ.get("DEVSYNTH_LLM_MAX_TOKENS", "2000")),
         "temperature": settings["llm_temperature"],
-        "auto_select_model": settings["llm_auto_select_model"]
+        "auto_select_model": settings["llm_auto_select_model"],
     }
 
     # Add API key if available

--- a/src/devsynth/exceptions.py
+++ b/src/devsynth/exceptions.py
@@ -14,7 +14,12 @@ from typing import Optional, Dict, Any, List
 class DevSynthError(Exception):
     """Base exception class for all DevSynth errors."""
 
-    def __init__(self, message: str, error_code: Optional[str] = None, details: Optional[Dict[str, Any]] = None):
+    def __init__(
+        self,
+        message: str,
+        error_code: Optional[str] = None,
+        details: Optional[Dict[str, Any]] = None,
+    ):
         self.message = message
         self.error_code = error_code
         self.details = details or {}
@@ -26,155 +31,227 @@ class DevSynthError(Exception):
             "error_type": self.__class__.__name__,
             "error_code": self.error_code,
             "message": self.message,
-            "details": self.details
+            "details": self.details,
         }
 
 
 # User Input Errors
 
+
 class UserInputError(DevSynthError):
     """Base exception for errors related to user input."""
+
     pass
 
 
 class ValidationError(UserInputError):
     """Exception raised when input validation fails."""
 
-    def __init__(self, message: str, field: Optional[str] = None, value: Any = None, 
-                 constraints: Optional[Dict[str, Any]] = None, error_code: Optional[str] = None):
-        details = {
-            "field": field,
-            "value": value,
-            "constraints": constraints or {}
-        }
-        super().__init__(message, error_code=error_code or "VALIDATION_ERROR", details=details)
+    def __init__(
+        self,
+        message: str,
+        field: Optional[str] = None,
+        value: Any = None,
+        constraints: Optional[Dict[str, Any]] = None,
+        error_code: Optional[str] = None,
+    ):
+        details = {"field": field, "value": value, "constraints": constraints or {}}
+        super().__init__(
+            message, error_code=error_code or "VALIDATION_ERROR", details=details
+        )
 
 
 class ConfigurationError(UserInputError):
     """Exception raised when there's an error in the configuration."""
 
-    def __init__(self, message: str, config_key: Optional[str] = None,
-                 config_value: Any = None, error_code: Optional[str] = None):
-        details = {
-            "config_key": config_key,
-            "config_value": config_value
-        }
-        super().__init__(message, error_code=error_code or "CONFIGURATION_ERROR", details=details)
+    def __init__(
+        self,
+        message: str,
+        config_key: Optional[str] = None,
+        config_value: Any = None,
+        error_code: Optional[str] = None,
+    ):
+        details = {"config_key": config_key, "config_value": config_value}
+        super().__init__(
+            message, error_code=error_code or "CONFIGURATION_ERROR", details=details
+        )
 
 
 class CommandError(UserInputError):
     """Exception raised when a command cannot be executed due to user input."""
 
-    def __init__(self, message: str, command: Optional[str] = None,
-                 args: Optional[Dict[str, Any]] = None, error_code: Optional[str] = None):
-        details = {
-            "command": command,
-            "args": args or {}
-        }
-        super().__init__(message, error_code=error_code or "COMMAND_ERROR", details=details)
+    def __init__(
+        self,
+        message: str,
+        command: Optional[str] = None,
+        args: Optional[Dict[str, Any]] = None,
+        error_code: Optional[str] = None,
+    ):
+        details = {"command": command, "args": args or {}}
+        super().__init__(
+            message, error_code=error_code or "COMMAND_ERROR", details=details
+        )
 
 
 # System Errors
 
+
 class SystemError(DevSynthError):
     """Base exception for internal system errors."""
+
     pass
 
 
 class InternalError(SystemError):
     """Exception raised for unexpected internal errors."""
 
-    def __init__(self, message: str, component: Optional[str] = None,
-                 error_code: Optional[str] = None, cause: Optional[Exception] = None):
+    def __init__(
+        self,
+        message: str,
+        component: Optional[str] = None,
+        error_code: Optional[str] = None,
+        cause: Optional[Exception] = None,
+    ):
         details = {
             "component": component,
-            "original_error": str(cause) if cause else None
+            "original_error": str(cause) if cause else None,
         }
-        super().__init__(message, error_code=error_code or "INTERNAL_ERROR", details=details)
+        super().__init__(
+            message, error_code=error_code or "INTERNAL_ERROR", details=details
+        )
         self.__cause__ = cause
 
 
 class ResourceExhaustedError(SystemError):
     """Exception raised when a system resource is exhausted."""
 
-    def __init__(self, message: str, resource_type: Optional[str] = None,
-                 limit: Any = None, error_code: Optional[str] = None):
-        details = {
-            "resource_type": resource_type,
-            "limit": limit
-        }
-        super().__init__(message, error_code=error_code or "RESOURCE_EXHAUSTED", details=details)
+    def __init__(
+        self,
+        message: str,
+        resource_type: Optional[str] = None,
+        limit: Any = None,
+        error_code: Optional[str] = None,
+    ):
+        details = {"resource_type": resource_type, "limit": limit}
+        super().__init__(
+            message, error_code=error_code or "RESOURCE_EXHAUSTED", details=details
+        )
 
 
 # Adapter Errors
 
+
 class AdapterError(DevSynthError):
     """Base exception for errors in adapter components."""
+
     pass
 
 
 class MemoryError(DevSynthError):
     """Base exception for memory system errors."""
+
     pass
 
 
 class MemoryCorruptionError(MemoryError):
     """Exception raised when memory data is corrupted."""
 
-    def __init__(self, message: str, store_type: Optional[str] = None,
-                 item_id: Optional[str] = None, error_code: Optional[str] = None):
-        details = {
-            "store_type": store_type,
-            "item_id": item_id
-        }
-        super().__init__(message, error_code=error_code or "MEMORY_CORRUPTION", details=details)
+    def __init__(
+        self,
+        message: str,
+        store_type: Optional[str] = None,
+        item_id: Optional[str] = None,
+        error_code: Optional[str] = None,
+    ):
+        details = {"store_type": store_type, "item_id": item_id}
+        super().__init__(
+            message, error_code=error_code or "MEMORY_CORRUPTION", details=details
+        )
 
 
 class ProviderError(AdapterError):
     """Exception raised for errors related to external providers."""
 
-    def __init__(self, message: str, provider: Optional[str] = None,
-                 operation: Optional[str] = None, error_code: Optional[str] = None,
-                 provider_error: Optional[Dict[str, Any]] = None):
+    def __init__(
+        self,
+        message: str,
+        provider: Optional[str] = None,
+        operation: Optional[str] = None,
+        error_code: Optional[str] = None,
+        provider_error: Optional[Dict[str, Any]] = None,
+    ):
         details = {
             "provider": provider,
             "operation": operation,
-            "provider_error": provider_error or {}
+            "provider_error": provider_error or {},
         }
-        super().__init__(message, error_code=error_code or "PROVIDER_ERROR", details=details)
+        super().__init__(
+            message, error_code=error_code or "PROVIDER_ERROR", details=details
+        )
 
 
 class LLMError(ProviderError):
     """Exception raised for errors related to LLM operations."""
 
-    def __init__(self, message: str, provider: Optional[str] = None,
-                 operation: Optional[str] = None, error_code: Optional[str] = None,
-                 provider_error: Optional[Dict[str, Any]] = None):
-        super().__init__(message, provider=provider, operation=operation,
-                         error_code=error_code or "LLM_ERROR", provider_error=provider_error)
+    def __init__(
+        self,
+        message: str,
+        provider: Optional[str] = None,
+        operation: Optional[str] = None,
+        error_code: Optional[str] = None,
+        provider_error: Optional[Dict[str, Any]] = None,
+    ):
+        super().__init__(
+            message,
+            provider=provider,
+            operation=operation,
+            error_code=error_code or "LLM_ERROR",
+            provider_error=provider_error,
+        )
 
 
 class TokenLimitExceededError(LLMError):
     """Exception raised when a text exceeds the token limit."""
 
-    def __init__(self, message: str, current_tokens: int, max_tokens: int,
-                 provider: Optional[str] = None, operation: Optional[str] = None):
+    def __init__(
+        self,
+        message: str,
+        current_tokens: int,
+        max_tokens: int,
+        provider: Optional[str] = None,
+        operation: Optional[str] = None,
+    ):
         details = {
             "current_tokens": current_tokens,
             "max_tokens": max_tokens,
-            "excess": current_tokens - max_tokens
+            "excess": current_tokens - max_tokens,
         }
-        super().__init__(message, provider=provider, operation=operation,
-                         error_code="TOKEN_LIMIT_EXCEEDED", provider_error=details)
+        super().__init__(
+            message,
+            provider=provider,
+            operation=operation,
+            error_code="TOKEN_LIMIT_EXCEEDED",
+            provider_error=details,
+        )
 
 
 class ProviderTimeoutError(ProviderError):
     """Exception raised when a provider operation times out."""
 
-    def __init__(self, message: str, provider: Optional[str] = None,
-                 operation: Optional[str] = None, timeout_seconds: Optional[float] = None):
+    def __init__(
+        self,
+        message: str,
+        provider: Optional[str] = None,
+        operation: Optional[str] = None,
+        timeout_seconds: Optional[float] = None,
+    ):
         # Call parent constructor
-        super().__init__(message, provider=provider, operation=operation, error_code="PROVIDER_TIMEOUT")
+        super().__init__(
+            message,
+            provider=provider,
+            operation=operation,
+            error_code="PROVIDER_TIMEOUT",
+        )
 
         # Add timeout_seconds directly to the details dictionary
         self.details["timeout_seconds"] = timeout_seconds
@@ -184,52 +261,70 @@ class ProviderAuthenticationError(ProviderError):
     """Exception raised when authentication with a provider fails."""
 
     def __init__(self, message: str, provider: Optional[str] = None):
-        super().__init__(message, provider=provider, error_code="PROVIDER_AUTHENTICATION_ERROR")
+        super().__init__(
+            message, provider=provider, error_code="PROVIDER_AUTHENTICATION_ERROR"
+        )
 
 
 class MemoryAdapterError(AdapterError):
     """Exception raised for errors related to the memory system."""
 
-    def __init__(self, message: str, store_type: Optional[str] = None,
-                 operation: Optional[str] = None, error_code: Optional[str] = None):
-        details = {
-            "store_type": store_type,
-            "operation": operation
-        }
-        super().__init__(message, error_code=error_code or "MEMORY_ERROR", details=details)
+    def __init__(
+        self,
+        message: str,
+        store_type: Optional[str] = None,
+        operation: Optional[str] = None,
+        error_code: Optional[str] = None,
+    ):
+        details = {"store_type": store_type, "operation": operation}
+        super().__init__(
+            message, error_code=error_code or "MEMORY_ERROR", details=details
+        )
 
 
 class MemoryNotFoundError(MemoryAdapterError):
     """Exception raised when an item is not found in memory."""
 
-    def __init__(self, message: str, item_id: Optional[str] = None,
-                 store_type: Optional[str] = None):
-        details = {
-            "item_id": item_id,
-            "store_type": store_type
-        }
+    def __init__(
+        self,
+        message: str,
+        item_id: Optional[str] = None,
+        store_type: Optional[str] = None,
+    ):
+        details = {"item_id": item_id, "store_type": store_type}
         super().__init__(message, error_code="MEMORY_NOT_FOUND", details=details)
 
 
 class MemoryItemNotFoundError(MemoryAdapterError):
     """Exception raised when a specific memory item is not found."""
 
-    def __init__(self, message: str, item_id: Optional[str] = None,
-                 store_type: Optional[str] = None):
-        details = {
-            "item_id": item_id,
-            "store_type": store_type
-        }
+    def __init__(
+        self,
+        message: str,
+        item_id: Optional[str] = None,
+        store_type: Optional[str] = None,
+    ):
+        details = {"item_id": item_id, "store_type": store_type}
         super().__init__(message, error_code="MEMORY_ITEM_NOT_FOUND", details=details)
 
 
 class MemoryStoreError(MemoryAdapterError):
     """Exception raised when there's an error with a memory store operation."""
 
-    def __init__(self, message: str, store_type: Optional[str] = None,
-                 operation: Optional[str] = None, original_error: Optional[Exception] = None):
+    def __init__(
+        self,
+        message: str,
+        store_type: Optional[str] = None,
+        operation: Optional[str] = None,
+        original_error: Optional[Exception] = None,
+    ):
         # Call parent constructor with the appropriate parameters
-        super().__init__(message, store_type=store_type, operation=operation, error_code="MEMORY_STORE_ERROR")
+        super().__init__(
+            message,
+            store_type=store_type,
+            operation=operation,
+            error_code="MEMORY_STORE_ERROR",
+        )
 
         # Add original_error to details dictionary
         if original_error:
@@ -241,111 +336,157 @@ class MemoryStoreError(MemoryAdapterError):
 
 # Domain Errors
 
+
 class DomainError(DevSynthError):
     """Base exception for errors in domain logic."""
+
     pass
 
 
 class AgentError(DomainError):
     """Exception raised for errors related to agents."""
 
-    def __init__(self, message: str, agent_id: Optional[str] = None,
-                 operation: Optional[str] = None, error_code: Optional[str] = None):
-        details = {
-            "agent_id": agent_id,
-            "operation": operation
-        }
-        super().__init__(message, error_code=error_code or "AGENT_ERROR", details=details)
+    def __init__(
+        self,
+        message: str,
+        agent_id: Optional[str] = None,
+        operation: Optional[str] = None,
+        error_code: Optional[str] = None,
+    ):
+        details = {"agent_id": agent_id, "operation": operation}
+        super().__init__(
+            message, error_code=error_code or "AGENT_ERROR", details=details
+        )
 
 
 class WorkflowError(DomainError):
     """Exception raised for errors in workflow execution."""
 
-    def __init__(self, message: str, workflow_id: Optional[str] = None,
-                 step: Optional[str] = None, error_code: Optional[str] = None):
-        details = {
-            "workflow_id": workflow_id,
-            "step": step
-        }
-        super().__init__(message, error_code=error_code or "WORKFLOW_ERROR", details=details)
+    def __init__(
+        self,
+        message: str,
+        workflow_id: Optional[str] = None,
+        step: Optional[str] = None,
+        error_code: Optional[str] = None,
+    ):
+        details = {"workflow_id": workflow_id, "step": step}
+        super().__init__(
+            message, error_code=error_code or "WORKFLOW_ERROR", details=details
+        )
 
 
 class NeedsHumanInterventionError(WorkflowError):
     """Exception raised when a workflow needs human intervention."""
 
-    def __init__(self, message: str, workflow_id: Optional[str] = None,
-                 step: Optional[str] = None, options: Optional[List[str]] = None):
+    def __init__(
+        self,
+        message: str,
+        workflow_id: Optional[str] = None,
+        step: Optional[str] = None,
+        options: Optional[List[str]] = None,
+    ):
         # Create details dictionary for this class
         self.options = options or []
 
         # Call parent constructor without passing details
-        super().__init__(message, workflow_id=workflow_id, step=step, 
-                         error_code="NEEDS_HUMAN_INTERVENTION")
+        super().__init__(
+            message,
+            workflow_id=workflow_id,
+            step=step,
+            error_code="NEEDS_HUMAN_INTERVENTION",
+        )
 
 
 class ContextError(DomainError):
     """Exception raised for errors related to context management."""
 
-    def __init__(self, message: str, context_id: Optional[str] = None,
-                 operation: Optional[str] = None, error_code: Optional[str] = None):
-        details = {
-            "context_id": context_id,
-            "operation": operation
-        }
-        super().__init__(message, error_code=error_code or "CONTEXT_ERROR", details=details)
+    def __init__(
+        self,
+        message: str,
+        context_id: Optional[str] = None,
+        operation: Optional[str] = None,
+        error_code: Optional[str] = None,
+    ):
+        details = {"context_id": context_id, "operation": operation}
+        super().__init__(
+            message, error_code=error_code or "CONTEXT_ERROR", details=details
+        )
 
 
 class DialecticalReasoningError(DomainError):
     """Exception raised for errors in dialectical reasoning processes."""
 
-    def __init__(self, message: str, phase: Optional[str] = None,
-                 arguments: Optional[List[str]] = None, error_code: Optional[str] = None):
-        details = {
-            "phase": phase,
-            "arguments": arguments
-        }
-        super().__init__(message, error_code=error_code or "REASONING_ERROR", details=details)
+    def __init__(
+        self,
+        message: str,
+        phase: Optional[str] = None,
+        arguments: Optional[List[str]] = None,
+        error_code: Optional[str] = None,
+    ):
+        details = {"phase": phase, "arguments": arguments}
+        super().__init__(
+            message, error_code=error_code or "REASONING_ERROR", details=details
+        )
 
 
 class ProjectModelError(DomainError):
     """Exception raised for errors related to the project model."""
 
-    def __init__(self, message: str, model_id: Optional[str] = None,
-                 operation: Optional[str] = None, error_code: Optional[str] = None):
-        details = {
-            "model_id": model_id,
-            "operation": operation
-        }
-        super().__init__(message, error_code=error_code or "PROJECT_MODEL_ERROR", details=details)
+    def __init__(
+        self,
+        message: str,
+        model_id: Optional[str] = None,
+        operation: Optional[str] = None,
+        error_code: Optional[str] = None,
+    ):
+        details = {"model_id": model_id, "operation": operation}
+        super().__init__(
+            message, error_code=error_code or "PROJECT_MODEL_ERROR", details=details
+        )
 
 
 # Application Errors
 
+
 class ApplicationError(DevSynthError):
     """Base exception for errors in application logic."""
+
     pass
 
 
 class PromiseError(ApplicationError):
     """Exception raised for errors related to the Promise system."""
 
-    def __init__(self, message: str, promise_id: Optional[str] = None,
-                 operation: Optional[str] = None, error_code: Optional[str] = None):
-        details = {
-            "promise_id": promise_id,
-            "operation": operation
-        }
-        super().__init__(message, error_code=error_code or "PROMISE_ERROR", details=details)
+    def __init__(
+        self,
+        message: str,
+        promise_id: Optional[str] = None,
+        operation: Optional[str] = None,
+        error_code: Optional[str] = None,
+    ):
+        details = {"promise_id": promise_id, "operation": operation}
+        super().__init__(
+            message, error_code=error_code or "PROMISE_ERROR", details=details
+        )
 
 
 class PromiseStateError(PromiseError):
     """Exception raised when an invalid promise state transition is attempted."""
 
-    def __init__(self, message: str, promise_id: Optional[str] = None,
-                 from_state: Optional[str] = None, to_state: Optional[str] = None):
+    def __init__(
+        self,
+        message: str,
+        promise_id: Optional[str] = None,
+        from_state: Optional[str] = None,
+        to_state: Optional[str] = None,
+    ):
         # Call parent constructor with state_transition as the operation
-        super().__init__(message, promise_id=promise_id, operation="state_transition", 
-                         error_code="PROMISE_STATE_ERROR")
+        super().__init__(
+            message,
+            promise_id=promise_id,
+            operation="state_transition",
+            error_code="PROMISE_STATE_ERROR",
+        )
 
         # Add from_state and to_state directly to the details dictionary
         self.details["from_state"] = from_state
@@ -355,225 +496,333 @@ class PromiseStateError(PromiseError):
 class IngestionError(ApplicationError):
     """Exception raised for errors during project ingestion."""
 
-    def __init__(self, message: str, phase: Optional[str] = None,
-                 artifact_path: Optional[str] = None, error_code: Optional[str] = None):
-        details = {
-            "phase": phase,
-            "artifact_path": artifact_path
-        }
-        super().__init__(message, error_code=error_code or "INGESTION_ERROR", details=details)
+    def __init__(
+        self,
+        message: str,
+        phase: Optional[str] = None,
+        artifact_path: Optional[str] = None,
+        error_code: Optional[str] = None,
+    ):
+        details = {"phase": phase, "artifact_path": artifact_path}
+        super().__init__(
+            message, error_code=error_code or "INGESTION_ERROR", details=details
+        )
 
 
 class DocumentationError(ApplicationError):
     """Exception raised for errors related to documentation processing."""
 
-    def __init__(self, message: str, doc_type: Optional[str] = None,
-                 doc_path: Optional[str] = None, error_code: Optional[str] = None):
-        details = {
-            "doc_type": doc_type,
-            "doc_path": doc_path
-        }
-        super().__init__(message, error_code=error_code or "DOCUMENTATION_ERROR", details=details)
+    def __init__(
+        self,
+        message: str,
+        doc_type: Optional[str] = None,
+        doc_path: Optional[str] = None,
+        error_code: Optional[str] = None,
+    ):
+        details = {"doc_type": doc_type, "doc_path": doc_path}
+        super().__init__(
+            message, error_code=error_code or "DOCUMENTATION_ERROR", details=details
+        )
 
 
 class ManifestError(ApplicationError):
     """Exception raised for errors related to the project manifest."""
 
-    def __init__(self, message: str, field: Optional[str] = None,
-                 manifest_path: Optional[str] = None, error_code: Optional[str] = None):
-        details = {
-            "field": field,
-            "manifest_path": manifest_path
-        }
-        super().__init__(message, error_code=error_code or "MANIFEST_ERROR", details=details)
+    def __init__(
+        self,
+        message: str,
+        field: Optional[str] = None,
+        manifest_path: Optional[str] = None,
+        error_code: Optional[str] = None,
+    ):
+        details = {"field": field, "manifest_path": manifest_path}
+        super().__init__(
+            message, error_code=error_code or "MANIFEST_ERROR", details=details
+        )
 
 
 class CodeGenerationError(ApplicationError):
     """Exception raised for errors during code generation."""
 
-    def __init__(self, message: str, language: Optional[str] = None,
-                 component: Optional[str] = None, error_code: Optional[str] = None):
-        details = {
-            "language": language,
-            "component": component
-        }
-        super().__init__(message, error_code=error_code or "CODE_GENERATION_ERROR", details=details)
+    def __init__(
+        self,
+        message: str,
+        language: Optional[str] = None,
+        component: Optional[str] = None,
+        error_code: Optional[str] = None,
+    ):
+        details = {"language": language, "component": component}
+        super().__init__(
+            message, error_code=error_code or "CODE_GENERATION_ERROR", details=details
+        )
 
 
 class TestGenerationError(ApplicationError):
     """Exception raised for errors during test generation."""
 
-    def __init__(self, message: str, test_type: Optional[str] = None,
-                 target: Optional[str] = None, error_code: Optional[str] = None):
-        details = {
-            "test_type": test_type,
-            "target": target
-        }
-        super().__init__(message, error_code=error_code or "TEST_GENERATION_ERROR", details=details)
+    def __init__(
+        self,
+        message: str,
+        test_type: Optional[str] = None,
+        target: Optional[str] = None,
+        error_code: Optional[str] = None,
+    ):
+        details = {"test_type": test_type, "target": target}
+        super().__init__(
+            message, error_code=error_code or "TEST_GENERATION_ERROR", details=details
+        )
 
 
 class EDRRCoordinatorError(ApplicationError):
     """Exception raised for errors in the EDRR coordinator."""
 
-    def __init__(self, message: str, phase: Optional[str] = None,
-                 component: Optional[str] = None, error_code: Optional[str] = None):
-        details = {
-            "phase": phase,
-            "component": component
-        }
-        super().__init__(message, error_code=error_code or "EDRR_COORDINATOR_ERROR", details=details)
+    def __init__(
+        self,
+        message: str,
+        phase: Optional[str] = None,
+        component: Optional[str] = None,
+        error_code: Optional[str] = None,
+    ):
+        details = {"phase": phase, "component": component}
+        super().__init__(
+            message, error_code=error_code or "EDRR_COORDINATOR_ERROR", details=details
+        )
 
 
 # Collaboration Errors
 
+
 class CollaborationError(DomainError):
     """Base exception for collaboration errors."""
 
-    def __init__(self, message: str, agent_id: Optional[str] = None, role: Optional[str] = None,
-                 task: Optional[str] = None, error_code: Optional[str] = None):
-        details = {
-            "agent_id": agent_id,
-            "role": role,
-            "task": task
-        }
-        super().__init__(message, error_code=error_code or "COLLABORATION_ERROR", details=details)
+    def __init__(
+        self,
+        message: str,
+        agent_id: Optional[str] = None,
+        role: Optional[str] = None,
+        task: Optional[str] = None,
+        error_code: Optional[str] = None,
+    ):
+        details = {"agent_id": agent_id, "role": role, "task": task}
+        super().__init__(
+            message, error_code=error_code or "COLLABORATION_ERROR", details=details
+        )
 
 
 class AgentExecutionError(CollaborationError):
     """Exception raised when an agent fails to execute a task."""
 
-    def __init__(self, message: str, agent_id: Optional[str] = None, task: Optional[str] = None,
-                 error_code: Optional[str] = None):
-        details = {
-            "agent_id": agent_id,
-            "task": task
-        }
-        super().__init__(message, agent_id=agent_id, task=task, error_code=error_code or "AGENT_EXECUTION_ERROR")
+    def __init__(
+        self,
+        message: str,
+        agent_id: Optional[str] = None,
+        task: Optional[str] = None,
+        error_code: Optional[str] = None,
+    ):
+        details = {"agent_id": agent_id, "task": task}
+        super().__init__(
+            message,
+            agent_id=agent_id,
+            task=task,
+            error_code=error_code or "AGENT_EXECUTION_ERROR",
+        )
 
 
 class ConsensusError(CollaborationError):
     """Exception raised when agents cannot reach consensus."""
 
-    def __init__(self, message: str, agent_ids: Optional[List[str]] = None, topic: Optional[str] = None,
-                 error_code: Optional[str] = None):
-        details = {
-            "agent_ids": agent_ids,
-            "topic": topic
-        }
-        super().__init__(message, error_code=error_code or "CONSENSUS_ERROR", details=details)
+    def __init__(
+        self,
+        message: str,
+        agent_ids: Optional[List[str]] = None,
+        topic: Optional[str] = None,
+        error_code: Optional[str] = None,
+    ):
+        details = {"agent_ids": agent_ids, "topic": topic}
+        super().__init__(
+            message, error_code=error_code or "CONSENSUS_ERROR", details=details
+        )
 
 
 class RoleAssignmentError(CollaborationError):
     """Exception raised when there's an issue with role assignment."""
 
-    def __init__(self, message: str, agent_id: Optional[str] = None, role: Optional[str] = None,
-                 error_code: Optional[str] = None):
-        details = {
-            "agent_id": agent_id,
-            "role": role
-        }
-        super().__init__(message, agent_id=agent_id, role=role, error_code=error_code or "ROLE_ASSIGNMENT_ERROR")
+    def __init__(
+        self,
+        message: str,
+        agent_id: Optional[str] = None,
+        role: Optional[str] = None,
+        error_code: Optional[str] = None,
+    ):
+        details = {"agent_id": agent_id, "role": role}
+        super().__init__(
+            message,
+            agent_id=agent_id,
+            role=role,
+            error_code=error_code or "ROLE_ASSIGNMENT_ERROR",
+        )
 
 
 class TeamConfigurationError(CollaborationError):
     """Exception raised when there's an issue with team configuration."""
 
-    def __init__(self, message: str, team_id: Optional[str] = None, error_code: Optional[str] = None):
-        details = {
-            "team_id": team_id
-        }
-        super().__init__(message, error_code=error_code or "TEAM_CONFIGURATION_ERROR", details=details)
+    def __init__(
+        self,
+        message: str,
+        team_id: Optional[str] = None,
+        error_code: Optional[str] = None,
+    ):
+        details = {"team_id": team_id}
+        super().__init__(
+            message,
+            error_code=error_code or "TEAM_CONFIGURATION_ERROR",
+            details=details,
+        )
 
 
 # Ports Errors
 
+
 class PortError(DevSynthError):
     """Base exception for errors in port interfaces."""
+
     pass
 
 
 class MemoryPortError(PortError):
     """Exception raised for errors in memory port operations."""
 
-    def __init__(self, message: str, operation: Optional[str] = None,
-                 error_code: Optional[str] = None):
-        details = {
-            "operation": operation
-        }
-        super().__init__(message, error_code=error_code or "MEMORY_PORT_ERROR", details=details)
+    def __init__(
+        self,
+        message: str,
+        operation: Optional[str] = None,
+        error_code: Optional[str] = None,
+    ):
+        details = {"operation": operation}
+        super().__init__(
+            message, error_code=error_code or "MEMORY_PORT_ERROR", details=details
+        )
 
 
 class ProviderPortError(PortError):
     """Exception raised for errors in provider port operations."""
 
-    def __init__(self, message: str, operation: Optional[str] = None,
-                 error_code: Optional[str] = None):
-        details = {
-            "operation": operation
-        }
-        super().__init__(message, error_code=error_code or "PROVIDER_PORT_ERROR", details=details)
+    def __init__(
+        self,
+        message: str,
+        operation: Optional[str] = None,
+        error_code: Optional[str] = None,
+    ):
+        details = {"operation": operation}
+        super().__init__(
+            message, error_code=error_code or "PROVIDER_PORT_ERROR", details=details
+        )
 
 
 class AgentPortError(PortError):
     """Exception raised for errors in agent port operations."""
 
-    def __init__(self, message: str, operation: Optional[str] = None,
-                 error_code: Optional[str] = None):
-        details = {
-            "operation": operation
-        }
-        super().__init__(message, error_code=error_code or "AGENT_PORT_ERROR", details=details)
+    def __init__(
+        self,
+        message: str,
+        operation: Optional[str] = None,
+        error_code: Optional[str] = None,
+    ):
+        details = {"operation": operation}
+        super().__init__(
+            message, error_code=error_code or "AGENT_PORT_ERROR", details=details
+        )
 
 
 # File System Errors
 
+
 class FileSystemError(DevSynthError):
     """Base exception for file system errors."""
+
     pass
 
 
 class FileNotFoundError(FileSystemError):
     """Exception raised when a file is not found."""
 
-    def __init__(self, message: str, file_path: Optional[str] = None,
-                 error_code: Optional[str] = None):
-        details = {
-            "file_path": file_path
-        }
-        super().__init__(message, error_code=error_code or "FILE_NOT_FOUND", details=details)
+    def __init__(
+        self,
+        message: str,
+        file_path: Optional[str] = None,
+        error_code: Optional[str] = None,
+    ):
+        details = {"file_path": file_path}
+        super().__init__(
+            message, error_code=error_code or "FILE_NOT_FOUND", details=details
+        )
 
 
 class FilePermissionError(FileSystemError):
     """Exception raised when there's a permission error with a file."""
 
-    def __init__(self, message: str, file_path: Optional[str] = None,
-                 operation: Optional[str] = None, error_code: Optional[str] = None):
-        details = {
-            "file_path": file_path,
-            "operation": operation
-        }
-        super().__init__(message, error_code=error_code or "FILE_PERMISSION_ERROR", details=details)
+    def __init__(
+        self,
+        message: str,
+        file_path: Optional[str] = None,
+        operation: Optional[str] = None,
+        error_code: Optional[str] = None,
+    ):
+        details = {"file_path": file_path, "operation": operation}
+        super().__init__(
+            message, error_code=error_code or "FILE_PERMISSION_ERROR", details=details
+        )
 
 
 class FileOperationError(FileSystemError):
     """Exception raised when a file operation fails."""
 
-    def __init__(self, message: str, file_path: Optional[str] = None,
-                 operation: Optional[str] = None, original_error: Optional[Exception] = None,
-                 error_code: Optional[str] = None):
+    def __init__(
+        self,
+        message: str,
+        file_path: Optional[str] = None,
+        operation: Optional[str] = None,
+        original_error: Optional[Exception] = None,
+        error_code: Optional[str] = None,
+    ):
         details = {
             "file_path": file_path,
             "operation": operation,
-            "original_error": str(original_error) if original_error else None
+            "original_error": str(original_error) if original_error else None,
         }
-        super().__init__(message, error_code=error_code or "FILE_OPERATION_ERROR", details=details)
+        super().__init__(
+            message, error_code=error_code or "FILE_OPERATION_ERROR", details=details
+        )
         self.__cause__ = original_error
+
+
+# Security Errors
+
+
+class SecurityError(ApplicationError):
+    """Base exception for security-related errors."""
+
+    pass
+
+
+class AuthenticationError(SecurityError):
+    """Exception raised when authentication fails."""
+
+
+class AuthorizationError(SecurityError):
+    """Exception raised when a user lacks required permissions."""
+
+
+class InputSanitizationError(SecurityError):
+    """Exception raised when unsafe input is detected."""
 
 
 # Initialize logger at the end to avoid circular imports
 try:
     from devsynth.logging_setup import get_logger
+
     logger = get_logger(__name__)
 except ImportError:
     import logging
+
     logger = logging.getLogger(__name__)

--- a/src/devsynth/security/__init__.py
+++ b/src/devsynth/security/__init__.py
@@ -1,0 +1,14 @@
+"""Security utilities for DevSynth."""
+
+from .authentication import hash_password, verify_password, authenticate
+from .authorization import is_authorized
+from .sanitization import sanitize_input, validate_safe_input
+
+__all__ = [
+    "hash_password",
+    "verify_password",
+    "authenticate",
+    "is_authorized",
+    "sanitize_input",
+    "validate_safe_input",
+]

--- a/src/devsynth/security/authentication.py
+++ b/src/devsynth/security/authentication.py
@@ -1,0 +1,46 @@
+"""Authentication utilities using Argon2 password hashing."""
+
+from typing import Dict
+from argon2 import PasswordHasher
+from argon2.exceptions import VerifyMismatchError
+
+from devsynth.exceptions import AuthenticationError
+
+# Argon2 password hasher instance
+_password_hasher = PasswordHasher()
+
+
+def hash_password(password: str) -> str:
+    """Hash a plain text password using Argon2."""
+    return _password_hasher.hash(password)
+
+
+def verify_password(stored_hash: str, password: str) -> bool:
+    """Verify a password against an existing Argon2 hash."""
+    try:
+        return _password_hasher.verify(stored_hash, password)
+    except VerifyMismatchError:
+        return False
+
+
+def authenticate(username: str, password: str, credentials: Dict[str, str]) -> bool:
+    """Authenticate a user using a dictionary of stored Argon2 hashes.
+
+    Args:
+        username: Username to authenticate.
+        password: Plain text password supplied by the user.
+        credentials: Mapping of usernames to stored password hashes.
+
+    Returns:
+        True if authentication succeeds.
+
+    Raises:
+        AuthenticationError: If the username is unknown or the password is invalid.
+    """
+    if username not in credentials:
+        raise AuthenticationError("Unknown username", details={"username": username})
+
+    if not verify_password(credentials[username], password):
+        raise AuthenticationError("Invalid credentials", details={"username": username})
+
+    return True

--- a/src/devsynth/security/authorization.py
+++ b/src/devsynth/security/authorization.py
@@ -1,0 +1,36 @@
+"""Simple role-based authorization utilities."""
+
+from typing import Dict, Iterable
+
+from devsynth.exceptions import AuthorizationError
+
+
+def is_authorized(
+    user_roles: Iterable[str], action: str, acl: Dict[str, Iterable[str]]
+) -> bool:
+    """Check whether any of the user's roles grants access to the action.
+
+    Args:
+        user_roles: Roles associated with the user.
+        action: Action being attempted.
+        acl: Mapping of role names to allowed actions.
+
+    Returns:
+        True if authorized, False otherwise.
+    """
+    for role in user_roles:
+        allowed = acl.get(role, [])
+        if action in allowed or "*" in allowed:
+            return True
+    return False
+
+
+def require_authorization(
+    user_roles: Iterable[str], action: str, acl: Dict[str, Iterable[str]]
+) -> None:
+    """Raise AuthorizationError if the user is not permitted to perform the action."""
+    if not is_authorized(user_roles, action, acl):
+        raise AuthorizationError(
+            "Permission denied",
+            details={"roles": list(user_roles), "action": action},
+        )

--- a/src/devsynth/security/sanitization.py
+++ b/src/devsynth/security/sanitization.py
@@ -1,0 +1,25 @@
+"""Input sanitization helpers for DevSynth."""
+
+import re
+from devsynth.exceptions import InputSanitizationError
+
+_SCRIPT_TAG_RE = re.compile(r"<script.*?>.*?</script>", re.IGNORECASE | re.DOTALL)
+_CONTROL_CHAR_RE = re.compile(r"[\x00-\x1f\x7f]")
+
+
+def sanitize_input(text: str) -> str:
+    """Remove dangerous content from a text string."""
+    text = _SCRIPT_TAG_RE.sub("", text)
+    text = _CONTROL_CHAR_RE.sub("", text)
+    return text.strip()
+
+
+def validate_safe_input(text: str) -> str:
+    """Sanitize and validate that text is safe.
+
+    Raises InputSanitizationError if content is modified.
+    """
+    sanitized = sanitize_input(text)
+    if sanitized != text:
+        raise InputSanitizationError("Unsafe input detected", details={"input": text})
+    return sanitized

--- a/tests/unit/security/test_authentication.py
+++ b/tests/unit/security/test_authentication.py
@@ -1,0 +1,30 @@
+from devsynth.security.authentication import (
+    hash_password,
+    verify_password,
+    authenticate,
+)
+from devsynth.exceptions import AuthenticationError
+
+
+def test_hash_and_verify_password():
+    password = "Secret123!"
+    hashed = hash_password(password)
+    assert password not in hashed
+    assert verify_password(hashed, password)
+    assert not verify_password(hashed, "wrong")
+
+
+def test_authenticate_success():
+    pwd = "password"
+    creds = {"alice": hash_password(pwd)}
+    assert authenticate("alice", pwd, creds)
+
+
+def test_authenticate_failure():
+    creds = {"bob": hash_password("password")}
+    try:
+        authenticate("bob", "bad", creds)
+    except AuthenticationError:
+        assert True
+    else:
+        assert False

--- a/tests/unit/security/test_authorization.py
+++ b/tests/unit/security/test_authorization.py
@@ -1,0 +1,22 @@
+from devsynth.security.authorization import is_authorized, require_authorization
+from devsynth.exceptions import AuthorizationError
+
+
+ACL = {"admin": ["read", "write"], "user": ["read"]}
+
+
+def test_is_authorized_true():
+    assert is_authorized(["admin"], "write", ACL)
+
+
+def test_is_authorized_false():
+    assert not is_authorized(["user"], "write", ACL)
+
+
+def test_require_authorization_raises():
+    try:
+        require_authorization(["user"], "write", ACL)
+    except AuthorizationError:
+        assert True
+    else:
+        assert False

--- a/tests/unit/security/test_sanitization.py
+++ b/tests/unit/security/test_sanitization.py
@@ -1,0 +1,17 @@
+from devsynth.security.sanitization import sanitize_input, validate_safe_input
+from devsynth.exceptions import InputSanitizationError
+
+
+def test_sanitize_input_removes_script():
+    text = "<script>alert('x')</script>Hello"
+    sanitized = sanitize_input(text)
+    assert sanitized == "Hello"
+
+
+def test_validate_safe_input_raises():
+    try:
+        validate_safe_input("<script>bad</script>")
+    except InputSanitizationError:
+        assert True
+    else:
+        assert False


### PR DESCRIPTION
## Summary
- implement authentication, authorization and sanitization helpers
- expose new security settings in configuration
- document usage of security utilities
- update feature matrix and RTM for security framework
- extend changelog
- add unit tests for security utilities

## Testing
- `poetry run pytest tests/unit/security -q`

------
https://chatgpt.com/codex/tasks/task_e_68479b8a17e0833382b7545783b35f32