### PR TITLE
Add implementation status notes across docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Full documentation is available in the [docs/](docs/index.md) directory and onli
 - [Progressive Feature Setup](docs/user_guides/progressive_setup.md)
 - [Architecture Overview](docs/architecture/overview.md)
 - [Project Analysis](docs/analysis/executive_summary.md)
-- [Implementation Status](docs/implementation/feature_status_matrix.md)
+- [Implementation Status Matrix](docs/implementation/feature_status_matrix.md)
 - [Requirements Traceability Matrix](docs/requirements_traceability.md)
 - [SDLC Policies](docs/policies/index.md)
 

--- a/docs/architecture/agent_system.md
+++ b/docs/architecture/agent_system.md
@@ -19,6 +19,8 @@ last_reviewed: "2025-05-28"
 
 The DevSynth agent system leverages LangGraph to create modular, stateful, and resilient AI agents. This architecture allows for the construction of complex workflows where agents can perform tasks, make decisions, and interact with other DevSynth components like the memory system and provider system.
 
+**Implementation Status:** Core agent orchestration is implemented, but advanced WSDE collaboration features remain in progress.
+
 The agent system is organized according to the Worker Self-Directed Enterprise (WSDE) model, which provides a non-hierarchical, collaborative framework for agent interaction. This model ensures that agents work together as peers with complementary capabilities, with leadership (Primus role) rotating based on task expertise.
 
 This document outlines the foundational components of the agent system, including the WSDE model, `AgentState`, and the `base_agent_graph`.

--- a/docs/implementation/edrr_assessment.md
+++ b/docs/implementation/edrr_assessment.md
@@ -21,6 +21,8 @@ This document provides a comprehensive assessment of the current implementation 
 
 The EDRR framework is a structured approach to problem-solving that guides the DevSynth system through four distinct phases:
 
+**Implementation Status:** The framework is partially implemented, with overall completeness around 55% across all phases.
+
 1. **Expand**: Divergent thinking to explore possibilities and generate ideas
 2. **Differentiate**: Comparative analysis to evaluate options and identify trade-offs
 3. **Refine**: Convergent thinking to elaborate details and optimize solutions

--- a/docs/implementation/feature_status_matrix.md
+++ b/docs/implementation/feature_status_matrix.md
@@ -16,6 +16,8 @@ last_reviewed: "2025-06-01"
 
 This document provides a comprehensive status matrix for all features in the DevSynth project. It is a key deliverable of the Feature Implementation Audit conducted as part of Phase 1: Foundation Stabilization.
 
+**Implementation Status:** The overall project is **partially implemented**. Each feature row below lists the current completion level and outstanding work.
+
 ## Status Categories
 
 Features are categorized according to their implementation status:
@@ -50,7 +52,7 @@ Each feature is scored on two dimensions:
 | Message Passing Protocol | Fully Implemented (100%) | src/devsynth/application/collaboration/message_protocol.py | 4 | 2 | WSDE Model | | Enables structured agent communication |
 | Peer Review Mechanism | Partially Implemented (50%) | src/devsynth/application/collaboration/peer_review.py | 4 | 3 | WSDE Model | | Initial review cycle implemented, full workflow pending |
 | Memory System | Fully Implemented (100%) | src/devsynth/application/memory | 5 | 4 | None | | Complete with ChromaDB integration |
-| LLM Provider System | Partially Implemented (80%) | src/devsynth/application/llm | 5 | 3 | None | | LM Studio provider fully implemented; OpenAI and Anthropic providers are stubs |
+| LLM Provider System | Partially Implemented (80%) | src/devsynth/application/llm | 5 | 3 | None | | LM Studio and OpenAI providers implemented; Anthropic provider remains a stub |
 | LM Studio Integration | Partially Implemented (90%) | src/devsynth/application/llm/lmstudio_provider.py | 4 | 3 | LLM Provider System | | Local provider stable; remote support experimental |
 | Code Analysis | Partially Implemented (60%) | src/devsynth/application/code_analysis | 4 | 4 | None | | AST visitor and project state analyzer implemented |
 | Knowledge Graph Utilities | Partially Implemented (50%) | src/devsynth/application/memory/knowledge_graph_utils.py | 3 | 3 | Memory System | | Basic querying available |
@@ -66,7 +68,7 @@ Each feature is scored on two dimensions:
 | Docker Containerization | Fully Implemented (100%) | Dockerfile, docker-compose.yml | 4 | 3 | None | | Dockerfile and Compose provided |
 | Configuration Management | Partially Implemented (75%) | src/devsynth/config, config/ | 4 | 3 | None | | Environment-specific templates available |
 | Deployment Automation | Partially Implemented (60%) | docker-compose.yml, scripts/deployment | 3 | 3 | Docker | | Basic Docker Compose workflows |
-| Security Framework | Partially Implemented (50%) | src/devsynth/security | 4 | 4 | None | | Environment validation and security policies added; encryption pending |
+| Security Framework | Partially Implemented (50%) | src/devsynth/security | 4 | 4 | None | | Environment validation, security policies, and Fernet-based encryption implemented |
 | Dependency Management | Partially Implemented (40%) | pyproject.toml | 3 | 2 | None | | Basic management implemented, optimization pending |
 
 ## Current Limitations and Workarounds

--- a/docs/implementation/wsde_validation.md
+++ b/docs/implementation/wsde_validation.md
@@ -22,6 +22,8 @@ This document provides a comprehensive validation of the current implementation 
 
 The Worker Self-Directed Enterprise model is a collaborative agent system with peer-based interactions that guides how agents work together in DevSynth. Key principles include:
 
+**Implementation Status:** The WSDE model is partially implemented with an overall completeness of about 45%.
+
 1. **Non-hierarchical Decision Making**: Decisions made through consensus rather than top-down authority
 2. **Dynamic Role Assignment**: Roles assigned based on expertise and context rather than fixed positions
 3. **Collaborative Problem Solving**: Multiple agents working together to solve complex problems

--- a/docs/technical_reference/code_analysis.md
+++ b/docs/technical_reference/code_analysis.md
@@ -4,6 +4,8 @@
 
 The Code Analysis feature enables DevSynth to analyze Python code and extract information about its structure, including imports, classes, functions, variables, and docstrings. This feature is a foundational component of the Self-Analysis Capabilities phase of the post-MVP roadmap, allowing DevSynth to understand its own codebase and other Python projects.
 
+**Implementation Status:** Core AST parsing and project analysis are implemented. Adapters for external tools are still under development.
+
 ## Architecture
 
 The Code Analysis feature follows the hexagonal architecture pattern used throughout DevSynth:

--- a/docs/technical_reference/expand_differentiate_refine_retrospect.md
+++ b/docs/technical_reference/expand_differentiate_refine_retrospect.md
@@ -19,6 +19,8 @@ last_reviewed: "2025-05-20"
 
 This document describes DevSynth's four-phase iterative approach that serves as the core methodology for all system processes. Originally developed for project ingestion, this dialectical methodology has evolved into DevSynth's fundamental approach for any task requiring iterative improvement and multi-disciplinary reasoning.
 
+**Implementation Status:** The EDRR framework is partially implemented. Phase behaviors and automation hooks are still being integrated across the codebase.
+
 The methodology enables DevSynth to tackle complex problems through a systematic cycle of bottom-up discovery, top-down validation, synthesis, and learning. While this document initially describes the process in the context of project ingestion, the principles apply universally across all DevSynth operations.
 
 > **Note**: While EDRR provides a logical progression for complex problem-solving, DevSynth does not require teams to adopt any specific workflow or timing for these phases. See the [Methodology Integration Framework](./methodology_integration_framework.md) for details on how to adapt EDRR to your team's preferred way of working.
@@ -310,6 +312,12 @@ While initially developed for project ingestion, the Expand-Differentiate-Refine
 2. **Differentiate**: Analyze patterns, identify potential causes, and prioritize hypotheses
 3. **Refine**: Develop and implement solution strategies, validating fixes against the identified issues
 4. **Retrospect**: Document root causes, solution patterns, and prevention strategies for future reference
+
+## Current Limitations
+
+- Full automation of phase transitions is still in development.
+- Monitoring and visualization tools are minimal.
+- Integration with WSDE collaboration features remains experimental.
 
 ## Conclusion
 

--- a/docs/technical_reference/knowledge_graph_utilities.md
+++ b/docs/technical_reference/knowledge_graph_utilities.md
@@ -6,6 +6,8 @@ This document provides an overview of the knowledge graph utilities in DevSynth 
 
 DevSynth includes a set of knowledge graph utilities that allow agents to query and use knowledge stored in a graph-based format. These utilities are particularly useful for enhancing dialectical reasoning by providing access to structured knowledge that can inform critiques, improvements, and evaluations.
 
+**Implementation Status:** Basic querying utilities are available, but advanced reasoning over graph relationships is still experimental.
+
 The knowledge graph utilities are implemented in the `WSDEMemoryIntegration` class and can be used with the `WSDETeam` class for dialectical reasoning.
 
 ## Knowledge Graph Utilities

--- a/docs/technical_reference/llm_integration.md
+++ b/docs/technical_reference/llm_integration.md
@@ -4,9 +4,13 @@ This document describes the LLM integration in DevSynth, focusing on the LM Stud
 
 ## Overview
 
-DevSynth supports multiple LLM providers through a flexible adapter pattern. The current implementation includes:
+DevSynth supports multiple LLM providers through a flexible adapter pattern.
 
-- OpenAI provider (stub)
+**Implementation Status:** LM Studio and OpenAI providers are fully implemented. The Anthropic provider remains a stub.
+
+The current implementation includes:
+
+- OpenAI provider (implemented)
 - Anthropic provider (stub)
 - LM Studio provider (fully implemented)
 

--- a/docs/technical_reference/lm_studio_integration.md
+++ b/docs/technical_reference/lm_studio_integration.md
@@ -6,6 +6,8 @@ This document describes the integration between DevSynth and LM Studio, includin
 
 DevSynth can use LM Studio as a provider for language models. LM Studio is a desktop application that allows you to run language models locally on your machine. By integrating with LM Studio, DevSynth can leverage these local models for various tasks, such as requirement analysis, specification generation, test generation, and code generation.
 
+**Implementation Status:** The LM Studio provider is stable for local use. Remote model support and advanced streaming remain experimental.
+
 ## Prerequisites
 
 - LM Studio installed and running on your machine

--- a/docs/technical_reference/methodology_integration_framework.md
+++ b/docs/technical_reference/methodology_integration_framework.md
@@ -4,6 +4,8 @@
 
 This document outlines DevSynth's approach to supporting multiple development methodologies while maintaining its core "Expand, Differentiate, Refine, Retrospect" (EDRR) process. Rather than prescribing a specific workflow, DevSynth provides an adaptable framework that can integrate with any team's preferred way of working.
 
+**Implementation Status:** A basic Sprint adapter is implemented. Additional methodology adapters and tooling integrations are planned.
+
 ## Core Design Principles
 
 1. **Methodology Agnosticism**: The core EDRR process functions independently of any specific development methodology

--- a/docs/technical_reference/sprint_edrr_integration.md
+++ b/docs/technical_reference/sprint_edrr_integration.md
@@ -4,6 +4,8 @@
 
 This document outlines a concrete strategy for aligning DevSynth's "Expand, Differentiate, Refine, Retrospect" (EDRR) methodology with traditional Agile sprint practices. This integration enhances DevSynth's ability to function as an effective SDLC tool by structuring its iterative processes within a familiar sprint framework.
 
+**Implementation Status:** Basic sprint alignment helpers exist, but full automation of sprint ceremonies within the EDRR workflow is ongoing.
+
 > **Note**: This document describes just one of several ways to integrate EDRR into your development workflow. If your team uses a different methodology, see the [Methodology Integration Framework](./methodology_integration_framework.md) for alternative approaches or how to customize DevSynth to your specific needs.
 
 ## 1. Core Principles of Integration


### PR DESCRIPTION
## Summary
- update feature status matrix with accurate provider and security info
- link to the matrix from README
- add implementation status notes and limitations across docs

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pytest_bdd')*

------
https://chatgpt.com/codex/tasks/task_e_684cc2ec473c8333a17a1ff47f5f5695