### PR TITLE
Improve EDRR cycle CLI config handling

### DIFF
--- a/src/devsynth/application/cli/commands/edrr_cycle_cmd.py
+++ b/src/devsynth/application/cli/commands/edrr_cycle_cmd.py
@@ -17,6 +17,7 @@ from devsynth.core import run_pipeline
 from devsynth.methodology.base import Phase
 from devsynth.logging_setup import DevSynthLogger
 from devsynth.exceptions import DevSynthError
+from devsynth.config import load_project_config
 
 logger = DevSynthLogger(__name__)
 bridge: UXBridge = CLIUXBridge()
@@ -49,6 +50,11 @@ def edrr_cycle_cmd(manifest: str, auto: bool = True) -> None:
         prompt_manager = PromptManager()
         documentation_manager = DocumentationManager(memory_manager)
 
+        project_cfg = load_project_config().config.as_dict()
+        edrr_cfg = project_cfg.get("edrr", {})
+        edrr_cfg.setdefault("phase_transition", {})["auto"] = auto
+        project_cfg["edrr"] = edrr_cfg
+
         coordinator = EDRRCoordinator(
             memory_manager=memory_manager,
             wsde_team=wsde_team,
@@ -56,7 +62,7 @@ def edrr_cycle_cmd(manifest: str, auto: bool = True) -> None:
             ast_transformer=ast_transformer,
             prompt_manager=prompt_manager,
             documentation_manager=documentation_manager,
-            config={"edrr": {"phase_transition": {"auto": auto}}},
+            config=project_cfg,
         )
 
         coordinator.start_cycle_from_manifest(manifest_path, is_file=True)

--- a/tests/behavior/steps/edrr_cycle_steps.py
+++ b/tests/behavior/steps/edrr_cycle_steps.py
@@ -33,7 +33,11 @@ def run_edrr_cycle(context):
     manifest = str(context['manifest'])
     with patch('devsynth.application.cli.commands.edrr_cycle_cmd.bridge') as mock_bridge, \
          patch('devsynth.application.cli.commands.edrr_cycle_cmd.EDRRCoordinator') as coord_cls, \
-         patch('devsynth.application.cli.commands.edrr_cycle_cmd.MemoryManager') as manager_cls:
+         patch('devsynth.application.cli.commands.edrr_cycle_cmd.MemoryManager') as manager_cls, \
+         patch('devsynth.application.cli.commands.edrr_cycle_cmd.load_project_config') as cfg_loader:
+        cfg = MagicMock()
+        cfg.config.as_dict.return_value = {}
+        cfg_loader.return_value = cfg
         coordinator = MagicMock()
         coordinator.generate_report.return_value = {'ok': True}
         coordinator.cycle_id = 'cid'


### PR DESCRIPTION
## Summary
- load project config when running `edrr_cycle_cmd`
- extend unit tests to patch config loading and check manual mode
- fix behavior step to patch project config loading

## Testing
- `poetry run pytest tests/unit/test_edrr_cycle_cmd.py -q`
- `poetry run pytest -q` *(fails: test failures in integration suites)*

------
https://chatgpt.com/codex/tasks/task_e_685d8ad6d0488333ba5a61df1064fa99