### PR TITLE
Handle optional backends gracefully

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,13 @@ Before running the test suite, **install DevSynth with its development extras**.
 pip install -e ".[dev]"
 ```
 
+Some tests rely on optional backends like **ChromaDB**, **FAISS**, and **LMDB**.
+Ensure these packages are installed as well:
+
+```bash
+pip install chromadb faiss-cpu lmdb
+```
+
 For a smaller core install you can instead run:
 
 ```bash

--- a/src/devsynth/adapters/chromadb_memory_store.py
+++ b/src/devsynth/adapters/chromadb_memory_store.py
@@ -1,6 +1,11 @@
-import chromadb
-from chromadb.config import Settings
-from chromadb.utils import embedding_functions
+try:
+    import chromadb
+    from chromadb.config import Settings
+    from chromadb.utils import embedding_functions
+except ImportError as e:  # pragma: no cover - optional dependency
+    raise ImportError(
+        "ChromaDBMemoryStore requires the 'chromadb' package. Install it with 'pip install chromadb' or use the dev extras."
+    ) from e
 from typing import Any, Dict, List, Optional, Union, ContextManager
 import os
 import logging

--- a/src/devsynth/adapters/memory/chroma_db_adapter.py
+++ b/src/devsynth/adapters/memory/chroma_db_adapter.py
@@ -6,7 +6,12 @@ ChromaDB adapter for vector storage.
 import os
 import json
 import uuid
-import chromadb
+try:
+    import chromadb
+except ImportError as e:  # pragma: no cover - optional dependency
+    raise ImportError(
+        "ChromaDBAdapter requires the 'chromadb' package. Install it with 'pip install chromadb' or use the dev extras."
+    ) from e
 import numpy as np
 from typing import Any, Dict, List, Optional, Union
 from ...domain.interfaces.memory import VectorStore

--- a/src/devsynth/application/memory/chromadb_store.py
+++ b/src/devsynth/application/memory/chromadb_store.py
@@ -14,7 +14,13 @@ from datetime import datetime
 from functools import lru_cache
 from typing import Any, Dict, List, Optional, Tuple, Union
 
-import chromadb
+try:
+    import chromadb
+except ImportError as e:  # pragma: no cover - optional dependency
+    raise ImportError(
+        "ChromaDBStore requires the 'chromadb' package. Install it with 'pip install chromadb' or use the dev extras."
+    ) from e
+
 import tiktoken
 
 from devsynth.exceptions import (

--- a/src/devsynth/application/memory/faiss_store.py
+++ b/src/devsynth/application/memory/faiss_store.py
@@ -9,7 +9,12 @@ import json
 import uuid
 import tiktoken
 import numpy as np
-import faiss
+try:
+    import faiss
+except ImportError as e:  # pragma: no cover - optional dependency
+    raise ImportError(
+        "FAISSStore requires the 'faiss' package. Install it with 'pip install faiss-cpu' or use the dev extras."
+    ) from e
 from typing import Dict, List, Any, Optional, Union, Tuple
 from datetime import datetime
 from pathlib import Path

--- a/src/devsynth/application/memory/lmdb_store.py
+++ b/src/devsynth/application/memory/lmdb_store.py
@@ -9,7 +9,12 @@ import os
 import json
 import uuid
 import tiktoken
-import lmdb
+try:
+    import lmdb
+except ImportError as e:  # pragma: no cover - optional dependency
+    raise ImportError(
+        "LMDBStore requires the 'lmdb' package. Install it with 'pip install lmdb' or use the dev extras."
+    ) from e
 from typing import Dict, List, Any, Optional, ContextManager
 from datetime import datetime
 from contextlib import contextmanager

--- a/tests/behavior/steps/additional_storage_backends_steps.py
+++ b/tests/behavior/steps/additional_storage_backends_steps.py
@@ -17,6 +17,11 @@ from devsynth.application.memory.lmdb_store import LMDBStore
 from devsynth.application.memory.faiss_store import FAISSStore
 from devsynth.ports.memory_port import MemoryPort
 
+pytestmark = [
+    pytest.mark.requires_resource("lmdb"),
+    pytest.mark.requires_resource("faiss"),
+]
+
 # Register the scenarios from the feature file
 scenarios('../features/additional_storage_backends.feature')
 

--- a/tests/behavior/steps/chromadb_steps.py
+++ b/tests/behavior/steps/chromadb_steps.py
@@ -15,6 +15,8 @@ from devsynth.adapters.chromadb_memory_store import ChromaDBMemoryStore
 from devsynth.ports.memory_port import MemoryPort
 from devsynth.adapters.provider_system import get_provider, embed
 
+pytestmark = pytest.mark.requires_resource("chromadb")
+
 
 @pytest.fixture
 def temp_chromadb_path(tmp_project_dir):

--- a/tests/behavior/steps/enhanced_chromadb_steps.py
+++ b/tests/behavior/steps/enhanced_chromadb_steps.py
@@ -17,6 +17,8 @@ from devsynth.adapters.chromadb_memory_store import ChromaDBMemoryStore
 from devsynth.ports.memory_port import MemoryPort
 from devsynth.adapters.provider_system import get_provider, embed
 
+pytestmark = pytest.mark.requires_resource("chromadb")
+
 
 class MemoryStoreWithCache(ChromaDBMemoryStore):
     """Extended ChromaDBMemoryStore with caching capabilities for testing."""

--- a/tests/behavior/steps/test_memory_backend_integration_steps.py
+++ b/tests/behavior/steps/test_memory_backend_integration_steps.py
@@ -18,6 +18,12 @@ from devsynth.adapters.agents.agent_adapter import WSDETeamCoordinator
 from devsynth.application.agents.unified_agent import UnifiedAgent
 from devsynth.domain.models.agent import AgentConfig, AgentType
 from devsynth.adapters.memory.memory_adapter import MemorySystemAdapter
+
+pytestmark = [
+    pytest.mark.requires_resource("chromadb"),
+    pytest.mark.requires_resource("lmdb"),
+    pytest.mark.requires_resource("faiss"),
+]
 from devsynth.application.memory.memory_manager import MemoryManager
 from devsynth.domain.models.memory import MemoryItem, MemoryType
 

--- a/tests/behavior/test_chromadb_integration.py
+++ b/tests/behavior/test_chromadb_integration.py
@@ -5,6 +5,8 @@ import os
 import pytest
 from pytest_bdd import scenarios
 
+pytestmark = pytest.mark.requires_resource("chromadb")
+
 # Import step definitions
 from .steps.cli_commands_steps import *
 from .steps.chromadb_steps import *

--- a/tests/behavior/test_enhanced_chromadb_integration.py
+++ b/tests/behavior/test_enhanced_chromadb_integration.py
@@ -5,6 +5,8 @@ import os
 import pytest
 from pytest_bdd import scenarios
 
+pytestmark = pytest.mark.requires_resource("chromadb")
+
 # Import step definitions
 from .steps.cli_commands_steps import *
 from .steps.chromadb_steps import *

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -430,6 +430,39 @@ def is_cli_available() -> bool:
     if os.environ.get("DEVSYNTH_RESOURCE_CLI_AVAILABLE", "true").lower() == "false":
         return False
 
+
+def is_chromadb_available() -> bool:
+    """Check if the chromadb package is installed."""
+    if os.environ.get("DEVSYNTH_RESOURCE_CHROMADB_AVAILABLE", "true").lower() == "false":
+        return False
+    try:  # pragma: no cover - simple import check
+        import chromadb  # noqa: F401
+        return True
+    except Exception:
+        return False
+
+
+def is_faiss_available() -> bool:
+    """Check if the faiss package is installed."""
+    if os.environ.get("DEVSYNTH_RESOURCE_FAISS_AVAILABLE", "true").lower() == "false":
+        return False
+    try:  # pragma: no cover - simple import check
+        import faiss  # noqa: F401
+        return True
+    except Exception:
+        return False
+
+
+def is_lmdb_available() -> bool:
+    """Check if the lmdb package is installed."""
+    if os.environ.get("DEVSYNTH_RESOURCE_LMDB_AVAILABLE", "true").lower() == "false":
+        return False
+    try:  # pragma: no cover - simple import check
+        import lmdb  # noqa: F401
+        return True
+    except Exception:
+        return False
+
     # Actual availability check
     try:
         import subprocess
@@ -459,6 +492,9 @@ def is_resource_available(resource: str) -> bool:
         "lmstudio": is_lmstudio_available,
         "codebase": is_codebase_available,
         "cli": is_cli_available,
+        "chromadb": is_chromadb_available,
+        "faiss": is_faiss_available,
+        "lmdb": is_lmdb_available,
     }
 
     # Get the checker function for the resource

--- a/tests/unit/adapters/memory/test_memory_adapter.py
+++ b/tests/unit/adapters/memory/test_memory_adapter.py
@@ -10,8 +10,14 @@ from devsynth.adapters.memory.memory_adapter import MemorySystemAdapter
 from devsynth.application.memory.json_file_store import JSONFileStore
 from devsynth.application.memory.tinydb_store import TinyDBStore
 from devsynth.application.memory.duckdb_store import DuckDBStore
-from devsynth.application.memory.lmdb_store import LMDBStore
-from devsynth.application.memory.faiss_store import FAISSStore
+try:
+    from devsynth.application.memory.lmdb_store import LMDBStore
+except ImportError:  # pragma: no cover - optional dependency
+    LMDBStore = None
+try:
+    from devsynth.application.memory.faiss_store import FAISSStore
+except ImportError:  # pragma: no cover - optional dependency
+    FAISSStore = None
 from devsynth.application.memory.rdflib_store import RDFLibStore
 from devsynth.application.memory.context_manager import InMemoryStore, SimpleContextManager
 from devsynth.application.memory.persistent_context_manager import PersistentContextManager
@@ -95,6 +101,7 @@ class TestMemorySystemAdapter:
             assert adapter.vector_store is not None
             assert adapter.vector_store is adapter.memory_store  # DuckDB implements both interfaces
 
+    @pytest.mark.requires_resource("lmdb")
     def test_init_with_lmdb_storage(self, temp_dir):
         """Test initialization with LMDB storage."""
         config = {
@@ -112,6 +119,7 @@ class TestMemorySystemAdapter:
         assert isinstance(adapter.context_manager, PersistentContextManager)
         assert adapter.vector_store is None
 
+    @pytest.mark.requires_resource("faiss")
     def test_init_with_faiss_storage(self, temp_dir):
         """Test initialization with FAISS storage."""
         config = {
@@ -130,6 +138,7 @@ class TestMemorySystemAdapter:
         assert adapter.vector_store is not None
         assert isinstance(adapter.vector_store, FAISSStore)
 
+    @pytest.mark.requires_resource("faiss")
     def test_faiss_vector_store_operations(self, temp_dir):
         """Test vector store operations with FAISS."""
         config = {
@@ -170,6 +179,7 @@ class TestMemorySystemAdapter:
         assert vector_store.delete_vector(vector_id) is True
         assert vector_store.retrieve_vector(vector_id) is None
 
+    @pytest.mark.requires_resource("faiss")
     def test_memory_and_vector_store_integration(self, temp_dir):
         """Test integration between memory store and vector store."""
         config = {

--- a/tests/unit/adapters/test_chromadb_memory_store.py
+++ b/tests/unit/adapters/test_chromadb_memory_store.py
@@ -15,9 +15,15 @@ from devsynth.domain.models.memory import MemoryItem, MemoryType
 from devsynth.adapters.provider_system import ProviderError
 
 # Import ChromaDB dependencies
-import chromadb
-from chromadb.api import ClientAPI
-from chromadb.api.models.Collection import Collection
+try:
+    import chromadb
+    from chromadb.api import ClientAPI
+    from chromadb.api.models.Collection import Collection
+except ImportError:  # pragma: no cover - optional dependency
+    chromadb = None
+    ClientAPI = Collection = object
+
+pytestmark = pytest.mark.requires_resource("chromadb")
 
 # Create a mock ChromaDB client and collection for testing
 @pytest.fixture

--- a/tests/unit/application/memory/test_faiss_store.py
+++ b/tests/unit/application/memory/test_faiss_store.py
@@ -1,15 +1,20 @@
 import os
 import json
 import uuid
-import pytest
 import numpy as np
-import faiss
+try:
+    import faiss
+except ImportError:  # pragma: no cover - optional dependency
+    faiss = None
+import pytest
 from typing import Dict, List, Any, Optional
 from datetime import datetime, timedelta
 
 from devsynth.domain.models.memory import MemoryItem, MemoryType, MemoryVector
 from devsynth.application.memory.faiss_store import FAISSStore
 from devsynth.exceptions import MemoryStoreError
+
+pytestmark = pytest.mark.requires_resource("faiss")
 
 class TestFAISSStore:
     """Tests for the FAISSStore class."""

--- a/tests/unit/application/memory/test_lmdb_store.py
+++ b/tests/unit/application/memory/test_lmdb_store.py
@@ -7,8 +7,13 @@ from typing import Dict, List, Any, Optional
 from datetime import datetime, timedelta
 
 from devsynth.domain.models.memory import MemoryItem, MemoryType
-from devsynth.application.memory.lmdb_store import LMDBStore
+try:
+    from devsynth.application.memory.lmdb_store import LMDBStore
+except ImportError:  # pragma: no cover - optional dependency
+    LMDBStore = None
 from devsynth.exceptions import MemoryStoreError
+
+pytestmark = pytest.mark.requires_resource("lmdb")
 
 class TestLMDBStore:
     """Tests for the LMDBStore class."""

--- a/tests/unit/security/test_memory_encryption.py
+++ b/tests/unit/security/test_memory_encryption.py
@@ -1,8 +1,12 @@
 import os
 import json
 import tempfile
+import pytest
 from devsynth.application.memory.json_file_store import JSONFileStore
-from devsynth.application.memory.lmdb_store import LMDBStore
+try:
+    from devsynth.application.memory.lmdb_store import LMDBStore
+except ImportError:  # pragma: no cover - optional dependency
+    LMDBStore = None
 from devsynth.domain.models.memory import MemoryItem, MemoryType
 from devsynth.security.encryption import generate_key
 
@@ -21,6 +25,7 @@ def test_json_file_store_encryption(tmp_path):
     assert retrieved.content == "secret"
 
 
+@pytest.mark.requires_resource("lmdb")
 def test_lmdb_store_encryption(tmp_path):
     key = generate_key()
     store = LMDBStore(str(tmp_path), encryption_enabled=True, encryption_key=key)

--- a/tests/unit/test_chromadb_store.py
+++ b/tests/unit/test_chromadb_store.py
@@ -1,6 +1,7 @@
 """
 Unit tests for the ChromaDBStore class.
 """
+import pytest
 import os
 import json
 import shutil
@@ -12,6 +13,8 @@ from unittest.mock import patch, MagicMock
 
 from devsynth.domain.models.memory import MemoryItem, MemoryType
 from devsynth.application.memory.chromadb_store import ChromaDBStore
+
+pytestmark = pytest.mark.requires_resource("chromadb")
 
 
 class TestChromaDBStore(unittest.TestCase):

--- a/tests/unit/test_enhanced_chromadb_store.py
+++ b/tests/unit/test_enhanced_chromadb_store.py
@@ -1,6 +1,7 @@
 """
 Unit tests for the enhanced ChromaDBStore class.
 """
+import pytest
 import os
 import json
 import shutil
@@ -13,6 +14,8 @@ from unittest.mock import patch, MagicMock, call
 
 from devsynth.domain.models.memory import MemoryItem, MemoryType
 from devsynth.application.memory.chromadb_store import ChromaDBStore
+
+pytestmark = pytest.mark.requires_resource("chromadb")
 
 
 class TestEnhancedChromaDBStore(unittest.TestCase):

--- a/tests/unit/test_memory_system_with_chromadb.py
+++ b/tests/unit/test_memory_system_with_chromadb.py
@@ -2,6 +2,7 @@
 """
 Unit tests for the MemorySystemAdapter with ChromaDB integration.
 """
+import pytest
 import os
 import json
 import shutil
@@ -18,6 +19,8 @@ from devsynth.domain.models.memory import MemoryItem, MemoryType, MemoryVector
 from devsynth.adapters.memory.memory_adapter import MemorySystemAdapter
 from devsynth.adapters.memory.chroma_db_adapter import ChromaDBAdapter
 from devsynth.exceptions import MemoryStoreError
+
+pytestmark = pytest.mark.requires_resource("chromadb")
 
 
 class TestMemorySystemWithChromaDB:


### PR DESCRIPTION
## Summary
- wrap optional imports in try/except blocks
- skip backend-specific tests when requirements missing
- mention optional extras for full test suite

## Testing
- `pip install pytest-bdd`
- `pip install -e .[dev]`
- `pytest -q` *(fails: 24 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_684c81f22b088333aab711f6da24ea6c