### PR TITLE
Update docs to promote Poetry workflow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,7 +30,7 @@ Refer to `docs/architecture/agent_system.md` and `docs/architecture/wsde_agent_m
 
 ## Agent Configuration
 
-- **Dependencies:** Managed exclusively with Poetry (`pyproject.toml`). Do **not** run `pip install` directly. Use `poetry install` or `poetry sync` so all packages are installed in the Poetry-managed virtual environment.
+- **Dependencies:** Managed exclusively with Poetry (`pyproject.toml`). Do **not** run `pip install` directly except when installing from PyPI with `pip` or `pipx`. Use `poetry install` or `poetry sync` so all packages are installed in the Poetry-managed virtual environment.
 - **Environment:** Use the provided `config/` files for environment-specific settings.
 - **Setup:**
   1. Install dependencies with `poetry install` or `poetry sync --all-extras --all-groups` for the full development environment.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,11 +39,11 @@ Thank you for your interest in contributing to DevSynth! This document provides 
 git clone https://github.com/YOUR-USERNAME/devsynth.git
 cd devsynth
 
-# Install dependencies
+# Install dependencies (recommended)
 poetry install --with dev,docs
 poetry install --all-extras --with dev,docs
 
-# Alternatively, install with pip or pipx using extras
+# Alternatively, install from PyPI using pip or pipx
 pip install 'devsynth[dev]'
 # or
 pipx install --editable 'devsynth[dev]'

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ DevSynth requires **Python 3.11 or higher**. Using [Poetry](https://python-poetr
 
 You can install DevSynth in a few different ways:
 
-1. **pip** – install from PyPI
+1. **pip** – install from PyPI (optional)
 
    ```bash
    pip install devsynth
@@ -90,16 +90,17 @@ You can install DevSynth in a few different ways:
    docker run --rm -p 8000:8000 devsynth
    ```
 
-4. **From Source for Development** – install with development dependencies
+4. **From Source for Development** – use Poetry
 
    ```bash
-   pip install -e '.[dev]'
-   # or for a smaller core install
-   pip install -e '.[minimal,dev]'
-   # or
+   # Install development and documentation dependencies
    poetry install --with dev,docs
-   # or for all optional dependencies
+   # Optionally include all extras
    poetry install --all-extras --with dev,docs
+
+   # If you prefer pip or pipx, install from PyPI instead
+   pip install -e '.[dev]'        # editable mode
+   pip install -e '.[minimal,dev]'  # smaller core install
    ```
 
 For more on Docker deployment, see the [Deployment Guide](docs/deployment/deployment_guide.md).
@@ -109,6 +110,8 @@ For more on Docker deployment, see the [Deployment Guide](docs/deployment/deploy
 Certain features use additional backends that are not installed by default. Install them if you need these capabilities:
 
 ```bash
+poetry install --extras retrieval
+# or install from PyPI
 pip install 'devsynth[retrieval]'
 ```
 
@@ -131,7 +134,7 @@ devsynth test
 devsynth code
 
 # Install development dependencies
-pip install -e '.[dev]'
+poetry install --with dev,docs
 
 # Run the tests or execute the app
 pytest
@@ -161,28 +164,33 @@ The repository includes runnable examples that walk through common workflows:
 Before running the test suite, you **must** install DevSynth with its development extras:
 
 ```bash
-pip install -e '.[dev]'
-# or
 poetry install --with dev,docs
 # or to install everything
 poetry install --all-extras --with dev,docs
+
+# (Optional) Install from PyPI instead
+pip install -e '.[dev]'
 ```
 
 Some tests and features rely on optional backends like **Kuzu**, **FAISS**, and **LMDB**. Support for **ChromaDB** can be enabled later, but only the embedded backend is currently supported. Install these packages if you plan to use them:
 
 ```bash
+poetry install --extras retrieval
+# or install from PyPI
 pip install 'devsynth[retrieval]'
 ```
 
 For a smaller core install you can instead run:
 
 ```bash
+poetry install --with dev,docs --extras retrieval
+# or using pip
 pip install -e '.[minimal,dev,retrieval]'
 ```
 
 After installation, execute the tests with:
 ```bash
-pytest
+poetry run pytest
 ```
 
 See [docs/developer_guides/testing.md](docs/developer_guides/testing.md) for detailed testing guidance.

--- a/docs/developer_guides/dependencies.md
+++ b/docs/developer_guides/dependencies.md
@@ -29,6 +29,8 @@ Some features rely on additional packages. These dependencies are grouped using 
 Example installation:
 
 ```bash
+poetry install --with dev --extras retrieval
+# or install from PyPI
 pip install "devsynth[dev,retrieval]"
 ```
 

--- a/docs/developer_guides/development_setup.md
+++ b/docs/developer_guides/development_setup.md
@@ -105,7 +105,7 @@ The pre-commit hooks will run automatically when you commit changes. They includ
 Ensure your setup is working correctly by running the tests:
 
 ```bash
-python -m pytest
+poetry run pytest
 ```
 
 ### Configuration Version Locking
@@ -198,23 +198,23 @@ DevSynth uses pytest for unit testing and pytest-bdd for behavior-driven tests.
 
 ```bash
 # Run all unit tests
-python -m pytest tests/unit/
+poetry run pytest tests/unit/
 
 # Run a specific test file
-python -m pytest tests/unit/test_workflow.py
+poetry run pytest tests/unit/test_workflow.py
 
 # Run tests with verbose output
-python -m pytest tests/unit/ -v
+poetry run pytest tests/unit/ -v
 ```
 
 ### Running Behavior Tests
 
 ```bash
 # Run all behavior tests
-python -m pytest tests/behavior/
+poetry run pytest tests/behavior/
 
 # Run a specific behavior test
-python -m pytest tests/behavior/test_simple_example_steps.py
+poetry run pytest tests/behavior/test_simple_example_steps.py
 ```
 
 ## Common Development Tasks

--- a/docs/developer_guides/tdd_bdd_edrr_training.md
+++ b/docs/developer_guides/tdd_bdd_edrr_training.md
@@ -358,7 +358,7 @@ Mutation testing evaluates the quality of your tests by introducing small change
 **Example**:
 ```bash
 # Using the pytest-mutate plugin
-python -m pytest --mutate=src/devsynth/module.py
+poetry run pytest --mutate=src/devsynth/module.py
 ```
 
 ### 7.3 Test-Driven Architecture

--- a/docs/developer_guides/testing.md
+++ b/docs/developer_guides/testing.md
@@ -249,57 +249,54 @@ The ChromaDB tests use fixtures for isolation and provider integration:
 ## Running Tests
 
 Before executing tests, install DevSynth with its development extras so that all
-test dependencies are available. Use either:
+test dependencies are available:
 
 ```bash
-pip install -e '.[dev]'
-```
-
-or
-
-```bash
-poetry install
+poetry install --with dev,docs
 poetry sync --all-extras --all-groups
+
+# (Optional) install from PyPI instead
+pip install -e '.[dev]'
 ```
 
 ### Running All Tests
 
 ```bash
-pytest
+poetry run pytest
 ```
 
 ### Running Specific Test Types
 
 ```bash
 # Run BDD tests
-pytest tests/behavior/
+poetry run pytest tests/behavior/
 
 # Run WebUI onboarding and API stub scenarios
-pytest tests/behavior/test_webui_onboarding_flow.py
-pytest tests/behavior/test_requirements_wizard_navigation.py
-pytest tests/behavior/test_api_stub_usage.py
+poetry run pytest tests/behavior/test_webui_onboarding_flow.py
+poetry run pytest tests/behavior/test_requirements_wizard_navigation.py
+poetry run pytest tests/behavior/test_api_stub_usage.py
 
 # Run integration tests
-pytest tests/integration/
+poetry run pytest tests/integration/
 
 # Run unit tests
-pytest tests/unit/
+poetry run pytest tests/unit/
 ```
 
 ### Running a Specific Test File
 
 ```bash
-pytest tests/behavior/test_chromadb_integration.py
+poetry run pytest tests/behavior/test_chromadb_integration.py
 ```
 
 ### Running Tests with Provider Selection
 
 ```bash
 # Use OpenAI provider
-DEVSYNTH_PROVIDER=openai pytest
+DEVSYNTH_PROVIDER=openai poetry run pytest
 
 # Use LM Studio provider
-DEVSYNTH_PROVIDER=lm_studio pytest
+DEVSYNTH_PROVIDER=lm_studio poetry run pytest
 ```
 
 ### Enabling Resource-Dependent Tests

--- a/docs/getting_started/installation.md
+++ b/docs/getting_started/installation.md
@@ -33,18 +33,18 @@ pip install devsynth
 pipx install devsynth
 ```
 
-## Install from Source
+## Install from Source (recommended for development)
 ```bash
 git clone https://github.com/ravenoak/devsynth.git
 cd devsynth
 
-# Install with development dependencies
-pip install -e '.[dev]'
-
-# Or use Poetry
-poetry install
+# Install with Poetry
+poetry install --with dev,docs
 poetry sync --all-extras --all-groups
 poetry shell
+
+# (Optional) install via pip if you prefer
+pip install -e '.[dev]'
 ```
 
 ### Running the Full Test Suite
@@ -54,7 +54,7 @@ extras. Key dependencies include `rdflib`, `tinydb`, `chromadb`, `astor`, and
 `networkx`. Install them along with the project:
 
 ```bash
-pip install -e '.[dev]'
+poetry install --with dev,docs
 ```
 
 For more details, see the [Quick Start Guide](../getting_started/quick_start_guide.md).

--- a/docs/getting_started/quick_start_guide.md
+++ b/docs/getting_started/quick_start_guide.md
@@ -36,20 +36,19 @@ pipx install devsynth
 ```
 
 
-### Install from Source
+### Install from Source (recommended for development)
 
 ```bash
 # Clone the repository
 git clone https://github.com/ravenoak/devsynth.git
 cd devsynth
 
-# Install with development dependencies
-pip install -e '.[dev]'
-
-# Or use Poetry
-poetry install
+# Install with Poetry
+poetry install --with dev,docs
 poetry sync --all-extras --all-groups
 
+# (Optional) install via pip
+pip install -e '.[dev]'
 
 # Activate the virtual environment
 poetry shell

--- a/docs/user_guides/cli_reference.md
+++ b/docs/user_guides/cli_reference.md
@@ -43,11 +43,20 @@ This document provides a comprehensive reference for the DevSynth Command Line I
 
 ## Installation
 
-The DevSynth CLI is installed automatically when you install the DevSynth package:
+The DevSynth CLI is installed automatically when you install the DevSynth package.
+For most users installing from PyPI is sufficient:
 
 ```bash
 pip install devsynth
 ```
+
+You can also use `pipx` for an isolated environment:
+
+```bash
+pipx install devsynth
+```
+
+For development from source, use a Poetry-managed environment instead of pip.
 
 After installation, the `devsynth` command should be available in your terminal.
 

--- a/docs/user_guides/progressive_setup.md
+++ b/docs/user_guides/progressive_setup.md
@@ -18,12 +18,18 @@ This guide describes how to install DevSynth with minimal features and progressi
 
 ## Basic Installation
 
-1. Install DevSynth using `pip` or `pipx`:
+1. Install DevSynth from PyPI using `pip` or `pipx`:
 
    ```bash
    pip install devsynth
    # or
    pipx install devsynth
+   ```
+
+   For development from source, clone the repository and run:
+
+   ```bash
+   poetry install --with dev,docs
    ```
 
 2. Initialize a new project:

--- a/scripts/install_dev.sh
+++ b/scripts/install_dev.sh
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
-# Install DevSynth with development extras
-pip install -e '.[dev]'
+# Install DevSynth with development extras using Poetry
+poetry install --with dev,docs

--- a/tests/README.md
+++ b/tests/README.md
@@ -96,7 +96,7 @@ export DEVSYNTH_RESOURCE_CLI_AVAILABLE=true
 # Enable OpenAI integration
 export OPENAI_API_KEY=sk-your-key
 
-python -m pytest
+poetry run pytest
 ```
 
 ### Environment Variables for Tests
@@ -164,7 +164,7 @@ def test_that_needs_my_resource():
 To run all tests:
 
 ```bash
-python -m pytest
+poetry run pytest
 ```
 
 ### Environment Setup
@@ -172,40 +172,45 @@ python -m pytest
 Before running tests, you **must** install DevSynth with the development extras:
 
 ```bash
-pip install -e '.[dev]'
-# or
-poetry install
+poetry install --with dev,docs
 poetry sync --all-extras --all-groups
+
+# (Optional) install from PyPI instead
+pip install -e '.[dev]'
 ```
 
 For a minimal install you can use:
 
 ```bash
+poetry install --with dev,docs --extras retrieval
+# or using pip
 pip install -e '.[minimal,dev]'
 ```
 
 Optional backends such as **ChromaDB**, **FAISS**, or **LMDB** require extra packages:
 
 ```bash
+poetry install --extras retrieval
+# or install from PyPI
 pip install 'devsynth[retrieval]'
 ```
 
 To run tests for a specific type:
 
 ```bash
-python -m pytest tests/unit/
-python -m pytest tests/integration/
-python -m pytest tests/behavior/
+poetry run pytest tests/unit/
+poetry run pytest tests/integration/
+poetry run pytest tests/behavior/
 ```
 
 To run tests with verbose output:
 
 ```bash
-python -m pytest -v
+poetry run pytest -v
 ```
 
 To see which tests would be skipped due to missing resources:
 
 ```bash
-python -m pytest --collect-only -v
+poetry run pytest --collect-only -v
 ```


### PR DESCRIPTION
## Summary
- emphasize Poetry-managed development across docs
- clarify optional pip/pipx usage for PyPI installs
- document poetry-based testing commands
- adjust agent guidelines and install script accordingly

## Testing
- `poetry run pytest tests/` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_68598e28b1e08333bace52558113e75c