### PR TITLE
Add CLI command tests

### DIFF
--- a/tests/unit/test_analyze_manifest_cmd.py
+++ b/tests/unit/test_analyze_manifest_cmd.py
@@ -1,0 +1,65 @@
+"""Tests for the analyze_manifest_cmd CLI command."""
+
+from pathlib import Path
+from unittest.mock import patch, MagicMock
+
+import yaml
+
+from devsynth.application.cli.commands.analyze_manifest_cmd import analyze_manifest_cmd
+
+
+@patch("devsynth.application.cli.commands.analyze_manifest_cmd.Console")
+@patch("devsynth.application.cli.commands.analyze_manifest_cmd.analyze_project_structure")
+@patch("devsynth.application.cli.commands.analyze_manifest_cmd.compare_with_manifest")
+@patch("devsynth.application.cli.commands.analyze_manifest_cmd.update_manifest")
+@patch("yaml.dump")
+def test_analyze_manifest_update(mock_dump, mock_update, mock_compare, mock_analyze, mock_console, tmp_path):
+    manifest_path = tmp_path / "devsynth.yaml"
+    yaml.safe_dump({"projectName": "Test"}, manifest_path.open("w"))
+
+    mock_analyze.return_value = {}
+    mock_compare.return_value = [{"type": "source", "path": "src", "status": "missing in manifest"}]
+    mock_update.return_value = {"updated": True}
+
+    analyze_manifest_cmd(path=str(tmp_path), update=True)
+
+    mock_analyze.assert_called_once_with(Path(str(tmp_path)))
+    mock_compare.assert_called_once()
+    mock_update.assert_called_once()
+    mock_dump.assert_called_once()
+    assert any(
+        "Configuration updated successfully" in str(call.args[0])
+        for call in mock_console.return_value.print.call_args_list
+    )
+
+
+@patch("devsynth.application.cli.commands.analyze_manifest_cmd.Console")
+@patch("devsynth.application.cli.commands.analyze_manifest_cmd.analyze_project_structure")
+@patch("devsynth.application.cli.commands.analyze_manifest_cmd.compare_with_manifest")
+@patch("devsynth.application.cli.commands.analyze_manifest_cmd.prune_manifest")
+@patch("yaml.dump")
+def test_analyze_manifest_prune(mock_dump, mock_prune, mock_compare, mock_analyze, mock_console, tmp_path):
+    manifest_path = tmp_path / "devsynth.yaml"
+    yaml.safe_dump({"projectName": "Test"}, manifest_path.open("w"))
+
+    mock_analyze.return_value = {}
+    mock_compare.return_value = [{"type": "tests", "path": "tests", "status": "missing in project"}]
+    mock_prune.return_value = {"pruned": True}
+
+    analyze_manifest_cmd(path=str(tmp_path), prune=True)
+
+    mock_analyze.assert_called_once_with(Path(str(tmp_path)))
+    mock_compare.assert_called_once()
+    mock_prune.assert_called_once()
+    mock_dump.assert_called_once()
+    assert any(
+        "Configuration pruned successfully" in str(call.args[0])
+        for call in mock_console.return_value.print.call_args_list
+    )
+
+
+@patch("devsynth.application.cli.commands.analyze_manifest_cmd.Console")
+def test_analyze_manifest_no_config(mock_console, tmp_path):
+    analyze_manifest_cmd(path=str(tmp_path))
+    mock_console.return_value.print.assert_any_call("[yellow]Warning: No configuration file found. Run 'devsynth init' to create it.[/yellow]")
+

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -70,3 +70,35 @@ class TestTyperCLI:
         result = self.runner.invoke(app, ["config", "enable-feature", "code_generation"])
         assert result.exit_code == 0
         mock_enable_cmd.assert_called_once_with("code_generation")
+
+    @patch("devsynth.adapters.cli.argparse_adapter.edrr_cycle_cmd", autospec=True)
+    def test_cli_edrr_cycle(self, mock_cmd):
+        app = build_app()
+        result = self.runner.invoke(app, ["edrr-cycle", "path/to/manifest.yaml"])
+        assert result.exit_code == 0
+        mock_cmd.assert_called_once_with("path/to/manifest.yaml")
+
+    @patch("devsynth.adapters.cli.argparse_adapter.analyze_manifest_cmd", autospec=True)
+    def test_cli_analyze_manifest_update(self, mock_cmd):
+        app = build_app()
+        result = self.runner.invoke(app, [
+            "analyze-manifest",
+            "--path",
+            "./proj",
+            "--update",
+        ])
+        assert result.exit_code == 0
+        mock_cmd.assert_called_once_with("./proj", True, False)
+
+    @patch("devsynth.adapters.cli.argparse_adapter.analyze_manifest_cmd", autospec=True)
+    def test_cli_analyze_manifest_prune(self, mock_cmd):
+        app = build_app()
+        result = self.runner.invoke(app, [
+            "analyze-manifest",
+            "--path",
+            "./proj",
+            "--prune",
+        ])
+        assert result.exit_code == 0
+        mock_cmd.assert_called_once_with("./proj", False, True)
+

--- a/tests/unit/test_edrr_cycle_cmd.py
+++ b/tests/unit/test_edrr_cycle_cmd.py
@@ -1,0 +1,56 @@
+"""Tests for the edrr_cycle_cmd CLI command."""
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from devsynth.application.cli.commands.edrr_cycle_cmd import edrr_cycle_cmd
+from devsynth.methodology.base import Phase
+
+
+@pytest.fixture
+def mock_console():
+    with patch("devsynth.application.cli.commands.edrr_cycle_cmd.Console") as mock:
+        yield mock.return_value
+
+
+@pytest.fixture
+def mock_components():
+    with patch("devsynth.application.cli.commands.edrr_cycle_cmd.EDRRCoordinator") as coord_cls, \
+        patch("devsynth.application.cli.commands.edrr_cycle_cmd.MemoryManager") as manager_cls:
+        coordinator = MagicMock()
+        coordinator.generate_report.return_value = {"ok": True}
+        coordinator.cycle_id = "cid"
+        coord_cls.return_value = coordinator
+
+        memory_manager = MagicMock()
+        memory_manager.store_with_edrr_phase.return_value = "rid"
+        manager_cls.return_value = memory_manager
+
+        yield coordinator, memory_manager
+
+
+def test_edrr_cycle_cmd_manifest_missing(tmp_path, mock_console):
+    missing = tmp_path / "manifest.yaml"
+    edrr_cycle_cmd(str(missing))
+    mock_console.print.assert_called_once_with(f"[red]Manifest file not found:[/red] {missing}")
+
+
+def test_edrr_cycle_cmd_success(tmp_path, mock_console, mock_components):
+    manifest = tmp_path / "manifest.yaml"
+    manifest.write_text("project: test")
+
+    coordinator, memory_manager = mock_components
+
+    edrr_cycle_cmd(str(manifest))
+
+    coordinator.start_cycle_from_manifest.assert_called_once_with(manifest, is_file=True)
+    assert coordinator.progress_to_phase.call_count == 4
+    memory_manager.store_with_edrr_phase.assert_called_once_with(
+        coordinator.generate_report.return_value,
+        "EDRR_CYCLE_RESULTS",
+        Phase.RETROSPECT.value,
+        {"cycle_id": coordinator.cycle_id},
+    )
+    assert any("EDRR cycle completed" in call.args[0] for call in mock_console.print.call_args_list)


### PR DESCRIPTION
## Summary
- test CLI options for `edrr-cycle` and `analyze-manifest`
- add unit tests for `edrr_cycle_cmd`
- add unit tests for `analyze_manifest_cmd`

## Testing
- `poetry run pytest tests/unit/test_cli.py::TestTyperCLI::test_cli_edrr_cycle -q`
- `poetry run pytest tests/unit/test_edrr_cycle_cmd.py::test_edrr_cycle_cmd_success -q`
- `poetry run pytest tests/unit/test_analyze_manifest_cmd.py::test_analyze_manifest_update -q`
- `poetry run pytest tests/unit/test_analyze_manifest_cmd.py::test_analyze_manifest_prune -q`
- `poetry run pytest tests/unit/test_analyze_manifest_cmd.py::test_analyze_manifest_no_config -q`
- `poetry run pytest` *(fails: ModuleNotFoundError and other errors)*

------
https://chatgpt.com/codex/tasks/task_e_684c56bdf56c8333bc81a7e894e04a7a