### PR TITLE
Prevent template tests from running

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,6 @@
+[pytest]
+addopts = -p no:warnings
+norecursedirs = templates
+# Run tests from the tests directory only
+# This prevents template files from being collected as tests.
+testpaths = tests


### PR DESCRIPTION
## Summary
- add `pytest.ini` to exclude the `templates` directory from test discovery and suppress warnings

## Testing
- `poetry run pytest -q` *(fails: ImportError: cannot import name 'edrr_cycle_cmd')*

------
https://chatgpt.com/codex/tasks/task_e_6849252ec99883339d289e3f46d1a50e