### PR TITLE
Fix CLI test for updated init args

### DIFF
--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -27,7 +27,15 @@ class TestTyperCLI:
         app = build_app()
         result = self.runner.invoke(app, ["init", "--path", "./test-project"])
         assert result.exit_code == 0
-        mock_init_cmd.assert_called_once_with("./test-project", None, None)
+        mock_init_cmd.assert_called_once_with(
+            "./test-project",
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+        )
 
     @patch("devsynth.adapters.cli.typer_adapter.spec_cmd", autospec=True)
     def test_cli_spec(self, mock_spec_cmd):


### PR DESCRIPTION
## Summary
- update CLI init test to match new parameter list

## Testing
- `poetry run pytest -q tests/unit/test_cli.py`
- `poetry run pytest -q tests` *(fails: 33 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_684f843fdec8833390042f99e01aa459