### PR TITLE
Update tests for new CLI commands

### DIFF
--- a/tests/behavior/features/config_loader.feature
+++ b/tests/behavior/features/config_loader.feature
@@ -12,3 +12,8 @@ Feature: Configuration Loader
     Given a project with a pyproject.toml containing a [tool.devsynth] section
     When the configuration loader runs
     Then the configuration should have the key "language" set to "python"
+
+  Scenario: Create configuration file
+    Given an empty project directory
+    When I save a default configuration
+    Then a devsynth.yml file should be created

--- a/tests/behavior/features/doctor_command.feature
+++ b/tests/behavior/features/doctor_command.feature
@@ -12,3 +12,8 @@ Feature: Doctor Command
     When I run the command "devsynth doctor"
     Then the system should display a warning message
     And the output should indicate configuration errors
+
+  Scenario: Validate existing environment configuration
+    Given valid environment configuration
+    When I run the command "devsynth doctor"
+    Then the system should display a success message

--- a/tests/behavior/steps/cli_commands_steps.py
+++ b/tests/behavior/steps/cli_commands_steps.py
@@ -155,7 +155,7 @@ def run_command(command, monkeypatch, mock_workflow_manager, command_context):
                 mock_workflow_manager.execute_command.assert_called_with(
                     "init", init_args
                 )
-            elif args[0] == "analyze":
+            elif args[0] == "inspect":
                 # Parse the arguments
                 input_file = None
                 interactive = False
@@ -172,7 +172,7 @@ def run_command(command, monkeypatch, mock_workflow_manager, command_context):
                     else:
                         i += 1
 
-                # Call the analyze command
+                # Call the inspect command
                 from devsynth.application.cli.cli_commands import inspect_cmd
 
                 inspect_cmd(input_file, interactive)
@@ -566,6 +566,16 @@ def project_with_invalid_env_config(tmp_project_dir):
     os.makedirs(config_path, exist_ok=True)
     with open(os.path.join(config_path, "development.yml"), "w") as f:
         f.write("application:\n  name: DevSynth\n")
+    return tmp_project_dir
+
+
+@given("valid environment configuration")
+def valid_environment_config(tmp_project_dir):
+    config_path = os.path.join(tmp_project_dir, "config")
+    os.makedirs(config_path, exist_ok=True)
+    for env in ["development", "testing"]:
+        with open(os.path.join(config_path, f"{env}.yml"), "w") as f:
+            f.write("application:\n  name: DevSynth\n")
     return tmp_project_dir
 
 

--- a/tests/behavior/steps/config_loader_steps.py
+++ b/tests/behavior/steps/config_loader_steps.py
@@ -5,7 +5,7 @@ from pathlib import Path
 from pytest_bdd import given, when, then, scenarios, parsers
 
 import pytest
-from devsynth.config.loader import load_config
+from devsynth.config.loader import load_config, save_config, ConfigModel
 
 scenarios('../features/config_loader.feature')
 
@@ -27,6 +27,23 @@ def project_with_yaml(tmp_path, monkeypatch):
 def project_with_toml(tmp_path, monkeypatch):
     (tmp_path / 'pyproject.toml').write_text('[tool.devsynth]\nlanguage = "python"\n')
     monkeypatch.chdir(tmp_path)
+
+
+@given('an empty project directory')
+def empty_project_dir(tmp_path, monkeypatch, context):
+    monkeypatch.chdir(tmp_path)
+    context['root'] = tmp_path
+
+
+@when('I save a default configuration')
+def save_default_config(context):
+    cfg = ConfigModel(project_root=str(context['root']))
+    context['cfg_path'] = save_config(cfg, path=str(context['root']))
+
+
+@then('a devsynth.yml file should be created')
+def check_cfg_created(context):
+    assert context['cfg_path'].exists()
 
 
 @when('the configuration loader runs')

--- a/tests/behavior/steps/requirement_analysis_steps.py
+++ b/tests/behavior/steps/requirement_analysis_steps.py
@@ -64,8 +64,8 @@ def check_requirements_parsed(mock_workflow_manager):
 
     command, cmd_args = args[0]
 
-    # Check that the command was "analyze"
-    assert command == "analyze"
+    # Check that the command was "inspect"
+    assert command == "inspect"
 
 
 @then("create a structured representation in the memory system")
@@ -137,8 +137,8 @@ def check_interactive_session(mock_workflow_manager, command_context):
 
     command, cmd_args = args[0]
 
-    # Check that the command was "analyze" and the interactive flag was set
-    assert command == "analyze"
+    # Check that the command was "inspect" and the interactive flag was set
+    assert command == "inspect"
     assert cmd_args.get("interactive") is True
 
 
@@ -157,6 +157,6 @@ def check_questions_asked(mock_workflow_manager):
 
     command, cmd_args = args[0]
 
-    # Check that the command was "analyze" and the interactive flag was set
-    assert command == "analyze"
+    # Check that the command was "inspect" and the interactive flag was set
+    assert command == "inspect"
     assert cmd_args.get("interactive") is True

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -72,6 +72,9 @@ def test_environment(tmp_path, monkeypatch):
     # Set up a basic project structure
     with open(devsynth_dir / "config.json", "w") as f:
         f.write('{"model": "test-model", "project_name": "test-project"}')
+    # Create devsynth.yml for the config loader
+    with open(devsynth_dir / "devsynth.yml", "w") as f:
+        f.write("language: python\n")
 
     # Return the environment information
     return {
@@ -105,6 +108,9 @@ def tmp_project_dir():
     # Create a mock config file
     with open(temp_dir / ".devsynth" / "config.json", "w") as f:
         f.write('{"model": "gpt-4", "project_name": "test-project"}')
+    # Also write a devsynth.yml file for the unified loader
+    with open(temp_dir / ".devsynth" / "devsynth.yml", "w") as f:
+        f.write("language: python\n")
 
     # Set environment variable to disable file logging
     old_env_value = os.environ.get("DEVSYNTH_NO_FILE_LOGGING")

--- a/tests/unit/test_unit_cli_commands.py
+++ b/tests/unit/test_unit_cli_commands.py
@@ -536,3 +536,20 @@ class TestCLICommands:
         output = capsys.readouterr().out
         assert res is False
         assert "OPENAI_API_KEY" in output
+
+    def test_doctor_cmd_invokes_loader(self):
+        with patch(
+            "devsynth.application.cli.commands.doctor_cmd.load_config"
+        ) as mock_load, patch(
+            "devsynth.application.cli.commands.doctor_cmd.console.print"
+        ) as mock_print:
+            cli_commands.doctor_cmd("config")
+            mock_load.assert_called_once()
+            assert mock_print.called
+
+    def test_check_cmd_alias(self):
+        with patch(
+            "devsynth.application.cli.cli_commands.doctor_cmd"
+        ) as mock_doctor:
+            cli_commands.check_cmd("config")
+            mock_doctor.assert_called_once_with("config")


### PR DESCRIPTION
## Summary
- update CLI behavior tests for renamed commands
- ensure test fixtures create `devsynth.yml`
- extend config loader and doctor feature scenarios
- add unit tests for `doctor_cmd` and `check_cmd` alias

## Testing
- `poetry run pytest tests/unit/test_unit_cli_commands.py::TestCLICommands::test_doctor_cmd_invokes_loader -q`
- `poetry run pytest tests` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6850b5d12e9c8333b13194aa7364dfd8