### PR TITLE
Fix Pytest warning for TestGenerationException

### DIFF
--- a/src/devsynth/exceptions.py
+++ b/src/devsynth/exceptions.py
@@ -557,8 +557,10 @@ class CodeGenerationError(ApplicationError):
         )
 
 
-class TestGenerationError(ApplicationError):
+class TestGenerationException(ApplicationError):
     """Exception raised for errors during test generation."""
+
+    __test__ = False
 
     def __init__(
         self,

--- a/tests/unit/test_exceptions.py
+++ b/tests/unit/test_exceptions.py
@@ -15,7 +15,7 @@ from devsynth.exceptions import (
     MemoryAdapterError, MemoryNotFoundError, MemoryStoreError,
     DomainError, AgentError, WorkflowError, ContextError, DialecticalReasoningError,
     ApplicationError, PromiseError, PromiseStateError, IngestionError, ManifestError,
-    CodeGenerationError, TestGenerationError,
+    CodeGenerationError, TestGenerationException,
     PortError, MemoryPortError, ProviderPortError, AgentPortError
 )
 


### PR DESCRIPTION
## Summary
- rename `TestGenerationError` to `TestGenerationException`
- mark the class with `__test__ = False`
- adjust tests to import the new name

## Testing
- `PYTHONPATH=src pytest tests/unit/test_exceptions.py::TestDevSynthError::test_init_with_message_only -q`
- `PYTHONPATH=src pytest -q` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_6849bd2d4094833383f4ae59136998c3