### PR TITLE
Update docs for Python requirements and CLI list

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,10 @@ Full documentation is available in the [docs/](docs/index.md) directory and onli
 
 Installation instructions are covered in detail in the [Installation Guide](docs/getting_started/installation.md) and the [Quick Start Guide](docs/getting_started/quick_start_guide.md).
 
+### Environment Requirements
+
+DevSynth requires **Python 3.11 or higher**. Using [Poetry](https://python-poetry.org/) is recommended for managing dependencies during development.
+
 ## Installation
 
 You can install DevSynth in a few different ways:

--- a/docs/getting_started/agent_adapter_example.md
+++ b/docs/getting_started/agent_adapter_example.md
@@ -17,6 +17,10 @@ This guide demonstrates how to combine the DevSynth CLI with direct use of the
 `AgentAdapter` Python API. The accompanying script lives in
 [`examples/agent_adapter/adapter_example.py`](../../examples/agent_adapter/adapter_example.py).
 
+## Environment Requirements
+
+Ensure **Python 3.11 or higher** is installed. Poetry is recommended for dependency management during development.
+
 ## 1. Initialize a Project
 
 Create a new project directory and initialize DevSynth:

--- a/docs/getting_started/basic_usage.md
+++ b/docs/getting_started/basic_usage.md
@@ -15,6 +15,10 @@ last_reviewed: "2025-06-15"
 
 This guide provides essential information about the basic usage of DevSynth, including initializing a project, defining requirements, and generating code.
 
+## Environment Requirements
+
+Ensure you are using **Python 3.11 or higher**. Poetry is recommended for managing dependencies during development.
+
 ## Overview
 
 DevSynth follows a structured workflow that takes you from requirements to working code. This guide covers the fundamental commands you'll use in a typical DevSynth project.

--- a/docs/getting_started/concise_walkthrough.md
+++ b/docs/getting_started/concise_walkthrough.md
@@ -16,6 +16,10 @@ last_reviewed: "2025-06-15"
 This walkthrough provides a short overview of the DevSynth workflow.
 For additional details, see the [Quick Start Guide](quick_start_guide.md).
 
+## Environment Requirements
+
+DevSynth requires **Python 3.11 or higher**. Poetry is recommended for managing dependencies.
+
 ## 1. Initialize a Project
 
 Create a new project directory named `demo`:

--- a/docs/getting_started/example_project.md
+++ b/docs/getting_started/example_project.md
@@ -14,6 +14,10 @@ last_reviewed: "2025-06-15"
 
 This guide walks through a small calculator example included in the `examples/` directory. It demonstrates project initialization, specification and test generation, code creation, and running the final program.
 
+## Environment Requirements
+
+Ensure you are running **Python 3.11 or higher**. Poetry is recommended for dependency management.
+
 ## Location
 
 The example lives in [`examples/calculator`](../../examples/calculator). Each file shows what you would have after running DevSynth commands.

--- a/docs/getting_started/index.md
+++ b/docs/getting_started/index.md
@@ -21,6 +21,10 @@ This section provides essential information for getting started with DevSynth, i
 - **[Basic Usage](basic_usage.md)**: An introduction to the basic usage of DevSynth.
 - **[Example Project](example_project.md)**: A complete walk-through using the calculator example.
 
+## Environment Requirements
+
+DevSynth requires **Python 3.11 or higher**. For development workflows, the team recommends managing dependencies with [Poetry](https://python-poetry.org/).
+
 ## Overview
 
 DevSynth is a powerful tool that helps developers generate code from requirements using AI. This section will help you install DevSynth, understand its basic usage, and get started with your first project.

--- a/docs/getting_started/troubleshooting.md
+++ b/docs/getting_started/troubleshooting.md
@@ -16,6 +16,10 @@ last_reviewed: "2025-06-01"
 
 This guide provides solutions to common issues you might encounter when using DevSynth. If you're experiencing problems, check this guide before submitting an issue.
 
+## Environment Requirements
+
+Ensure your environment is running **Python 3.11 or higher**. Managing dependencies with Poetry can help avoid version conflicts.
+
 ## Table of Contents
 
 - [Installation Issues](#installation-issues)

--- a/docs/specifications/devsynth_specification_mvp_updated.md
+++ b/docs/specifications/devsynth_specification_mvp_updated.md
@@ -117,7 +117,12 @@ The MVP architecture follows a simplified layered approach with clear separation
 
 **MVP Scope:**
 - Command parser using Click or Typer library
-- Core command set: init, spec, test, code, run-pipeline, inspect, refactor, retrace, doctor, config, tokens, help
+ - Core command set: `init`, `spec`, `test`, `code`, `run-pipeline`, `inspect`,
+   `refactor`, `retrace`, `doctor`/`check`, `ingest`, `apispec`, `webapp`,
+   `dbschema`, `analyze-code`, `edrr-cycle`, `align`, `alignment-metrics`,
+   `analyze-manifest` (alias `analyze-config`), `validate-manifest`,
+   `validate-metadata`, `test-metrics`, `generate-docs`, `serve`, and the
+   `config` subcommands (including `enable-feature`).
 - Simple progress indicators
 - Basic error handling with clear messages
 - Unified YAML/TOML configuration loader
@@ -439,7 +444,8 @@ Multi-agent collaboration will be deferred to a future version. The MVP will use
 - Token usage limits and tracking
 
 **Implementation Guidance:**
-- Use YAML for configuration files
+ - Use YAML or TOML for configuration files. The loader relies on the `toml`
+   package to read settings from `pyproject.toml` under `[tool.devsynth]`.
 - Support environment variable overrides
 - Validate configuration on load
 - Provide sensible defaults
@@ -500,8 +506,7 @@ Multi-agent collaboration will be deferred to a future version. The MVP will use
 
 #### 4.1.6 Unified Configuration Loader
 
-- **FR-69**: Load project configuration from YAML or TOML using a common parser
-The loader merges settings from `devsynth.yml` or `[tool.devsynth]` in `pyproject.toml` into a single `DevSynthConfig` object for consistent access across commands.
+- **FR-69**: Load project configuration from YAML or TOML using a common parser. The loader merges settings from `devsynth.yml` or `[tool.devsynth]` in `pyproject.toml` into a single `DevSynthConfig` object for consistent access across commands. Parsing of `pyproject.toml` uses the `toml` library.
 
 #### 4.1.7 CLI/WebUI Bridge Preparation
 


### PR DESCRIPTION
## Summary
- specify Python 3.11+ requirement in README
- document environment prerequisites across getting started docs
- expand CLI command list in specification doc
- mention TOML loader details for configuration

## Testing
- `poetry run pytest tests` *(fails: ImportError during collection)*

------
https://chatgpt.com/codex/tasks/task_e_6851f286a1188333966a616fe4edaa3a