### PR TITLE
Remove Chromadb services

### DIFF
--- a/deployment/docker-compose.yml
+++ b/deployment/docker-compose.yml
@@ -13,12 +13,7 @@ services:
     environment:
       - DEVSYNTH_ENV=development
       - DEVSYNTH_LOG_LEVEL=DEBUG
-      - DEVSYNTH_MEMORY_STORE=chromadb
       - DEVSYNTH_LLM_PROVIDER=openai
-      - DEVSYNTH_CHROMADB_HOST=chromadb
-      - DEVSYNTH_CHROMADB_PORT=8000
-    depends_on:
-      - chromadb
     networks:
       - devsynth-network
     healthcheck:
@@ -29,28 +24,6 @@ services:
       start_period: 5s
     restart: unless-stopped
 
-  chromadb:
-    image: ghcr.io/chroma-core/chroma:latest
-    volumes:
-      - chromadb-data:/chroma/chroma
-    ports:
-      - "8001:8000"
-    environment:
-      - CHROMA_DB_IMPL=duckdb+parquet
-      - CHROMA_PERSIST_DIRECTORY=/chroma/chroma
-    networks:
-      - devsynth-network
-    healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:8000/api/v1/heartbeat"]
-      interval: 30s
-      timeout: 10s
-      retries: 3
-      start_period: 5s
-    restart: unless-stopped
-
-volumes:
-  chromadb-data:
-    name: devsynth-chromadb-data
 
 networks:
   devsynth-network:

--- a/docker-compose.production.yml
+++ b/docker-compose.production.yml
@@ -9,13 +9,8 @@ services:
     environment:
       - DEVSYNTH_ENV=production
       - DEVSYNTH_LOG_LEVEL=INFO
-      - DEVSYNTH_MEMORY_STORE=chromadb
-      - DEVSYNTH_CHROMADB_HOST=chromadb
-      - DEVSYNTH_CHROMADB_PORT=8000
     volumes:
       - devsynth-data:/data/devsynth
-    depends_on:
-      - chromadb
     ports:
       - "8000:8000"
     networks:
@@ -41,23 +36,6 @@ services:
     profiles:
       - cli
 
-  chromadb:
-    image: ghcr.io/chroma-core/chroma:latest
-    volumes:
-      - chromadb-data:/chroma/chroma
-    ports:
-      - "8001:8000"
-    environment:
-      - CHROMA_DB_IMPL=duckdb+parquet
-      - CHROMA_PERSIST_DIRECTORY=/chroma/chroma
-    networks:
-      - devsynth-network
-    healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:8000/api/v1/heartbeat"]
-      interval: 30s
-      timeout: 10s
-      retries: 3
-      start_period: 5s
 
   prometheus:
     image: prom/prometheus
@@ -82,8 +60,6 @@ services:
       - devsynth-network
 
 volumes:
-  chromadb-data:
-    name: devsynth-chromadb-data
   grafana-data:
     name: devsynth-grafana-data
   devsynth-data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,12 +14,7 @@ services:
     environment:
       - DEVSYNTH_ENV=development
       - DEVSYNTH_LOG_LEVEL=DEBUG
-      - DEVSYNTH_MEMORY_STORE=chromadb
       - DEVSYNTH_LLM_PROVIDER=openai
-      - DEVSYNTH_CHROMADB_HOST=chromadb
-      - DEVSYNTH_CHROMADB_PORT=8000
-    depends_on:
-      - chromadb
     networks:
       - devsynth-network
     healthcheck:
@@ -30,25 +25,6 @@ services:
       start_period: 5s
     restart: unless-stopped
 
-  # ChromaDB vector database for memory storage
-  chromadb:
-    image: ghcr.io/chroma-core/chroma:latest
-    volumes:
-      - chromadb-data:/chroma/chroma
-    ports:
-      - "8001:8000"
-    environment:
-      - CHROMA_DB_IMPL=duckdb+parquet
-      - CHROMA_PERSIST_DIRECTORY=/chroma/chroma
-    networks:
-      - devsynth-network
-    healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:8000/api/v1/heartbeat"]
-      interval: 30s
-      timeout: 10s
-      retries: 3
-      start_period: 5s
-    restart: unless-stopped
 
   # Development tools
   dev-tools:
@@ -72,30 +48,11 @@ services:
       - .:/opt/pysetup
     environment:
       - DEVSYNTH_ENV=testing
-      - DEVSYNTH_MEMORY_STORE=chromadb
-      - DEVSYNTH_CHROMADB_HOST=chromadb-test
-      - DEVSYNTH_CHROMADB_PORT=8000
-    depends_on:
-      - chromadb-test
     networks:
       - devsynth-network
     profiles:
       - test
 
-  # Separate ChromaDB instance for testing
-  chromadb-test:
-    image: ghcr.io/chroma-core/chroma:latest
-    environment:
-      - CHROMA_DB_IMPL=duckdb+parquet
-      - CHROMA_PERSIST_DIRECTORY=/chroma/chroma
-    networks:
-      - devsynth-network
-    profiles:
-      - test
-
-volumes:
-  chromadb-data:
-    name: devsynth-chromadb-data
 
 networks:
   devsynth-network:


### PR DESCRIPTION
## Summary
- drop ChromaDB service blocks from all docker-compose files
- remove container dependencies on external DBMS

## Testing
- `poetry run pytest -q` *(fails: ModuleNotFoundError: No module named 'uvicorn')*

------
https://chatgpt.com/codex/tasks/task_e_6855a1ba62c88333882acd5724240d44