### PR TITLE
Update testing docs and verify dependencies

### DIFF
--- a/docs/developer_guides/testing.md
+++ b/docs/developer_guides/testing.md
@@ -255,6 +255,9 @@ test dependencies are available:
 poetry install --with dev,docs
 poetry sync --all-extras --all-groups
 
+# Verify that pytest can start without import errors
+poetry run pytest -q
+
 # pip commands are for installing from PyPI only
 ```
 


### PR DESCRIPTION
## Summary
- mention verifying pytest startup in the testing docs

## Testing
- `poetry install --with dev,docs`
- `poetry run pytest -q` *(fails: 113 failed, 861 passed, 62 skipped, 1 error)*

------
https://chatgpt.com/codex/tasks/task_e_685d9a214cd883339f5c8f82dbcf4f28