### PR TITLE
Add HTML escaping test for CLIUXBridge

### DIFF
--- a/tests/unit/interface/test_output_sanitization.py
+++ b/tests/unit/interface/test_output_sanitization.py
@@ -1,9 +1,9 @@
+import sys
 from types import ModuleType
 from unittest.mock import MagicMock, patch
-import sys
 
-from devsynth.interface.cli import CLIUXBridge
 from devsynth.interface.agentapi import APIBridge
+from devsynth.interface.cli import CLIUXBridge
 
 
 def test_cliuxbridge_sanitizes_output():
@@ -11,6 +11,14 @@ def test_cliuxbridge_sanitizes_output():
     with patch("rich.console.Console.print") as out:
         bridge.display_result("<script>alert('x')</script>Hello")
         out.assert_called_once_with("Hello", highlight=False)
+
+
+def test_cliuxbridge_escapes_html():
+    """Ensure raw HTML is escaped before printing to the console."""
+    bridge = CLIUXBridge()
+    with patch("rich.console.Console.print") as out:
+        bridge.display_result("<script>")
+        out.assert_called_once_with("&lt;script&gt;", highlight=False)
 
 
 def test_apibridge_sanitizes_output():
@@ -29,6 +37,7 @@ def test_webui_sanitizes_output(monkeypatch):
     monkeypatch.setitem(sys.modules, "streamlit", st)
 
     import importlib
+
     import devsynth.interface.webui as webui
 
     importlib.reload(webui)


### PR DESCRIPTION
## Summary
- cover CLIUXBridge.display_result HTML escaping in output sanitization tests

## Testing
- `poetry run pytest tests/unit/interface/test_output_sanitization.py::test_cliuxbridge_escapes_html -q`
- `poetry run pytest tests/unit/interface/test_output_sanitization.py -q`
- `poetry run pytest tests/unit/interface/test_uxbridge_sanitization.py::test_cliuxbridge_sanitizes_display_result -q`


------
https://chatgpt.com/codex/tasks/task_e_685b415206f4833385c301dcd736556f