### PR TITLE
Enhance security policy and API access

### DIFF
--- a/.github/workflows/static_analysis.yml
+++ b/.github/workflows/static_analysis.yml
@@ -1,0 +1,24 @@
+name: Static Analysis
+
+on:
+  pull_request:
+    paths:
+      - '**/*.py'
+      - '.github/workflows/static_analysis.yml'
+  workflow_dispatch:
+
+jobs:
+  bandit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+      - name: Install Bandit
+        run: |
+          python -m pip install --upgrade pip
+          pip install bandit
+      - name: Run Bandit
+        run: bandit -r src -ll

--- a/docs/policies/data_retention.md
+++ b/docs/policies/data_retention.md
@@ -1,0 +1,9 @@
+# Data Retention Policy
+
+DevSynth retains data only as long as necessary for active tasks and auditing.
+
+- Memory store items are deleted when tasks complete unless archived.
+- Logs are rotated and removed after 30 days.
+- Backups of encrypted storage are kept for up to 90 days for disaster recovery.
+
+Users may request early deletion of their data via the project maintainers.

--- a/docs/policies/index.md
+++ b/docs/policies/index.md
@@ -27,6 +27,8 @@ This document serves as the central index and navigation point for all Software 
 | **Deployment** | [Deployment Policy](deployment.md) | Deployment workflow, environment management, and release process | Implemented |
 | **Maintenance** | [Maintenance Policy](maintenance.md) | Bug fixing, enhancement process, and version management | Implemented |
 | **Cross-Cutting** | [Cross-Cutting Concerns](cross_cutting.md) | Security, performance, accessibility, and other cross-cutting concerns | Implemented |
+| **Privacy** | [Privacy Policy](privacy.md) | Data handling and user privacy commitments | Implemented |
+| **Data Retention** | [Data Retention Policy](data_retention.md) | How long different data types are stored | Implemented |
 | **Alignment** | [Continuous Alignment Process](continuous_alignment_process.md) | Processes, checks, and metrics for maintaining alignment between SDLC artifacts | Implemented |
 
 ## Implementation Guides

--- a/docs/policies/privacy.md
+++ b/docs/policies/privacy.md
@@ -1,0 +1,9 @@
+# Privacy Policy
+
+DevSynth collects the minimal data necessary to operate. Personal data is processed only for project functionality and is never sold or shared with third parties.
+
+- Store all sensitive information in encrypted form when possible.
+- Use collected data solely for the stated purposes.
+- Provide a mechanism for users to request deletion of their data.
+
+See [data retention](data_retention.md) for how long data is stored.

--- a/docs/policies/security.md
+++ b/docs/policies/security.md
@@ -12,6 +12,7 @@ This policy outlines security design principles and operational guidelines for D
 ## Operational Guidelines
 - Enable or disable authentication, authorization and input sanitization via environment variables (`DEVSYNTH_AUTHENTICATION_ENABLED`, `DEVSYNTH_AUTHORIZATION_ENABLED`, `DEVSYNTH_SANITIZATION_ENABLED`).
 - Encryption at rest for memory stores can be toggled with `DEVSYNTH_ENCRYPTION_AT_REST` and a base64 key provided via `DEVSYNTH_ENCRYPTION_KEY`.
+- Encryption in transit can be enforced with `DEVSYNTH_ENCRYPTION_IN_TRANSIT`.
 - TLS verification and certificates are configured using `DEVSYNTH_TLS_VERIFY`, `DEVSYNTH_TLS_CERT_FILE`, `DEVSYNTH_TLS_KEY_FILE` and `DEVSYNTH_TLS_CA_FILE`.
 - Store API keys and secrets in environment variables or a secrets manager; never commit them to the repository.
 - Report suspected security issues or vulnerabilities through the issue tracker.
@@ -26,4 +27,17 @@ export DEVSYNTH_ENCRYPTION_KEY="$(python -c 'from devsynth.security.encryption i
 export DEVSYNTH_TLS_CERT_FILE=/path/to/cert.pem
 export DEVSYNTH_TLS_KEY_FILE=/path/to/key.pem
 export DEVSYNTH_TLS_CA_FILE=/path/to/ca.pem
+export DEVSYNTH_ACCESS_TOKEN=my-secret-token
 ```
+
+## Threat Model
+
+The primary threats considered include:
+
+- Unauthorized access to memory stores
+- Interception of API traffic
+- Misuse of agent or API credentials
+
+Mitigations include encryption at rest, optional TLS for all network
+communication, bearer token authentication for API and agent actions,
+and routine dependency and static analysis checks in CI.

--- a/src/devsynth/api.py
+++ b/src/devsynth/api.py
@@ -1,15 +1,28 @@
-from fastapi import FastAPI
+from fastapi import FastAPI, Depends, HTTPException, status, Header
 from fastapi.responses import Response
 from prometheus_client import Counter, generate_latest, CONTENT_TYPE_LATEST
 
 from devsynth.logging_setup import DevSynthLogger, configure_logging
+from devsynth.config.settings import get_settings
 
 configure_logging()
 logger = DevSynthLogger(__name__)
+settings = get_settings()
+
+
+def verify_token(authorization: str | None = Header(None)) -> None:
+    """Verify Bearer token from Authorization header if access control enabled."""
+    token = settings.access_token
+    if token and authorization != f"Bearer {token}":
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED, detail="Unauthorized"
+        )
+
 
 REQUEST_COUNT = Counter("request_count", "Total HTTP requests", ["endpoint"])
 
 app = FastAPI(title="DevSynth API")
+
 
 @app.middleware("http")
 async def count_requests(request, call_next):
@@ -17,14 +30,16 @@ async def count_requests(request, call_next):
     REQUEST_COUNT.labels(endpoint=request.url.path).inc()
     return RESPONSE
 
+
 @app.get("/health")
-async def health() -> dict[str, str]:
+async def health(token: None = Depends(verify_token)) -> dict[str, str]:
     """Simple health check endpoint."""
     logger.logger.debug("Health check accessed")
     return {"status": "ok"}
 
+
 @app.get("/metrics")
-async def metrics() -> Response:
+async def metrics(token: None = Depends(verify_token)) -> Response:
     """Expose Prometheus metrics."""
     data = generate_latest()
     return Response(data, media_type=CONTENT_TYPE_LATEST)

--- a/src/devsynth/config/settings.py
+++ b/src/devsynth/config/settings.py
@@ -130,6 +130,7 @@ class Settings(BaseSettings):
                 "DEVSYNTH_MEMORY_STORE", "memory"
             ),
             "openai_api_key": lambda s: os.environ.get("OPENAI_API_KEY", None),
+            "access_token": lambda s: os.environ.get("DEVSYNTH_ACCESS_TOKEN", None),
         }
 
         # Check if we have a mapping for this key
@@ -236,6 +237,11 @@ class Settings(BaseSettings):
         default=None,
         validation_alias="DEVSYNTH_ENCRYPTION_KEY",
         json_schema_extra={"env": "DEVSYNTH_ENCRYPTION_KEY"},
+    )
+    access_token: Optional[str] = Field(
+        default=None,
+        validation_alias="DEVSYNTH_ACCESS_TOKEN",
+        json_schema_extra={"env": "DEVSYNTH_ACCESS_TOKEN"},
     )
     tls_verify: bool = Field(
         default=True,

--- a/tests/unit/test_api_health.py
+++ b/tests/unit/test_api_health.py
@@ -1,14 +1,18 @@
+import os
 from devsynth.api import app
 from fastapi.testclient import TestClient
 
+os.environ["DEVSYNTH_ACCESS_TOKEN"] = "test-token"
 client = TestClient(app)
 
+
 def test_health_endpoint():
-    resp = client.get("/health")
+    resp = client.get("/health", headers={"Authorization": "Bearer test-token"})
     assert resp.status_code == 200
     assert resp.json() == {"status": "ok"}
 
+
 def test_metrics_endpoint():
-    resp = client.get("/metrics")
+    resp = client.get("/metrics", headers={"Authorization": "Bearer test-token"})
     assert resp.status_code == 200
     assert b"request_count" in resp.content


### PR DESCRIPTION
## Summary
- add privacy and data retention policies
- document threat model and new encryption options
- secure API endpoints with bearer token auth
- expose access token setting in configuration
- provide static analysis workflow
- update tests for new API token

## Testing
- `poetry run pytest -q tests/unit/test_api_health.py`
- `poetry run pytest -q` *(fails: ModuleNotFoundError: No module named 'pytest_bdd')*

------
https://chatgpt.com/codex/tasks/task_e_684d1a0ce45c83339af94c7c180bf4d8