### PR TITLE
Improve project init flow

### DIFF
--- a/docs/getting_started/quick_start_guide.md
+++ b/docs/getting_started/quick_start_guide.md
@@ -74,13 +74,14 @@ devsynth init --path ./my-first-project
 cd my-first-project
 ```
 
-This command creates a new project directory with the necessary structure for DevSynth to work with. If run inside an existing project, `devsynth init` now launches an interactive wizard that detects your settings from `pyproject.toml` or `devsynth.yml`.
-
-DevSynth generates a `.devsynth/project.yaml` file during initialization and
-asks which optional features to enable. The selected flags are written to the
-configuration file. You can use the
-[templates/project.yaml](../../templates/project.yaml) file as a minimal
-example configuration.
+This command creates a new project directory and then launches an interactive
+wizard. The wizard prompts for the project root, source layout, language, and
+any optional goals or constraint file. These answers are written to
+`.devsynth/devsynth.yml` by default or stored under `[tool.devsynth]` in
+`pyproject.toml` if you choose. After initialization you are asked which optional
+features to enable. The selected flags are saved in the configuration file. You
+can use the [templates/project.yaml](../../templates/project.yaml) file as a
+minimal example configuration.
 
 ### Step 2: Define Your Requirements
 

--- a/docs/user_guides/user_guide.md
+++ b/docs/user_guides/user_guide.md
@@ -49,7 +49,11 @@ devsynth init --path ./my-new-project
 ```
 
 **Details:**
-This command creates a new project directory with the necessary structure for DevSynth to work with. It initializes configuration files and sets up the project environment.
+Running `devsynth init` launches a short interactive wizard. The wizard asks for
+the project root, preferred source layout (`single_package` or `monorepo`),
+primary language, optional project goals and an optional path to a constraint
+file. Your answers are written to `.devsynth/devsynth.yml` by default or to the
+`pyproject.toml` file if you choose that option when prompted.
 
 ### `inspect`
 

--- a/src/devsynth/application/cli/cli_commands.py
+++ b/src/devsynth/application/cli/cli_commands.py
@@ -67,10 +67,6 @@ def init_cmd(
     project_root: Optional[str] = None,
     language: Optional[str] = None,
     constraints: Optional[str] = None,
-    source_dirs: Optional[str] = None,
-    test_dirs: Optional[str] = None,
-    docs_dirs: Optional[str] = None,
-    extra_languages: Optional[str] = None,
     goals: Optional[str] = None,
 ) -> None:
     """Initialize a new project or onboard an existing one."""
@@ -84,45 +80,26 @@ def init_cmd(
             if not Confirm.ask("Continue initializing?", default=True):
                 return
 
-        project_root = project_root or Prompt.ask("Project root", default=str(path))
+        project_root = project_root or Prompt.ask(
+            "Project root",
+            default=str(path),
+        )
         structure = Prompt.ask(
-            "Project structure",
+            "Source layout",
             choices=["single_package", "monorepo"],
             default="single_package",
         )
         language = language or Prompt.ask("Primary language", default="python")
-        extra_languages = (
-            extra_languages
-            if extra_languages is not None
-            else Prompt.ask(
-                "Additional languages (comma separated, optional)",
-                default="",
-                show_default=False,
-            )
-        )
-        source_dirs = (
-            source_dirs
-            if source_dirs is not None
-            else Prompt.ask("Source directories (comma separated)", default="src")
-        )
-        test_dirs = (
-            test_dirs
-            if test_dirs is not None
-            else Prompt.ask("Test directories (comma separated)", default="tests")
-        )
-        docs_dirs = (
-            docs_dirs
-            if docs_dirs is not None
-            else Prompt.ask("Docs directories (comma separated)", default="docs")
-        )
         goals = goals or Prompt.ask(
-            "High-level goals/constraints", default="", show_default=False
+            "Project goals (optional)", default="", show_default=False
         )
         constraints = (
             constraints
             if constraints is not None
             else Prompt.ask(
-                "Path to constraint file (optional)", default="", show_default=False
+                "Path to constraint file (optional)",
+                default="",
+                show_default=False,
             )
         )
 
@@ -138,11 +115,8 @@ def init_cmd(
                 "project_root": project_root,
                 "language": language,
                 "constraints": constraints,
-                "source_dirs": source_dirs,
-                "test_dirs": test_dirs,
-                "docs_dirs": docs_dirs,
-                "extra_languages": extra_languages,
                 "goals": goals,
+                "structure": structure,
             }
         )
 
@@ -168,16 +142,11 @@ def init_cmd(
             config = {
                 "project_root": project_root,
                 "structure": structure,
-                "languages": {
-                    "primary": language,
-                    "additional": [
-                        l.strip() for l in extra_languages.split(",") if l.strip()
-                    ],
-                },
+                "language": language,
                 "directories": {
-                    "source": [d.strip() for d in source_dirs.split(",") if d.strip()],
-                    "tests": [d.strip() for d in test_dirs.split(",") if d.strip()],
-                    "docs": [d.strip() for d in docs_dirs.split(",") if d.strip()],
+                    "source": ["src"],
+                    "tests": ["tests"],
+                    "docs": ["docs"],
                 },
                 "features": feature_flags,
             }

--- a/tests/behavior/features/project_initialization.feature
+++ b/tests/behavior/features/project_initialization.feature
@@ -8,12 +8,12 @@ Feature: Project Initialization
     Given the DevSynth CLI is installed
     When I run the command "devsynth init --name my-project"
     Then a new project directory "my-project" should be created
-    And the project should have the default structure
+    And the project should use the default layout
     And a configuration file should be created with default settings
 
   Scenario: Initialize a project with custom settings
     Given the DevSynth CLI is installed
-    When I run the command "devsynth init --name custom-project --template web-app"
+    When I run the command "devsynth init --name custom-project --language javascript"
     Then a new project directory "custom-project" should be created
-    And the project should have the web-app template structure
-    And a configuration file should be created with web-app template settings
+    And the project should use the single_package layout
+    And a configuration file should be created with javascript settings

--- a/tests/behavior/steps/project_init_steps.py
+++ b/tests/behavior/steps/project_init_steps.py
@@ -1,7 +1,7 @@
-
 """
 Step definitions for Project Initialization feature.
 """
+
 import os
 import sys
 import pytest
@@ -26,85 +26,46 @@ def check_project_directory_created(directory, mock_workflow_manager, tmp_path):
     """
     # In our test environment, we're mocking the actual directory creation
     # But we can verify that the init command was called with the correct parameters
-    
+
     # Extract the name parameter from the command
     # Get the actual call arguments
     args = mock_workflow_manager.execute_command.call_args[0][1]
-    
+
     # Check that the command was called with the correct name
     assert args.get("name") == directory
     assert args.get("path") == "."
-    
+
     # In a real implementation, we would check if the directory exists
     # But since we're mocking, we'll just assert that the command was called
 
 
-@then("the project should have the default structure")
+@then("the project should use the default layout")
 def check_default_structure(mock_workflow_manager):
-    """
-    Verify that the project has the default structure.
-    """
-    # Verify that the init command was called
+    """Verify the project uses the single_package layout."""
     assert mock_workflow_manager.execute_command.called
-    
-    # In a real implementation, we would check for specific directories and files
-    # But since we're mocking, we'll just assert that the command was called with default template
-    
-    # The template parameter should not be specified or should be "default"
-    # Extract the last call arguments
     args = mock_workflow_manager.execute_command.call_args[0][1]
-    
-    # Check that template is either not specified or is "default"
-    assert "template" not in args or args.get("template") == "default"
+    assert args.get("structure") == "single_package"
 
 
 @then("a configuration file should be created with default settings")
 def check_default_config_created(mock_workflow_manager):
-    """
-    Verify that a configuration file was created with default settings.
-    """
-    # Verify that the init command was called
+    """Verify that the configuration defaults were applied."""
     assert mock_workflow_manager.execute_command.called
-    
-    # In a real implementation, we would check for the config file and its contents
-    # But since we're mocking, we'll just assert that the command was called
-    
-    # The template parameter should not be specified or should be "default"
-    # Extract the last call arguments
     args = mock_workflow_manager.execute_command.call_args[0][1]
-    
-    # Check that template is either not specified or is "default"
-    assert "template" not in args or args.get("template") == "default"
+    assert args.get("language") == "python"
 
 
-@then(parsers.parse('the project should have the {template} template structure'))
-def check_template_structure(template, mock_workflow_manager):
-    """
-    Verify that the project has the specified template structure.
-    """
-    # Verify that the init command was called
+@then(parsers.parse("the project should use the {layout} layout"))
+def check_custom_layout(layout, mock_workflow_manager):
+    """Verify that the selected layout was used."""
     assert mock_workflow_manager.execute_command.called
-    
-    # Extract the last call arguments
     args = mock_workflow_manager.execute_command.call_args[0][1]
-    
-    # Check that the template parameter matches the expected template
-    # The template in the feature file might be "web-app" but in the args it's "web-app"
-    # So we need to handle both cases
-    template_value = template.replace("-", "-")  # This is a no-op but makes the intention clear
-    assert args.get("template") == template_value
+    assert args.get("structure") == layout
 
 
-@then(parsers.parse('a configuration file should be created with {template} template settings'))
-def check_template_config_created(template, mock_workflow_manager):
-    """
-    Verify that a configuration file was created with template-specific settings.
-    """
-    # Verify that the init command was called
+@then(parsers.parse("a configuration file should be created with {lang} settings"))
+def check_language_config_created(lang, mock_workflow_manager):
+    """Verify that the language choice was recorded."""
     assert mock_workflow_manager.execute_command.called
-    
-    # Extract the last call arguments
     args = mock_workflow_manager.execute_command.call_args[0][1]
-    
-    # Check that the template parameter matches the expected template
-    assert args.get("template") == template
+    assert args.get("language") == lang

--- a/tests/unit/test_unit_cli_commands.py
+++ b/tests/unit/test_unit_cli_commands.py
@@ -56,10 +56,6 @@ class TestCLICommands:
                 "./test-project",  # project_root
                 "single_package",  # structure
                 "python",  # language
-                "",  # extra_languages
-                "src",  # source_dirs
-                "tests",  # test_dirs
-                "docs",  # docs_dirs
                 "",  # goals
                 "",  # constraints path
             ],
@@ -76,12 +72,9 @@ class TestCLICommands:
                 "path": "./test-project",
                 "project_root": "./test-project",
                 "language": "python",
-                "source_dirs": "src",
-                "test_dirs": "tests",
-                "docs_dirs": "docs",
-                "extra_languages": "",
-                "goals": "",
                 "constraints": "",
+                "goals": "",
+                "structure": "single_package",
             },
         )
         # Check that one of the print calls contains the expected message
@@ -109,10 +102,6 @@ class TestCLICommands:
                 "single_package",
                 "python",
                 "",
-                "src",
-                "tests",
-                "docs",
-                "",
                 "",
             ],
         ), patch(
@@ -128,12 +117,9 @@ class TestCLICommands:
                 "path": "./test-project",
                 "project_root": "./test-project",
                 "language": "python",
-                "source_dirs": "src",
-                "test_dirs": "tests",
-                "docs_dirs": "docs",
-                "extra_languages": "",
-                "goals": "",
                 "constraints": "",
+                "goals": "",
+                "structure": "single_package",
             },
         )
         mock_console.print.assert_called_once_with(
@@ -153,10 +139,6 @@ class TestCLICommands:
                 "single_package",
                 "python",
                 "",
-                "src",
-                "tests",
-                "docs",
-                "",
                 "",
             ],
         ), patch(
@@ -172,12 +154,9 @@ class TestCLICommands:
                 "path": "./test-project",
                 "project_root": "./test-project",
                 "language": "python",
-                "source_dirs": "src",
-                "test_dirs": "tests",
-                "docs_dirs": "docs",
-                "extra_languages": "",
-                "goals": "",
                 "constraints": "",
+                "goals": "",
+                "structure": "single_package",
             },
         )
         mock_console.print.assert_called_once_with(
@@ -250,7 +229,9 @@ class TestCLICommands:
             for call in mock_console.print.call_args_list
         )
 
-    def test_run_pipeline_cmd_success_with_target(self, mock_workflow_manager, mock_console):
+    def test_run_pipeline_cmd_success_with_target(
+        self, mock_workflow_manager, mock_console
+    ):
         """Test successful run with target."""
         # Setup
         mock_workflow_manager.execute_command.return_value = {
@@ -269,7 +250,9 @@ class TestCLICommands:
             "[green]Executed target: unit-tests[/green]"
         )
 
-    def test_run_pipeline_cmd_success_without_target(self, mock_workflow_manager, mock_console):
+    def test_run_pipeline_cmd_success_without_target(
+        self, mock_workflow_manager, mock_console
+    ):
         """Test successful run without target."""
         # Setup
         mock_workflow_manager.execute_command.return_value = {
@@ -370,10 +353,6 @@ class TestCLICommands:
                 "single_package",
                 "python",
                 "",
-                "src",
-                "tests",
-                "docs",
-                "",
                 "",
             ],
         ), patch(
@@ -389,12 +368,9 @@ class TestCLICommands:
                 "template": "web-app",
                 "project_root": ".",
                 "language": "python",
-                "source_dirs": "src",
-                "test_dirs": "tests",
-                "docs_dirs": "docs",
-                "extra_languages": "",
-                "goals": "",
                 "constraints": "",
+                "goals": "",
+                "structure": "single_package",
             },
         )
 
@@ -422,10 +398,6 @@ class TestCLICommands:
                 "single_package",
                 "python",
                 "",
-                "src",
-                "tests",
-                "docs",
-                "",
                 "",
             ],
         ):
@@ -438,12 +410,9 @@ class TestCLICommands:
                 "name": "proj",
                 "project_root": "./proj",
                 "language": "python",
-                "source_dirs": "src",
-                "test_dirs": "tests",
-                "docs_dirs": "docs",
-                "extra_languages": "",
-                "goals": "",
                 "constraints": "",
+                "goals": "",
+                "structure": "single_package",
             },
         )
         assert mock_yaml_dump.called
@@ -472,10 +441,6 @@ class TestCLICommands:
                 "./proj",
                 "single_package",
                 "python",
-                "",
-                "src",
-                "tests",
-                "docs",
                 "",
                 "",
             ],


### PR DESCRIPTION
## Summary
- simplify `init` wizard to ask for root, layout, language, goals and constraints
- store answers in `.devsynth/devsynth.yml` or `pyproject.toml`
- update workflow tests and docs for the revised setup

## Testing
- `poetry run pytest tests` *(fails: ImportError during collection)*

------
https://chatgpt.com/codex/tasks/task_e_684f7c3a131483338c3df06e81c3c027