### PR TITLE
Add requirements gathering workflow

### DIFF
--- a/src/devsynth/application/cli/cli_commands.py
+++ b/src/devsynth/application/cli/cli_commands.py
@@ -21,6 +21,7 @@ from devsynth.core.workflows import (
     run_pipeline,
     update_config,
     inspect_requirements,
+    gather_requirements,
 )
 import uvicorn
 from devsynth.logging_setup import configure_logging
@@ -337,8 +338,6 @@ def gather_cmd(
     output_file: str = "requirements_plan.yaml", *, bridge: UXBridge = bridge
 ) -> None:
     """Interactively gather project goals, constraints and priority."""
-
-    from devsynth.application.requirements.interactions import gather_requirements
 
     gather_requirements(bridge, output_file=output_file)
 

--- a/src/devsynth/application/cli/requirements_commands.py
+++ b/src/devsynth/application/cli/requirements_commands.py
@@ -821,6 +821,6 @@ def gather_requirements_cmd(
 ) -> None:
     """Gather project goals, constraints and priority."""
 
-    from devsynth.application.requirements.interactions import gather_requirements
+    from devsynth.core.workflows import gather_requirements
 
     gather_requirements(bridge, output_file=output_file)

--- a/src/devsynth/interface/webui.py
+++ b/src/devsynth/interface/webui.py
@@ -197,11 +197,9 @@ class WebUI(UXBridge):
             )
 
     def _gather_wizard(self) -> None:
-        """Run the requirements gathering workflow via :mod:`interactions`."""
+        """Run the requirements gathering workflow via :mod:`core.workflows`."""
         if st.button("Start Requirements Plan Wizard", key="g_start"):
-            from devsynth.application.requirements.interactions import (
-                gather_requirements,
-            )
+            from devsynth.core.workflows import gather_requirements
 
             gather_requirements(self)
 

--- a/tests/unit/test_core_workflows.py
+++ b/tests/unit/test_core_workflows.py
@@ -1,3 +1,4 @@
+import json
 import pytest
 from unittest.mock import patch
 
@@ -62,3 +63,27 @@ def test_wrappers_call_execute_command(func, command, kwargs, expected):
         result = func(**kwargs)
         mock.assert_called_once_with(command, expected)
         assert result == {"success": True}
+
+
+def test_gather_requirements_creates_file(tmp_path):
+    class Bridge:
+        def __init__(self):
+            self.i = 0
+
+        def prompt(self, *args, **kwargs):
+            responses = ["goal1", "constraint1", "high"]
+            res = responses[self.i]
+            self.i += 1
+            return res
+
+        def confirm(self, *a, **k):
+            return True
+
+        def display_result(self, *a, **k):
+            pass
+
+    output = tmp_path / "req.json"
+    workflows.gather_requirements(Bridge(), output_file=str(output))
+    assert output.exists()
+    data = json.load(open(output))
+    assert data["priority"] == "high"


### PR DESCRIPTION
## Summary
- add a new `gather_requirements` workflow helper
- wire CLI and Typer commands to use the new workflow
- call workflow in the WebUI requirements wizard
- test requirements gathering logic

## Testing
- `poetry run pytest -q` *(fails: ModuleNotFoundError: No module named 'chromadb')*

------
https://chatgpt.com/codex/tasks/task_e_6854640c82a88333905b7d5abeb2d7de