### PR TITLE
Update AGENTS env setup docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 # AGENTS.md
 
-> Special note: the environment that ChatGPT Codex operates in executes `scripts/codex_setup.sh` as the setup setup. If it fails, a CODEX_ENVIRONMENT_SETUP_FAILED file will be created.
+> Special note: the environment that ChatGPT Codex operates in executes `scripts/codex_setup.sh` as the setup script **while network access is enabled**. If the script fails for any reason, a `CODEX_ENVIRONMENT_SETUP_FAILED` file will be created. After provisioning finishes, network access is disabled.
 
 ## Introduction
 
@@ -9,6 +9,27 @@ This document provides a comprehensive guide to the agent-based components withi
 ## Scope
 
 This file covers all AI and service agents implemented in the `src/devsynth/` directory and related scripts in `scripts/` that embody agentic behavior.
+
+## Environment Setup
+
+The automated Codex environment runs the setup script as:
+
+```bash
+scripts/codex_setup.sh || touch CODEX_ENVIRONMENT_SETUP_FAILED
+```
+
+If `scripts/codex_setup.sh` fails, a file named `CODEX_ENVIRONMENT_SETUP_FAILED`
+will appear in the repository root. After the initial provisioning, network
+access is disabled, so you may need to adjust the script or install packages
+manually to make it succeed. To fix your environment:
+
+1. Review and update `scripts/codex_setup.sh` so it succeeds in your
+   environment. You may need to install packages manually or modify the script.
+2. Run `bash scripts/codex_setup.sh` (without network access) until it completes
+   without errors.
+3. Remove the failure marker with `rm CODEX_ENVIRONMENT_SETUP_FAILED`.
+
+Development and test commands may fail until the setup script completes successfully and the marker file is removed.
 
 ## Project Structure
 

--- a/README.md
+++ b/README.md
@@ -67,6 +67,8 @@ Installation instructions are covered in detail in the [Installation Guide](docs
 
 DevSynth requires **Python 3.11 or higher**. Using [Poetry](https://python-poetry.org/) is recommended for managing dependencies during development.
 
+The initial workspace setup runs [`scripts/codex_setup.sh`](scripts/codex_setup.sh) with network access enabled. If the script fails, a file named `CODEX_ENVIRONMENT_SETUP_FAILED` will appear in the repository root. After provisioning, network access is disabled. See [AGENTS.md#environment-setup](AGENTS.md#environment-setup) for instructions on fixing and rerunning the setup offline.
+
 ## Installation
 
 You can install DevSynth in a few different ways:

--- a/docs/developer_guides/development_setup.md
+++ b/docs/developer_guides/development_setup.md
@@ -54,6 +54,8 @@ Before setting up the development environment, ensure you have the following ins
 
 ## Development Environment Setup
 
+The workspace automatically runs [`scripts/codex_setup.sh`](../../scripts/codex_setup.sh) with network access enabled during provisioning. If the script fails, a `CODEX_ENVIRONMENT_SETUP_FAILED` file will appear in the project root. Network access is disabled afterward. Follow the steps in [AGENTS.md#environment-setup](../../AGENTS.md#environment-setup) to repair the environment and remove the marker offline.
+
 ### 1. Clone the Repository
 
 ```bash

--- a/tests/README.md
+++ b/tests/README.md
@@ -175,6 +175,8 @@ poetry run pytest
 
 ### Environment Setup
 
+The test environment relies on [`scripts/codex_setup.sh`](../scripts/codex_setup.sh) being executed successfully during provisioning (with network access). If the script fails, a `CODEX_ENVIRONMENT_SETUP_FAILED` file will be present in the repository root. Network access is disabled when you run the tests manually. See [AGENTS.md#environment-setup](../AGENTS.md#environment-setup) for instructions on how to resolve the failure and remove the marker offline.
+
 Before running tests, you **must** install DevSynth with the development extras:
 
 ```bash


### PR DESCRIPTION
## Summary
- document codex_setup mechanism and failure marker
- mention that codex_setup.sh runs with network access but must be fixed offline after provisioning
- reference updated docs from README, development_setup guide and test docs

## Testing
- `poetry run pytest -q` *(fails: 114 failed, 735 passed, 58 skipped, 1 error)*


------
https://chatgpt.com/codex/tasks/task_e_685dadefdaf88333ac3c0f8d8b9d65e1