### PR TITLE
Add core config loader

### DIFF
--- a/docs/developer_guides/devsynth_configuration.md
+++ b/docs/developer_guides/devsynth_configuration.md
@@ -117,6 +117,22 @@ resources: {project: {memoryDir: str, logsDir: str}}
 
 `load_config()` returns a `DevSynthConfig` dataclass with defaults when no configuration file exists. `save_config()` writes the dataclass back to YAML or TOML and is used by the CLI to persist preferences during initialization and later configuration updates.
 
+### Core configuration loader
+
+`src/devsynth/core/config_loader.py` provides a lightweight loader used by
+internal tools. It merges environment variables with project-level files and the
+global configuration stored in `~/.devsynth/config/`. Environment variables with
+the `DEVSYNTH_` prefix always take precedence. The module also exposes
+`config_key_autocomplete()` so Typer commands can offer CLI autocompletion for
+configuration keys and `save_global_config()` to persist user preferences.
+
+```python
+from devsynth.core.config_loader import load_config, save_global_config
+
+cfg = load_config()
+save_global_config(cfg)
+```
+
 ## Best Practices
 
 1. **Version Control**: Include the `.devsynth/devsynth.yml` file in version control to ensure consistent configuration across all developers.

--- a/src/devsynth/core/__init__.py
+++ b/src/devsynth/core/__init__.py
@@ -1,0 +1,10 @@
+"""Core utilities for DevSynth."""
+
+from .config_loader import (
+    CoreConfig,
+    load_config,
+    save_global_config,
+    config_key_autocomplete,
+)
+
+__all__ = ["CoreConfig", "load_config", "save_global_config", "config_key_autocomplete"]

--- a/src/devsynth/core/config_loader.py
+++ b/src/devsynth/core/config_loader.py
@@ -1,0 +1,151 @@
+"""Unified configuration loader for DevSynth core modules."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+import toml
+import yaml
+from pydantic.dataclasses import dataclass
+
+
+@dataclass
+class CoreConfig:
+    """Dataclass representing configuration options."""
+
+    project_root: str = "."
+    structure: str = "single_package"
+    language: str = "python"
+    goals: Optional[str] = None
+    constraints: Optional[str] = None
+    directories: Dict[str, list[str]] | None = None
+    features: Dict[str, bool] | None = None
+    resources: Dict[str, Any] | None = None
+
+    def as_dict(self) -> Dict[str, Any]:
+        return {
+            "project_root": self.project_root,
+            "structure": self.structure,
+            "language": self.language,
+            "goals": self.goals,
+            "constraints": self.constraints,
+            "directories": self.directories
+            or {
+                "source": ["src"],
+                "tests": ["tests"],
+                "docs": ["docs"],
+            },
+            "features": self.features or {},
+            "resources": self.resources or {},
+        }
+
+
+_ENV_PREFIX = "DEVSYNTH_"
+
+
+def _parse_env(cfg: CoreConfig) -> Dict[str, Any]:
+    data: Dict[str, Any] = {}
+    for field in cfg.as_dict().keys():
+        env_key = f"{_ENV_PREFIX}{field.upper()}"
+        value = os.environ.get(env_key)
+        if value is not None:
+            if isinstance(getattr(cfg, field), bool):
+                data[field] = value.strip().lower() in {"1", "true", "yes"}
+            else:
+                data[field] = value
+    return data
+
+
+def _load_yaml(path: Path) -> Dict[str, Any]:
+    if not path.exists():
+        return {}
+    with open(path, "r") as f:
+        return yaml.safe_load(f) or {}
+
+
+def _load_toml(path: Path) -> Dict[str, Any]:
+    if not path.exists():
+        return {}
+    data = toml.load(path)
+    return data.get("tool", {}).get("devsynth", data.get("devsynth", {}))
+
+
+def _find_project_config(start: Path) -> Optional[Path]:
+    yaml_path = start / ".devsynth" / "devsynth.yml"
+    if yaml_path.exists():
+        return yaml_path
+    toml_path = start / "devsynth.toml"
+    if toml_path.exists():
+        return toml_path
+    pyproject = start / "pyproject.toml"
+    if pyproject.exists():
+        try:
+            data = toml.load(pyproject)
+            if "devsynth" in data.get("tool", {}):
+                return pyproject
+        except Exception:
+            return None
+    return None
+
+
+def load_config(start_path: Optional[str] = None) -> CoreConfig:
+    """Load configuration merging global, project and environment settings."""
+
+    root = Path(start_path or os.getcwd())
+
+    defaults = CoreConfig(project_root=str(root))
+    config_data: Dict[str, Any] = defaults.as_dict()
+
+    # Global configuration
+    home = Path(os.path.expanduser("~"))
+    global_dir = home / ".devsynth" / "config"
+    global_yaml = global_dir / "global_config.yaml"
+    global_toml = global_dir / "devsynth.toml"
+    if global_yaml.exists():
+        config_data.update(_load_yaml(global_yaml))
+    elif global_toml.exists():
+        config_data.update(_load_toml(global_toml))
+
+    # Project configuration
+    project_cfg = _find_project_config(root)
+    if project_cfg:
+        if project_cfg.suffix in {".yaml", ".yml"}:
+            config_data.update(_load_yaml(project_cfg))
+        else:
+            config_data.update(_load_toml(project_cfg))
+
+    # Environment overrides
+    config_data.update(_parse_env(defaults))
+
+    return CoreConfig(**config_data)
+
+
+def save_global_config(config: CoreConfig, use_toml: bool = False) -> Path:
+    """Persist global configuration to the user's home directory."""
+    home = Path(os.path.expanduser("~"))
+    cfg_dir = home / ".devsynth" / "config"
+    cfg_dir.mkdir(parents=True, exist_ok=True)
+    if use_toml:
+        path = cfg_dir / "devsynth.toml"
+        with open(path, "w") as f:
+            toml.dump({"devsynth": config.as_dict()}, f)
+    else:
+        path = cfg_dir / "global_config.yaml"
+        with open(path, "w") as f:
+            yaml.safe_dump(config.as_dict(), f)
+    return path
+
+
+# ---- Typer integration ----
+try:  # pragma: no cover - optional import
+    import typer
+except Exception:  # pragma: no cover - optional import
+    typer = None
+
+
+def config_key_autocomplete(ctx: "typer.Context", incomplete: str):
+    """Return config keys matching the partial input for Typer."""
+    keys = CoreConfig().__dataclass_fields__.keys()
+    return [k for k in keys if k.startswith(incomplete)]

--- a/tests/unit/test_core_config_loader.py
+++ b/tests/unit/test_core_config_loader.py
@@ -1,0 +1,51 @@
+import os
+from pathlib import Path
+from devsynth.core.config_loader import load_config, save_global_config, CoreConfig
+
+
+def test_precedence_env_over_project_over_global(tmp_path, monkeypatch):
+    # set up fake home
+    home = tmp_path / "home"
+    global_dir = home / ".devsynth" / "config"
+    global_dir.mkdir(parents=True)
+    (global_dir / "global_config.yaml").write_text("language: python\n")
+
+    # project config
+    project_dir = tmp_path / "project"
+    project_cfg_dir = project_dir / ".devsynth"
+    project_cfg_dir.mkdir(parents=True, exist_ok=True)
+    (project_cfg_dir / "devsynth.yml").write_text("language: go\n")
+
+    monkeypatch.setattr(
+        os.path,
+        "expanduser",
+        lambda x: str(home) if x == "~" else os.path.expanduser(x),
+    )
+    monkeypatch.setenv("DEVSYNTH_LANGUAGE", "rust")
+
+    cfg = load_config(str(project_dir))
+    assert cfg.language == "rust"
+
+
+def test_load_toml_project(tmp_path, monkeypatch):
+    project_dir = tmp_path / "project2"
+    project_dir.mkdir()
+    (project_dir / "pyproject.toml").write_text("[tool.devsynth]\nlanguage = 'java'\n")
+
+    cfg = load_config(str(project_dir))
+    assert cfg.language == "java"
+
+
+def test_save_global_config_yaml(tmp_path, monkeypatch):
+    home = tmp_path / "home"
+    monkeypatch.setattr(
+        os.path,
+        "expanduser",
+        lambda x: str(home) if x == "~" else os.path.expanduser(x),
+    )
+
+    cfg = CoreConfig(language="python")
+    path = save_global_config(cfg)
+    assert path.exists()
+    loaded = load_config(start_path=tmp_path)
+    assert loaded.language == "python"


### PR DESCRIPTION
## Summary
- add `core.config_loader` with global/env merging and Typer autocomplete
- document the new loader in devsynth_configuration guide
- unit tests for precedence and persistence logic

## Testing
- `pytest tests/unit/test_core_config_loader.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6850285f4208833394e2804bd6046076