### PR TITLE
Add deployment automation and monitoring configuration

### DIFF
--- a/config/prometheus.yml
+++ b/config/prometheus.yml
@@ -1,0 +1,9 @@
+global:
+  scrape_interval: 15s
+
+scrape_configs:
+  - job_name: 'devsynth'
+    static_configs:
+      - targets: ['devsynth-api:8000']
+        labels:
+          service: devsynth-api

--- a/docker-compose.production.yml
+++ b/docker-compose.production.yml
@@ -1,0 +1,94 @@
+version: '3.8'
+
+services:
+  devsynth-api:
+    build:
+      context: .
+      target: production
+    command: uvicorn devsynth.api:app --host 0.0.0.0 --port 8000
+    environment:
+      - DEVSYNTH_ENV=production
+      - DEVSYNTH_LOG_LEVEL=INFO
+      - DEVSYNTH_MEMORY_STORE=chromadb
+      - DEVSYNTH_CHROMADB_HOST=chromadb
+      - DEVSYNTH_CHROMADB_PORT=8000
+    volumes:
+      - devsynth-data:/data/devsynth
+    depends_on:
+      - chromadb
+    ports:
+      - "8000:8000"
+    networks:
+      - devsynth-network
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8000/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 5s
+
+  devsynth-cli:
+    build:
+      context: .
+      target: production
+    command: devsynth
+    environment:
+      - DEVSYNTH_ENV=production
+    volumes:
+      - devsynth-data:/data/devsynth
+    networks:
+      - devsynth-network
+    profiles:
+      - cli
+
+  chromadb:
+    image: ghcr.io/chroma-core/chroma:latest
+    volumes:
+      - chromadb-data:/chroma/chroma
+    ports:
+      - "8001:8000"
+    environment:
+      - CHROMA_DB_IMPL=duckdb+parquet
+      - CHROMA_PERSIST_DIRECTORY=/chroma/chroma
+    networks:
+      - devsynth-network
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8000/api/v1/heartbeat"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 5s
+
+  prometheus:
+    image: prom/prometheus
+    volumes:
+      - ./config/prometheus.yml:/etc/prometheus/prometheus.yml:ro
+    ports:
+      - "9090:9090"
+    networks:
+      - devsynth-network
+
+  grafana:
+    image: grafana/grafana
+    ports:
+      - "3000:3000"
+    environment:
+      - GF_SECURITY_ADMIN_PASSWORD=admin
+    volumes:
+      - grafana-data:/var/lib/grafana
+    depends_on:
+      - prometheus
+    networks:
+      - devsynth-network
+
+volumes:
+  chromadb-data:
+    name: devsynth-chromadb-data
+  grafana-data:
+    name: devsynth-grafana-data
+  devsynth-data:
+    name: devsynth-app-data
+
+networks:
+  devsynth-network:
+    name: devsynth-network

--- a/docs/deployment/deployment_guide.md
+++ b/docs/deployment/deployment_guide.md
@@ -94,6 +94,8 @@ docker compose -f docker-compose.yml -f docker-compose.staging.yml up -d
 
 ### Production Environment
 
+Use the production compose file which includes Prometheus and Grafana for monitoring.
+
 ```bash
 # Set required environment variables
 export DEVSYNTH_ENV=production
@@ -155,6 +157,9 @@ Monitor container health with:
 docker compose ps
 docker compose top
 ```
+
+Prometheus scrapes metrics from `http://localhost:8000/metrics` and Grafana is
+available at `http://localhost:3000` (default credentials admin/admin).
 
 ## Troubleshooting
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -4066,6 +4066,21 @@ pyyaml = ">=5.1"
 virtualenv = ">=20.10.0"
 
 [[package]]
+name = "prometheus-client"
+version = "0.20.0"
+description = "Python client for the Prometheus monitoring system."
+optional = false
+python-versions = ">=3.8"
+groups = ["main"]
+files = [
+    {file = "prometheus_client-0.20.0-py3-none-any.whl", hash = "sha256:cde524a85bce83ca359cc837f28b8c0db5cac7aa653a588fd7e84ba061c329e7"},
+    {file = "prometheus_client-0.20.0.tar.gz", hash = "sha256:287629d00b147a32dcb2be0b9df905da599b2d82f80377083ec8463309a4bb89"},
+]
+
+[package.extras]
+twisted = ["twisted"]
+
+[[package]]
 name = "propcache"
 version = "0.3.2"
 description = "Accelerated property cache"
@@ -6554,4 +6569,4 @@ minimal = ["astor", "chromadb", "duckdb", "faiss-cpu", "langgraph", "lmdb", "net
 [metadata]
 lock-version = "2.1"
 python-versions = "<3.13,>=3.11"
-content-hash = "787f1447dbb540d01dd0dd0859c8892d8d2b2a0e3720c5522f63f74551a3e1d8"
+content-hash = "f32992e83694cc14660612c20d8569d8d0a5195389ec58b2f9c4135e205a39d9"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,7 @@ astor = "0.8.1"
 diskcache = "5.6.3"
 argon2-cffi = "23.1.0"
 cryptography = "^45.0.4"
+prometheus-client = "0.20.0"
 
 [tool.poetry.group.dev.dependencies]
 responses = "0.25.7"

--- a/src/devsynth/adapters/cli/argparse_adapter.py
+++ b/src/devsynth/adapters/cli/argparse_adapter.py
@@ -18,6 +18,7 @@ from devsynth.application.cli import (
     adaptive_cmd,
     analyze_code_cmd,
     edrr_cycle_cmd,
+    serve_cmd,
 )
 from devsynth.application.cli.ingest_cmd import ingest_cmd
 from devsynth.application.cli.apispec import apispec_cmd
@@ -71,6 +72,7 @@ def build_app() -> typer.Typer:
     app.command(name="generate-docs")(generate_docs_cmd)
     app.command(name="ingest")(ingest_cmd)
     app.command(name="apispec")(apispec_cmd)
+    app.command(name="serve")(serve_cmd)
 
     @app.callback(invoke_without_command=True)
     def main(ctx: typer.Context):

--- a/src/devsynth/api.py
+++ b/src/devsynth/api.py
@@ -1,0 +1,30 @@
+from fastapi import FastAPI
+from fastapi.responses import Response
+from prometheus_client import Counter, generate_latest, CONTENT_TYPE_LATEST
+
+from devsynth.logging_setup import DevSynthLogger, configure_logging
+
+configure_logging()
+logger = DevSynthLogger(__name__)
+
+REQUEST_COUNT = Counter("request_count", "Total HTTP requests", ["endpoint"])
+
+app = FastAPI(title="DevSynth API")
+
+@app.middleware("http")
+async def count_requests(request, call_next):
+    RESPONSE = await call_next(request)
+    REQUEST_COUNT.labels(endpoint=request.url.path).inc()
+    return RESPONSE
+
+@app.get("/health")
+async def health() -> dict[str, str]:
+    """Simple health check endpoint."""
+    logger.logger.debug("Health check accessed")
+    return {"status": "ok"}
+
+@app.get("/metrics")
+async def metrics() -> Response:
+    """Expose Prometheus metrics."""
+    data = generate_latest()
+    return Response(data, media_type=CONTENT_TYPE_LATEST)

--- a/src/devsynth/application/cli/__init__.py
+++ b/src/devsynth/application/cli/__init__.py
@@ -22,6 +22,7 @@ from .cli_commands import (
     webapp_cmd,
     dbschema_cmd,
     adaptive_cmd,
+    serve_cmd,
 )
 
 # Import commands from the commands directory
@@ -41,6 +42,7 @@ __all__ = [
     "webapp_cmd",
     "dbschema_cmd",
     "adaptive_cmd",
+    "serve_cmd",
     "analyze_code_cmd",
     "edrr_cycle_cmd",
 ]

--- a/src/devsynth/application/cli/cli_commands.py
+++ b/src/devsynth/application/cli/cli_commands.py
@@ -9,6 +9,8 @@ import importlib.util
 import yaml
 
 from ..orchestration.workflow import workflow_manager
+import uvicorn
+from devsynth.logging_setup import configure_logging
 from ..orchestration.adaptive_workflow import adaptive_workflow_manager
 from devsynth.logging_setup import DevSynthLogger
 from devsynth.exceptions import DevSynthError
@@ -621,6 +623,15 @@ Note: Full support for {framework} will be implemented in a future version.
                 border_style="red",
             )
         )
+
+
+def serve_cmd(host: str = "0.0.0.0", port: int = 8000) -> None:
+    """Run the DevSynth API server."""
+    try:
+        configure_logging()
+        uvicorn.run("devsynth.api:app", host=host, port=port, log_level="info")
+    except Exception as err:  # pragma: no cover - defensive
+        console.print(f"[red]Error:[/red] {err}", highlight=False)
 
 
 def dbschema_cmd(

--- a/tests/unit/test_api_health.py
+++ b/tests/unit/test_api_health.py
@@ -1,0 +1,14 @@
+from devsynth.api import app
+from fastapi.testclient import TestClient
+
+client = TestClient(app)
+
+def test_health_endpoint():
+    resp = client.get("/health")
+    assert resp.status_code == 200
+    assert resp.json() == {"status": "ok"}
+
+def test_metrics_endpoint():
+    resp = client.get("/metrics")
+    assert resp.status_code == 200
+    assert b"request_count" in resp.content


### PR DESCRIPTION
## Summary
- provide basic FastAPI service exposing /health and /metrics
- add `serve` command to CLI and register it
- include prometheus client dependency
- production docker compose with Prometheus and Grafana
- monitoring configuration and documentation updates
- include Prometheus configuration file
- add API health tests

## Testing
- `poetry run pytest tests/unit/test_api_health.py`
- `poetry run pytest` *(fails: TestLMStudioProvider::test_generate, TestLMStudioProvider::test_generate_with_context, TestLMStudioProvider::test_get_embedding, TestMemorySystemWithChromaDB::test_initialization_with_chromadb, TestMemorySystemWithChromaDB::test_initialization_without_vector_store, TestTokenTracker::test_count_conversation_tokens, TestTokenTracker::test_count_message_tokens, TestTokenTracker::test_count_tokens, TestTokenTracker::test_ensure_token_limit, TestTokenTracker::test_fallback_tokenizer, TestTokenTracker::test_prune_conversation, TestCLICommands::test_config_cmd_set_value, TestCLICommands::test_config_cmd_get_value, TestCLICommands::test_config_cmd_list_all, TestCLICommands::test_enable_feature_cmd, test_assign_roles_with_explicit_mapping, TestWSDETeam::test_assign_roles, TestMemorySystemWithChromaDB::test_memory_and_vector_store_integration, TestMemorySystemWithChromaDB::test_context_manager_with_chromadb)*

------
https://chatgpt.com/codex/tasks/task_e_684b4e19dba48333aef32e0538ea594a