### PR TITLE
Rename analyze-manifest command to inspect-config

### DIFF
--- a/src/devsynth/adapters/cli/typer_adapter.py
+++ b/src/devsynth/adapters/cli/typer_adapter.py
@@ -28,7 +28,7 @@ from devsynth.application.cli.commands.align_cmd import align_cmd
 from devsynth.application.cli.commands.alignment_metrics_cmd import (
     alignment_metrics_cmd,
 )
-from devsynth.application.cli.commands.analyze_manifest_cmd import analyze_manifest_cmd
+from devsynth.application.cli.commands.inspect_config_cmd import inspect_config_cmd
 from devsynth.application.cli.commands.validate_manifest_cmd import (
     validate_manifest_cmd,
 )
@@ -131,13 +131,9 @@ def build_app() -> typer.Typer:
         help="Collect alignment metrics. Example: devsynth alignment-metrics",
     )(alignment_metrics_cmd)
     app.command(
-        name="analyze-manifest",
-        help="Analyze project configuration. Example: devsynth analyze-manifest",
-    )(analyze_manifest_cmd)
-    app.command(
-        name="analyze-config",
-        help="Alias for analyze-manifest. Example: devsynth analyze-config",
-    )(analyze_manifest_cmd)
+        name="inspect-config",
+        help="Inspect project configuration. Example: devsynth inspect-config",
+    )(inspect_config_cmd)
     app.command(
         name="validate-manifest",
         help="Validate project config file. Example: devsynth validate-manifest",

--- a/src/devsynth/application/cli/commands/__init__.py
+++ b/src/devsynth/application/cli/commands/__init__.py
@@ -4,5 +4,6 @@ Command modules for the CLI application.
 
 # Import the analyze_code_cmd function to make it available from this package
 from .analyze_code_cmd import analyze_code_cmd
+from .inspect_config_cmd import inspect_config_cmd
 
-__all__ = ["analyze_code_cmd"]
+__all__ = ["analyze_code_cmd", "inspect_config_cmd"]

--- a/src/devsynth/application/cli/commands/inspect_config_cmd.py
+++ b/src/devsynth/application/cli/commands/inspect_config_cmd.py
@@ -1,5 +1,7 @@
 """
-Command to analyze and manage the project configuration file (devsynth.yaml, formerly manifest.yaml).
+Command to inspect and manage the project configuration file (``devsynth.yaml``).
+
+This command was previously called ``analyze-manifest``.
 """
 
 import os
@@ -20,11 +22,11 @@ from devsynth.logging_setup import DevSynthLogger
 logger = DevSynthLogger(__name__)
 bridge: UXBridge = CLIUXBridge()
 
-def analyze_manifest_cmd(path: Optional[str] = None, update: bool = False, prune: bool = False) -> None:
-    """Analyze and manage the project configuration file.
+def inspect_config_cmd(path: Optional[str] = None, update: bool = False, prune: bool = False) -> None:
+    """Inspect and manage the project configuration file.
 
     Example:
-        `devsynth analyze-manifest --update`
+        ``devsynth inspect-config --update``
 
     This command scans the project structure and can update, refine, or prune the configuration file
     based on the actual project structure.
@@ -37,14 +39,16 @@ def analyze_manifest_cmd(path: Optional[str] = None, update: bool = False, prune
     console = Console()
 
     try:
-        # Show a welcome message for the analyze-manifest command
-        bridge.print(Panel(
-            "[bold blue]DevSynth Configuration Analysis[/bold blue]\n\n"
-            "This command will analyze the project configuration file (devsynth.yaml) and the project structure, "
-            "and can update the configuration to reflect the actual project structure.",
-            title="Configuration Analysis",
-            border_style="blue"
-        ))
+        # Show a welcome message for the inspect-config command
+        bridge.print(
+            Panel(
+                "[bold blue]DevSynth Configuration Analysis[/bold blue]\n\n"
+                "This command will analyze the project configuration file (devsynth.yaml) and the project structure, "
+                "and can update the configuration to reflect the actual project structure.",
+                title="Configuration Analysis",
+                border_style="blue",
+            )
+        )
 
         # Determine the path to analyze
         if path is None:
@@ -146,13 +150,19 @@ def analyze_manifest_cmd(path: Optional[str] = None, update: bool = False, prune
 
             # Show update/prune options if not requested
             else:
-                bridge.print("\n[yellow]To update the configuration with new findings, run:[/yellow]")
-                bridge.print(f"  devsynth analyze-manifest --update")
+                bridge.print(
+                    "\n[yellow]To update the configuration with new findings, run:[/yellow]"
+                )
+                bridge.print("  devsynth inspect-config --update")
 
-                bridge.print("\n[yellow]To prune entries that no longer exist, run:[/yellow]")
-                bridge.print(f"  devsynth analyze-manifest --prune")
+                bridge.print(
+                    "\n[yellow]To prune entries that no longer exist, run:[/yellow]"
+                )
+                bridge.print("  devsynth inspect-config --prune")
 
-                bridge.print("\n[yellow]Note: This command will be renamed to 'analyze-config' in a future version.[/yellow]")
+                bridge.print(
+                    "\n[yellow]Previously known as 'analyze-manifest'.[/yellow]"
+                )
         else:
             bridge.print("\n[green]No differences found. Configuration is up to date![/green]")
 

--- a/src/devsynth/application/cli/commands/validate_manifest_cmd.py
+++ b/src/devsynth/application/cli/commands/validate_manifest_cmd.py
@@ -146,7 +146,9 @@ def validate_manifest_cmd(manifest_path: Optional[str] = None, schema_path: Opti
             bridge.print("\n[bold green]✓ Project configuration is valid![/bold green]")
         else:
             bridge.print("\n[bold red]✗ Project configuration has validation errors.[/bold red]")
-            bridge.print("[yellow]Run 'devsynth analyze-manifest --update' to update the project configuration.[/yellow]")
+            bridge.print(
+                "[yellow]Run 'devsynth inspect-config --update' to update the project configuration.[/yellow]"
+            )
 
     except Exception as err:
         bridge.print(f"[red]Error:[/red] {err}", highlight=False)

--- a/src/devsynth/application/orchestration/adaptive_workflow.py
+++ b/src/devsynth/application/orchestration/adaptive_workflow.py
@@ -108,7 +108,7 @@ class AdaptiveWorkflowManager:
         logger.info(f"Determining entry point for {workflow} workflow")
 
         if workflow == "requirements":
-            return "analyze"
+            return "inspect"
         elif workflow == "specifications":
             return "spec"
         elif workflow == "tests":
@@ -116,7 +116,7 @@ class AdaptiveWorkflowManager:
         elif workflow == "code":
             return "code"
         else:
-            return "analyze"
+            return "inspect"
 
     def suggest_next_steps(self, project_path: str) -> List[Dict[str, Any]]:
         """
@@ -144,11 +144,13 @@ class AdaptiveWorkflowManager:
 
         # Check for missing requirements
         if project_state['requirements_count'] == 0:
-            suggestions.append({
-                'command': 'analyze',
-                'description': 'Create requirements documentation to define project goals',
-                'priority': 'high'
-            })
+            suggestions.append(
+                {
+                    'command': 'inspect',
+                    'description': 'Create requirements documentation to define project goals',
+                    'priority': 'high',
+                }
+            )
 
         # Check for missing specifications
         if project_state['specifications_count'] == 0:

--- a/src/devsynth/application/orchestration/workflow.py
+++ b/src/devsynth/application/orchestration/workflow.py
@@ -65,8 +65,8 @@ class WorkflowManager:
         # Add steps based on the command
         if command == "init":
             self._add_init_workflow_steps(workflow, args)
-        elif command == "analyze":
-            self._add_analyze_workflow_steps(workflow, args)
+        elif command == "inspect":
+            self._add_inspect_workflow_steps(workflow, args)
         elif command == "spec":
             self._add_spec_workflow_steps(workflow, args)
         elif command == "test":
@@ -80,10 +80,10 @@ class WorkflowManager:
 
         return workflow
 
-    def _add_analyze_workflow_steps(
+    def _add_inspect_workflow_steps(
         self, workflow: Workflow, args: Dict[str, Any]
     ) -> None:
-        """Add steps for the analyze command workflow."""
+        """Add steps for the inspect command workflow."""
         if args.get("interactive"):
             # Step 1: Start interactive session
             self.orchestration_port.add_step(

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -112,13 +112,13 @@ class TestTyperCLI:
         result = self.runner.invoke(app, ["edrr-cycle", "path/to/manifest.yaml"])
         assert result.exit_code == 0
 
-    @patch("devsynth.adapters.cli.typer_adapter.analyze_manifest_cmd", autospec=True)
-    def test_cli_analyze_manifest_update(self, mock_cmd):
+    @patch("devsynth.adapters.cli.typer_adapter.inspect_config_cmd", autospec=True)
+    def test_cli_inspect_config_update(self, mock_cmd):
         app = build_app()
         result = self.runner.invoke(
             app,
             [
-                "analyze-manifest",
+                "inspect-config",
                 "--path",
                 "./proj",
                 "--update",
@@ -127,13 +127,13 @@ class TestTyperCLI:
         assert result.exit_code == 0
         mock_cmd.assert_called_once_with("./proj", True, False)
 
-    @patch("devsynth.adapters.cli.typer_adapter.analyze_manifest_cmd", autospec=True)
-    def test_cli_analyze_manifest_prune(self, mock_cmd):
+    @patch("devsynth.adapters.cli.typer_adapter.inspect_config_cmd", autospec=True)
+    def test_cli_inspect_config_prune(self, mock_cmd):
         app = build_app()
         result = self.runner.invoke(
             app,
             [
-                "analyze-manifest",
+                "inspect-config",
                 "--path",
                 "./proj",
                 "--prune",

--- a/tests/unit/test_inspect_config_cmd.py
+++ b/tests/unit/test_inspect_config_cmd.py
@@ -1,19 +1,19 @@
-"""Tests for the analyze_manifest_cmd CLI command."""
+"""Tests for the inspect_config_cmd CLI command."""
 
 from pathlib import Path
 from unittest.mock import patch, MagicMock
 
 import yaml
 
-from devsynth.application.cli.commands.analyze_manifest_cmd import analyze_manifest_cmd
+from devsynth.application.cli.commands.inspect_config_cmd import inspect_config_cmd
 
 
-@patch("devsynth.application.cli.commands.analyze_manifest_cmd.bridge")
-@patch("devsynth.application.cli.commands.analyze_manifest_cmd.analyze_project_structure")
-@patch("devsynth.application.cli.commands.analyze_manifest_cmd.compare_with_manifest")
-@patch("devsynth.application.cli.commands.analyze_manifest_cmd.update_manifest")
+@patch("devsynth.application.cli.commands.inspect_config_cmd.bridge")
+@patch("devsynth.application.cli.commands.inspect_config_cmd.analyze_project_structure")
+@patch("devsynth.application.cli.commands.inspect_config_cmd.compare_with_manifest")
+@patch("devsynth.application.cli.commands.inspect_config_cmd.update_manifest")
 @patch("yaml.dump")
-def test_analyze_manifest_update(mock_dump, mock_update, mock_compare, mock_analyze, mock_bridge, tmp_path):
+def test_inspect_config_update(mock_dump, mock_update, mock_compare, mock_analyze, mock_bridge, tmp_path):
     manifest_path = tmp_path / "devsynth.yaml"
     yaml.safe_dump({"projectName": "Test"}, manifest_path.open("w"))
 
@@ -21,7 +21,7 @@ def test_analyze_manifest_update(mock_dump, mock_update, mock_compare, mock_anal
     mock_compare.return_value = [{"type": "source", "path": "src", "status": "missing in manifest"}]
     mock_update.return_value = {"updated": True}
 
-    analyze_manifest_cmd(path=str(tmp_path), update=True)
+    inspect_config_cmd(path=str(tmp_path), update=True)
 
     mock_analyze.assert_called_once_with(Path(str(tmp_path)))
     mock_compare.assert_called_once()
@@ -33,12 +33,12 @@ def test_analyze_manifest_update(mock_dump, mock_update, mock_compare, mock_anal
     )
 
 
-@patch("devsynth.application.cli.commands.analyze_manifest_cmd.bridge")
-@patch("devsynth.application.cli.commands.analyze_manifest_cmd.analyze_project_structure")
-@patch("devsynth.application.cli.commands.analyze_manifest_cmd.compare_with_manifest")
-@patch("devsynth.application.cli.commands.analyze_manifest_cmd.prune_manifest")
+@patch("devsynth.application.cli.commands.inspect_config_cmd.bridge")
+@patch("devsynth.application.cli.commands.inspect_config_cmd.analyze_project_structure")
+@patch("devsynth.application.cli.commands.inspect_config_cmd.compare_with_manifest")
+@patch("devsynth.application.cli.commands.inspect_config_cmd.prune_manifest")
 @patch("yaml.dump")
-def test_analyze_manifest_prune(mock_dump, mock_prune, mock_compare, mock_analyze, mock_bridge, tmp_path):
+def test_inspect_config_prune(mock_dump, mock_prune, mock_compare, mock_analyze, mock_bridge, tmp_path):
     manifest_path = tmp_path / "devsynth.yaml"
     yaml.safe_dump({"projectName": "Test"}, manifest_path.open("w"))
 
@@ -46,7 +46,7 @@ def test_analyze_manifest_prune(mock_dump, mock_prune, mock_compare, mock_analyz
     mock_compare.return_value = [{"type": "tests", "path": "tests", "status": "missing in project"}]
     mock_prune.return_value = {"pruned": True}
 
-    analyze_manifest_cmd(path=str(tmp_path), prune=True)
+    inspect_config_cmd(path=str(tmp_path), prune=True)
 
     mock_analyze.assert_called_once_with(Path(str(tmp_path)))
     mock_compare.assert_called_once()
@@ -58,8 +58,8 @@ def test_analyze_manifest_prune(mock_dump, mock_prune, mock_compare, mock_analyz
     )
 
 
-@patch("devsynth.application.cli.commands.analyze_manifest_cmd.bridge")
-def test_analyze_manifest_no_config(mock_bridge, tmp_path):
-    analyze_manifest_cmd(path=str(tmp_path))
+@patch("devsynth.application.cli.commands.inspect_config_cmd.bridge")
+def test_inspect_config_no_config(mock_bridge, tmp_path):
+    inspect_config_cmd(path=str(tmp_path))
     mock_bridge.print.assert_any_call("[yellow]Warning: No configuration file found. Run 'devsynth init' to create it.[/yellow]")
 


### PR DESCRIPTION
## Summary
- rename `analyze-manifest` command implementation to `inspect-config`
- register new command name in Typer adapter
- update workflow manager to use `inspect` instead of `analyze`
- adjust adaptive workflow suggestions for the renamed command
- update help text and validation message
- update unit tests for new command name

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_68602c071ffc833393c3545bf1e5f891