### PR TITLE
Add doctor cmd env-var warnings tests

### DIFF
--- a/docs/getting_started/troubleshooting.md
+++ b/docs/getting_started/troubleshooting.md
@@ -73,6 +73,22 @@ Ensure your environment is running **Python 3.11 or higher**. Managing dependenc
 - Validate the configuration file format (should be valid YAML)
 - Try running `devsynth config --reset` to reset to default configuration
 
+### Running `devsynth doctor`
+
+Use this command to check your environment and configuration files. It warns
+about Python versions below 3.11 and any missing API keys.
+
+```bash
+$ devsynth doctor
+No project configuration found. Run 'devsynth init' to create it.
+Warning: Python 3.11 or higher is required. Current version: 3.10.0
+Missing environment variables: OPENAI_API_KEY, ANTHROPIC_API_KEY
+Configuration issues detected. Run 'devsynth init' to generate defaults.
+
+$ devsynth doctor
+All configuration files are valid.
+```
+
 ## LLM Provider Issues
 
 ### Connection Errors with LM Studio


### PR DESCRIPTION
## Summary
- extend `doctor_cmd` unit tests for invalid configs
- cover missing environment variables
- document sample output of `devsynth doctor`

## Testing
- `poetry run pytest tests/unit/application/cli/test_doctor_cmd.py -q`

------
https://chatgpt.com/codex/tasks/task_e_685c8372e79c8333877a126c84dfc7d9