### PR TITLE
Add expanded WSDE tests and delegate task integration

### DIFF
--- a/tests/integration/test_delegate_task_consensus.py
+++ b/tests/integration/test_delegate_task_consensus.py
@@ -1,0 +1,32 @@
+import types
+from unittest.mock import MagicMock, patch
+
+from devsynth.application.collaboration.coordinator import AgentCoordinatorImpl
+
+class SimpleAgent:
+    def __init__(self, name, agent_type):
+        self.name = name
+        self.agent_type = agent_type
+        self.current_role = None
+        self.expertise = []
+        self.process = MagicMock(return_value={"solution": f"{name}-sol"})
+        self.config = types.SimpleNamespace(name=name, parameters={})
+
+
+def test_delegate_task_team_consensus():
+    coordinator = AgentCoordinatorImpl({"features": {"wsde_collaboration": True}})
+    a1 = SimpleAgent("planner", "planner")
+    a2 = SimpleAgent("coder", "code")
+    for a in [a1, a2]:
+        coordinator.add_agent(a)
+
+    consensus = {"consensus": "final", "contributors": ["planner", "coder"], "method": "consensus_synthesis"}
+
+    with patch.object(coordinator.team, "build_consensus", return_value=consensus):
+        result = coordinator.delegate_task({"team_task": True, "action": "do"})
+
+    assert result["team_result"]["consensus"] == consensus
+    assert result["contributors"] == ["planner", "coder"]
+    assert result["method"] == "consensus_synthesis"
+    assert result["result"] == "final"
+    assert len(result["team_result"]["solutions"]) == 2


### PR DESCRIPTION
## Summary
- extend WSDE team tests for role assignment and voting
- add integration test for coordinator consensus output structure

## Testing
- `poetry run pytest tests/unit/test_wsde_team_extended.py tests/integration/test_delegate_task_consensus.py -q`


------
https://chatgpt.com/codex/tasks/task_e_6857549dc55c83339048ff5f94ae0387