### PR TITLE
Fix codex setup script to verify deps

### DIFF
--- a/scripts/codex_setup.sh
+++ b/scripts/codex_setup.sh
@@ -9,4 +9,19 @@ apt-get install -y \
 apt-get clean
 rm -rf /var/lib/apt/lists/*
 
-poetry sync --all-groups --all-extras
+# Install all project dependencies including optional groups
+poetry install --all-extras --with dev,docs
+
+# Verify that core and development packages are available
+poetry run python - <<'EOF'
+import sys
+import pkg_resources
+
+required = ["typer", "pytest"]
+missing = [pkg for pkg in required if pkg not in {d.key for d in pkg_resources.working_set}]
+if missing:
+    sys.exit(f"Missing packages: {', '.join(missing)}")
+EOF
+
+# Cleanup any failure marker if the setup completes successfully
+[ -f CODEX_ENVIRONMENT_SETUP_FAILED ] && rm CODEX_ENVIRONMENT_SETUP_FAILED


### PR DESCRIPTION
## Summary
- update `codex_setup.sh` to install all Poetry extras
- verify that key packages are installed
- remove the setup failure marker when complete

## Testing
- `poetry run pytest tests/unit/application/memory/test_chromadb_store.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6861c2c794448333927761129a0418d5