### PR TITLE
Add recursive EDRR specifications

### DIFF
--- a/docs/architecture/index.md
+++ b/docs/architecture/index.md
@@ -34,6 +34,7 @@ This section provides detailed information about the architecture of DevSynth, i
 
 - **[Dialectical Reasoning](dialectical_reasoning.md)**: Information about the dialectical reasoning approach used in DevSynth.
 - **[EDRR Framework](edrr_framework.md)**: Documentation on the Expand-Differentiate-Refine-Retrospect framework.
+- **[Recursive EDRR Architecture](recursive_edrr_architecture.md)**: Details on nesting EDRR cycles and termination logic.
 - **[WSDE Agent Model](wsde_agent_model.md)**: Details on the Wide Sweep, Deep Exploration agent model.
 
 ## Overview

--- a/docs/architecture/recursive_edrr_architecture.md
+++ b/docs/architecture/recursive_edrr_architecture.md
@@ -1,0 +1,33 @@
+---
+title: "Recursive EDRR Architecture"
+date: "2025-06-16"
+version: "0.1.0"
+tags:
+  - "architecture"
+  - "edrr"
+  - "design"
+status: "draft"
+author: "DevSynth Team"
+last_reviewed: "2025-06-16"
+---
+
+# Recursive EDRR Architecture
+
+This document describes how the Expand-Differentiate-Refine-Retrospect (EDRR) framework operates recursively within DevSynth. It explains the flow of nested cycles and points to the underlying algorithms.
+
+## Overview
+
+The EDRR framework can spawn micro-cycles within each major phase. These micro-cycles execute the same four phases, allowing complex tasks to be broken down into smaller problems. Recursion continues until termination heuristics indicate no further benefit.
+
+See the [Recursive EDRR Pseudocode](../specifications/recursive_edrr_pseudocode.md) for function signatures and recursion flow. Termination heuristics are covered in [Delimiting Recursion Algorithms](../specifications/delimiting_recursion_algorithms.md).
+
+## Benefits
+
+- **Scalable Problem Solving**: Complex tasks are decomposed into manageable subtasks.
+- **Continuous Learning**: Each cycle captures lessons that inform higher-level cycles.
+- **Adaptive Depth**: Recursion depth adjusts based on context and heuristics.
+
+## Related Documents
+
+- [EDRR Framework](edrr_framework.md)
+- [EDRR Cycle Specification](../specifications/edrr_cycle_specification.md)

--- a/docs/index.md
+++ b/docs/index.md
@@ -23,6 +23,7 @@ Welcome to the DevSynth documentation! This site provides comprehensive guides, 
 - [User Guide](user_guides/user_guide.md)
 - [Developer Guides](developer_guides/contributing.md)
 - [Architecture Overview](architecture/overview.md)
+- [Recursive EDRR Architecture](architecture/recursive_edrr_architecture.md)
 - [API Reference](technical_reference/api_reference/index.md)
 - [Project Analysis](analysis/executive_summary.md)
 - [Implementation Status](implementation/feature_status_matrix.md)

--- a/docs/specifications/delimiting_recursion_algorithms.md
+++ b/docs/specifications/delimiting_recursion_algorithms.md
@@ -1,0 +1,31 @@
+---
+title: "Delimiting Recursion Algorithms"
+date: "2025-06-16"
+version: "0.1.0"
+tags:
+  - "specification"
+  - "edrr"
+  - "heuristics"
+status: "draft"
+author: "DevSynth Team"
+last_reviewed: "2025-06-16"
+---
+
+# Delimiting Recursion Algorithms
+
+This specification describes heuristics for terminating recursive EDRR cycles. These algorithms ensure the system balances thorough exploration with resource constraints.
+
+## Termination Heuristics
+
+1. **Maximum Depth**
+   - Abort recursion when `depth` exceeds a configurable limit.
+2. **Granularity Threshold**
+   - Skip recursion for tasks estimated below a complexity threshold.
+3. **Cost Benefit Ratio**
+   - Estimate potential benefit of another cycle versus expected cost. Stop when benefit drops below a defined ratio.
+4. **Quality Plateau Detection**
+   - Track quality metrics between cycles and stop when improvements fall below a minimum delta.
+5. **Human Override**
+   - Allow manual confirmation to continue or abort recursion when automated metrics are inconclusive.
+
+These heuristics are referenced by `should_terminate` in the [Recursive EDRR Pseudocode](recursive_edrr_pseudocode.md).

--- a/docs/specifications/index.md
+++ b/docs/specifications/index.md
@@ -27,6 +27,8 @@ This section contains the official specifications for the DevSynth project, outl
 ## Implementation Plans
 
 - **[EDRR Framework Integration Plan](edrr_framework_integration_plan.md)**: Plan for integrating the EDRR framework into DevSynth.
+- **[Recursive EDRR Pseudocode](recursive_edrr_pseudocode.md)**: Function signatures and recursion flow for nested cycles.
+- **[Delimiting Recursion Algorithms](delimiting_recursion_algorithms.md)**: Heuristics for ending recursive cycles.
 - **[Post-MVP Documentation Plan](post_mvp_documentation_plan.md)**: Comprehensive plan for DevSynth's post-MVP documentation structure and organization.
 - **[Testing Infrastructure](testing_infrastructure.md)**: Specification for DevSynth's testing infrastructure.
 

--- a/docs/specifications/recursive_edrr_pseudocode.md
+++ b/docs/specifications/recursive_edrr_pseudocode.md
@@ -1,0 +1,66 @@
+---
+title: "Recursive EDRR Pseudocode"
+date: "2025-06-16"
+version: "0.1.0"
+tags:
+  - "specification"
+  - "edrr"
+  - "pseudocode"
+status: "draft"
+author: "DevSynth Team"
+last_reviewed: "2025-06-16"
+---
+
+# Recursive EDRR Pseudocode
+
+This document outlines the pseudocode for orchestrating recursive EDRR cycles. It focuses on the main function signatures and how control flows between nested cycles.
+
+## Core Functions
+
+```pseudocode
+function run_cycle(context, depth = 0) -> CycleResult:
+    if should_terminate(context, depth):
+        return finalize_cycle(context)
+
+    expanded = expand(context)
+    differentiated = differentiate(expanded)
+    refined = refine(differentiated)
+    retrospected = retrospect(refined)
+
+    for subtask in retrospected.spawned_subtasks:
+        child_context = context.create_child(subtask)
+        run_cycle(child_context, depth + 1)
+
+    return retrospected
+```
+
+```pseudocode
+function expand(context) -> Context:
+    // gather ideas and options
+```
+
+```pseudocode
+function differentiate(context) -> Context:
+    // evaluate and narrow options
+```
+
+```pseudocode
+function refine(context) -> Context:
+    // implement the chosen approach
+```
+
+```pseudocode
+function retrospect(context) -> Context:
+    // capture lessons learned and spawn follow-ups
+```
+```
+
+## Recursion Flow
+
+1. **run_cycle** begins with the current context and recursion `depth`.
+2. **should_terminate** checks if recursion should stop, based on heuristics described in [Delimiting Recursion Algorithms](delimiting_recursion_algorithms.md).
+3. Each phase (expand, differentiate, refine, retrospect) transforms the context.
+4. The **retrospect** phase may spawn subtasks. For each subtask, `run_cycle` recurses with a child context and increased `depth`.
+5. Results propagate back up the call stack once termination conditions are met.
+
+For more background on the EDRR methodology, see the [EDRR Cycle Specification](edrr_cycle_specification.md).


### PR DESCRIPTION
## Summary
- add architecture doc for recursive EDRR design
- add pseudocode specification for recursive EDRR cycles
- add termination heuristics for recursion
- reference new docs from architecture and specs indices
- list recursive EDRR architecture in documentation quick links

## Testing
- `pre-commit run --files docs/architecture/index.md docs/index.md docs/specifications/index.md docs/architecture/recursive_edrr_architecture.md docs/specifications/delimiting_recursion_algorithms.md docs/specifications/recursive_edrr_pseudocode.md`
- `poetry run pytest tests` *(fails: ModuleNotFoundError: No module named 'devsynth.application.memory.knowledge_graph_utils')*

------
https://chatgpt.com/codex/tasks/task_e_685816e7339c8333b4c9c1bdad7b7669