### PR TITLE
Add missing docstrings

### DIFF
--- a/src/devsynth/adapters/memory/__init__.py
+++ b/src/devsynth/adapters/memory/__init__.py
@@ -1,6 +1,7 @@
+"""Memory adapter package for abstracting persistence layers."""
+
 from devsynth.logging_setup import DevSynthLogger
 from devsynth.exceptions import DevSynthError
 
 # Create a logger for this module
 logger = DevSynthLogger(__name__)
-

--- a/src/devsynth/adapters/memory/memory_adapter.py
+++ b/src/devsynth/adapters/memory/memory_adapter.py
@@ -1,3 +1,5 @@
+"""Adapter that coordinates memory-related components."""
+
 import os
 from typing import Any, Dict, List, Optional, Union
 from pathlib import Path
@@ -20,6 +22,7 @@ from devsynth.logging_setup import DevSynthLogger
 logger = DevSynthLogger(__name__)
 from devsynth.exceptions import DevSynthError
 
+
 class MemorySystemAdapter:
     """
     Adapter for the memory system.
@@ -29,10 +32,14 @@ class MemorySystemAdapter:
     deferred path creation for better test isolation.
     """
 
-    def __init__(self, config: Dict[str, Any] = None, memory_store: Optional[MemoryStore] = None,
-                 context_manager: Optional[ContextManager] = None,
-                 vector_store: Optional[VectorStore] = None,
-                 create_paths: bool = True):
+    def __init__(
+        self,
+        config: Dict[str, Any] = None,
+        memory_store: Optional[MemoryStore] = None,
+        context_manager: Optional[ContextManager] = None,
+        vector_store: Optional[VectorStore] = None,
+        create_paths: bool = True,
+    ):
         """
         Initialize the memory system adapter.
 
@@ -47,12 +54,24 @@ class MemorySystemAdapter:
         settings = get_settings()
 
         # Determine storage type from config or settings
-        self.storage_type = self.config.get("memory_store_type", settings.memory_store_type)
-        self.memory_path = self.config.get("memory_file_path", settings.memory_file_path)
-        self.max_context_size = self.config.get("max_context_size", settings.max_context_size)
-        self.context_expiration_days = self.config.get("context_expiration_days", settings.context_expiration_days)
-        self.vector_store_enabled = self.config.get("vector_store_enabled", settings.vector_store_enabled)
-        self.chromadb_collection_name = self.config.get("chromadb_collection_name", settings.chromadb_collection_name)
+        self.storage_type = self.config.get(
+            "memory_store_type", settings.memory_store_type
+        )
+        self.memory_path = self.config.get(
+            "memory_file_path", settings.memory_file_path
+        )
+        self.max_context_size = self.config.get(
+            "max_context_size", settings.max_context_size
+        )
+        self.context_expiration_days = self.config.get(
+            "context_expiration_days", settings.context_expiration_days
+        )
+        self.vector_store_enabled = self.config.get(
+            "vector_store_enabled", settings.vector_store_enabled
+        )
+        self.chromadb_collection_name = self.config.get(
+            "chromadb_collection_name", settings.chromadb_collection_name
+        )
 
         # Support for direct dependency injection
         self.memory_store = memory_store
@@ -60,7 +79,10 @@ class MemorySystemAdapter:
         self.vector_store = vector_store
 
         # Initialize components only if they weren't injected
-        if all(component is None for component in [memory_store, context_manager, vector_store]):
+        if all(
+            component is None
+            for component in [memory_store, context_manager, vector_store]
+        ):
             self._initialize_memory_system(create_paths=create_paths)
         else:
             # Log what components were injected
@@ -72,7 +94,9 @@ class MemorySystemAdapter:
             if vector_store is not None:
                 injected.append("vector_store")
 
-            logger.info(f"Memory system initialized with injected components: {', '.join(injected)}")
+            logger.info(
+                f"Memory system initialized with injected components: {', '.join(injected)}"
+            )
 
     def _initialize_memory_system(self, create_paths: bool = True):
         """
@@ -91,7 +115,7 @@ class MemorySystemAdapter:
             self.context_manager = PersistentContextManager(
                 self.memory_path,
                 max_context_size=self.max_context_size,
-                expiration_days=self.context_expiration_days
+                expiration_days=self.context_expiration_days,
             )
             # No vector store for file-based storage by default
             self.vector_store = None
@@ -100,13 +124,13 @@ class MemorySystemAdapter:
             self.context_manager = PersistentContextManager(
                 self.memory_path,
                 max_context_size=self.max_context_size,
-                expiration_days=self.context_expiration_days
+                expiration_days=self.context_expiration_days,
             )
             # Initialize vector store if enabled
             if self.vector_store_enabled:
                 self.vector_store = ChromaDBAdapter(
                     persist_directory=self.memory_path,
-                    collection_name=self.chromadb_collection_name
+                    collection_name=self.chromadb_collection_name,
                 )
             else:
                 self.vector_store = None
@@ -115,7 +139,7 @@ class MemorySystemAdapter:
             self.context_manager = PersistentContextManager(
                 self.memory_path,
                 max_context_size=self.max_context_size,
-                expiration_days=self.context_expiration_days
+                expiration_days=self.context_expiration_days,
             )
             # No vector store for TinyDB-based storage by default
             self.vector_store = None
@@ -124,7 +148,7 @@ class MemorySystemAdapter:
             self.context_manager = PersistentContextManager(
                 self.memory_path,
                 max_context_size=self.max_context_size,
-                expiration_days=self.context_expiration_days
+                expiration_days=self.context_expiration_days,
             )
             # DuckDBStore implements both MemoryStore and VectorStore interfaces
             if self.vector_store_enabled:
@@ -136,7 +160,7 @@ class MemorySystemAdapter:
             self.context_manager = PersistentContextManager(
                 self.memory_path,
                 max_context_size=self.max_context_size,
-                expiration_days=self.context_expiration_days
+                expiration_days=self.context_expiration_days,
             )
             # No vector store for LMDB-based storage by default
             self.vector_store = None
@@ -147,7 +171,7 @@ class MemorySystemAdapter:
             self.context_manager = PersistentContextManager(
                 self.memory_path,
                 max_context_size=self.max_context_size,
-                expiration_days=self.context_expiration_days
+                expiration_days=self.context_expiration_days,
             )
             # Initialize FAISS vector store if enabled
             if self.vector_store_enabled:
@@ -160,7 +184,7 @@ class MemorySystemAdapter:
             self.context_manager = PersistentContextManager(
                 self.memory_path,
                 max_context_size=self.max_context_size,
-                expiration_days=self.context_expiration_days
+                expiration_days=self.context_expiration_days,
             )
             # RDFLibStore implements both MemoryStore and VectorStore interfaces
             if self.vector_store_enabled:
@@ -175,7 +199,9 @@ class MemorySystemAdapter:
 
         logger.info(f"Initialized memory system with storage type: {self.storage_type}")
         if self.vector_store:
-            logger.info(f"Vector store enabled with ChromaDB collection: {self.chromadb_collection_name}")
+            logger.info(
+                f"Vector store enabled with ChromaDB collection: {self.chromadb_collection_name}"
+            )
 
     def get_memory_store(self) -> MemoryStore:
         """Get the memory store."""
@@ -202,7 +228,7 @@ class MemorySystemAdapter:
         return {
             "memory_tokens": store_tokens,
             "context_tokens": context_tokens,
-            "total_tokens": store_tokens + context_tokens
+            "total_tokens": store_tokens + context_tokens,
         }
 
     def store(self, memory_item: Any) -> str:
@@ -239,13 +265,13 @@ class MemorySystemAdapter:
             raise ValueError("Memory store is not initialized")
 
         # Check if the memory store has a query_by_type method
-        if hasattr(self.memory_store, 'query_by_type'):
+        if hasattr(self.memory_store, "query_by_type"):
             return self.memory_store.query_by_type(memory_type)
 
         # Fall back to using the search method
-        if hasattr(self.memory_store, 'search'):
+        if hasattr(self.memory_store, "search"):
             # Convert MemoryType enum to string if needed
-            if hasattr(memory_type, 'value'):
+            if hasattr(memory_type, "value"):
                 memory_type_value = memory_type.value
             else:
                 memory_type_value = memory_type
@@ -274,11 +300,11 @@ class MemorySystemAdapter:
             raise ValueError("Memory store is not initialized")
 
         # Check if the memory store has a query_by_metadata method
-        if hasattr(self.memory_store, 'query_by_metadata'):
+        if hasattr(self.memory_store, "query_by_metadata"):
             return self.memory_store.query_by_metadata(metadata)
 
         # Fall back to using the search method
-        if hasattr(self.memory_store, 'search'):
+        if hasattr(self.memory_store, "search"):
             return self.memory_store.search(metadata)
 
         # If neither method is available, return an empty list
@@ -331,7 +357,11 @@ class MemorySystemAdapter:
         return self.memory_store.get_all()
 
     @classmethod
-    def create_for_testing(cls, storage_type: str = "memory", memory_path: Optional[Union[str, Path]] = None) -> "MemorySystemAdapter":
+    def create_for_testing(
+        cls,
+        storage_type: str = "memory",
+        memory_path: Optional[Union[str, Path]] = None,
+    ) -> "MemorySystemAdapter":
         """
         Create a memory system adapter configured specifically for testing.
 
@@ -350,7 +380,7 @@ class MemorySystemAdapter:
             "memory_store_type": storage_type,
             "max_context_size": 1000,  # Small context size for tests
             "context_expiration_days": 1,  # Short expiration for tests
-            "vector_store_enabled": storage_type == "chromadb"
+            "vector_store_enabled": storage_type == "chromadb",
         }
 
         if memory_path:

--- a/src/devsynth/metrics.py
+++ b/src/devsynth/metrics.py
@@ -1,3 +1,5 @@
+"""Utility module for tracking runtime metrics."""
+
 from collections import Counter
 from typing import Dict
 


### PR DESCRIPTION
## Summary
- add module docstring for metrics utilities
- document memory adapters package and class

## Testing
- `black src/devsynth/metrics.py src/devsynth/adapters/memory/memory_adapter.py src/devsynth/adapters/memory/__init__.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_6849a257eac48333afbfcb87a3a2c72f