### PR TITLE
Handle optional TinyDB import

### DIFF
--- a/src/devsynth/application/memory/__init__.py
+++ b/src/devsynth/application/memory/__init__.py
@@ -5,17 +5,35 @@ This module provides memory storage and retrieval functionality for DevSynth,
 including a Memory Manager with adapters for different storage backends.
 """
 
-from .context_manager import InMemoryStore, SimpleContextManager
-from .json_file_store import JSONFileStore
-from .persistent_context_manager import PersistentContextManager
-from .memory_manager import MemoryManager
-from .adapters import GraphMemoryAdapter, VectorMemoryAdapter, TinyDBMemoryAdapter
-
 # Create a logger for this module
 from devsynth.logging_setup import DevSynthLogger
 
+from .context_manager import InMemoryStore, SimpleContextManager
+from .json_file_store import JSONFileStore
+from .memory_manager import MemoryManager
+from .persistent_context_manager import PersistentContextManager
+
 logger = DevSynthLogger(__name__)
+
 from devsynth.exceptions import DevSynthError
+
+try:  # pragma: no cover - optional dependency
+    from .adapters.graph_memory_adapter import GraphMemoryAdapter
+except ImportError as exc:  # pragma: no cover - fallback path
+    GraphMemoryAdapter = None
+    logger.warning("GraphMemoryAdapter not available: %s", exc)
+
+try:  # pragma: no cover - optional dependency
+    from .adapters.vector_memory_adapter import VectorMemoryAdapter
+except ImportError as exc:  # pragma: no cover - fallback path
+    VectorMemoryAdapter = None
+    logger.warning("VectorMemoryAdapter not available: %s", exc)
+
+try:  # pragma: no cover - optional dependency
+    from .adapters.tinydb_memory_adapter import TinyDBMemoryAdapter
+except ImportError as exc:  # pragma: no cover - fallback path
+    TinyDBMemoryAdapter = None
+    logger.warning("TinyDBMemoryAdapter not available: %s", exc)
 
 __all__ = [
     "InMemoryStore",
@@ -23,7 +41,13 @@ __all__ = [
     "JSONFileStore",
     "PersistentContextManager",
     "MemoryManager",
-    "GraphMemoryAdapter",
-    "VectorMemoryAdapter",
-    "TinyDBMemoryAdapter",
 ]
+
+if GraphMemoryAdapter is not None:
+    __all__.append("GraphMemoryAdapter")
+
+if VectorMemoryAdapter is not None:
+    __all__.append("VectorMemoryAdapter")
+
+if TinyDBMemoryAdapter is not None:
+    __all__.append("TinyDBMemoryAdapter")

--- a/tests/unit/application/memory/test_import_without_tinydb.py
+++ b/tests/unit/application/memory/test_import_without_tinydb.py
@@ -1,0 +1,25 @@
+import builtins
+import importlib
+import sys
+
+
+def test_import_memory_without_tinydb(monkeypatch):
+    """Importing memory module should succeed without tinydb installed."""
+
+    # Ensure module not already loaded
+    sys.modules.pop("devsynth.application.memory", None)
+    sys.modules.pop("devsynth.application.memory.adapters.tinydb_memory_adapter", None)
+
+    real_import = builtins.__import__
+
+    def fake_import(name, globals=None, locals=None, fromlist=(), level=0):
+        if name.startswith("tinydb"):
+            raise ImportError("No module named 'tinydb'")
+        return real_import(name, globals, locals, fromlist, level)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+
+    module = importlib.import_module("devsynth.application.memory")
+
+    assert module.TinyDBMemoryAdapter is None
+    assert "TinyDBMemoryAdapter" not in module.__all__


### PR DESCRIPTION
## Summary
- gracefully import optional memory adapters
- skip TinyDB adapter when dependency is missing
- test importing memory package without TinyDB

## Testing
- `poetry run pytest tests/unit/application/memory/test_import_without_tinydb.py -q`
- `poetry run pytest tests/ -q` *(fails: ModuleNotFoundError: No module named 'devsynth')*

------
https://chatgpt.com/codex/tasks/task_e_6859780f33dc83339a2e6d1915db9cf9