### PR TITLE
Add limitations sections for advanced features

### DIFF
--- a/docs/architecture/dialectical_reasoning.md
+++ b/docs/architecture/dialectical_reasoning.md
@@ -468,6 +468,15 @@ explains how to gradually increase reasoning depth as your project grows.
 - **Resource Management**: Monitor and limit concurrent reasoning processes
 - **Persistence Strategy**: Store reasoning artifacts efficiently based on access patterns
 
+## Current Limitations
+
+Dialectical reasoning support is only partially implemented. Argument weighting,
+multi-agent interaction, and transparency tooling are still incomplete. The
+feature is disabled by default via the `features.dialectical_reasoning` flag in
+`config/default.yml`. See the
+[Feature Status Matrix](../implementation/feature_status_matrix.md) for up-to-date
+implementation progress.
+
 ## Future Enhancements
 
 - **Collaborative Reasoning**: Support multiple participants in the dialectical process

--- a/docs/architecture/edrr_framework.md
+++ b/docs/architecture/edrr_framework.md
@@ -317,6 +317,15 @@ phases:
 6. **Use Human Judgment**: Override automatic recursion decisions when human expertise suggests a different approach.
 7. **Document Recursive Structure**: Maintain clear documentation of the recursive structure for better understanding and maintenance.
 
+## Current Limitations
+
+The recursive EDRR framework is only partially implemented. Advanced phase
+transitions and orchestration depend on collaborative capabilities that are
+disabled by default via the `features.wsde_collaboration` and
+`features.dialectical_reasoning` flags in `config/default.yml`. Refer to the
+[Feature Status Matrix](../implementation/feature_status_matrix.md) for detailed
+progress tracking.
+
 ## Related Documents
 
 - [EDRR Cycle Specification](../specifications/edrr_cycle_specification.md)

--- a/docs/architecture/wsde_agent_model.md
+++ b/docs/architecture/wsde_agent_model.md
@@ -251,6 +251,15 @@ COLLABORATIVE CODE REVIEW PROCESS:
 7. **Respect Expertise**: Value each agent's domain expertise
 8. **Collective Ownership**: Foster a sense of collective ownership of outcomes
 
+## Current Limitations
+
+Full WSDE collaboration is still under development. Dynamic role assignment and
+advanced consensus mechanisms remain incomplete. Collaboration is disabled by
+default via the `features.wsde_collaboration` flag in `config/default.yml`.
+Refer to the
+[Feature Status Matrix](../implementation/feature_status_matrix.md) for the
+latest progress details.
+
 ## Related Documents
 
 - [EDRR Framework](edrr_framework.md)

--- a/docs/implementation/edrr_assessment.md
+++ b/docs/implementation/edrr_assessment.md
@@ -83,6 +83,15 @@ The EDRR framework is a structured approach to problem-solving that guides the D
 
 **Overall Integration Completeness**: 55%
 
+## Current Limitations
+
+The EDRR framework remains partially implemented. Phase transition logic and
+context persistence are still maturing. Advanced collaboration features are
+disabled by default through the `features.wsde_collaboration` and
+`features.dialectical_reasoning` flags in `config/default.yml`. Progress is
+tracked in the
+[Feature Status Matrix](feature_status_matrix.md).
+
 ## Critical Gaps and Priorities
 
 ### High Priority Components (Essential)

--- a/docs/implementation/wsde_validation.md
+++ b/docs/implementation/wsde_validation.md
@@ -95,6 +95,15 @@ The Worker Self-Directed Enterprise model is a collaborative agent system with p
 
 **Overall Integration Completeness**: 50%
 
+## Current Limitations
+
+The WSDE model is only partially realized. Dynamic leadership, consensus
+building, and collaborative memory are still incomplete. By default the
+`features.wsde_collaboration` and `features.dialectical_reasoning` flags in
+`config/default.yml` are disabled, so these capabilities must be manually
+enabled. The
+[Feature Status Matrix](feature_status_matrix.md) tracks ongoing progress.
+
 ## Critical Gaps and Priorities
 
 ### High Priority Components (Essential)


### PR DESCRIPTION
## Summary
- document default off flags in feature docs
- highlight incomplete EDRR, WSDE collaboration, and dialectical reasoning
- link to the feature status matrix for progress tracking

## Testing
- `poetry run pytest tests/` *(fails: EnhancedChromaDBStore, LMStudioProvider, MemorySystem and TokenTracker tests)*

------
https://chatgpt.com/codex/tasks/task_e_6848655da21c833387ec6605bbb8c0f9