### PR TITLE
Remove pip install from tests init

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -6,6 +6,12 @@ This directory contains tests for the DevSynth project, organized into different
 - **Integration Tests**: Tests for interactions between components (`tests/integration/`)
 - **Behavior Tests**: Tests for user-facing features using BDD (`tests/behavior/`)
 
+To execute the entire suite run:
+
+```bash
+poetry run pytest
+```
+
 ## Conditional Test Execution
 
 The test framework includes a mechanism for conditionally skipping tests based on resource availability. This is useful for tests that depend on external resources like LM Studio or other services that might not always be available.

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,29 +1,39 @@
 """DevSynth Test Package.
 
-This package ensures the test suite can import ``devsynth`` from the
-working tree.  If the package isn't already installed in editable mode,
-it installs it before tests are collected.  This mirrors the behaviour
-of CI workflows which call ``pip install -e '.[dev]'``.
+Ensure the ``devsynth`` package can be imported from the working tree
+without performing an editable ``pip install``.  CI installs the package
+normally, so local test runs should succeed if the sources are present or
+the package has been installed via Poetry.
 """
 
 from __future__ import annotations
 
-import subprocess
 import sys
 from pathlib import Path
 
+def _ensure_dev_synth_importable() -> None:
+    """Ensure ``devsynth`` can be imported from ``src`` or is installed."""
 
-def _ensure_editable_install() -> None:
-    """Install ``devsynth`` in editable mode if it's not available."""
-
-    try:  # pragma: no cover - minimal safety check
+    try:  # pragma: no cover - quick check
         import devsynth  # noqa: F401
         return
     except Exception:
         pass
 
     root = Path(__file__).resolve().parents[1]
-    subprocess.check_call([sys.executable, "-m", "pip", "install", "-e", str(root)])
+    src = root / "src"
+    if src.exists():
+        sys.path.insert(0, str(src))
+        try:
+            import devsynth  # noqa: F401
+            return
+        except Exception:
+            pass
+
+    raise RuntimeError(
+        "DevSynth is not installed and could not be imported from the 'src'\n"
+        "directory. Install the package with 'poetry install --with dev,docs --all-extras'"
+    )
 
 
-_ensure_editable_install()
+_ensure_dev_synth_importable()


### PR DESCRIPTION
## Summary
- simplify tests package setup to avoid running `pip install -e`
- document running tests with `poetry run pytest`

## Testing
- `poetry run pytest` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_6859f81d1d088333a9f294c45d06749d