### PR TITLE
Add Kuzu memory store type

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ Certain features use additional backends that are not installed by default. Inst
 pip install 'devsynth[retrieval]'
 ```
 
-These packages enable the ChromaDB, FAISS, and LMDB memory stores and are required for the tests that cover them.
+These packages enable the ChromaDB, Kuzu, FAISS, and LMDB memory stores and are required for the tests that cover them.
 
 ## Minimal Project Example
 

--- a/docs/user_guides/user_guide.md
+++ b/docs/user_guides/user_guide.md
@@ -218,7 +218,7 @@ DevSynth can be configured using the `config` command or by editing the configur
 | `endpoint` | LM Studio API endpoint | `http://localhost:1234/v1` | Any valid URL |
 | `openai_api_key` | OpenAI API key for using OpenAI models | None | Valid OpenAI API key |
 | `serper_api_key` | Serper API key for web search functionality | None | Valid Serper API key |
-| `memory_store_type` | Type of memory store to use | `memory` | `memory`, `file`, `chromadb` |
+| `memory_store_type` | Type of memory store to use | `memory` | `memory`, `file`, `chromadb`, `kuzu` |
 
 ### Environment Variables and .env Files
 
@@ -374,6 +374,22 @@ version2 = store.retrieve_version("item-id", 2)
 ##### Optimized Embedding Storage
 
 The ChromaDB memory store optimizes the storage of embeddings for similar content, reducing storage requirements and improving performance. This is particularly beneficial when storing multiple items with similar content.
+
+#### Kuzu Memory Store
+
+The `kuzu` memory store type uses KuzuDB as a lightweight database for persistent storage. If the `kuzu` Python package is unavailable, the store falls back to an in-memory implementation.
+
+```bash
+# Configure Kuzu store
+devsynth config --key memory_store_type --value kuzu
+devsynth config --key memory_file_path --value /path/to/kuzu/directory
+```
+
+Key features of the Kuzu memory store:
+
+- **Embedded Database**: Stores memory items in KuzuDB for fast local access
+- **Vector Support**: Integrates a simple vector adapter for similarity search
+- **Fallback Mode**: Automatically falls back to an in-memory store when KuzuDB is not available
 
 ## Workflow Guide
 

--- a/src/devsynth/application/cli/cli_commands.py
+++ b/src/devsynth/application/cli/cli_commands.py
@@ -63,6 +63,12 @@ def _check_services(bridge: Optional[UXBridge] = None) -> bool:
             messages.append(
                 "ChromaDB support is enabled but the 'chromadb' package is missing."
             )
+    # Check Kuzu availability when vector store is enabled
+    if settings.vector_store_enabled and settings.memory_store_type == "kuzu":
+        if importlib.util.find_spec("kuzu") is None:
+            messages.append(
+                "Kuzu support is enabled but the 'kuzu' package is missing."
+            )
 
     # Check LLM provider configuration
     provider = settings.provider_type

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -459,6 +459,17 @@ def is_faiss_available() -> bool:
         return False
 
 
+def is_kuzu_available() -> bool:
+    """Check if the kuzu package is installed."""
+    if os.environ.get("DEVSYNTH_RESOURCE_KUZU_AVAILABLE", "true").lower() == "false":
+        return False
+    try:  # pragma: no cover - simple import check
+        import kuzu  # noqa: F401
+        return True
+    except Exception:
+        return False
+
+
 def is_lmdb_available() -> bool:
     """Check if the lmdb package is installed."""
     if os.environ.get("DEVSYNTH_RESOURCE_LMDB_AVAILABLE", "true").lower() == "false":
@@ -500,6 +511,7 @@ def is_resource_available(resource: str) -> bool:
         "cli": is_cli_available,
         "chromadb": is_chromadb_available,
         "faiss": is_faiss_available,
+        "kuzu": is_kuzu_available,
         "lmdb": is_lmdb_available,
     }
 

--- a/tests/unit/adapters/memory/test_memory_adapter.py
+++ b/tests/unit/adapters/memory/test_memory_adapter.py
@@ -18,6 +18,8 @@ try:
     from devsynth.application.memory.faiss_store import FAISSStore
 except ImportError:  # pragma: no cover - optional dependency
     FAISSStore = None
+from devsynth.adapters.kuzu_memory_store import KuzuMemoryStore
+from devsynth.adapters.memory.kuzu_adapter import KuzuAdapter
 from devsynth.application.memory.rdflib_store import RDFLibStore
 from devsynth.application.memory.context_manager import InMemoryStore, SimpleContextManager
 from devsynth.application.memory.persistent_context_manager import PersistentContextManager
@@ -118,6 +120,24 @@ class TestMemorySystemAdapter:
         assert isinstance(adapter.memory_store, LMDBStore)
         assert isinstance(adapter.context_manager, PersistentContextManager)
         assert adapter.vector_store is None
+
+    def test_init_with_kuzu_storage(self, temp_dir):
+        """Test initialization with Kuzu storage."""
+        config = {
+            "memory_store_type": "kuzu",
+            "memory_file_path": temp_dir,
+            "max_context_size": 1000,
+            "context_expiration_days": 1,
+            "vector_store_enabled": True,
+        }
+        adapter = MemorySystemAdapter(config=config)
+
+        assert adapter.storage_type == "kuzu"
+        assert adapter.memory_path == temp_dir
+        assert isinstance(adapter.memory_store, KuzuMemoryStore)
+        assert isinstance(adapter.context_manager, PersistentContextManager)
+        assert adapter.vector_store is not None
+        assert isinstance(adapter.vector_store, KuzuAdapter)
 
     @pytest.mark.requires_resource("faiss")
     def test_init_with_faiss_storage(self, temp_dir):

--- a/tests/unit/test_memory_system_with_kuzu.py
+++ b/tests/unit/test_memory_system_with_kuzu.py
@@ -1,0 +1,63 @@
+import pytest
+import os
+import shutil
+import tempfile
+
+from devsynth.domain.models.memory import MemoryItem, MemoryType, MemoryVector
+from devsynth.adapters.memory.memory_adapter import MemorySystemAdapter
+from devsynth.adapters.memory.kuzu_adapter import KuzuAdapter
+
+pytestmark = pytest.mark.requires_resource("kuzu")
+
+
+class TestMemorySystemWithKuzu:
+    @pytest.fixture
+    def temp_dir(self):
+        temp_dir = tempfile.mkdtemp()
+        yield temp_dir
+        shutil.rmtree(temp_dir)
+
+    @pytest.fixture
+    def memory_system(self, temp_dir):
+        config = {
+            "memory_store_type": "kuzu",
+            "memory_file_path": temp_dir,
+            "vector_store_enabled": True,
+        }
+        return MemorySystemAdapter(config=config)
+
+    def test_initialization_with_kuzu(self, temp_dir):
+        config = {
+            "memory_store_type": "kuzu",
+            "memory_file_path": temp_dir,
+            "vector_store_enabled": True,
+        }
+        memory_system = MemorySystemAdapter(config=config)
+        assert memory_system.memory_store is not None
+        assert memory_system.vector_store is not None
+        assert isinstance(memory_system.vector_store, KuzuAdapter)
+        assert memory_system.has_vector_store() is True
+
+    def test_memory_and_vector_store_integration(self, memory_system):
+        memory_item = MemoryItem(
+            id="test-item",
+            content="This is a test item",
+            memory_type=MemoryType.LONG_TERM,
+            metadata={"test": "memory"},
+        )
+        memory_store = memory_system.get_memory_store()
+        item_id = memory_store.store(memory_item)
+        vector = MemoryVector(
+            id="test-vector",
+            content="This is a test vector",
+            embedding=[0.1, 0.2, 0.3],
+            metadata={"memory_item_id": item_id},
+        )
+        vector_store = memory_system.get_vector_store()
+        vector_id = vector_store.store_vector(vector)
+
+        retrieved_item = memory_store.retrieve(item_id)
+        assert retrieved_item is not None
+        retrieved_vector = vector_store.retrieve_vector(vector_id)
+        assert retrieved_vector is not None
+        assert retrieved_vector.metadata["memory_item_id"] == item_id

--- a/tests/unit/test_unit_cli_commands.py
+++ b/tests/unit/test_unit_cli_commands.py
@@ -521,6 +521,35 @@ class TestCLICommands:
                 for call in mock_bridge.display_result.call_args_list
             )
 
+    def test_spec_cmd_missing_kuzu_package(
+        self, mock_workflow_manager, mock_bridge
+    ):
+        """spec_cmd should warn when Kuzu package is unavailable."""
+
+        class DummySettings:
+            vector_store_enabled = True
+            memory_store_type = "kuzu"
+            provider_type = "openai"
+            openai_api_key = "key"
+            lm_studio_endpoint = None
+
+        with patch(
+            "devsynth.application.cli.cli_commands.get_settings",
+            return_value=DummySettings,
+        ), patch(
+            "devsynth.application.cli.cli_commands.importlib.util.find_spec",
+            return_value=None,
+        ), patch(
+            "devsynth.application.cli.cli_commands._check_services",
+            new=ORIG_CHECK_SERVICES,
+        ):
+            spec_cmd("req.md")
+            mock_workflow_manager.assert_not_called()
+            assert any(
+                "kuzu" in call.args[0].lower()
+                for call in mock_bridge.display_result.call_args_list
+            )
+
     def test_config_key_autocomplete(self, tmp_path, monkeypatch):
         cfg_dir = tmp_path / ".devsynth"
         cfg_dir.mkdir()


### PR DESCRIPTION
## Summary
- support `kuzu` memory store type via `MemorySystemAdapter`
- integrate new store with CLI service checks
- document Kuzu in user guide and README
- add tests for Kuzu adapter and memory system
- enable Kuzu resource checks for test suite

## Testing
- `poetry run pytest -q` *(fails: 36 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68557c61f7508333b3ccdca2e59e4655