### PR TITLE
Add config version locking

### DIFF
--- a/docs/developer_guides/development_setup.md
+++ b/docs/developer_guides/development_setup.md
@@ -108,6 +108,14 @@ Ensure your setup is working correctly by running the tests:
 python -m pytest
 ```
 
+### Configuration Version Locking
+
+DevSynth locks the configuration format to a specific version. The `version` key
+in `.devsynth/devsynth.yml` (or `[tool.devsynth]` in `pyproject.toml`) must
+match the version expected by the current DevSynth release. When `load_config`
+reads a file with a mismatched version, it logs a warning so you can regenerate
+the configuration with `devsynth init`.
+
 ## Project Structure
 
 DevSynth follows a hexagonal architecture pattern with the following key directories:

--- a/tests/unit/test_config_loader.py
+++ b/tests/unit/test_config_loader.py
@@ -1,5 +1,12 @@
 from pathlib import Path
-from devsynth.config.loader import load_config, config_key_autocomplete
+import logging
+import yaml
+from devsynth.config.loader import (
+    load_config,
+    config_key_autocomplete,
+    save_config,
+    ConfigModel,
+)
 
 def test_load_yaml_config(tmp_path):
     cfg_dir = tmp_path / ".devsynth"
@@ -20,3 +27,19 @@ def test_autocomplete(monkeypatch, tmp_path):
     monkeypatch.chdir(tmp_path)
     result = config_key_autocomplete(None, "l")
     assert "language" in result
+
+
+def test_save_persists_version(tmp_path):
+    cfg = ConfigModel(project_root=str(tmp_path))
+    path = save_config(cfg, path=str(tmp_path))
+    data = yaml.safe_load(path.read_text())
+    assert data["version"] == cfg.version
+
+
+def test_version_mismatch_logs_warning(tmp_path, caplog):
+    cfg_dir = tmp_path / ".devsynth"
+    cfg_dir.mkdir()
+    (cfg_dir / "devsynth.yml").write_text("version: '0.0'\n")
+    caplog.set_level(logging.WARNING)
+    load_config(tmp_path)
+    assert any("version" in rec.message for rec in caplog.records)


### PR DESCRIPTION
## Summary
- expand ConfigModel with version field and logger
- warn when config version mismatches
- persist version field when saving
- test version validation and saving
- document configuration version locking

## Testing
- `pytest tests/unit/test_config_loader.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6855fe6e88448333a162b0ae66daf738