### PR TITLE
Add EDRR cycle BDD tests

### DIFF
--- a/tests/behavior/features/edrr_cycle.feature
+++ b/tests/behavior/features/edrr_cycle.feature
@@ -1,0 +1,15 @@
+Feature: EDRR cycle command
+  As a developer
+  I want to run the edrr-cycle command with a manifest file
+  So that DevSynth executes an EDRR cycle based on that manifest
+
+  Scenario: Run EDRR cycle with manifest file
+    Given a valid manifest file
+    When I execute the edrr cycle command with that file
+    Then the coordinator should process the manifest
+    And the workflow should complete successfully
+
+  Scenario: Handle missing manifest file
+    Given no manifest file exists at the provided path
+    When I execute the edrr cycle command with that file
+    Then the system should report that the manifest file was not found

--- a/tests/behavior/steps/edrr_cycle_steps.py
+++ b/tests/behavior/steps/edrr_cycle_steps.py
@@ -1,0 +1,81 @@
+from unittest.mock import MagicMock, patch
+
+import pytest
+from pytest_bdd import given, when, then, scenarios
+
+from devsynth.application.cli.commands.edrr_cycle_cmd import edrr_cycle_cmd
+from devsynth.methodology.base import Phase
+
+scenarios('../features/edrr_cycle.feature')
+
+
+@pytest.fixture
+def context():
+    return {}
+
+
+@given('a valid manifest file')
+def valid_manifest(tmp_path, context):
+    manifest = tmp_path / 'manifest.yaml'
+    manifest.write_text('project: test')
+    context['manifest'] = manifest
+    return manifest
+
+
+@given('no manifest file exists at the provided path')
+def missing_manifest(tmp_path, context):
+    context['manifest'] = tmp_path / 'missing.yaml'
+    return context['manifest']
+
+
+@when('I execute the edrr cycle command with that file')
+def run_edrr_cycle(context):
+    manifest = str(context['manifest'])
+    with patch('devsynth.application.cli.commands.edrr_cycle_cmd.bridge') as mock_bridge, \
+         patch('devsynth.application.cli.commands.edrr_cycle_cmd.EDRRCoordinator') as coord_cls, \
+         patch('devsynth.application.cli.commands.edrr_cycle_cmd.MemoryManager') as manager_cls:
+        coordinator = MagicMock()
+        coordinator.generate_report.return_value = {'ok': True}
+        coordinator.cycle_id = 'cid'
+        coord_cls.return_value = coordinator
+
+        memory_manager = MagicMock()
+        memory_manager.store_with_edrr_phase.return_value = 'rid'
+        manager_cls.return_value = memory_manager
+
+        edrr_cycle_cmd(manifest)
+
+        context['bridge'] = mock_bridge
+        context['coordinator'] = coordinator
+        context['memory_manager'] = memory_manager
+        context['coord_cls'] = coord_cls
+
+
+@then('the coordinator should process the manifest')
+def coordinator_processed_manifest(context):
+    context['coord_cls'].assert_called_once()
+    context['coordinator'].start_cycle_from_manifest.assert_called_once_with(
+        context['manifest'], is_file=True
+    )
+    assert context['coordinator'].progress_to_phase.call_count == 4
+
+
+@then('the workflow should complete successfully')
+def workflow_completed(context):
+    context['memory_manager'].store_with_edrr_phase.assert_called_once_with(
+        context['coordinator'].generate_report.return_value,
+        'EDRR_CYCLE_RESULTS',
+        Phase.RETROSPECT.value,
+        {'cycle_id': context['coordinator'].cycle_id},
+    )
+    assert any(
+        'EDRR cycle completed' in call.args[0]
+        for call in context['bridge'].print.call_args_list
+    )
+
+
+@then('the system should report that the manifest file was not found')
+def manifest_not_found_error(context):
+    context['bridge'].print.assert_called_once_with(
+        f"[red]Manifest file not found:[/red] {context['manifest']}"
+    )

--- a/tests/behavior/test_cli_commands.py
+++ b/tests/behavior/test_cli_commands.py
@@ -7,12 +7,14 @@ from pytest_bdd import scenario, given, when, then, parsers
 
 # Import the step definitions
 from .steps.cli_commands_steps import *
+from .steps.edrr_cycle_steps import *
 
 # Mark scenarios that require specific resources
 cli_available = pytest.mark.requires_resource("cli")
 
 # Define the feature file path
 FEATURE_FILE = os.path.join(os.path.dirname(__file__), 'features', 'cli_commands.feature')
+EDRR_FEATURE = os.path.join(os.path.dirname(__file__), 'features', 'edrr_cycle.feature')
 
 # Create a scenario for each scenario in the feature file
 @cli_available
@@ -73,4 +75,16 @@ def test_view_all_config():
 @scenario(FEATURE_FILE, 'Handle invalid command')
 def test_handle_invalid_command():
     """Test handling an invalid command."""
+    pass
+
+@cli_available
+@scenario(EDRR_FEATURE, 'Run EDRR cycle with manifest file')
+def test_edrr_cycle_with_manifest():
+    """Test running the edrr-cycle command with a manifest."""
+    pass
+
+@cli_available
+@scenario(EDRR_FEATURE, 'Handle missing manifest file')
+def test_edrr_cycle_missing_manifest():
+    """Test running the edrr-cycle command with a missing manifest file."""
     pass


### PR DESCRIPTION
## Summary
- cover `edrr_cycle_cmd` with BDD scenarios
- implement step definitions calling `edrr_cycle_cmd`
- reference new feature in CLI behavior tests

## Testing
- `poetry run pytest tests/` *(fails: ModuleNotFoundError: No module named 'devsynth.application.memory.chromadb_store')*

------
https://chatgpt.com/codex/tasks/task_e_6856d55f022c833398a5b3bb8467f29b