### PR TITLE
Add APIRouter-based agent API

### DIFF
--- a/docs/specifications/agent_api_stub.md
+++ b/docs/specifications/agent_api_stub.md
@@ -13,7 +13,9 @@ author: "DevSynth Team"
 
 This document outlines the minimal HTTP interface for driving DevSynth
 workflows programmatically. The API mirrors the CLI and WebUI behaviour
-through the `UXBridge` abstraction.
+through the `UXBridge` abstraction. The stub is implemented as a
+`fastapi.APIRouter` in `src/devsynth/interface/agentapi.py` which can be
+mounted into the main application.
 
 ## Design Choices
 

--- a/src/devsynth/interface/agentapi.py
+++ b/src/devsynth/interface/agentapi.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 
 from typing import Optional, Sequence, List
 
-from fastapi import FastAPI, Depends
+from fastapi import APIRouter, Depends, FastAPI
 from pydantic import BaseModel
 
 from devsynth.api import verify_token
@@ -20,6 +20,7 @@ from devsynth.logging_setup import DevSynthLogger
 from devsynth.interface.ux_bridge import UXBridge
 
 logger = DevSynthLogger(__name__)
+router = APIRouter()
 app = FastAPI(title="DevSynth Agent API")
 
 
@@ -77,7 +78,7 @@ class WorkflowResponse(BaseModel):
     messages: List[str]
 
 
-@app.post("/init", response_model=WorkflowResponse)
+@router.post("/init", response_model=WorkflowResponse)
 def init_endpoint(
     request: InitRequest, token: None = Depends(verify_token)
 ) -> WorkflowResponse:
@@ -96,7 +97,7 @@ def init_endpoint(
     return WorkflowResponse(messages=bridge.messages)
 
 
-@app.post("/gather", response_model=WorkflowResponse)
+@router.post("/gather", response_model=WorkflowResponse)
 def gather_endpoint(
     request: GatherRequest, token: None = Depends(verify_token)
 ) -> WorkflowResponse:
@@ -110,7 +111,7 @@ def gather_endpoint(
     return WorkflowResponse(messages=bridge.messages)
 
 
-@app.post("/synthesize", response_model=WorkflowResponse)
+@router.post("/synthesize", response_model=WorkflowResponse)
 def synthesize_endpoint(
     request: SynthesizeRequest, token: None = Depends(verify_token)
 ) -> WorkflowResponse:
@@ -123,14 +124,18 @@ def synthesize_endpoint(
     return WorkflowResponse(messages=bridge.messages)
 
 
-@app.get("/status", response_model=WorkflowResponse)
+@router.get("/status", response_model=WorkflowResponse)
 def status_endpoint(token: None = Depends(verify_token)) -> WorkflowResponse:
     """Return messages from the most recent workflow invocation."""
     return WorkflowResponse(messages=LATEST_MESSAGES)
 
 
+app.include_router(router)
+
+
 __all__ = [
     "app",
+    "router",
     "APIBridge",
     "InitRequest",
     "GatherRequest",

--- a/tests/integration/test_agent_api.py
+++ b/tests/integration/test_agent_api.py
@@ -1,0 +1,63 @@
+from types import ModuleType
+from unittest.mock import MagicMock
+import importlib
+import sys
+
+from fastapi.testclient import TestClient
+
+
+def _setup(monkeypatch):
+    cli_stub = ModuleType("devsynth.application.cli")
+
+    def init_cmd(path=".", project_root=None, language=None, goals=None, *, bridge):
+        bridge.display_result("init")
+
+    def gather_cmd(output_file="requirements_plan.yaml", *, bridge):
+        g = bridge.ask_question("g")
+        c = bridge.ask_question("c")
+        p = bridge.ask_question("p")
+        bridge.display_result(f"{g},{c},{p}")
+
+    def run_pipeline_cmd(target=None, *, bridge):
+        bridge.display_result(f"run:{target}")
+
+    cli_stub.init_cmd = MagicMock(side_effect=init_cmd)
+    cli_stub.gather_cmd = MagicMock(side_effect=gather_cmd)
+    cli_stub.run_pipeline_cmd = MagicMock(side_effect=run_pipeline_cmd)
+    monkeypatch.setitem(sys.modules, "devsynth.application.cli", cli_stub)
+
+    import devsynth.interface.agentapi as agentapi
+
+    importlib.reload(agentapi)
+    return cli_stub, agentapi
+
+
+def test_init_route(monkeypatch):
+    cli_stub, agentapi = _setup(monkeypatch)
+    client = TestClient(agentapi.app)
+    resp = client.post("/init", json={"path": "proj"})
+    assert resp.status_code == 200
+    assert resp.json() == {"messages": ["init"]}
+    cli_stub.init_cmd.assert_called_once()
+
+
+def test_gather_route(monkeypatch):
+    cli_stub, agentapi = _setup(monkeypatch)
+    client = TestClient(agentapi.app)
+    resp = client.post(
+        "/gather",
+        json={"goals": "g1", "constraints": "c1", "priority": "high"},
+    )
+    assert resp.status_code == 200
+    assert resp.json() == {"messages": ["g1,c1,high"]}
+    cli_stub.gather_cmd.assert_called_once()
+
+
+def test_synthesize_and_status(monkeypatch):
+    cli_stub, agentapi = _setup(monkeypatch)
+    client = TestClient(agentapi.app)
+    resp = client.post("/synthesize", json={"target": "unit"})
+    assert resp.json() == {"messages": ["run:unit"]}
+    status = client.get("/status")
+    assert status.json() == {"messages": ["run:unit"]}
+    cli_stub.run_pipeline_cmd.assert_called_once()


### PR DESCRIPTION
## Summary
- expose agent API routes on an APIRouter
- document router usage in Agent API specification
- add integration test using FastAPI's test client

## Testing
- `poetry run pytest tests/integration/test_agent_api.py tests/integration/test_agentapi_routes.py -q`

------
https://chatgpt.com/codex/tasks/task_e_685449dfd54c8333a11332145871704e