### PR TITLE
Implement RequirementsCollector gather and tests

### DIFF
--- a/tests/behavior/features/interactive_flow_cli.feature
+++ b/tests/behavior/features/interactive_flow_cli.feature
@@ -1,0 +1,9 @@
+Feature: Interactive Requirements Flow CLI
+  As a developer
+  I want to gather basic project settings interactively
+  So that they are saved for later use
+
+  Scenario: Gather project settings using the CLI
+    Given the DevSynth CLI is installed
+    When I run the interactive requirements flow
+    Then an interactive requirements file "interactive_requirements.json" should exist

--- a/tests/behavior/features/interactive_flow_webui.feature
+++ b/tests/behavior/features/interactive_flow_webui.feature
@@ -1,0 +1,9 @@
+Feature: Interactive Requirements Flow WebUI
+  As a developer
+  I want to gather basic project settings through the WebUI
+  So that they are saved for later use
+
+  Scenario: Gather project settings using the WebUI
+    Given the WebUI is initialized
+    When I run the interactive requirements flow in the WebUI
+    Then an interactive requirements file "interactive_requirements.json" should exist

--- a/tests/behavior/steps/interactive_flow_steps.py
+++ b/tests/behavior/steps/interactive_flow_steps.py
@@ -1,0 +1,84 @@
+import os
+import json
+import sys
+from typing import Sequence, Optional
+from unittest.mock import MagicMock
+
+import pytest
+from pytest_bdd import scenarios, given, when, then
+
+from devsynth.application.requirements.interactions import RequirementsCollector
+from devsynth.interface.ux_bridge import UXBridge
+from .webui_steps import webui_context
+
+
+class DummyBridge(UXBridge):
+    def __init__(self, answers: Sequence[str]):
+        self.answers = list(answers)
+        self.index = 0
+
+    def ask_question(
+        self,
+        message: str,
+        *,
+        choices: Optional[Sequence[str]] = None,
+        default: Optional[str] = None,
+        show_default: bool = True,
+    ) -> str:
+        response = self.answers[self.index]
+        self.index += 1
+        return response
+
+    def confirm_choice(self, message: str, *, default: bool = False) -> bool:
+        return True
+
+    def display_result(self, message: str, *, highlight: bool = False) -> None:
+        pass
+
+
+scenarios("../features/interactive_flow_cli.feature")
+scenarios("../features/interactive_flow_webui.feature")
+
+
+@given("the DevSynth CLI is installed")
+def cli_installed():
+    return True
+
+
+@given("the WebUI is initialized")
+def webui_initialized(webui_context):
+    return webui_context
+
+
+@when("I run the interactive requirements flow")
+def run_flow(tmp_project_dir, monkeypatch):
+    monkeypatch.setitem(sys.modules, "chromadb", MagicMock())
+    monkeypatch.setitem(sys.modules, "uvicorn", MagicMock())
+    answers = ["My Project", "python", "feature1,feature2"]
+    bridge = DummyBridge(answers)
+    output = os.path.join(tmp_project_dir, "interactive_requirements.json")
+    collector = RequirementsCollector(bridge, output_file=output)
+    collector.gather()
+
+
+@when("I run the interactive requirements flow in the WebUI")
+def run_flow_webui(tmp_project_dir, webui_context):
+    webui_context["st"].sidebar.radio.return_value = "Onboarding"
+    webui_context["st"].text_input.side_effect = [
+        "My Project",
+        "python",
+        "feature1,feature2",
+    ]
+    webui_context["st"].checkbox.return_value = True
+    output = os.path.join(tmp_project_dir, "interactive_requirements.json")
+    collector = RequirementsCollector(webui_context["ui"], output_file=output)
+    collector.gather()
+
+
+@then('an interactive requirements file "interactive_requirements.json" should exist')
+def check_interactive_file(tmp_project_dir):
+    path = os.path.join(tmp_project_dir, "interactive_requirements.json")
+    assert os.path.exists(path)
+    with open(path, "r", encoding="utf-8") as f:
+        data = json.load(f)
+    assert data.get("name") == "My Project"


### PR DESCRIPTION
## Summary
- implement RequirementsCollector.gather based on pseudocode
- persist collected answers and handle errors
- add BDD scenarios for interactive flow via CLI and WebUI

## Testing
- `poetry run pytest tests/behavior/steps/interactive_flow_steps.py`

------
https://chatgpt.com/codex/tasks/task_e_685820b8478083338e62aba254c79247