### PR TITLE
Use UnifiedConfigLoader across CLI

### DIFF
--- a/src/devsynth/application/cli/commands/doctor_cmd.py
+++ b/src/devsynth/application/cli/commands/doctor_cmd.py
@@ -1,7 +1,7 @@
 from pathlib import Path
 from rich.console import Console
 from devsynth.logging_setup import DevSynthLogger
-from devsynth.config.loader import load_config
+from devsynth.config.unified_loader import UnifiedConfigLoader
 from devsynth.interface.cli import CLIUXBridge
 from devsynth.interface.ux_bridge import UXBridge
 import importlib.util
@@ -20,16 +20,11 @@ def doctor_cmd(config_dir: str = "config") -> None:
         `devsynth doctor --config-dir ./config`
     """
     try:
-        # Ensure project configuration is present
-        cfg_path_yaml = Path(".devsynth/devsynth.yml")
-        cfg_path_toml = Path("pyproject.toml")
-        if not cfg_path_yaml.exists() and not cfg_path_toml.exists():
+        config = UnifiedConfigLoader.load()
+        if not config.exists():
             bridge.print(
                 "[yellow]No project configuration found. Run 'devsynth init' to create it.[/yellow]"
             )
-
-        # Load project configuration with the unified loader
-        load_config()
 
         warnings = False
 
@@ -62,7 +57,9 @@ def doctor_cmd(config_dir: str = "config") -> None:
         for env in envs:
             cfg_path = Path(config_dir) / f"{env}.yml"
             if not cfg_path.exists():
-                bridge.print(f"[yellow]Warning: configuration file not found: {cfg_path}[/yellow]")
+                bridge.print(
+                    f"[yellow]Warning: configuration file not found: {cfg_path}[/yellow]"
+                )
                 warnings = True
                 continue
 

--- a/tests/unit/application/cli/test_config_validation.py
+++ b/tests/unit/application/cli/test_config_validation.py
@@ -28,7 +28,9 @@ def test_config_warnings(tmp_path, monkeypatch):
     config_dir.mkdir()
 
     # intentionally incomplete config to trigger validation errors
-    (config_dir / "default.yml").write_text("application: {name: App, version: '1.0'}\n")
+    (config_dir / "default.yml").write_text(
+        "application: {name: App, version: '1.0'}\n"
+    )
 
     real_spec = doctor_cmd.importlib.util.spec_from_file_location
 
@@ -36,7 +38,13 @@ def test_config_warnings(tmp_path, monkeypatch):
         path = Path(__file__).parents[4] / "scripts" / "validate_config.py"
         return real_spec(name, path, *args, **kwargs)
 
-    with patch.object(doctor_cmd.importlib.util, "spec_from_file_location", side_effect=fake_spec), patch.object(doctor_cmd, "load_config"), patch.object(doctor_cmd.bridge, "print") as mock_print:
+    with (
+        patch.object(
+            doctor_cmd.importlib.util, "spec_from_file_location", side_effect=fake_spec
+        ),
+        patch.object(doctor_cmd.UnifiedConfigLoader, "load"),
+        patch.object(doctor_cmd.bridge, "print") as mock_print,
+    ):
         doctor_cmd.doctor_cmd(str(config_dir))
         output = "".join(str(c.args[0]) for c in mock_print.call_args_list)
         assert "Configuration issues detected" in output
@@ -95,7 +103,13 @@ def test_config_success(tmp_path, monkeypatch):
         path = Path(__file__).parents[4] / "scripts" / "validate_config.py"
         return real_spec(name, path, *args, **kwargs)
 
-    with patch.object(doctor_cmd.importlib.util, "spec_from_file_location", side_effect=fake_spec), patch.object(doctor_cmd, "load_config"), patch.object(doctor_cmd.bridge, "print") as mock_print:
+    with (
+        patch.object(
+            doctor_cmd.importlib.util, "spec_from_file_location", side_effect=fake_spec
+        ),
+        patch.object(doctor_cmd.UnifiedConfigLoader, "load"),
+        patch.object(doctor_cmd.bridge, "print") as mock_print,
+    ):
         doctor_cmd.doctor_cmd(str(config_dir))
         output = "".join(str(c.args[0]) for c in mock_print.call_args_list)
         assert "All configuration files are valid" in output

--- a/tests/unit/application/cli/test_doctor_cmd.py
+++ b/tests/unit/application/cli/test_doctor_cmd.py
@@ -21,9 +21,11 @@ spec.loader.exec_module(doctor_cmd)  # type: ignore
 
 
 def test_python_version_warning():
-    with patch.object(doctor_cmd, "load_config"), patch.object(
-        doctor_cmd.sys, "version_info", (3, 10, 0)
-    ), patch.object(doctor_cmd.bridge, "print") as mock_print:
+    with (
+        patch.object(doctor_cmd.UnifiedConfigLoader, "load"),
+        patch.object(doctor_cmd.sys, "version_info", (3, 10, 0)),
+        patch.object(doctor_cmd.bridge, "print") as mock_print,
+    ):
         doctor_cmd.doctor_cmd("config")
         assert any(
             "Python 3.11 or higher" in str(call.args[0])
@@ -34,10 +36,10 @@ def test_python_version_warning():
 def test_missing_api_keys_warning(monkeypatch):
     monkeypatch.delenv("OPENAI_API_KEY", raising=False)
     monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
-    with patch.object(doctor_cmd, "load_config"), patch.object(
-        doctor_cmd.bridge, "print"
-    ) as mock_print:
+    with (
+        patch.object(doctor_cmd.UnifiedConfigLoader, "load"),
+        patch.object(doctor_cmd.bridge, "print") as mock_print,
+    ):
         doctor_cmd.doctor_cmd("config")
         output = "".join(str(c.args[0]) for c in mock_print.call_args_list)
         assert "OPENAI_API_KEY" in output and "ANTHROPIC_API_KEY" in output
-


### PR DESCRIPTION
## Summary
- consolidate config handling by switching `doctor_cmd` to `UnifiedConfigLoader`
- update tests to patch the unified loader
- add regression test ensuring `init_cmd` writes config and later commands load it

## Testing
- `poetry run pytest tests/unit/test_unit_cli_commands.py::TestCLICommands::test_init_creates_config_and_commands_use_loader -q`
- `poetry run pytest tests/unit/application/cli/test_doctor_cmd.py tests/unit/application/cli/test_config_validation.py tests/unit/test_unit_cli_commands.py::TestCLICommands::test_doctor_cmd_invokes_loader -q`
- `poetry run pytest tests -q` *(fails: ModuleNotFoundError: No module named 'devsynth.application.memory.knowledge_graph_utils')*

------
https://chatgpt.com/codex/tasks/task_e_685ae18fb50c8333a4592ccfd76b9ee8