### PR TITLE
Add CLI to WebUI mapping

### DIFF
--- a/docs/user_guides/cli_reference.md
+++ b/docs/user_guides/cli_reference.md
@@ -392,6 +392,23 @@ devsynth webui
 
 The WebUI mirrors CLI commands using the same `UXBridge` workflows.
 
+| CLI Command | WebUI Page/Action |
+|-------------|------------------|
+| `init` | **Onboarding** page – Initialize Project |
+| `spec` | **Requirements** page – Generate Specs |
+| `inspect` | **Requirements** page – Inspect Requirements |
+| `test` | **Synthesis** page – Generate Tests |
+| `code` | **Synthesis** page – Generate Code |
+| `run-pipeline` | **Synthesis** page – Run Pipeline |
+| `config` | **Config** page – Update Settings |
+
+```python
+# Pseudocode: WebUI page invoking a CLI workflow
+def trigger_action(command: str, **kwargs):
+    cli_fn = getattr(cli_commands, f"{command}_cmd")
+    cli_fn(**kwargs, bridge=self)  # 'self' implements UXBridge
+```
+
 ### dbschema
 
 Generate a database schema for a given database type.

--- a/docs/user_guides/webui_reference.md
+++ b/docs/user_guides/webui_reference.md
@@ -30,3 +30,10 @@ The sidebar offers the following pages:
 Each page shows progress spinners and uses collapsible sections for optional input.
 
 For more details on individual commands see the [CLI Reference](cli_reference.md).
+
+```python
+# Pseudocode
+def webui_button_clicked():
+    # delegate to CLI workflow via UXBridge
+    spec_cmd(requirements_file="req.md", bridge=self)
+```


### PR DESCRIPTION
## Summary
- document how CLI commands map to WebUI pages
- include UXBridge routing pseudocode for users

## Testing
- `pytest tests/behavior/test_webui_commands.py -q` *(fails: Step definition not found)*

------
https://chatgpt.com/codex/tasks/task_e_6853171b43508333b23b47a35cb9c118