### PR TITLE
Add CLI config validation tests

### DIFF
--- a/tests/unit/application/cli/test_config_validation.py
+++ b/tests/unit/application/cli/test_config_validation.py
@@ -1,0 +1,101 @@
+from unittest.mock import patch
+from textwrap import dedent
+
+import importlib.util
+from pathlib import Path
+
+spec = importlib.util.spec_from_file_location(
+    "doctor_cmd",
+    Path(__file__).parents[4]
+    / "src"
+    / "devsynth"
+    / "application"
+    / "cli"
+    / "commands"
+    / "doctor_cmd.py",
+)
+doctor_cmd = importlib.util.module_from_spec(spec)
+assert spec and spec.loader
+spec.loader.exec_module(doctor_cmd)  # type: ignore
+
+
+def test_config_warnings(tmp_path, monkeypatch):
+    monkeypatch.setattr(doctor_cmd.sys, "version_info", (3, 11, 0))
+    monkeypatch.setenv("OPENAI_API_KEY", "1")
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "1")
+
+    config_dir = tmp_path / "cfg"
+    config_dir.mkdir()
+
+    # intentionally incomplete config to trigger validation errors
+    (config_dir / "default.yml").write_text("application: {name: App, version: '1.0'}\n")
+
+    real_spec = doctor_cmd.importlib.util.spec_from_file_location
+
+    def fake_spec(name, location, *args, **kwargs):
+        path = Path(__file__).parents[4] / "scripts" / "validate_config.py"
+        return real_spec(name, path, *args, **kwargs)
+
+    with patch.object(doctor_cmd.importlib.util, "spec_from_file_location", side_effect=fake_spec), patch.object(doctor_cmd, "load_config"), patch.object(doctor_cmd.bridge, "print") as mock_print:
+        doctor_cmd.doctor_cmd(str(config_dir))
+        output = "".join(str(c.args[0]) for c in mock_print.call_args_list)
+        assert "Configuration issues detected" in output
+
+
+VALID_CONFIG = dedent(
+    """
+    application:
+      name: App
+      version: "1.0"
+    logging:
+      level: INFO
+      format: "%(message)s"
+    memory:
+      default_store: kuzu
+      stores:
+        chromadb:
+          enabled: true
+        kuzu: {}
+        faiss:
+          enabled: false
+    llm:
+      default_provider: openai
+      providers:
+        openai:
+          enabled: true
+    agents:
+      max_agents: 1
+      default_timeout: 1
+    edrr:
+      enabled: false
+      default_phase: expand
+    security:
+      input_validation: true
+    performance: {}
+    features:
+      wsde_collaboration: false
+    """
+)
+
+
+def test_config_success(tmp_path, monkeypatch):
+    monkeypatch.setattr(doctor_cmd.sys, "version_info", (3, 11, 0))
+    monkeypatch.setenv("OPENAI_API_KEY", "1")
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "1")
+
+    config_dir = tmp_path / "cfg"
+    config_dir.mkdir()
+
+    for env in ["default", "development", "testing", "staging", "production"]:
+        (config_dir / f"{env}.yml").write_text(VALID_CONFIG)
+
+    real_spec = doctor_cmd.importlib.util.spec_from_file_location
+
+    def fake_spec(name, location, *args, **kwargs):
+        path = Path(__file__).parents[4] / "scripts" / "validate_config.py"
+        return real_spec(name, path, *args, **kwargs)
+
+    with patch.object(doctor_cmd.importlib.util, "spec_from_file_location", side_effect=fake_spec), patch.object(doctor_cmd, "load_config"), patch.object(doctor_cmd.bridge, "print") as mock_print:
+        doctor_cmd.doctor_cmd(str(config_dir))
+        output = "".join(str(c.args[0]) for c in mock_print.call_args_list)
+        assert "All configuration files are valid" in output

--- a/tests/unit/application/cli/test_doctor_cmd.py
+++ b/tests/unit/application/cli/test_doctor_cmd.py
@@ -2,14 +2,28 @@ from unittest.mock import patch
 
 import pytest
 
-from devsynth.application.cli.commands import doctor_cmd
+import importlib.util
+from pathlib import Path
+
+spec = importlib.util.spec_from_file_location(
+    "doctor_cmd",
+    Path(__file__).parents[4]
+    / "src"
+    / "devsynth"
+    / "application"
+    / "cli"
+    / "commands"
+    / "doctor_cmd.py",
+)
+doctor_cmd = importlib.util.module_from_spec(spec)
+assert spec and spec.loader
+spec.loader.exec_module(doctor_cmd)  # type: ignore
 
 
-@patch("devsynth.application.cli.commands.doctor_cmd.load_config")
-def test_python_version_warning(mock_load):
-    with patch.object(doctor_cmd.sys, "version_info", (3, 10, 0)), patch.object(
-        doctor_cmd.bridge, "print"
-    ) as mock_print:
+def test_python_version_warning():
+    with patch.object(doctor_cmd, "load_config"), patch.object(
+        doctor_cmd.sys, "version_info", (3, 10, 0)
+    ), patch.object(doctor_cmd.bridge, "print") as mock_print:
         doctor_cmd.doctor_cmd("config")
         assert any(
             "Python 3.11 or higher" in str(call.args[0])
@@ -17,11 +31,12 @@ def test_python_version_warning(mock_load):
         )
 
 
-@patch("devsynth.application.cli.commands.doctor_cmd.load_config")
-def test_missing_api_keys_warning(mock_load, monkeypatch):
+def test_missing_api_keys_warning(monkeypatch):
     monkeypatch.delenv("OPENAI_API_KEY", raising=False)
     monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
-    with patch.object(doctor_cmd.bridge, "print") as mock_print:
+    with patch.object(doctor_cmd, "load_config"), patch.object(
+        doctor_cmd.bridge, "print"
+    ) as mock_print:
         doctor_cmd.doctor_cmd("config")
         output = "".join(str(c.args[0]) for c in mock_print.call_args_list)
         assert "OPENAI_API_KEY" in output and "ANTHROPIC_API_KEY" in output


### PR DESCRIPTION
## Summary
- add dynamic imports in unit tests to avoid heavy dependencies
- test config validation warnings and success paths

## Testing
- `pytest tests/unit/application/cli/test_doctor_cmd.py tests/unit/application/cli/test_config_validation.py -q`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pytest_bdd')*

------
https://chatgpt.com/codex/tasks/task_e_6856f83cef408333b72e5ba3b31c266f