### PR TITLE
Improve Poetry docs and apt setup

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,12 +30,12 @@ Refer to `docs/architecture/agent_system.md` and `docs/architecture/wsde_agent_m
 
 ## Agent Configuration
 
-- **Dependencies:** Managed via Poetry (`pyproject.toml`).
+- **Dependencies:** Managed exclusively with Poetry (`pyproject.toml`). Do **not** run `pip install` directly. Use `poetry install` or `poetry sync` so all packages are installed in the Poetry-managed virtual environment.
 - **Environment:** Use the provided `config/` files for environment-specific settings.
 - **Setup:**
-  1. Install dependencies: `poetry install`
-  2. Activate environment: `poetry shell`
-  3. Configure environment variables as needed (see `config/`)
+  1. Install dependencies with `poetry install` or `poetry sync --all-extras --all-groups` for the full development environment.
+  2. Activate the virtual environment using `poetry shell` (or prefix commands with `poetry run`).
+  3. Configure environment variables as needed (see `config/`).
 
 ## Coding Conventions
 
@@ -107,4 +107,3 @@ For questions or suggestions regarding agents, open an issue or contact the main
 ---
 
 *Keep this file up to date as the agent system evolves.*
-

--- a/scripts/codex_setup.sh
+++ b/scripts/codex_setup.sh
@@ -1,6 +1,12 @@
 set -exo pipefail
 
-apt update
-apt install -y build-essential python3-dev python3-venv cmake pkg-config git libssl-dev libffi-dev libxml2-dev libargon2-dev libblas-dev liblapack-dev libopenblas-dev liblmdb-dev libz3-dev libcurl4-openssl-dev
+export DEBIAN_FRONTEND=noninteractive
+apt-get update
+apt-get install -y \
+  build-essential python3-dev python3-venv cmake pkg-config git \
+  libssl-dev libffi-dev libxml2-dev libargon2-dev libblas-dev \
+  liblapack-dev libopenblas-dev liblmdb-dev libz3-dev libcurl4-openssl-dev
+apt-get clean
+rm -rf /var/lib/apt/lists/*
 
 poetry sync --all-groups --all-extras


### PR DESCRIPTION
## Summary
- update setup script to use noninteractive apt operations and clean cache
- refine Poetry dependency instructions in AGENTS guidelines

## Testing
- `pre-commit run --files AGENTS.md scripts/codex_setup.sh`
- `poetry run pytest -q` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_6857353a672483339361c73541ffa591