### PR TITLE
Add calculator example project and docs

### DIFF
--- a/.github/workflows/example_project.yml
+++ b/.github/workflows/example_project.yml
@@ -1,0 +1,36 @@
+name: Run Example Project
+
+on:
+  push:
+    paths:
+      - 'examples/**'
+      - '.github/workflows/example_project.yml'
+  pull_request:
+    paths:
+      - 'examples/**'
+      - '.github/workflows/example_project.yml'
+
+jobs:
+  run-example:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+
+      - name: Install DevSynth
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e .[dev]
+
+      - name: Execute DevSynth workflow
+        run: |
+          cd examples/calculator
+          devsynth init --path .
+          devsynth spec --requirements-file requirements.md
+          devsynth test
+          devsynth code
+          devsynth run

--- a/docs/getting_started/example_project.md
+++ b/docs/getting_started/example_project.md
@@ -1,0 +1,49 @@
+---
+title: "DevSynth Example Project"
+date: "2025-07-01"
+version: "1.0.0"
+tags:
+  - "getting-started"
+  - "example"
+status: "published"
+author: "DevSynth Team"
+last_reviewed: "2025-07-01"
+---
+
+# DevSynth Example Project
+
+This guide walks through a small calculator example included in the `examples/` directory. It demonstrates project initialization, specification and test generation, code creation, and running the final program.
+
+## Location
+
+The example lives in [`examples/calculator`](../../examples/calculator). Each file shows what you would have after running DevSynth commands.
+
+## Workflow Overview
+
+1. **Initialize** the project
+   ```bash
+   cd examples/calculator
+   devsynth init --path .
+   ```
+2. **Generate specifications** from the requirements
+   ```bash
+   devsynth spec --requirements-file requirements.md
+   ```
+3. **Generate tests**
+   ```bash
+   devsynth test
+   ```
+4. **Generate code**
+   ```bash
+   devsynth code
+   ```
+5. **Run** the project
+   ```bash
+   devsynth run
+   ```
+
+The repository contains the resulting `specs.md`, tests in `tests/`, and code in `src/`. You can modify the requirements and re-run the DevSynth commands to update the project.
+
+## Continuous Integration Example
+
+The `.github/workflows/example_project.yml` file provides a minimal CI setup that runs the same DevSynth commands on every push or pull request affecting the example. Use it as a starting point for your own projects.

--- a/docs/getting_started/index.md
+++ b/docs/getting_started/index.md
@@ -19,6 +19,7 @@ This section provides essential information for getting started with DevSynth, i
 - **[Quick Start Guide](quick_start_guide.md)**: A step-by-step tutorial to help you get started with DevSynth quickly.
 - **[Installation](installation.md)**: Detailed instructions for installing DevSynth and its dependencies.
 - **[Basic Usage](basic_usage.md)**: An introduction to the basic usage of DevSynth.
+- **[Example Project](example_project.md)**: A complete walk-through using the calculator example.
 
 ## Overview
 

--- a/examples/calculator/.devsynth/project.yaml
+++ b/examples/calculator/.devsynth/project.yaml
@@ -1,0 +1,12 @@
+projectName: calculator-example
+version: 0.1.0
+structure:
+  type: single_package
+  primaryLanguage: python
+  directories:
+    source: ["src"]
+    tests: ["tests"]
+    docs: ["."]
+features:
+  code_generation: true
+  test_generation: true

--- a/examples/calculator/README.md
+++ b/examples/calculator/README.md
@@ -1,0 +1,37 @@
+# DevSynth Calculator Example
+
+This example demonstrates how to use DevSynth to generate a simple calculator project.
+It walks through project initialization, specification generation, test creation, implementation, and running the final code.
+
+## Steps
+
+1. **Initialize the project**
+   ```bash
+   devsynth init --path .
+   ```
+   This creates the `.devsynth/project.yaml` configuration.
+
+2. **Define requirements**
+   Edit `requirements.md` with the desired functionality.
+
+3. **Generate specifications**
+   ```bash
+   devsynth spec --requirements-file requirements.md
+   ```
+
+4. **Generate tests**
+   ```bash
+   devsynth test
+   ```
+
+5. **Generate code**
+   ```bash
+   devsynth code
+   ```
+
+6. **Run the project**
+   ```bash
+   devsynth run
+   ```
+
+The files in this directory show the final result after running these commands.

--- a/examples/calculator/requirements.md
+++ b/examples/calculator/requirements.md
@@ -1,0 +1,12 @@
+# Project Requirements
+
+## Calculator Functionality
+- The system shall provide addition of two numbers
+- The system shall provide subtraction of two numbers
+- The system shall provide multiplication of two numbers
+- The system shall provide division of two numbers
+- The system shall handle division by zero gracefully
+
+## User Interface
+- The system shall provide a command-line interface
+- The system shall display results with appropriate formatting

--- a/examples/calculator/specs.md
+++ b/examples/calculator/specs.md
@@ -1,0 +1,9 @@
+# Generated Specifications
+
+## Calculator Module
+- Provide functions for `add`, `subtract`, `multiply`, and `divide`.
+- Raise `ZeroDivisionError` when attempting to divide by zero.
+
+## Command-line Interface
+- Accept two numbers and an operation (add, sub, mul, div).
+- Display the result to the user.

--- a/examples/calculator/src/calculator.py
+++ b/examples/calculator/src/calculator.py
@@ -1,0 +1,16 @@
+class Calculator:
+    """Simple calculator implementation."""
+
+    def add(self, a: float, b: float) -> float:
+        return a + b
+
+    def subtract(self, a: float, b: float) -> float:
+        return a - b
+
+    def multiply(self, a: float, b: float) -> float:
+        return a * b
+
+    def divide(self, a: float, b: float) -> float:
+        if b == 0:
+            raise ZeroDivisionError("Cannot divide by zero")
+        return a / b

--- a/examples/calculator/src/main.py
+++ b/examples/calculator/src/main.py
@@ -1,0 +1,37 @@
+import typer
+from calculator import Calculator
+
+app = typer.Typer()
+calc = Calculator()
+
+
+@app.command()
+def add(a: float, b: float):
+    """Add two numbers."""
+    typer.echo(calc.add(a, b))
+
+
+@app.command()
+def sub(a: float, b: float):
+    """Subtract two numbers."""
+    typer.echo(calc.subtract(a, b))
+
+
+@app.command()
+def mul(a: float, b: float):
+    """Multiply two numbers."""
+    typer.echo(calc.multiply(a, b))
+
+
+@app.command()
+def div(a: float, b: float):
+    """Divide two numbers."""
+    try:
+        result = calc.divide(a, b)
+        typer.echo(result)
+    except ZeroDivisionError as exc:
+        typer.echo(f"Error: {exc}")
+
+
+if __name__ == "__main__":
+    app()

--- a/examples/calculator/tests/test_calculator.py
+++ b/examples/calculator/tests/test_calculator.py
@@ -1,0 +1,28 @@
+import pytest
+from calculator import Calculator
+
+
+def test_add():
+    calc = Calculator()
+    assert calc.add(2, 3) == 5
+
+
+def test_subtract():
+    calc = Calculator()
+    assert calc.subtract(5, 2) == 3
+
+
+def test_multiply():
+    calc = Calculator()
+    assert calc.multiply(4, 3) == 12
+
+
+def test_divide():
+    calc = Calculator()
+    assert calc.divide(10, 2) == 5
+
+
+def test_divide_by_zero():
+    calc = Calculator()
+    with pytest.raises(ZeroDivisionError):
+        calc.divide(1, 0)


### PR DESCRIPTION
## Summary
- add an example calculator project under `examples/`
- document how to run the example and link it from the getting started index
- provide CI workflow to run DevSynth on the example

## Testing
- `poetry run pytest tests/` *(fails: LM Studio provider and ChromaDB tests)*

------
https://chatgpt.com/codex/tasks/task_e_6849d05a73388333aa3fc1dd07d94292