### PR TITLE
Add CLI command walkthrough examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,11 @@ The repository includes runnable examples that walk through common workflows:
 - [Full Workflow](examples/full_workflow) – demonstrates the refactor workflow
 - [Agent Adapter](docs/getting_started/agent_adapter_example.md) – shows how to
   use the `AgentAdapter` directly from Python
+- [Init Example](examples/init_example) – project setup using `devsynth init`
+- [Spec Example](examples/spec_example) – generate specifications from requirements
+- [Test Example](examples/test_example) – create tests from specs
+- [Code Example](examples/code_example) – produce code that passes the tests
+- [EDRR Cycle Example](examples/edrr_cycle_example) – run the Expand–Differentiate–Refine–Retrospect workflow
 
 ## Running Tests
 

--- a/docs/user_guides/cli_reference.md
+++ b/docs/user_guides/cli_reference.md
@@ -499,6 +499,14 @@ logging:
 
 ## Examples
 
+Additional walkthroughs for each command can be found in the `examples` directory:
+
+- [Init](../../examples/init_example)
+- [Spec](../../examples/spec_example)
+- [Test](../../examples/test_example)
+- [Code](../../examples/code_example)
+- [EDRR Cycle](../../examples/edrr_cycle_example)
+
 ### Complete Workflow Example
 
 ```bash

--- a/examples/code_example/README.md
+++ b/examples/code_example/README.md
@@ -1,0 +1,14 @@
+# DevSynth Code Example
+
+This walkthrough demonstrates generating implementation code from tests.
+
+## Steps
+
+1. **Make sure tests exist**
+   The `tests/` directory should contain the generated test cases.
+
+2. **Run the code command**
+   ```bash
+   devsynth code
+   ```
+   DevSynth writes the implementation files under `src/` to satisfy the tests.

--- a/examples/edrr_cycle_example/README.md
+++ b/examples/edrr_cycle_example/README.md
@@ -1,0 +1,17 @@
+# DevSynth EDRR Cycle Example
+
+This walkthrough shows how to run a full Expand-Differentiate-Refine-Retrospect cycle.
+
+## Steps
+
+1. **Create a manifest**
+   Save the following as `manifest.yaml`:
+   ```yaml
+   project: edrr-demo
+   ```
+
+2. **Run the edrr-cycle command**
+   ```bash
+   devsynth edrr-cycle manifest.yaml
+   ```
+   The command orchestrates the EDRR cycle using the provided manifest and reports the results.

--- a/examples/edrr_cycle_example/manifest.yaml
+++ b/examples/edrr_cycle_example/manifest.yaml
@@ -1,0 +1,1 @@
+project: edrr-demo

--- a/examples/init_example/README.md
+++ b/examples/init_example/README.md
@@ -1,0 +1,11 @@
+# DevSynth Init Example
+
+This walkthrough demonstrates how to initialize a new DevSynth project.
+
+## Steps
+
+1. **Run the init command**
+   ```bash
+   devsynth init --path ./my-project
+   ```
+   This creates the `.devsynth/project.yaml` configuration and sets up the project directory.

--- a/examples/spec_example/README.md
+++ b/examples/spec_example/README.md
@@ -1,0 +1,14 @@
+# DevSynth Spec Example
+
+This walkthrough demonstrates generating specifications from a requirements file.
+
+## Steps
+
+1. **Create requirements**
+   Write your requirements in `requirements.md`.
+
+2. **Run the spec command**
+   ```bash
+   devsynth spec --requirements-file requirements.md
+   ```
+   This produces `specs.md` outlining the planned implementation.

--- a/examples/test_example/README.md
+++ b/examples/test_example/README.md
@@ -1,0 +1,14 @@
+# DevSynth Test Example
+
+This walkthrough shows how to generate tests from the project specifications.
+
+## Steps
+
+1. **Ensure specs are generated**
+   The file `specs.md` should contain your specifications.
+
+2. **Run the test command**
+   ```bash
+   devsynth test
+   ```
+   DevSynth creates tests in the `tests/` directory based on your specs.


### PR DESCRIPTION
## Summary
- document CLI command walkthroughs under examples/
- reference the new walkthroughs from the CLI reference
- point README examples section to the walkthroughs

## Testing
- `poetry run pytest tests/` *(fails: ImportError during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68570648944c8333b82efa91e1ebe550