### PR TITLE
Add Doctor page to WebUI

### DIFF
--- a/src/devsynth/interface/webui.py
+++ b/src/devsynth/interface/webui.py
@@ -35,6 +35,7 @@ from devsynth.application.cli import (
     config_cmd,
     inspect_cmd,
 )
+from devsynth.application.cli.commands.doctor_cmd import doctor_cmd
 from devsynth.config import get_project_config, save_config
 from devsynth.application.cli.commands.analyze_code_cmd import analyze_code_cmd
 from devsynth.domain.models.requirement import RequirementPriority, RequirementType
@@ -255,6 +256,12 @@ class WebUI(UXBridge):
             with st.spinner("Loading configuration..."):
                 config_cmd(bridge=self)
 
+    def doctor_page(self) -> None:
+        """Render the doctor diagnostics page."""
+        st.header("Doctor")
+        with st.spinner("Validating configuration..."):
+            doctor_cmd()
+
     # ------------------------------------------------------------------
     # Application entry point
     # ------------------------------------------------------------------
@@ -270,6 +277,7 @@ class WebUI(UXBridge):
                 "Analysis",
                 "Synthesis",
                 "Config",
+                "Doctor",
             ),
         )
         if nav == "Onboarding":
@@ -282,6 +290,8 @@ class WebUI(UXBridge):
             self.synthesis_page()
         elif nav == "Config":
             self.config_page()
+        elif nav == "Doctor":
+            self.doctor_page()
 
 
 def run() -> None:

--- a/tests/behavior/features/webui_doctor.feature
+++ b/tests/behavior/features/webui_doctor.feature
@@ -1,0 +1,11 @@
+Feature: WebUI Doctor
+  As a developer
+  I want to validate configuration from the WebUI
+  So that I can fix issues easily
+
+  Background:
+    Given the WebUI is initialized
+
+  Scenario: Run doctor diagnostics
+    When I navigate to "Doctor"
+    Then the doctor command should be executed

--- a/tests/behavior/steps/webui_doctor_steps.py
+++ b/tests/behavior/steps/webui_doctor_steps.py
@@ -1,0 +1,10 @@
+from pytest_bdd import scenarios, then
+
+from .webui_steps import *  # noqa: F401,F403
+
+scenarios("../features/webui_doctor.feature")
+
+
+@then("the doctor command should be executed")
+def check_doctor(webui_context):
+    assert webui_context["cli"].doctor_cmd.called

--- a/tests/behavior/steps/webui_steps.py
+++ b/tests/behavior/steps/webui_steps.py
@@ -25,6 +25,7 @@ class DummyForm:
 @pytest.fixture
 def webui_context(monkeypatch):
     st = ModuleType("streamlit")
+
     class SS(dict):
         pass
 
@@ -66,6 +67,7 @@ def webui_context(monkeypatch):
         "run_pipeline_cmd",
         "config_cmd",
         "inspect_cmd",
+        "doctor_cmd",
     ]:
         setattr(cli_stub, name, MagicMock())
     monkeypatch.setitem(sys.modules, "devsynth.application.cli", cli_stub)
@@ -75,6 +77,13 @@ def webui_context(monkeypatch):
     monkeypatch.setitem(
         sys.modules, "devsynth.application.cli.commands.analyze_code_cmd", analyze_stub
     )
+
+    doctor_stub = ModuleType("devsynth.application.cli.commands.doctor_cmd")
+    doctor_stub.doctor_cmd = MagicMock()
+    monkeypatch.setitem(
+        sys.modules, "devsynth.application.cli.commands.doctor_cmd", doctor_stub
+    )
+    cli_stub.doctor_cmd = doctor_stub.doctor_cmd
 
     import importlib
     import devsynth.interface.webui as webui

--- a/tests/behavior/test_webui_doctor.py
+++ b/tests/behavior/test_webui_doctor.py
@@ -1,0 +1,6 @@
+from pytest_bdd import scenarios
+
+from .steps.webui_steps import *  # noqa: F401,F403
+from .steps.webui_doctor_steps import *  # noqa: F401,F403
+
+scenarios("features/webui_doctor.feature")


### PR DESCRIPTION
## Summary
- add doctor page to WebUI navigation
- call doctor_cmd when the Doctor page is viewed
- route sidebar to new page
- support doctor_cmd in behaviour test fixtures
- test the Doctor page behaviour

## Testing
- `poetry run pytest tests/behavior/test_webui_doctor.py -q`
- `poetry run pytest tests/ -q` *(fails: ModuleNotFoundError: No module named 'devsynth.application.memory.knowledge_graph_utils')*

------
https://chatgpt.com/codex/tasks/task_e_6858e108af00833381210aca285762c5