### PR TITLE
Add WebUI command BDD scenarios and agent API tests

### DIFF
--- a/src/devsynth/interface/agentapi.py
+++ b/src/devsynth/interface/agentapi.py
@@ -1,0 +1,64 @@
+"""Programmatic API mirroring the CLI workflows."""
+from __future__ import annotations
+
+from typing import Optional
+
+from devsynth.interface.ux_bridge import UXBridge
+
+
+class AgentAPI:
+    """Expose workflow functions for other integrations."""
+
+    def __init__(self, bridge: UXBridge) -> None:
+        self.bridge = bridge
+
+    def init(
+        self,
+        path: str = ".",
+        *,
+        project_root: Optional[str] = None,
+        language: Optional[str] = None,
+        goals: Optional[str] = None,
+    ) -> None:
+        from devsynth.application.cli import init_cmd
+
+        init_cmd(
+            path=path,
+            project_root=project_root,
+            language=language,
+            goals=goals,
+            bridge=self.bridge,
+        )
+
+    def spec(self, requirements_file: str = "requirements.md") -> None:
+        from devsynth.application.cli import spec_cmd
+
+        spec_cmd(requirements_file=requirements_file, bridge=self.bridge)
+
+    def inspect(self, input_file: str = "requirements.md") -> None:
+        from devsynth.application.cli import inspect_cmd
+
+        inspect_cmd(input_file=input_file, interactive=False, bridge=self.bridge)
+
+    def test(self, spec_file: str = "specs.md") -> None:
+        from devsynth.application.cli import test_cmd
+
+        test_cmd(spec_file=spec_file, bridge=self.bridge)
+
+    def code(self) -> None:
+        from devsynth.application.cli import code_cmd
+
+        code_cmd(bridge=self.bridge)
+
+    def run_pipeline(self, target: Optional[str] = None) -> None:
+        from devsynth.application.cli import run_pipeline_cmd
+
+        run_pipeline_cmd(target=target, bridge=self.bridge)
+
+    def config(self, key: Optional[str] = None, value: Optional[str] = None) -> None:
+        from devsynth.application.cli import config_cmd
+
+        config_cmd(key=key, value=value, bridge=self.bridge)
+
+
+__all__ = ["AgentAPI"]

--- a/tests/behavior/features/webui_commands.feature
+++ b/tests/behavior/features/webui_commands.feature
@@ -1,0 +1,46 @@
+Feature: WebUI Command Execution
+  As a developer
+  I want to run DevSynth workflows from the WebUI
+  So that I can manage my project graphically
+
+  Background:
+    Given the WebUI is initialized
+
+  Scenario: Initialize a project through onboarding
+    When I submit the onboarding form
+    Then the init command should be executed
+
+  Scenario: Generate specifications from the requirements page
+    When I navigate to "Requirements"
+    And I submit the specification form
+    Then the spec command should be executed
+
+  Scenario: Inspect requirements from the requirements page
+    When I navigate to "Requirements"
+    And I submit the inspect form
+    Then the inspect command should be executed
+
+  Scenario: Generate tests from the synthesis page
+    When I navigate to "Synthesis"
+    And I submit the test form
+    Then the test command should be executed
+
+  Scenario: Generate code from the synthesis page
+    When I navigate to "Synthesis"
+    And I click the generate code button
+    Then the code command should be executed
+
+  Scenario: Run the pipeline from the synthesis page
+    When I navigate to "Synthesis"
+    And I click the run pipeline button
+    Then the run_pipeline command should be executed
+
+  Scenario: Update configuration via the config page
+    When I navigate to "Config"
+    And I update a configuration value
+    Then the config command should be executed
+
+  Scenario: View all configuration via the config page
+    When I navigate to "Config"
+    And I view all configuration
+    Then the config command should be executed

--- a/tests/behavior/steps/webui_commands_steps.py
+++ b/tests/behavior/steps/webui_commands_steps.py
@@ -1,0 +1,86 @@
+from types import ModuleType
+from unittest.mock import MagicMock
+import sys
+
+import pytest
+from pytest_bdd import given, when, then, scenarios
+
+from .webui_steps import webui_context, DummyForm
+
+scenarios("../features/webui_commands.feature")
+
+
+@given("the WebUI is initialized")
+def _init(webui_context):
+    return webui_context
+
+
+@when("I submit the specification form")
+def submit_spec(webui_context):
+    webui_context["st"].sidebar.radio.return_value = "Requirements"
+    webui_context["st"].form_submit_button.side_effect = [True, False]
+    webui_context["ui"].run()
+
+
+@when("I submit the inspect form")
+def submit_inspect(webui_context):
+    webui_context["st"].sidebar.radio.return_value = "Requirements"
+    webui_context["st"].form_submit_button.side_effect = [False, True]
+    webui_context["ui"].run()
+
+
+@when("I submit the test form")
+def submit_test(webui_context):
+    webui_context["st"].sidebar.radio.return_value = "Synthesis"
+    webui_context["st"].form_submit_button.return_value = True
+    webui_context["st"].button.side_effect = [False, False]
+    webui_context["ui"].run()
+
+
+@when("I click the generate code button")
+def click_generate_code(webui_context):
+    webui_context["st"].sidebar.radio.return_value = "Synthesis"
+    webui_context["st"].form_submit_button.return_value = False
+    webui_context["st"].button.side_effect = [True, False]
+    webui_context["ui"].run()
+
+
+@when("I click the run pipeline button")
+def click_run_pipeline(webui_context):
+    webui_context["st"].sidebar.radio.return_value = "Synthesis"
+    webui_context["st"].form_submit_button.return_value = False
+    webui_context["st"].button.side_effect = [False, True]
+    webui_context["ui"].run()
+
+
+@when("I view all configuration")
+def view_all_config(webui_context):
+    webui_context["st"].sidebar.radio.return_value = "Config"
+    webui_context["st"].form_submit_button.return_value = False
+    webui_context["st"].button.return_value = True
+    webui_context["ui"].run()
+
+
+@then("the spec command should be executed")
+def check_spec(webui_context):
+    assert webui_context["cli"].spec_cmd.called
+
+
+@then("the inspect command should be executed")
+def check_inspect(webui_context):
+    assert webui_context["cli"].inspect_cmd.called
+
+
+@then("the test command should be executed")
+def check_test(webui_context):
+    assert webui_context["cli"].test_cmd.called
+
+
+@then("the code command should be executed")
+def check_code(webui_context):
+    assert webui_context["cli"].code_cmd.called
+
+
+@then("the run_pipeline command should be executed")
+def check_run_pipeline(webui_context):
+    assert webui_context["cli"].run_pipeline_cmd.called

--- a/tests/behavior/steps/webui_steps.py
+++ b/tests/behavior/steps/webui_steps.py
@@ -25,9 +25,15 @@ class DummyForm:
 @pytest.fixture
 def webui_context(monkeypatch):
     st = ModuleType("streamlit")
-    st.session_state = {}
+    class SS(dict):
+        pass
+
+    st.session_state = SS()
+    st.session_state.wizard_step = 0
+    st.session_state.wizard_data = {}
     st.sidebar = ModuleType("sidebar")
     st.sidebar.radio = MagicMock(return_value="Onboarding")
+    st.sidebar.title = MagicMock()
     st.set_page_config = MagicMock()
     st.header = MagicMock()
     st.expander = lambda *_a, **_k: DummyForm(True)

--- a/tests/behavior/test_webui_commands.py
+++ b/tests/behavior/test_webui_commands.py
@@ -1,0 +1,6 @@
+from pytest_bdd import scenarios
+
+from .steps.webui_steps import *  # noqa: F401,F403
+from .steps.webui_commands_steps import *  # noqa: F401,F403
+
+scenarios("features/webui_commands.feature")

--- a/tests/integration/test_agentapi.py
+++ b/tests/integration/test_agentapi.py
@@ -1,0 +1,134 @@
+"""Integration tests for the AgentAPI wrapper."""
+from types import ModuleType
+from unittest.mock import MagicMock
+import sys
+import importlib
+
+from devsynth.interface.ux_bridge import UXBridge
+
+
+def _setup(monkeypatch):
+    cli_stub = ModuleType("devsynth.application.cli")
+    for name in [
+        "init_cmd",
+        "spec_cmd",
+        "inspect_cmd",
+        "test_cmd",
+        "code_cmd",
+        "run_pipeline_cmd",
+        "config_cmd",
+    ]:
+        setattr(cli_stub, name, MagicMock())
+    monkeypatch.setitem(sys.modules, "devsynth.application.cli", cli_stub)
+
+    analyze_stub = ModuleType("devsynth.application.cli.commands.analyze_code_cmd")
+    analyze_stub.analyze_code_cmd = MagicMock()
+    monkeypatch.setitem(
+        sys.modules,
+        "devsynth.application.cli.commands.analyze_code_cmd",
+        analyze_stub,
+    )
+
+    st = ModuleType("streamlit")
+    class SS(dict):
+        pass
+
+    st.session_state = SS()
+    st.session_state.wizard_step = 0
+    st.session_state.wizard_data = {}
+    st.sidebar = ModuleType("sidebar")
+    st.sidebar.radio = MagicMock(return_value="Onboarding")
+    st.sidebar.title = MagicMock()
+    st.set_page_config = MagicMock()
+    st.header = MagicMock()
+    st.expander = lambda *_a, **_k: DummyForm(True)
+    st.form = lambda *_a, **_k: DummyForm(True)
+    st.form_submit_button = MagicMock(return_value=True)
+    st.text_input = MagicMock(return_value="text")
+    st.text_area = MagicMock(return_value="desc")
+    st.selectbox = MagicMock(return_value="choice")
+    st.checkbox = MagicMock(return_value=True)
+    st.button = MagicMock(return_value=False)
+    st.spinner = DummyForm
+    st.divider = MagicMock()
+    st.columns = MagicMock(return_value=(MagicMock(button=lambda *a, **k: False), MagicMock(button=lambda *a, **k: False)))
+    st.progress = MagicMock()
+    st.write = MagicMock()
+    st.markdown = MagicMock()
+    monkeypatch.setitem(sys.modules, "streamlit", st)
+
+    import devsynth.interface.webui as webui
+    importlib.reload(webui)
+
+    return cli_stub, webui
+
+
+class DummyForm:
+    def __init__(self, submitted: bool = True):
+        self.submitted = submitted
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+    def form_submit_button(self, *_args, **_kwargs):
+        return self.submitted
+
+
+def test_init_matches_webui(monkeypatch):
+    cli_stub, webui = _setup(monkeypatch)
+    bridge = MagicMock(spec=UXBridge)
+    from devsynth.interface.agentapi import AgentAPI
+    api = AgentAPI(bridge)
+    api.init(path="text", project_root="text", language="text", goals="text")
+
+    ui = webui.WebUI()
+    ui.onboarding_page()
+
+    assert cli_stub.init_cmd.call_count == 2
+    args_api = cli_stub.init_cmd.call_args_list[0].kwargs
+    args_ui = cli_stub.init_cmd.call_args_list[1].kwargs
+    args_api.pop("bridge", None)
+    args_ui.pop("bridge", None)
+    assert args_api == args_ui
+
+
+def test_spec_matches_webui(monkeypatch):
+    cli_stub, webui = _setup(monkeypatch)
+    bridge = MagicMock(spec=UXBridge)
+    from devsynth.interface.agentapi import AgentAPI
+    api = AgentAPI(bridge)
+    api.spec("req.md")
+
+    webui.st.sidebar.radio.return_value = "Requirements"
+    webui.st.form_submit_button.side_effect = [True, False]
+    webui.WebUI().run()
+
+    assert cli_stub.spec_cmd.call_count == 2
+    args_api = cli_stub.spec_cmd.call_args_list[0].kwargs
+    args_ui = cli_stub.spec_cmd.call_args_list[1].kwargs
+    args_api.pop("bridge", None)
+    args_ui.pop("bridge", None)
+    assert args_api == args_ui
+
+
+def test_config_matches_webui(monkeypatch):
+    cli_stub, webui = _setup(monkeypatch)
+    bridge = MagicMock(spec=UXBridge)
+    from devsynth.interface.agentapi import AgentAPI
+    api = AgentAPI(bridge)
+    api.config(key="model", value="gpt-4")
+
+    webui.st.sidebar.radio.return_value = "Config"
+    webui.st.form_submit_button.return_value = True
+    webui.st.text_input.side_effect = ["model", "gpt-4"]
+    webui.WebUI().run()
+
+    assert cli_stub.config_cmd.call_count == 2
+    args_api = cli_stub.config_cmd.call_args_list[0].kwargs
+    args_ui = cli_stub.config_cmd.call_args_list[1].kwargs
+    args_api.pop("bridge", None)
+    args_ui.pop("bridge", None)
+    assert args_api == args_ui


### PR DESCRIPTION
## Summary
- add feature file for WebUI command workflow
- implement step definitions mocking streamlit
- provide AgentAPI wrapper over CLI commands
- test AgentAPI integration and WebUI parity

## Testing
- `pytest tests/integration/test_agentapi.py tests/behavior/test_webui_commands.py -q` *(fails: StepDefinitionNotFound and ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_6852f083a2408333a437742686d5c6d1