### PR TITLE
docs: switch default storage backend to kuzu

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ DevSynth is an agentic software engineering platform that leverages LLMs, advanc
 
 ## Key Features
 - Modular, hexagonal architecture for extensibility and testability
-- Unified memory system with ChromaDB, TinyDB, RDFLib, and JSON backends
+- Unified memory system with Kuzu, TinyDB, RDFLib, and JSON backends
 - Agent system powered by LangGraph for orchestrated workflows
 - Advanced code analysis using NetworkX
 - Provider abstraction for OpenAI, LM Studio, and more
@@ -112,7 +112,7 @@ Certain features use additional backends that are not installed by default. Inst
 pip install 'devsynth[retrieval]'
 ```
 
-These packages enable the ChromaDB, Kuzu, FAISS, and LMDB memory stores and are required for the tests that cover them.
+These packages enable the Kuzu, FAISS, and LMDB memory stores; support for ChromaDB is presently disabled.
 
 ## Minimal Project Example
 
@@ -163,7 +163,7 @@ poetry install
 poetry sync --all-extras --all-groups
 ```
 
-Some tests and features rely on optional backends like **ChromaDB**, **FAISS**, and **LMDB**. Install these packages if you plan to use them:
+Some tests and features rely on optional backends like **Kuzu**, **FAISS**, and **LMDB**. Support for **ChromaDB** is presently disabled. Install these packages if you plan to use them:
 
 ```bash
 pip install 'devsynth[retrieval]'

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -27,7 +27,7 @@ An autonomous software entity powered by LLMs that performs specific tasks withi
 ## C
 
 ### ChromaDB
-A vector database used in DevSynth's memory system for storing and retrieving embeddings. ChromaDB enables semantic search capabilities.
+A vector database used in DevSynth's memory system for storing and retrieving embeddings. ChromaDB enables semantic search capabilities. Support is currently disabled.
 
 ## D
 
@@ -51,10 +51,16 @@ A numerical representation of text that captures its semantic meaning. DevSynth 
 ### Hexagonal Architecture
 Also known as Ports and Adapters architecture, it's a design pattern that separates core business logic from external systems. DevSynth uses hexagonal architecture with domain, application, ports, and adapters layers.
 
+## K
+
+### Kuzu
+A lightweight graph database used as DevSynth's primary persistent memory backend.
+
 ## M
 
+
 ### Memory Adapter
-A component that implements the MemoryStore interface to provide specific storage capabilities. DevSynth includes adapters for ChromaDB, TinyDB, RDFLib, JSON, and in-memory storage.
+A component that implements the MemoryStore interface to provide specific storage capabilities. DevSynth includes adapters for Kuzu, TinyDB, RDFLib, JSON, and in-memory storage.
 
 ### Memory System
 The subsystem responsible for storing, retrieving, and managing information in DevSynth. It supports multiple backends and provides a unified interface for semantic search and structured data storage.

--- a/docs/repo_structure.md
+++ b/docs/repo_structure.md
@@ -33,7 +33,7 @@ src/devsynth/
 ├── adapters/                 # External adapters (hexagonal architecture)
 │   ├── __init__.py
 │   ├── cli.py                # CLI adapter
-│   ├── chromadb_memory_store.py  # ChromaDB memory store adapter
+│   ├── kuzu_memory_store.py      # Kuzu memory store adapter
 │   ├── json_file_store.py    # JSON file store adapter
 │   └── provider_system.py    # LLM provider system (OpenAI, LM Studio)
 ├── application/              # Application services
@@ -97,7 +97,7 @@ docs/
 
 - **`src/devsynth/__main__.py`**: Main entry point for the application
 - **`src/devsynth/adapters/provider_system.py`**: Provider abstraction for LLM integration (OpenAI, LM Studio)
-- **`src/devsynth/adapters/chromadb_memory_store.py`**: ChromaDB-based memory store implementation
+- **`src/devsynth/adapters/kuzu_memory_store.py`**: Kuzu-based memory store implementation
 - **`src/devsynth/ports/memory_store.py`**: Memory store interface definition
 - **`src/devsynth/ports/memory_port.py`**: Memory system port for application interaction
 
@@ -111,18 +111,18 @@ docs/
 ### Testing Files
 
 - **`tests/behavior/conftest.py`**: Test fixtures for isolation and cleanliness
-- **`tests/behavior/test_chromadb_integration.py`**: ChromaDB integration tests
+- **`tests/unit/test_kuzu_store.py`**: Kuzu memory store tests
 
 ## File and Symbol Naming Conventions
 
 DevSynth follows these naming conventions:
 
-- **Files**: Snake case (`memory_store.py`, `test_chromadb_integration.py`)
-- **Classes**: Pascal case (`ChromaDBMemoryStore`, `MemoryPort`)
+- **Files**: Snake case (`memory_store.py`, `test_kuzu_store.py`)
+- **Classes**: Pascal case (`KuzuMemoryStore`, `MemoryPort`)
 - **Functions/Methods**: Snake case (`store_memory`, `get_from_context`)
 - **Constants**: Upper snake case (`DEFAULT_CONFIG_PATH`)
-- **Tests**: Prefixed with `test_` (`test_chromadb_integration.py`)
-- **BDD Features**: Descriptive naming (`chromadb_integration.feature`)
+- **Tests**: Prefixed with `test_` (`test_kuzu_store.py`)
+- **BDD Features**: Descriptive naming (`additional_storage_backends.feature`)
 
 ## Metadata Tags and Traceability
 

--- a/docs/user_guides/user_guide.md
+++ b/docs/user_guides/user_guide.md
@@ -218,7 +218,7 @@ DevSynth can be configured using the `config` command or by editing the configur
 | `endpoint` | LM Studio API endpoint | `http://localhost:1234/v1` | Any valid URL |
 | `openai_api_key` | OpenAI API key for using OpenAI models | None | Valid OpenAI API key |
 | `serper_api_key` | Serper API key for web search functionality | None | Valid Serper API key |
-| `memory_store_type` | Type of memory store to use | `memory` | `memory`, `file`, `chromadb`, `kuzu` |
+| `memory_store_type` | Type of memory store to use | `memory` | `memory`, `file`, `kuzu` |
 
 ### Environment Variables and .env Files
 
@@ -301,7 +301,7 @@ API keys use their standard environment variable names:
 
 ### Memory Configuration
 
-DevSynth supports multiple memory store types for storing and retrieving memory items:
+DevSynth supports multiple memory store types for storing and retrieving memory items. ChromaDB support is presently disabled; Kuzu is the recommended persistent backend.
 
 #### In-Memory Store
 
@@ -322,60 +322,6 @@ devsynth config --key memory_store_type --value file
 devsynth config --key memory_file_path --value /path/to/memory/directory
 ```
 
-#### ChromaDB Vector Store
-
-The `chromadb` memory store type uses ChromaDB, a vector database, for persistent storage with semantic search capabilities. This is particularly useful for projects with large amounts of text data that benefit from semantic similarity search.
-
-```bash
-# Configure ChromaDB store
-devsynth config --key memory_store_type --value chromadb
-devsynth config --key memory_file_path --value /path/to/chromadb/directory
-```
-
-Key features of the ChromaDB memory store:
-
-- **Semantic Search**: Search for memory items based on semantic similarity rather than exact matches
-- **Vector Embeddings**: Automatically creates embeddings for text content to enable semantic search
-- **Persistence**: Memory items are preserved across sessions
-- **Scalability**: Efficiently handles large amounts of data
-- **Caching Layer**: Reduces disk I/O operations by caching frequently accessed items
-- **Version Tracking**: Maintains a history of changes to items over time
-- **Optimized Embedding Storage**: Efficiently stores similar embeddings to reduce storage requirements
-
-##### Caching
-
-The ChromaDB memory store includes a caching layer that reduces disk I/O operations by storing frequently accessed items in memory. This improves performance when the same items are accessed multiple times.
-
-##### Version Tracking
-
-The ChromaDB memory store automatically tracks versions of items when they are updated. This allows you to:
-
-- Retrieve the history of changes to an item
-- Access specific versions of an item
-- See when changes were made
-
-Example usage in code:
-
-```python
-from devsynth.adapters.memory.memory_adapter import MemorySystemAdapter
-
-# Initialize the memory system adapter
-adapter = MemorySystemAdapter()
-store = adapter.get_memory_store()
-
-# Get all versions of an item
-versions = store.get_versions("item-id")
-
-# Get the history of an item
-history = store.get_history("item-id")
-
-# Retrieve a specific version of an item
-version2 = store.retrieve_version("item-id", 2)
-```
-
-##### Optimized Embedding Storage
-
-The ChromaDB memory store optimizes the storage of embeddings for similar content, reducing storage requirements and improving performance. This is particularly beneficial when storing multiple items with similar content.
 
 #### Kuzu Memory Store
 


### PR DESCRIPTION
## Summary
- describe Kuzu as the primary persistent backend in docs
- mention ChromaDB support is disabled
- add glossary entry for Kuzu

## Testing
- `pip install -e '.[dev]'`
- `pytest -q` *(fails: ImportError and 30 errors)*

------
https://chatgpt.com/codex/tasks/task_e_6855a6ca5f488333ab452de65583bece