### PR TITLE
Update CLI docs and requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ tags:
   - "readme"
 status: "published"
 author: "DevSynth Team"
-last_reviewed: "2025-05-30"
+last_reviewed: "2025-06-15"
 ---
 
 > Special note: LLMs have synthesized this project, with minimal manual editing, using a dialectical HITL methodology.

--- a/README.md
+++ b/README.md
@@ -26,6 +26,10 @@ DevSynth is an agentic software engineering platform that leverages LLMs, advanc
 - Provider abstraction for OpenAI, LM Studio, and more
 - Comprehensive SDLC policy corpus for agentic and human contributors
 - Automated documentation, testing, and CI/CD pipelines
+- Interactive `init` wizard for onboarding existing projects
+- Command names updated (`refactor`, `inspect`, `run-pipeline`, `retrace`)
+- Unified YAML/TOML configuration loader
+- CLI/WebUI bridge groundwork for future web interface
 - **Worker Self-Directed Enterprise (WSDE) Model**: Sophisticated multi-agent collaboration framework with role management, dialectical reasoning, consensus building, and knowledge integration capabilities
 - Dialectical reasoning hooks automatically analyze new solutions added to a WSDE team
 - **Adaptive Project Ingestion**: Dynamically understands and adapts to diverse project structures (including monorepos, multi-language projects, and custom layouts) using a `.devsynth/project.yaml` file and an "Expand, Differentiate, Refine, Retrospect" (EDRR) framework to keep its knowledge current. The EDRR framework is implemented through the EDRRCoordinator but is not yet fully integrated with all system components. The presence of a `.devsynth/` directory is the marker that a project is managed by DevSynth.
@@ -134,7 +138,7 @@ Use [`templates/project.yaml`](templates/project.yaml) as a reference for your `
 The repository includes runnable examples that walk through common workflows:
 
 - [Calculator](examples/calculator) – basic CLI-driven project generation
-- [Full Workflow](examples/full_workflow) – demonstrates the adaptive workflow
+- [Full Workflow](examples/full_workflow) – demonstrates the refactor workflow
 - [Agent Adapter](docs/getting_started/agent_adapter_example.md) – shows how to
   use the `AgentAdapter` directly from Python
 

--- a/docs/getting_started/agent_adapter_example.md
+++ b/docs/getting_started/agent_adapter_example.md
@@ -8,7 +8,7 @@ tags:
   - "example"
 status: "published"
 author: "DevSynth Team"
-last_reviewed: "2025-07-01"
+last_reviewed: "2025-06-15"
 ---
 
 # Agent Adapter Example

--- a/docs/getting_started/agent_adapter_example.md
+++ b/docs/getting_started/agent_adapter_example.md
@@ -26,6 +26,7 @@ Create a new project directory and initialize DevSynth:
 devsynth init --path agent-demo
 cd agent-demo
 ```
+The initializer detects existing configuration files and will prompt you interactively when run in an existing project directory.
 
 ## 2. Invoke the CLI
 

--- a/docs/getting_started/basic_usage.md
+++ b/docs/getting_started/basic_usage.md
@@ -31,7 +31,7 @@ devsynth init --path ./my-project
 cd my-project
 ```
 
-This command creates a new project directory with the necessary structure for DevSynth to work with.
+This command creates a new project directory with the necessary structure for DevSynth to work with. When executed inside an existing project, it now launches an interactive wizard that reads any `pyproject.toml` or `devsynth.yml` it finds.
 
 ## Define Requirements
 

--- a/docs/getting_started/basic_usage.md
+++ b/docs/getting_started/basic_usage.md
@@ -8,7 +8,7 @@ tags:
   - "tutorial"
 status: "published"
 author: "DevSynth Team"
-last_reviewed: "2024-06-01"
+last_reviewed: "2025-06-15"
 ---
 
 # Basic Usage

--- a/docs/getting_started/concise_walkthrough.md
+++ b/docs/getting_started/concise_walkthrough.md
@@ -25,6 +25,7 @@ Create a new project directory named `demo`:
 devsynth init --path demo
 cd demo
 ```
+`devsynth init` now walks you through an interactive setup if it detects existing project files.
 
 The command generates a `.devsynth/project.yaml` file. For reference, you can look at the example configuration in [`templates/project.yaml`](../../templates/project.yaml).
 

--- a/docs/getting_started/example_project.md
+++ b/docs/getting_started/example_project.md
@@ -7,7 +7,7 @@ tags:
   - "example"
 status: "published"
 author: "DevSynth Team"
-last_reviewed: "2025-07-01"
+last_reviewed: "2025-06-15"
 ---
 
 # DevSynth Example Project
@@ -18,7 +18,7 @@ This guide walks through a small calculator example included in the `examples/` 
 
 The example lives in [`examples/calculator`](../../examples/calculator). Each file shows what you would have after running DevSynth commands.
 
-For a complete demonstration of the adaptive workflow, see the full workflow example in [`examples/full_workflow`](../../examples/full_workflow).
+For a complete demonstration of the refactor workflow, see the full workflow example in [`examples/full_workflow`](../../examples/full_workflow).
 
 ## Workflow Overview
 

--- a/docs/getting_started/example_project.md
+++ b/docs/getting_started/example_project.md
@@ -27,6 +27,7 @@ For a complete demonstration of the adaptive workflow, see the full workflow exa
    cd examples/calculator
    devsynth init --path .
    ```
+   The command now launches an interactive wizard when run in an existing directory and will read any `pyproject.toml` or `devsynth.yml` it detects.
 2. **Generate specifications** from the requirements
    ```bash
    devsynth spec --requirements-file requirements.md

--- a/docs/getting_started/quick_start_guide.md
+++ b/docs/getting_started/quick_start_guide.md
@@ -8,7 +8,7 @@ tags:
   - "tutorial"
 status: "published"
 author: "DevSynth Team"
-last_reviewed: "2025-06-01"
+last_reviewed: "2025-06-15"
 ---
 
 # DevSynth Quick Start Guide

--- a/docs/getting_started/quick_start_guide.md
+++ b/docs/getting_started/quick_start_guide.md
@@ -74,7 +74,7 @@ devsynth init --path ./my-first-project
 cd my-first-project
 ```
 
-This command creates a new project directory with the necessary structure for DevSynth to work with.
+This command creates a new project directory with the necessary structure for DevSynth to work with. If run inside an existing project, `devsynth init` now launches an interactive wizard that detects your settings from `pyproject.toml` or `devsynth.yml`.
 
 DevSynth generates a `.devsynth/project.yaml` file during initialization and
 asks which optional features to enable. The selected flags are written to the

--- a/docs/requirements_traceability.md
+++ b/docs/requirements_traceability.md
@@ -9,7 +9,7 @@ tags:
   - "testing"
 status: "published"
 author: "DevSynth Team"
-last_reviewed: "2025-05-28"
+last_reviewed: "2025-06-15"
 ---
 
 # Requirements Traceability Matrix (RTM)

--- a/docs/requirements_traceability.md
+++ b/docs/requirements_traceability.md
@@ -72,5 +72,8 @@ This matrix links requirements to design, code modules, and tests, ensuring bidi
 | FR-62 | Role-based authorization checks | [Security and Privacy Framework](analysis/critical_recommendations.md#5-security-and-privacy-framework-high) | src/devsynth/security/authorization.py | tests/unit/security/test_authorization.py | Implemented |
 | FR-63 | Input sanitization utilities | [Secure Coding Guidelines](developer_guides/secure_coding.md) | src/devsynth/security/sanitization.py | tests/unit/security/test_sanitization.py | Implemented |
 | FR-64 | Onboard existing projects via interactive init wizard | [DevSynth Technical Specification](specifications/devsynth_specification_mvp_updated.md#interactive-init-workflow) | src/devsynth/application/cli/cli_commands.py | tests/behavior/features/cli_commands.feature, tests/unit/test_unit_cli_commands.py | Implemented |
+| FR-65 | Renamed commands (`adaptive`→`refactor`, `analyze`→`inspect`, `exec`→`run-pipeline`, `replay`→`retrace`) | [CLI Reference](user_guides/cli_reference.md) | src/devsynth/application/cli/cli_commands.py | tests/behavior/features/cli_commands.feature | Planned |
+| FR-66 | Unified YAML/TOML configuration loader | [DevSynth Technical Specification](specifications/devsynth_specification_mvp_updated.md#41-6-unified-configuration-loader) | src/devsynth/config/loader.py | tests/unit/test_settings.py | Planned |
+| FR-67 | CLI/WebUI bridge preparation | [DevSynth Technical Specification](specifications/devsynth_specification_mvp_updated.md#41-7-cliwebui-bridge-preparation) | src/devsynth/application/server/bridge.py | tests/integration/test_webui_bridge.py | Planned |
 
 _Last updated: June 15, 2025_

--- a/docs/roadmap/development_status.md
+++ b/docs/roadmap/development_status.md
@@ -10,7 +10,7 @@ tags:
   - "foundation-stabilization"
 status: "active"
 author: "DevSynth Team"
-last_reviewed: "2025-06-01"
+last_reviewed: "2025-06-15"
 ---
 
 # DevSynth Development Status

--- a/docs/roadmap/development_status.md
+++ b/docs/roadmap/development_status.md
@@ -209,6 +209,7 @@ This work is planned for after the completion of Month 2.
 - Initial project structure established with hexagonal architecture
 - Core domain models and interfaces defined
 - Basic CLI functionality implemented
+- Interactive `init` wizard and command renames (`refactor`, `inspect`, `run-pipeline`, `retrace`) added with unified config loader and early WebUI bridge
 - Memory system with ChromaDB integration
 - LLM provider system with multiple backend support
 

--- a/docs/specifications/devsynth_specification_mvp_updated.md
+++ b/docs/specifications/devsynth_specification_mvp_updated.md
@@ -484,6 +484,22 @@ Multi-agent collaboration will be deferred to a future version. The MVP will use
 **Future Extension Points:**
 - Detect additional configuration formats
 - Prepopulate answers from existing files
+- **FR-64**: Provide an interactive `init` wizard for onboarding existing projects
+
+#### 4.1.5 CLI Command Updates
+
+- **FR-65**: Rename the `adaptive` command to `refactor`
+- **FR-66**: Rename the `analyze` command to `inspect`
+- **FR-67**: Replace the `exec` command with `run-pipeline`
+- **FR-68**: Replace the `replay` command with `retrace`
+
+#### 4.1.6 Unified Configuration Loader
+
+- **FR-69**: Load project configuration from YAML or TOML using a common parser
+
+#### 4.1.7 CLI/WebUI Bridge Preparation
+
+- **FR-70**: Provide a shared interface layer to enable future WebUI integration with the CLI
 
 ### 4.2 Requirement Analysis and Specification
 

--- a/docs/system_requirements_specification.md
+++ b/docs/system_requirements_specification.md
@@ -73,6 +73,8 @@ Primary users are individual software developers who:
 - [CON-02] The system must function within the resource constraints of a typical developer workstation
 - [CON-03] The system must optimize token usage to maintain reasonable performance and resource usage
 - [CON-04] The system must adhere to security practices appropriate for a single-developer proof of concept
+- [CON-05] Configuration files may be written in YAML or TOML and must be loaded using a unified parser
+- [CON-06] The CLI and WebUI shall share a common command interface to preserve feature parity
 
 ## 3. Functional Requirements
 
@@ -171,6 +173,16 @@ Primary users are individual software developers who:
 - [FR-54] The system shall support offline documentation ingestion
 - [FR-55] The system shall implement AST-based code transformations
 - [FR-56] The system shall provide prompt auto-tuning mechanisms
+
+### 3.9 CLI Enhancements
+
+- [FR-64] The system shall provide an interactive `init` workflow for onboarding existing projects
+- [FR-65] The system shall rename the `adaptive` command to `refactor`
+- [FR-66] The system shall rename the `analyze` command to `inspect`
+- [FR-67] The system shall rename the `exec` command to `run-pipeline`
+- [FR-68] The system shall rename the `replay` command to `retrace`
+- [FR-69] The system shall load configuration from either YAML or TOML using a unified parser
+- [FR-70] The system shall expose a bridge interface to enable future WebUI integration
 
 ## 4. Non-Functional Requirements
 

--- a/docs/user_guides/cli_reference.md
+++ b/docs/user_guides/cli_reference.md
@@ -9,7 +9,7 @@ tags:
   - "user-guide"
 status: "published"
 author: "DevSynth Team"
-last_reviewed: "2025-06-01"
+last_reviewed: "2025-06-15"
 ---
 
 # DevSynth CLI Reference

--- a/docs/user_guides/cli_reference.md
+++ b/docs/user_guides/cli_reference.md
@@ -30,8 +30,10 @@ This document provides a comprehensive reference for the DevSynth Command Line I
   - [config](#config)
   - [memory](#memory)
   - [agent](#agent)
-  - [adaptive](#adaptive)
-  - [analyze](#analyze)
+  - [run-pipeline](#run-pipeline)
+  - [refactor](#refactor)
+  - [inspect](#inspect)
+  - [retrace](#retrace)
   - [webapp](#webapp)
   - [dbschema](#dbschema)
 - [Environment Variables](#environment-variables)
@@ -103,6 +105,8 @@ devsynth init [--path PATH] [--template TEMPLATE] [--project-root ROOT] [--langu
 - `--extra-languages`: Additional languages used in the project
 - `--goals`: High-level goals or constraints for the project
 - `--constraints`: Path to a constraint configuration file
+
+This command now detects existing projects and launches an interactive wizard when run inside a directory containing `pyproject.toml` or `devsynth.yml`.
 
 **Examples:**
 ```bash
@@ -296,12 +300,25 @@ devsynth agent --list
 devsynth agent --run documentation --input requirements.md --output docs.md
 ```
 
-### adaptive
+### run-pipeline
+
+Execute a predefined pipeline of DevSynth commands.
+
+```bash
+devsynth run-pipeline <pipeline-name>
+```
+
+**Examples:**
+```bash
+devsynth run-pipeline default
+```
+
+### refactor
 
 Analyze the project and suggest an appropriate workflow.
 
 ```bash
-devsynth adaptive [--path PATH]
+devsynth refactor [--path PATH]
 ```
 
 **Options:**
@@ -309,16 +326,16 @@ devsynth adaptive [--path PATH]
 
 **Examples:**
 ```bash
-devsynth adaptive
-devsynth adaptive --path ./my-project
+devsynth refactor
+devsynth refactor --path ./my-project
 ```
 
-### analyze
+### inspect
 
 Analyze requirements from a file or interactively.
 
 ```bash
-devsynth analyze [--input FILE] [--interactive]
+devsynth inspect [--input FILE] [--interactive]
 ```
 
 **Options:**
@@ -327,8 +344,21 @@ devsynth analyze [--input FILE] [--interactive]
 
 **Examples:**
 ```bash
-devsynth analyze --input requirements.md
-devsynth analyze --interactive
+devsynth inspect --input requirements.md
+devsynth inspect --interactive
+```
+
+### retrace
+
+Replay a previous pipeline execution for debugging.
+
+```bash
+devsynth retrace <run-id>
+```
+
+**Examples:**
+```bash
+devsynth retrace 20240601T123000
 ```
 
 ### webapp

--- a/examples/full_workflow/README.md
+++ b/examples/full_workflow/README.md
@@ -1,6 +1,6 @@
 # DevSynth Full Workflow Example
 
-This example demonstrates the full DevSynth workflow using a simple word counter project. It covers project initialization, specification and test generation, code creation, the adaptive workflow, and reviewing the generated output.
+This example demonstrates the full DevSynth workflow using a simple word counter project. It covers project initialization, specification and test generation, code creation, the refactor workflow, and reviewing the generated output.
 
 ## Steps
 
@@ -28,9 +28,9 @@ This example demonstrates the full DevSynth workflow using a simple word counter
    devsynth code
    ```
 
-6. **Run the adaptive workflow**
+6. **Run the refactor workflow**
    ```bash
-   devsynth adaptive
+   devsynth refactor
    ```
    This analyzes the project and suggests further steps.
 


### PR DESCRIPTION
## Summary
- document new CLI names and interactive init wizard
- add unified configuration loader and WebUI bridge requirements
- trace new FRs in the RTM
- update quick-start and example docs
- mention changes in README and roadmap

## Testing
- `poetry run pytest -q` *(fails: ModuleNotFoundError: No module named 'pytest_bdd')*

------
https://chatgpt.com/codex/tasks/task_e_684e6c88644c8333914410ec42d5d132