### PR TITLE
Ensure editable install for tests

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -57,6 +57,9 @@ pre-commit install
 ## Testing
 
 ```bash
+# Ensure the project is installed in editable mode
+poetry install
+
 # Run all tests
 poetry run pytest
 

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,5 +1,29 @@
-"""
-DevSynth Test Package
+"""DevSynth Test Package.
 
-This package contains all tests for the DevSynth project.
+This package ensures the test suite can import ``devsynth`` from the
+working tree.  If the package isn't already installed in editable mode,
+it installs it before tests are collected.  This mirrors the behaviour
+of CI workflows which call ``pip install -e .[dev]``.
 """
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+
+def _ensure_editable_install() -> None:
+    """Install ``devsynth`` in editable mode if it's not available."""
+
+    try:  # pragma: no cover - minimal safety check
+        import devsynth  # noqa: F401
+        return
+    except Exception:
+        pass
+
+    root = Path(__file__).resolve().parents[1]
+    subprocess.check_call([sys.executable, "-m", "pip", "install", "-e", str(root)])
+
+
+_ensure_editable_install()


### PR DESCRIPTION
## Summary
- install devsynth in editable mode from tests package so imports work
- mention running `poetry install` before tests

## Testing
- `poetry run pytest --collect-only`

------
https://chatgpt.com/codex/tasks/task_e_684d02a361788333bc806a576362845a