### PR TITLE
Switch memory store to Kuzu

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -15,15 +15,15 @@ logging:
 
 # Memory system configuration
 memory:
-  default_store: chromadb
+  default_store: kuzu
   stores:
     chromadb:
       enabled: true
-      host: localhost
-      port: 8000
       collection_name: devsynth
       distance_function: cosine
       persist_directory: ./.devsynth/chromadb
+    kuzu:
+      persist_directory: ./.devsynth/kuzu
     faiss:
       enabled: false
       index_file: ./.devsynth/faiss/index.bin

--- a/config/development.yml
+++ b/config/development.yml
@@ -8,11 +8,12 @@ logging:
 
 # Memory system configuration
 memory:
+  default_store: kuzu
   stores:
     chromadb:
-      host: localhost
-      port: 8001  # Mapped port in docker-compose
       persist_directory: ./.devsynth/dev/chromadb
+    kuzu:
+      persist_directory: ./.devsynth/dev/kuzu
 
 # LLM provider configuration
 llm:

--- a/config/production.yml
+++ b/config/production.yml
@@ -9,13 +9,14 @@ logging:
 
 # Memory system configuration
 memory:
+  default_store: kuzu
   stores:
     chromadb:
-      host: ${DEVSYNTH_CHROMADB_HOST}  # Use environment variable
-      port: ${DEVSYNTH_CHROMADB_PORT}
       persist_directory: /data/devsynth/chromadb  # Persistent storage
       collection_name: devsynth-prod
       distance_function: cosine
+    kuzu:
+      persist_directory: /data/devsynth/kuzu
     faiss:
       enabled: true  # Enable FAISS in production for performance
       index_file: /data/devsynth/faiss/index.bin

--- a/config/staging.yml
+++ b/config/staging.yml
@@ -9,12 +9,13 @@ logging:
 
 # Memory system configuration
 memory:
+  default_store: kuzu
   stores:
     chromadb:
-      host: ${DEVSYNTH_CHROMADB_HOST}
-      port: ${DEVSYNTH_CHROMADB_PORT}
       persist_directory: /data/devsynth-staging/chromadb
       collection_name: devsynth-staging
+    kuzu:
+      persist_directory: /data/devsynth-staging/kuzu
     faiss:
       enabled: true
       index_file: /data/devsynth-staging/faiss/index.bin

--- a/config/testing.yml
+++ b/config/testing.yml
@@ -8,12 +8,13 @@ logging:
 
 # Memory system configuration
 memory:
+  default_store: kuzu
   stores:
     chromadb:
-      host: chromadb-test  # Use the test-specific ChromaDB instance
-      port: 8000
       persist_directory: /tmp/devsynth-test/chromadb  # Ephemeral storage for tests
       collection_name: devsynth-test
+    kuzu:
+      persist_directory: /tmp/devsynth-test/kuzu
 
 # LLM provider configuration
 llm:

--- a/docs/deployment/deployment_guide.md
+++ b/docs/deployment/deployment_guide.md
@@ -83,8 +83,6 @@ docker compose --profile test run test-runner pytest tests/unit/
 ```bash
 # Set required environment variables
 export DEVSYNTH_ENV=staging
-export DEVSYNTH_CHROMADB_HOST=chromadb
-export DEVSYNTH_CHROMADB_PORT=8000
 export DEVSYNTH_LLM_PROVIDER=openai
 export DEVSYNTH_OPENAI_API_KEY=your-api-key
 
@@ -99,8 +97,6 @@ Use the production compose file which includes Prometheus and Grafana for monito
 ```bash
 # Set required environment variables
 export DEVSYNTH_ENV=production
-export DEVSYNTH_CHROMADB_HOST=chromadb
-export DEVSYNTH_CHROMADB_PORT=8000
 export DEVSYNTH_LLM_PROVIDER=openai
 export DEVSYNTH_OPENAI_API_KEY=your-api-key
 export DEVSYNTH_OPENAI_MODEL=gpt-4

--- a/docs/technical_reference/configuration_reference.md
+++ b/docs/technical_reference/configuration_reference.md
@@ -118,9 +118,7 @@ DevSynth uses the following environment variables for configuration:
 | `DEVSYNTH_ENV` | Deployment environment | development |
 | `DEVSYNTH_PROVIDER` | Default LLM provider | openai |
 | `DEVSYNTH_LLM_PROVIDER` | LLM provider override | openai |
-| `DEVSYNTH_MEMORY_STORE` | Memory store to use | chromadb |
-| `DEVSYNTH_CHROMADB_HOST` | ChromaDB host | chromadb |
-| `DEVSYNTH_CHROMADB_PORT` | ChromaDB port | 8000 |
+| `DEVSYNTH_MEMORY_STORE` | Memory store to use | kuzu |
 | `DEVSYNTH_OPENAI_API_KEY` | OpenAI API key (config override) | None |
 | `OPENAI_API_KEY` | OpenAI API key | None |
 | `DEVSYNTH_OPENAI_MODEL` | OpenAI model to use | gpt-4 |

--- a/scripts/validate_config.py
+++ b/scripts/validate_config.py
@@ -17,7 +17,17 @@ from typing import Dict, Any, List, Optional
 # Configuration schema definition
 CONFIG_SCHEMA = {
     "type": "object",
-    "required": ["application", "logging", "memory", "llm", "agents", "edrr", "security", "performance", "features"],
+    "required": [
+        "application",
+        "logging",
+        "memory",
+        "llm",
+        "agents",
+        "edrr",
+        "security",
+        "performance",
+        "features",
+    ],
     "properties": {
         "application": {
             "type": "object",
@@ -25,17 +35,20 @@ CONFIG_SCHEMA = {
             "properties": {
                 "name": {"type": "string"},
                 "version": {"type": "string"},
-                "description": {"type": "string"}
-            }
+                "description": {"type": "string"},
+            },
         },
         "logging": {
             "type": "object",
             "required": ["level", "format"],
             "properties": {
-                "level": {"type": "string", "enum": ["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"]},
+                "level": {
+                    "type": "string",
+                    "enum": ["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"],
+                },
                 "format": {"type": "string"},
-                "file": {"type": ["string", "null"]}
-            }
+                "file": {"type": ["string", "null"]},
+            },
         },
         "memory": {
             "type": "object",
@@ -44,19 +57,21 @@ CONFIG_SCHEMA = {
                 "default_store": {"type": "string"},
                 "stores": {
                     "type": "object",
-                    "required": ["chromadb"],
+                    "required": ["chromadb", "kuzu"],
                     "properties": {
                         "chromadb": {
                             "type": "object",
                             "required": ["enabled"],
                             "properties": {
                                 "enabled": {"type": "boolean"},
-                                "host": {"type": "string"},
-                                "port": {"type": ["integer", "string"]},
                                 "collection_name": {"type": "string"},
                                 "distance_function": {"type": "string"},
-                                "persist_directory": {"type": "string"}
-                            }
+                                "persist_directory": {"type": "string"},
+                            },
+                        },
+                        "kuzu": {
+                            "type": "object",
+                            "properties": {"persist_directory": {"type": "string"}},
                         },
                         "faiss": {
                             "type": "object",
@@ -64,12 +79,12 @@ CONFIG_SCHEMA = {
                             "properties": {
                                 "enabled": {"type": "boolean"},
                                 "index_file": {"type": "string"},
-                                "dimension": {"type": "integer"}
-                            }
-                        }
-                    }
-                }
-            }
+                                "dimension": {"type": "integer"},
+                            },
+                        },
+                    },
+                },
+            },
         },
         "llm": {
             "type": "object",
@@ -85,14 +100,18 @@ CONFIG_SCHEMA = {
                             "properties": {
                                 "enabled": {"type": "boolean"},
                                 "model": {"type": "string"},
-                                "temperature": {"type": "number", "minimum": 0, "maximum": 1},
+                                "temperature": {
+                                    "type": "number",
+                                    "minimum": 0,
+                                    "maximum": 1,
+                                },
                                 "max_tokens": {"type": "integer", "minimum": 1},
-                                "timeout": {"type": "integer", "minimum": 1}
-                            }
+                                "timeout": {"type": "integer", "minimum": 1},
+                            },
                         }
-                    }
-                }
-            }
+                    },
+                },
+            },
         },
         "agents": {
             "type": "object",
@@ -100,8 +119,8 @@ CONFIG_SCHEMA = {
             "properties": {
                 "max_agents": {"type": "integer", "minimum": 1},
                 "default_timeout": {"type": "integer", "minimum": 1},
-                "memory_context_size": {"type": "integer", "minimum": 1}
-            }
+                "memory_context_size": {"type": "integer", "minimum": 1},
+            },
         },
         "edrr": {
             "type": "object",
@@ -113,10 +132,10 @@ CONFIG_SCHEMA = {
                     "type": "object",
                     "properties": {
                         "auto": {"type": "boolean"},
-                        "timeout": {"type": "integer", "minimum": 1}
-                    }
-                }
-            }
+                        "timeout": {"type": "integer", "minimum": 1},
+                    },
+                },
+            },
         },
         "security": {
             "type": "object",
@@ -128,17 +147,17 @@ CONFIG_SCHEMA = {
                     "properties": {
                         "enabled": {"type": "boolean"},
                         "max_requests": {"type": "integer", "minimum": 1},
-                        "period": {"type": "integer", "minimum": 1}
-                    }
+                        "period": {"type": "integer", "minimum": 1},
+                    },
                 },
                 "encryption": {
                     "type": "object",
                     "properties": {
                         "at_rest": {"type": "boolean"},
-                        "in_transit": {"type": "boolean"}
-                    }
-                }
-            }
+                        "in_transit": {"type": "boolean"},
+                    },
+                },
+            },
         },
         "performance": {
             "type": "object",
@@ -147,17 +166,17 @@ CONFIG_SCHEMA = {
                     "type": "object",
                     "properties": {
                         "enabled": {"type": "boolean"},
-                        "ttl": {"type": "integer", "minimum": 1}
-                    }
+                        "ttl": {"type": "integer", "minimum": 1},
+                    },
                 },
                 "concurrency": {
                     "type": "object",
                     "properties": {
                         "max_workers": {"type": ["integer", "string"], "minimum": 1},
-                        "timeout": {"type": "integer", "minimum": 1}
-                    }
-                }
-            }
+                        "timeout": {"type": "integer", "minimum": 1},
+                    },
+                },
+            },
         },
         "features": {
             "type": "object",
@@ -166,17 +185,17 @@ CONFIG_SCHEMA = {
                 "dialectical_reasoning": {"type": "boolean"},
                 "code_generation": {"type": "boolean"},
                 "test_generation": {"type": "boolean"},
-                "documentation_generation": {"type": "boolean"}
-            }
-        }
-    }
+                "documentation_generation": {"type": "boolean"},
+            },
+        },
+    },
 }
 
 
 def load_config(file_path: str) -> Dict[str, Any]:
     """Load a YAML configuration file."""
     try:
-        with open(file_path, 'r') as f:
+        with open(file_path, "r") as f:
             return yaml.safe_load(f)
     except Exception as e:
         print(f"Error loading configuration file {file_path}: {e}")
@@ -187,13 +206,15 @@ def validate_config(config: Dict[str, Any], schema: Dict[str, Any]) -> List[str]
     """Validate a configuration against a schema."""
     validator = jsonschema.Draft7Validator(schema)
     errors = list(validator.iter_errors(config))
-    return [f"{'.'.join(str(p) for p in error.path)}: {error.message}" for error in errors]
+    return [
+        f"{'.'.join(str(p) for p in error.path)}: {error.message}" for error in errors
+    ]
 
 
 def validate_environment_variables(config: Dict[str, Any]) -> List[str]:
     """Check for environment variables in the configuration and validate they're set."""
     errors = []
-    
+
     def check_env_vars(obj, path=""):
         if isinstance(obj, dict):
             for key, value in obj.items():
@@ -207,10 +228,12 @@ def validate_environment_variables(config: Dict[str, Any]) -> List[str]:
             env_var = obj[2:-1]
             if ":-" in env_var:  # Has default value
                 env_var = env_var.split(":-")[0]
-            
+
             if not os.environ.get(env_var):
-                errors.append(f"Environment variable {env_var} referenced in {path} is not set")
-    
+                errors.append(
+                    f"Environment variable {env_var} referenced in {path} is not set"
+                )
+
     check_env_vars(config)
     return errors
 
@@ -218,57 +241,71 @@ def validate_environment_variables(config: Dict[str, Any]) -> List[str]:
 def check_config_consistency(configs: Dict[str, Dict[str, Any]]) -> List[str]:
     """Check consistency across different environment configurations."""
     errors = []
-    
+
     # Check that all environments have the same feature flags
-    default_features = set(configs.get('default', {}).get('features', {}).keys())
+    default_features = set(configs.get("default", {}).get("features", {}).keys())
     for env, config in configs.items():
-        if env == 'default':
+        if env == "default":
             continue
-        
-        env_features = set(config.get('features', {}).keys())
+
+        env_features = set(config.get("features", {}).keys())
         missing_features = default_features - env_features
         if missing_features:
-            errors.append(f"Environment {env} is missing feature flags: {', '.join(missing_features)}")
-    
+            errors.append(
+                f"Environment {env} is missing feature flags: {', '.join(missing_features)}"
+            )
+
     return errors
 
 
 def main():
-    parser = argparse.ArgumentParser(description="Validate DevSynth configuration files")
-    parser.add_argument("--config-dir", default="./config", help="Directory containing configuration files")
-    parser.add_argument("--environments", nargs="+", default=["default", "development", "testing", "staging", "production"],
-                        help="Environments to validate")
+    parser = argparse.ArgumentParser(
+        description="Validate DevSynth configuration files"
+    )
+    parser.add_argument(
+        "--config-dir",
+        default="./config",
+        help="Directory containing configuration files",
+    )
+    parser.add_argument(
+        "--environments",
+        nargs="+",
+        default=["default", "development", "testing", "staging", "production"],
+        help="Environments to validate",
+    )
     args = parser.parse_args()
-    
+
     configs = {}
     all_errors = []
-    
+
     # Load and validate each configuration file
     for env in args.environments:
         config_path = os.path.join(args.config_dir, f"{env}.yml")
         if not os.path.exists(config_path):
-            print(f"Warning: Configuration file for environment {env} not found at {config_path}")
+            print(
+                f"Warning: Configuration file for environment {env} not found at {config_path}"
+            )
             continue
-        
+
         print(f"Validating {env} configuration...")
         config = load_config(config_path)
         configs[env] = config
-        
+
         # Validate against schema
         schema_errors = validate_config(config, CONFIG_SCHEMA)
         if schema_errors:
             all_errors.extend([f"[{env}] {error}" for error in schema_errors])
-        
+
         # Validate environment variables
         env_var_errors = validate_environment_variables(config)
         if env_var_errors:
             all_errors.extend([f"[{env}] {error}" for error in env_var_errors])
-    
+
     # Check consistency across configurations
     consistency_errors = check_config_consistency(configs)
     if consistency_errors:
         all_errors.extend([f"[consistency] {error}" for error in consistency_errors])
-    
+
     # Report results
     if all_errors:
         print("\nValidation errors found:")

--- a/src/devsynth/config/__init__.py
+++ b/src/devsynth/config/__init__.py
@@ -4,9 +4,7 @@ Configuration module for DevSynth.
 
 import os
 
-from .settings import (
-    get_settings, get_llm_settings, load_dotenv, _settings
-)
+from .settings import get_settings, get_llm_settings, load_dotenv, _settings
 from pathlib import Path
 from .loader import ConfigModel, load_config, save_config, config_key_autocomplete
 
@@ -21,9 +19,11 @@ def get_project_config(path: Path | None = None) -> ConfigModel:
         _PROJECT_CONFIG = load_config(path)
     return _PROJECT_CONFIG
 
+
 # Expose settings as module-level variables for backward compatibility
 MEMORY_STORE_TYPE = _settings.memory_store_type
 MEMORY_FILE_PATH = _settings.memory_file_path
+KUZU_DB_PATH = _settings.memory_file_path
 MAX_CONTEXT_SIZE = _settings.max_context_size
 CONTEXT_EXPIRATION_DAYS = _settings.context_expiration_days
 
@@ -38,7 +38,9 @@ LLM_API_BASE = _settings.lm_studio_endpoint
 LLM_MODEL = os.environ.get("DEVSYNTH_LLM_MODEL", "gpt-3.5-turbo")
 LLM_MAX_TOKENS = int(os.environ.get("DEVSYNTH_LLM_MAX_TOKENS", "2000"))
 LLM_TEMPERATURE = float(os.environ.get("DEVSYNTH_LLM_TEMPERATURE", "0.7"))
-LLM_AUTO_SELECT_MODEL = os.environ.get("DEVSYNTH_LLM_AUTO_SELECT_MODEL", "true").lower() in ["true", "1", "yes"]
+LLM_AUTO_SELECT_MODEL = os.environ.get(
+    "DEVSYNTH_LLM_AUTO_SELECT_MODEL", "true"
+).lower() in ["true", "1", "yes"]
 
 # Create a logger for this module
 from devsynth.logging_setup import DevSynthLogger
@@ -57,18 +59,16 @@ __all__ = [
     "config_key_autocomplete",
     "ConfigModel",
     "PROJECT_CONFIG",
-
     # Memory settings
     "MEMORY_STORE_TYPE",
     "MEMORY_FILE_PATH",
+    "KUZU_DB_PATH",
     "MAX_CONTEXT_SIZE",
     "CONTEXT_EXPIRATION_DAYS",
-
     # Vector store settings
     "VECTOR_STORE_ENABLED",
     "CHROMADB_COLLECTION_NAME",
     "CHROMADB_DISTANCE_FUNC",
-
     # LLM settings
     "LLM_PROVIDER",
     "LLM_API_BASE",


### PR DESCRIPTION
## Summary
- use `kuzu` as the default memory store
- remove ChromaDB host/port settings
- expose `KUZU_DB_PATH` constant
- update configuration validation
- refresh docs to remove chromadb host/port env vars

## Testing
- `poetry run black src/devsynth/config/__init__.py scripts/validate_config.py -q`
- `poetry run pytest -q` *(fails: ModuleNotFoundError: No module named 'chromadb')*

------
https://chatgpt.com/codex/tasks/task_e_68558af94798833381b1aa2617a55406