### PR TITLE
Fix default config flags for AgentCoordinator tests

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -115,10 +115,10 @@ formalVerification:
 
 # Feature flags
 features:
-  wsde_collaboration: false
+  wsde_collaboration: true
   dialectical_reasoning: false
   code_generation: false
   test_generation: false
   documentation_generation: false
   automatic_phase_transitions: true
-  collaboration_notifications: false
+  collaboration_notifications: true

--- a/tests/unit/test_agent_coordinator.py
+++ b/tests/unit/test_agent_coordinator.py
@@ -24,7 +24,14 @@ class TestAgentCoordinatorImpl:
 
     def setup_method(self):
         """Set up test fixtures."""
-        self.coordinator = AgentCoordinatorImpl()
+        self.coordinator = AgentCoordinatorImpl(
+            {
+                "features": {
+                    "wsde_collaboration": True,
+                    "collaboration_notifications": True,
+                }
+            }
+        )
 
         # Create mock agents
         self.agent1 = MagicMock(spec=Agent)


### PR DESCRIPTION
## Summary
- enable wsde collaboration and collaboration notifications in default config
- pass collaboration feature flags explicitly in AgentCoordinator unit tests

## Testing
- `pytest tests/unit/test_agent_coordinator.py -q`

------
https://chatgpt.com/codex/tasks/task_e_684b7f153fe48333a2e53cdc294d1891