### PR TITLE
Align CLI command names across docs and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ pip install -e '.[dev]'
 # Run the tests or execute the app
 pytest
 # or
-devsynth run
+devsynth run-pipeline
 ```
 
 Use [`templates/project.yaml`](templates/project.yaml) as a reference for your `.devsynth/project.yaml`. If you run into issues, see [docs/getting_started/troubleshooting.md](docs/getting_started/troubleshooting.md).

--- a/docs/user_guides/cli_reference.md
+++ b/docs/user_guides/cli_reference.md
@@ -459,10 +459,10 @@ devsynth test --spec-file specifications.md
 devsynth code --test-dir tests/
 
 # Run the tests to verify the implementation
-devsynth run --target unit-tests
+devsynth run-pipeline --target unit-tests
 
 # Run the application
-devsynth run
+devsynth run-pipeline
 ```
 
 ### Configuration Example

--- a/docs/user_guides/user_guide.md
+++ b/docs/user_guides/user_guide.md
@@ -368,7 +368,7 @@ In this phase, DevSynth takes high-level requirements and expands them into deta
 4. Organizing specifications into a coherent structure
 
 **Commands used in this phase:**
-- `analyze`
+- `inspect`
 - `spec`
 
 ### 2. Differentiate

--- a/src/devsynth/application/cli/cli_commands.py
+++ b/src/devsynth/application/cli/cli_commands.py
@@ -336,7 +336,7 @@ def refactor_cmd(path: Optional[str] = None) -> None:
 
         console = Console()
 
-        # Show a welcome message for the adaptive command
+        # Show a welcome message for the refactor command
         console.print(
             Panel(
                 "[bold blue]DevSynth Refactor Workflow[/bold blue]\n\n"
@@ -350,7 +350,7 @@ def refactor_cmd(path: Optional[str] = None) -> None:
         # Set the project path
         project_path = path or os.getcwd()
 
-        # Execute the adaptive workflow
+        # Execute the refactor workflow
         result = adaptive_workflow_manager.execute_adaptive_workflow(project_path)
 
         if result.get("success", False):

--- a/tests/behavior/features/cli_commands.feature
+++ b/tests/behavior/features/cli_commands.feature
@@ -53,7 +53,7 @@ Feature: CLI Command Execution
     And the system should display a success message
 
   Scenario: Run with specific target
-    When I run the command "devsynth run --target unit-tests"
+    When I run the command "devsynth run-pipeline --target unit-tests"
     Then the system should execute the "unit-tests" target
     And the workflow should execute successfully
     And the system should display a success message

--- a/tests/behavior/features/requirement_analysis.feature
+++ b/tests/behavior/features/requirement_analysis.feature
@@ -7,14 +7,14 @@ Feature: Requirement Analysis
   Scenario: Analyze requirements from a text file
     Given I have initialized a DevSynth project
     And I have a requirements file "requirements.txt"
-    When I run the command "devsynth analyze --input requirements.txt"
+    When I run the command "devsynth inspect --input requirements.txt"
     Then the system should parse the requirements
     And create a structured representation in the memory system
     And generate a requirements summary
 
   Scenario: Interactive requirement gathering
     Given I have initialized a DevSynth project
-    When I run the command "devsynth analyze --interactive"
+    When I run the command "devsynth inspect --interactive"
     Then the system should start an interactive session
     And ask me questions about my requirements
     And create a structured representation in the memory system


### PR DESCRIPTION
## Summary
- update docs with `run-pipeline` command
- adjust workflow instructions from `analyze` to `inspect`
- fix internal comments for refactor workflow
- update BDD feature files for renamed commands

## Testing
- `poetry run pytest tests` *(fails: ImportError during collection)*

------
https://chatgpt.com/codex/tasks/task_e_684f53458f748333a04c29602f492dbd