### PR TITLE
Add primus expertise and routing tests

### DIFF
--- a/tests/integration/test_delegate_task_primus_selection.py
+++ b/tests/integration/test_delegate_task_primus_selection.py
@@ -1,0 +1,36 @@
+import types
+from unittest.mock import MagicMock, patch
+
+from devsynth.application.collaboration.coordinator import AgentCoordinatorImpl
+
+
+class SimpleAgent:
+    def __init__(self, name, agent_type, expertise):
+        self.name = name
+        self.agent_type = agent_type
+        self.current_role = None
+        self.expertise = expertise
+        self.config = types.SimpleNamespace(name=name, parameters={})
+        self.process = MagicMock(return_value={"solution": name})
+
+
+def test_delegate_task_calls_select_primus_by_expertise_and_updates_primus():
+    coordinator = AgentCoordinatorImpl({"features": {"wsde_collaboration": True}})
+    doc = SimpleAgent("doc", "docs", ["documentation", "markdown"])
+    coder = SimpleAgent("coder", "code", ["python"])
+    coordinator.add_agent(doc)
+    coordinator.add_agent(coder)
+
+    consensus = {"consensus": "x", "contributors": ["doc", "coder"], "method": "consensus_synthesis"}
+    with patch.object(coordinator.team, "build_consensus", return_value=consensus), \
+         patch.object(coordinator.team, "select_primus_by_expertise", wraps=coordinator.team.select_primus_by_expertise) as spy:
+        result1 = coordinator.delegate_task({"team_task": True, "type": "coding", "language": "python"})
+        first_primus = coordinator.team.get_primus().name
+        result2 = coordinator.delegate_task({"team_task": True, "type": "documentation"})
+        second_primus = coordinator.team.get_primus().name
+
+    assert spy.call_count == 2
+    assert first_primus == "coder"
+    assert second_primus == "doc"
+    assert result1["method"] == "consensus_synthesis"
+    assert result2["method"] == "consensus_synthesis"

--- a/tests/unit/domain/test_wsde_team.py
+++ b/tests/unit/domain/test_wsde_team.py
@@ -83,6 +83,36 @@ def test_build_consensus_multiple_and_single(team_with_agents):
     assert consensus["method"] == "consensus_synthesis"
     assert set(consensus["contributors"]) == {doc.name, coder.name}
 
+
+def test_documentation_task_selects_unused_doc_agent(team_with_agents):
+    team, doc, coder, tester = team_with_agents
+    team.select_primus_by_expertise({"type": "coding", "language": "python"})
+    assert team.get_primus() is coder
+
+    team.select_primus_by_expertise({"type": "documentation"})
+    assert team.get_primus() is doc
+
+
+def test_rotation_resets_after_all_have_served(team_with_agents):
+    team, doc, coder, tester = team_with_agents
+
+    team.select_primus_by_expertise({"type": "documentation"})
+    assert team.get_primus() is doc
+
+    team.select_primus_by_expertise({"type": "coding", "language": "python"})
+    assert team.get_primus() is coder
+
+    team.select_primus_by_expertise({"type": "testing"})
+    assert team.get_primus() is tester
+
+    assert all(a.has_been_primus for a in [doc, coder, tester])
+
+    team.select_primus_by_expertise({"type": "documentation"})
+    assert team.get_primus() is doc
+    assert doc.has_been_primus
+    assert not coder.has_been_primus
+    assert not tester.has_been_primus
+
 def test_force_wsde_coverage():
     import pathlib
     base = pathlib.Path(__file__).resolve().parents[3]


### PR DESCRIPTION
## Summary
- extend WSDE team unit tests for documentation preference and primus rotation
- add integration test verifying delegate_task uses select_primus_by_expertise

## Testing
- `poetry run pytest tests/unit/domain/test_wsde_team.py::test_documentation_task_selects_unused_doc_agent -q`
- `poetry run pytest tests/unit/domain/test_wsde_team.py::test_rotation_resets_after_all_have_served -q`
- `poetry run pytest tests/integration/test_delegate_task_primus_selection.py::test_delegate_task_calls_select_primus_by_expertise_and_updates_primus -q`

------
https://chatgpt.com/codex/tasks/task_e_685a1eb6102883338b10cc93bdc47fa4