### PR TITLE
Add WSDETeam voting tests

### DIFF
--- a/tests/unit/test_wsde_voting.py
+++ b/tests/unit/test_wsde_voting.py
@@ -1,0 +1,77 @@
+"""Tests for WSDETeam voting mechanisms."""
+
+from unittest.mock import MagicMock, patch
+
+from devsynth.domain.models.wsde import WSDETeam
+
+
+def _make_agent(name: str, vote: str, expertise=None, level="novice"):
+    agent = MagicMock()
+    agent.name = name
+    agent.config = MagicMock()
+    agent.config.name = name
+    params = {}
+    if expertise:
+        params["expertise"] = expertise
+    params["expertise_level"] = level
+    agent.config.parameters = params
+    agent.process = MagicMock(return_value={"vote": vote})
+    return agent
+
+
+def _basic_task():
+    return {
+        "type": "critical_decision",
+        "description": "choose option",
+        "options": [
+            {"id": "option1"},
+            {"id": "option2"},
+            {"id": "option3"},
+        ],
+        "is_critical": True,
+    }
+
+
+def test_majority_vote_with_three_unique_choices():
+    team = WSDETeam()
+    a1 = _make_agent("a1", "option1")
+    a2 = _make_agent("a2", "option2")
+    a3 = _make_agent("a3", "option3")
+    team.add_agents([a1, a2, a3])
+
+    task = _basic_task()
+    with patch.object(team, "build_consensus", return_value={"consensus": ""}):
+        result = team.vote_on_critical_decision(task)
+
+    assert result["result"]["method"] == "tied_vote"
+    assert set(result["result"]["tied_options"]) == {"option1", "option2", "option3"}
+
+
+def test_tie_triggers_handle_tied_vote():
+    team = WSDETeam()
+    a1 = _make_agent("a1", "option1")
+    a2 = _make_agent("a2", "option2")
+    team.add_agents([a1, a2])
+
+    task = _basic_task()
+    with (
+        patch.object(team, "build_consensus", return_value={"consensus": ""}),
+        patch.object(team, "_handle_tied_vote", wraps=team._handle_tied_vote) as mocked,
+    ):
+        team.vote_on_critical_decision(task)
+        mocked.assert_called_once()
+
+
+def test_weighted_voting_prefers_expert_vote():
+    team = WSDETeam()
+    expert = _make_agent("expert", "option2", ["security"], level="expert")
+    novice1 = _make_agent("novice1", "option1", ["security"], level="novice")
+    novice2 = _make_agent("novice2", "option1", ["security"], level="novice")
+    team.add_agents([expert, novice1, novice2])
+
+    task = _basic_task()
+    task["domain"] = "security"
+    result = team.vote_on_critical_decision(task)
+
+    assert result["result"]["method"] == "weighted_vote"
+    assert result["result"]["winner"] == "option2"


### PR DESCRIPTION
## Summary
- add unit tests covering majority, tie and weighted voting behaviors

## Testing
- `poetry run pytest tests/unit/test_wsde_voting.py -q`

------
https://chatgpt.com/codex/tasks/task_e_685ad4bf2cbc83339dd622733ce771a3