### PR TITLE
Add delegate task BDD scenario

### DIFF
--- a/tests/behavior/features/delegate_task.feature
+++ b/tests/behavior/features/delegate_task.feature
@@ -7,6 +7,7 @@ Feature: Multi-agent task delegation
     Given a team coordinator with multiple agents
     When I delegate a collaborative team task
     Then each agent should process the task
+    And the consensus result should be final
     And the delegation result should include all contributors
     And the delegation method should be consensus based
 
@@ -16,4 +17,5 @@ Feature: Multi-agent task delegation
     When I delegate a dialectical reasoning task
     Then each agent should process the task
     And the team should apply dialectical reasoning before consensus
+    And the consensus result should be final
     And the delegation method should be consensus based

--- a/tests/behavior/steps/delegate_task_steps.py
+++ b/tests/behavior/steps/delegate_task_steps.py
@@ -99,6 +99,11 @@ def result_includes_contributors(context):
     }
 
 
+@then("the consensus result should be final")
+def consensus_result_final(context):
+    assert context.result.get("result") == "final"
+
+
 @then("the delegation method should be consensus based")
 def method_consensus(context):
     assert context.result.get("method") == "consensus_synthesis"
@@ -108,4 +113,4 @@ def method_consensus(context):
 def dialectical_reasoning_applied(context):
     team = context.coordinator.teams[context.coordinator.current_team_id]
     team.perform_dialectical_reasoning.assert_called()
-    assert "dialectical" in context.result
+    assert "dialectical_analysis" in context.result

--- a/tests/behavior/test_delegate_task.py
+++ b/tests/behavior/test_delegate_task.py
@@ -1,0 +1,5 @@
+from pytest_bdd import scenarios
+
+from .steps.delegate_task_steps import *  # noqa: F401,F403
+
+scenarios("features/delegate_task.feature")


### PR DESCRIPTION
## Summary
- expand delegate_task feature with consensus result step
- update step definitions to verify consensus output
- add BDD test file for delegate_task

## Testing
- `poetry run black tests/behavior/steps/delegate_task_steps.py tests/behavior/test_delegate_task.py --check`
- `poetry run pytest tests/behavior/test_delegate_task.py -q`

------
https://chatgpt.com/codex/tasks/task_e_685ddac7d4a08333b4456fd630081b6d