### PR TITLE
Improve config loader defaults and validation

### DIFF
--- a/tests/integration/test_config_loader_workflow.py
+++ b/tests/integration/test_config_loader_workflow.py
@@ -1,0 +1,31 @@
+import pytest
+from devsynth.config.loader import load_config, ConfigurationError
+
+
+def test_load_config_merges_defaults(tmp_path):
+    dev_dir = tmp_path / ".devsynth"
+    dev_dir.mkdir()
+    (dev_dir / "devsynth.yml").write_text("language: python\n")
+
+    cfg = load_config(tmp_path)
+
+    assert cfg.language == "python"
+    assert cfg.directories["source"] == ["src"]
+    assert cfg.features["code_generation"] is False
+
+
+def test_malformed_yaml_raises(tmp_path):
+    dev_dir = tmp_path / ".devsynth"
+    dev_dir.mkdir()
+    (dev_dir / "devsynth.yml").write_text(": - bad")
+
+    with pytest.raises(ConfigurationError):
+        load_config(tmp_path)
+
+
+def test_malformed_toml_raises(tmp_path):
+    toml_path = tmp_path / "pyproject.toml"
+    toml_path.write_text("[tool.devsynth\nfoo = 'bar'")
+
+    with pytest.raises(ConfigurationError):
+        load_config(tmp_path)


### PR DESCRIPTION
## Summary
- handle malformed YAML/TOML configuration by raising `ConfigurationError`
- merge parsed values with defaults when loading config
- document updated workflow in `config_loader_workflow.md`
- test configuration loader workflow including defaults and errors

## Testing
- `poetry run pytest tests/integration/test_config_loader_workflow.py -q`
- `poetry run pytest tests/integration/test_config_loader_integration.py tests/integration/test_config_loader.py tests/unit/test_config_loader.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6858bbd5650c8333a2ebe31f338afcc1