### PR TITLE
Fix dev install instructions

### DIFF
--- a/.github/workflows/validate_documentation.yml
+++ b/.github/workflows/validate_documentation.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Install Python dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install .[docs] pyyaml markdown-link-check
+          pip install -e .[dev,docs] pyyaml markdown-link-check
           
       - name: Set up Node.js
         uses: actions/setup-node@v3

--- a/.github/workflows/validate_metadata.yml
+++ b/.github/workflows/validate_metadata.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install .[docs] pyyaml
+          pip install -e .[dev,docs] pyyaml
           
       - name: Validate Markdown metadata
         run: |

--- a/.github/workflows/verify_code_examples.yml
+++ b/.github/workflows/verify_code_examples.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install .[docs]
+          pip install -e .[dev,docs]
           
       - name: Set up Node.js
         uses: actions/setup-node@v3

--- a/README.md
+++ b/README.md
@@ -79,6 +79,14 @@ You can install DevSynth in a few different ways:
    docker run --rm -p 8000:8000 devsynth
    ```
 
+4. **From Source for Development** – install with development dependencies
+
+   ```bash
+   pip install -e .[dev]
+   # or
+   poetry install
+   ```
+
 For more on Docker deployment, see the [Deployment Guide](docs/deployment/deployment_guide.md).
 
 ## Running Tests

--- a/docs/getting_started/installation.md
+++ b/docs/getting_started/installation.md
@@ -38,8 +38,8 @@ pipx install devsynth
 git clone https://github.com/ravenoak/devsynth.git
 cd devsynth
 
-# Install in an isolated environment
-pipx install --editable .
+# Install with development dependencies
+pip install -e .[dev]
 
 # Or use Poetry
 poetry install

--- a/docs/getting_started/quick_start_guide.md
+++ b/docs/getting_started/quick_start_guide.md
@@ -43,8 +43,8 @@ pipx install devsynth
 git clone https://github.com/ravenoak/devsynth.git
 cd devsynth
 
-# Install in an isolated environment
-pipx install --editable .
+# Install with development dependencies
+pip install -e .[dev]
 
 # Or use Poetry
 poetry install


### PR DESCRIPTION
## Summary
- document dev install in README and docs
- ensure CI uses `pip install -e .[dev,docs]`

## Testing
- `pip install -e .[dev]`
- `pytest -q` *(fails: 34 errors during collection)*
- `poetry run pytest -q` *(fails: keyboard interrupt)*

------
https://chatgpt.com/codex/tasks/task_e_684846faa68c8333aa48aa229c1d723d