### PR TITLE
Add init workflow docs and CLI overhaul pseudocode

### DIFF
--- a/docs/architecture/index.md
+++ b/docs/architecture/index.md
@@ -1,6 +1,6 @@
 ---
 title: "DevSynth Architecture"
-date: "2024-06-01"
+date: "2025-06-16"
 version: "1.0.0"
 tags:
   - "architecture"
@@ -8,7 +8,7 @@ tags:
   - "system"
 status: "published"
 author: "DevSynth Team"
-last_reviewed: "2024-06-01"
+last_reviewed: "2025-06-16"
 ---
 
 # Architecture
@@ -19,6 +19,7 @@ This section provides detailed information about the architecture of DevSynth, i
 
 - **[Overview](overview.md)**: A high-level overview of the DevSynth architecture.
 - **[Hexagonal Architecture](hexagonal_architecture.md)**: Details on the hexagonal (ports and adapters) architecture used in DevSynth.
+- **[Init Workflow](init_workflow.md)**: Sequence diagram for the interactive initialization process.
 
 ## System Components
 
@@ -59,3 +60,4 @@ If you're new to DevSynth's architecture, we recommend starting with the [Overvi
 - [Developer Guides](../developer_guides/index.md) - Information for developers contributing to DevSynth
 - [Technical Reference](../technical_reference/index.md) - Technical reference documentation
 - [Specifications](../specifications/index.md) - Detailed specifications for DevSynth components
+- [CLI Overhaul Pseudocode](../specifications/cli_overhaul_pseudocode.md) - Design reference for the updated initialization command

--- a/docs/architecture/init_workflow.md
+++ b/docs/architecture/init_workflow.md
@@ -1,0 +1,35 @@
+---
+title: "Init Workflow"
+date: "2025-06-16"
+version: "1.0.0"
+tags:
+  - "architecture"
+  - "workflow"
+  - "cli"
+status: "draft"
+author: "DevSynth Team"
+last_reviewed: "2025-06-16"
+---
+
+# Init Workflow Sequence
+
+The redesigned `init` command collects essential project details before creating a configuration file.
+
+```mermaid
+sequenceDiagram
+    participant U as User
+    participant CLI as CLI
+    participant UX as UXBridge
+    participant App as Application Layer
+    U->>CLI: run `devsynth init`
+    CLI->>UX: request setup info
+    UX->>U: prompt for project root
+    U-->>UX: provide path
+    UX->>U: select language(s)
+    U-->>UX: choose language(s)
+    UX->>U: describe project goals
+    U-->>UX: confirm goals
+    UX->>App: initialize project
+    App-->>UX: summary
+    UX->>U: display completion
+```

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -1,6 +1,6 @@
 ---
 title: "DevSynth Architecture Overview"
-date: "2025-05-01"
+date: "2025-06-16"
 version: "1.0.0"
 tags:
   - "architecture"
@@ -9,7 +9,7 @@ tags:
   - "structure"
 status: "published"
 author: "DevSynth Team"
-last_reviewed: "2025-05-01"
+last_reviewed: "2025-06-16"
 ---
 
 # DevSynth Architecture Overview
@@ -32,9 +32,10 @@ DevSynth is a modular, agentic software engineering platform designed for extens
 
 ```mermaid
 graph TD
-    A[CLI / Chat Interface] --> B[Application Layer]
-    B --> UX[UXBridge]
-    UX --> W[Init Wizard]
+    CLI[CLI / Chat Interface] --> UX[UXBridge]
+    Web[WebUI (Future)] --> UX
+    UX --> B[Application Layer]
+    UX --> IW[Init Wizard]
     B --> C[Agent System]
     B --> D[Code Analysis]
     B --> E[MemoryPort]

--- a/docs/implementation/index.md
+++ b/docs/implementation/index.md
@@ -6,6 +6,8 @@ This section provides documentation on the implementation details of DevSynth, i
 - **[Feature Status Matrix](feature_status_matrix.md)**: A matrix showing the status of various features in DevSynth.
 - **[Phase 1 Month 1 Summary](phase1_month1_summary.md)**: A summary of the first month of Phase 1 implementation.
 - **[WSDE Validation](wsde_validation.md)**: Validation of the Wide Sweep, Deep Exploration (WSDE) agent model implementation.
+- **[CLI Overhaul Pseudocode](../specifications/cli_overhaul_pseudocode.md)**: Pseudocode for the refactored `init` command and UXBridge abstraction.
+- **[Init Workflow](../architecture/init_workflow.md)**: Detailed sequence for project initialization.
 
 ## Related Documentation
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,6 @@
 ---
 title: "DevSynth Documentation"
-date: "2025-06-01"
+date: "2025-06-16"
 version: "1.0.0"
 tags:
   - "documentation"
@@ -8,7 +8,7 @@ tags:
   - "index"
 status: "published"
 author: "DevSynth Team"
-last_reviewed: "2025-06-01"
+last_reviewed: "2025-06-16"
 ---
 
 # DevSynth Documentation

--- a/docs/specifications/cli_overhaul_pseudocode.md
+++ b/docs/specifications/cli_overhaul_pseudocode.md
@@ -1,0 +1,58 @@
+---
+title: "CLI Overhaul Pseudocode"
+date: "2025-06-16"
+version: "0.1.0"
+tags:
+  - "specification"
+  - "cli"
+  - "pseudocode"
+status: "draft"
+author: "DevSynth Team"
+last_reviewed: "2025-06-16"
+---
+
+# Refactored `init` Command
+
+```pseudocode
+function init_command():
+    config = UnifiedConfigLoader.load()
+    if config.exists():
+        UXBridge.notify("Project already initialized")
+        return
+    root = UXBridge.prompt("Project root directory?")
+    language = UXBridge.prompt("Primary language?")
+    goals = UXBridge.prompt("Project goals?")
+    config.set_root(root)
+    config.set_language(language)
+    config.set_goals(goals)
+    config.save()
+    UXBridge.notify("Initialization complete")
+```
+
+# Unified Configuration Loader
+
+```pseudocode
+class UnifiedConfigLoader:
+    static function load(path = default_location) -> Config:
+        if file_exists(path):
+            return Config.parse_yaml(read_file(path))
+        else:
+            return Config()
+```
+
+# `UXBridge` Abstraction
+
+```pseudocode
+class UXBridge:
+    function prompt(message) -> Response:
+        if running_in_cli:
+            return CLI.prompt(message)
+        else if running_in_web:
+            return WebUI.prompt(message)
+
+    function notify(message):
+        if running_in_cli:
+            CLI.display(message)
+        else if running_in_web:
+            WebUI.display(message)
+```

--- a/docs/specifications/index.md
+++ b/docs/specifications/index.md
@@ -1,6 +1,6 @@
 ---
 title: "DevSynth Specifications"
-date: "2025-06-01"
+date: "2025-06-16"
 version: "1.0.0"
 tags:
   - "specifications"
@@ -8,7 +8,7 @@ tags:
   - "design"
 status: "published"
 author: "DevSynth Team"
-last_reviewed: "2025-06-01"
+last_reviewed: "2025-06-16"
 ---
 
 # Specifications


### PR DESCRIPTION
## Summary
- update doc dates to 2025-06-16
- show UXBridge connecting CLI and future WebUI in the architecture overview
- document redesigned init workflow sequence diagram
- outline pseudocode for the init command and UXBridge abstraction
- link the new documents from architecture and implementation indices

## Testing
- `poetry run pytest tests/` *(fails: 55 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_684f66c638748333a26480ff03a1bd08