### PR TITLE
Fix CLI command references

### DIFF
--- a/docs/developer_guides/configuration_storage_system.md
+++ b/docs/developer_guides/configuration_storage_system.md
@@ -153,7 +153,7 @@ This pattern is implemented in the `settings.py` file, which provides validators
 
 - Use the `devsynth init` command to create the initial `.devsynth/project.yaml` file
 - Use the `devsynth analyze-config` command (formerly `analyze-manifest`) to keep the configuration up to date
-- Use the `devsynth validate-manifest` command to validate the configuration against its schema
+ - Use the `devsynth validate-config` command to validate the configuration against its schema
 - Avoid modifying global configuration files directly unless necessary
 - Use environment variables for temporary configuration changes
 

--- a/docs/developer_guides/devsynth_contexts.md
+++ b/docs/developer_guides/devsynth_contexts.md
@@ -75,7 +75,7 @@ This context refers to applying DevSynth as a tool to assist in the development 
 - Generating specifications with `devsynth spec`
 - Creating tests with `devsynth test`
 - Generating code with `devsynth code`
-- Managing project structure with `devsynth analyze-manifest`
+ - Managing project structure with `devsynth analyze-config`
 
 ## 3. Self-Improvement: Using DevSynth to Improve DevSynth
 
@@ -101,7 +101,7 @@ This context refers to the advanced scenario where a functional version of DevSy
 ### Example Tasks
 
 - Using `devsynth analyze-code` to identify architectural improvements
-- Applying `devsynth analyze-manifest` to maintain DevSynth's own manifest
+ - Applying `devsynth analyze-config` to maintain DevSynth's own manifest
 - Using `devsynth test` to generate additional test cases
 - Leveraging `devsynth spec` to refine internal specifications
 
@@ -133,7 +133,7 @@ This context refers to the advanced scenario where a functional version of DevSy
 
 - Start with `devsynth init` to create the `.devsynth/project.yaml` file
 - Use `devsynth analyze-config` (formerly `analyze-manifest`) to keep the configuration up to date
-- Use `devsynth validate-manifest` to validate the configuration against its schema
+ - Use `devsynth validate-config` to validate the configuration against its schema
 - Follow the recommended workflow: analyze → spec → test → code
 - Provide detailed requirements for better results
 - Review and validate all generated outputs

--- a/docs/getting_started/quick_start_guide.md
+++ b/docs/getting_started/quick_start_guide.md
@@ -140,6 +140,15 @@ Finally, run the generated code to verify it works as expected:
 devsynth run-pipeline
 ```
 
+### Step 7: Manage Configuration
+
+Keep your project configuration up to date and validate it:
+
+```bash
+devsynth analyze-config
+devsynth validate-config
+```
+
 ## Viewing and Modifying Generated Artifacts
 
 After completing the steps above, your project directory will contain:

--- a/tests/behavior/features/analyze_commands.feature
+++ b/tests/behavior/features/analyze_commands.feature
@@ -35,8 +35,8 @@ Feature: Analyze Commands
     And the error message should indicate the analysis problem
 
   @manifest-analysis
-  Scenario: Analyze manifest in the current directory
-    When I run the command "devsynth analyze-manifest"
+  Scenario: Analyze config in the current directory
+    When I run the command "devsynth analyze-config"
     Then the system should analyze the project configuration
     And the output should include project information
     And the output should include structure information
@@ -44,8 +44,8 @@ Feature: Analyze Commands
     And the workflow should execute successfully
 
   @manifest-analysis
-  Scenario: Analyze manifest in a specific directory
-    When I run the command "devsynth analyze-manifest --path ./my-project"
+  Scenario: Analyze config in a specific directory
+    When I run the command "devsynth analyze-config --path ./my-project"
     Then the system should analyze the project configuration at "./my-project"
     And the output should include project information
     And the output should include structure information
@@ -53,18 +53,18 @@ Feature: Analyze Commands
     And the workflow should execute successfully
 
   @manifest-analysis
-  Scenario: Update manifest with new findings
+  Scenario: Update config with new findings
     Given a project with outdated configuration
-    When I run the command "devsynth analyze-manifest --update"
+    When I run the command "devsynth analyze-config --update"
     Then the system should analyze the project configuration
     And the system should update the configuration with new findings
     And the output should indicate that the configuration was updated
     And the workflow should execute successfully
 
   @manifest-analysis
-  Scenario: Prune manifest entries that no longer exist
+  Scenario: Prune config entries that no longer exist
     Given a project with configuration entries that no longer exist
-    When I run the command "devsynth analyze-manifest --prune"
+    When I run the command "devsynth analyze-config --prune"
     Then the system should analyze the project configuration
     And the system should remove entries that no longer exist
     And the output should indicate that the configuration was pruned
@@ -73,6 +73,6 @@ Feature: Analyze Commands
   @manifest-analysis
   Scenario: Handle missing configuration file
     Given a project without a configuration file
-    When I run the command "devsynth analyze-manifest"
+    When I run the command "devsynth analyze-config"
     Then the system should display a warning message
     And the warning message should indicate that no configuration file was found

--- a/tests/behavior/features/cli_commands.feature
+++ b/tests/behavior/features/cli_commands.feature
@@ -91,7 +91,7 @@ Feature: CLI Command Execution
     And the system should display a success message
 
 Scenario: Validate project configuration
-  When I run the command "devsynth validate-manifest"
+  When I run the command "devsynth validate-config"
   Then the system should display a success message
   And the workflow should execute successfully
 

--- a/tests/behavior/features/validate_manifest.feature
+++ b/tests/behavior/features/validate_manifest.feature
@@ -8,38 +8,38 @@ Feature: Validate Manifest
     And I have a valid DevSynth project
 
   @manifest-validation
-  Scenario: Validate manifest with default paths
-    When I run the command "devsynth validate-manifest"
+  Scenario: Validate config with default paths
+    When I run the command "devsynth validate-config"
     Then the system should validate the project configuration
     And the output should indicate that the configuration is valid
     And the workflow should execute successfully
 
   @manifest-validation
-  Scenario: Validate manifest with custom configuration path
-    When I run the command "devsynth validate-manifest --config ./custom-path/project.yaml"
+  Scenario: Validate config with custom configuration path
+    When I run the command "devsynth validate-config --config ./custom-path/project.yaml"
     Then the system should validate the project configuration at "./custom-path/project.yaml"
     And the output should indicate that the configuration is valid
     And the workflow should execute successfully
 
   @manifest-validation
-  Scenario: Validate manifest with custom schema path
-    When I run the command "devsynth validate-manifest --schema ./custom-schema.json"
+  Scenario: Validate config with custom schema path
+    When I run the command "devsynth validate-config --schema ./custom-schema.json"
     Then the system should validate the project configuration against "./custom-schema.json"
     And the output should indicate that the configuration is valid
     And the workflow should execute successfully
 
   @manifest-validation
-  Scenario: Handle invalid manifest
+  Scenario: Handle invalid configuration
     Given a project with an invalid configuration file
-    When I run the command "devsynth validate-manifest"
+    When I run the command "devsynth validate-config"
     Then the system should display an error message
     And the error message should indicate the validation errors
     And the workflow should not execute successfully
 
   @manifest-validation
-  Scenario: Handle missing manifest
+  Scenario: Handle missing configuration file
     Given a project without a configuration file
-    When I run the command "devsynth validate-manifest"
+    When I run the command "devsynth validate-config"
     Then the system should display an error message
     And the error message should indicate that no configuration file was found
     And the workflow should not execute successfully
@@ -47,7 +47,7 @@ Feature: Validate Manifest
   @manifest-validation
   Scenario: Handle missing schema
     Given a project with a missing schema file
-    When I run the command "devsynth validate-manifest --schema ./missing-schema.json"
+    When I run the command "devsynth validate-config --schema ./missing-schema.json"
     Then the system should display an error message
     And the error message should indicate that the schema file was not found
     And the workflow should not execute successfully


### PR DESCRIPTION
## Summary
- update docs to use `analyze-config` and `validate-config`
- add configuration management step to the quick start guide
- update feature files for new command names

## Testing
- `poetry run pytest tests/` *(fails: ModuleNotFoundError: No module named 'toml')*

------
https://chatgpt.com/codex/tasks/task_e_68518c919f4883338c263470a490fff3