### PR TITLE
Add doctor command module and docs

### DIFF
--- a/docs/user_guides/cli_reference.md
+++ b/docs/user_guides/cli_reference.md
@@ -35,7 +35,7 @@ This document provides a comprehensive reference for the DevSynth Command Line I
   - [retrace](#retrace)
   - [webapp](#webapp)
   - [dbschema](#dbschema)
-  - [doctor](#doctor)
+  - [doctor](#doctor-check)
 - [Environment Variables](#environment-variables)
 - [Configuration File](#configuration-file)
 - [Examples](#examples)
@@ -399,7 +399,7 @@ devsynth dbschema [--db-type TYPE] [--name NAME] [--path PATH]
 devsynth dbschema --db-type sqlite --name blog --path ./schema
 ```
 
-### doctor
+### doctor / check {#doctor-check}
 
 Validate environment configuration files for common issues. The command is also
 available as `devsynth check`.

--- a/docs/user_guides/user_guide.md
+++ b/docs/user_guides/user_guide.md
@@ -187,6 +187,23 @@ devsynth config --key model --value gpt-4
 **Details:**
 This command allows you to view or modify DevSynth configuration settings. It provides a way to customize the behavior of DevSynth for your specific needs.
 
+### `doctor` / `check`
+
+Validates environment configuration files for common issues.
+
+```bash
+devsynth doctor [--config-dir DIR]
+devsynth check [--config-dir DIR]
+```
+
+**Example:**
+```bash
+devsynth doctor --config-dir ./config
+```
+
+**Details:**
+Run this command before other workflows to ensure your `config/*.yml` files are complete. If no configuration is found, the output suggests running `devsynth init` to generate defaults.
+
 ## Configuration Options
 
 DevSynth can be configured using the `config` command or by editing the configuration file directly. The following configuration options are available:

--- a/src/devsynth/adapters/cli/typer_adapter.py
+++ b/src/devsynth/adapters/cli/typer_adapter.py
@@ -88,20 +88,62 @@ def build_app() -> typer.Typer:
         name="check",
         help="Alias for doctor. Example: devsynth check",
     )(doctor_cmd)
-    app.command(name="refactor")(refactor_cmd)
-    app.command(name="analyze-code")(analyze_code_cmd)
-    app.command(name="edrr-cycle")(edrr_cycle_cmd)
-    app.command(name="align")(align_cmd)
-    app.command(name="alignment-metrics")(alignment_metrics_cmd)
-    app.command(name="analyze-manifest")(analyze_manifest_cmd)
-    app.command(name="analyze-config")(analyze_manifest_cmd)
-    app.command(name="validate-manifest")(validate_manifest_cmd)
-    app.command(name="validate-metadata")(validate_metadata_cmd)
-    app.command(name="test-metrics")(test_metrics_cmd)
-    app.command(name="generate-docs")(generate_docs_cmd)
-    app.command(name="ingest")(ingest_cmd)
-    app.command(name="apispec")(apispec_cmd)
-    app.command(name="serve")(serve_cmd)
+    app.command(
+        name="refactor",
+        help="Suggest next workflow steps. Example: devsynth refactor",
+    )(refactor_cmd)
+    app.command(
+        name="analyze-code",
+        help="Analyze a codebase. Example: devsynth analyze-code --path ./src",
+    )(analyze_code_cmd)
+    app.command(
+        name="edrr-cycle",
+        help="Run an EDRR cycle. Example: devsynth edrr-cycle manifest.yaml",
+    )(edrr_cycle_cmd)
+    app.command(
+        name="align",
+        help="Check SDLC artifact alignment. Example: devsynth align --verbose",
+    )(align_cmd)
+    app.command(
+        name="alignment-metrics",
+        help="Collect alignment metrics. Example: devsynth alignment-metrics",
+    )(alignment_metrics_cmd)
+    app.command(
+        name="analyze-manifest",
+        help="Analyze project configuration. Example: devsynth analyze-manifest",
+    )(analyze_manifest_cmd)
+    app.command(
+        name="analyze-config",
+        help="Alias for analyze-manifest. Example: devsynth analyze-config",
+    )(analyze_manifest_cmd)
+    app.command(
+        name="validate-manifest",
+        help="Validate project config file. Example: devsynth validate-manifest",
+    )(validate_manifest_cmd)
+    app.command(
+        name="validate-metadata",
+        help="Validate documentation metadata. Example: devsynth validate-metadata --directory docs",
+    )(validate_metadata_cmd)
+    app.command(
+        name="test-metrics",
+        help="Analyze test-first metrics. Example: devsynth test-metrics --days 30",
+    )(test_metrics_cmd)
+    app.command(
+        name="generate-docs",
+        help="Generate API docs. Example: devsynth generate-docs",
+    )(generate_docs_cmd)
+    app.command(
+        name="ingest",
+        help="Ingest a project. Example: devsynth ingest manifest.yaml",
+    )(ingest_cmd)
+    app.command(
+        name="apispec",
+        help="Generate an API spec. Example: devsynth apispec",
+    )(apispec_cmd)
+    app.command(
+        name="serve",
+        help="Run the DevSynth API server. Example: devsynth serve --port 8080",
+    )(serve_cmd)
 
     @app.callback(invoke_without_command=True)
     def main(ctx: typer.Context):

--- a/src/devsynth/application/cli/__init__.py
+++ b/src/devsynth/application/cli/__init__.py
@@ -21,11 +21,12 @@ from .cli_commands import (
     inspect_cmd,
     webapp_cmd,
     dbschema_cmd,
-    doctor_cmd,
     check_cmd,
     refactor_cmd,
     serve_cmd,
 )
+# Doctor command now lives in the commands package
+from .commands.doctor_cmd import doctor_cmd
 
 # Import commands from the commands directory
 from .commands.analyze_code_cmd import analyze_code_cmd

--- a/src/devsynth/application/cli/cli_commands.py
+++ b/src/devsynth/application/cli/cli_commands.py
@@ -20,6 +20,7 @@ from devsynth.config import (
     config_key_autocomplete as loader_autocomplete,
 )
 from .commands.edrr_cycle_cmd import edrr_cycle_cmd
+from .commands.doctor_cmd import doctor_cmd
 
 logger = DevSynthLogger(__name__)
 console = Console()
@@ -1228,59 +1229,6 @@ def dbschema_cmd(
                 border_style="red",
             )
         )
-
-
-def doctor_cmd(config_dir: str = "config") -> None:
-    """Validate environment configuration files and provide hints.
-
-    Example:
-        `devsynth doctor --config-dir ./config`
-    """
-    try:
-        import importlib.util
-
-        repo_root = Path(__file__).resolve().parents[4]
-        script_path = repo_root / "scripts" / "validate_config.py"
-        spec = importlib.util.spec_from_file_location("validate_config", script_path)
-        module = importlib.util.module_from_spec(spec)
-        assert spec and spec.loader
-        spec.loader.exec_module(module)
-
-        envs = ["default", "development", "testing", "staging", "production"]
-        configs = {}
-        warnings = False
-
-        for env in envs:
-            cfg_path = Path(config_dir) / f"{env}.yml"
-            if not cfg_path.exists():
-                console.print(
-                    f"[yellow]Warning: configuration file not found: {cfg_path}[/yellow]"
-                )
-                warnings = True
-                continue
-
-            data = module.load_config(str(cfg_path))
-            configs[env] = data
-
-            schema_errors = module.validate_config(data, module.CONFIG_SCHEMA)
-            env_errors = module.validate_environment_variables(data)
-            for err in schema_errors + env_errors:
-                console.print(f"[yellow]{env}: {err}[/yellow]")
-                warnings = True
-
-        consistency_errors = module.check_config_consistency(configs)
-        for err in consistency_errors:
-            console.print(f"[yellow]{err}[/yellow]")
-            warnings = True
-
-        if warnings:
-            console.print(
-                "[yellow]Configuration issues detected. Run 'devsynth init' to generate defaults.[/yellow]"
-            )
-        else:
-            console.print("[green]All configuration files are valid.[/green]")
-    except Exception as err:  # pragma: no cover - defensive
-        console.print(f"[red]Error:[/red] {err}", highlight=False)
 
 
 def check_cmd(config_dir: str = "config") -> None:

--- a/src/devsynth/application/cli/commands/align_cmd.py
+++ b/src/devsynth/application/cli/commands/align_cmd.py
@@ -216,9 +216,11 @@ def display_issues(issues: List[Dict]):
     console.print(table)
 
 def align_cmd(path: str = '.', verbose: bool = False, output: Optional[str] = None):
-    """
-    Check alignment between SDLC artifacts.
-    
+    """Check alignment between SDLC artifacts.
+
+    Example:
+        `devsynth align --path . --verbose`
+
     Args:
         path: Path to the project directory
         verbose: Whether to show verbose output

--- a/src/devsynth/application/cli/commands/alignment_metrics_cmd.py
+++ b/src/devsynth/application/cli/commands/alignment_metrics_cmd.py
@@ -329,9 +329,11 @@ def generate_metrics_report(metrics: Dict, historical_metrics: List[Dict], outpu
         console.print(f"[red]Error generating metrics report: {e}[/red]")
 
 def alignment_metrics_cmd(path: str = '.', metrics_file: str = '.devsynth/alignment_metrics.json', output: Optional[str] = None):
-    """
-    Collect and report on alignment metrics.
-    
+    """Collect and report on alignment metrics.
+
+    Example:
+        `devsynth alignment-metrics --path .`
+
     Args:
         path: Path to the project directory
         metrics_file: Path to the metrics file

--- a/src/devsynth/application/cli/commands/analyze_code_cmd.py
+++ b/src/devsynth/application/cli/commands/analyze_code_cmd.py
@@ -16,9 +16,11 @@ from devsynth.logging_setup import DevSynthLogger
 logger = DevSynthLogger(__name__)
 
 def analyze_code_cmd(path: Optional[str] = None) -> None:
-    """
-    Analyze a codebase to understand its architecture, structure, and quality.
-    
+    """Analyze a codebase to understand its architecture and quality.
+
+    Example:
+        `devsynth analyze-code --path ./my-project`
+
     Args:
         path: Path to the codebase to analyze (default: current directory)
     """

--- a/src/devsynth/application/cli/commands/analyze_manifest_cmd.py
+++ b/src/devsynth/application/cli/commands/analyze_manifest_cmd.py
@@ -18,8 +18,10 @@ from devsynth.logging_setup import DevSynthLogger
 logger = DevSynthLogger(__name__)
 
 def analyze_manifest_cmd(path: Optional[str] = None, update: bool = False, prune: bool = False) -> None:
-    """
-    Analyze and manage the project configuration file (devsynth.yaml, formerly manifest.yaml).
+    """Analyze and manage the project configuration file.
+
+    Example:
+        `devsynth analyze-manifest --update`
 
     This command scans the project structure and can update, refine, or prune the configuration file
     based on the actual project structure.

--- a/src/devsynth/application/cli/commands/doctor_cmd.py
+++ b/src/devsynth/application/cli/commands/doctor_cmd.py
@@ -1,0 +1,69 @@
+from pathlib import Path
+from rich.console import Console
+from devsynth.logging_setup import DevSynthLogger
+from devsynth.config.loader import load_config
+import importlib.util
+
+logger = DevSynthLogger(__name__)
+console = Console()
+
+
+def doctor_cmd(config_dir: str = "config") -> None:
+    """Validate environment configuration files and provide hints.
+
+    Example:
+        `devsynth doctor --config-dir ./config`
+    """
+    try:
+        # Ensure project configuration is present
+        cfg_path_yaml = Path(".devsynth/devsynth.yml")
+        cfg_path_toml = Path("pyproject.toml")
+        if not cfg_path_yaml.exists() and not cfg_path_toml.exists():
+            console.print(
+                "[yellow]No project configuration found. Run 'devsynth init' to create it.[/yellow]"
+            )
+
+        # Load project configuration with the unified loader
+        load_config()
+
+        # Load validation utilities dynamically
+        repo_root = Path(__file__).resolve().parents[4]
+        script_path = repo_root / "scripts" / "validate_config.py"
+        spec = importlib.util.spec_from_file_location("validate_config", script_path)
+        module = importlib.util.module_from_spec(spec)  # type: ignore
+        assert spec and spec.loader
+        spec.loader.exec_module(module)  # type: ignore
+
+        envs = ["default", "development", "testing", "staging", "production"]
+        configs = {}
+        warnings = False
+
+        for env in envs:
+            cfg_path = Path(config_dir) / f"{env}.yml"
+            if not cfg_path.exists():
+                console.print(f"[yellow]Warning: configuration file not found: {cfg_path}[/yellow]")
+                warnings = True
+                continue
+
+            data = module.load_config(str(cfg_path))
+            configs[env] = data
+
+            schema_errors = module.validate_config(data, module.CONFIG_SCHEMA)
+            env_errors = module.validate_environment_variables(data)
+            for err in schema_errors + env_errors:
+                console.print(f"[yellow]{env}: {err}[/yellow]")
+                warnings = True
+
+        consistency_errors = module.check_config_consistency(configs)
+        for err in consistency_errors:
+            console.print(f"[yellow]{err}[/yellow]")
+            warnings = True
+
+        if warnings:
+            console.print(
+                "[yellow]Configuration issues detected. Run 'devsynth init' to generate defaults.[/yellow]"
+            )
+        else:
+            console.print("[green]All configuration files are valid.[/green]")
+    except Exception as err:  # pragma: no cover - defensive
+        console.print(f"[red]Error:[/red] {err}", highlight=False)

--- a/src/devsynth/application/cli/commands/edrr_cycle_cmd.py
+++ b/src/devsynth/application/cli/commands/edrr_cycle_cmd.py
@@ -19,6 +19,9 @@ logger = DevSynthLogger(__name__)
 def edrr_cycle_cmd(manifest: str, auto: bool = True) -> None:
     """Run an EDRR cycle from a manifest file.
 
+    Example:
+        `devsynth edrr-cycle manifest.yaml`
+
     Args:
         manifest: Path to the manifest file.
         auto: Whether to automatically progress through phases.

--- a/src/devsynth/application/cli/commands/generate_docs_cmd.py
+++ b/src/devsynth/application/cli/commands/generate_docs_cmd.py
@@ -18,12 +18,14 @@ from devsynth.logging_setup import DevSynthLogger
 logger = DevSynthLogger(__name__)
 
 def generate_docs_cmd(path: Optional[str] = None, output_dir: Optional[str] = None) -> None:
-    """
-    Generate API reference documentation for a project.
-    
+    """Generate API reference documentation for a project.
+
+    Example:
+        `devsynth generate-docs --path .`
+
     This command generates API reference documentation for a project based on the manifest.yaml file,
     creating a page for each module in the project.
-    
+
     Args:
         path: Path to the project directory (default: current directory)
         output_dir: Directory where the documentation should be generated (default: docs/api_reference)

--- a/src/devsynth/application/cli/commands/test_metrics_cmd.py
+++ b/src/devsynth/application/cli/commands/test_metrics_cmd.py
@@ -20,9 +20,11 @@ from devsynth.logging_setup import DevSynthLogger
 logger = DevSynthLogger(__name__)
 
 def test_metrics_cmd(days: int = 30, output_file: Optional[str] = None) -> None:
-    """
-    Analyze test-first development metrics.
-    
+    """Analyze test-first development metrics.
+
+    Example:
+        `devsynth test-metrics --days 14`
+
     Args:
         days: Number of days of commit history to analyze (default: 30)
         output_file: Path to output file for metrics report (default: None, prints to console)

--- a/src/devsynth/application/cli/commands/validate_manifest_cmd.py
+++ b/src/devsynth/application/cli/commands/validate_manifest_cmd.py
@@ -21,8 +21,10 @@ from devsynth.logging_setup import DevSynthLogger
 logger = DevSynthLogger(__name__)
 
 def validate_manifest_cmd(manifest_path: Optional[str] = None, schema_path: Optional[str] = None) -> None:
-    """
-    Validate the project configuration file against its schema and project structure.
+    """Validate the project configuration file against its schema.
+
+    Example:
+        `devsynth validate-manifest --manifest-path manifest.yaml`
 
     Args:
         manifest_path: Path to the project configuration file (default: .devsynth/project.yaml or manifest.yaml)

--- a/src/devsynth/application/cli/commands/validate_metadata_cmd.py
+++ b/src/devsynth/application/cli/commands/validate_metadata_cmd.py
@@ -22,9 +22,11 @@ from devsynth.logging_setup import DevSynthLogger
 logger = DevSynthLogger(__name__)
 
 def validate_metadata_cmd(directory: Optional[str] = None, file: Optional[str] = None, verbose: bool = False) -> None:
-    """
-    Validate metadata in Markdown files.
-    
+    """Validate metadata in Markdown files.
+
+    Example:
+        `devsynth validate-metadata --directory docs`
+
     Args:
         directory: Directory containing Markdown files to validate (default: docs/)
         file: Single Markdown file to validate

--- a/src/devsynth/application/cli/ingest_cmd.py
+++ b/src/devsynth/application/cli/ingest_cmd.py
@@ -28,8 +28,10 @@ def ingest_cmd(
     verbose: bool = False,
     validate_only: bool = False
 ) -> None:
-    """
-    Ingest a project into DevSynth.
+    """Ingest a project into DevSynth.
+
+    Example:
+        `devsynth ingest manifest.yaml`
 
     This command triggers the full ingestion and adaptation pipeline (Expand, Differentiate, Refine, Retrospect),
     driven by .devsynth/project.yaml and its project structure definitions.

--- a/tests/behavior/features/devsynth_doctor.feature
+++ b/tests/behavior/features/devsynth_doctor.feature
@@ -1,0 +1,14 @@
+Feature: DevSynth Doctor
+  As a developer
+  I want helpful feedback when configuration is missing
+  So that I can onboard my project correctly
+
+  Background:
+    Given the DevSynth CLI is installed
+    And I have a valid DevSynth project
+
+  Scenario: Suggest initialization when config is absent
+    Given no DevSynth configuration file in the project
+    When I run the command "devsynth doctor"
+    Then the system should display a warning message
+    And the output should include onboarding hints

--- a/tests/behavior/steps/cli_commands_steps.py
+++ b/tests/behavior/steps/cli_commands_steps.py
@@ -343,7 +343,7 @@ def run_command(command, monkeypatch, mock_workflow_manager, command_context):
                 if len(args) > 2 and args[1] in ["--config-dir", "-c"]:
                     config_dir = args[2]
 
-                from devsynth.application.cli.cli_commands import doctor_cmd
+                from devsynth.application.cli.commands.doctor_cmd import doctor_cmd
 
                 doctor_cmd(config_dir or "config")
             else:

--- a/tests/behavior/steps/devsynth_doctor_steps.py
+++ b/tests/behavior/steps/devsynth_doctor_steps.py
@@ -1,0 +1,19 @@
+"""Step definitions for DevSynth doctor command."""
+
+import os
+from pytest_bdd import given, then
+
+@given("no DevSynth configuration file in the project")
+def no_devsynth_config(tmp_project_dir):
+    cfg_yaml = os.path.join(tmp_project_dir, "devsynth.yml")
+    if os.path.exists(cfg_yaml):
+        os.remove(cfg_yaml)
+    legacy = os.path.join(tmp_project_dir, "manifest.yaml")
+    if os.path.exists(legacy):
+        os.remove(legacy)
+    return tmp_project_dir
+
+@then("the output should include onboarding hints")
+def output_should_include_hint(command_context):
+    output = command_context.get("output", "")
+    assert "devsynth init" in output

--- a/tests/behavior/test_devsynth_doctor.py
+++ b/tests/behavior/test_devsynth_doctor.py
@@ -1,0 +1,6 @@
+from pytest_bdd import scenarios
+
+from .steps.cli_commands_steps import *
+from .steps.devsynth_doctor_steps import *
+
+scenarios('features/devsynth_doctor.feature')


### PR DESCRIPTION
## Summary
- include concise usage examples across CLI modules
- implement doctor_cmd as a separate module with unified loader
- register doctor/help text with Typer and expand help strings
- add behavior spec for doctor onboarding hints
- document doctor/check usage in reference and user guide

## Testing
- `poetry run pytest tests/` *(fails: ModuleNotFoundError and multiple import errors)*

------
https://chatgpt.com/codex/tasks/task_e_68509eb1e9788333b99aebb07449c230