### PR TITLE
Update install docs for poetry workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,12 +96,10 @@ You can install DevSynth in a few different ways:
    # Install development and documentation dependencies
    poetry install --with dev,docs
    # Optionally include all extras
-   poetry install --all-extras --with dev,docs
-
-   # If you prefer pip or pipx, install from PyPI instead
-   pip install -e '.[dev]'        # editable mode
-   pip install -e '.[minimal,dev]'  # smaller core install
+   poetry sync --all-extras --all-groups
    ```
+
+   Use pip or pipx only when installing from PyPI.
 
 For more on Docker deployment, see the [Deployment Guide](docs/deployment/deployment_guide.md).
 
@@ -165,12 +163,11 @@ Before running the test suite, you **must** install DevSynth with its developmen
 
 ```bash
 poetry install --with dev,docs
-# or to install everything
-poetry install --all-extras --with dev,docs
-
-# (Optional) Install from PyPI instead
-pip install -e '.[dev]'
+# or install everything
+poetry sync --all-extras --all-groups
 ```
+
+Use pip only for installing from PyPI, not for local development.
 
 Some tests and features rely on optional backends like **Kuzu**, **FAISS**, and **LMDB**. Support for **ChromaDB** can be enabled later, but only the embedded backend is currently supported. Install these packages if you plan to use them:
 
@@ -184,8 +181,7 @@ For a smaller core install you can instead run:
 
 ```bash
 poetry install --with dev,docs --extras retrieval
-# or using pip
-pip install -e '.[minimal,dev,retrieval]'
+poetry sync --all-extras --all-groups
 ```
 
 After installation, execute the tests with:

--- a/docs/developer_guides/testing.md
+++ b/docs/developer_guides/testing.md
@@ -255,8 +255,7 @@ test dependencies are available:
 poetry install --with dev,docs
 poetry sync --all-extras --all-groups
 
-# (Optional) install from PyPI instead
-pip install -e '.[dev]'
+# pip commands are for installing from PyPI only
 ```
 
 ### Running All Tests

--- a/docs/getting_started/installation.md
+++ b/docs/getting_started/installation.md
@@ -43,8 +43,7 @@ poetry install --with dev,docs
 poetry sync --all-extras --all-groups
 poetry shell
 
-# (Optional) install via pip if you prefer
-pip install -e '.[dev]'
+# pip commands are for installing from PyPI only
 ```
 
 ### Running the Full Test Suite

--- a/docs/getting_started/quick_start_guide.md
+++ b/docs/getting_started/quick_start_guide.md
@@ -47,8 +47,7 @@ cd devsynth
 poetry install --with dev,docs
 poetry sync --all-extras --all-groups
 
-# (Optional) install via pip
-pip install -e '.[dev]'
+# pip commands are for installing from PyPI only
 
 # Activate the virtual environment
 poetry shell

--- a/tests/README.md
+++ b/tests/README.md
@@ -175,16 +175,14 @@ Before running tests, you **must** install DevSynth with the development extras:
 poetry install --with dev,docs
 poetry sync --all-extras --all-groups
 
-# (Optional) install from PyPI instead
-pip install -e '.[dev]'
+# pip commands are for installing from PyPI only
 ```
 
 For a minimal install you can use:
 
 ```bash
 poetry install --with dev,docs --extras retrieval
-# or using pip
-pip install -e '.[minimal,dev]'
+poetry sync --all-extras --all-groups
 ```
 
 Optional backends such as **ChromaDB**, **FAISS**, or **LMDB** require extra packages:


### PR DESCRIPTION
## Summary
- recommend `poetry install`/`poetry sync` instead of `pip install -e`
- mention that `pip` commands are only for PyPI installs

## Testing
- `poetry run pytest tests` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_68599ae065e88333a66748b584f47d6f