### PR TITLE
Update CLI docs and add help test

### DIFF
--- a/docs/user_guides/cli_reference.md
+++ b/docs/user_guides/cli_reference.md
@@ -26,14 +26,28 @@ This document provides a comprehensive reference for the DevSynth Command Line I
   - [spec](#spec)
   - [test](#test)
   - [code](#code)
-  - [config](#config)
   - [run-pipeline](#run-pipeline)
-  - [refactor](#refactor)
+  - [config](#config)
   - [inspect](#inspect)
+  - [gather](#gather)
   - [webapp](#webapp)
   - [webui](#webui)
   - [dbschema](#dbschema)
   - [doctor](#doctor-check)
+  - [check](#doctor-check)
+  - [refactor](#refactor)
+  - [analyze-code](#analyze-code)
+  - [edrr-cycle](#edrr-cycle)
+  - [align](#align)
+  - [alignment-metrics](#alignment-metrics)
+  - [inspect-config](#inspect-config)
+  - [validate-manifest](#validate-manifest)
+  - [validate-metadata](#validate-metadata)
+  - [test-metrics](#test-metrics)
+  - [generate-docs](#generate-docs)
+  - [ingest](#ingest)
+  - [apispec](#apispec)
+  - [serve](#serve)
 - [Environment Variables](#environment-variables)
 - [Configuration File](#configuration-file)
 - [Examples](#examples)
@@ -70,6 +84,36 @@ These options can be used with any command:
 | `--help`, `-h` | Show help message and exit | - |
 
 ## Command Reference
+
+The following commands are available via `devsynth`:
+
+```
+init
+spec
+test
+code
+run-pipeline
+config
+inspect
+gather
+webapp
+webui
+dbschema
+doctor (alias: check)
+refactor
+analyze-code
+edrr-cycle
+align
+alignment-metrics
+inspect-config
+validate-manifest
+validate-metadata
+test-metrics
+generate-docs
+ingest
+apispec
+serve
+```
 
 ### help
 
@@ -397,6 +441,27 @@ devsynth doctor --config-dir ./configs
 
 # Using the alias
 devsynth check
+```
+
+### Additional commands
+
+The CLI also provides several specialized commands used for advanced workflows.
+These commands mirror the names reported by `devsynth --help`:
+
+```
+gather
+analyze-code
+edrr-cycle
+align
+alignment-metrics
+inspect-config
+validate-manifest
+validate-metadata
+test-metrics
+generate-docs
+ingest
+apispec
+serve
 ```
 
 ## Environment Variables

--- a/tests/unit/test_cli_commands.py
+++ b/tests/unit/test_cli_commands.py
@@ -1,0 +1,66 @@
+import click
+import typer
+import typer.main
+from typer.testing import CliRunner
+import pytest
+
+from devsynth.adapters.cli.typer_adapter import build_app
+from devsynth.interface.ux_bridge import UXBridge
+
+
+@pytest.fixture(autouse=True)
+def patch_typer_types(monkeypatch):
+    orig = typer.main.get_click_type
+
+    def patched_get_click_type(*, annotation, parameter_info):
+        if annotation in {UXBridge, typer.models.Context}:
+            return click.STRING
+        origin = getattr(annotation, "__origin__", None)
+        if (
+            origin in {UXBridge, typer.models.Context}
+            or annotation is dict
+            or origin is dict
+        ):
+            return click.STRING
+        return orig(annotation=annotation, parameter_info=parameter_info)
+
+    monkeypatch.setattr(typer.main, "get_click_type", patched_get_click_type)
+
+
+class TestCLIHelpOutput:
+    runner = CliRunner()
+
+    def test_help_lists_commands(self):
+        app = build_app()
+        result = self.runner.invoke(app, ["--help"])
+        assert result.exit_code == 0
+        expected = [
+            "init",
+            "spec",
+            "test",
+            "code",
+            "run-pipeline",
+            "config",
+            "inspect",
+            "gather",
+            "webapp",
+            "webui",
+            "dbschema",
+            "doctor",
+            "check",
+            "refactor",
+            "analyze-code",
+            "edrr-cycle",
+            "align",
+            "alignment-metrics",
+            "inspect-config",
+            "validate-manifest",
+            "validate-metadata",
+            "test-metrics",
+            "generate-docs",
+            "ingest",
+            "apispec",
+            "serve",
+        ]
+        for cmd in expected:
+            assert cmd in result.output


### PR DESCRIPTION
## Summary
- document all available CLI commands in user guide
- add a unit test that checks `devsynth --help` output

## Testing
- `pytest -q tests/unit/test_cli_commands.py`
- `pytest -q` *(fails: 51 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_686085a3eeac83338c3c84f9071ad440