### PR TITLE
Add micro cycle termination test

### DIFF
--- a/tests/unit/application/edrr/test_edrr_coordinator.py
+++ b/tests/unit/application/edrr/test_edrr_coordinator.py
@@ -522,3 +522,12 @@ class TestEDRRCoordinator:
         history_len = len(coordinator.get_execution_history())
         coordinator.progress_to_phase(Phase.DIFFERENTIATE)
         assert len(coordinator.get_execution_history()) > history_len
+
+    def test_create_micro_cycle_triggers_termination(self, coordinator):
+        """Ensure micro cycle is not created when granularity threshold triggers termination."""
+        coordinator.start_cycle({"description": "Macro"})
+        micro_task = {"description": "Sub", "granularity_score": 0.1}
+        assert coordinator.should_terminate_recursion(micro_task) is True
+        with pytest.raises(EDRRCoordinatorError):
+            coordinator.create_micro_cycle(micro_task, Phase.EXPAND)
+        assert not coordinator.child_cycles


### PR DESCRIPTION
## Summary
- ensure micro cycle creation aborts when granularity threshold triggers termination

## Testing
- `poetry run pytest -q` *(fails: ModuleNotFoundError: No module named 'devsynth.application.memory.knowledge_graph_utils')*

------
https://chatgpt.com/codex/tasks/task_e_685a16eacb908333b3351e4c84c5b5e8