### PR TITLE
Handle Chromadb feature flag and improve Kuzu tests

### DIFF
--- a/tests/behavior/steps/test_memory_backend_integration_steps.py
+++ b/tests/behavior/steps/test_memory_backend_integration_steps.py
@@ -6,6 +6,15 @@ feature file, testing all available memory backends with the WSDE model.
 """
 import pytest
 import time
+import os
+
+chromadb_enabled = os.environ.get("ENABLE_CHROMADB", "false").lower() not in {
+    "0",
+    "false",
+    "no",
+}
+if not chromadb_enabled:
+    pytest.skip("ChromaDB feature not enabled", allow_module_level=True)
 from pytest_bdd import given, when, then, parsers, scenarios
 from unittest.mock import MagicMock
 

--- a/tests/behavior/test_chromadb_integration.py
+++ b/tests/behavior/test_chromadb_integration.py
@@ -3,6 +3,14 @@ Test runner for the ChromaDB Integration feature.
 """
 import os
 import pytest
+
+chromadb_enabled = os.environ.get("ENABLE_CHROMADB", "false").lower() not in {
+    "0",
+    "false",
+    "no",
+}
+if not chromadb_enabled:
+    pytest.skip("ChromaDB feature not enabled", allow_module_level=True)
 from pytest_bdd import scenarios
 
 pytestmark = pytest.mark.requires_resource("chromadb")

--- a/tests/behavior/test_enhanced_chromadb_integration.py
+++ b/tests/behavior/test_enhanced_chromadb_integration.py
@@ -3,6 +3,14 @@ Test runner for the Enhanced ChromaDB Integration feature.
 """
 import os
 import pytest
+
+chromadb_enabled = os.environ.get("ENABLE_CHROMADB", "false").lower() not in {
+    "0",
+    "false",
+    "no",
+}
+if not chromadb_enabled:
+    pytest.skip("ChromaDB feature not enabled", allow_module_level=True)
 from pytest_bdd import scenarios
 
 pytestmark = pytest.mark.requires_resource("chromadb")

--- a/tests/unit/adapters/test_kuzu_memory_store.py
+++ b/tests/unit/adapters/test_kuzu_memory_store.py
@@ -29,13 +29,13 @@ spec_adapter.loader.exec_module(kuzu_memory_store)
 KuzuMemoryStore = kuzu_memory_store.KuzuMemoryStore
 
 
-@patch("devsynth.adapters.kuzu_memory_store.embed", return_value=[[0.1, 0.2, 0.3]])
-def test_store_and_search(mock_embed):
+def test_store_and_search():
     temp_dir = tempfile.mkdtemp()
     store = KuzuMemoryStore(persist_directory=temp_dir, use_provider_system=True)
-    item = MemoryItem(id="t1", content="hello world", memory_type=MemoryType.WORKING)
-    store.store(item)
-    results = store.search({"query": "hello", "top_k": 1})
+    with patch.object(store, "_get_embedding", return_value=[0.1, 0.2, 0.3]):
+        item = MemoryItem(id="t1", content="hello world", memory_type=MemoryType.WORKING)
+        store.store(item)
+        results = store.search({"query": "hello", "top_k": 1})
     shutil.rmtree(temp_dir)
     assert len(results) == 1
     assert results[0].id == "t1"

--- a/tests/unit/test_enhanced_chromadb_store.py
+++ b/tests/unit/test_enhanced_chromadb_store.py
@@ -3,6 +3,14 @@ Unit tests for the enhanced ChromaDBStore class.
 """
 import pytest
 import os
+
+chromadb_enabled = os.environ.get("ENABLE_CHROMADB", "false").lower() not in {
+    "0",
+    "false",
+    "no",
+}
+if not chromadb_enabled:
+    pytest.skip("ChromaDB feature not enabled", allow_module_level=True)
 import json
 import shutil
 import tempfile

--- a/tests/unit/test_memory_system_with_kuzu.py
+++ b/tests/unit/test_memory_system_with_kuzu.py
@@ -2,6 +2,7 @@ import pytest
 import os
 import shutil
 import tempfile
+from unittest.mock import patch
 
 from devsynth.domain.models.memory import MemoryItem, MemoryType, MemoryVector
 from devsynth.adapters.memory.memory_adapter import MemorySystemAdapter
@@ -16,6 +17,14 @@ class TestMemorySystemWithKuzu:
         temp_dir = tempfile.mkdtemp()
         yield temp_dir
         shutil.rmtree(temp_dir)
+
+    @pytest.fixture(autouse=True)
+    def mock_embed(self):
+        with patch(
+            "devsynth.adapters.kuzu_memory_store.embed",
+            return_value=[[0.1, 0.2, 0.3]],
+        ):
+            yield
 
     @pytest.fixture
     def memory_system(self, temp_dir):


### PR DESCRIPTION
## Summary
- skip Chromadb unit & BDD tests if the `ENABLE_CHROMADB` flag is disabled
- avoid network calls in Kuzu tests by mocking embeddings

## Testing
- `poetry run pytest tests/unit/test_kuzu_store.py tests/unit/test_memory_system_with_kuzu.py tests/unit/adapters/test_kuzu_memory_store.py tests/unit/test_enhanced_chromadb_store.py tests/behavior/test_chromadb_integration.py tests/behavior/test_enhanced_chromadb_integration.py tests/behavior/steps/test_memory_backend_integration_steps.py`

------
https://chatgpt.com/codex/tasks/task_e_6855bcf84f2883339e9552e66ada57e6