### PR TITLE
Add Agent API stub docs and tests

### DIFF
--- a/docs/requirements_traceability.md
+++ b/docs/requirements_traceability.md
@@ -89,5 +89,6 @@ This matrix links requirements to design, code modules, and tests, ensuring bidi
 | FR-81 | Wizard stores responses to `requirements_plan.yaml` and updates config | [Interactive Requirements Gathering](specifications/interactive_requirements_gathering.md) | src/devsynth/application/cli/requirements_commands.py | tests/behavior/features/interactive_requirements.feature | Implemented |
 | FR-82 | WebUI provides equivalent forms for requirements gathering | [Interactive Requirements Wizard](specifications/interactive_requirements_wizard.md) | src/devsynth/interface/webui.py | tests/behavior/features/interactive_requirements.feature | Implemented |
 | FR-83 | Step-wise wizard via UXBridge collects goals, constraints and priority | [Requirements Gathering Workflow](specifications/requirements_gathering.md) | src/devsynth/application/requirements/interactions.py, src/devsynth/application/cli/requirements_commands.py, src/devsynth/interface/webui.py | tests/behavior/features/requirements_gathering.feature | Implemented |
+| FR-84 | Agent API endpoints `/init`, `/gather`, `/synthesize`, `/status` using UXBridge | [Agent API Stub](specifications/agent_api_stub.md) | src/devsynth/interface/agentapi.py | tests/integration/test_agentapi_routes.py, tests/behavior/test_agentapi.py | Implemented |
 
-_Last updated: July 20, 2025_
+_Last updated: June 19, 2025

--- a/docs/specifications/agent_api_stub.md
+++ b/docs/specifications/agent_api_stub.md
@@ -82,3 +82,68 @@ Example response:
 ```json
 { "messages": ["Execution complete."] }
 ```
+## Request and Response Schemas
+
+```json
+// InitRequest
+{
+  "path": "string",
+  "project_root": "string?",
+  "language": "string?",
+  "goals": "string?"
+}
+```
+
+```json
+// GatherRequest
+{
+  "goals": "string",
+  "constraints": "string",
+  "priority": "string"
+}
+```
+
+```json
+// SynthesizeRequest
+{
+  "target": "string?"
+}
+```
+
+```json
+// WorkflowResponse
+{
+  "messages": ["string", "..."]
+}
+```
+
+## Sequence Diagram
+
+```mermaid
+sequenceDiagram
+    participant Client
+    participant API
+    participant Bridge
+    participant Workflows
+    Client->>API: POST /init
+    API->>Bridge: create APIBridge
+    API->>Workflows: init_cmd(..., bridge)
+    Workflows-->>Bridge: messages
+    Bridge-->>API: messages
+    API-->>Client: JSON response
+```
+
+## Pseudocode
+
+```pseudocode
+function handle_request(path, body):
+    bridge = APIBridge()
+    if path == "/init":
+        init_cmd(**body, bridge=bridge)
+    elif path == "/gather":
+        answers = [body.goals, body.constraints, body.priority]
+        gather_cmd(bridge=APIBridge(answers))
+    elif path == "/synthesize":
+        run_pipeline_cmd(target=body.target, bridge=bridge)
+    return {"messages": bridge.messages}
+```

--- a/docs/user_guides/api_reference.md
+++ b/docs/user_guides/api_reference.md
@@ -1,0 +1,40 @@
+---
+title: "Agent API Reference"
+date: "2025-06-19"
+version: "0.1.0"
+tags:
+  - "api"
+  - "reference"
+  - "user-guide"
+status: "draft"
+author: "DevSynth Team"
+---
+
+# Agent API Reference
+
+This guide demonstrates how to interact with DevSynth programmatically using the stubbed Agent API. The API mirrors CLI behaviour through the `UXBridge` layer.
+
+## Available Endpoints
+
+- `POST /init` – initialize or onboard a project
+- `POST /gather` – collect project goals and constraints
+- `POST /synthesize` – run the synthesis pipeline
+- `GET /status` – fetch messages from the most recent invocation
+
+All requests must include the bearer token header `Authorization: Bearer <token>`.
+
+### Example Usage
+
+```python
+import requests
+
+base = "http://localhost:8000"
+headers = {"Authorization": "Bearer my-token"}
+
+resp = requests.post(
+    f"{base}/init",
+    json={"path": ".", "language": "python"},
+    headers=headers,
+)
+print(resp.json())
+```

--- a/tests/behavior/test_agentapi.py
+++ b/tests/behavior/test_agentapi.py
@@ -1,0 +1,57 @@
+from types import ModuleType
+from unittest.mock import MagicMock
+import importlib
+import sys
+
+from fastapi.testclient import TestClient
+
+
+def _setup(monkeypatch):
+    cli_stub = ModuleType("devsynth.application.cli")
+
+    def init_cmd(path=".", project_root=None, language=None, goals=None, *, bridge):
+        bridge.display_result("init")
+
+    def gather_cmd(output_file="requirements_plan.yaml", *, bridge):
+        g = bridge.ask_question("g")
+        c = bridge.ask_question("c")
+        p = bridge.ask_question("p")
+        bridge.display_result(f"{g},{c},{p}")
+
+    def run_pipeline_cmd(target=None, *, bridge):
+        bridge.display_result(f"run:{target}")
+
+    cli_stub.init_cmd = MagicMock(side_effect=init_cmd)
+    cli_stub.gather_cmd = MagicMock(side_effect=gather_cmd)
+    cli_stub.run_pipeline_cmd = MagicMock(side_effect=run_pipeline_cmd)
+    monkeypatch.setitem(sys.modules, "devsynth.application.cli", cli_stub)
+
+    import devsynth.interface.agentapi as agentapi
+
+    importlib.reload(agentapi)
+    return cli_stub, agentapi
+
+
+def test_json_requests(monkeypatch):
+    cli_stub, agentapi = _setup(monkeypatch)
+    client = TestClient(agentapi.app)
+
+    resp = client.post("/init", json={"path": "proj"})
+    assert resp.status_code == 200
+    assert resp.json() == {"messages": ["init"]}
+
+    resp = client.post(
+        "/gather",
+        json={"goals": "g1", "constraints": "c1", "priority": "high"},
+    )
+    assert resp.json() == {"messages": ["g1,c1,high"]}
+
+    resp = client.post("/synthesize", json={"target": "unit"})
+    assert resp.json() == {"messages": ["run:unit"]}
+
+    status = client.get("/status")
+    assert status.json() == {"messages": ["run:unit"]}
+
+    assert cli_stub.init_cmd.called
+    assert cli_stub.gather_cmd.called
+    assert cli_stub.run_pipeline_cmd.called


### PR DESCRIPTION
## Summary
- specify UXBridge-based Agent API stub with schema, diagrams and pseudocode
- document API usage in new user guide
- track requirements for Agent API in RTM
- add behavior tests for API JSON routes
- fix incorrect future dates in documentation

## Testing
- `poetry run pytest tests/unit/test_api_health.py tests/integration/test_agentapi_routes.py tests/behavior/test_api_stub_usage.py tests/behavior/test_agentapi.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6853a028795083338e3d13a99e491299