### PR TITLE
Add serve command BDD scenario

### DIFF
--- a/tests/behavior/features/cli_commands.feature
+++ b/tests/behavior/features/cli_commands.feature
@@ -100,3 +100,7 @@ Scenario: Validate environment configuration
   When I run the command "devsynth doctor"
   Then the system should display a warning message
   And the output should indicate configuration errors
+
+Scenario: Serve API on custom port
+  When I run the command "devsynth serve --port 8081"
+  Then uvicorn should be called with host "0.0.0.0" and port 8081

--- a/tests/behavior/test_cli_commands.py
+++ b/tests/behavior/test_cli_commands.py
@@ -1,6 +1,7 @@
 """
 Test file for CLI Command Execution feature.
 """
+
 import os
 import pytest
 from pytest_bdd import scenario, given, when, then, parsers
@@ -15,92 +16,119 @@ from .steps.doctor_command_steps import *
 cli_available = pytest.mark.requires_resource("cli")
 
 # Define the feature file path
-FEATURE_FILE = os.path.join(os.path.dirname(__file__), 'features', 'cli_commands.feature')
-EDRR_FEATURE = os.path.join(os.path.dirname(__file__), 'features', 'edrr_cycle.feature')
-DELEGATE_FEATURE = os.path.join(os.path.dirname(__file__), 'features', 'delegate_task.feature')
-DOCTOR_FEATURE = os.path.join(os.path.dirname(__file__), 'features', 'doctor_command.feature')
+FEATURE_FILE = os.path.join(
+    os.path.dirname(__file__), "features", "cli_commands.feature"
+)
+EDRR_FEATURE = os.path.join(os.path.dirname(__file__), "features", "edrr_cycle.feature")
+DELEGATE_FEATURE = os.path.join(
+    os.path.dirname(__file__), "features", "delegate_task.feature"
+)
+DOCTOR_FEATURE = os.path.join(
+    os.path.dirname(__file__), "features", "doctor_command.feature"
+)
+
 
 # Create a scenario for each scenario in the feature file
 @cli_available
-@scenario(FEATURE_FILE, 'Display help information')
+@scenario(FEATURE_FILE, "Display help information")
 def test_display_help():
     """Test displaying help information."""
     pass
 
+
 @cli_available
-@scenario(FEATURE_FILE, 'Initialize a project with path parameter')
+@scenario(FEATURE_FILE, "Initialize a project with path parameter")
 def test_init_with_path():
     """Test initializing a project with a path parameter."""
     pass
 
+
 @cli_available
-@scenario(FEATURE_FILE, 'Generate specifications with custom requirements file')
+@scenario(FEATURE_FILE, "Generate specifications with custom requirements file")
 def test_generate_specs():
     """Test generating specifications with a custom requirements file."""
     pass
 
+
 @cli_available
-@scenario(FEATURE_FILE, 'Generate tests with custom specification file')
+@scenario(FEATURE_FILE, "Generate tests with custom specification file")
 def test_generate_tests():
     """Test generating tests with a custom specification file."""
     pass
 
+
 @cli_available
-@scenario(FEATURE_FILE, 'Generate code without parameters')
+@scenario(FEATURE_FILE, "Generate code without parameters")
 def test_generate_code():
     """Test generating code without parameters."""
     pass
 
+
 @cli_available
-@scenario(FEATURE_FILE, 'Run with specific target')
+@scenario(FEATURE_FILE, "Run with specific target")
 def test_run_with_target():
     """Test running with a specific target."""
     pass
 
+
 @cli_available
-@scenario(FEATURE_FILE, 'Configure with key and value')
+@scenario(FEATURE_FILE, "Configure with key and value")
 def test_configure_key_value():
     """Test configuring with a key and value."""
     pass
 
+
 @cli_available
-@scenario(FEATURE_FILE, 'View configuration for specific key')
+@scenario(FEATURE_FILE, "View configuration for specific key")
 def test_view_config_key():
     """Test viewing configuration for a specific key."""
     pass
 
+
 @cli_available
-@scenario(FEATURE_FILE, 'View all configuration')
+@scenario(FEATURE_FILE, "View all configuration")
 def test_view_all_config():
     """Test viewing all configuration."""
     pass
 
+
 @cli_available
-@scenario(FEATURE_FILE, 'Handle invalid command')
+@scenario(FEATURE_FILE, "Handle invalid command")
 def test_handle_invalid_command():
     """Test handling an invalid command."""
     pass
 
+
 @cli_available
-@scenario(EDRR_FEATURE, 'Run EDRR cycle with manifest file')
+@scenario(EDRR_FEATURE, "Run EDRR cycle with manifest file")
 def test_edrr_cycle_with_manifest():
     """Test running the edrr-cycle command with a manifest."""
     pass
 
+
 @cli_available
-@scenario(EDRR_FEATURE, 'Handle missing manifest file')
+@scenario(EDRR_FEATURE, "Handle missing manifest file")
 def test_edrr_cycle_missing_manifest():
     """Test running the edrr-cycle command with a missing manifest file."""
     pass
 
+
 @cli_available
-@scenario(DELEGATE_FEATURE, 'Delegate a team task to multiple agents')
+@scenario(DELEGATE_FEATURE, "Delegate a team task to multiple agents")
 def test_delegate_task_multi_agent():
     """Test delegating a collaborative task to multiple agents."""
     pass
 
+
 @cli_available
-@scenario(DOCTOR_FEATURE, 'Validate configuration using the check alias')
+@scenario(DOCTOR_FEATURE, "Validate configuration using the check alias")
 def test_doctor_check_alias():
     """Test doctor command via the check alias."""
+    pass
+
+
+@cli_available
+@scenario(FEATURE_FILE, "Serve API on custom port")
+def test_serve_custom_port():
+    """Test serving the API on a custom port."""
     pass


### PR DESCRIPTION
## Summary
- expand feature coverage for CLI serve command
- call `uvicorn.run` with custom host/port in step definitions
- verify `uvicorn.run` invocation
- test scenario wiring in CLI behavior tests

## Testing
- `poetry run pytest tests/behavior/test_cli_commands.py::test_serve_custom_port -q`

------
https://chatgpt.com/codex/tasks/task_e_685b0494832c83339d0cfa1b2dc26892