### PR TITLE
Fix logging prints & enforce project dir safety

### DIFF
--- a/src/devsynth/config/settings.py
+++ b/src/devsynth/config/settings.py
@@ -568,9 +568,11 @@ def ensure_path_exists(path: str, create: bool = True) -> str:
     )
 
     # Debug logging
-    print(f"ensure_path_exists called with path={path}, create={create}")
-    print(
-        f"in_test_env={in_test_env}, DEVSYNTH_PROJECT_DIR={os.environ.get('DEVSYNTH_PROJECT_DIR')}"
+    logger.debug("ensure_path_exists called with path=%s, create=%s", path, create)
+    logger.debug(
+        "in_test_env=%s, DEVSYNTH_PROJECT_DIR=%s",
+        in_test_env,
+        os.environ.get("DEVSYNTH_PROJECT_DIR"),
     )
 
     # If we're in a test environment with DEVSYNTH_PROJECT_DIR set, ensure paths are within the test directory
@@ -578,12 +580,16 @@ def ensure_path_exists(path: str, create: bool = True) -> str:
         test_project_dir = os.environ.get("DEVSYNTH_PROJECT_DIR")
         path_obj = Path(path)
 
-        print(f"test_project_dir={test_project_dir}, path_obj={path_obj}")
-        print(f"path_obj.is_absolute()={path_obj.is_absolute()}")
-        print(
-            f"str(path_obj).startswith(test_project_dir)={str(path_obj).startswith(test_project_dir)}"
+        logger.debug("test_project_dir=%s, path_obj=%s", test_project_dir, path_obj)
+        logger.debug("path_obj.is_absolute()=%s", path_obj.is_absolute())
+        logger.debug(
+            "str(path_obj).startswith(test_project_dir)=%s",
+            str(path_obj).startswith(test_project_dir),
         )
 
+        if not path_obj.is_absolute():
+            path = os.path.join(test_project_dir, str(path_obj))
+            path_obj = Path(path)
         # If the path is absolute and not within the test project directory,
         # redirect it to be within the test project directory
         if path_obj.is_absolute() and not str(path_obj).startswith(test_project_dir):
@@ -591,17 +597,15 @@ def ensure_path_exists(path: str, create: bool = True) -> str:
             if str(path_obj).startswith(str(Path.home())):
                 relative_path = str(path_obj).replace(str(Path.home()), "")
                 new_path = os.path.join(test_project_dir, relative_path.lstrip("/\\"))
-                print(f"Redirecting home path {path} to test path {new_path}")
-                logger.debug(f"Redirecting home path {path} to test path {new_path}")
+                logger.debug("Redirecting home path %s to test path %s", path, new_path)
                 path = new_path
             # For other absolute paths
             else:
                 # Extract the path components after the root
                 relative_path = str(path_obj.relative_to(path_obj.anchor))
                 new_path = os.path.join(test_project_dir, relative_path)
-                print(f"Redirecting absolute path {path} to test path {new_path}")
                 logger.debug(
-                    f"Redirecting absolute path {path} to test path {new_path}"
+                    "Redirecting absolute path %s to test path %s", path, new_path
                 )
                 path = new_path
 

--- a/tests/unit/test_path_restrictions.py
+++ b/tests/unit/test_path_restrictions.py
@@ -1,0 +1,48 @@
+import importlib
+from pathlib import Path
+
+import devsynth.config.settings as settings_module
+import devsynth.logging_setup as logging_setup_module
+
+
+def test_ensure_path_exists_within_project_dir(tmp_path, monkeypatch):
+    project_dir = tmp_path / "project"
+    outside_dir = tmp_path / "outside"
+    project_dir.mkdir(exist_ok=True)
+    outside_dir.mkdir(exist_ok=True)
+
+    monkeypatch.setenv("DEVSYNTH_PROJECT_DIR", str(project_dir))
+    monkeypatch.setenv("DEVSYNTH_NO_FILE_LOGGING", "1")
+
+    settings = importlib.reload(settings_module)
+
+    outside_path = outside_dir / "data"
+    result = settings.ensure_path_exists(str(outside_path), create=True)
+    assert str(project_dir) in result
+    assert not outside_path.exists()
+
+    relative_result = settings.ensure_path_exists("rel/data", create=True)
+    assert Path(relative_result) == project_dir / "rel" / "data"
+
+
+def test_configure_logging_within_project_dir(tmp_path, monkeypatch):
+    project_dir = tmp_path / "project"
+    outside_dir = tmp_path / "outside"
+    project_dir.mkdir(exist_ok=True)
+    outside_dir.mkdir(exist_ok=True)
+
+    monkeypatch.setenv("DEVSYNTH_PROJECT_DIR", str(project_dir))
+    monkeypatch.setenv("DEVSYNTH_NO_FILE_LOGGING", "1")
+
+    logging_setup = importlib.reload(logging_setup_module)
+
+    log_dir = outside_dir / "logs"
+    log_file = log_dir / "app.log"
+
+    logging_setup.configure_logging(
+        log_dir=str(log_dir), log_file=str(log_file), create_dir=False
+    )
+
+    assert str(project_dir) in logging_setup._configured_log_dir
+    assert str(project_dir) in logging_setup._configured_log_file
+    assert not log_dir.exists()


### PR DESCRIPTION
## Summary
- replace debug `print` statements with logger calls
- sanitize log and filesystem paths to stay inside project directory
- add unit tests for path restrictions

## Testing
- `pytest tests/unit/test_path_restrictions.py -q`

------
https://chatgpt.com/codex/tasks/task_e_684ba61ade2883338fe8129631aef5ec