### PR TITLE
Add UnifiedConfigLoader file detection tests

### DIFF
--- a/tests/unit/core/test_unified_config_loader.py
+++ b/tests/unit/core/test_unified_config_loader.py
@@ -1,0 +1,21 @@
+from devsynth.config.unified_loader import UnifiedConfigLoader
+
+
+def test_unified_loader_detects_yaml(tmp_path):
+    """use_pyproject is False when only YAML config exists."""
+    cfg_dir = tmp_path / ".devsynth"
+    cfg_dir.mkdir()
+    (cfg_dir / "devsynth.yml").write_text("language: python\n")
+
+    unified = UnifiedConfigLoader.load(tmp_path)
+
+    assert not unified.use_pyproject
+
+
+def test_unified_loader_detects_pyproject(tmp_path):
+    """use_pyproject is True when pyproject.toml exists."""
+    (tmp_path / "pyproject.toml").write_text("[tool.devsynth]\nlanguage = 'go'\n")
+
+    unified = UnifiedConfigLoader.load(tmp_path)
+
+    assert unified.use_pyproject


### PR DESCRIPTION
## Summary
- add unit tests for UnifiedConfigLoader

## Testing
- `poetry run pytest tests/unit/core/test_unified_config_loader.py -q`
- `poetry run pytest tests/unit/core/test_unified_config_loader.py -q`

------
https://chatgpt.com/codex/tasks/task_e_685b2b0f897c8333b78e8e1b3d28648e