### PR TITLE
Add delegate task feature and CLI alias tests

### DIFF
--- a/tests/behavior/features/delegate_task.feature
+++ b/tests/behavior/features/delegate_task.feature
@@ -1,0 +1,11 @@
+Feature: Multi-agent task delegation
+  As a coordinator
+  I want to delegate tasks to a team of agents
+  So that they collaborate to produce a consensus result
+
+  Scenario: Delegate a team task to multiple agents
+    Given a team coordinator with multiple agents
+    When I delegate a collaborative team task
+    Then each agent should process the task
+    And the delegation result should include all contributors
+    And the delegation method should be consensus based

--- a/tests/behavior/features/doctor_command.feature
+++ b/tests/behavior/features/doctor_command.feature
@@ -17,3 +17,8 @@ Feature: Doctor Command
     Given valid environment configuration
     When I run the command "devsynth doctor"
     Then the system should display a success message
+
+  Scenario: Validate configuration using the check alias
+    Given valid environment configuration
+    When I run the command "devsynth check"
+    Then the system should display a success message

--- a/tests/behavior/features/edrr_cycle.feature
+++ b/tests/behavior/features/edrr_cycle.feature
@@ -5,11 +5,11 @@ Feature: EDRR cycle command
 
   Scenario: Run EDRR cycle with manifest file
     Given a valid manifest file
-    When I execute the edrr cycle command with that file
+    When I run the command "devsynth edrr-cycle" with that file
     Then the coordinator should process the manifest
     And the workflow should complete successfully
 
   Scenario: Handle missing manifest file
     Given no manifest file exists at the provided path
-    When I execute the edrr cycle command with that file
+    When I run the command "devsynth edrr-cycle" with that file
     Then the system should report that the manifest file was not found

--- a/tests/behavior/steps/delegate_task_steps.py
+++ b/tests/behavior/steps/delegate_task_steps.py
@@ -1,0 +1,65 @@
+"""Step definitions for delegate_task.feature."""
+
+import pytest
+from unittest.mock import MagicMock
+from pytest_bdd import scenarios, given, when, then
+
+from devsynth.adapters.agents.agent_adapter import WSDETeamCoordinator
+from devsynth.domain.interfaces.agent import Agent
+
+scenarios("../features/delegate_task.feature")
+
+
+@pytest.fixture
+def context():
+    class Context:
+        def __init__(self):
+            self.coordinator = WSDETeamCoordinator()
+            self.agents = []
+            self.result = None
+            self.task = None
+    return Context()
+
+
+@given("a team coordinator with multiple agents")
+def setup_team(context):
+    # Create mock agents with names and types
+    agent_types = ["planner", "code", "test", "validation"]
+    for idx, a_type in enumerate(agent_types):
+        agent = MagicMock(spec=Agent)
+        agent.name = f"agent{idx}"
+        agent.agent_type = a_type
+        agent.process.return_value = {"solution": f"solution from {agent.name}"}
+        context.coordinator.add_agent(agent)
+        context.agents.append(agent)
+
+
+@when("I delegate a collaborative team task")
+def delegate_task(context):
+    context.task = {"team_task": True, "description": "do work"}
+    # Mock build_consensus on the team to return contributions from all agents
+    team = context.coordinator.teams[context.coordinator.current_team_id]
+    team.build_consensus = MagicMock(
+        return_value={
+            "consensus": "final",
+            "contributors": [a.name for a in context.agents],
+            "method": "consensus_synthesis",
+        }
+    )
+    context.result = context.coordinator.delegate_task(context.task)
+
+
+@then("each agent should process the task")
+def each_agent_processed(context):
+    for agent in context.agents:
+        agent.process.assert_called()
+
+
+@then("the delegation result should include all contributors")
+def result_includes_contributors(context):
+    assert set(context.result.get("contributors", [])) == {a.name for a in context.agents}
+
+
+@then("the delegation method should be consensus based")
+def method_consensus(context):
+    assert context.result.get("method") == "consensus_synthesis"

--- a/tests/behavior/steps/doctor_command_steps.py
+++ b/tests/behavior/steps/doctor_command_steps.py
@@ -1,20 +1,13 @@
-"""Steps for the doctor command feature."""
+"""Step definitions for doctor_command.feature."""
 
-from pytest_bdd import scenarios, given, when, then
+from pytest_bdd import scenarios, when
+
+from .cli_commands_steps import run_command
 
 scenarios("../features/doctor_command.feature")
 
 
-@given("the doctor_command feature context")
-def given_context():
-    pass
-
-
-@when("we execute the doctor_command workflow")
-def when_execute():
-    pass
-
-
-@then("the doctor_command workflow completes")
-def then_complete():
-    pass
+@when('I run the command "devsynth check"')
+def run_check_alias(monkeypatch, mock_workflow_manager, command_context):
+    """Invoke the doctor command via its check alias."""
+    return run_command("devsynth check", monkeypatch, mock_workflow_manager, command_context)

--- a/tests/behavior/steps/edrr_cycle_steps.py
+++ b/tests/behavior/steps/edrr_cycle_steps.py
@@ -28,7 +28,7 @@ def missing_manifest(tmp_path, context):
     return context['manifest']
 
 
-@when('I execute the edrr cycle command with that file')
+@when('I run the command "devsynth edrr-cycle" with that file')
 def run_edrr_cycle(context):
     manifest = str(context['manifest'])
     with patch('devsynth.application.cli.commands.edrr_cycle_cmd.bridge') as mock_bridge, \

--- a/tests/behavior/test_cli_commands.py
+++ b/tests/behavior/test_cli_commands.py
@@ -8,6 +8,8 @@ from pytest_bdd import scenario, given, when, then, parsers
 # Import the step definitions
 from .steps.cli_commands_steps import *
 from .steps.edrr_cycle_steps import *
+from .steps.delegate_task_steps import *
+from .steps.doctor_command_steps import *
 
 # Mark scenarios that require specific resources
 cli_available = pytest.mark.requires_resource("cli")
@@ -15,6 +17,8 @@ cli_available = pytest.mark.requires_resource("cli")
 # Define the feature file path
 FEATURE_FILE = os.path.join(os.path.dirname(__file__), 'features', 'cli_commands.feature')
 EDRR_FEATURE = os.path.join(os.path.dirname(__file__), 'features', 'edrr_cycle.feature')
+DELEGATE_FEATURE = os.path.join(os.path.dirname(__file__), 'features', 'delegate_task.feature')
+DOCTOR_FEATURE = os.path.join(os.path.dirname(__file__), 'features', 'doctor_command.feature')
 
 # Create a scenario for each scenario in the feature file
 @cli_available
@@ -87,4 +91,16 @@ def test_edrr_cycle_with_manifest():
 @scenario(EDRR_FEATURE, 'Handle missing manifest file')
 def test_edrr_cycle_missing_manifest():
     """Test running the edrr-cycle command with a missing manifest file."""
+    pass
+
+@cli_available
+@scenario(DELEGATE_FEATURE, 'Delegate a team task to multiple agents')
+def test_delegate_task_multi_agent():
+    """Test delegating a collaborative task to multiple agents."""
+    pass
+
+@cli_available
+@scenario(DOCTOR_FEATURE, 'Validate configuration using the check alias')
+def test_doctor_check_alias():
+    """Test doctor command via the check alias."""
     pass

--- a/tests/behavior/test_doctor_command.py
+++ b/tests/behavior/test_doctor_command.py
@@ -1,5 +1,6 @@
 from pytest_bdd import scenarios
 
 from .steps.cli_commands_steps import *
+from .steps.doctor_command_steps import *
 
 scenarios('features/doctor_command.feature')


### PR DESCRIPTION
## Summary
- add BDD feature for multi-agent task delegation
- expand doctor command feature with `check` alias
- update edrr cycle feature text to show CLI invocation
- implement corresponding step definitions
- register new scenarios in `test_cli_commands`

## Testing
- `poetry run pytest tests/behavior/steps/delegate_task_steps.py -q`
- `poetry run pytest tests/behavior/test_cli_commands.py::test_doctor_check_alias -q`
- `poetry run pytest tests/behavior/test_cli_commands.py::test_edrr_cycle_with_manifest -q`


------
https://chatgpt.com/codex/tasks/task_e_685846891b5c8333b9e91a4932ccb3c5