### PR TITLE
Add dialectical reasoning delegation BDD test

### DIFF
--- a/tests/behavior/features/delegate_task.feature
+++ b/tests/behavior/features/delegate_task.feature
@@ -9,3 +9,11 @@ Feature: Multi-agent task delegation
     Then each agent should process the task
     And the delegation result should include all contributors
     And the delegation method should be consensus based
+
+  Scenario: Delegate a task with dialectical reasoning and consensus
+    Given a team coordinator with multiple agents
+    And a critic agent with dialectical reasoning expertise
+    When I delegate a dialectical reasoning task
+    Then each agent should process the task
+    And the team should apply dialectical reasoning before consensus
+    And the delegation method should be consensus based

--- a/tests/behavior/steps/delegate_task_steps.py
+++ b/tests/behavior/steps/delegate_task_steps.py
@@ -18,6 +18,8 @@ def context():
             self.agents = []
             self.result = None
             self.task = None
+            self.critic = None
+
     return Context()
 
 
@@ -32,6 +34,23 @@ def setup_team(context):
         agent.process.return_value = {"solution": f"solution from {agent.name}"}
         context.coordinator.add_agent(agent)
         context.agents.append(agent)
+
+
+@given("a critic agent with dialectical reasoning expertise")
+def add_critic_agent(context):
+    critic = MagicMock(spec=Agent)
+    critic.name = "critic"
+    critic.agent_type = "critic"
+    critic.perform_dialectical_reasoning = MagicMock(
+        return_value={
+            "thesis": "t",
+            "antithesis": "a",
+            "synthesis": "s",
+        }
+    )
+    context.coordinator.add_agent(critic)
+    context.agents.append(critic)
+    context.critic = critic
 
 
 @when("I delegate a collaborative team task")
@@ -49,6 +68,24 @@ def delegate_task(context):
     context.result = context.coordinator.delegate_task(context.task)
 
 
+@when("I delegate a dialectical reasoning task")
+def delegate_dialectical_task(context):
+    context.task = {"team_task": True, "dialectical": True, "description": "debate"}
+    team = context.coordinator.teams[context.coordinator.current_team_id]
+    team.perform_dialectical_reasoning = MagicMock(
+        return_value={"steps": ["thesis", "antithesis", "synthesis"]}
+    )
+    team.build_consensus = MagicMock(
+        return_value={
+            "consensus": "final",
+            "contributors": [a.name for a in context.agents],
+            "dialectical": team.perform_dialectical_reasoning(),
+            "method": "consensus_synthesis",
+        }
+    )
+    context.result = context.coordinator.delegate_task(context.task)
+
+
 @then("each agent should process the task")
 def each_agent_processed(context):
     for agent in context.agents:
@@ -57,9 +94,18 @@ def each_agent_processed(context):
 
 @then("the delegation result should include all contributors")
 def result_includes_contributors(context):
-    assert set(context.result.get("contributors", [])) == {a.name for a in context.agents}
+    assert set(context.result.get("contributors", [])) == {
+        a.name for a in context.agents
+    }
 
 
 @then("the delegation method should be consensus based")
 def method_consensus(context):
     assert context.result.get("method") == "consensus_synthesis"
+
+
+@then("the team should apply dialectical reasoning before consensus")
+def dialectical_reasoning_applied(context):
+    team = context.coordinator.teams[context.coordinator.current_team_id]
+    team.perform_dialectical_reasoning.assert_called()
+    assert "dialectical" in context.result


### PR DESCRIPTION
## Summary
- expand delegate_task.feature with dialectical reasoning scenario
- update delegate_task_steps with mocks for dialectical reasoning flow

## Testing
- `poetry run pytest tests/` *(fails: ModuleNotFoundError: No module named 'devsynth.application.memory.chromadb_store')*

------
https://chatgpt.com/codex/tasks/task_e_685b534af4488333ada4d7f611877d68