### PR TITLE
Add UXBridge-based requirements wizard

### DIFF
--- a/docs/requirements_traceability.md
+++ b/docs/requirements_traceability.md
@@ -88,5 +88,6 @@ This matrix links requirements to design, code modules, and tests, ensuring bidi
 | FR-80 | CLI wizard gathers goals, constraints and priority | [Interactive Requirements Gathering](specifications/interactive_requirements_gathering.md) | src/devsynth/application/cli/requirements_commands.py | tests/behavior/features/interactive_requirements.feature | Implemented |
 | FR-81 | Wizard stores responses to `requirements_plan.yaml` and updates config | [Interactive Requirements Gathering](specifications/interactive_requirements_gathering.md) | src/devsynth/application/cli/requirements_commands.py | tests/behavior/features/interactive_requirements.feature | Implemented |
 | FR-82 | WebUI provides equivalent forms for requirements gathering | [Interactive Requirements Wizard](specifications/interactive_requirements_wizard.md) | src/devsynth/interface/webui.py | tests/behavior/features/interactive_requirements.feature | Implemented |
+| FR-83 | Step-wise wizard via UXBridge collects goals, constraints and priority | [Requirements Gathering Workflow](specifications/requirements_gathering.md) | src/devsynth/application/requirements/interactions.py, src/devsynth/application/cli/requirements_commands.py, src/devsynth/interface/webui.py | tests/behavior/features/requirements_gathering.feature | Implemented |
 
-_Last updated: July 13, 2025_
+_Last updated: July 20, 2025_

--- a/docs/specifications/requirements_gathering.md
+++ b/docs/specifications/requirements_gathering.md
@@ -1,0 +1,54 @@
+---
+title: "Requirements Gathering Workflow"
+date: "2025-07-20"
+version: "0.1.0"
+tags:
+  - "specification"
+  - "requirements"
+status: "draft"
+author: "DevSynth Team"
+---
+
+# Requirements Gathering Workflow
+
+This document describes the step-wise process for collecting project goals,
+constraints and a priority ranking. The workflow is reused by both the CLI and
+WebUI through the `UXBridge` abstraction so the same logic can serve different
+interfaces.
+
+## Sequence Diagram
+
+```mermaid
+sequenceDiagram
+    participant User
+    participant Bridge
+    User->>Bridge: Provide goals
+    Bridge-->>User: Next prompt
+    User->>Bridge: Provide constraints
+    Bridge-->>User: Next prompt
+    User->>Bridge: Select priority
+    Bridge-->>User: Confirmation and save notice
+```
+
+## Pseudocode
+
+```pseudocode
+function gather_requirements(output_file="requirements_plan.yaml"):
+    steps = ["goals", "constraints", "priority"]
+    responses = {}
+    index = 0
+    while index < len(steps):
+        key = steps[index]
+        message = prompt_for(key)
+        reply = bridge.ask_question(message, choices=choices_for(key))
+        if reply == "back":
+            index = max(0, index - 1)
+            continue
+        responses[key] = reply
+        index += 1
+    write_yaml_or_json(output_file, responses)
+    update_project_config(responses)
+```
+
+The CLI exposes this via `devsynth requirements gather` while the WebUI
+presents a button that runs the same function through its bridge.

--- a/src/devsynth/application/cli/cli_commands.py
+++ b/src/devsynth/application/cli/cli_commands.py
@@ -338,58 +338,9 @@ def gather_cmd(
 ) -> None:
     """Interactively gather project goals, constraints and priority."""
 
-    steps = [
-        ("goals", "Project goals (comma separated)", None, ""),
-        ("constraints", "Project constraints (comma separated)", None, ""),
-        (
-            "priority",
-            "Overall priority",
-            ["low", "medium", "high"],
-            "medium",
-        ),
-    ]
+    from devsynth.application.requirements.interactions import gather_requirements
 
-    responses: dict[str, str] = {}
-    index = 0
-    while index < len(steps):
-        key, message, choices, default = steps[index]
-        prefix = f"Step {index + 1}/{len(steps)}: "
-        reply = bridge.ask_question(
-            prefix + message + " (type 'back' to go back)",
-            choices=choices,
-            default=default,
-        )
-        if reply.lower() == "back":
-            if index > 0:
-                index -= 1
-            else:
-                bridge.display_result("[yellow]Already at first step.[/yellow]")
-            continue
-        responses[key] = reply
-        index += 1
-
-    data = {
-        "goals": [g.strip() for g in responses["goals"].split(",") if g.strip()],
-        "constraints": [
-            c.strip() for c in responses["constraints"].split(",") if c.strip()
-        ],
-        "priority": responses["priority"],
-    }
-
-    with open(output_file, "w", encoding="utf-8") as f:
-        if output_file.endswith(".json"):
-            json.dump(data, f, indent=2)
-        else:
-            yaml.safe_dump(data, f, sort_keys=False)
-
-    cfg = get_project_config()
-    cfg.goals = responses["goals"]
-    cfg.constraints = responses["constraints"]
-    if hasattr(cfg, "priority"):
-        setattr(cfg, "priority", responses["priority"])
-    save_config(cfg, use_pyproject=(Path("pyproject.toml").exists()))
-
-    bridge.display_result(f"[green]Requirements saved to {output_file}[/green]")
+    gather_requirements(bridge, output_file=output_file)
 
 
 def refactor_cmd(path: Optional[str] = None) -> None:

--- a/src/devsynth/application/cli/requirements_commands.py
+++ b/src/devsynth/application/cli/requirements_commands.py
@@ -809,3 +809,18 @@ def wizard_cmd(
         json.dump(result, f, indent=2)
 
     bridge.display_result(f"[green]Requirements saved to {output_file}[/green]")
+
+
+@requirements_app.command("gather")
+def gather_requirements_cmd(
+    output_file: str = typer.Option(
+        "requirements_plan.yaml", help="File to store collected goals"
+    ),
+    *,
+    bridge: UXBridge = CLIUXBridge(),
+) -> None:
+    """Gather project goals, constraints and priority."""
+
+    from devsynth.application.requirements.interactions import gather_requirements
+
+    gather_requirements(bridge, output_file=output_file)

--- a/src/devsynth/application/requirements/interactions.py
+++ b/src/devsynth/application/requirements/interactions.py
@@ -1,0 +1,86 @@
+"""Step-wise requirements gathering workflow using :class:`UXBridge`."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Optional, Sequence
+
+import yaml
+
+from devsynth.interface.ux_bridge import UXBridge
+from devsynth.config import get_project_config, save_config
+
+
+def gather_requirements(
+    bridge: UXBridge,
+    *,
+    output_file: str = "requirements_plan.yaml",
+) -> None:
+    """Interactively gather project goals, constraints and priority.
+
+    Parameters
+    ----------
+    bridge:
+        Interface bridge used to ask questions and display results.
+    output_file:
+        Path where the gathered plan should be written. Extension determines
+        whether YAML or JSON is used.
+    """
+
+    steps: Sequence[tuple[str, str, Optional[Sequence[str]], str]] = [
+        ("goals", "Project goals (comma separated)", None, ""),
+        ("constraints", "Project constraints (comma separated)", None, ""),
+        (
+            "priority",
+            "Overall priority",
+            ["low", "medium", "high"],
+            "medium",
+        ),
+    ]
+
+    responses: dict[str, str] = {}
+    index = 0
+    while index < len(steps):
+        key, message, choices, default = steps[index]
+        prefix = f"Step {index + 1}/{len(steps)}: "
+        reply = bridge.ask_question(
+            prefix + message + " (type 'back' to go back)",
+            choices=choices,
+            default=default,
+        )
+        if reply.lower() == "back":
+            if index > 0:
+                index -= 1
+            else:
+                bridge.display_result("[yellow]Already at first step.[/yellow]")
+            continue
+        responses[key] = reply
+        index += 1
+
+    data = {
+        "goals": [g.strip() for g in responses["goals"].split(",") if g.strip()],
+        "constraints": [
+            c.strip() for c in responses["constraints"].split(",") if c.strip()
+        ],
+        "priority": responses["priority"],
+    }
+
+    path = Path(output_file)
+    with open(path, "w", encoding="utf-8") as f:
+        if path.suffix == ".json":
+            json.dump(data, f, indent=2)
+        else:
+            yaml.safe_dump(data, f, sort_keys=False)
+
+    cfg = get_project_config(Path("."))
+    cfg.goals = responses["goals"]
+    cfg.constraints = responses["constraints"]
+    if hasattr(cfg, "priority"):
+        setattr(cfg, "priority", responses["priority"])
+    save_config(cfg, use_pyproject=(Path("pyproject.toml").exists()))
+
+    bridge.display_result(f"[green]Requirements saved to {output_file}[/green]")
+
+
+__all__ = ["gather_requirements"]

--- a/src/devsynth/interface/webui.py
+++ b/src/devsynth/interface/webui.py
@@ -180,61 +180,13 @@ class WebUI(UXBridge):
             )
 
     def _gather_wizard(self) -> None:
-        """Wizard to gather project goals and constraints."""
-        if "gather_step" not in st.session_state:
-            st.session_state.gather_step = 0
-            st.session_state.gather_data = {
-                "goals": "",
-                "constraints": "",
-                "priority": "medium",
-            }
-
-        steps = ["Goals", "Constraints", "Priority"]
-        step = st.session_state.gather_step
-        st.write(f"Step {step + 1} of {len(steps)}: {steps[step]}")
-        st.progress((step + 1) / len(steps))
-        data = st.session_state.gather_data
-
-        if step == 0:
-            data["goals"] = st.text_area(
-                "Project Goals (comma separated)", data["goals"]
+        """Run the requirements gathering workflow via :mod:`interactions`."""
+        if st.button("Start Requirements Plan Wizard", key="g_start"):
+            from devsynth.application.requirements.interactions import (
+                gather_requirements,
             )
-        elif step == 1:
-            data["constraints"] = st.text_area(
-                "Project Constraints (comma separated)", data["constraints"]
-            )
-        elif step == 2:
-            options = ["low", "medium", "high"]
-            index = options.index(data["priority"])
-            data["priority"] = st.selectbox("Overall Priority", options, index=index)
 
-        col1, col2 = st.columns(2)
-        if col1.button("Back", key="g_back", disabled=step == 0):
-            st.session_state.gather_step = max(0, step - 1)
-            return
-        if col2.button("Next", key="g_next", disabled=step >= len(steps) - 1):
-            st.session_state.gather_step = min(len(steps) - 1, step + 1)
-            return
-
-        if step == len(steps) - 1 and st.button("Save Plan", key="g_save"):
-            result = {
-                "goals": [g.strip() for g in data["goals"].split(",") if g.strip()],
-                "constraints": [
-                    c.strip() for c in data["constraints"].split(",") if c.strip()
-                ],
-                "priority": data["priority"],
-            }
-            with open("requirements_plan.yaml", "w", encoding="utf-8") as f:
-                yaml.safe_dump(result, f, sort_keys=False)
-            cfg = get_project_config(Path("."))
-            cfg.goals = data["goals"]
-            cfg.constraints = data["constraints"]
-            if hasattr(cfg, "priority"):
-                setattr(cfg, "priority", data["priority"])
-            save_config(cfg, use_pyproject=(Path("pyproject.toml").exists()))
-            self.display_result(
-                "[green]Requirements saved to requirements_plan.yaml[/green]"
-            )
+            gather_requirements(self)
 
     def analysis_page(self) -> None:
         """Render the code analysis page."""

--- a/tests/behavior/features/requirements_gathering.feature
+++ b/tests/behavior/features/requirements_gathering.feature
@@ -7,3 +7,8 @@ Feature: Requirements Gathering Wizard
     Given the DevSynth CLI is installed
     When I run the requirements gathering wizard
     Then a requirements plan file "requirements_plan.yaml" should exist
+
+  Scenario: Gather goals using the WebUI wizard
+    Given the WebUI is initialized
+    When I run the requirements gathering wizard in the WebUI
+    Then a requirements plan file "requirements_plan.yaml" should exist

--- a/tests/behavior/steps/requirements_gathering_steps.py
+++ b/tests/behavior/steps/requirements_gathering_steps.py
@@ -1,5 +1,6 @@
 import os
 from typing import Sequence, Optional
+from types import ModuleType
 from unittest.mock import MagicMock
 
 import yaml
@@ -7,6 +8,7 @@ import sys
 from pytest_bdd import scenarios, given, when, then
 
 from devsynth.interface.ux_bridge import UXBridge
+from .webui_steps import webui_context
 
 
 class DummyBridge(UXBridge):
@@ -56,6 +58,21 @@ def run_wizard(tmp_project_dir, monkeypatch):
     output = os.path.join(tmp_project_dir, "requirements_plan.yaml")
     os.chdir(tmp_project_dir)
     gather_cmd(output_file=output, bridge=bridge)
+
+
+@when("I run the requirements gathering wizard in the WebUI")
+def run_webui_wizard(tmp_project_dir, webui_context):
+    webui_context["st"].sidebar.radio.return_value = "Requirements"
+    webui_context["st"].text_area.side_effect = [
+        "Goal one,Goal two",
+        "Constraint A,Constraint B",
+    ]
+    webui_context["st"].selectbox.return_value = "high"
+    output = os.path.join(tmp_project_dir, "requirements_plan.yaml")
+    os.chdir(tmp_project_dir)
+    from devsynth.application.requirements.interactions import gather_requirements
+
+    gather_requirements(webui_context["ui"], output_file=output)
 
 
 @then('a requirements plan file "requirements_plan.yaml" should exist')


### PR DESCRIPTION
## Summary
- implement step-wise requirements gathering workflow
- expose workflow via `devsynth requirements gather` and the WebUI
- document requirements gathering workflow with pseudocode and diagram
- update requirements traceability matrix for FR-83
- extend BDD tests for CLI and WebUI flows

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'devsynth')*

------
https://chatgpt.com/codex/tasks/task_e_6853870e1cbc8333a4b0240e4f8059c5