### PR TITLE
Add links to WebUI and API docs

### DIFF
--- a/docs/architecture/index.md
+++ b/docs/architecture/index.md
@@ -64,3 +64,5 @@ If you're new to DevSynth's architecture, we recommend starting with the [Overvi
 - [Technical Reference](../technical_reference/index.md) - Technical reference documentation
 - [Specifications](../specifications/index.md) - Detailed specifications for DevSynth components
 - [CLI Overhaul Pseudocode](../specifications/cli_overhaul_pseudocode.md) - Design reference for the updated initialization command
+- [WebUI Reference](../user_guides/webui_reference.md) - How to use the Streamlit interface
+- [Agent API Reference](../user_guides/api_reference.md) - Programmatic endpoints for automating DevSynth

--- a/docs/implementation/index.md
+++ b/docs/implementation/index.md
@@ -12,6 +12,8 @@ This section provides documentation on the implementation details of DevSynth, i
 - **[Configuration Loader Workflow](config_loader_workflow.md)**: Unified YAML/TOML configuration loader pseudocode.
 - **[Interactive Requirements Pseudocode](interactive_requirements_pseudocode.md)**: Outline of prompts for collecting project details.
 - **[Agent API Pseudocode](agent_api_pseudocode.md)**: Simple request/response handling for core agent routes.
+- **[WebUI Reference](../user_guides/webui_reference.md)**: Streamlit interface usage guide.
+- **[Agent API Reference](../user_guides/api_reference.md)**: Documentation for programmatic access to DevSynth.
 
 ## Related Documentation
 


### PR DESCRIPTION
## Summary
- link to WebUI and Agent API docs from architecture index
- link to WebUI and Agent API docs from implementation index

## Testing
- `python scripts/validate_metadata.py docs/user_guides/webui_reference.md docs/user_guides/api_reference.md docs/architecture/index.md`
- `poetry run pytest -q` *(fails: ModuleNotFoundError: No module named 'chromadb')*

------
https://chatgpt.com/codex/tasks/task_e_68546a07cd2c83339b7b27d89dd5f991