### PR TITLE
Add compose configs

### DIFF
--- a/deployment/README.md
+++ b/deployment/README.md
@@ -1,0 +1,13 @@
+# Deployment Configurations
+
+This directory contains Docker Compose files for running DevSynth and its dependencies.
+
+- `docker-compose.yml` – core services (DevSynth API and ChromaDB)
+- `docker-compose.monitoring.yml` – optional monitoring stack with Prometheus and Grafana
+
+Use these files together to spin up a complete local environment:
+
+```bash
+# Start DevSynth with monitoring
+docker compose -f deployment/docker-compose.yml -f deployment/docker-compose.monitoring.yml up -d
+```

--- a/deployment/docker-compose.monitoring.yml
+++ b/deployment/docker-compose.monitoring.yml
@@ -1,0 +1,32 @@
+version: '3.8'
+
+services:
+  prometheus:
+    image: prom/prometheus
+    volumes:
+      - ../config/prometheus.yml:/etc/prometheus/prometheus.yml:ro
+    ports:
+      - "9090:9090"
+    networks:
+      - devsynth-network
+
+  grafana:
+    image: grafana/grafana
+    ports:
+      - "3000:3000"
+    environment:
+      - GF_SECURITY_ADMIN_PASSWORD=admin
+    volumes:
+      - grafana-data:/var/lib/grafana
+    depends_on:
+      - prometheus
+    networks:
+      - devsynth-network
+
+volumes:
+  grafana-data:
+    name: devsynth-grafana-data
+
+networks:
+  devsynth-network:
+    name: devsynth-network

--- a/deployment/docker-compose.yml
+++ b/deployment/docker-compose.yml
@@ -1,0 +1,57 @@
+version: '3.8'
+
+services:
+  devsynth:
+    build:
+      context: ..
+      target: development
+    volumes:
+      - ..:/opt/pysetup
+      - ~/.devsynth:/home/devsynth/.devsynth
+    ports:
+      - "8000:8000"
+    environment:
+      - DEVSYNTH_ENV=development
+      - DEVSYNTH_LOG_LEVEL=DEBUG
+      - DEVSYNTH_MEMORY_STORE=chromadb
+      - DEVSYNTH_LLM_PROVIDER=openai
+      - DEVSYNTH_CHROMADB_HOST=chromadb
+      - DEVSYNTH_CHROMADB_PORT=8000
+    depends_on:
+      - chromadb
+    networks:
+      - devsynth-network
+    healthcheck:
+      test: ["CMD", "python", "-c", "import requests; requests.get('http://localhost:8000/health')"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 5s
+    restart: unless-stopped
+
+  chromadb:
+    image: ghcr.io/chroma-core/chroma:latest
+    volumes:
+      - chromadb-data:/chroma/chroma
+    ports:
+      - "8001:8000"
+    environment:
+      - CHROMA_DB_IMPL=duckdb+parquet
+      - CHROMA_PERSIST_DIRECTORY=/chroma/chroma
+    networks:
+      - devsynth-network
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8000/api/v1/heartbeat"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 5s
+    restart: unless-stopped
+
+volumes:
+  chromadb-data:
+    name: devsynth-chromadb-data
+
+networks:
+  devsynth-network:
+    name: devsynth-network

--- a/docs/getting_started/quick_start_guide.md
+++ b/docs/getting_started/quick_start_guide.md
@@ -49,9 +49,20 @@ pip install -e .[dev]
 # Or use Poetry
 poetry install
 
+
 # Activate the virtual environment
 poetry shell
 ```
+
+### Run with Docker Compose
+
+To start DevSynth and its dependencies using Docker Compose:
+
+```bash
+docker compose -f deployment/docker-compose.yml -f deployment/docker-compose.monitoring.yml up -d
+```
+
+This launches the DevSynth API, ChromaDB, and the optional Prometheus and Grafana stack.
 
 ## Creating Your First DevSynth Project
 

--- a/docs/policies/deployment.md
+++ b/docs/policies/deployment.md
@@ -11,12 +11,24 @@ This policy defines best practices for deployment, CI/CD, and operational safety
 - Require post-deployment verification (smoke tests, monitoring checks).
 - Limit production deployment permissions to authorized roles/agents.
 - Maintain observability: log standards, monitoring, and alerting must be documented and followed.
+- Provide Docker Compose files for local and production deployments in the
+  `deployment/` directory. The monitoring compose file enables Prometheus metrics
+  scraping and Grafana dashboards.
 
 ## Artifacts
 - Deployment Scripts: `deployment/`
 - Deployment Docs: `deployment/README.md`
 - CI/CD Config: `.github/workflows/` or `ci/`
 - Monitoring/Logging: `deployment/monitoring.md` (if present)
+
+## Compose Usage
+
+Example command to start the core services with monitoring:
+
+```bash
+docker compose -f deployment/docker-compose.yml -f deployment/docker-compose.monitoring.yml up -d
+```
+
 
 ## References
 - See [Testing Policy](testing.md) for release testing.


### PR DESCRIPTION
## Summary
- add docker-compose files for DevSynth and monitoring under `deployment/`
- document compose usage in policies and quick start guide

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pytest_bdd')*

------
https://chatgpt.com/codex/tasks/task_e_684ba49117588333a7db106cc4d04797