### PR TITLE
Move mypy to dev extras

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -3315,9 +3315,9 @@ dill = ">=0.3.8"
 name = "mypy"
 version = "1.15.0"
 description = "Optional static typing for Python"
-optional = false
+optional = true
 python-versions = ">=3.9"
-groups = ["main"]
+groups = ["dev"]
 files = [
     {file = "mypy-1.15.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:979e4e1a006511dacf628e36fadfecbcc0160a8af6ca7dad2f5025529e082c13"},
     {file = "mypy-1.15.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:c4bb0e1bd29f7d34efcccd71cf733580191e9a264a2202b0239da95984c5b559"},
@@ -6892,4 +6892,4 @@ retrieval = ["chromadb", "faiss-cpu"]
 [metadata]
 lock-version = "2.1"
 python-versions = "<3.13,>=3.11"
-content-hash = "9af7a7919ab1ac6d4cb177e7f2470ae3dd14aa4b33be0560ea3e6ee17d120ff9"
+content-hash = "f0230dca452c9ce19f971c0efa4bb63d5b58a38d875cc06595e57331edbf97b5"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,6 @@ requests = "2.32.3"
 fastapi = "0.115.12"
 "dspy-ai" = {version = "2.6.27", optional = true}
 structlog = "25.3.0"
-mypy = "1.15.0"
 tinydb = {version = "4.8.2", optional = true}
 duckdb = {version = "1.3.0", optional = true}
 lmdb = {version = "1.6.2", optional = true}
@@ -67,6 +66,7 @@ pytest-xdist = "3.7.0"
 black = "25.1.0"
 pre-commit = "3.8.0"
 psutil = "5.9.8"
+mypy = {version = "1.15.0", optional = true}
 
 [tool.poetry.group.docs]
 optional = true


### PR DESCRIPTION
## Summary
- move `mypy` dependency to the `dev` group
- update lock file

## Testing
- `poetry check`
- `poetry run pytest tests/` *(fails: 161 failed, 583 passed, 18 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_6854bd6b81988333acc7411ef9852ada