### PR TITLE
Extend team consensus test

### DIFF
--- a/tests/integration/test_delegate_task_consensus.py
+++ b/tests/integration/test_delegate_task_consensus.py
@@ -4,29 +4,41 @@ from unittest.mock import MagicMock, patch
 from devsynth.application.collaboration.coordinator import AgentCoordinatorImpl
 
 class SimpleAgent:
-    def __init__(self, name, agent_type):
+    def __init__(self, name, agent_type, expertise=None):
         self.name = name
         self.agent_type = agent_type
         self.current_role = None
-        self.expertise = []
+        self.expertise = expertise or []
         self.process = MagicMock(return_value={"solution": f"{name}-sol"})
         self.config = types.SimpleNamespace(name=name, parameters={})
 
 
 def test_delegate_task_team_consensus():
     coordinator = AgentCoordinatorImpl({"features": {"wsde_collaboration": True}})
-    a1 = SimpleAgent("planner", "planner")
-    a2 = SimpleAgent("coder", "code")
-    for a in [a1, a2]:
+
+    planner = SimpleAgent("planner", "planner", ["planning"])
+    coder = SimpleAgent("coder", "code", ["python"])
+    writer = SimpleAgent("writer", "docs", ["documentation"])
+
+    for a in [planner, coder, writer]:
         coordinator.add_agent(a)
 
-    consensus = {"consensus": "final", "contributors": ["planner", "coder"], "method": "consensus_synthesis"}
+    def fake_consensus(_task):
+        primus_name = coordinator.team.get_primus().name
+        return {
+            "consensus": "final",
+            "contributors": [primus_name, writer.name],
+            "method": "consensus_synthesis",
+        }
 
-    with patch.object(coordinator.team, "build_consensus", return_value=consensus):
-        result = coordinator.delegate_task({"team_task": True, "action": "do"})
+    with patch.object(coordinator.team, "build_consensus", side_effect=fake_consensus):
+        result = coordinator.delegate_task({"team_task": True, "type": "coding", "language": "python"})
 
-    assert result["team_result"]["consensus"] == consensus
-    assert result["contributors"] == ["planner", "coder"]
+    primus = coordinator.team.get_primus()
+    assert primus == coder
+    assert coordinator.team.primus_index == coordinator.team.agents.index(coder)
+    assert primus.name in result["team_result"]["consensus"]["contributors"]
+    assert result["contributors"] == [coder.name, writer.name]
     assert result["method"] == "consensus_synthesis"
     assert result["result"] == "final"
-    assert len(result["team_result"]["solutions"]) == 2
+    assert len(result["team_result"]["solutions"]) == 3


### PR DESCRIPTION
## Summary
- verify that Primus selection uses expertise
- ensure consensus contributors include the Primus agent

## Testing
- `poetry run pytest tests/integration/test_delegate_task_consensus.py -q`
- `poetry run pytest tests/` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_685abefe344c83339b465421214f1595