### PR TITLE
Implement multi-agent role management

### DIFF
--- a/src/devsynth/adapters/agents/agent_adapter.py
+++ b/src/devsynth/adapters/agents/agent_adapter.py
@@ -140,6 +140,11 @@ class WSDETeamCoordinator(AgentCoordinator):
         if len(team.agents) > 1:
             team.assign_roles()
 
+    def add_agents(self, agents: List[Agent]) -> None:
+        """Add multiple agents to the current team."""
+        for agent in agents:
+            self.add_agent(agent)
+
     def delegate_task(self, task: Dict[str, Any]) -> Dict[str, Any]:
         """
         Delegate a task to the appropriate agent(s) in the current team.
@@ -248,6 +253,10 @@ class AgentAdapter:
     def add_agent_to_team(self, agent: Agent) -> None:
         """Add an agent to the current team."""
         self.agent_coordinator.add_agent(agent)
+
+    def add_agents_to_team(self, agents: List[Agent]) -> None:
+        """Add multiple agents to the current team."""
+        self.agent_coordinator.add_agents(agents)
 
     def process_task(self, task: Dict[str, Any]) -> Dict[str, Any]:
         """Process a task using the current team."""

--- a/tests/unit/test_multi_agent_adapter_workflow.py
+++ b/tests/unit/test_multi_agent_adapter_workflow.py
@@ -1,0 +1,69 @@
+import pytest
+from unittest.mock import MagicMock, patch
+
+from devsynth.adapters.agents.agent_adapter import AgentAdapter
+from devsynth.application.agents.unified_agent import UnifiedAgent
+
+
+class TestMultiAgentAdapterWorkflow:
+    def setup_method(self):
+        self.adapter = AgentAdapter()
+        self.team = self.adapter.create_team("team1")
+        self.adapter.set_current_team("team1")
+
+        self.agent1 = MagicMock(spec=UnifiedAgent)
+        self.agent1.name = "PythonAgent"
+        self.agent1.config = MagicMock()
+        self.agent1.config.name = "PythonAgent"
+        self.agent1.config.parameters = {"expertise": ["python", "backend"]}
+        self.agent1.process.return_value = {"result": "py"}
+
+        self.agent2 = MagicMock(spec=UnifiedAgent)
+        self.agent2.name = "JSAgent"
+        self.agent2.config = MagicMock()
+        self.agent2.config.name = "JSAgent"
+        self.agent2.config.parameters = {"expertise": ["javascript", "frontend"]}
+        self.agent2.process.return_value = {"result": "js"}
+
+        self.agent3 = MagicMock(spec=UnifiedAgent)
+        self.agent3.name = "DocAgent"
+        self.agent3.config = MagicMock()
+        self.agent3.config.name = "DocAgent"
+        self.agent3.config.parameters = {"expertise": ["documentation"]}
+        self.agent3.process.return_value = {"result": "doc"}
+
+        self.adapter.add_agents_to_team([self.agent1, self.agent2, self.agent3])
+
+    def test_multi_agent_consensus_and_primus_selection(self):
+        task = {"type": "coding", "language": "python"}
+
+        with patch.object(
+            self.team,
+            "build_consensus",
+            return_value={
+                "consensus": "done",
+                "contributors": ["PythonAgent", "JSAgent", "DocAgent"],
+                "method": "consensus_synthesis",
+                "reasoning": "",
+            },
+        ) as mock_consensus, patch.object(
+            self.team,
+            "select_primus_by_expertise",
+            wraps=self.team.select_primus_by_expertise,
+        ) as mock_select:
+            result = self.adapter.process_task(task)
+            mock_consensus.assert_called_once_with(task)
+            mock_select.assert_called_once_with(task)
+
+        assert self.team.get_primus() == self.agent1
+        assert result["method"] == "consensus_synthesis"
+        assert set(result["contributors"]) == {"PythonAgent", "JSAgent", "DocAgent"}
+
+    def test_bulk_add_agents(self):
+        adapter = AgentAdapter()
+        adapter.create_team("bulk")
+        adapter.set_current_team("bulk")
+        adapter.add_agents_to_team([self.agent1, self.agent2])
+        team = adapter.get_team("bulk")
+        assert len(team.agents) == 2
+

--- a/tests/unit/test_wsde_role_mapping.py
+++ b/tests/unit/test_wsde_role_mapping.py
@@ -1,0 +1,27 @@
+from unittest.mock import MagicMock
+
+from devsynth.domain.models.wsde import WSDETeam
+
+
+def test_assign_roles_with_explicit_mapping():
+    team = WSDETeam()
+    a1 = MagicMock()
+    a2 = MagicMock()
+    a3 = MagicMock()
+    team.add_agents([a1, a2, a3])
+
+    mapping = {
+        "primus": a1,
+        "worker": [a1],
+        "supervisor": a2,
+        "designer": a3,
+        "evaluator": None,
+    }
+
+    team.assign_roles(mapping)
+
+    assert team.role_assignments["primus"] == a1
+    assert a1.current_role == "Primus"
+    assert a2.current_role == "Supervisor"
+    assert a3.current_role == "Designer"
+


### PR DESCRIPTION
## Summary
- support role assignments in `WSDETeam`
- add helper methods for validating and auto-assigning roles
- allow bulk agent operations in the adapter
- add unit tests covering primus selection and role mapping

## Testing
- `poetry run pytest tests/unit -q`


------
https://chatgpt.com/codex/tasks/task_e_684909891bac83339956105a05567748