### PR TITLE
Add doctor command edge case tests

### DIFF
--- a/tests/behavior/features/doctor_command.feature
+++ b/tests/behavior/features/doctor_command.feature
@@ -22,3 +22,14 @@ Feature: Doctor Command
     Given valid environment configuration
     When I run the command "devsynth check"
     Then the system should display a success message
+
+  Scenario: Warn when essential environment variables are missing
+    Given essential environment variables are missing
+    When I run the command "devsynth doctor"
+    Then the output should mention the missing variables
+
+  Scenario: Warn about invalid YAML files in the config directory
+    Given a config directory with invalid YAML
+    When I run the command "devsynth doctor"
+    Then the system should display a warning message
+    And the output should indicate configuration errors

--- a/tests/behavior/steps/doctor_command_steps.py
+++ b/tests/behavior/steps/doctor_command_steps.py
@@ -1,6 +1,6 @@
 """Step definitions for doctor_command.feature."""
 
-from pytest_bdd import scenarios, when
+from pytest_bdd import given, scenarios, then, when
 
 from .cli_commands_steps import run_command
 
@@ -10,4 +10,30 @@ scenarios("../features/doctor_command.feature")
 @when('I run the command "devsynth check"')
 def run_check_alias(monkeypatch, mock_workflow_manager, command_context):
     """Invoke the doctor command via its check alias."""
-    return run_command("devsynth check", monkeypatch, mock_workflow_manager, command_context)
+    return run_command(
+        "devsynth check", monkeypatch, mock_workflow_manager, command_context
+    )
+
+
+@given("essential environment variables are missing")
+def missing_env_vars(monkeypatch):
+    """Remove environment variables required by the doctor command."""
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.delenv("LM_STUDIO_ENDPOINT", raising=False)
+
+
+@then("the output should mention the missing variables")
+def output_mentions_missing_vars(command_context):
+    """Check that the command output references the missing variables."""
+    output = command_context.get("output", "")
+    assert "OPENAI_API_KEY" in output or "LM_STUDIO_ENDPOINT" in output
+
+
+@given("a config directory with invalid YAML")
+def config_dir_with_invalid_yaml(tmp_path, monkeypatch):
+    """Create a temporary config directory containing malformed YAML."""
+    config_path = tmp_path / "config"
+    config_path.mkdir()
+    (config_path / "development.yml").write_text("invalid: [unclosed")
+    monkeypatch.chdir(tmp_path)
+    return config_path

--- a/tests/behavior/test_doctor_command.py
+++ b/tests/behavior/test_doctor_command.py
@@ -1,6 +1,9 @@
+import pytest
 from pytest_bdd import scenarios
 
-from .steps.cli_commands_steps import *
-from .steps.doctor_command_steps import *
+from .steps.cli_commands_steps import *  # noqa: F401,F403
+from .steps.doctor_command_steps import *  # noqa: F401,F403
 
-scenarios('features/doctor_command.feature')
+pytestmark = pytest.mark.requires_resource("cli")
+
+scenarios("features/doctor_command.feature")


### PR DESCRIPTION
## Summary
- extend `doctor_command.feature` with missing env and invalid YAML scenarios
- implement new steps in `doctor_command_steps.py`
- mark doctor command tests with `requires_resource('cli')`

## Testing
- `poetry run pytest tests/behavior/test_doctor_command.py -vv`

------
https://chatgpt.com/codex/tasks/task_e_685b2d3faabc8333b49be94e7ed55ab5