### PR TITLE
Add CLI entry for Streamlit WebUI

### DIFF
--- a/docs/specifications/webui_detailed_spec.md
+++ b/docs/specifications/webui_detailed_spec.md
@@ -35,7 +35,7 @@ flowchart TD
 
 ## Constraints
 
-- Must run locally via `streamlit run src/devsynth/interface/webui.py`.
+- Must run locally via `devsynth webui`.
 - Shares the same environment and configuration files as the CLI.
 - Requires the user to have Python and dependencies installed.
 

--- a/docs/user_guides/cli_reference.md
+++ b/docs/user_guides/cli_reference.md
@@ -387,7 +387,7 @@ devsynth webapp --framework flask --name demo --path ./apps
 Launch the Streamlit based graphical interface.
 
 ```bash
-streamlit run src/devsynth/interface/webui.py
+devsynth webui
 ```
 
 The WebUI mirrors CLI commands using the same `UXBridge` workflows.

--- a/docs/user_guides/webui_reference.md
+++ b/docs/user_guides/webui_reference.md
@@ -14,7 +14,7 @@ author: "DevSynth Team"
 The WebUI provides a Streamlit front-end that mirrors the CLI workflow commands. Start it with:
 
 ```bash
-streamlit run src/devsynth/interface/webui.py
+devsynth webui
 ```
 
 ## Navigation

--- a/src/devsynth/adapters/cli/typer_adapter.py
+++ b/src/devsynth/adapters/cli/typer_adapter.py
@@ -13,6 +13,7 @@ from devsynth.application.cli import (
     config_app,
     inspect_cmd,
     webapp_cmd,
+    webui_cmd,
     dbschema_cmd,
     doctor_cmd,
     refactor_cmd,
@@ -62,7 +63,9 @@ def build_app() -> typer.Typer:
         name="test",
         help="Generate tests from specs. Example: devsynth test --spec-file specs.md",
     )(test_cmd)
-    app.command(name="code", help="Generate code from tests. Example: devsynth code")(code_cmd)
+    app.command(name="code", help="Generate code from tests. Example: devsynth code")(
+        code_cmd
+    )
     app.command(
         name="run-pipeline",
         help="Execute the generated code. Example: devsynth run-pipeline --target unit-tests",
@@ -76,6 +79,10 @@ def build_app() -> typer.Typer:
         name="webapp",
         help="Generate a web application. Example: devsynth webapp --framework flask",
     )(webapp_cmd)
+    app.command(
+        name="webui",
+        help="Launch the Streamlit UI. Example: devsynth webui",
+    )(webui_cmd)
     app.command(
         name="dbschema",
         help="Generate a database schema. Example: devsynth dbschema --db-type sqlite",

--- a/src/devsynth/application/cli/__init__.py
+++ b/src/devsynth/application/cli/__init__.py
@@ -2,6 +2,7 @@
 Application-level CLI facades that delegate into orchestration layer.
 Each function contains only I/O & user interaction concerns.
 """
+
 from devsynth.logging_setup import DevSynthLogger
 from devsynth.exceptions import DevSynthError
 
@@ -20,11 +21,13 @@ from .cli_commands import (
     config_app,
     inspect_cmd,
     webapp_cmd,
+    webui_cmd,
     dbschema_cmd,
     check_cmd,
     refactor_cmd,
     serve_cmd,
 )
+
 # Doctor command now lives in the commands package
 from .commands.doctor_cmd import doctor_cmd
 
@@ -43,6 +46,7 @@ __all__ = [
     "config_app",
     "inspect_cmd",
     "webapp_cmd",
+    "webui_cmd",
     "dbschema_cmd",
     "doctor_cmd",
     "check_cmd",

--- a/src/devsynth/application/cli/cli_commands.py
+++ b/src/devsynth/application/cli/cli_commands.py
@@ -1273,3 +1273,13 @@ def check_cmd(config_dir: str = "config") -> None:
         `devsynth check`
     """
     doctor_cmd(config_dir)
+
+
+def webui_cmd() -> None:
+    """Launch the Streamlit WebUI."""
+    try:
+        from devsynth.interface.webui import run
+
+        run()
+    except Exception as err:  # pragma: no cover - defensive
+        console.print(f"[red]Error:[/red] {err}")

--- a/src/devsynth/interface/webui.py
+++ b/src/devsynth/interface/webui.py
@@ -248,9 +248,17 @@ class WebUI(UXBridge):
             self.config_page()
 
 
-def run_webui() -> None:
-    """Convenience entry point for ``streamlit run``."""
+def run() -> None:
+    """Convenience entry point for ``streamlit run`` or the CLI."""
     WebUI().run()
 
 
-__all__ = ["WebUI", "run_webui"]
+# Backwards compatibility with older docs
+run_webui = run
+
+
+__all__ = ["WebUI", "run"]
+
+
+if __name__ == "__main__":  # pragma: no cover - manual invocation
+    run()


### PR DESCRIPTION
## Summary
- expose `run()` in `webui.py` and add `__main__` guard
- add `webui_cmd` and register `webui` command with Typer
- document new usage in CLI and WebUI docs

## Testing
- `poetry run pytest tests/unit/interface/test_webui.py`
- `poetry run pytest tests` *(fails: ModuleNotFoundError: No module named 'chromadb')*

------
https://chatgpt.com/codex/tasks/task_e_6852f5d5b29c83338a6d26d859417803