### PR TITLE
Add AgentAPI docs

### DIFF
--- a/docs/architecture/webui_overview.md
+++ b/docs/architecture/webui_overview.md
@@ -67,3 +67,20 @@ the same CLI commands used in the terminal interface, ensuring feature
 parity while benefiting from Streamlit components such as collapsible
 sections and progress indicators.
 
+## Programmatic Access
+
+Agents or external tools can drive these workflows using the
+`AgentAPI`. The FastAPI application defined in
+`src/devsynth/interface/agentapi.py` exposes the following JSON
+endpoints:
+
+- `/init` – initialize or onboard a project
+- `/gather` – run the requirements gathering wizard
+- `/synthesize` – execute the synthesis pipeline
+- `/status` – retrieve messages from the most recent workflow
+
+Each endpoint mirrors the `UXBridge` interactions so that automated
+clients receive the same feedback a human would see in the CLI or
+WebUI. This allows scripted agents to orchestrate DevSynth without a
+user present.
+


### PR DESCRIPTION
## Summary
- document Agent API usage in `webui_overview.md`

## Testing
- `poetry run pytest tests/integration/test_agent_api.py -q`
- `poetry run pytest -q` *(fails: ModuleNotFoundError for `openai` and `chromadb`)*

------
https://chatgpt.com/codex/tasks/task_e_685468a4af9883339883cf0cad05075f