### PR TITLE
Fix TLS provider docs and add environment provider tests

### DIFF
--- a/docs/implementation/feature_status_matrix.md
+++ b/docs/implementation/feature_status_matrix.md
@@ -51,7 +51,7 @@ Each feature is scored on two dimensions:
 | Message Passing Protocol | Complete | src/devsynth/application/collaboration/message_protocol.py | 4 | 2 | WSDE Model | | Enables structured agent communication |
 | Peer Review Mechanism | Complete | src/devsynth/application/collaboration/peer_review.py | 4 | 3 | WSDE Model | | Initial review cycle implemented, full workflow pending |
 | Memory System | Complete | src/devsynth/application/memory | 5 | 4 | None | | Complete with ChromaDB integration and vector store provider factory |
-| LLM Provider System | Complete | src/devsynth/application/llm | 5 | 3 | None | | LM Studio and OpenAI providers implemented; Anthropic provider remains a stub |
+| LLM Provider System | Complete | src/devsynth/application/llm | 5 | 3 | None | | LM Studio and OpenAI providers implemented; Anthropic and Local providers unsupported |
 | LM Studio Integration | Complete | src/devsynth/application/llm/lmstudio_provider.py | 4 | 3 | LLM Provider System | | Local provider stable; remote support experimental |
 | Code Analysis | Complete | src/devsynth/application/code_analysis | 4 | 4 | None | | AST visitor and project state analyzer implemented |
 | Knowledge Graph Utilities | Complete | src/devsynth/application/memory/knowledge_graph_utils.py | 3 | 3 | Memory System | | Basic querying available |

--- a/src/devsynth/domain/models/wsde.py
+++ b/src/devsynth/domain/models/wsde.py
@@ -270,8 +270,9 @@ class WSDETeam:
         agent_expertise: List[str] = []
         if hasattr(agent, "expertise"):
             agent_expertise = agent.expertise or []
-        elif (
-            hasattr(agent, "config")
+        if (
+            not agent_expertise
+            and hasattr(agent, "config")
             and hasattr(agent.config, "parameters")
             and "expertise" in agent.config.parameters
         ):
@@ -347,8 +348,9 @@ class WSDETeam:
                 a = self.agents[i]
                 if hasattr(a, "expertise"):
                     expertise = a.expertise or []
-                elif (
-                    hasattr(a, "config")
+                if (
+                    not expertise
+                    and hasattr(a, "config")
                     and hasattr(a.config, "parameters")
                     and "expertise" in a.config.parameters
                 ):

--- a/tests/unit/adapters/test_provider_factory_env_vars.py
+++ b/tests/unit/adapters/test_provider_factory_env_vars.py
@@ -1,0 +1,23 @@
+from devsynth.adapters.provider_system import (
+    ProviderFactory,
+    OpenAIProvider,
+    LMStudioProvider,
+    get_provider_config,
+)
+
+
+def test_env_provider_openai(monkeypatch):
+    get_provider_config.cache_clear()
+    monkeypatch.setenv("DEVSYNTH_PROVIDER", "openai")
+    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+    provider = ProviderFactory.create_provider()
+    assert isinstance(provider, OpenAIProvider)
+
+
+def test_env_provider_lmstudio(monkeypatch):
+    get_provider_config.cache_clear()
+    monkeypatch.setenv("DEVSYNTH_PROVIDER", "lm_studio")
+    monkeypatch.setenv("LM_STUDIO_ENDPOINT", "http://localhost:8888")
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    provider = ProviderFactory.create_provider()
+    assert isinstance(provider, LMStudioProvider)


### PR DESCRIPTION
## Summary
- ensure expertise falls back to config in WSDE team
- document unsupported provider types
- add unit tests for provider factory env vars

## Testing
- `poetry run pytest -q` *(fails: ModuleNotFoundError)*
- `poetry run pytest tests/unit -q` *(fails: FileNotFoundError)*
- `poetry run pytest tests/unit/adapters/test_provider_factory_env_vars.py -q`

------
https://chatgpt.com/codex/tasks/task_e_686058f9c4d083338b4b3e6a3b44ecad