### PR TITLE
Add message store and peer review workflow

### DIFF
--- a/src/devsynth/application/collaboration/message_protocol.py
+++ b/src/devsynth/application/collaboration/message_protocol.py
@@ -2,7 +2,9 @@ from __future__ import annotations
 
 """Message passing protocol for WSDE agents."""
 
-from dataclasses import dataclass
+import json
+import os
+from dataclasses import dataclass, field, asdict
 from datetime import datetime
 from enum import Enum
 from typing import Any, Dict, List, Optional
@@ -34,11 +36,117 @@ class Message:
     timestamp: datetime
 
 
-class MessageProtocol:
-    """Simple in-memory message passing implementation."""
+@dataclass
+class MessageThread:
+    """Group of messages in a conversation."""
 
-    def __init__(self) -> None:
-        self.history: List[Message] = []
+    thread_id: str
+    participants: List[str]
+    messages: List[str] = field(default_factory=list)
+
+    def add_message(self, message: Message) -> None:
+        if message.message_id not in self.messages:
+            self.messages.append(message.message_id)
+
+
+class MessageStore:
+    """Simple JSON file-based storage for messages."""
+
+    def __init__(self, storage_file: Optional[str] = None) -> None:
+        self.storage_file = storage_file or os.path.join(
+            os.getcwd(), ".devsynth", "messages.json"
+        )
+        self._ensure_directory_exists()
+        self.messages: Dict[str, Message] = self._load_messages()
+
+    # ------------------------------------------------------------------
+    # Internal utilities
+    # ------------------------------------------------------------------
+    def _ensure_directory_exists(self) -> None:
+        directory = os.path.dirname(self.storage_file)
+        no_file_logging = os.environ.get("DEVSYNTH_NO_FILE_LOGGING", "0").lower() in (
+            "1",
+            "true",
+            "yes",
+        )
+        if not no_file_logging:
+            os.makedirs(directory, exist_ok=True)
+
+    def _load_messages(self) -> Dict[str, Message]:
+        no_file_logging = os.environ.get("DEVSYNTH_NO_FILE_LOGGING", "0").lower() in (
+            "1",
+            "true",
+            "yes",
+        )
+        if no_file_logging or not os.path.exists(self.storage_file):
+            return {}
+        try:
+            with open(self.storage_file, "r", encoding="utf-8") as f:
+                data = json.load(f)
+        except Exception:
+            return {}
+
+        messages = {}
+        for item in data.get("messages", []):
+            try:
+                msg = Message(
+                    message_id=item["message_id"],
+                    message_type=MessageType(item["message_type"]),
+                    sender=item["sender"],
+                    recipients=item.get("recipients", []),
+                    subject=item.get("subject", ""),
+                    content=item.get("content"),
+                    metadata=item.get("metadata", {}),
+                    timestamp=datetime.fromisoformat(item["timestamp"]),
+                )
+                messages[msg.message_id] = msg
+            except Exception:
+                continue
+        return messages
+
+    def _save_messages(self) -> None:
+        no_file_logging = os.environ.get("DEVSYNTH_NO_FILE_LOGGING", "0").lower() in (
+            "1",
+            "true",
+            "yes",
+        )
+        if no_file_logging:
+            return
+        data = {
+            "messages": [
+                {
+                    "message_id": m.message_id,
+                    "message_type": m.message_type.value,
+                    "sender": m.sender,
+                    "recipients": m.recipients,
+                    "subject": m.subject,
+                    "content": m.content,
+                    "metadata": m.metadata,
+                    "timestamp": m.timestamp.isoformat(),
+                }
+                for m in self.messages.values()
+            ]
+        }
+        with open(self.storage_file, "w", encoding="utf-8") as f:
+            json.dump(data, f, indent=2)
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+    def add_message(self, message: Message) -> None:
+        self.messages[message.message_id] = message
+        self._save_messages()
+
+    def get_all_messages(self) -> List[Message]:
+        return list(self.messages.values())
+
+
+class MessageProtocol:
+    """Message passing implementation with optional persistence."""
+
+    def __init__(self, store: Optional[MessageStore] = None) -> None:
+        self.store = store or MessageStore()
+        self.history: List[Message] = self.store.get_all_messages()
 
     def send_message(
         self,
@@ -68,6 +176,8 @@ class MessageProtocol:
             self.history.insert(0, message)
         else:
             self.history.append(message)
+
+        self.store.add_message(message)
         return message
 
     def get_messages(
@@ -75,7 +185,7 @@ class MessageProtocol:
     ) -> List[Message]:
         """Retrieve messages optionally filtered by agent or criteria."""
 
-        messages = list(self.history)
+        messages = list(self.store.get_all_messages())
         if agent:
             messages = [
                 m for m in messages if agent in m.recipients or m.sender == agent

--- a/src/devsynth/application/collaboration/peer_review.py
+++ b/src/devsynth/application/collaboration/peer_review.py
@@ -56,9 +56,53 @@ class PeerReview:
 
         self.status = "revision_requested"
 
+    def submit_revision(self, revision: Any) -> None:
+        """Submit a revised work product for further review."""
+
+        self.revision = revision
+        self.status = "revised"
+
     def finalize(self, approved: bool = True) -> Dict[str, Any]:
         """Finalize the peer review and return aggregated feedback."""
 
         self.status = "approved" if approved else "rejected"
         feedback = self.aggregate_feedback()
         return {"status": self.status, "feedback": feedback}
+
+
+@dataclass
+class PeerReviewWorkflow:
+    """Encapsulates a full peer review workflow."""
+
+    work_product: Any
+    author: Any
+    reviewers: List[Any]
+    send_message: Optional[Callable[..., Any]] = None
+
+    def run(self) -> Dict[str, Any]:
+        review = PeerReview(
+            work_product=self.work_product,
+            author=self.author,
+            reviewers=self.reviewers,
+            send_message=self.send_message,
+        )
+        review.assign_reviews()
+        review.collect_reviews()
+        return review.finalize()
+
+
+def run_peer_review(
+    work_product: Any,
+    author: Any,
+    reviewers: List[Any],
+    send_message: Optional[Callable[..., Any]] = None,
+) -> Dict[str, Any]:
+    """Convenience function to execute a full peer review."""
+
+    workflow = PeerReviewWorkflow(
+        work_product=work_product,
+        author=author,
+        reviewers=reviewers,
+        send_message=send_message,
+    )
+    return workflow.run()


### PR DESCRIPTION
## Summary
- extend message protocol with persistent `MessageStore`
- implement `PeerReviewWorkflow` utilities
- test persistence and peer review workflow

## Testing
- `pytest tests/integration/test_agent_collaboration_integration.py -q`
- `pytest tests -q` *(fails: 56 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_684d028e18bc8333a7cd7adde21da520