### PR TITLE
Add Kuzu DB configuration

### DIFF
--- a/docs/user_guides/user_guide.md
+++ b/docs/user_guides/user_guide.md
@@ -264,6 +264,8 @@ DevSynth-specific configuration variables use the `DEVSYNTH_` prefix:
 |----------------------|------------------|
 | `DEVSYNTH_MEMORY_STORE` | `memory_store_type` |
 | `DEVSYNTH_MEMORY_PATH` | `memory_file_path` |
+| `DEVSYNTH_KUZU_DB_PATH` | `kuzu_db_path` |
+| `DEVSYNTH_KUZU_EMBEDDED` | `kuzu_embedded` |
 | `DEVSYNTH_MAX_CONTEXT_SIZE` | `max_context_size` |
 | `DEVSYNTH_CONTEXT_EXPIRATION_DAYS` | `context_expiration_days` |
 | `DEVSYNTH_LLM_PROVIDER` | `llm_provider` |
@@ -383,6 +385,8 @@ The `kuzu` memory store type uses KuzuDB as a lightweight database for persisten
 # Configure Kuzu store
 devsynth config --key memory_store_type --value kuzu
 devsynth config --key memory_file_path --value /path/to/kuzu/directory
+devsynth config --key kuzu_db_path --value /path/to/kuzu.db
+devsynth config --key kuzu_embedded --value true
 ```
 
 Key features of the Kuzu memory store:

--- a/src/devsynth/config/__init__.py
+++ b/src/devsynth/config/__init__.py
@@ -3,10 +3,10 @@ Configuration module for DevSynth.
 """
 
 import os
-
-from .settings import get_settings, get_llm_settings, load_dotenv, _settings
 from pathlib import Path
-from .loader import ConfigModel, load_config, save_config, config_key_autocomplete
+
+from .loader import ConfigModel, config_key_autocomplete, load_config, save_config
+from .settings import _settings, get_llm_settings, get_settings, load_dotenv
 
 _PROJECT_CONFIG: ConfigModel = load_config()
 PROJECT_CONFIG = _PROJECT_CONFIG
@@ -23,7 +23,8 @@ def get_project_config(path: Path | None = None) -> ConfigModel:
 # Expose settings as module-level variables for backward compatibility
 MEMORY_STORE_TYPE = _settings.memory_store_type
 MEMORY_FILE_PATH = _settings.memory_file_path
-KUZU_DB_PATH = _settings.memory_file_path
+KUZU_DB_PATH = _settings.kuzu_db_path
+KUZU_EMBEDDED = _settings.kuzu_embedded
 MAX_CONTEXT_SIZE = _settings.max_context_size
 CONTEXT_EXPIRATION_DAYS = _settings.context_expiration_days
 
@@ -63,6 +64,7 @@ __all__ = [
     "MEMORY_STORE_TYPE",
     "MEMORY_FILE_PATH",
     "KUZU_DB_PATH",
+    "KUZU_EMBEDDED",
     "MAX_CONTEXT_SIZE",
     "CONTEXT_EXPIRATION_DAYS",
     # Vector store settings


### PR DESCRIPTION
## Summary
- extend `Settings` with `kuzu_db_path` and `kuzu_embedded`
- expose new options via `devsynth.config`
- document new environment variables and usage
- test Kuzu config behaviour

## Testing
- `poetry run black src/devsynth/config/settings.py src/devsynth/config/__init__.py tests/unit/test_config_settings.py`
- `poetry run pytest tests/unit/test_config_settings.py`
- `poetry run pytest` *(fails: ImportError: Error importing ...)*

------
https://chatgpt.com/codex/tasks/task_e_68558fa008e483338faccbc09c108b6a