### PR TITLE
Enable EDRR cycle results in pipeline workflow

### DIFF
--- a/src/devsynth/application/cli/cli_commands.py
+++ b/src/devsynth/application/cli/cli_commands.py
@@ -1,7 +1,7 @@
 import os
 import json
 from pathlib import Path
-from typing import Optional, Union, List
+from typing import Optional, Union, List, Dict, Any
 
 import yaml
 
@@ -197,16 +197,29 @@ def code_cmd(*, bridge: Optional[UXBridge] = None) -> None:
 
 
 def run_pipeline_cmd(
-    target: Optional[str] = None, *, bridge: Optional[UXBridge] = None
+    target: Optional[str] = None,
+    report: Optional[Dict[str, Any]] = None,
+    *,
+    bridge: Optional[UXBridge] = None,
 ) -> None:
     """Run the generated code or a specific target.
 
-    Example:
-        `devsynth run-pipeline --target unit-tests`
+    Parameters
+    ----------
+    target:
+        Execution target (e.g. ``unit-tests``).
+    report:
+        Optional report data that should be persisted with pipeline results.
+
+    Example
+    -------
+    ``devsynth run-pipeline --target unit-tests``
     """
     bridge = _resolve_bridge(bridge)
     try:
-        result = workflows.execute_command("run-pipeline", {"target": target})
+        result = workflows.execute_command(
+            "run-pipeline", {"target": target, "report": report}
+        )
         if result["success"]:
             if target:
                 bridge.display_result(f"[green]Executed target: {target}[/green]")

--- a/src/devsynth/application/cli/commands/edrr_cycle_cmd.py
+++ b/src/devsynth/application/cli/commands/edrr_cycle_cmd.py
@@ -13,6 +13,7 @@ from devsynth.application.code_analysis.ast_transformer import AstTransformer
 from devsynth.application.prompts.prompt_manager import PromptManager
 from devsynth.application.documentation.documentation_manager import DocumentationManager
 from devsynth.application.edrr.coordinator import EDRRCoordinator
+from devsynth.core import run_pipeline
 from devsynth.methodology.base import Phase
 from devsynth.logging_setup import DevSynthLogger
 from devsynth.exceptions import DevSynthError
@@ -70,6 +71,12 @@ def edrr_cycle_cmd(manifest: str, auto: bool = True) -> None:
             Phase.RETROSPECT.value,
             {"cycle_id": coordinator.cycle_id},
         )
+
+        # Persist report through the standard pipeline workflow
+        try:
+            run_pipeline(report=final_report)
+        except Exception as pipeline_err:  # pragma: no cover - best effort
+            logger.error(f"Failed to persist report via pipeline: {pipeline_err}")
 
         bridge.print(
             f"[green]EDRR cycle completed.[/green] Results stored with id {result_id}"

--- a/src/devsynth/core/workflows.py
+++ b/src/devsynth/core/workflows.py
@@ -40,9 +40,21 @@ def generate_code() -> Dict[str, Any]:
     return execute_command("code", {})
 
 
-def run_pipeline(target: str | None = None) -> Dict[str, Any]:
-    """Execute the generated code or a specific target."""
-    return execute_command("run-pipeline", filter_args({"target": target}))
+def run_pipeline(target: str | None = None, report: Dict[str, Any] | None = None) -> Dict[str, Any]:
+    """Execute the generated code or a specific target.
+
+    Parameters
+    ----------
+    target:
+        Specific execution target such as ``unit-tests``.
+    report:
+        Optional report data to persist alongside pipeline results.
+    """
+
+    return execute_command(
+        "run-pipeline",
+        filter_args({"target": target, "report": report}),
+    )
 
 
 def update_config(

--- a/tests/unit/application/edrr/test_phase_progression.py
+++ b/tests/unit/application/edrr/test_phase_progression.py
@@ -88,3 +88,23 @@ def test_micro_cycle_result_aggregation(coordinator):
         assert stored["task"] == {"description": "Micro"}
         for key, value in micro_cycle.results.items():
             assert stored[key] == value
+
+
+def test_result_aggregation_after_full_cycle(coordinator):
+    """All phase results should be aggregated after auto progression."""
+    with patch.object(
+        coordinator, "_execute_expand_phase", return_value={"expand": True, "phase_complete": True}
+    ), patch.object(
+        coordinator, "_execute_differentiate_phase", return_value={"differentiate": True, "phase_complete": True}
+    ), patch.object(
+        coordinator, "_execute_refine_phase", return_value={"refine": True, "phase_complete": True}
+    ), patch.object(
+        coordinator, "_execute_retrospect_phase", return_value={"retrospect": True, "phase_complete": True}
+    ):
+        coordinator.start_cycle({"description": "Task"})
+
+    aggregated = coordinator.results.get("AGGREGATED", {})
+    assert aggregated["expand"]["expand"] is True
+    assert aggregated["differentiate"]["differentiate"] is True
+    assert aggregated["refine"]["refine"] is True
+    assert aggregated["retrospect"]["retrospect"] is True

--- a/tests/unit/test_core_workflows.py
+++ b/tests/unit/test_core_workflows.py
@@ -34,8 +34,8 @@ def test_filter_args_removes_none_values():
         (
             workflows.run_pipeline,
             "run-pipeline",
-            {"target": "build"},
-            {"target": "build"},
+            {"target": "build", "report": None},
+            {"target": "build", "report": None},
         ),
         (
             workflows.update_config,

--- a/tests/unit/test_unit_cli_commands.py
+++ b/tests/unit/test_unit_cli_commands.py
@@ -175,7 +175,7 @@ class TestCLICommands:
 
         # Verify
         mock_workflow_manager.assert_called_once_with(
-            "run-pipeline", {"target": "unit-tests"}
+            "run-pipeline", {"target": "unit-tests", "report": None}
         )
         mock_bridge.display_result.assert_called_once_with(
             "[green]Executed target: unit-tests[/green]"
@@ -195,7 +195,9 @@ class TestCLICommands:
         run_pipeline_cmd()
 
         # Verify
-        mock_workflow_manager.assert_called_once_with("run-pipeline", {"target": None})
+        mock_workflow_manager.assert_called_once_with(
+            "run-pipeline", {"target": None, "report": None}
+        )
         mock_bridge.display_result.assert_called_once_with(
             "[green]Execution complete.[/green]"
         )


### PR DESCRIPTION
## Summary
- ensure `edrr_cycle_cmd` saves results to the pipeline workflow
- allow `run_pipeline_cmd` to accept and forward report data
- expose optional `report` parameter in core `run_pipeline`
- test full result aggregation and CLI integration

## Testing
- `poetry run pytest tests/unit/application/edrr -q`

------
https://chatgpt.com/codex/tasks/task_e_685a01399d8883339f022b22f14ac4af