### PR TITLE
Introduce UXBridge core abstraction

### DIFF
--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -49,6 +49,19 @@ graph TD
     D --> M[NetworkX Graph Analysis]
 ```
 
+### Shared UX Bridge
+
+The CLI and upcoming WebUI interact with the application through a common
+`UXBridge`. This abstraction exposes simple `prompt`, `confirm` and `print`
+methods used by the workflow layer.
+
+```mermaid
+graph LR
+    CLI --> Bridge[UXBridge]
+    WebUI --> Bridge
+    Bridge --> Core[Workflow Functions]
+```
+
 ## Key Components
 
 - **CLI / Chat Interface**: Entry points for user and agent interaction

--- a/src/devsynth/application/cli/cli_commands.py
+++ b/src/devsynth/application/cli/cli_commands.py
@@ -9,7 +9,9 @@ from rich.console import Console
 from devsynth.interface.cli import CLIUXBridge
 from devsynth.interface.ux_bridge import UXBridge
 
-from ..orchestration.workflow import workflow_manager
+from devsynth.core.workflows import (
+    execute_command as execute_workflow_command,
+)
 import uvicorn
 from devsynth.logging_setup import configure_logging
 from ..orchestration.adaptive_workflow import adaptive_workflow_manager
@@ -138,7 +140,7 @@ def init_cmd(
             }
         )
 
-        result = workflow_manager.execute_command("init", args)
+        result = execute_workflow_command("init", args)
         if result.get("success"):
             bridge.print(f"[green]Initialized DevSynth project in {path}[/green]")
 
@@ -190,7 +192,7 @@ def spec_cmd(
         if not _check_services(bridge):
             return
         args = _filter_args({"requirements_file": requirements_file})
-        result = workflow_manager.execute_command("spec", args)
+        result = execute_workflow_command("spec", args)
         if result.get("success"):
             bridge.print(
                 f"[green]Specifications generated from {requirements_file}.[/green]"
@@ -211,7 +213,7 @@ def test_cmd(spec_file: str = "specs.md", *, bridge: UXBridge = bridge) -> None:
         if not _check_services(bridge):
             return
         args = _filter_args({"spec_file": spec_file})
-        result = workflow_manager.execute_command("test", args)
+        result = execute_workflow_command("test", args)
         if result.get("success"):
             bridge.print(f"[green]Tests generated from {spec_file}.[/green]")
         else:
@@ -229,7 +231,7 @@ def code_cmd(*, bridge: UXBridge = bridge) -> None:
     try:
         if not _check_services(bridge):
             return
-        result = workflow_manager.execute_command("code", {})
+        result = execute_workflow_command("code", {})
         if result.get("success"):
             bridge.print("[green]Code generated successfully.[/green]")
         else:
@@ -247,7 +249,7 @@ def run_pipeline_cmd(
         `devsynth run-pipeline --target unit-tests`
     """
     try:
-        result = workflow_manager.execute_command("run-pipeline", {"target": target})
+        result = execute_workflow_command("run-pipeline", {"target": target})
         if result["success"]:
             if target:
                 bridge.print(f"[green]Executed target: {target}[/green]")
@@ -279,7 +281,7 @@ def config_cmd(
         args = {"key": key, "value": value}
         if list_models:
             args["list_models"] = True
-        result = workflow_manager.execute_command("config", args)
+        result = execute_workflow_command("config", args)
         if result.get("success"):
             if key and value:
                 bridge.print(f"[green]Configuration updated: {key} = {value}[/green]")
@@ -397,7 +399,7 @@ def inspect_cmd(
         if not _check_services(bridge):
             return
         args = _filter_args({"input": input_file, "interactive": interactive})
-        result = workflow_manager.execute_command("inspect", args)
+        result = execute_workflow_command("inspect", args)
         if result.get("success"):
             bridge.print("[green]Requirements inspection completed.[/green]")
         else:

--- a/src/devsynth/core/ux_bridge.py
+++ b/src/devsynth/core/ux_bridge.py
@@ -1,0 +1,32 @@
+"""User interaction abstraction for DevSynth."""
+
+from abc import ABC, abstractmethod
+from typing import Optional, Sequence
+
+
+class UXBridge(ABC):
+    """Abstract interface for user interaction.
+
+    Concrete frontends implement this interface so that core workflow
+    functions can interact with users without depending on a specific
+    UI framework.
+    """
+
+    @abstractmethod
+    def prompt(
+        self,
+        message: str,
+        *,
+        choices: Optional[Sequence[str]] = None,
+        default: Optional[str] = None,
+        show_default: bool = True,
+    ) -> str:
+        """Prompt the user for input and return the response."""
+
+    @abstractmethod
+    def confirm(self, message: str, *, default: bool = False) -> bool:
+        """Ask the user to confirm an action."""
+
+    @abstractmethod
+    def print(self, message: str, *, highlight: bool = False) -> None:
+        """Display a message to the user."""

--- a/src/devsynth/core/workflows.py
+++ b/src/devsynth/core/workflows.py
@@ -1,0 +1,10 @@
+"""Wrapper functions for executing workflows."""
+
+from typing import Any, Dict
+
+from devsynth.application.orchestration.workflow import workflow_manager
+
+
+def execute_command(command: str, args: Dict[str, Any]) -> Dict[str, Any]:
+    """Execute a workflow command through the application workflow manager."""
+    return workflow_manager.execute_command(command, args)

--- a/src/devsynth/interface/cli.py
+++ b/src/devsynth/interface/cli.py
@@ -1,14 +1,20 @@
-"""CLI implementation of the UXBridge."""
+"""CLI implementation of the UXBridge using Typer and Rich."""
+
+from typing import Optional, Sequence
 
 from rich.console import Console
 from rich.prompt import Confirm, Prompt
-from typing import Optional, Sequence
 
-from .ux_bridge import UXBridge
+from devsynth.core.ux_bridge import UXBridge
 
 
 class CLIUXBridge(UXBridge):
-    """Bridge for command line interactions using Rich."""
+    """Bridge for command line interactions.
+
+    This implementation uses Rich for formatted output and Typer-compatible
+    prompts so that the same workflow logic can be reused by different
+    frontends.
+    """
 
     def __init__(self) -> None:
         self.console = Console()

--- a/src/devsynth/interface/ux_bridge.py
+++ b/src/devsynth/interface/ux_bridge.py
@@ -1,25 +1,5 @@
-from abc import ABC, abstractmethod
-from typing import Optional, Sequence
+"""Compatibility wrapper for the core UXBridge."""
 
+from devsynth.core.ux_bridge import UXBridge
 
-class UXBridge(ABC):
-    """Abstract interface for user interaction."""
-
-    @abstractmethod
-    def prompt(
-        self,
-        message: str,
-        *,
-        choices: Optional[Sequence[str]] = None,
-        default: Optional[str] = None,
-        show_default: bool = True,
-    ) -> str:
-        """Prompt the user for input."""
-
-    @abstractmethod
-    def confirm(self, message: str, *, default: bool = False) -> bool:
-        """Ask the user to confirm an action."""
-
-    @abstractmethod
-    def print(self, message: str, *, highlight: bool = False) -> None:
-        """Display a message to the user."""
+__all__ = ["UXBridge"]

--- a/tests/unit/test_unit_cli_commands.py
+++ b/tests/unit/test_unit_cli_commands.py
@@ -31,8 +31,10 @@ class TestCLICommands:
 
     @pytest.fixture
     def mock_workflow_manager(self):
-        """Create a mock workflow manager."""
-        with patch("devsynth.application.cli.cli_commands.workflow_manager") as mock:
+        """Create a mock workflow executor."""
+        with patch(
+            "devsynth.application.cli.cli_commands.execute_workflow_command"
+        ) as mock:
             yield mock
 
     @pytest.fixture
@@ -44,7 +46,7 @@ class TestCLICommands:
     def test_init_cmd_success(self, mock_workflow_manager, mock_bridge):
         """Test successful project initialization."""
         # Setup
-        mock_workflow_manager.execute_command.return_value = {
+        mock_workflow_manager.return_value = {
             "success": True,
             "message": "Project initialized successfully",
         }
@@ -66,7 +68,7 @@ class TestCLICommands:
             init_cmd("./test-project")
 
         # Verify
-        mock_workflow_manager.execute_command.assert_called_once_with(
+        mock_workflow_manager.assert_called_once_with(
             "init",
             {
                 "path": "./test-project",
@@ -88,7 +90,7 @@ class TestCLICommands:
     def test_init_cmd_failure(self, mock_workflow_manager, mock_bridge):
         """Test failed project initialization."""
         # Setup
-        mock_workflow_manager.execute_command.return_value = {
+        mock_workflow_manager.return_value = {
             "success": False,
             "message": "Path already exists",
         }
@@ -110,7 +112,7 @@ class TestCLICommands:
             init_cmd("./test-project")
 
         # Verify
-        mock_workflow_manager.execute_command.assert_called_once_with(
+        mock_workflow_manager.assert_called_once_with(
             "init",
             {
                 "path": "./test-project",
@@ -128,7 +130,7 @@ class TestCLICommands:
     def test_init_cmd_exception(self, mock_workflow_manager, mock_bridge):
         """Test exception handling in project initialization."""
         # Setup
-        mock_workflow_manager.execute_command.side_effect = Exception("Test error")
+        mock_workflow_manager.side_effect = Exception("Test error")
 
         # Execute
         with patch(
@@ -147,7 +149,7 @@ class TestCLICommands:
             init_cmd("./test-project")
 
         # Verify
-        mock_workflow_manager.execute_command.assert_called_once_with(
+        mock_workflow_manager.assert_called_once_with(
             "init",
             {
                 "path": "./test-project",
@@ -165,7 +167,7 @@ class TestCLICommands:
     def test_spec_cmd_success(self, mock_workflow_manager, mock_bridge):
         """Test successful spec generation."""
         # Setup
-        mock_workflow_manager.execute_command.return_value = {
+        mock_workflow_manager.return_value = {
             "success": True,
             "message": "Specs generated successfully",
         }
@@ -174,7 +176,7 @@ class TestCLICommands:
         spec_cmd("requirements.md")
 
         # Verify
-        mock_workflow_manager.execute_command.assert_called_once_with(
+        mock_workflow_manager.assert_called_once_with(
             "spec", {"requirements_file": "requirements.md"}
         )
         # Check that one of the print calls contains the expected message
@@ -188,7 +190,7 @@ class TestCLICommands:
     def test_test_cmd_success(self, mock_workflow_manager, mock_bridge):
         """Test successful test generation."""
         # Setup
-        mock_workflow_manager.execute_command.return_value = {
+        mock_workflow_manager.return_value = {
             "success": True,
             "message": "Tests generated successfully",
         }
@@ -197,9 +199,7 @@ class TestCLICommands:
         test_cmd("specs.md")
 
         # Verify
-        mock_workflow_manager.execute_command.assert_called_once_with(
-            "test", {"spec_file": "specs.md"}
-        )
+        mock_workflow_manager.assert_called_once_with("test", {"spec_file": "specs.md"})
         # Check that one of the print calls contains the expected message
         success_message = "[green]Tests generated from specs.md.[/green]"
         assert any(
@@ -209,7 +209,7 @@ class TestCLICommands:
     def test_code_cmd_success(self, mock_workflow_manager, mock_bridge):
         """Test successful code generation."""
         # Setup
-        mock_workflow_manager.execute_command.return_value = {
+        mock_workflow_manager.return_value = {
             "success": True,
             "message": "Code generated successfully",
         }
@@ -218,7 +218,7 @@ class TestCLICommands:
         code_cmd()
 
         # Verify
-        mock_workflow_manager.execute_command.assert_called_once_with("code", {})
+        mock_workflow_manager.assert_called_once_with("code", {})
         # Check that one of the print calls contains the expected message
         success_message = "[green]Code generated successfully.[/green]"
         assert any(
@@ -230,7 +230,7 @@ class TestCLICommands:
     ):
         """Test successful run with target."""
         # Setup
-        mock_workflow_manager.execute_command.return_value = {
+        mock_workflow_manager.return_value = {
             "success": True,
             "message": "Target executed successfully",
         }
@@ -239,7 +239,7 @@ class TestCLICommands:
         run_pipeline_cmd("unit-tests")
 
         # Verify
-        mock_workflow_manager.execute_command.assert_called_once_with(
+        mock_workflow_manager.assert_called_once_with(
             "run-pipeline", {"target": "unit-tests"}
         )
         mock_bridge.print.assert_called_once_with(
@@ -251,7 +251,7 @@ class TestCLICommands:
     ):
         """Test successful run without target."""
         # Setup
-        mock_workflow_manager.execute_command.return_value = {
+        mock_workflow_manager.return_value = {
             "success": True,
             "message": "Execution complete",
         }
@@ -260,15 +260,13 @@ class TestCLICommands:
         run_pipeline_cmd()
 
         # Verify
-        mock_workflow_manager.execute_command.assert_called_once_with(
-            "run-pipeline", {"target": None}
-        )
+        mock_workflow_manager.assert_called_once_with("run-pipeline", {"target": None})
         mock_bridge.print.assert_called_once_with("[green]Execution complete.[/green]")
 
     def test_config_cmd_set_value(self, mock_workflow_manager, mock_bridge):
         """Test setting a configuration value."""
         # Setup
-        mock_workflow_manager.execute_command.return_value = {
+        mock_workflow_manager.return_value = {
             "success": True,
             "message": "Configuration updated",
         }
@@ -277,7 +275,7 @@ class TestCLICommands:
         config_cmd("model", "gpt-4")
 
         # Verify
-        mock_workflow_manager.execute_command.assert_called_once_with(
+        mock_workflow_manager.assert_called_once_with(
             "config", {"key": "model", "value": "gpt-4"}
         )
         mock_bridge.print.assert_called_once_with(
@@ -287,7 +285,7 @@ class TestCLICommands:
     def test_config_cmd_get_value(self, mock_workflow_manager, mock_bridge):
         """Test getting a configuration value."""
         # Setup
-        mock_workflow_manager.execute_command.return_value = {
+        mock_workflow_manager.return_value = {
             "success": True,
             "value": "gpt-4",
         }
@@ -296,7 +294,7 @@ class TestCLICommands:
         config_cmd("model")
 
         # Verify
-        mock_workflow_manager.execute_command.assert_called_once_with(
+        mock_workflow_manager.assert_called_once_with(
             "config", {"key": "model", "value": None}
         )
         mock_bridge.print.assert_called_once_with("[blue]model:[/blue] gpt-4")
@@ -304,7 +302,7 @@ class TestCLICommands:
     def test_config_cmd_list_all(self, mock_workflow_manager, mock_bridge):
         """Test listing all configuration values."""
         # Setup
-        mock_workflow_manager.execute_command.return_value = {
+        mock_workflow_manager.return_value = {
             "success": True,
             "config": {"model": "gpt-4", "temperature": 0.7, "max_tokens": 2000},
         }
@@ -313,7 +311,7 @@ class TestCLICommands:
         config_cmd()
 
         # Verify
-        mock_workflow_manager.execute_command.assert_called_once_with(
+        mock_workflow_manager.assert_called_once_with(
             "config", {"key": None, "value": None}
         )
         assert mock_bridge.print.call_count == 4  # Header + 3 config items
@@ -341,7 +339,7 @@ class TestCLICommands:
 
     def test_init_cmd_with_name_template(self, mock_workflow_manager, mock_bridge):
         """Init command with additional parameters."""
-        mock_workflow_manager.execute_command.return_value = {"success": True}
+        mock_workflow_manager.return_value = {"success": True}
         with patch(
             "devsynth.application.cli.cli_commands.bridge.prompt",
             side_effect=[
@@ -356,7 +354,7 @@ class TestCLICommands:
             return_value=False,
         ):
             init_cmd(path=".", name="proj", template="web-app")
-        mock_workflow_manager.execute_command.assert_called_once_with(
+        mock_workflow_manager.assert_called_once_with(
             "init",
             {
                 "path": ".",
@@ -384,7 +382,7 @@ class TestCLICommands:
         mock_bridge,
     ):
         """Init command writes feature flags to project.yaml."""
-        mock_workflow_manager.execute_command.return_value = {"success": True}
+        mock_workflow_manager.return_value = {"success": True}
         mock_confirm.side_effect = [True, False, False, False, False, False]
 
         with patch(
@@ -399,7 +397,7 @@ class TestCLICommands:
         ):
             init_cmd(path="./proj", name="proj")
 
-        mock_workflow_manager.execute_command.assert_called_once_with(
+        mock_workflow_manager.assert_called_once_with(
             "init",
             {
                 "path": "./proj",
@@ -429,7 +427,7 @@ class TestCLICommands:
         mock_bridge,
     ):
         """init_cmd should create .devsynth/devsynth.yml."""
-        mock_workflow_manager.execute_command.return_value = {"success": True}
+        mock_workflow_manager.return_value = {"success": True}
 
         with patch(
             "devsynth.application.cli.cli_commands.bridge.prompt",
@@ -450,20 +448,18 @@ class TestCLICommands:
 
     def test_inspect_cmd_file(self, mock_workflow_manager, mock_bridge):
         """Inspect command with input file."""
-        mock_workflow_manager.execute_command.return_value = {"success": True}
+        mock_workflow_manager.return_value = {"success": True}
         inspect_cmd("requirements.md")
-        mock_workflow_manager.execute_command.assert_called_once_with(
+        mock_workflow_manager.assert_called_once_with(
             "inspect",
             {"input": "requirements.md", "interactive": False},
         )
 
     def test_inspect_cmd_interactive(self, mock_workflow_manager, mock_bridge):
         """Inspect command in interactive mode."""
-        mock_workflow_manager.execute_command.return_value = {"success": True}
+        mock_workflow_manager.return_value = {"success": True}
         inspect_cmd(interactive=True)
-        mock_workflow_manager.execute_command.assert_called_once_with(
-            "inspect", {"interactive": True}
-        )
+        mock_workflow_manager.assert_called_once_with("inspect", {"interactive": True})
 
     def test_spec_cmd_missing_openai_key(self, mock_workflow_manager, mock_bridge):
         """spec_cmd should warn when OpenAI API key is missing."""
@@ -483,7 +479,7 @@ class TestCLICommands:
             new=ORIG_CHECK_SERVICES,
         ):
             spec_cmd("req.md")
-            mock_workflow_manager.execute_command.assert_not_called()
+            mock_workflow_manager.assert_not_called()
             assert any(
                 "OPENAI_API_KEY" in call.args[0]
                 for call in mock_bridge.print.call_args_list
@@ -512,7 +508,7 @@ class TestCLICommands:
             new=ORIG_CHECK_SERVICES,
         ):
             spec_cmd("req.md")
-            mock_workflow_manager.execute_command.assert_not_called()
+            mock_workflow_manager.assert_not_called()
             assert any(
                 "chromadb" in call.args[0].lower()
                 for call in mock_bridge.print.call_args_list


### PR DESCRIPTION
## Summary
- move `UXBridge` abstract class to `src/devsynth/core`
- implement CLI bridge using Typer & rich
- call new `execute_workflow_command` wrapper from CLI commands
- update unit tests to patch the workflow executor
- document shared UX bridge in architecture overview

## Testing
- `poetry run pytest -q` *(fails: ModuleNotFoundError: No module named 'pytest_bdd')*

------
https://chatgpt.com/codex/tasks/task_e_6850b01cc3b08333bad67a3450a3c854