### PR TITLE
Update WebUI and API specs

### DIFF
--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -32,8 +32,9 @@ DevSynth is a modular, agentic software engineering platform designed for extens
 
 ```mermaid
 graph TD
-    CLI[interface/cli] --> UXBridge[UXBridge]
-    Web[interface/webui (future)] --> UXBridge
+    CLI[CLI] --> UXBridge[UXBridge]
+    WebUI[Streamlit WebUI] --> UXBridge
+    API[Agent API] --> UXBridge
     UXBridge --> B[Core Modules]
     UXBridge --> IW[Init Wizard]
     B --> C[Agent System]
@@ -51,16 +52,18 @@ graph TD
 
 ### Shared UX Bridge
 
-The CLI and upcoming WebUI interact with the application through a common
-`UXBridge`. This abstraction exposes simple `prompt`, `confirm` and `print`
-methods used by the workflow layer. CLI modules in `src/devsynth/application/cli` call
-these methods so that the same logic can be consumed by a WebUI without
-modification.
+The CLI, Streamlit WebUI and Agent API all interact with the core
+application through a common `UXBridge`. The bridge exposes
+`ask_question`, `confirm_choice` and `display_result` methods so that
+workflows remain UI agnostic. CLI modules in `src/devsynth/application/cli`
+call these methods, enabling both graphical and programmatic interfaces to
+reuse the same orchestration logic without modification.
 
 ```mermaid
 graph LR
-    CLI[interface/cli] --> Bridge[UXBridge]
-    WebUI[interface/webui (future)] --> Bridge
+    CLI[CLI] --> Bridge[UXBridge]
+    WebUI[Streamlit WebUI] --> Bridge
+    API[Agent API] --> Bridge
     Bridge --> Core[Core Workflows]
 ```
 

--- a/docs/requirements_traceability.md
+++ b/docs/requirements_traceability.md
@@ -80,6 +80,13 @@ This matrix links requirements to design, code modules, and tests, ensuring bidi
 | FR-72 | Streamlit-based WebUI for running workflows | [WebUI Specification](specifications/webui_spec.md) | src/devsynth/interface/webui.py | tests/behavior/features/webui.feature | Planned |
 | FR-73 | Interactive requirement-gathering workflow | [Interactive Requirements Wizard](specifications/interactive_requirements_wizard.md) | src/devsynth/application/cli/requirements_commands.py, src/devsynth/interface/webui.py | tests/behavior/features/interactive_requirements.feature | Planned |
 | FR-74 | HTTP API for agent operations | [HTTP API Specification](specifications/http_api_spec.md) | src/devsynth/api.py | tests/integration/test_api_server.py | Planned |
-| FR-72 | Sidebar WebUI with pages for onboarding, requirements, analysis, synthesis and config | [WebUI Architecture](architecture/webui_overview.md) | src/devsynth/interface/webui.py | tests/behavior/features/webui.feature, tests/unit/interface/test_webui.py | Implemented |
+| FR-75 | Sidebar WebUI with pages for onboarding, requirements, analysis, synthesis and config | [WebUI Architecture](architecture/webui_overview.md) | src/devsynth/interface/webui.py | tests/behavior/features/webui.feature, tests/unit/interface/test_webui.py | Implemented |
+| FR-76 | WebUI invokes workflows through UXBridge | [WebUI Detailed Specification](specifications/webui_detailed_spec.md) | src/devsynth/interface/webui.py | tests/behavior/features/webui.feature | Implemented |
+| FR-77 | WebUI shows progress indicators during execution | [WebUI Detailed Specification](specifications/webui_detailed_spec.md) | src/devsynth/interface/webui.py | tests/behavior/features/webui.feature | Implemented |
+| FR-78 | WebUI offers collapsible sections for complex forms | [WebUI Detailed Specification](specifications/webui_detailed_spec.md) | src/devsynth/interface/webui.py | tests/behavior/features/webui.feature | Implemented |
+| FR-79 | WebUI actions mirror CLI commands | [WebUI Specification](specifications/webui_spec.md) | src/devsynth/interface/webui.py | tests/behavior/features/webui.feature | Implemented |
+| FR-80 | CLI wizard gathers goals, constraints and priority | [Interactive Requirements Gathering](specifications/interactive_requirements_gathering.md) | src/devsynth/application/cli/requirements_commands.py | tests/behavior/features/interactive_requirements.feature | Implemented |
+| FR-81 | Wizard stores responses to `requirements_plan.yaml` and updates config | [Interactive Requirements Gathering](specifications/interactive_requirements_gathering.md) | src/devsynth/application/cli/requirements_commands.py | tests/behavior/features/interactive_requirements.feature | Implemented |
+| FR-82 | WebUI provides equivalent forms for requirements gathering | [Interactive Requirements Wizard](specifications/interactive_requirements_wizard.md) | src/devsynth/interface/webui.py | tests/behavior/features/interactive_requirements.feature | Implemented |
 
-_Last updated: June 19, 2025_
+_Last updated: July 13, 2025_

--- a/docs/specifications/agent_api_stub.md
+++ b/docs/specifications/agent_api_stub.md
@@ -15,6 +15,24 @@ This document outlines the minimal HTTP interface for driving DevSynth
 workflows programmatically. The API mirrors the CLI and WebUI behaviour
 through the `UXBridge` abstraction.
 
+## Design Choices
+
+- **REST Style** – A small set of POST endpoints invoke the same workflows as
+  the CLI to keep the surface area minimal.
+- **Message Queue** – Responses return a list of messages that match those
+  printed by the CLI or WebUI allowing clients to display progress.
+
+## Constraints
+
+- The API runs locally and exposes no authentication in this stub version.
+- Only JSON payloads are accepted and all errors return HTTP 400 with details.
+
+## Expected Behaviour
+
+- Each endpoint triggers the corresponding workflow via the UXBridge layer.
+- Subsequent `GET /status` calls return any accumulated messages until cleared
+  by the next workflow invocation.
+
 ## Endpoints
 
 ### `POST /init`

--- a/docs/specifications/cli_overhaul_pseudocode.md
+++ b/docs/specifications/cli_overhaul_pseudocode.md
@@ -17,16 +17,18 @@ last_reviewed: "2025-06-16"
 function init_command():
     config = UnifiedConfigLoader.load()
     if config.exists():
-        UXBridge.notify("Project already initialized")
+        UXBridge.display_result("Project already initialized")
         return
-    root = UXBridge.prompt("Project root directory?")
-    language = UXBridge.prompt("Primary language?")
-    goals = UXBridge.prompt("Project goals?")
+    root = UXBridge.ask_question("Project root directory?")
+    language = UXBridge.ask_question("Primary language?")
+    goals = UXBridge.ask_question("Project goals?")
+    if not UXBridge.confirm_choice("Proceed with initialization?", default=True):
+        return
     config.set_root(root)
     config.set_language(language)
     config.set_goals(goals)
     config.save()
-    UXBridge.notify("Initialization complete")
+    UXBridge.display_result("Initialization complete", highlight=True)
 ```
 
 # Unified Configuration Loader
@@ -44,15 +46,26 @@ class UnifiedConfigLoader:
 
 ```pseudocode
 class UXBridge:
-    function prompt(message) -> Response:
+    function ask_question(message, choices=None, default=None) -> Response:
         if running_in_cli:
-            return CLI.prompt(message)
+            return CLI.prompt(message, choices, default)
         else if running_in_web:
-            return WebUI.prompt(message)
+            return WebUI.prompt(message, choices, default)
 
-    function notify(message):
+    function confirm_choice(message, default=False) -> bool:
         if running_in_cli:
-            CLI.display(message)
+            return CLI.confirm(message, default)
         else if running_in_web:
-            WebUI.display(message)
+            return WebUI.confirm(message, default)
+
+    function display_result(message, highlight=False):
+        if running_in_cli:
+            CLI.display(message, highlight)
+        else if running_in_web:
+            WebUI.display(message, highlight)
+
+    # legacy aliases
+    prompt = ask_question
+    confirm = confirm_choice
+    print = display_result
 ```

--- a/docs/specifications/interactive_requirements_wizard.md
+++ b/docs/specifications/interactive_requirements_wizard.md
@@ -28,3 +28,21 @@ Streamlit WebUI through the `UXBridge` interface.
 The wizard allows moving backward by typing `back` in the CLI or using
 the *Back* button in the WebUI. Collected data is saved to a JSON file
 named `requirements_wizard.json`.
+
+## Design Choices
+
+- **Step Driven** – Each question is presented as a discrete step so the user
+  can review and revise answers.
+- **Bridge Integration** – All prompts use `UXBridge.ask_question` and
+  `UXBridge.confirm_choice` to remain interface agnostic.
+
+## Constraints
+
+- Inputs must be validated according to requirement type and priority options.
+- The wizard state is stored in memory until the user confirms completion.
+
+## Expected Behaviour
+
+- Users may navigate backward to edit previous answers.
+- On completion the responses are written to `requirements_wizard.json` and
+  merged into the current project configuration.

--- a/docs/specifications/uxbridge_extension.md
+++ b/docs/specifications/uxbridge_extension.md
@@ -40,3 +40,25 @@ workflow code. As additional interfaces were introduced it became necessary to
 abstract user interactions behind a stable API. These methods map cleanly to
 both textual and graphical UIs and allow tests to mock the interface easily.
 
+## Design Choices
+
+- **Clear Method Semantics** – New method names explicitly describe user
+  interactions to reduce confusion when multiple front‑ends coexist.
+- **Alias Support** – Backward compatibility is preserved via the legacy
+  `prompt`, `confirm` and `print` methods.
+- **Testability** – By avoiding direct `input()`/`print()` calls, workflows can
+  be unit tested without patching built‑ins.
+
+## Constraints
+
+- Implementations must not directly read from or write to STDOUT/STDIN.
+- Methods should return data types appropriate for the calling interface.
+- Bridge implementations are responsible for rendering choice lists and
+  highlights.
+
+## Expected Behaviour
+
+- CLI, WebUI and Agent API layers call these methods when interacting with the
+  user.
+- The same workflow code runs identically regardless of the active interface.
+

--- a/docs/specifications/webui_detailed_spec.md
+++ b/docs/specifications/webui_detailed_spec.md
@@ -14,6 +14,15 @@ author: "DevSynth Team"
 
 This document details the features, constraints and interaction flow for the Streamlit based WebUI. The interface builds upon the `UXBridge` abstraction to reuse the same workflow functions as the CLI.
 
+## Design Choices
+
+- **Streamlit Framework** – Chosen for its rapid prototyping capability and
+  simple state management.
+- **Bridge-Centric** – All workflow calls pass through `UXBridge` so new
+  interfaces (e.g., the Agent API) behave identically.
+- **Sidebar Navigation** – Pages are organized in a sidebar to mirror the CLI
+  command structure.
+
 ## Features
 
 - Sidebar navigation with pages:


### PR DESCRIPTION
## Summary
- append WebUI, UXBridge and API requirements to RTM
- clarify bridge interface extension and wizard specs
- document API design and Streamlit choices
- update architecture overview diagrams
- revise CLI pseudocode to use new methods

## Testing
- `poetry run pytest -q` *(fails: ModuleNotFoundError: No module named 'chromadb')*

------
https://chatgpt.com/codex/tasks/task_e_68535714cb948333af61989d93619fec