### PR TITLE
Implement UXBridge workflow runner

### DIFF
--- a/src/devsynth/interface/simple_run.py
+++ b/src/devsynth/interface/simple_run.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+"""Simple workflow execution using :class:`UXBridge`."""
+
+from dataclasses import dataclass
+from typing import Optional, Dict, Any
+
+from devsynth.interface.ux_bridge import UXBridge
+from devsynth.core.workflows import execute_command
+
+
+@dataclass
+class WorkflowResult:
+    """Result returned from :func:`run_workflow`."""
+
+    summary: str
+
+
+def run_workflow(bridge: UXBridge) -> Optional[Dict[str, Any]]:
+    """Run a workflow selected via ``bridge``.
+
+    This mirrors the pseudocode in ``docs/implementation/uxbridge_interaction_pseudocode.md``.
+    The user is asked which command to run and whether to execute it. The chosen
+    command is then executed via :func:`devsynth.core.workflows.execute_command`.
+    The command's summary is displayed through the bridge.
+    """
+
+    task = bridge.ask_question("What task should DevSynth run?")
+    if not bridge.confirm_choice(f"Run {task} now?"):
+        return None
+
+    result = execute_command(task, {})
+    summary = str(result.get("summary", result))
+    bridge.display_result(summary)
+    return result

--- a/tests/behavior/test_interactive_workflow.py
+++ b/tests/behavior/test_interactive_workflow.py
@@ -1,0 +1,80 @@
+import sys
+from types import ModuleType
+from unittest.mock import MagicMock
+
+import pytest
+
+from devsynth.interface.simple_run import run_workflow
+from devsynth.interface.ux_bridge import UXBridge
+
+
+class DummyBridge(UXBridge):
+    def __init__(self) -> None:
+        self.messages: list[str] = []
+
+    def ask_question(
+        self, message: str, *, choices=None, default=None, show_default=True
+    ):
+        return "init"
+
+    def confirm_choice(self, message: str, *, default: bool = False) -> bool:
+        return True
+
+    def display_result(self, message: str, *, highlight: bool = False) -> None:
+        self.messages.append(message)
+
+
+def test_run_workflow_cli(monkeypatch):
+    bridge = DummyBridge()
+
+    called = {}
+
+    def fake_execute(cmd, args):
+        called["cmd"] = cmd
+        return {"summary": "ok"}
+
+    monkeypatch.setattr("devsynth.interface.simple_run.execute_command", fake_execute)
+
+    result = run_workflow(bridge)
+
+    assert called["cmd"] == "init"
+    assert result == {"summary": "ok"}
+    assert "ok" in bridge.messages
+
+
+def test_run_workflow_webui(monkeypatch):
+    st = ModuleType("streamlit")
+    st.selectbox = MagicMock(return_value="init")
+    st.text_input = MagicMock(return_value="init")
+    st.checkbox = MagicMock(return_value=True)
+    st.progress = MagicMock()
+    st.write = MagicMock()
+    st.markdown = MagicMock()
+    st.sidebar = ModuleType("sidebar")
+    st.sidebar.radio = MagicMock(return_value="Onboarding")
+    st.sidebar.title = MagicMock()
+    st.expander = lambda *a, **k: DummyBridge()
+    st.form = lambda *a, **k: DummyBridge()
+    st.form_submit_button = MagicMock(return_value=True)
+    st.set_page_config = MagicMock()
+
+    monkeypatch.setitem(sys.modules, "streamlit", st)
+
+    from devsynth.interface.webui import WebUI
+
+    bridge = WebUI()
+
+    monkeypatch.setattr(bridge, "ask_question", lambda *a, **k: "init")
+    monkeypatch.setattr(bridge, "confirm_choice", lambda *a, **k: True)
+    messages = []
+    monkeypatch.setattr(bridge, "display_result", lambda msg, **k: messages.append(msg))
+
+    def fake_execute(cmd, args):
+        return {"summary": "ok"}
+
+    monkeypatch.setattr("devsynth.interface.simple_run.execute_command", fake_execute)
+
+    result = run_workflow(bridge)
+
+    assert result == {"summary": "ok"}
+    assert "ok" in messages


### PR DESCRIPTION
## Summary
- add `run_workflow` helper using the `UXBridge` prompts
- test `run_workflow` with CLI and WebUI bridges

## Testing
- `poetry run pytest tests/behavior/test_interactive_workflow.py -q`
- `poetry run pytest tests/` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_68581b026f10833387cb0a29fea2b4b1