### PR TITLE
Implement trade-off analysis and tests

### DIFF
--- a/tests/unit/domain/models/test_wsde_team.py
+++ b/tests/unit/domain/models/test_wsde_team.py
@@ -4,9 +4,11 @@ Unit Tests for WSDE Team Model
 This file contains unit tests for the WSDETeam class, which implements
 the Worker Self-Directed Enterprise model.
 """
+
 import pytest
 from unittest.mock import MagicMock, patch
 from devsynth.domain.models.wsde import WSDE, WSDETeam
+
 
 class TestWSDETeam:
     """Test suite for the WSDETeam class."""
@@ -60,7 +62,9 @@ class TestWSDETeam:
 
         # Assert
         assert self.team.primus_index != initial_primus_index
-        assert self.team.primus_index == (initial_primus_index + 1) % len(self.team.agents)
+        assert self.team.primus_index == (initial_primus_index + 1) % len(
+            self.team.agents
+        )
 
     def test_get_primus(self):
         """Test getting the current Primus agent."""
@@ -100,13 +104,54 @@ class TestWSDETeam:
 
         # Assert
         assert self.agent1.current_role == "Primus"
-        assert self.agent2.current_role in ["Worker", "Supervisor", "Designer", "Evaluator"]
-        assert self.agent3.current_role in ["Worker", "Supervisor", "Designer", "Evaluator"]
-        assert self.agent4.current_role in ["Worker", "Supervisor", "Designer", "Evaluator"]
+        assert self.agent2.current_role in [
+            "Worker",
+            "Supervisor",
+            "Designer",
+            "Evaluator",
+        ]
+        assert self.agent3.current_role in [
+            "Worker",
+            "Supervisor",
+            "Designer",
+            "Evaluator",
+        ]
+        assert self.agent4.current_role in [
+            "Worker",
+            "Supervisor",
+            "Designer",
+            "Evaluator",
+        ]
 
         # Ensure each role is assigned exactly once
-        roles = [self.agent2.current_role, self.agent3.current_role, self.agent4.current_role]
+        roles = [
+            self.agent2.current_role,
+            self.agent3.current_role,
+            self.agent4.current_role,
+        ]
         assert "Worker" in roles
         assert "Supervisor" in roles
         # Since we can't assign all 4 roles to 3 agents, we check for either Designer or Evaluator
         assert "Designer" in roles or "Evaluator" in roles
+
+    def test_analyze_trade_offs_detects_conflicts(self):
+        """Trade-off analysis should flag options with similar scores as conflicts."""
+
+        evaluated = [
+            {"id": 1, "score": 0.8},
+            {"id": 2, "score": 0.78},
+            {"id": 3, "score": 0.2},
+        ]
+
+        trade_offs = self.team.analyze_trade_offs(
+            evaluated, conflict_detection_threshold=0.7
+        )
+
+        opt1 = next(o for o in trade_offs if o["id"] == 1)
+
+        assert any(
+            t["type"] == "conflict" and t["other_id"] == 2 for t in opt1["trade_offs"]
+        )
+        assert not any(
+            t["type"] == "conflict" and t["other_id"] == 3 for t in opt1["trade_offs"]
+        )


### PR DESCRIPTION
## Summary
- implement real trade-off analysis in `WSDETeam.analyze_trade_offs`
- format files with black
- add unit test covering conflict detection

## Testing
- `poetry run black src/devsynth/domain/models/wsde.py tests/unit/domain/models/test_wsde_team.py`
- `poetry run pytest tests/unit/domain/models/test_wsde_team.py::TestWSDETeam::test_analyze_trade_offs_detects_conflicts -q`
- `poetry run pytest tests/unit/domain/models/test_wsde_team.py`
- `poetry run pytest tests/unit` *(fails: ModuleNotFoundError: No module named 'devsynth.application.memory.chromadb_store')*

------
https://chatgpt.com/codex/tasks/task_e_685618e6c17c83339e9d807469026822