### PR TITLE
Add UXBridge documentation and roadmap milestone

### DIFF
--- a/docs/architecture/index.md
+++ b/docs/architecture/index.md
@@ -20,6 +20,7 @@ This section provides detailed information about the architecture of DevSynth, i
 - **[Overview](overview.md)**: A high-level overview of the DevSynth architecture.
 - **[Hexagonal Architecture](hexagonal_architecture.md)**: Details on the hexagonal (ports and adapters) architecture used in DevSynth.
 - **[Init Workflow](init_workflow.md)**: Sequence diagram for the interactive initialization process.
+- **[UXBridge](uxbridge.md)**: How CLI modules are decoupled from the UI and reused by the future WebUI.
 
 ## System Components
 

--- a/docs/architecture/init_workflow.md
+++ b/docs/architecture/init_workflow.md
@@ -20,7 +20,7 @@ sequenceDiagram
     participant U as User
     participant CLI as CLI
     participant UX as UXBridge
-    participant App as Application Layer
+    participant Core as CoreModules
     U->>CLI: run `devsynth init`
     CLI->>UX: request setup info
     UX->>U: prompt for project root
@@ -29,7 +29,11 @@ sequenceDiagram
     U-->>UX: choose language(s)
     UX->>U: describe project goals
     U-->>UX: confirm goals
-    UX->>App: initialize project
-    App-->>UX: summary
+    UX->>Core: initialize project
+    Core-->>UX: summary
     UX->>U: display completion
 ```
+
+Both the CLI and the future WebUI will use this same sequence by invoking the
+`CoreModules` through the `UXBridge`. This keeps initialization logic in one
+place while supporting multiple user interfaces.

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -34,7 +34,7 @@ DevSynth is a modular, agentic software engineering platform designed for extens
 graph TD
     CLI[CLI / Chat Interface] --> UXBridge[UXBridge]
     Web[WebUI (Future)] --> UXBridge
-    UXBridge --> B[Application Core]
+    UXBridge --> B[Core Modules]
     UXBridge --> IW[Init Wizard]
     B --> C[Agent System]
     B --> D[Code Analysis]
@@ -53,7 +53,9 @@ graph TD
 
 The CLI and upcoming WebUI interact with the application through a common
 `UXBridge`. This abstraction exposes simple `prompt`, `confirm` and `print`
-methods used by the workflow layer.
+methods used by the workflow layer. CLI modules in `src/devsynth/core` call
+these methods so that the same logic can be consumed by a WebUI without
+modification.
 
 ```mermaid
 graph LR

--- a/docs/architecture/uxbridge.md
+++ b/docs/architecture/uxbridge.md
@@ -1,0 +1,51 @@
+---
+title: "UXBridge Abstraction"
+date: "2025-06-16"
+version: "1.0.0"
+tags:
+  - "architecture"
+  - "ux"
+  - "cli"
+  - "webui"
+status: "draft"
+author: "DevSynth Team"
+last_reviewed: "2025-06-16"
+---
+
+# UXBridge Abstraction
+
+The **UXBridge** is a thin interface that decouples DevSynth's workflow logic from
+any specific user interface framework. CLI commands and future WebUI components
+invoke workflow functions through this common layer, allowing the same code in
+`src/devsynth/core` to be reused across different front‑ends.
+
+## Responsibilities
+
+- Expose simple `prompt`, `confirm`, and `print` methods
+- Hide presentation details from workflow logic
+- Allow mocking during tests
+- Provide a single point where alternative UIs (e.g., a WebUI) can plug in
+
+```mermaid
+graph LR
+    CLI[CLI Modules] --> Bridge[UXBridge]
+    WebUI[Future WebUI] --> Bridge
+    Bridge --> Core[Workflow Functions]
+```
+
+## WebUI Consumption
+
+The WebUI will implement the `UXBridge` interface so it can call the existing
+workflow functions without modification. CLI modules in `src/devsynth/core` will
+therefore serve both command-line users and the WebUI. By adhering to the
+`UXBridge` interface, the WebUI can provide richer interactivity while leveraging
+the same orchestration logic already used by the CLI.
+
+## Related Components
+
+- **CLI Implementation:** `src/devsynth/interface/cli.py`
+- **Bridge Definition:** `src/devsynth/core/ux_bridge.py`
+- **Workflow Functions:** `src/devsynth/core/workflows.py`
+
+The UXBridge ensures these components remain loosely coupled, enabling a smooth
+transition from a purely CLI experience to a more graphical WebUI.

--- a/docs/roadmap/actionable_roadmap.md
+++ b/docs/roadmap/actionable_roadmap.md
@@ -239,6 +239,7 @@ This roadmap transforms the comprehensive analysis findings into a practical, ph
 - [ ] All critical features have complete implementation
 - [x] Docker deployment working on major platforms
 - [x] EDRR and WSDE frameworks fully functional
+- [ ] UXBridge abstraction implemented to support future WebUI
 - [ ] Dependency count reduced by 30% with improved security
 - [x] Basic security measures implemented and tested
 


### PR DESCRIPTION
## Summary
- document UXBridge abstraction
- reference UXBridge in architecture index
- update architecture diagrams to show UXBridge and core modules
- mention UXBridge usage in init workflow
- add UXBridge milestone to Phase 1 roadmap

## Testing
- `poetry run pytest` *(fails: ImportError and multiple errors)*

------
https://chatgpt.com/codex/tasks/task_e_6850b418b4bc8333be24e819875236e8