### PR TITLE
Add collaborative WSDE utilities and micro-cycle tests

### DIFF
--- a/src/devsynth/application/collaboration/__init__.py
+++ b/src/devsynth/application/collaboration/__init__.py
@@ -4,7 +4,8 @@ from devsynth.exceptions import DevSynthError
 # Create a logger for this module
 logger = DevSynthLogger(__name__)
 
+"""Collaboration module for agent coordination and team-based workflows."""
 
-"""
-Collaboration module for agent coordination and team-based workflows.
-"""
+from .wsde_team_extended import CollaborativeWSDETeam
+
+__all__ = ["CollaborativeWSDETeam"]

--- a/src/devsynth/application/collaboration/wsde_team_extended.py
+++ b/src/devsynth/application/collaboration/wsde_team_extended.py
@@ -1,0 +1,18 @@
+"""Extended WSDE team utilities."""
+
+from typing import Any, Dict, List
+
+from devsynth.domain.models.wsde import WSDETeam
+
+
+class CollaborativeWSDETeam(WSDETeam):
+    """WSDETeam with convenience methods for collaboration."""
+
+    def collaborative_decision(self, task: Dict[str, Any]) -> Dict[str, Any]:
+        """Run a collaborative voting process for a critical decision task."""
+        return self.vote_on_critical_decision(task)
+
+    def peer_review_solution(self, work_product: Any, author: Any) -> Dict[str, Any]:
+        """Conduct a full peer review cycle for a work product."""
+        reviewers = [a for a in self.agents if a is not author]
+        return self.conduct_peer_review(work_product, author, reviewers)

--- a/tests/integration/test_collaborative_voting.py
+++ b/tests/integration/test_collaborative_voting.py
@@ -1,0 +1,86 @@
+from unittest.mock import MagicMock
+import types
+import sys
+import pytest
+
+argon2_mod = types.ModuleType("argon2")
+setattr(argon2_mod, "PasswordHasher", object)
+exceptions_mod = types.ModuleType("exceptions")
+setattr(exceptions_mod, "VerifyMismatchError", type("VerifyMismatchError", (), {}))
+setattr(argon2_mod, "exceptions", exceptions_mod)
+sys.modules.setdefault("argon2", argon2_mod)
+sys.modules.setdefault("argon2.exceptions", exceptions_mod)
+sys.modules.setdefault("requests", types.ModuleType("requests"))
+crypto_mod = types.ModuleType("cryptography")
+fernet_mod = types.ModuleType("fernet")
+setattr(fernet_mod, "Fernet", object)
+crypto_mod.fernet = fernet_mod
+sys.modules.setdefault("cryptography", crypto_mod)
+sys.modules.setdefault("cryptography.fernet", fernet_mod)
+sys.modules.setdefault("jsonschema", types.ModuleType("jsonschema"))
+rdflib_mod = types.ModuleType("rdflib")
+setattr(rdflib_mod, "Graph", object)
+setattr(rdflib_mod, "Literal", object)
+setattr(rdflib_mod, "URIRef", object)
+setattr(rdflib_mod, "Namespace", lambda *a, **k: object())
+setattr(rdflib_mod, "RDF", object)
+setattr(rdflib_mod, "RDFS", object)
+setattr(rdflib_mod, "XSD", object)
+namespace_mod = types.ModuleType("namespace")
+setattr(namespace_mod, "FOAF", object)
+setattr(namespace_mod, "DC", object)
+rdflib_mod.namespace = namespace_mod
+sys.modules.setdefault("rdflib", rdflib_mod)
+sys.modules.setdefault("rdflib.namespace", namespace_mod)
+astor_mod = types.ModuleType("astor")
+setattr(astor_mod, "to_source", lambda *a, **k: "")
+sys.modules.setdefault("astor", astor_mod)
+
+from devsynth.application.collaboration.wsde_team_extended import CollaborativeWSDETeam
+
+
+class VotingAgent:
+    def __init__(self, name, vote, expertise=None, level="expert"):
+        self.name = name
+        self.vote = vote
+        self.current_role = None
+        if expertise is None:
+            expertise = ["general"]
+        self.config = types.SimpleNamespace(
+            name=name, parameters={"expertise": expertise, "expertise_level": level}
+        )
+
+    def process(self, task):
+        return {"vote": self.vote}
+
+
+def test_majority_voting():
+    team = CollaborativeWSDETeam()
+    team.add_agents(
+        [VotingAgent("a1", "o1"), VotingAgent("a2", "o2"), VotingAgent("a3", "o2")]
+    )
+    decision = {
+        "type": "critical_decision",
+        "is_critical": True,
+        "options": [{"id": "o1"}, {"id": "o2"}],
+    }
+    result = team.collaborative_decision(decision)
+    assert result["result"]["winner"] == "o2"
+
+
+def test_weighted_voting():
+    team = CollaborativeWSDETeam()
+    team.add_agents(
+        [
+            VotingAgent("e1", "o1", expertise=["ml"], level="expert"),
+            VotingAgent("e2", "o2", expertise=["ml"], level="novice"),
+        ]
+    )
+    decision = {
+        "type": "critical_decision",
+        "is_critical": True,
+        "domain": "ml",
+        "options": [{"id": "o1"}, {"id": "o2"}],
+    }
+    result = team.collaborative_decision(decision)
+    assert result["result"]["winner"] == "o1"

--- a/tests/integration/test_edrr_micro_cycle_auto_transition.py
+++ b/tests/integration/test_edrr_micro_cycle_auto_transition.py
@@ -1,0 +1,105 @@
+from unittest.mock import MagicMock
+import types
+import sys
+import pytest
+
+# Create minimal stub modules for optional deps
+argon2_mod = types.ModuleType("argon2")
+setattr(argon2_mod, "PasswordHasher", object)
+exceptions_mod = types.ModuleType("exceptions")
+setattr(exceptions_mod, "VerifyMismatchError", type("VerifyMismatchError", (), {}))
+setattr(argon2_mod, "exceptions", exceptions_mod)
+sys.modules.setdefault("argon2", argon2_mod)
+sys.modules.setdefault("argon2.exceptions", exceptions_mod)
+sys.modules.setdefault("requests", types.ModuleType("requests"))
+crypto_mod = types.ModuleType("cryptography")
+fernet_mod = types.ModuleType("fernet")
+setattr(fernet_mod, "Fernet", object)
+crypto_mod.fernet = fernet_mod
+sys.modules.setdefault("cryptography", crypto_mod)
+sys.modules.setdefault("cryptography.fernet", fernet_mod)
+sys.modules.setdefault("jsonschema", types.ModuleType("jsonschema"))
+rdflib_mod = types.ModuleType("rdflib")
+setattr(rdflib_mod, "Graph", object)
+setattr(rdflib_mod, "Literal", object)
+setattr(rdflib_mod, "URIRef", object)
+setattr(rdflib_mod, "Namespace", lambda *a, **k: object())
+setattr(rdflib_mod, "RDF", object)
+setattr(rdflib_mod, "RDFS", object)
+setattr(rdflib_mod, "XSD", object)
+namespace_mod = types.ModuleType("namespace")
+setattr(namespace_mod, "FOAF", object)
+setattr(namespace_mod, "DC", object)
+rdflib_mod.namespace = namespace_mod
+sys.modules.setdefault("rdflib", rdflib_mod)
+sys.modules.setdefault("rdflib.namespace", namespace_mod)
+astor_mod = types.ModuleType("astor")
+setattr(astor_mod, "to_source", lambda *a, **k: "")
+sys.modules.setdefault("astor", astor_mod)
+
+from devsynth.application.edrr.coordinator import EDRRCoordinator
+from devsynth.domain.models.wsde import WSDETeam
+from devsynth.application.memory.memory_manager import MemoryManager
+from devsynth.application.code_analysis.analyzer import CodeAnalyzer
+from devsynth.application.code_analysis.ast_transformer import AstTransformer
+from devsynth.application.prompts.prompt_manager import PromptManager
+from devsynth.application.documentation.documentation_manager import (
+    DocumentationManager,
+)
+from devsynth.methodology.base import Phase
+
+
+class SimpleAgent:
+    def __init__(self, name):
+        self.name = name
+        self.expertise = []
+        self.current_role = None
+
+    def process(self, task):
+        return {"processed_by": self.name}
+
+
+@pytest.fixture
+def coordinator():
+    team = WSDETeam()
+    team.add_agent(SimpleAgent("agent1"))
+    team.generate_diverse_ideas = MagicMock(return_value=["idea"])
+    team.create_comparison_matrix = MagicMock(return_value={})
+    team.evaluate_options = MagicMock(return_value=[])
+    team.analyze_trade_offs = MagicMock(return_value=[])
+    team.formulate_decision_criteria = MagicMock(return_value={})
+    team.select_best_option = MagicMock(return_value={})
+    team.elaborate_details = MagicMock(return_value=[])
+    team.create_implementation_plan = MagicMock(return_value=[])
+    team.optimize_implementation = MagicMock(return_value={})
+    team.perform_quality_assurance = MagicMock(return_value={})
+    team.extract_learnings = MagicMock(return_value=[])
+    team.recognize_patterns = MagicMock(return_value=[])
+    team.integrate_knowledge = MagicMock(return_value={})
+    team.generate_improvement_suggestions = MagicMock(return_value=[])
+
+    mm = MagicMock(spec=MemoryManager)
+    mm.retrieve_with_edrr_phase.side_effect = lambda *a, **k: {}
+    mm.retrieve_relevant_knowledge.return_value = []
+    mm.retrieve_historical_patterns.return_value = []
+    analyzer = MagicMock(spec=CodeAnalyzer)
+    analyzer.analyze_project_structure.return_value = []
+    return EDRRCoordinator(
+        memory_manager=mm,
+        wsde_team=team,
+        code_analyzer=analyzer,
+        ast_transformer=MagicMock(spec=AstTransformer),
+        prompt_manager=MagicMock(spec=PromptManager),
+        documentation_manager=MagicMock(spec=DocumentationManager),
+        enable_enhanced_logging=False,
+    )
+
+
+def test_micro_cycle_auto_transitions(coordinator):
+    coordinator.start_cycle({"description": "macro"})
+    context = {"micro_tasks": [{"description": "micro"}]}
+    coordinator.execute_current_phase(context)
+    assert len(coordinator.child_cycles) == 1
+    child = coordinator.child_cycles[0]
+    assert child.current_phase == Phase.RETROSPECT
+    assert all(p.name in child.results for p in Phase)


### PR DESCRIPTION
## Summary
- expose `CollaborativeWSDETeam` from collaboration package
- add helper methods for collaborative decisions and peer reviews
- add integration tests for automatic micro-cycle transitions
- add integration tests for collaborative voting

## Testing
- `poetry run pytest tests/integration/test_edrr_micro_cycle_auto_transition.py tests/integration/test_collaborative_voting.py`
- `poetry run pytest tests` *(fails: ModuleNotFoundError: tinydb, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_684ba065af148333adaed5d1dfad03a7