### PR TITLE
Implement result analysis for EDRR

### DIFF
--- a/docs/analysis/codebase_analysis.md
+++ b/docs/analysis/codebase_analysis.md
@@ -149,7 +149,7 @@ The agent system has several implementations:
 
 ### 4.2 Areas for Improvement
 
-1. **Incomplete Implementations**: Some components have incomplete or placeholder implementations.
+1. **Incomplete Implementations**: Several areas previously contained placeholder implementations. Recent updates replaced the EDRR result summarization helpers with real logic, but a few modules still require completion.
 2. **Limited Test Coverage**: Some areas of the codebase have limited test coverage.
 3. **Inconsistent Error Handling**: Error handling is inconsistent across different components.
 4. **Limited Logging**: Logging is limited and inconsistent across different components.

--- a/src/devsynth/application/edrr/coordinator.py
+++ b/src/devsynth/application/edrr/coordinator.py
@@ -1313,56 +1313,119 @@ class EDRRCoordinator:
         return report
 
     def _extract_key_insights(self, expand_results: Dict[str, Any]) -> List[str]:
-        """Extract key insights from expand phase results"""
-        # Implementation would extract most significant findings
-        return ["Key insight 1", "Key insight 2", "Key insight 3"]
+        """Extract key insights from expand phase results."""
+
+        insights: List[str] = []
+
+        ideas = expand_results.get("ideas", [])
+        if ideas:
+            idea_names = [str(i.get("idea", i)) for i in ideas[:3]]
+            insights.append(f"Top ideas: {', '.join(idea_names)}")
+
+        knowledge_items = expand_results.get("knowledge", [])
+        if knowledge_items:
+            insights.append(f"Retrieved {len(knowledge_items)} knowledge items")
+
+        code_elements = expand_results.get("code_elements")
+        if isinstance(code_elements, dict):
+            counts = [f"{k}={v}" for k, v in code_elements.items()]
+            insights.append("Code structure -> " + ", ".join(counts))
+        elif code_elements:
+            insights.append(f"Code elements count: {len(code_elements)}")
+
+        return insights
 
     def _summarize_implementation(
         self, implementation_plan: List[Dict[str, Any]]
     ) -> Dict[str, Any]:
-        """Summarize the implementation plan"""
-        # Implementation would create a concise summary
+        """Summarize the implementation plan."""
+
+        steps = len(implementation_plan)
+        components: Set[str] = set()
+        for step in implementation_plan:
+            component = step.get("component")
+            if component:
+                components.add(str(component))
+
+        if steps > 10:
+            complexity = "High"
+        elif steps > 5:
+            complexity = "Medium"
+        else:
+            complexity = "Low"
+
         return {
-            "steps": len(implementation_plan),
-            "estimated_complexity": "Medium",
-            "primary_components": ["Component A", "Component B"],
+            "steps": steps,
+            "estimated_complexity": complexity,
+            "primary_components": sorted(components),
         }
 
     def _summarize_quality_checks(
         self, quality_checks: Dict[str, Any]
     ) -> Dict[str, Any]:
-        """Summarize quality checks"""
-        # Implementation would create a summary of quality assessment
+        """Summarize quality checks."""
+
+        issues = quality_checks.get("issues", [])
+        critical = [i for i in issues if i.get("severity") == "critical"]
+        areas = {i.get("area") for i in issues if isinstance(i, dict) and i.get("area")}
+
         return {
-            "issues_found": len(quality_checks),
-            "critical_issues": 0,
-            "areas_of_concern": ["Area 1", "Area 2"],
+            "issues_found": len(issues),
+            "critical_issues": len(critical),
+            "areas_of_concern": sorted(a for a in areas if a),
         }
 
     def _extract_key_learnings(self, learnings: List[Dict[str, Any]]) -> List[str]:
-        """Extract key learnings"""
-        # Implementation would extract most important learnings
-        return ["Key learning 1", "Key learning 2", "Key learning 3"]
+        """Extract key learnings."""
+
+        if not learnings:
+            return []
+
+        summaries = []
+        for item in learnings[:3]:
+            if isinstance(item, dict):
+                summaries.append(str(item.get("learning", item)))
+            else:
+                summaries.append(str(item))
+
+        return summaries
 
     def _generate_next_steps(self, cycle_data: Dict[str, Any]) -> List[str]:
-        """Generate recommended next steps"""
-        # Implementation would create actionable next steps
-        return [
-            "Implement core functionality",
-            "Create test suite",
-            "Update documentation",
-        ]
+        """Generate recommended next steps."""
+
+        steps = []
+        refine = cycle_data.get("refine", {})
+        retrospect = cycle_data.get("retrospect", {})
+
+        if refine.get("optimized_plan"):
+            steps.append("Execute optimized plan")
+        elif refine.get("implementation_plan"):
+            steps.append("Implement selected option")
+
+        if retrospect.get("improvement_suggestions"):
+            steps.append("Address improvement suggestions")
+
+        if not steps:
+            steps.append("Review cycle results with team")
+
+        return steps
 
     def _extract_future_considerations(
         self, retrospect_results: Dict[str, Any]
     ) -> List[str]:
-        """Extract future considerations"""
-        # Implementation would identify important future considerations
-        return [
-            "Consider scaling strategy",
-            "Evaluate performance under high load",
-            "Plan for internationalization",
-        ]
+        """Extract future considerations."""
+
+        considerations = []
+        patterns = retrospect_results.get("patterns", [])
+        suggestions = retrospect_results.get("improvement_suggestions", [])
+
+        if patterns:
+            considerations.append(f"Monitor {len(patterns)} pattern(s)")
+
+        if suggestions:
+            considerations.append(f"Track {len(suggestions)} improvement suggestions")
+
+        return considerations
 
     def execute_current_phase(self, context: Dict[str, Any] = None) -> Dict[str, Any]:
         """

--- a/tests/unit/application/edrr/test_result_analysis.py
+++ b/tests/unit/application/edrr/test_result_analysis.py
@@ -1,0 +1,112 @@
+from unittest.mock import MagicMock
+
+import pytest
+
+from devsynth.application.code_analysis.analyzer import CodeAnalyzer
+from devsynth.application.code_analysis.ast_transformer import AstTransformer
+from devsynth.application.documentation.documentation_manager import (
+    DocumentationManager,
+)
+from devsynth.application.edrr.coordinator import EDRRCoordinator
+from devsynth.application.memory.memory_manager import MemoryManager
+from devsynth.application.prompts.prompt_manager import PromptManager
+from devsynth.domain.models.wsde import WSDETeam
+
+
+@pytest.fixture
+def coordinator():
+    memory_manager = MagicMock(spec=MemoryManager)
+    memory_manager.stored_items = {}
+    memory_manager.store_with_edrr_phase.side_effect = (
+        lambda item, item_type, phase, metadata: memory_manager.stored_items.update(
+            {item_type: {"item": item, "phase": phase, "metadata": metadata}}
+        )
+    )
+    memory_manager.retrieve_with_edrr_phase.side_effect = (
+        lambda item_type, phase, metadata: memory_manager.stored_items.get(
+            item_type, {}
+        ).get("item", {})
+    )
+    wsde_team = MagicMock(spec=WSDETeam)
+    code_analyzer = MagicMock(spec=CodeAnalyzer)
+    ast_transformer = MagicMock(spec=AstTransformer)
+    prompt_manager = MagicMock(spec=PromptManager)
+    documentation_manager = MagicMock(spec=DocumentationManager)
+
+    return EDRRCoordinator(
+        memory_manager=memory_manager,
+        wsde_team=wsde_team,
+        code_analyzer=code_analyzer,
+        ast_transformer=ast_transformer,
+        prompt_manager=prompt_manager,
+        documentation_manager=documentation_manager,
+    )
+
+
+def test_extract_key_insights(coordinator):
+    expand_results = {
+        "ideas": [{"idea": "A"}, {"idea": "B"}],
+        "knowledge": [1, 2, 3],
+        "code_elements": {"files": 5, "functions": 2},
+    }
+    insights = coordinator._extract_key_insights(expand_results)
+    assert insights
+    assert any("A" in i for i in insights)
+    assert any("5" in i for i in insights)
+
+
+def test_summarize_implementation(coordinator):
+    plan = [
+        {"component": "X"},
+        {"component": "Y"},
+    ]
+    summary = coordinator._summarize_implementation(plan)
+    assert summary["steps"] == 2
+    assert "X" in summary["primary_components"]
+    assert summary["estimated_complexity"] == "Low"
+
+
+def test_summarize_quality_checks(coordinator):
+    checks = {
+        "issues": [
+            {"severity": "critical", "area": "security"},
+            {"severity": "minor", "area": "style"},
+        ]
+    }
+    summary = coordinator._summarize_quality_checks(checks)
+    assert summary["issues_found"] == 2
+    assert summary["critical_issues"] == 1
+    assert "security" in summary["areas_of_concern"]
+
+
+def test_extract_key_learnings(coordinator):
+    learnings = [
+        {"learning": "L1"},
+        {"learning": "L2"},
+        {"learning": "L3"},
+        {"learning": "L4"},
+    ]
+    result = coordinator._extract_key_learnings(learnings)
+    assert result == ["L1", "L2", "L3"]
+
+
+def test_generate_next_steps(coordinator):
+    cycle_data = {
+        "refine": {"implementation_plan": [1]},
+        "retrospect": {"improvement_suggestions": ["a"]},
+    }
+    steps = coordinator._generate_next_steps(cycle_data)
+    assert steps
+    assert any("Implement" in s for s in steps)
+    assert any("improvement" in s for s in steps)
+
+
+def test_extract_future_considerations(coordinator):
+    retrospect_results = {
+        "patterns": [1, 2],
+        "improvement_suggestions": [1],
+    }
+    considerations = coordinator._extract_future_considerations(retrospect_results)
+    assert considerations
+    assert any("pattern" in c for c in considerations)
+    assert any("improvement" in c for c in considerations)


### PR DESCRIPTION
## Summary
- analyze phase output instead of returning placeholders
- add unit tests for new summarization helpers
- mention new implementation in codebase analysis docs

## Testing
- `pre-commit run --files src/devsynth/application/edrr/coordinator.py tests/unit/application/edrr/test_result_analysis.py` *(fails: flake8, mypy)*
- `pytest -q tests/unit/application/edrr/test_result_analysis.py`

------
https://chatgpt.com/codex/tasks/task_e_6854dd3a342083339b5468f87b048587