### PR TITLE
Add more doctor command scenarios

### DIFF
--- a/tests/behavior/features/doctor_command.feature
+++ b/tests/behavior/features/doctor_command.feature
@@ -33,3 +33,21 @@ Feature: Doctor Command
     When I run the command "devsynth doctor"
     Then the system should display a warning message
     And the output should indicate configuration errors
+
+  Scenario: Detect invalid YAML syntax in devsynth.yml
+    Given a devsynth.yml file with invalid YAML syntax
+    When I run the command "devsynth doctor"
+    Then the system should display a warning message
+    And the output should indicate configuration errors
+
+  Scenario: Warn about unsupported configuration keys
+    Given a devsynth.yml file with unsupported configuration keys
+    When I run the command "devsynth doctor"
+    Then the system should display a warning message
+    And the output should indicate configuration errors
+
+  Scenario: Warn when .env file is missing
+    Given no .env file exists in the project
+    When I run the command "devsynth doctor"
+    Then the system should display a warning message
+    And the output should mention the missing .env file

--- a/tests/behavior/steps/devsynth_doctor_steps.py
+++ b/tests/behavior/steps/devsynth_doctor_steps.py
@@ -17,3 +17,42 @@ def no_devsynth_config(tmp_project_dir):
 def output_should_include_hint(command_context):
     output = command_context.get("output", "")
     assert "devsynth init" in output
+
+
+@given("a devsynth.yml file with invalid YAML syntax")
+def devsynth_yaml_invalid(tmp_project_dir, monkeypatch):
+    """Create a DevSynth config file containing malformed YAML."""
+    dev_dir = os.path.join(tmp_project_dir, ".devsynth")
+    os.makedirs(dev_dir, exist_ok=True)
+    with open(os.path.join(dev_dir, "devsynth.yml"), "w") as f:
+        f.write("invalid: [unclosed")
+    monkeypatch.chdir(tmp_project_dir)
+    return tmp_project_dir
+
+
+@given("a devsynth.yml file with unsupported configuration keys")
+def devsynth_yaml_unsupported_keys(tmp_project_dir, monkeypatch):
+    """Create a DevSynth config file containing unknown keys."""
+    dev_dir = os.path.join(tmp_project_dir, ".devsynth")
+    os.makedirs(dev_dir, exist_ok=True)
+    with open(os.path.join(dev_dir, "devsynth.yml"), "w") as f:
+        f.write("unsupported_option: true\n")
+    monkeypatch.chdir(tmp_project_dir)
+    return tmp_project_dir
+
+
+@given("no .env file exists in the project")
+def remove_env_file(tmp_project_dir, monkeypatch):
+    """Ensure the project has no .env file."""
+    env_path = os.path.join(tmp_project_dir, ".env")
+    if os.path.exists(env_path):
+        os.remove(env_path)
+    monkeypatch.chdir(tmp_project_dir)
+    return tmp_project_dir
+
+
+@then("the output should mention the missing .env file")
+def output_mentions_missing_env_file(command_context):
+    """Verify that the doctor output references the missing .env file."""
+    output = command_context.get("output", "")
+    assert ".env" in output

--- a/tests/behavior/test_doctor_command.py
+++ b/tests/behavior/test_doctor_command.py
@@ -3,6 +3,7 @@ from pytest_bdd import scenarios
 
 from .steps.cli_commands_steps import *  # noqa: F401,F403
 from .steps.doctor_command_steps import *  # noqa: F401,F403
+from .steps.devsynth_doctor_steps import *  # noqa: F401,F403
 
 pytestmark = pytest.mark.requires_resource("cli")
 


### PR DESCRIPTION
## Summary
- expand `doctor_command.feature` with cases for invalid YAML, unsupported keys, and missing `.env`
- implement matching step definitions in `devsynth_doctor_steps.py`
- register new steps in `test_doctor_command.py`

## Testing
- `poetry run pytest tests/behavior/test_doctor_command.py -q`
- `poetry run pytest tests/` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_68618c8ca9108333af6868692db80060