### PR TITLE
Add WebUI overview doc and update UXBridge diagram

### DIFF
--- a/docs/architecture/index.md
+++ b/docs/architecture/index.md
@@ -22,6 +22,7 @@ This section provides detailed information about the architecture of DevSynth, i
 - **[Init Workflow](init_workflow.md)**: Sequence diagram for the interactive initialization process.
 - **[UXBridge](uxbridge.md)**: How CLI modules are decoupled from the UI and reused by the future WebUI.
 - **[Phase 1 Overhaul](phase1_overhaul.md)**: Summary of the CLI refactor, unified configuration, and UXBridge pattern.
+- **[WebUI Overview](webui_overview.md)**: Layout of the Streamlit interface and its use of UXBridge.
 
 ## System Components
 

--- a/docs/architecture/uxbridge.md
+++ b/docs/architecture/uxbridge.md
@@ -29,7 +29,8 @@ invoke workflow functions through this common layer, allowing the same code in
 ```mermaid
 graph LR
     CLI[CLI Modules] --> Bridge[UXBridge]
-    WebUI[Future WebUI] --> Bridge
+    WebUI[WebUI] --> Bridge
+    AgentAPI[Agent API] --> Bridge
     Bridge --> Core[Workflow Functions]
 ```
 

--- a/docs/architecture/webui_overview.md
+++ b/docs/architecture/webui_overview.md
@@ -8,6 +8,7 @@ tags:
   - "ux"
 status: "draft"
 author: "DevSynth Team"
+last_reviewed: "2025-06-18"
 ---
 
 # WebUI Architecture Overview
@@ -15,7 +16,20 @@ author: "DevSynth Team"
 The WebUI presents DevSynth workflows via Streamlit while reusing the
 existing CLI logic through the `UXBridge` abstraction. The `WebUI`
 class implements the bridge methods and exposes navigable pages for the
-core workflows.
+core workflows. By consuming the `UXBridge` interface it reuses the same
+workflow orchestration that powers the CLI.
+
+## Side Navigation Layout
+
+```mermaid
+flowchart TB
+    Sidebar["Sidebar Navigation"]
+    Sidebar --> Onboarding
+    Sidebar --> Requirements
+    Sidebar --> Analysis
+    Sidebar --> Synthesis
+    Sidebar --> Config
+```
 
 ## Pseudocode
 


### PR DESCRIPTION
## Summary
- add front matter and navigation diagram for WebUI
- update UXBridge diagram with Agent API
- link WebUI overview from architecture index

## Testing
- `python scripts/validate_metadata.py docs/architecture/webui_overview.md docs/architecture/uxbridge.md docs/architecture/index.md`
- `poetry run pytest tests/` *(fails: ModuleNotFoundError for chromadb and openai)*

------
https://chatgpt.com/codex/tasks/task_e_6852ed6cbcec8333a05b6a43b388ec68