### PR TITLE
Add Anthropic provider unit tests and factory registration

### DIFF
--- a/src/devsynth/application/llm/providers.py
+++ b/src/devsynth/application/llm/providers.py
@@ -1,4 +1,3 @@
-
 from typing import Any, Dict, List, Optional
 import httpx
 from ...domain.interfaces.llm import LLMProvider, LLMProviderFactory
@@ -10,27 +9,36 @@ from devsynth.logging_setup import DevSynthLogger
 logger = DevSynthLogger(__name__)
 from devsynth.exceptions import DevSynthError
 
+
 class ValidationError(DevSynthError):
     """Exception raised when validation fails."""
+
     pass
+
 
 class BaseLLMProvider:
     """Base class for LLM providers."""
-    
+
     def __init__(self, config: Dict[str, Any] = None):
         self.config = config or {}
-    
+
     def generate(self, prompt: str, parameters: Dict[str, Any] = None) -> str:
         """Generate text from a prompt."""
         raise NotImplementedError("Subclasses must implement this method")
-    
-    def generate_with_context(self, prompt: str, context: List[Dict[str, str]], parameters: Dict[str, Any] = None) -> str:
+
+    def generate_with_context(
+        self,
+        prompt: str,
+        context: List[Dict[str, str]],
+        parameters: Dict[str, Any] = None,
+    ) -> str:
         """Generate text from a prompt with conversation context."""
         raise NotImplementedError("Subclasses must implement this method")
-    
+
     def get_embedding(self, text: str) -> List[float]:
         """Get an embedding vector for the given text."""
         raise NotImplementedError("Subclasses must implement this method")
+
 
 class AnthropicConnectionError(DevSynthError):
     """Exception raised when there's an issue connecting to Anthropic."""
@@ -66,7 +74,9 @@ class AnthropicProvider(BaseLLMProvider):
     def _post(self, endpoint: str, payload: Dict[str, Any]) -> Dict[str, Any]:
         url = f"{self.api_base}{endpoint}"
         try:
-            response = httpx.post(url, headers=self.headers, json=payload, timeout=self.timeout)
+            response = httpx.post(
+                url, headers=self.headers, json=payload, timeout=self.timeout
+            )
             response.raise_for_status()
             return response.json()
         except httpx.HTTPStatusError as e:
@@ -104,7 +114,12 @@ class AnthropicProvider(BaseLLMProvider):
             return data["completion"]
         raise AnthropicModelError("Invalid response from Anthropic")
 
-    def generate_with_context(self, prompt: str, context: List[Dict[str, str]], parameters: Dict[str, Any] | None = None) -> str:
+    def generate_with_context(
+        self,
+        prompt: str,
+        context: List[Dict[str, str]],
+        parameters: Dict[str, Any] | None = None,
+    ) -> str:
         """Generate text from a prompt with conversation context using Anthropic."""
 
         messages = context.copy()
@@ -149,25 +164,27 @@ class AnthropicProvider(BaseLLMProvider):
             return data["data"][0]["embedding"]
         raise AnthropicModelError("Invalid embedding response from Anthropic")
 
+
 class SimpleLLMProviderFactory(LLMProviderFactory):
     """Simple implementation of LLMProviderFactory."""
-    
+
     def __init__(self):
-        self.provider_types = {
-            "anthropic": AnthropicProvider,
-        }
-    
-    def create_provider(self, provider_type: str, config: Dict[str, Any] = None) -> LLMProvider:
+        self.provider_types: Dict[str, type] = {}
+
+    def create_provider(
+        self, provider_type: str, config: Dict[str, Any] = None
+    ) -> LLMProvider:
         """Create an LLM provider of the specified type."""
         if provider_type not in self.provider_types:
             raise ValidationError(f"Unknown provider type: {provider_type}")
-        
+
         provider_class = self.provider_types[provider_type]
         return provider_class(config)
-    
+
     def register_provider_type(self, provider_type: str, provider_class: type) -> None:
         """Register a new provider type."""
         self.provider_types[provider_type] = provider_class
+
 
 # Import providers at the end to avoid circular imports
 from .lmstudio_provider import LMStudioProvider
@@ -177,5 +194,6 @@ from .openai_provider import OpenAIProvider
 factory = SimpleLLMProviderFactory()
 
 # Register providers
+factory.register_provider_type("anthropic", AnthropicProvider)
 factory.register_provider_type("lmstudio", LMStudioProvider)
 factory.register_provider_type("openai", OpenAIProvider)

--- a/tests/unit/test_anthropic_provider_unit.py
+++ b/tests/unit/test_anthropic_provider_unit.py
@@ -1,0 +1,79 @@
+import unittest
+from unittest.mock import patch, MagicMock
+import httpx
+
+from devsynth.application.llm.providers import (
+    AnthropicProvider,
+    AnthropicConnectionError,
+    AnthropicModelError,
+)
+
+
+class TestAnthropicProvider(unittest.TestCase):
+    """Unit tests for AnthropicProvider."""
+
+    def setUp(self):
+        self.provider = AnthropicProvider({"api_key": "test_key"})
+
+    @patch("httpx.post")
+    def test_generate(self, mock_post):
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"content": [{"text": "hello"}]}
+        mock_response.raise_for_status.return_value = None
+        mock_post.return_value = mock_response
+
+        result = self.provider.generate("hi")
+        self.assertEqual(result, "hello")
+        mock_post.assert_called_once()
+        self.assertIn("/v1/messages", mock_post.call_args[0][0])
+        self.assertEqual(mock_post.call_args[1]["headers"]["x-api-key"], "test_key")
+
+    @patch("httpx.post")
+    def test_generate_with_context(self, mock_post):
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"content": [{"text": "context"}]}
+        mock_response.raise_for_status.return_value = None
+        mock_post.return_value = mock_response
+
+        context = [{"role": "system", "content": "ok"}]
+        result = self.provider.generate_with_context("prompt", context)
+
+        self.assertEqual(result, "context")
+        mock_post.assert_called_once()
+        messages = mock_post.call_args[1]["json"]["messages"]
+        self.assertEqual(len(messages), 2)
+        self.assertEqual(messages[-1]["content"], "prompt")
+
+    @patch("httpx.post")
+    def test_get_embedding(self, mock_post):
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"embedding": [0.1, 0.2]}
+        mock_response.raise_for_status.return_value = None
+        mock_post.return_value = mock_response
+
+        embedding = self.provider.get_embedding("text")
+        self.assertEqual(embedding, [0.1, 0.2])
+        mock_post.assert_called_once()
+        self.assertIn("/v1/embeddings", mock_post.call_args[0][0])
+
+    @patch("httpx.post")
+    def test_connection_error(self, mock_post):
+        mock_post.side_effect = httpx.RequestError("boom", request=MagicMock())
+        with self.assertRaises(AnthropicConnectionError):
+            self.provider.generate("fail")
+
+    @patch("httpx.post")
+    def test_model_error(self, mock_post):
+        response = MagicMock()
+        response.text = "server error"
+        request = httpx.Request("POST", "http://test")
+        mock_post.return_value = response
+        response.raise_for_status.side_effect = httpx.HTTPStatusError(
+            "bad", request=request, response=httpx.Response(500, request=request)
+        )
+        with self.assertRaises(AnthropicModelError):
+            self.provider.generate("bad")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- wire up Anthropic provider in `SimpleLLMProviderFactory`
- implement unit tests for `AnthropicProvider`

## Testing
- `poetry run pytest tests/unit/test_anthropic_provider_unit.py tests/integration/test_anthropic_provider.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6856f416fd508333ad63d2f6a7781fa1