### PR TITLE
Update CLI tests for new command behavior

### DIFF
--- a/tests/behavior/features/cli_commands.feature
+++ b/tests/behavior/features/cli_commands.feature
@@ -26,10 +26,15 @@ Feature: CLI Command Execution
     And the workflow should execute successfully
     And the system should display a success message
 
-  Scenario: Initialize a project with directories and goals
-    When I run the command "devsynth init --project-root . --language python --source-dirs src --test-dirs tests --docs-dirs docs --extra-languages javascript --goals demo"
+  Scenario: Initialize a project with goals
+    When I run the command "devsynth init --project-root . --language python --goals demo"
     Then a new project should be created at "."
     And the workflow should execute successfully
+    And the system should display a success message
+
+  Scenario: Initialize interactively
+    When I run the command "devsynth init"
+    Then the workflow should execute successfully
     And the system should display a success message
 
   Scenario: Generate specifications with custom requirements file
@@ -84,3 +89,8 @@ Feature: CLI Command Execution
     When I run the command "devsynth edrr-cycle sample_manifest.yaml"
     Then the workflow should execute successfully
     And the system should display a success message
+
+  Scenario: Validate project configuration
+    When I run the command "devsynth validate-manifest"
+    Then the system should display a success message
+    And the workflow should execute successfully

--- a/tests/behavior/features/project_initialization.feature
+++ b/tests/behavior/features/project_initialization.feature
@@ -17,3 +17,9 @@ Feature: Project Initialization
     Then a new project directory "custom-project" should be created
     And the project should use the single_package layout
     And a configuration file should be created with javascript settings
+
+  Scenario: Interactive initialization
+    Given the DevSynth CLI is installed
+    When I run the command "devsynth init"
+    Then the project should use the default layout
+    And a configuration file should be created with default settings

--- a/tests/unit/test_unit_cli_commands.py
+++ b/tests/unit/test_unit_cli_commands.py
@@ -521,3 +521,26 @@ class TestCLICommands:
                 "chromadb" in call.args[0].lower()
                 for call in mock_console.print.call_args_list
             )
+
+    def test_config_key_autocomplete(self, tmp_path, monkeypatch):
+        cfg_dir = tmp_path / ".devsynth"
+        cfg_dir.mkdir()
+        (cfg_dir / "devsynth.yml").write_text("language: python\nmodel: gpt-4\n")
+        monkeypatch.chdir(tmp_path)
+
+        result = cli_commands.config_key_autocomplete(None, "l")
+        assert "language" in result
+
+    def test_check_services_warns(self, monkeypatch, capsys):
+        class DummySettings:
+            vector_store_enabled = False
+            memory_store_type = "chromadb"
+            provider_type = "openai"
+            openai_api_key = None
+            lm_studio_endpoint = None
+
+        monkeypatch.setattr(cli_commands, "get_settings", lambda: DummySettings)
+        res = cli_commands._check_services()
+        output = capsys.readouterr().out
+        assert res is False
+        assert "OPENAI_API_KEY" in output


### PR DESCRIPTION
## Summary
- update CLI command feature scenarios for interactive flows
- cover validate manifest and remove outdated init params
- update step logic for renamed commands
- test config key autocomplete and service checks

## Testing
- `poetry run pytest tests/` *(fails: 56 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68502b6e45d4833388003747ca6de685