### PR TITLE
Replace prints with logger

### DIFF
--- a/src/devsynth/adapters/cli/argparse_adapter.py
+++ b/src/devsynth/adapters/cli/argparse_adapter.py
@@ -96,7 +96,9 @@ def _warn_if_features_disabled() -> None:
                 config = yaml.safe_load(f) or {}
             features = config.get("features", {})
         else:
-            default_config = Path(__file__).resolve().parents[3] / "config" / "default.yml"
+            default_config = (
+                Path(__file__).resolve().parents[3] / "config" / "default.yml"
+            )
             with open(default_config, "r") as f:
                 config = yaml.safe_load(f) or {}
             features = config.get("features", {})
@@ -116,8 +118,8 @@ def show_help() -> None:
     except SystemExit:
         pass
     # Provide a simple marker line for tests to assert
-    print("Commands:")
-    print("Run 'devsynth [COMMAND] --help' for more information on a command.")
+    logger.info("Commands:")
+    logger.info("Run 'devsynth [COMMAND] --help' for more information on a command.")
 
 
 def parse_args(args: list[str]) -> None:

--- a/src/devsynth/adapters/requirements/cli_chat.py
+++ b/src/devsynth/adapters/requirements/cli_chat.py
@@ -1,143 +1,156 @@
-
 """
 CLI chat adapter for requirements management.
 """
+
 from typing import List, Optional
 from uuid import UUID
 
+from devsynth.logging_setup import DevSynthLogger
 from devsynth.domain.models.requirement import ChatMessage, ChatSession
 from devsynth.ports.requirement_port import ChatPort, DialecticalReasonerPort
+
+logger = DevSynthLogger(__name__)
 
 
 class CLIChatAdapter(ChatPort):
     """
     CLI implementation of the chat port.
     """
-    
+
     def __init__(self, dialectical_reasoner: DialecticalReasonerPort):
         """
         Initialize the CLI chat adapter.
-        
+
         Args:
             dialectical_reasoner: The dialectical reasoner service.
         """
         self.dialectical_reasoner = dialectical_reasoner
-    
+
     def send_message(self, session_id: UUID, message: str, user_id: str) -> ChatMessage:
         """
         Send a message in a chat session.
-        
+
         Args:
             session_id: The ID of the chat session.
             message: The message content.
             user_id: The ID of the user sending the message.
-            
+
         Returns:
             The response message.
         """
         return self.dialectical_reasoner.process_message(session_id, message, user_id)
-    
-    def create_session(self, user_id: str, change_id: Optional[UUID] = None) -> ChatSession:
+
+    def create_session(
+        self, user_id: str, change_id: Optional[UUID] = None
+    ) -> ChatSession:
         """
         Create a new chat session.
-        
+
         Args:
             user_id: The ID of the user.
             change_id: The ID of the change to discuss, if any.
-            
+
         Returns:
             The created chat session.
         """
         return self.dialectical_reasoner.create_session(user_id, change_id)
-    
+
     def get_session(self, session_id: UUID) -> Optional[ChatSession]:
         """
         Get a chat session by ID.
-        
+
         Args:
             session_id: The ID of the chat session.
-            
+
         Returns:
             The chat session if found, None otherwise.
         """
         # This is delegated to the dialectical reasoner, which uses the chat repository
         # We could implement this directly using the chat repository, but for simplicity,
         # we'll reuse the dialectical reasoner's implementation
-        session = self.dialectical_reasoner.create_session("system")  # Create a temporary session
+        session = self.dialectical_reasoner.create_session(
+            "system"
+        )  # Create a temporary session
         # This is a hack to get access to the chat repository
         return self.dialectical_reasoner.chat_repository.get_session(session_id)
-    
+
     def get_sessions_for_user(self, user_id: str) -> List[ChatSession]:
         """
         Get chat sessions for a user.
-        
+
         Args:
             user_id: The ID of the user.
-            
+
         Returns:
             A list of chat sessions for the user.
         """
         # Similar to get_session, we'll use the dialectical reasoner's chat repository
-        session = self.dialectical_reasoner.create_session("system")  # Create a temporary session
+        session = self.dialectical_reasoner.create_session(
+            "system"
+        )  # Create a temporary session
         return self.dialectical_reasoner.chat_repository.get_sessions_for_user(user_id)
-    
+
     def get_messages_for_session(self, session_id: UUID) -> List[ChatMessage]:
         """
         Get messages for a chat session.
-        
+
         Args:
             session_id: The ID of the chat session.
-            
+
         Returns:
             A list of messages for the chat session.
         """
         # Similar to get_session, we'll use the dialectical reasoner's chat repository
-        session = self.dialectical_reasoner.create_session("system")  # Create a temporary session
-        return self.dialectical_reasoner.chat_repository.get_messages_for_session(session_id)
-    
+        session = self.dialectical_reasoner.create_session(
+            "system"
+        )  # Create a temporary session
+        return self.dialectical_reasoner.chat_repository.get_messages_for_session(
+            session_id
+        )
+
     def display_message(self, message: ChatMessage) -> None:
         """
         Display a chat message in the CLI.
-        
+
         Args:
             message: The message to display.
         """
         sender = message.sender
         content = message.content
-        
+
         if sender == "system":
-            print(f"\n[System] {content}\n")
+            logger.info("[System] %s", content)
         else:
-            print(f"\n[{sender}] {content}\n")
-    
+            logger.info("[%s] %s", sender, content)
+
     def run_interactive_session(self, session_id: UUID, user_id: str) -> None:
         """
         Run an interactive chat session in the CLI.
-        
+
         Args:
             session_id: The ID of the chat session.
             user_id: The ID of the user.
         """
         session = self.get_session(session_id)
         if not session:
-            print(f"Error: Session with ID {session_id} not found.")
+            logger.error("Session with ID %s not found", session_id)
             return
-        
+
         # Display existing messages
         messages = self.get_messages_for_session(session_id)
         for message in messages:
             self.display_message(message)
-        
+
         # Interactive loop
-        print("\nEnter your messages below. Type 'exit' to end the session.\n")
+        logger.info("Enter your messages below. Type 'exit' to end the session.")
         while True:
             user_input = input(f"[{user_id}] ")
             if user_input.lower() in ["exit", "quit", "bye"]:
-                print("\nEnding chat session. Goodbye!\n")
+                logger.info("Ending chat session. Goodbye!")
                 break
-            
+
             # Send the message and get the response
             response = self.send_message(session_id, user_input, user_id)
-            
+
             # Display the response
             self.display_message(response)

--- a/src/devsynth/application/promises/examples.py
+++ b/src/devsynth/application/promises/examples.py
@@ -4,17 +4,21 @@ Examples of using the Promise System in DevSynth.
 This module provides concrete examples of how to use the Promise System
 for capability declaration, discovery, and fulfillment between agents.
 """
+
 import time
-import logging
+from devsynth.logging_setup import DevSynthLogger
 from typing import Dict, List, Any, Optional
 
 from devsynth.application.promises import (
-    Promise, PromiseBroker, PromiseAgent,
-    CapabilityNotFoundError, UnauthorizedAccessError
+    Promise,
+    PromiseBroker,
+    PromiseAgent,
+    CapabilityNotFoundError,
+    UnauthorizedAccessError,
 )
 
 # Setup logger
-logger = logging.getLogger(__name__)
+logger = DevSynthLogger(__name__)
 
 
 class MathAgent(PromiseAgent):
@@ -22,7 +26,9 @@ class MathAgent(PromiseAgent):
     Example agent that provides math capabilities.
     """
 
-    def __init__(self, agent_id: str = "math_agent", broker: Optional[PromiseBroker] = None):
+    def __init__(
+        self, agent_id: str = "math_agent", broker: Optional[PromiseBroker] = None
+    ):
         """Initialize the Math Agent."""
         super().__init__(agent_id, broker)
 
@@ -31,31 +37,33 @@ class MathAgent(PromiseAgent):
             name="add",
             handler_func=self.add_numbers,
             description="Add two numbers together",
-            parameters={"a": "float", "b": "float"}
+            parameters={"a": "float", "b": "float"},
         )
 
         self.register_capability(
             name="subtract",
             handler_func=self.subtract_numbers,
             description="Subtract one number from another",
-            parameters={"a": "float", "b": "float"}
+            parameters={"a": "float", "b": "float"},
         )
 
         self.register_capability(
             name="multiply",
             handler_func=self.multiply_numbers,
             description="Multiply two numbers together",
-            parameters={"a": "float", "b": "float"}
+            parameters={"a": "float", "b": "float"},
         )
 
         self.register_capability(
             name="divide",
             handler_func=self.divide_numbers,
             description="Divide one number by another",
-            parameters={"a": "float", "b": "float"}
+            parameters={"a": "float", "b": "float"},
         )
 
-        logger.info(f"Math Agent initialized with {len(self.get_own_capabilities())} capabilities")
+        logger.info(
+            f"Math Agent initialized with {len(self.get_own_capabilities())} capabilities"
+        )
 
     def add_numbers(self, a: float, b: float) -> float:
         """Add two numbers together."""
@@ -90,7 +98,9 @@ class TextAgent(PromiseAgent):
     Example agent that provides text processing capabilities.
     """
 
-    def __init__(self, agent_id: str = "text_agent", broker: Optional[PromiseBroker] = None):
+    def __init__(
+        self, agent_id: str = "text_agent", broker: Optional[PromiseBroker] = None
+    ):
         """Initialize the Text Agent."""
         super().__init__(agent_id, broker)
 
@@ -99,24 +109,26 @@ class TextAgent(PromiseAgent):
             name="concatenate",
             handler_func=self.concatenate_texts,
             description="Concatenate multiple strings",
-            parameters={"texts": "List[str]", "separator": "str"}
+            parameters={"texts": "List[str]", "separator": "str"},
         )
 
         self.register_capability(
             name="reverse",
             handler_func=self.reverse_text,
             description="Reverse a string",
-            parameters={"text": "str"}
+            parameters={"text": "str"},
         )
 
         self.register_capability(
             name="tokenize",
             handler_func=self.tokenize_text,
             description="Split text into tokens",
-            parameters={"text": "str", "delimiter": "str"}
+            parameters={"text": "str", "delimiter": "str"},
         )
 
-        logger.info(f"Text Agent initialized with {len(self.get_own_capabilities())} capabilities")
+        logger.info(
+            f"Text Agent initialized with {len(self.get_own_capabilities())} capabilities"
+        )
 
     def concatenate_texts(self, texts: List[str], separator: str = " ") -> str:
         """Concatenate multiple strings with a separator."""
@@ -133,7 +145,9 @@ class TextAgent(PromiseAgent):
     def tokenize_text(self, text: str, delimiter: str = " ") -> List[str]:
         """Split text into tokens using the delimiter."""
         tokens = text.split(delimiter)
-        logger.debug(f"Tokenized text into {len(tokens)} tokens using delimiter '{delimiter}'")
+        logger.debug(
+            f"Tokenized text into {len(tokens)} tokens using delimiter '{delimiter}'"
+        )
         return tokens
 
 
@@ -142,7 +156,9 @@ class ProjectAgent(PromiseAgent):
     Example agent that manages a project and orchestrates other agents.
     """
 
-    def __init__(self, agent_id: str = "project_agent", broker: Optional[PromiseBroker] = None):
+    def __init__(
+        self, agent_id: str = "project_agent", broker: Optional[PromiseBroker] = None
+    ):
         """Initialize the Project Agent."""
         super().__init__(agent_id, broker)
 
@@ -151,17 +167,19 @@ class ProjectAgent(PromiseAgent):
             name="create_project",
             handler_func=self.create_project,
             description="Create a new project",
-            parameters={"name": "str", "description": "str"}
+            parameters={"name": "str", "description": "str"},
         )
 
         self.register_capability(
             name="analyze_requirements",
             handler_func=self.analyze_requirements,
             description="Analyze project requirements",
-            parameters={"requirements": "str"}
+            parameters={"requirements": "str"},
         )
 
-        logger.info(f"Project Agent initialized with {len(self.get_own_capabilities())} capabilities")
+        logger.info(
+            f"Project Agent initialized with {len(self.get_own_capabilities())} capabilities"
+        )
 
     def create_project(self, name: str, description: str) -> Dict[str, Any]:
         """Create a new project."""
@@ -172,7 +190,7 @@ class ProjectAgent(PromiseAgent):
             "name": name,
             "description": description,
             "created_at": time.time(),
-            "status": "active"
+            "status": "active",
         }
 
         return project
@@ -189,9 +207,7 @@ class ProjectAgent(PromiseAgent):
         # Use text agent to tokenize requirements
         try:
             tokenize_promise = self.request_capability(
-                name="tokenize",
-                text=requirements,
-                delimiter="\n"
+                name="tokenize", text=requirements, delimiter="\n"
             )
             req_lines = self.wait_for_capability(tokenize_promise)
             logger.debug(f"Tokenized requirements into {len(req_lines)} lines")
@@ -206,7 +222,7 @@ class ProjectAgent(PromiseAgent):
         analysis = {
             "total_requirements": count,
             "lines": req_lines,
-            "analyzed_at": time.time()
+            "analyzed_at": time.time(),
         }
 
         return analysis
@@ -235,8 +251,7 @@ def run_example():
 
     # Step 1: Create a new project
     create_promise = project_agent.request_capability(
-        name="create_project",
-        description="A demonstration of the Promise System"
+        name="create_project", description="A demonstration of the Promise System"
     )
     process_all_agents()
 
@@ -244,16 +259,8 @@ def run_example():
     logger.info(f"Created project: {project_info['name']}")
 
     # Step 2: Use math capabilities
-    add_promise = math_agent.request_capability(
-        name="add",
-        a=5,
-        b=7
-    )
-    multiply_promise = math_agent.request_capability(
-        name="multiply",
-        a=3,
-        b=4
-    )
+    add_promise = math_agent.request_capability(name="add", a=5, b=7)
+    multiply_promise = math_agent.request_capability(name="multiply", a=3, b=4)
     process_all_agents()
 
     add_result = add_promise.value
@@ -262,9 +269,7 @@ def run_example():
 
     # Step 3: Use text capabilities
     concat_promise = text_agent.request_capability(
-        name="concatenate",
-        texts=["Hello", "Promise", "System"],
-        separator=", "
+        name="concatenate", texts=["Hello", "Promise", "System"], separator=", "
     )
     process_all_agents()
 
@@ -280,8 +285,7 @@ def run_example():
     """
 
     analyze_promise = project_agent.request_capability(
-        name="analyze_requirements",
-        requirements=requirements
+        name="analyze_requirements", requirements=requirements
     )
     process_all_agents()
 
@@ -292,14 +296,9 @@ def run_example():
     logger.info("Example workflow completed successfully!")
     return {
         "project": project_info,
-        "math_results": {
-            "addition": add_result,
-            "multiplication": multiply_result
-        },
-        "text_results": {
-            "concatenation": concat_result
-        },
-        "requirements_analysis": analysis
+        "math_results": {"addition": add_result, "multiplication": multiply_result},
+        "text_results": {"concatenation": concat_result},
+        "requirements_analysis": analysis,
     }
 
 
@@ -307,13 +306,16 @@ if __name__ == "__main__":
     # Configure logging
     logging.basicConfig(
         level=logging.INFO,
-        format="%(asctime)s - %(name)s - %(levelname)s - %(message)s"
+        format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
     )
 
     # Run the example
     result = run_example()
-    print("\nExample Result:")
-    print(f"Project: {result['project']['name']}")
-    print(f"Math Results: {result['math_results']}")
-    print(f"Text Results: {result['text_results']}")
-    print(f"Requirements Analysis: {result['requirements_analysis']['total_requirements']} requirements")
+    logger.info("Example Result:")
+    logger.info("Project: %s", result["project"]["name"])
+    logger.info("Math Results: %s", result["math_results"])
+    logger.info("Text Results: %s", result["text_results"])
+    logger.info(
+        "Requirements Analysis: %s requirements",
+        result["requirements_analysis"]["total_requirements"],
+    )

--- a/tests/unit/test_methodology_logging.py
+++ b/tests/unit/test_methodology_logging.py
@@ -1,0 +1,13 @@
+import logging
+from devsynth.methodology.sprint import SprintAdapter
+from devsynth.methodology.base import Phase
+
+
+def test_phase_timeout_logs_warning(caplog):
+    caplog.set_level(logging.WARNING)
+    adapter = SprintAdapter({"settings": {}})
+    adapter._log_phase_timeout(Phase.EXPAND, ["activity1", "activity2"])
+    assert any(
+        "timed out" in record.message and record.levelno == logging.WARNING
+        for record in caplog.records
+    )


### PR DESCRIPTION
## Summary
- use `DevSynthLogger` in adapter modules and methodology classes
- log CLI help info instead of printing
- log interactive chat events
- add warning logs in sprint retrospective
- test that sprint timeouts are logged
- update CLI command steps to capture log output

## Testing
- `poetry run pytest tests/unit/test_methodology_logging.py -q`
- `poetry run pytest tests > /tmp/pytest.log` *(fails: ModuleNotFoundError: No module named 'pytest_bdd')*

------
https://chatgpt.com/codex/tasks/task_e_684c5301ebe883339a6f1148e7a9723d