### PR TITLE
Fix CLI help and update examples

### DIFF
--- a/.github/workflows.disabled/example_project.yml
+++ b/.github/workflows.disabled/example_project.yml
@@ -33,4 +33,4 @@ jobs:
           devsynth spec --requirements-file requirements.md
           devsynth test
           devsynth code
-          devsynth run
+          devsynth run-pipeline

--- a/examples/calculator/README.md
+++ b/examples/calculator/README.md
@@ -31,7 +31,7 @@ It walks through project initialization, specification generation, test creation
 
 6. **Run the project**
    ```bash
-   devsynth run
+   devsynth run-pipeline
    ```
 
 The files in this directory show the final result after running these commands.

--- a/examples/full_workflow/README.md
+++ b/examples/full_workflow/README.md
@@ -37,7 +37,7 @@ This example demonstrates the full DevSynth workflow using a simple word counter
 7. **Review and run**
    Inspect `specs.md`, the `tests/` directory, and the `src/` implementation. Then run:
    ```bash
-   devsynth run
+   devsynth run-pipeline
    ```
 
 The files in this directory show the final result after executing these commands.

--- a/src/devsynth/adapters/cli/typer_adapter.py
+++ b/src/devsynth/adapters/cli/typer_adapter.py
@@ -46,8 +46,9 @@ def build_app() -> typer.Typer:
     """Create a Typer application with all commands registered."""
     app = typer.Typer(
         help=(
-            "DevSynth CLI - Iterative 'expand, differentiate, refine' automation. "
-            "ChromaDB can be enabled later, but only the embedded backend is currently supported."
+            "DevSynth CLI - automate iterative 'Expand, Differentiate, Refine, "
+            "Retrace' workflows. Only the embedded ChromaDB backend is currently"
+            " supported."
         ),
     )
 
@@ -77,7 +78,10 @@ def build_app() -> typer.Typer:
     app.add_typer(config_app, name="config", help="Manage configuration settings")
     app.command(
         name="inspect",
-        help="Inspect requirements. Example: devsynth inspect --input reqs.txt",
+        help=(
+            "Inspect a requirements file or run an interactive analysis. "
+            "Example: devsynth inspect --input reqs.txt"
+        ),
     )(inspect_cmd)
     app.command(
         name="gather",
@@ -109,7 +113,10 @@ def build_app() -> typer.Typer:
     )(refactor_cmd)
     app.command(
         name="analyze-code",
-        help="Analyze a codebase. Example: devsynth analyze-code --path ./src",
+        help=(
+            "Analyze a codebase and report architecture, quality and health "
+            "metrics. Example: devsynth analyze-code --path ./src"
+        ),
     )(analyze_code_cmd)
     app.command(
         name="edrr-cycle",


### PR DESCRIPTION
## Summary
- refine CLI help messages for inspect and analyze-code
- update docs to use `devsynth run-pipeline`
- tweak Typer root description

## Testing
- `poetry run pytest -q` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_68585555d5fc8333a8affac2e5940898