### PR TITLE
Add logging context and metrics

### DIFF
--- a/docs/developer_guides/error_handling.md
+++ b/docs/developer_guides/error_handling.md
@@ -100,6 +100,14 @@ Follow these guidelines for error logging:
 - Don't log sensitive information (passwords, tokens, personal data)
 - Use structured logging for machine-readable logs
 
+#### Logging Configuration
+
+DevSynth uses a centralized logging setup defined in `devsynth.logging_setup`.
+Call `configure_logging()` at startup to initialize handlers. During runtime you
+can set a request identifier and the current EDRR phase with `set_request_context(request_id, phase)`.
+These values are automatically attached to all log records, enabling correlation
+across components.
+
 ## Error Handling Patterns
 
 ### Validation Errors

--- a/src/devsynth/__init__.py
+++ b/src/devsynth/__init__.py
@@ -2,11 +2,10 @@
 __version__ = "0.1.0"
 
 # Import the DevSynthLogger class first
-from devsynth.logging_setup import DevSynthLogger
+from devsynth.logging_setup import DevSynthLogger, set_request_context, clear_request_context
 
 # Now make it available for all modules
-__all__ = ["DevSynthLogger"]
+__all__ = ["DevSynthLogger", "set_request_context", "clear_request_context"]
 
 # Initialize logger for this module
 logger = DevSynthLogger(__name__)
-

--- a/src/devsynth/metrics.py
+++ b/src/devsynth/metrics.py
@@ -1,0 +1,32 @@
+from collections import Counter
+from typing import Dict
+
+# Counters for operations
+_memory_metrics: Counter = Counter()
+_provider_metrics: Counter = Counter()
+
+
+def inc_memory(op: str) -> None:
+    """Increment memory operation counter."""
+    _memory_metrics[op] += 1
+
+
+def inc_provider(op: str) -> None:
+    """Increment provider operation counter."""
+    _provider_metrics[op] += 1
+
+
+def get_memory_metrics() -> Dict[str, int]:
+    """Return memory operation counters."""
+    return dict(_memory_metrics)
+
+
+def get_provider_metrics() -> Dict[str, int]:
+    """Return provider operation counters."""
+    return dict(_provider_metrics)
+
+
+def reset_metrics() -> None:
+    """Reset all metrics counters."""
+    _memory_metrics.clear()
+    _provider_metrics.clear()

--- a/src/devsynth/ports/memory_port.py
+++ b/src/devsynth/ports/memory_port.py
@@ -4,9 +4,11 @@ from ..domain.models.memory import MemoryItem, MemoryType
 
 # Create a logger for this module
 from devsynth.logging_setup import DevSynthLogger
+from devsynth.metrics import inc_memory
 
 logger = DevSynthLogger(__name__)
 from devsynth.exceptions import DevSynthError
+
 
 class MemoryPort:
     """Port for the memory and context system, using ChromaDB as the default backend."""
@@ -16,31 +18,40 @@ class MemoryPort:
         if memory_store is None:
             # Lazy import to avoid circular dependency
             from devsynth.adapters.chromadb_memory_store import ChromaDBMemoryStore
+
             memory_store = ChromaDBMemoryStore()
         self.memory_store = memory_store
         self.context_manager = context_manager
 
-    def store_memory(self, content: Any, memory_type: MemoryType, metadata: Dict[str, Any] = None) -> str:
+    def store_memory(
+        self, content: Any, memory_type: MemoryType, metadata: Dict[str, Any] = None
+    ) -> str:
         """Store an item in memory and return its ID."""
         item = MemoryItem(id="", content=content, memory_type=memory_type, metadata=metadata)
+        inc_memory("store")
         return self.memory_store.store(item)
 
     def retrieve_memory(self, item_id: str) -> Optional[MemoryItem]:
         """Retrieve an item from memory by ID."""
+        inc_memory("retrieve")
         return self.memory_store.retrieve(item_id)
 
     def search_memory(self, query: Dict[str, Any]) -> List[MemoryItem]:
         """Search for items in memory matching the query."""
+        inc_memory("search")
         return self.memory_store.search(query)
 
     def add_to_context(self, key: str, value: Any) -> None:
         """Add a value to the current context."""
+        inc_memory("add_context")
         self.context_manager.add_to_context(key, value)
 
     def get_from_context(self, key: str) -> Optional[Any]:
         """Get a value from the current context."""
+        inc_memory("get_context")
         return self.context_manager.get_from_context(key)
 
     def get_full_context(self) -> Dict[str, Any]:
         """Get the full current context."""
+        inc_memory("get_full_context")
         return self.context_manager.get_full_context()

--- a/tests/unit/test_logging_setup.py
+++ b/tests/unit/test_logging_setup.py
@@ -1,0 +1,21 @@
+import logging
+from devsynth.logging_setup import (
+    configure_logging,
+    get_logger,
+    set_request_context,
+    clear_request_context,
+)
+from _pytest.logging import LogCaptureHandler
+
+
+def test_log_records_include_request_context(caplog, monkeypatch):
+    monkeypatch.setenv("DEVSYNTH_NO_FILE_LOGGING", "1")
+    configure_logging(create_dir=False)
+    logger = get_logger(__name__)
+    handler = LogCaptureHandler()
+    logging.getLogger().addHandler(handler)
+    set_request_context("req-123", "EXPAND")
+    logger.info("hello")
+    clear_request_context()
+    logging.getLogger().removeHandler(handler)
+    assert ("req-123", "EXPAND") in [(rec.request_id, rec.phase) for rec in handler.records]


### PR DESCRIPTION
## Summary
- extend `logging_setup` with request context tracking
- increment metrics for memory and provider operations
- document logging configuration
- test logging request context

## Testing
- `poetry run pytest tests/unit/test_logging_setup.py -q`
- `poetry run pytest tests/unit -k logging_setup -q`

------
https://chatgpt.com/codex/tasks/task_e_6849196b4f048333a25b416abdd5b419