### PR TITLE
Update docs for new command names

### DIFF
--- a/docs/developer_guides/configuration_storage_system.md
+++ b/docs/developer_guides/configuration_storage_system.md
@@ -152,8 +152,8 @@ This pattern is implemented in the `settings.py` file, which provides validators
 ### For DevSynth Users
 
 - Use the `devsynth init` command to create the initial `.devsynth/project.yaml` file
-- Use the `devsynth analyze-config` command (formerly `analyze-manifest`) to keep the configuration up to date
- - Use the `devsynth validate-config` command to validate the configuration against its schema
+- Use the `devsynth inspect-config` command (formerly `analyze-manifest`) to keep the configuration up to date
+ - Use the `devsynth validate-manifest` command to validate the configuration against its schema
 - Avoid modifying global configuration files directly unless necessary
 - Use environment variables for temporary configuration changes
 

--- a/docs/developer_guides/devsynth_configuration.md
+++ b/docs/developer_guides/devsynth_configuration.md
@@ -21,7 +21,7 @@ Note: The presence of a `.devsynth/` directory is the marker that a project is m
 
 The `.devsynth/devsynth.yml` file is the configuration file for projects managed by DevSynth. It describes the shape and attributes of the project in a minimal but functional, featureful, and human-friendly way. This file is created automatically when you run `devsynth init` in a directory, which also creates the `.devsynth/` directory.
 
-The project configuration file follows a schema defined in `src/devsynth/schemas/project_schema.json` and can be validated using the `devsynth validate-config` command (formerly `validate-manifest`).
+The project configuration file follows a schema defined in `src/devsynth/schemas/project_schema.json` and can be validated using the `devsynth validate-manifest` command (formerly `validate-manifest`).
 
 Example devsynth.yml:
 ```yaml
@@ -97,8 +97,8 @@ Project-level resources are specific to each DevSynth project:
 DevSynth provides several commands for managing configuration:
 
 - `devsynth init`: Creates a new project with a default `.devsynth/devsynth.yml` file and establishes the project as managed by DevSynth
-- `devsynth analyze-config` (formerly `analyze-manifest`): Analyzes and updates the `.devsynth/devsynth.yml` file based on the actual project structure
-- `devsynth validate-config` (formerly `validate-manifest`): Validates the `.devsynth/devsynth.yml` file against its schema
+- `devsynth inspect-config` (formerly `analyze-manifest`): Analyzes and updates the `.devsynth/devsynth.yml` file based on the actual project structure
+- `devsynth validate-manifest` (formerly `validate-manifest`): Validates the `.devsynth/devsynth.yml` file against its schema
 
 ### Configuration Schema and Loader
 
@@ -138,5 +138,5 @@ save_global_config(cfg)
 1. **Version Control**: Include the `.devsynth/devsynth.yml` file in version control to ensure consistent configuration across all developers.
 2. **Gitignore**: Add `.devsynth/cache/`, `.devsynth/logs/`, and `.devsynth/memory/` to your `.gitignore` file to exclude volatile project-level resources from version control, but keep `.devsynth/devsynth.yml`.
 3. **Environment Variables**: Use environment variables for sensitive information like API keys instead of storing them in configuration files.
-4. **Regular Updates**: Periodically run `devsynth analyze-config` to keep your project configuration file in sync with the actual project structure.
+4. **Regular Updates**: Periodically run `devsynth inspect-config` to keep your project configuration file in sync with the actual project structure.
 5. **Project Marker**: Remember that the presence of a `.devsynth/` directory is the marker that a project is managed by DevSynth. Do not create this directory manually; use `devsynth init` to establish a project as managed by DevSynth.

--- a/docs/developer_guides/devsynth_contexts.md
+++ b/docs/developer_guides/devsynth_contexts.md
@@ -75,7 +75,7 @@ This context refers to applying DevSynth as a tool to assist in the development 
 - Generating specifications with `devsynth inspect`
 - Creating tests with `devsynth run-pipeline`
 - Generating code with `devsynth refactor`
- - Managing project structure with `devsynth analyze-config`
+ - Managing project structure with `devsynth inspect-config`
 
 ## 3. Self-Improvement: Using DevSynth to Improve DevSynth
 
@@ -100,8 +100,8 @@ This context refers to the advanced scenario where a functional version of DevSy
 
 ### Example Tasks
 
-- Using `devsynth analyze-code` to identify architectural improvements
- - Applying `devsynth analyze-config` to maintain DevSynth's own manifest
+- Using `devsynth inspect-code` to identify architectural improvements
+ - Applying `devsynth inspect-config` to maintain DevSynth's own manifest
 - Using `devsynth run-pipeline` to generate additional test cases
 - Leveraging `devsynth inspect` to refine internal specifications
 
@@ -132,8 +132,8 @@ This context refers to the advanced scenario where a functional version of DevSy
 ### For DevSynth Usage
 
 - Start with `devsynth init` to create the `.devsynth/project.yaml` file
-- Use `devsynth analyze-config` (formerly `analyze-manifest`) to keep the configuration up to date
- - Use `devsynth validate-config` to validate the configuration against its schema
+- Use `devsynth inspect-config` (formerly `analyze-manifest`) to keep the configuration up to date
+ - Use `devsynth validate-manifest` to validate the configuration against its schema
 - Follow the recommended workflow: inspect → spec → test → code
 - Provide detailed requirements for better results
 - Review and validate all generated outputs

--- a/docs/getting_started/quick_start_guide.md
+++ b/docs/getting_started/quick_start_guide.md
@@ -156,8 +156,8 @@ devsynth run-pipeline
 Keep your project configuration up to date and validate it:
 
 ```bash
-devsynth analyze-config
-devsynth validate-config
+devsynth inspect-config
+devsynth validate-manifest
 ```
 
 ## Viewing and Modifying Generated Artifacts

--- a/docs/user_guides/cli_reference.md
+++ b/docs/user_guides/cli_reference.md
@@ -27,12 +27,9 @@ This document provides a comprehensive reference for the DevSynth Command Line I
   - [test](#test)
   - [code](#code)
   - [config](#config)
-  - [memory](#memory)
-  - [agent](#agent)
   - [run-pipeline](#run-pipeline)
   - [refactor](#refactor)
   - [inspect](#inspect)
-  - [retrace](#retrace)
   - [webapp](#webapp)
   - [webui](#webui)
   - [dbschema](#dbschema)
@@ -259,58 +256,6 @@ Toggle a feature flag in your project configuration.
 devsynth config enable-feature <name>
 ```
 
-### memory
-
-Manage the DevSynth memory system.
-
-```bash
-devsynth memory [--clear] [--backup FILE] [--restore FILE] [--list] [--type TYPE]
-```
-
-**Options:**
-- `--clear`, `-c`: Clear the memory store
-- `--backup`, `-b`: Backup memory to a file
-- `--restore`, `-r`: Restore memory from a file
-- `--list`, `-l`: List memory contents
-- `--type`, `-t`: Memory store type (vector, document, graph, all) (default: all)
-
-**Examples:**
-```bash
-# List all memory contents
-devsynth memory --list
-
-# Clear vector memory
-devsynth memory --clear --type vector
-
-# Backup all memory to a file
-devsynth memory --backup memory_backup.json
-
-# Restore memory from a file
-devsynth memory --restore memory_backup.json
-```
-
-### agent
-
-Manage and interact with DevSynth agents.
-
-```bash
-devsynth agent [--list] [--run AGENT] [--input FILE] [--output FILE]
-```
-
-**Options:**
-- `--list`, `-l`: List available agents
-- `--run`, `-r`: Run a specific agent
-- `--input`, `-i`: Input file for the agent
-- `--output`, `-o`: Output file for agent results
-
-**Examples:**
-```bash
-# List all available agents
-devsynth agent --list
-
-# Run a specific agent with input and output files
-devsynth agent --run documentation --input requirements.md --output docs.md
-```
 
 ### run-pipeline
 
@@ -360,18 +305,6 @@ devsynth inspect --input requirements.md
 devsynth inspect --interactive
 ```
 
-### retrace
-
-Replay a previous pipeline execution for debugging.
-
-```bash
-devsynth retrace <run-id>
-```
-
-**Examples:**
-```bash
-devsynth retrace 20240601T123000
-```
 
 ### webapp
 

--- a/docs/user_guides/user_guide.md
+++ b/docs/user_guides/user_guide.md
@@ -80,7 +80,7 @@ This command processes requirements and provides insights about their completene
 Analyzes a codebase to understand its architecture, structure, and quality.
 
 ```bash
-devsynth analyze-code [--path PATH]
+devsynth inspect-code [--path PATH]
 ```
 
 **Options:**
@@ -88,7 +88,7 @@ devsynth analyze-code [--path PATH]
 
 **Example:**
 ```bash
-devsynth analyze-code --path ./my-project
+devsynth inspect-code --path ./my-project
 ```
 
 **Details:**


### PR DESCRIPTION
## Summary
- replace `devsynth analyze` usages with `devsynth inspect`
- remove outdated memory/agent/retrace sections from CLI reference
- update quick start and configuration docs to use `validate-manifest`

## Testing
- `poetry run pytest tests/` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_685c7be4361c8333a570e5f36f31122e