### PR TITLE
Fix README license reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ The [Repository Structure](docs/repo_structure.md) document provides a comprehen
 See [CONTRIBUTING.md](CONTRIBUTING.md) and [docs/developer_guides/contributing.md](docs/developer_guides/contributing.md) for guidelines, code style, and development setup.
 
 ## License
-DevSynth is released under the MIT License. See [LICENSE.md](LICENSE.md) for details.
+DevSynth is released under the MIT License. See [LICENSE](LICENSE) for details.
 
 ---
 


### PR DESCRIPTION
## Summary
- point README license link to LICENSE

## Testing
- `poetry run pytest tests/` *(fails: 86 failed, 297 passed, 10 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_684899add63883339da964c3458ebdbe