### PR TITLE
Add ONNX runtime port and fixtures

### DIFF
--- a/docs/developer_guides/hermetic_testing.md
+++ b/docs/developer_guides/hermetic_testing.md
@@ -183,6 +183,22 @@ def test_with_mocked_llm(mock_openai_provider):
     assert "Test completion response" in result
 ```
 
+### Mocked Ports
+
+Use the lightweight port fixtures from `tests/fixtures/ports.py` to avoid real
+service calls:
+
+```python
+from devsynth.domain.models.memory import MemoryType
+
+def test_with_mocked_ports(llm_port, memory_port, onnx_port):
+    assert "mock" in llm_port.generate("hi").lower()
+    item_id = memory_port.store_memory("data", MemoryType.WORKING)
+    assert memory_port.retrieve_memory(item_id)
+    onnx_port.load_model("model.onnx")
+    assert list(onnx_port.run({"x": [1]}))
+```
+
 ## Best Practices
 
 1. **Use `tmp_path` or `tempfile.TemporaryDirectory`** for all file operations

--- a/src/devsynth/adapters/onnx_runtime_adapter.py
+++ b/src/devsynth/adapters/onnx_runtime_adapter.py
@@ -1,0 +1,26 @@
+"""Adapter providing an OnnxRuntime implementation using onnxruntime."""
+
+from typing import Any, Iterable, Dict
+
+import onnxruntime as ort
+
+from devsynth.domain.interfaces.onnx import OnnxRuntime
+from devsynth.logging_setup import DevSynthLogger
+
+logger = DevSynthLogger(__name__)
+
+
+class ONNXRuntimeAdapter(OnnxRuntime):
+    """Thin wrapper around ``onnxruntime.InferenceSession``."""
+
+    def __init__(self) -> None:
+        self.session: ort.InferenceSession | None = None
+
+    def load_model(self, model_path: str) -> None:
+        logger.debug(f"Initializing ONNX runtime with model: {model_path}")
+        self.session = ort.InferenceSession(model_path)
+
+    def run(self, inputs: Dict[str, Any]) -> Iterable[Any]:
+        if self.session is None:
+            raise RuntimeError("Model not loaded")
+        return self.session.run(None, inputs)

--- a/src/devsynth/domain/interfaces/__init__.py
+++ b/src/devsynth/domain/interfaces/__init__.py
@@ -1,6 +1,8 @@
 from devsynth.logging_setup import DevSynthLogger
 from devsynth.exceptions import DevSynthError
 
+from .onnx import OnnxRuntime
+
 # Create a logger for this module
 logger = DevSynthLogger(__name__)
 

--- a/src/devsynth/domain/interfaces/onnx.py
+++ b/src/devsynth/domain/interfaces/onnx.py
@@ -1,0 +1,18 @@
+from abc import ABC, abstractmethod
+from typing import Any, Iterable, Dict
+
+from devsynth.logging_setup import DevSynthLogger
+
+logger = DevSynthLogger(__name__)
+
+
+class OnnxRuntime(ABC):
+    """Protocol for ONNX runtime implementations."""
+
+    @abstractmethod
+    def load_model(self, model_path: str) -> None:
+        """Load an ONNX model from the given path."""
+
+    @abstractmethod
+    def run(self, inputs: Dict[str, Any]) -> Iterable[Any]:
+        """Run inference on the loaded model."""

--- a/src/devsynth/ports/__init__.py
+++ b/src/devsynth/ports/__init__.py
@@ -11,6 +11,7 @@ from .llm_port import LLMPort
 from .memory_port import MemoryPort
 from .orchestration_port import OrchestrationPort
 from .vector_store_port import VectorStorePort
+from .onnx_port import OnnxPort
 
 # Create a logger for this module
 from devsynth.logging_setup import DevSynthLogger
@@ -25,4 +26,5 @@ __all__ = [
     "MemoryPort",
     "OrchestrationPort",
     "VectorStorePort",
+    "OnnxPort",
 ]

--- a/src/devsynth/ports/onnx_port.py
+++ b/src/devsynth/ports/onnx_port.py
@@ -1,0 +1,25 @@
+"""Port for ONNX runtime operations."""
+
+from typing import Any, Iterable, Dict
+
+from ..domain.interfaces.onnx import OnnxRuntime
+from devsynth.logging_setup import DevSynthLogger
+
+logger = DevSynthLogger(__name__)
+
+
+class OnnxPort:
+    """Port that wraps an OnnxRuntime implementation."""
+
+    def __init__(self, runtime: OnnxRuntime):
+        self.runtime = runtime
+
+    def load_model(self, model_path: str) -> None:
+        """Load an ONNX model using the underlying runtime."""
+        logger.debug(f"Loading ONNX model from {model_path}")
+        self.runtime.load_model(model_path)
+
+    def run(self, inputs: Dict[str, Any]) -> Iterable[Any]:
+        """Run inference on the loaded model."""
+        logger.debug("Running ONNX model")
+        return self.runtime.run(inputs)

--- a/tests/fixtures/__init__.py
+++ b/tests/fixtures/__init__.py
@@ -1,0 +1,1 @@
+pytest_plugins = ["tests.fixtures.ports"]

--- a/tests/fixtures/ports.py
+++ b/tests/fixtures/ports.py
@@ -1,0 +1,76 @@
+"""Example fixtures for mocking DevSynth ports."""
+
+import pytest
+
+from devsynth.ports.llm_port import LLMPort
+from devsynth.adapters.llm.mock_llm_adapter import MockLLMAdapter
+from devsynth.ports.memory_port import MemoryPort
+from devsynth.domain.interfaces.memory import MemoryStore, ContextManager
+from devsynth.domain.models.memory import MemoryItem, MemoryType
+from devsynth.ports.onnx_port import OnnxPort
+from tests.unit.fakes.fake_onnx_runtime import FakeOnnxRuntime
+
+
+class _InMemoryStore(MemoryStore):
+    def __init__(self):
+        self.items = {}
+
+    def store(self, item: MemoryItem) -> str:
+        item_id = item.id or str(len(self.items))
+        item.id = item_id
+        self.items[item_id] = item
+        return item_id
+
+    def retrieve(self, item_id: str):
+        return self.items.get(item_id)
+
+    def search(self, query: dict):
+        return list(self.items.values())
+
+    def delete(self, item_id: str) -> bool:
+        return self.items.pop(item_id, None) is not None
+
+
+class _SimpleContextManager(ContextManager):
+    def __init__(self):
+        self.ctx = {}
+
+    def add_to_context(self, key: str, value):
+        self.ctx[key] = value
+
+    def get_from_context(self, key: str):
+        return self.ctx.get(key)
+
+    def get_full_context(self):
+        return dict(self.ctx)
+
+    def clear_context(self):
+        self.ctx.clear()
+
+
+class _MockProviderFactory:
+    def create_provider(self, provider_type: str, config=None):
+        return MockLLMAdapter()
+
+    def register_provider_type(self, provider_type: str, provider_class: type) -> None:
+        pass
+
+
+@pytest.fixture
+def llm_port():
+    """Provide an LLMPort using the MockLLMAdapter."""
+    port = LLMPort(_MockProviderFactory())
+    port.set_default_provider("mock")
+    return port
+
+
+@pytest.fixture
+def memory_port():
+    """Provide a MemoryPort using in-memory stores."""
+    return MemoryPort(_SimpleContextManager(), _InMemoryStore())
+
+
+@pytest.fixture
+def onnx_port():
+    """Provide an OnnxPort with a fake runtime."""
+    return OnnxPort(FakeOnnxRuntime())

--- a/tests/unit/fakes/fake_onnx_runtime.py
+++ b/tests/unit/fakes/fake_onnx_runtime.py
@@ -1,0 +1,17 @@
+from typing import Any, Iterable, Dict
+
+from devsynth.domain.interfaces.onnx import OnnxRuntime
+
+
+class FakeOnnxRuntime(OnnxRuntime):
+    """Simple in-memory fake for ONNX runtime."""
+
+    def __init__(self) -> None:
+        self.loaded_model: str | None = None
+
+    def load_model(self, model_path: str) -> None:
+        self.loaded_model = model_path
+
+    def run(self, inputs: Dict[str, Any]) -> Iterable[Any]:
+        # Echo the inputs back as inference result
+        return [inputs]

--- a/tests/unit/test_onnx_port.py
+++ b/tests/unit/test_onnx_port.py
@@ -1,0 +1,13 @@
+from devsynth.ports.onnx_port import OnnxPort
+from tests.unit.fakes.fake_onnx_runtime import FakeOnnxRuntime
+
+
+def test_onnx_port_load_and_run():
+    runtime = FakeOnnxRuntime()
+    port = OnnxPort(runtime)
+
+    port.load_model("model.onnx")
+    assert runtime.loaded_model == "model.onnx"
+
+    result = list(port.run({"input": [1, 2, 3]}))
+    assert result == [{"input": [1, 2, 3]}]

--- a/tests/unit/test_ports_with_fixtures.py
+++ b/tests/unit/test_ports_with_fixtures.py
@@ -1,0 +1,20 @@
+pytest_plugins = ["tests.fixtures.ports"]
+
+from devsynth.domain.models.memory import MemoryItem, MemoryType
+
+
+def test_ports_fixtures(llm_port, memory_port, onnx_port):
+    # LLM port should generate mock responses
+    response = llm_port.generate("Tell me a joke")
+    assert "mock" in response.lower()
+
+    # Memory port should store and retrieve items in memory
+    item = MemoryItem(id="", content="data", memory_type=MemoryType.WORKING)
+    item_id = memory_port.store_memory(item.content, item.memory_type)
+    retrieved = memory_port.retrieve_memory(item_id)
+    assert retrieved.content == "data"
+
+    # ONNX port should echo inputs via the fake runtime
+    onnx_port.load_model("model.onnx")
+    result = list(onnx_port.run({"x": [1]}))
+    assert result == [{"x": [1]}]


### PR DESCRIPTION
## Summary
- add `OnnxRuntime` protocol and `OnnxPort`
- implement `ONNXRuntimeAdapter`
- expose `OnnxPort` in ports package
- provide test doubles and fixtures for ports
- document mocked port usage
- test `OnnxPort` and example fixtures

## Testing
- `poetry run pytest tests/unit/test_onnx_port.py tests/unit/test_ports_with_fixtures.py -q`

------
https://chatgpt.com/codex/tasks/task_e_684c40dbe1448333968c81a89ded1b81