### PR TITLE
Add limitations note for WSDE docs

### DIFF
--- a/docs/architecture/agent_system.md
+++ b/docs/architecture/agent_system.md
@@ -312,7 +312,12 @@ This base agent architecture is designed for extensibility:
 
 ## Error Handling
 
+
 The `AgentState` includes an `error` field. Nodes in the graph can populate this field if an issue occurs. Subsequent nodes can check this field to decide whether to proceed, attempt recovery, or terminate the workflow gracefully.
+
+## Current Limitations
+
+WSDE collaboration and dialectical reasoning are only partially implemented. These capabilities are disabled by default via the `features.wsde_collaboration` and `features.dialectical_reasoning` flags in `config/default.yml`. Refer to the [Feature Status Matrix](../implementation/feature_status_matrix.md) for progress tracking.
 
 ## Future Enhancements (as per Comprehensive Plan)
 

--- a/docs/specifications/wsde_interaction_specification.md
+++ b/docs/specifications/wsde_interaction_specification.md
@@ -455,6 +455,10 @@ The WSDE multi-agent interaction system can be customized through configuration:
 - **Review Policies**: Requirements for peer review processes
 - **Communication Patterns**: Allowed message types and frequencies
 
+## Current Limitations
+
+Full WSDE collaboration is still under development. Dynamic role assignment and advanced consensus mechanisms remain incomplete. Collaboration features are disabled by default via the `features.wsde_collaboration` flag in `config/default.yml`. See the [Feature Status Matrix](../implementation/feature_status_matrix.md) for progress tracking.
+
 ## 9. Future Enhancements
 
 Planned improvements to the WSDE multi-agent interaction system:


### PR DESCRIPTION
## Summary
- document current WSDE and dialectical reasoning limitations in the agent architecture docs
- add limitations note to WSDE interaction spec

## Testing
- `poetry run pytest -q` *(fails: EnhancedChromaDBStore, LMStudioProvider, MemorySystem, TokenTracker tests)*

------
https://chatgpt.com/codex/tasks/task_e_6848b543cea08333b3e13e61670f3a02