### PR TITLE
Add BDD scenarios for WebUI onboarding and API stub

### DIFF
--- a/docs/developer_guides/testing.md
+++ b/docs/developer_guides/testing.md
@@ -273,6 +273,11 @@ pytest
 # Run BDD tests
 pytest tests/behavior/
 
+# Run WebUI onboarding and API stub scenarios
+pytest tests/behavior/test_webui_onboarding_flow.py
+pytest tests/behavior/test_requirements_wizard_navigation.py
+pytest tests/behavior/test_api_stub_usage.py
+
 # Run integration tests
 pytest tests/integration/
 

--- a/tests/behavior/features/api_stub_usage.feature
+++ b/tests/behavior/features/api_stub_usage.feature
@@ -1,0 +1,9 @@
+Feature: Agent API Stub Usage
+  As a developer
+  I want to invoke workflows via the Agent API stub
+  So that automation can leverage the same UXBridge logic
+
+  Scenario: Initialize a project through the API stub
+    Given the Agent API stub is available
+    When I call the init endpoint
+    Then the init command should be executed through the bridge

--- a/tests/behavior/features/requirements_wizard_navigation.feature
+++ b/tests/behavior/features/requirements_wizard_navigation.feature
@@ -1,0 +1,12 @@
+Feature: Requirements Wizard Navigation
+  As a developer
+  I want to move through the requirements wizard
+  So that I can review my answers before saving
+
+  Scenario: Navigate forward and backward
+    Given the WebUI is initialized
+    When I open the requirements wizard
+    And I click the wizard next button
+    Then the wizard should show step 2
+    When I click the wizard back button
+    Then the wizard should show step 1

--- a/tests/behavior/features/webui_onboarding_flow.feature
+++ b/tests/behavior/features/webui_onboarding_flow.feature
@@ -1,0 +1,14 @@
+Feature: WebUI Onboarding Flow
+  As a developer
+  I want to onboard my project using the WebUI
+  So that initialization runs through a graphical form
+
+  Scenario: Open onboarding page
+    Given the WebUI is initialized
+    When I navigate to "Onboarding"
+    Then the "Project Onboarding" header is shown
+
+  Scenario: Submit onboarding form via WebUI
+    Given the WebUI is initialized
+    When I submit the onboarding form
+    Then the init command should be executed

--- a/tests/behavior/steps/api_stub_steps.py
+++ b/tests/behavior/steps/api_stub_steps.py
@@ -1,0 +1,37 @@
+from types import ModuleType
+from unittest.mock import MagicMock
+import sys
+import importlib
+
+import pytest
+from pytest_bdd import given, when, then, scenarios
+
+scenarios("../features/api_stub_usage.feature")
+
+
+@pytest.fixture
+def api_context(monkeypatch):
+    cli_stub = ModuleType("devsynth.application.cli")
+    cli_stub.init_cmd = MagicMock()
+    monkeypatch.setitem(sys.modules, "devsynth.application.cli", cli_stub)
+    import devsynth.interface.agentapi as agentapi
+    importlib.reload(agentapi)
+    ctx = {"api": agentapi, "cli": cli_stub}
+    return ctx
+
+
+@given("the Agent API stub is available")
+def api_available(api_context):
+    return api_context
+
+
+@when("I call the init endpoint")
+def call_init(api_context):
+    req = api_context["api"].InitRequest(path=".")
+    api_context["api"].init_endpoint(req, token=None)
+
+
+@then("the init command should be executed through the bridge")
+def check_called(api_context):
+    assert api_context["cli"].init_cmd.called
+

--- a/tests/behavior/steps/requirements_wizard_navigation_steps.py
+++ b/tests/behavior/steps/requirements_wizard_navigation_steps.py
@@ -1,0 +1,98 @@
+from types import ModuleType
+from unittest.mock import MagicMock
+import sys
+import importlib
+
+import pytest
+from pytest_bdd import given, when, then, scenarios
+
+from devsynth.interface.webui import WebUI
+
+scenarios("../features/requirements_wizard_navigation.feature")
+
+
+class DummyForm:
+    def __init__(self, submitted: bool = False):
+        self.submitted = submitted
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+    def form_submit_button(self, *_args, **_kwargs):
+        return self.submitted
+
+
+@pytest.fixture
+def wizard_context(monkeypatch):
+    st = ModuleType("streamlit")
+    class SS(dict):
+        pass
+    st.session_state = SS()
+    st.session_state.wizard_step = 0
+    st.session_state.wizard_data = {}
+    st.sidebar = ModuleType("sidebar")
+    st.sidebar.radio = MagicMock(return_value="Requirements")
+    st.sidebar.title = MagicMock()
+    st.set_page_config = MagicMock()
+    st.header = MagicMock()
+    st.expander = lambda *_a, **_k: DummyForm(True)
+    st.form = lambda *_a, **_k: DummyForm(True)
+    st.form_submit_button = MagicMock(return_value=False)
+    st.text_input = MagicMock(return_value="text")
+    st.text_area = MagicMock(return_value="desc")
+    st.selectbox = MagicMock(return_value="choice")
+    st.checkbox = MagicMock(return_value=True)
+    st.button = MagicMock(side_effect=[False, True, False])
+    st.spinner = DummyForm
+    st.divider = MagicMock()
+    st.columns = MagicMock(return_value=(MagicMock(button=lambda *a, **k: False), MagicMock(button=lambda *a, **k: False)))
+    st.progress = MagicMock()
+    st.write = MagicMock()
+    st.markdown = MagicMock()
+    monkeypatch.setitem(sys.modules, "streamlit", st)
+
+    import devsynth.interface.webui as webui
+    importlib.reload(webui)
+
+    ctx = {"st": st, "ui": webui.WebUI()}
+    return ctx
+
+
+@given("the WebUI is initialized")
+def _init(wizard_context):
+    return wizard_context
+
+
+@when("I open the requirements wizard")
+def open_wizard(wizard_context):
+    wizard_context["st"].sidebar.radio.return_value = "Requirements"
+    wizard_context["ui"].requirements_page()
+
+
+@when("I click the wizard next button")
+def click_next(wizard_context):
+    col1 = MagicMock(button=lambda *a, **k: False)
+    col2 = MagicMock(button=lambda *a, **k: True)
+    wizard_context["st"].columns.return_value = (col1, col2)
+    wizard_context["ui"]._requirements_wizard()
+
+
+@when("I click the wizard back button")
+def click_back(wizard_context):
+    col1 = MagicMock(button=lambda *a, **k: True)
+    col2 = MagicMock(button=lambda *a, **k: False)
+    wizard_context["st"].columns.return_value = (col1, col2)
+    wizard_context["ui"]._requirements_wizard()
+
+
+@then("the wizard should show step 2")
+def show_step_two(wizard_context):
+    assert wizard_context["st"].session_state.wizard_step == 1
+
+
+@then("the wizard should show step 1")
+def show_step_one(wizard_context):
+    assert wizard_context["st"].session_state.wizard_step == 0

--- a/tests/behavior/steps/webui_onboarding_steps.py
+++ b/tests/behavior/steps/webui_onboarding_steps.py
@@ -1,0 +1,111 @@
+from types import ModuleType
+from unittest.mock import MagicMock
+import sys
+import importlib
+
+import pytest
+from pytest_bdd import given, when, then, scenarios
+
+
+class DummyForm:
+    def __init__(self, submitted: bool = True):
+        self.submitted = submitted
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+    def form_submit_button(self, *_args, **_kwargs):
+        return self.submitted
+
+
+@pytest.fixture
+def webui_context(monkeypatch):
+    st = ModuleType("streamlit")
+    class SS(dict):
+        pass
+
+    st.session_state = SS()
+    st.session_state.wizard_step = 0
+    st.session_state.wizard_data = {}
+    st.sidebar = ModuleType("sidebar")
+    st.sidebar.radio = MagicMock(return_value="Onboarding")
+    st.sidebar.title = MagicMock()
+    st.set_page_config = MagicMock()
+    st.header = MagicMock()
+    st.expander = lambda *_a, **_k: DummyForm(True)
+    st.form = lambda *_a, **_k: DummyForm(True)
+    st.form_submit_button = MagicMock(return_value=True)
+    st.text_input = MagicMock(return_value="text")
+    st.text_area = MagicMock(return_value="desc")
+    st.selectbox = MagicMock(return_value="choice")
+    st.checkbox = MagicMock(return_value=True)
+    st.button = MagicMock(return_value=True)
+    st.spinner = DummyForm
+    st.divider = MagicMock()
+    st.columns = MagicMock(return_value=(MagicMock(button=lambda *a, **k: False), MagicMock(button=lambda *a, **k: False)))
+    st.progress = MagicMock()
+    st.write = MagicMock()
+    st.markdown = MagicMock()
+    monkeypatch.setitem(sys.modules, "streamlit", st)
+
+    cli_stub = ModuleType("devsynth.application.cli")
+    for name in [
+        "init_cmd",
+        "spec_cmd",
+        "test_cmd",
+        "code_cmd",
+        "run_pipeline_cmd",
+        "config_cmd",
+        "inspect_cmd",
+    ]:
+        setattr(cli_stub, name, MagicMock())
+    monkeypatch.setitem(sys.modules, "devsynth.application.cli", cli_stub)
+
+    analyze_stub = ModuleType("devsynth.application.cli.commands.analyze_code_cmd")
+    analyze_stub.analyze_code_cmd = MagicMock()
+    monkeypatch.setitem(
+        sys.modules, "devsynth.application.cli.commands.analyze_code_cmd", analyze_stub
+    )
+
+    import devsynth.interface.webui as webui
+    importlib.reload(webui)
+    ctx = {
+        "st": st,
+        "cli": cli_stub,
+        "webui": webui,
+        "ui": webui.WebUI(),
+    }
+    return ctx
+
+scenarios("../features/webui_onboarding_flow.feature")
+
+
+@given("the WebUI is initialized")
+def _init(webui_context):
+    return webui_context
+
+
+@when("I navigate to \"Onboarding\"")
+def nav_onboarding(webui_context):
+    webui_context["st"].sidebar.radio.return_value = "Onboarding"
+    webui_context["ui"].run()
+
+
+@when("I submit the onboarding form")
+def submit_onboarding(webui_context):
+    webui_context["st"].sidebar.radio.return_value = "Onboarding"
+    webui_context["st"].form_submit_button.return_value = True
+    webui_context["ui"].run()
+
+
+@then("the \"Project Onboarding\" header is shown")
+def header_onboarding(webui_context):
+    webui_context["st"].header.assert_any_call("Project Onboarding")
+
+
+@then("the init command should be executed")
+def check_init(webui_context):
+    assert webui_context["cli"].init_cmd.called

--- a/tests/behavior/test_api_stub_usage.py
+++ b/tests/behavior/test_api_stub_usage.py
@@ -1,0 +1,5 @@
+from pytest_bdd import scenarios
+
+from .steps.api_stub_steps import *  # noqa: F401,F403
+
+scenarios("features/api_stub_usage.feature")

--- a/tests/behavior/test_requirements_wizard_navigation.py
+++ b/tests/behavior/test_requirements_wizard_navigation.py
@@ -1,0 +1,5 @@
+from pytest_bdd import scenarios
+
+from .steps.requirements_wizard_navigation_steps import *  # noqa: F401,F403
+
+scenarios("features/requirements_wizard_navigation.feature")

--- a/tests/behavior/test_webui_onboarding_flow.py
+++ b/tests/behavior/test_webui_onboarding_flow.py
@@ -1,0 +1,5 @@
+from pytest_bdd import scenarios
+
+from .steps.webui_onboarding_steps import *  # noqa: F401,F403
+
+scenarios("features/webui_onboarding_flow.feature")


### PR DESCRIPTION
## Summary
- add BDD feature files for WebUI onboarding flow, requirements wizard navigation, and API stub usage
- implement step definitions using mocked UXBridge interactions
- document how to run the new tests

## Testing
- `pytest tests/behavior/test_api_stub_usage.py tests/behavior/test_webui_onboarding_flow.py tests/behavior/test_requirements_wizard_navigation.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6853592e889883339bbfbdffc1d430a4