### PR TITLE
Update installation docs to highlight Poetry

### DIFF
--- a/docs/getting_started/installation.md
+++ b/docs/getting_started/installation.md
@@ -43,7 +43,9 @@ poetry install --with dev,docs
 poetry sync --all-extras --all-groups
 poetry shell
 
-# pip commands are for installing from PyPI only
+# Older instructions may reference `pip install -e '.[dev]'`. Use Poetry instead
+# to ensure a consistent virtual environment. Pip commands are only required for
+# installing from PyPI or via `pipx`.
 ```
 
 ### Running the Full Test Suite

--- a/docs/getting_started/quick_start_guide.md
+++ b/docs/getting_started/quick_start_guide.md
@@ -47,7 +47,9 @@ cd devsynth
 poetry install --with dev,docs
 poetry sync --all-extras --all-groups
 
-# pip commands are for installing from PyPI only
+# Older instructions may use `pip install -e '.[dev]'`. Prefer the Poetry
+# workflow above for a fully managed virtual environment. Pip commands are only
+# required for installing from PyPI or via `pipx`.
 
 # Activate the virtual environment
 poetry shell


### PR DESCRIPTION
## Summary
- clarify that Poetry should be used for local setup
- note replacement of `pip install -e '.[dev]'` with `poetry install`

## Testing
- `poetry run pytest tests/` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_6859b705fb848333bc05592594da6bec