### PR TITLE
Add FastAPI agent API with tests

### DIFF
--- a/docs/specifications/agent_api_stub.md
+++ b/docs/specifications/agent_api_stub.md
@@ -1,0 +1,66 @@
+---
+title: "Agent API Stub"
+date: "2025-06-19"
+version: "0.1.0"
+tags:
+  - "specification"
+  - "api"
+status: "draft"
+author: "DevSynth Team"
+---
+
+# Agent API Stub
+
+This document outlines the minimal HTTP interface for driving DevSynth
+workflows programmatically. The API mirrors the CLI and WebUI behaviour
+through the `UXBridge` abstraction.
+
+## Endpoints
+
+### `POST /init`
+Initializes or onboards a project.
+
+Example request:
+```json
+{ "path": ".", "project_root": ".", "language": "python", "goals": "demo" }
+```
+Example response:
+```json
+{ "messages": ["Initialized DevSynth project"] }
+```
+
+### `POST /gather`
+Collects project goals and constraints.
+
+Example request:
+```json
+{
+  "goals": "ai, tests",
+  "constraints": "offline",
+  "priority": "medium"
+}
+```
+Example response:
+```json
+{ "messages": ["Requirements saved to requirements_plan.yaml"] }
+```
+
+### `POST /synthesize`
+Runs the synthesis pipeline.
+
+Example request:
+```json
+{ "target": "unit-tests" }
+```
+Example response:
+```json
+{ "messages": ["Execution complete."] }
+```
+
+### `GET /status`
+Returns the messages from the most recent workflow invocation.
+
+Example response:
+```json
+{ "messages": ["Execution complete."] }
+```

--- a/tests/integration/test_agentapi_routes.py
+++ b/tests/integration/test_agentapi_routes.py
@@ -1,0 +1,63 @@
+from types import ModuleType
+from unittest.mock import MagicMock
+import importlib
+import sys
+
+from fastapi.testclient import TestClient
+
+
+def _setup(monkeypatch):
+    cli_stub = ModuleType("devsynth.application.cli")
+
+    def init_cmd(path=".", project_root=None, language=None, goals=None, *, bridge):
+        bridge.display_result("init")
+
+    def gather_cmd(output_file="requirements_plan.yaml", *, bridge):
+        g = bridge.ask_question("g")
+        c = bridge.ask_question("c")
+        p = bridge.ask_question("p")
+        bridge.display_result(f"{g},{c},{p}")
+
+    def run_pipeline_cmd(target=None, *, bridge):
+        bridge.display_result(f"run:{target}")
+
+    cli_stub.init_cmd = MagicMock(side_effect=init_cmd)
+    cli_stub.gather_cmd = MagicMock(side_effect=gather_cmd)
+    cli_stub.run_pipeline_cmd = MagicMock(side_effect=run_pipeline_cmd)
+    monkeypatch.setitem(sys.modules, "devsynth.application.cli", cli_stub)
+
+    import devsynth.interface.agentapi as agentapi
+
+    importlib.reload(agentapi)
+    return cli_stub, agentapi
+
+
+def test_init_route(monkeypatch):
+    cli_stub, agentapi = _setup(monkeypatch)
+    client = TestClient(agentapi.app)
+    resp = client.post("/init", json={"path": "proj"})
+    assert resp.status_code == 200
+    assert resp.json() == {"messages": ["init"]}
+    cli_stub.init_cmd.assert_called_once()
+
+
+def test_gather_route(monkeypatch):
+    cli_stub, agentapi = _setup(monkeypatch)
+    client = TestClient(agentapi.app)
+    resp = client.post(
+        "/gather",
+        json={"goals": "g1", "constraints": "c1", "priority": "high"},
+    )
+    assert resp.status_code == 200
+    assert resp.json() == {"messages": ["g1,c1,high"]}
+    cli_stub.gather_cmd.assert_called_once()
+
+
+def test_synthesize_and_status(monkeypatch):
+    cli_stub, agentapi = _setup(monkeypatch)
+    client = TestClient(agentapi.app)
+    resp = client.post("/synthesize", json={"target": "unit"})
+    assert resp.json() == {"messages": ["run:unit"]}
+    status = client.get("/status")
+    assert status.json() == {"messages": ["run:unit"]}
+    cli_stub.run_pipeline_cmd.assert_called_once()


### PR DESCRIPTION
## Summary
- implement new FastAPI-based Agent API with /init, /gather, /synthesize and /status routes
- capture workflow messages using APIBridge
- document usage in `agent_api_stub.md`
- add integration tests for the API endpoints
- refine bridge docstrings and correct spec date

## Testing
- `PYTHONPATH=src pytest tests/integration/test_agentapi_routes.py -q`

------
https://chatgpt.com/codex/tasks/task_e_685350b71c848333a9a45e12f94928d6