### PR TITLE
Integrate prompt auto tuning

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -120,5 +120,6 @@ features:
   code_generation: false
   test_generation: false
   documentation_generation: false
+  prompt_auto_tuning: false
   automatic_phase_transitions: true
   collaboration_notifications: true

--- a/src/devsynth/application/prompts/prompt_manager.py
+++ b/src/devsynth/application/prompts/prompt_manager.py
@@ -9,8 +9,17 @@ from typing import Dict, List, Optional, Any
 import os
 import json
 from pathlib import Path
+import yaml
 
-from devsynth.application.prompts.prompt_template import PromptTemplate, PromptTemplateVersion
+from devsynth.application.prompts.auto_tuning import (
+    PromptAutoTuner,
+    PromptAutoTuningError,
+)
+
+from devsynth.application.prompts.prompt_template import (
+    PromptTemplate,
+    PromptTemplateVersion,
+)
 from devsynth.application.prompts.prompt_efficacy import PromptEfficacyTracker
 from devsynth.application.prompts.prompt_reflection import PromptReflection
 from devsynth.logging_setup import DevSynthLogger
@@ -18,100 +27,134 @@ from devsynth.logging_setup import DevSynthLogger
 # Create a logger for this module
 logger = DevSynthLogger(__name__)
 
+# Load default configuration for feature flags
+_DEFAULT_CONFIG_PATH = Path(__file__).resolve().parents[3] / "config" / "default.yml"
+try:
+    with open(_DEFAULT_CONFIG_PATH, "r") as f:
+        _DEFAULT_CONFIG = yaml.safe_load(f) or {}
+except Exception:
+    _DEFAULT_CONFIG = {}
+
 
 class PromptManager:
     """
     Manages prompt templates for all agents in the system.
-    
+
     This class provides methods for registering, retrieving, and rendering
     prompt templates, as well as tracking their usage and efficacy.
     """
-    
-    def __init__(self, storage_path: Optional[str] = None, 
-                 efficacy_tracker: Optional[PromptEfficacyTracker] = None,
-                 reflection_system: Optional[PromptReflection] = None):
+
+    def __init__(
+        self,
+        storage_path: Optional[str] = None,
+        efficacy_tracker: Optional[PromptEfficacyTracker] = None,
+        reflection_system: Optional[PromptReflection] = None,
+        config: Optional[Dict[str, Any]] = None,
+    ):
         """
         Initialize the prompt manager.
-        
+
         Args:
             storage_path: Path to store prompt templates (defaults to .devsynth/prompts)
             efficacy_tracker: Optional efficacy tracker to use
             reflection_system: Optional reflection system to use
         """
         self.templates: Dict[str, PromptTemplate] = {}
-        self.storage_path = storage_path or os.path.join(os.getcwd(), ".devsynth", "prompts")
+        self.storage_path = storage_path or os.path.join(
+            os.getcwd(), ".devsynth", "prompts"
+        )
         self.efficacy_tracker = efficacy_tracker
         self.reflection_system = reflection_system
-        
+        self.config = config or _DEFAULT_CONFIG
+        feature_cfg = self.config.get("features", {})
+        self.auto_tuning_enabled = feature_cfg.get("prompt_auto_tuning", False)
+        self.auto_tuner: Optional[PromptAutoTuner] = None
+        self._last_variant_ids: Dict[str, str] = {}
+
+        if self.auto_tuning_enabled:
+            self.auto_tuner = PromptAutoTuner(storage_path=self.storage_path)
+            logger.info("Prompt auto-tuning enabled")
+
         # Create the storage directory if it doesn't exist
         os.makedirs(self.storage_path, exist_ok=True)
-        
+
         # Load any existing templates
         self._load_templates()
-        
-        logger.info(f"Prompt manager initialized with storage path: {self.storage_path}")
-    
-    def register_template(self, name: str, description: str, template_text: str, 
-                         metadata: Optional[Dict[str, Any]] = None,
-                         edrr_phase: Optional[str] = None) -> PromptTemplate:
+
+        logger.info(
+            f"Prompt manager initialized with storage path: {self.storage_path}"
+        )
+
+    def register_template(
+        self,
+        name: str,
+        description: str,
+        template_text: str,
+        metadata: Optional[Dict[str, Any]] = None,
+        edrr_phase: Optional[str] = None,
+    ) -> PromptTemplate:
         """
         Register a new prompt template.
-        
+
         Args:
             name: Unique name for the template
             description: Description of the template's purpose
             template_text: The template text with placeholders
             metadata: Optional metadata for the template
             edrr_phase: Optional EDRR phase this template is associated with
-            
+
         Returns:
             The newly created template
-            
+
         Raises:
             ValueError: If a template with the given name already exists
         """
         if name in self.templates:
             raise ValueError(f"Template with name '{name}' already exists")
-        
+
         template = PromptTemplate(
             name=name,
             description=description,
             metadata=metadata or {},
-            edrr_phase=edrr_phase
+            edrr_phase=edrr_phase,
         )
-        
+
         # Add the initial version
         template.add_version(template_text, metadata)
-        
+
         # Store the template
         self.templates[name] = template
         self._save_template(template)
-        
+
+        if self.auto_tuner:
+            self.auto_tuner.register_template(name, template_text)
+
         logger.info(f"Registered new prompt template: {name}")
         return template
-    
+
     def get_template(self, name: str) -> Optional[PromptTemplate]:
         """
         Get a prompt template by name.
-        
+
         Args:
             name: The name of the template to retrieve
-            
+
         Returns:
             The template, or None if not found
         """
         return self.templates.get(name)
-    
-    def update_template(self, name: str, template_text: str, 
-                       metadata: Optional[Dict[str, Any]] = None) -> Optional[PromptTemplateVersion]:
+
+    def update_template(
+        self, name: str, template_text: str, metadata: Optional[Dict[str, Any]] = None
+    ) -> Optional[PromptTemplateVersion]:
         """
         Update a prompt template by adding a new version.
-        
+
         Args:
             name: The name of the template to update
             template_text: The new template text
             metadata: Optional metadata for the new version
-            
+
         Returns:
             The newly created version, or None if the template doesn't exist
         """
@@ -119,23 +162,27 @@ class PromptManager:
         if not template:
             logger.warning(f"Cannot update non-existent template: {name}")
             return None
-        
+
         version = template.add_version(template_text, metadata)
         self._save_template(template)
-        
+
+        if self.auto_tuner:
+            self.auto_tuner.register_template(name, template_text)
+
         logger.info(f"Updated template '{name}' with new version {version.version_id}")
         return version
-    
-    def render_prompt(self, name: str, variables: Dict[str, str], 
-                     version_id: Optional[str] = None) -> Optional[str]:
+
+    def render_prompt(
+        self, name: str, variables: Dict[str, str], version_id: Optional[str] = None
+    ) -> Optional[str]:
         """
         Render a prompt template with the provided variables.
-        
+
         Args:
             name: The name of the template to render
             variables: Dictionary of variable names and their values
             version_id: Optional ID of the version to use (uses latest if not specified)
-            
+
         Returns:
             The rendered prompt, or None if the template doesn't exist
         """
@@ -143,63 +190,100 @@ class PromptManager:
         if not template:
             logger.warning(f"Cannot render non-existent template: {name}")
             return None
-        
+
         try:
+            if self.auto_tuner and name in self.auto_tuner.prompt_variants:
+                variant = self.auto_tuner.select_variant(name)
+                self._last_variant_ids[name] = variant.variant_id
+                rendered = variant.template
+                for var_name, var_value in variables.items():
+                    rendered = rendered.replace(f"{{{var_name}}}", var_value)
+                if self.efficacy_tracker:
+                    self.efficacy_tracker.track_usage(name, variant.variant_id)
+                return rendered
+
             rendered = template.render(variables, version_id)
-            
+
             # Track usage if efficacy tracker is available
             if self.efficacy_tracker:
-                self.efficacy_tracker.track_usage(name, version_id or template.get_latest_version().version_id)
-            
+                self.efficacy_tracker.track_usage(
+                    name, version_id or template.get_latest_version().version_id
+                )
+
             return rendered
-        except ValueError as e:
+        except (ValueError, PromptAutoTuningError) as e:
             logger.error(f"Error rendering template '{name}': {str(e)}")
             return None
-    
-    def render_and_reflect(self, name: str, variables: Dict[str, str], 
-                          version_id: Optional[str] = None) -> Dict[str, Any]:
+
+    def render_and_reflect(
+        self, name: str, variables: Dict[str, str], version_id: Optional[str] = None
+    ) -> Dict[str, Any]:
         """
         Render a prompt template and set up reflection for the response.
-        
+
         Args:
             name: The name of the template to render
             variables: Dictionary of variable names and their values
             version_id: Optional ID of the version to use
-            
+
         Returns:
             A dictionary containing the rendered prompt and a reflection ID
         """
         rendered = self.render_prompt(name, variables, version_id)
         if not rendered or not self.reflection_system:
             return {"prompt": rendered, "reflection_id": None}
-        
-        reflection_id = self.reflection_system.prepare_reflection(name, variables, rendered)
+
+        reflection_id = self.reflection_system.prepare_reflection(
+            name, variables, rendered
+        )
         return {"prompt": rendered, "reflection_id": reflection_id}
-    
+
     def process_response(self, reflection_id: str, response: str) -> Dict[str, Any]:
         """
         Process a response to a prompt, triggering reflection if available.
-        
+
         Args:
             reflection_id: The ID of the reflection to use
             response: The response to process
-            
+
         Returns:
             A dictionary containing the reflection results
         """
         if not self.reflection_system or not reflection_id:
             return {"reflection": None}
-        
+
         reflection = self.reflection_system.reflect(reflection_id, response)
         return {"reflection": reflection}
-    
+
+    def record_tuning_feedback(
+        self,
+        name: str,
+        success: bool | None = None,
+        feedback_score: float | None = None,
+    ) -> None:
+        """Record feedback for the last rendered variant of a template."""
+        if not self.auto_tuner:
+            return
+
+        variant_id = self._last_variant_ids.get(name)
+        if not variant_id:
+            logger.warning(
+                f"No variant recorded for template '{name}' to provide feedback"
+            )
+            return
+
+        try:
+            self.auto_tuner.record_feedback(name, variant_id, success, feedback_score)
+        except PromptAutoTuningError as e:
+            logger.error(f"Failed to record auto-tuning feedback: {e}")
+
     def list_templates(self, edrr_phase: Optional[str] = None) -> List[Dict[str, Any]]:
         """
         List all available templates, optionally filtered by EDRR phase.
-        
+
         Args:
             edrr_phase: Optional EDRR phase to filter by
-            
+
         Returns:
             A list of template metadata dictionaries
         """
@@ -207,19 +291,21 @@ class PromptManager:
         for name, template in self.templates.items():
             if edrr_phase and template.edrr_phase != edrr_phase:
                 continue
-            
+
             latest = template.get_latest_version()
-            result.append({
-                "name": name,
-                "description": template.description,
-                "edrr_phase": template.edrr_phase,
-                "versions": len(template.versions),
-                "latest_version_id": latest.version_id if latest else None,
-                "created_at": latest.created_at.isoformat() if latest else None
-            })
-        
+            result.append(
+                {
+                    "name": name,
+                    "description": template.description,
+                    "edrr_phase": template.edrr_phase,
+                    "versions": len(template.versions),
+                    "latest_version_id": latest.version_id if latest else None,
+                    "created_at": latest.created_at.isoformat() if latest else None,
+                }
+            )
+
         return result
-    
+
     def _load_templates(self) -> None:
         """Load templates from the storage path."""
         template_files = Path(self.storage_path).glob("*.json")
@@ -227,14 +313,14 @@ class PromptManager:
             try:
                 with open(file_path, "r") as f:
                     data = json.load(f)
-                
+
                 template = self._deserialize_template(data)
                 if template:
                     self.templates[template.name] = template
                     logger.debug(f"Loaded template: {template.name}")
             except Exception as e:
                 logger.error(f"Error loading template from {file_path}: {str(e)}")
-    
+
     def _save_template(self, template: PromptTemplate) -> None:
         """Save a template to the storage path."""
         file_path = os.path.join(self.storage_path, f"{template.name}.json")
@@ -244,7 +330,7 @@ class PromptManager:
             logger.debug(f"Saved template: {template.name}")
         except Exception as e:
             logger.error(f"Error saving template {template.name}: {str(e)}")
-    
+
     def _serialize_template(self, template: PromptTemplate) -> Dict[str, Any]:
         """Serialize a template to a dictionary."""
         return {
@@ -257,12 +343,12 @@ class PromptManager:
                     "version_id": v.version_id,
                     "template_text": v.template_text,
                     "created_at": v.created_at.isoformat(),
-                    "metadata": v.metadata
+                    "metadata": v.metadata,
                 }
                 for v in template.versions
-            ]
+            ],
         }
-    
+
     def _deserialize_template(self, data: Dict[str, Any]) -> Optional[PromptTemplate]:
         """Deserialize a template from a dictionary."""
         try:
@@ -270,18 +356,18 @@ class PromptManager:
                 name=data["name"],
                 description=data["description"],
                 metadata=data.get("metadata", {}),
-                edrr_phase=data.get("edrr_phase")
+                edrr_phase=data.get("edrr_phase"),
             )
-            
+
             for v_data in data.get("versions", []):
                 version = PromptTemplateVersion(
                     version_id=v_data["version_id"],
                     template_text=v_data["template_text"],
                     created_at=datetime.fromisoformat(v_data["created_at"]),
-                    metadata=v_data.get("metadata", {})
+                    metadata=v_data.get("metadata", {}),
                 )
                 template.versions.append(version)
-            
+
             return template
         except Exception as e:
             logger.error(f"Error deserializing template: {str(e)}")

--- a/tests/integration/test_prompt_auto_tuning.py
+++ b/tests/integration/test_prompt_auto_tuning.py
@@ -1,0 +1,31 @@
+import os
+from devsynth.application.prompts.prompt_manager import PromptManager
+
+
+def test_auto_tuner_disabled_by_default(tmp_path):
+    storage = tmp_path / "prompts"
+    pm = PromptManager(storage_path=str(storage))
+    assert pm.auto_tuner is None
+
+
+def test_prompt_auto_tuning_feedback_loop(tmp_path):
+    storage = tmp_path / "prompts"
+    pm = PromptManager(
+        storage_path=str(storage),
+        config={"features": {"prompt_auto_tuning": True}},
+    )
+    assert pm.auto_tuner is not None
+    pm.auto_tuner.exploration_rate = 0.0
+
+    pm.register_template("greet", "Greeting template", "Hello {name}")
+
+    for i in range(6):
+        rendered = pm.render_prompt("greet", {"name": f"User{i}"})
+        assert f"User{i}" in rendered
+        success = i % 2 == 0
+        score = 0.9 if success else 0.1
+        pm.record_tuning_feedback("greet", success=success, feedback_score=score)
+
+    variants = pm.auto_tuner.prompt_variants["greet"]
+    assert variants[0].usage_count >= 6
+    assert os.path.exists(storage / "prompt_variants.json")


### PR DESCRIPTION
## Summary
- enable optional auto tuning via PromptAutoTuner in prompt manager
- store auto-tuning data under `.devsynth/prompts/`
- add feature flag `prompt_auto_tuning` (disabled by default)
- create integration tests for prompt auto tuning

## Testing
- `poetry run pytest tests/integration/test_prompt_auto_tuning.py -q`
- `poetry run pytest tests/unit/application/test_prompt_auto_tuning.py::TestPromptAutoTuner::test_initialization tests/integration/test_prompt_auto_tuning.py -q`


------
https://chatgpt.com/codex/tasks/task_e_6860bb5c2f9083338ad9c24b05035967