### PR TITLE
Implement config loader precedence and tests

### DIFF
--- a/src/devsynth/config/loader.py
+++ b/src/devsynth/config/loader.py
@@ -55,6 +55,10 @@ logger = DevSynthLogger(__name__)
 
 def _find_config_path(start: Path) -> Optional[Path]:
     """Return the configuration file path if one exists."""
+    yaml_path = start / ".devsynth" / "devsynth.yml"
+    if yaml_path.exists():
+        return yaml_path
+
     toml_path = start / "pyproject.toml"
     if toml_path.exists():
         try:
@@ -63,10 +67,6 @@ def _find_config_path(start: Path) -> Optional[Path]:
                 return toml_path
         except Exception:
             return None
-
-    yaml_path = start / ".devsynth" / "devsynth.yml"
-    if yaml_path.exists():
-        return yaml_path
 
     return None
 

--- a/tests/integration/test_config_loader_integration.py
+++ b/tests/integration/test_config_loader_integration.py
@@ -1,0 +1,34 @@
+import os
+from devsynth.config.loader import load_config
+
+
+def test_load_config_from_yaml(tmp_path):
+    project_dir = tmp_path
+    dev_dir = project_dir / ".devsynth"
+    dev_dir.mkdir()
+    (dev_dir / "devsynth.yml").write_text("language: python\n")
+
+    os.chdir(project_dir)
+    cfg = load_config(project_dir)
+    assert cfg.language == "python"
+
+
+def test_load_config_from_pyproject(tmp_path):
+    project_dir = tmp_path
+    (project_dir / "pyproject.toml").write_text("[tool.devsynth]\nlanguage = 'go'\n")
+
+    os.chdir(project_dir)
+    cfg = load_config(project_dir)
+    assert cfg.language == "go"
+
+
+def test_yaml_precedence_over_pyproject(tmp_path):
+    project_dir = tmp_path
+    dev_dir = project_dir / ".devsynth"
+    dev_dir.mkdir()
+    (dev_dir / "devsynth.yml").write_text("language: python\n")
+    (project_dir / "pyproject.toml").write_text("[tool.devsynth]\nlanguage='go'\n")
+
+    os.chdir(project_dir)
+    cfg = load_config(project_dir)
+    assert cfg.language == "python"


### PR DESCRIPTION
## Summary
- load devsynth configuration preferring `.devsynth/devsynth.yml`
- test integration loading from yaml and pyproject files

## Testing
- `poetry run pytest tests/integration/test_config_loader_integration.py -q`
- `poetry run pytest tests/unit/test_config_loader.py -q`
- `poetry run pytest tests/unit/core/test_config_loader.py -q`

------
https://chatgpt.com/codex/tasks/task_e_685783c9f6a88333936158112304736e