### PR TITLE
docs: emphasize dev install before tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,20 +115,15 @@ Use [`templates/project.yaml`](templates/project.yaml) as a reference for your `
 
 ## Running Tests
 
-Before running the test suite, install DevSynth with its development dependencies.
-You can use `pip` in editable mode:
+Before running the test suite, **install DevSynth with its development extras**. Use either of the following commands:
 
 ```bash
 pip install -e .[dev]
-```
-
-Or install using Poetry, which also sets up the dev extras:
-
-```bash
+# or
 poetry install
 ```
 
-Once installed, execute the tests with:
+After installation, execute the tests with:
 
 ```bash
 pytest

--- a/tests/README.md
+++ b/tests/README.md
@@ -131,11 +131,12 @@ python -m pytest
 
 ### Environment Setup
 
-Ensure dependencies are installed and the `devsynth` package is available in your environment before running tests:
+Before running tests, **install DevSynth with its development dependencies**:
 
 ```bash
+pip install -e .[dev]
+# or
 poetry install
-pip install -e .  # optional but recommended for editable installs
 ```
 
 To run tests for a specific type:


### PR DESCRIPTION
## Summary
- highlight `pip install -e .[dev]` or `poetry install` before running tests
- update test README with the same instructions

## Testing
- `poetry run pytest tests/` *(fails: UnknownMarkWarning and collection errors)*

------
https://chatgpt.com/codex/tasks/task_e_684925385f98833399399144e8eba739