### PR TITLE
Add sanitization tests for UX bridges

### DIFF
--- a/tests/unit/interface/test_uxbridge_sanitization.py
+++ b/tests/unit/interface/test_uxbridge_sanitization.py
@@ -1,0 +1,44 @@
+import sys
+from types import ModuleType
+from unittest.mock import MagicMock, patch
+
+from devsynth.interface.cli import CLIUXBridge
+from devsynth.interface.agentapi import APIBridge
+
+
+def _mock_streamlit(monkeypatch):
+    st = ModuleType("streamlit")
+    st.write = MagicMock()
+    st.markdown = MagicMock()
+    st.text_input = MagicMock(return_value="t")
+    st.selectbox = MagicMock(return_value="c")
+    st.checkbox = MagicMock(return_value=True)
+    monkeypatch.setitem(sys.modules, "streamlit", st)
+    return st
+
+
+def test_cliuxbridge_sanitizes_display_result():
+    bridge = CLIUXBridge()
+    with patch("rich.console.Console.print") as out:
+        bridge.display_result("<script>")
+        out.assert_called_once_with("&lt;script&gt;", highlight=False)
+
+
+def test_apibridge_sanitizes_display_result():
+    bridge = APIBridge()
+    bridge.display_result("<script>")
+    assert bridge.messages == ["&lt;script&gt;"]
+
+
+def test_webui_sanitizes_display_result(monkeypatch):
+    st = _mock_streamlit(monkeypatch)
+
+    import importlib
+    import devsynth.interface.webui as webui
+
+    importlib.reload(webui)
+    from devsynth.interface.webui import WebUI
+
+    bridge = WebUI()
+    bridge.display_result("<script>")
+    st.write.assert_called_once_with("&lt;script&gt;")


### PR DESCRIPTION
## Summary
- cover UXBridge HTML escaping across CLIUXBridge, APIBridge and WebUI

## Testing
- `poetry run pytest tests/unit/interface/test_uxbridge_sanitization.py -q`

------
https://chatgpt.com/codex/tasks/task_e_685b07e880548333a7e39d0a7530ef47