### PR TITLE
Update docs for extras installation

### DIFF
--- a/.github/workflows.disabled/example_project.yml
+++ b/.github/workflows.disabled/example_project.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Install DevSynth
         run: |
           python -m pip install --upgrade pip
-          pip install -e .[dev]
+          pip install -e '.[dev]'
 
       - name: Execute DevSynth workflow
         run: |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,11 +41,12 @@ cd devsynth
 
 # Install dependencies
 poetry install
+poetry sync --all-extras --all-groups
 
 # Alternatively, install with pip or pipx using extras
-pip install .[dev]
+pip install 'devsynth[dev]'
 # or
-pipx install --editable .[dev]
+pipx install --editable 'devsynth[dev]'
 
 # Activate virtual environment
 poetry shell

--- a/README.md
+++ b/README.md
@@ -98,6 +98,8 @@ You can install DevSynth in a few different ways:
    pip install -e '.[minimal,dev]'
    # or
    poetry install
+   # or for all optional dependencies
+   poetry sync --all-extras --all-groups
    ```
 
 For more on Docker deployment, see the [Deployment Guide](docs/deployment/deployment_guide.md).
@@ -157,6 +159,8 @@ Before running the test suite, you **must** install DevSynth with its developmen
 pip install -e '.[dev]'
 # or
 poetry install
+# or to install everything
+poetry sync --all-extras --all-groups
 ```
 
 Some tests and features rely on optional backends like **ChromaDB**, **FAISS**, and **LMDB**. Install these packages if you plan to use them:

--- a/docs/developer_guides/testing.md
+++ b/docs/developer_guides/testing.md
@@ -252,13 +252,14 @@ Before executing tests, install DevSynth with its development extras so that all
 test dependencies are available. Use either:
 
 ```bash
-pip install -e .[dev]
+pip install -e '.[dev]'
 ```
 
 or
 
 ```bash
 poetry install
+poetry sync --all-extras --all-groups
 ```
 
 ### Running All Tests

--- a/docs/getting_started/installation.md
+++ b/docs/getting_started/installation.md
@@ -39,10 +39,11 @@ git clone https://github.com/ravenoak/devsynth.git
 cd devsynth
 
 # Install with development dependencies
-pip install -e .[dev]
+pip install -e '.[dev]'
 
 # Or use Poetry
 poetry install
+poetry sync --all-extras --all-groups
 poetry shell
 ```
 

--- a/docs/getting_started/quick_start_guide.md
+++ b/docs/getting_started/quick_start_guide.md
@@ -44,10 +44,11 @@ git clone https://github.com/ravenoak/devsynth.git
 cd devsynth
 
 # Install with development dependencies
-pip install -e .[dev]
+pip install -e '.[dev]'
 
 # Or use Poetry
 poetry install
+poetry sync --all-extras --all-groups
 
 
 # Activate the virtual environment

--- a/tests/README.md
+++ b/tests/README.md
@@ -175,6 +175,7 @@ Before running tests, you **must** install DevSynth with the development extras:
 pip install -e '.[dev]'
 # or
 poetry install
+poetry sync --all-extras --all-groups
 ```
 
 For a minimal install you can use:
@@ -186,7 +187,7 @@ pip install -e '.[minimal,dev]'
 Optional backends such as **ChromaDB**, **FAISS**, or **LMDB** require extra packages:
 
 ```bash
-pip install chromadb faiss-cpu lmdb
+pip install 'devsynth[retrieval]'
 ```
 
 To run tests for a specific type:

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -3,7 +3,7 @@
 This package ensures the test suite can import ``devsynth`` from the
 working tree.  If the package isn't already installed in editable mode,
 it installs it before tests are collected.  This mirrors the behaviour
-of CI workflows which call ``pip install -e .[dev]``.
+of CI workflows which call ``pip install -e '.[dev]'``.
 """
 
 from __future__ import annotations


### PR DESCRIPTION
## Summary
- document `poetry sync --all-extras --all-groups`
- fix extras examples in README, docs and CONTRIBUTING
- update tests README and CI example

## Testing
- `poetry run pytest -q tests/` *(fails: 165 failed, 653 passed, 18 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_6854bffa17088333a2617111a09d1968