### PR TITLE
Add micro cycle and memory adapter BDD tests

### DIFF
--- a/tests/behavior/custom_steps/test_memory_adapter_integration_steps.py
+++ b/tests/behavior/custom_steps/test_memory_adapter_integration_steps.py
@@ -1,0 +1,51 @@
+from pytest_bdd import given, when, then, scenarios, parsers
+import pytest
+
+from devsynth.application.memory.memory_manager import MemoryManager
+from devsynth.application.memory.adapters.graph_memory_adapter import GraphMemoryAdapter
+from devsynth.application.memory.adapters.tinydb_memory_adapter import (
+    TinyDBMemoryAdapter,
+)
+from devsynth.domain.models.memory import MemoryItem, MemoryType
+
+scenarios("../features/memory_adapter_integration.feature")
+
+
+@pytest.fixture
+def context(tmp_path):
+    class Context:
+        pass
+
+    ctx = Context()
+    ctx.manager = MemoryManager(
+        {
+            "graph": GraphMemoryAdapter(base_path=str(tmp_path)),
+            "tinydb": TinyDBMemoryAdapter(),
+        }
+    )
+    return ctx
+
+
+@given("a memory manager with graph and tinydb adapters")
+def have_manager(context):
+    assert context.manager is not None
+
+
+@when(parsers.parse('I store a graph memory item with id "{item_id}"'))
+def store_graph_item(context, item_id):
+    item = MemoryItem(id=item_id, content="graph", memory_type=MemoryType.CODE)
+    context.manager.adapters["graph"].store(item)
+
+
+@when(parsers.parse('I store a tinydb memory item with id "{item_id}"'))
+def store_tinydb_item(context, item_id):
+    item = MemoryItem(id=item_id, content="tinydb", memory_type=MemoryType.REQUIREMENT)
+    context.manager.adapters["tinydb"].store(item)
+
+
+@then("querying items by type should return both stored items")
+def query_items(context):
+    codes = context.manager.query_by_type(MemoryType.CODE)
+    reqs = context.manager.query_by_type(MemoryType.REQUIREMENT)
+    ids = {i.id for i in codes + reqs}
+    assert {"G1", "T1"} <= ids

--- a/tests/behavior/custom_steps/test_micro_edrr_cycle_steps.py
+++ b/tests/behavior/custom_steps/test_micro_edrr_cycle_steps.py
@@ -1,0 +1,72 @@
+from pytest_bdd import given, when, then, scenarios, parsers
+import pytest
+
+from devsynth.application.memory.memory_manager import MemoryManager
+from devsynth.application.memory.adapters.tinydb_memory_adapter import (
+    TinyDBMemoryAdapter,
+)
+from devsynth.domain.models.wsde import WSDETeam
+from devsynth.application.code_analysis.analyzer import CodeAnalyzer
+from devsynth.application.code_analysis.ast_transformer import AstTransformer
+from devsynth.application.prompts.prompt_manager import PromptManager
+from devsynth.application.documentation.documentation_manager import (
+    DocumentationManager,
+)
+from devsynth.application.edrr.coordinator import EDRRCoordinator
+from devsynth.methodology.base import Phase
+
+scenarios("../features/micro_edrr_cycle.feature")
+
+
+@pytest.fixture
+def context(tmp_path):
+    class Context:
+        pass
+
+    ctx = Context()
+    ctx.base = tmp_path
+    return ctx
+
+
+@given("an initialized EDRR coordinator")
+def init_coordinator(context):
+    memory_adapter = TinyDBMemoryAdapter()
+    memory_manager = MemoryManager({"tinydb": memory_adapter})
+    wsde_team = WSDETeam()
+    code_analyzer = CodeAnalyzer()
+    ast_transformer = AstTransformer()
+    prompt_manager = PromptManager(storage_path=str(context.base / "prompts"))
+    documentation_manager = DocumentationManager(
+        memory_manager, storage_path=str(context.base / "docs")
+    )
+    context.coordinator = EDRRCoordinator(
+        memory_manager=memory_manager,
+        wsde_team=wsde_team,
+        code_analyzer=code_analyzer,
+        ast_transformer=ast_transformer,
+        prompt_manager=prompt_manager,
+        documentation_manager=documentation_manager,
+    )
+
+
+@when(parsers.parse('I start an EDRR cycle for "{task}"'))
+def start_cycle(context, task):
+    context.coordinator.start_cycle({"description": task})
+
+
+@when(parsers.parse('I create a micro cycle for "{subtask}" in phase "{phase}"'))
+def create_micro(context, subtask, phase):
+    micro = context.coordinator.create_micro_cycle(
+        {"description": subtask}, Phase[phase.upper()]
+    )
+    context.micro = micro
+
+
+@then("the micro cycle should have recursion depth 1")
+def check_depth(context):
+    assert context.micro.recursion_depth == 1
+
+
+@then("the parent cycle should include the micro cycle")
+def parent_has_child(context):
+    assert context.micro in context.coordinator.child_cycles

--- a/tests/behavior/features/memory_adapter_integration.feature
+++ b/tests/behavior/features/memory_adapter_integration.feature
@@ -1,0 +1,10 @@
+Feature: Memory Adapter Integration
+  As a developer
+  I want the memory manager to work with multiple adapters
+  So that information stored in different adapters can be queried consistently
+
+  Scenario: Store items in graph and tinydb adapters
+    Given a memory manager with graph and tinydb adapters
+    When I store a graph memory item with id "G1"
+    And I store a tinydb memory item with id "T1"
+    Then querying items by type should return both stored items

--- a/tests/behavior/features/micro_edrr_cycle.feature
+++ b/tests/behavior/features/micro_edrr_cycle.feature
@@ -1,0 +1,11 @@
+Feature: Micro EDRR Cycle
+  As a developer
+  I want to create micro EDRR cycles within a parent cycle
+  So that complex tasks can be broken down recursively
+
+  Scenario: Create a micro cycle from the expand phase
+    Given an initialized EDRR coordinator
+    When I start an EDRR cycle for "implement feature"
+    And I create a micro cycle for "sub task" in phase "Expand"
+    Then the micro cycle should have recursion depth 1
+    And the parent cycle should include the micro cycle


### PR DESCRIPTION
## Summary
- add micro EDRR cycle feature and steps
- add memory adapter integration feature and steps

## Testing
- `behave tests/behavior/features/micro_edrr_cycle.feature tests/behavior/features/memory_adapter_integration.feature` *(fails: No module named 'pydantic_settings')*

------
https://chatgpt.com/codex/tasks/task_e_685b6cb6851c83338900a276912876df