### PR TITLE
Add CLI-WebUI map and mention WebUI in guides

### DIFF
--- a/docs/architecture/cli_webui_mapping.md
+++ b/docs/architecture/cli_webui_mapping.md
@@ -34,20 +34,23 @@ to reuse the CLI's backend functions.
 
 ## Workflows Missing WebUI Support
 
-Several CLI workflows are not yet represented in the WebUI:
+Several CLI workflows are not yet represented in the WebUI. The table below
+lists the missing commands along with proposed locations in the interface:
 
-- `edrr-cycle`
-- `align` and `alignment-metrics`
-- `analyze-manifest`
-- `generate-docs`
-- `ingest`
-- `apispec`
-- `doctor` / `check`
-- `validate-manifest` and `validate-metadata`
-- `test-metrics`
-- `refactor`
-- database helpers (`webapp`, `serve`, `dbschema`)
+| CLI Command(s)                           | Proposed WebUI Location / Action                     |
+|-----------------------------------------|------------------------------------------------------|
+| `edrr-cycle`                            | New **EDRR Cycle** page under **Analysis**           |
+| `align`, `alignment-metrics`            | **Reports** page for SDLC alignment metrics          |
+| `analyze-manifest`, `analyze-config`    | **Config** page – Manifest analysis section          |
+| `generate-docs`                         | **Synthesis** page – Add “Generate Docs” button      |
+| `ingest`                                | **Synthesis** page – Project ingestion form          |
+| `apispec`                               | **Synthesis** page – API specification form          |
+| `doctor`, `check`                       | **Config** page – Validation utility                 |
+| `validate-manifest`, `validate-metadata`| **Config** page – Validation utility                 |
+| `test-metrics`                          | **Analysis** page – Test metrics report              |
+| `refactor`                              | **Analysis** page – Workflow suggestions             |
+| `webapp`, `serve`, `dbschema`           | New **Database** helper page                         |
 
-Adding pages or sidebar entries for these commands would provide complete parity.
-Where appropriate, terminology should mirror the CLI (e.g. “EDRR Cycle”) to avoid
+Adding these pages or sidebar entries would provide complete parity. Where
+appropriate, terminology should mirror the CLI (e.g., “EDRR Cycle”) to avoid
 confusion.

--- a/docs/getting_started/agent_adapter_example.md
+++ b/docs/getting_started/agent_adapter_example.md
@@ -21,6 +21,8 @@ This guide demonstrates how to combine the DevSynth CLI with direct use of the
 
 Ensure **Python 3.11 or higher** is installed. Poetry is recommended for dependency management during development.
 
+You can perform the following CLI steps via the WebUI as well. Launch it with `devsynth webui` and use the pages that correspond to each command.
+
 ## 1. Initialize a Project
 
 Create a new project directory and initialize DevSynth:

--- a/docs/getting_started/basic_usage.md
+++ b/docs/getting_started/basic_usage.md
@@ -23,6 +23,8 @@ Ensure you are using **Python 3.11 or higher**. Poetry is recommended for managi
 
 DevSynth follows a structured workflow that takes you from requirements to working code. This guide covers the fundamental commands you'll use in a typical DevSynth project.
 
+If you prefer a graphical interface, start the WebUI with `devsynth webui`. The WebUI provides pages that correspond to the CLI commands described below.
+
 ## Initialize a Project
 
 Start by creating a new DevSynth project:

--- a/docs/getting_started/concise_walkthrough.md
+++ b/docs/getting_started/concise_walkthrough.md
@@ -20,6 +20,8 @@ For additional details, see the [Quick Start Guide](quick_start_guide.md).
 
 DevSynth requires **Python 3.11 or higher**. Poetry is recommended for managing dependencies.
 
+If you prefer a GUI, you can run `devsynth webui` and follow the same steps using the WebUI pages.
+
 ## 1. Initialize a Project
 
 Create a new project directory named `demo`:

--- a/docs/getting_started/example_project.md
+++ b/docs/getting_started/example_project.md
@@ -24,6 +24,8 @@ The example lives in [`examples/calculator`](../../examples/calculator). Each fi
 
 For a complete demonstration of the refactor workflow, see the full workflow example in [`examples/full_workflow`](../../examples/full_workflow).
 
+You can also explore the example using the WebUI. Start it with `devsynth webui` and navigate through the onboarding and synthesis pages instead of running commands manually.
+
 ## Workflow Overview
 
 1. **Initialize** the project

--- a/docs/getting_started/quick_start_guide.md
+++ b/docs/getting_started/quick_start_guide.md
@@ -64,6 +64,16 @@ docker compose -f deployment/docker-compose.yml -f deployment/docker-compose.mon
 
 This launches the DevSynth API, ChromaDB, and the optional Prometheus and Grafana stack.
 
+### Launch the WebUI
+
+After installation you can optionally use the Streamlit-based WebUI instead of the CLI. Start it with:
+
+```bash
+devsynth webui
+```
+
+The interface mirrors the CLI workflows and provides pages for onboarding, requirements, analysis, synthesis, and configuration.
+
 ## Creating Your First DevSynth Project
 
 ### Step 1: Initialize a New Project

--- a/docs/user_guides/progressive_setup.md
+++ b/docs/user_guides/progressive_setup.md
@@ -35,6 +35,8 @@ This guide describes how to install DevSynth with minimal features and progressi
 
    The initialization command creates a `.devsynth/project.yaml` file with default settings and feature flags disabled.
 
+You may also use the WebUI for these steps by running `devsynth webui` and navigating through the onboarding page.
+
 ## Enabling Dialectical Reasoning
 
 1. Edit `.devsynth/project.yaml` or use the CLI to enable the feature:


### PR DESCRIPTION
## Summary
- document mapping of CLI commands to WebUI pages
- point out how missing CLI commands could map to new WebUI pages
- reference the WebUI in quick start and other getting started docs

## Testing
- `poetry run pytest tests/` *(fails: ImportError during collection)*

------
https://chatgpt.com/codex/tasks/task_e_6854450c94a8833389579e0804b8d333