### PR TITLE
Add CLI doctor and EDRR cycle warning scenarios

### DIFF
--- a/src/devsynth/application/cli/commands/analyze_manifest_cmd.py
+++ b/src/devsynth/application/cli/commands/analyze_manifest_cmd.py
@@ -1,0 +1,18 @@
+"""Placeholder analyze-manifest command."""
+
+from typing import Optional
+from devsynth.interface.cli import CLIUXBridge
+from devsynth.interface.ux_bridge import UXBridge
+from devsynth.logging_setup import DevSynthLogger
+
+logger = DevSynthLogger(__name__)
+bridge: UXBridge = CLIUXBridge()
+
+
+def analyze_manifest_cmd(
+    path: Optional[str] = None, update: bool = False, prune: bool = False
+) -> None:
+    """Dummy implementation for analyze-manifest."""
+    bridge.print(
+        "[yellow]Warning:[/yellow] analyze-manifest command is not implemented"
+    )

--- a/tests/behavior/features/cli_commands.feature
+++ b/tests/behavior/features/cli_commands.feature
@@ -104,3 +104,15 @@ Scenario: Validate environment configuration
 Scenario: Serve API on custom port
   When I run the command "devsynth serve --port 8081"
   Then uvicorn should be called with host "0.0.0.0" and port 8081
+
+Scenario: Doctor warns about missing environment variables
+  Given essential environment variables are missing
+  When I run the command "devsynth doctor"
+  Then the system should display a warning message
+  And the output should mention the missing variables
+
+Scenario: Handle invalid manifest in EDRR cycle
+  Given a project with an invalid manifest file
+  When I run the command "devsynth edrr-cycle invalid_manifest.yaml"
+  Then the system should display a warning message
+  And the output should indicate configuration errors

--- a/tests/behavior/steps/cli_commands_steps.py
+++ b/tests/behavior/steps/cli_commands_steps.py
@@ -614,3 +614,26 @@ def uvicorn_called_with(host, port, command_context):
         assert args[0] == "devsynth.api:app"
     assert kwargs.get("host") == host
     assert kwargs.get("port") == port
+
+
+@given("essential environment variables are missing")
+def missing_env_vars(monkeypatch):
+    """Unset environment variables required for the doctor command."""
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.delenv("LM_STUDIO_ENDPOINT", raising=False)
+
+
+@given("a project with an invalid manifest file")
+def invalid_manifest_file(tmp_project_dir):
+    """Create a malformed manifest file in the project directory."""
+    manifest_path = os.path.join(tmp_project_dir, "invalid_manifest.yaml")
+    with open(manifest_path, "w") as f:
+        f.write("invalid: [unclosed")
+    return manifest_path
+
+
+@then("the output should mention the missing variables")
+def output_mentions_missing_vars(command_context):
+    """Check that missing environment variables are referenced in output."""
+    output = command_context.get("output", "")
+    assert "OPENAI_API_KEY" in output or "LM_STUDIO_ENDPOINT" in output


### PR DESCRIPTION
## Summary
- add scenarios for missing environment vars and invalid manifest
- create placeholder `analyze_manifest_cmd` to satisfy imports
- implement steps for missing env vars and invalid manifest

## Testing
- `poetry run pytest tests/` *(fails: ModuleNotFoundError and other errors)*

------
https://chatgpt.com/codex/tasks/task_e_6860c57d6cc88333acd6742fef1e5022