### PR TITLE
Update CLI/WebUI mapping

### DIFF
--- a/docs/architecture/cli_webui_mapping.md
+++ b/docs/architecture/cli_webui_mapping.md
@@ -50,6 +50,29 @@ backend functions.
 | `apispec`                 | N/A (planned API specification form)                 |
 | `webui`                   | Launches the WebUI                                   |
 
+The following CLI commands remain **N/A** in the WebUI:
+
+- `refactor`
+- `webapp`
+- `serve`
+- `dbschema`
+- `doctor` / `check`
+- `edrr-cycle`
+- `align`
+- `alignment-metrics`
+- `analyze-manifest`
+- `analyze-config`
+- `validate-manifest`
+- `validate-metadata`
+- `test-metrics`
+- `generate-docs`
+- `ingest`
+- `apispec`
+
+Because each page calls workflow functions through the `UXBridge` layer,
+adding UI support for these commands later only requires new pages that
+invoke the same shared functions.
+
 Terminology across the CLI and WebUI is kept consistent. For example, the
 interactive workflow started by `gather` is called the *Requirements Plan
 Wizard* in both interfaces.


### PR DESCRIPTION
## Summary
- list CLI commands still missing WebUI pages
- explain how UXBridge allows these pages to be added later

## Testing
- `poetry run pytest -q` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_6858c40e699c83339cbdad579765bd99