### PR TITLE
Add coordinator voting tests

### DIFF
--- a/src/devsynth/application/collaboration/coordinator.py
+++ b/src/devsynth/application/collaboration/coordinator.py
@@ -126,6 +126,10 @@ class AgentCoordinatorImpl(AgentCoordinator):
         if not self.agents:
             raise TeamConfigurationError("No agents available in the team")
 
+        # Critical decisions use the WSDE voting mechanism
+        if task.get("type") == "critical_decision" and task.get("is_critical", False):
+            return self.team.vote_on_critical_decision(task)
+
         # Assign roles to team members
         phase_name = task.get("phase")
         if phase_name:

--- a/tests/unit/application/collaboration/test_coordinator.py
+++ b/tests/unit/application/collaboration/test_coordinator.py
@@ -4,6 +4,7 @@ from unittest.mock import MagicMock, patch
 from devsynth.domain.interfaces.agent import Agent
 from devsynth.application.collaboration.coordinator import AgentCoordinatorImpl
 from devsynth.exceptions import ValidationError
+from devsynth.application.collaboration.exceptions import TeamConfigurationError
 
 
 class TestAgentCoordinatorPrimusSelection:
@@ -58,6 +59,46 @@ class TestAgentCoordinatorPrimusSelection:
         assert result["contributors"] == consensus["contributors"]
         assert result["method"] == consensus["method"]
 
+    def test_multi_agent_consensus_reached(self):
+        consensus = {
+            "consensus": "final-result",
+            "contributors": ["python", "javascript", "docs"],
+            "method": "consensus_synthesis",
+        }
+
+        with patch.object(
+            self.coordinator.team, "build_consensus", return_value=consensus
+        ) as bc:
+            task = {"team_task": True, "language": "python", "type": "coding"}
+            result = self.coordinator.delegate_task(task)
+
+        bc.assert_called_once_with(task)
+        self.python_agent.process.assert_called_once()
+        self.js_agent.process.assert_called_once()
+        self.doc_agent.process.assert_called_once()
+        assert result["result"] == consensus["consensus"]
+        assert result["contributors"] == consensus["contributors"]
+        assert result["method"] == consensus["method"]
+
+    def test_role_assignment_and_primus_selection(self):
+        consensus = {
+            "consensus": "ok",
+            "contributors": ["python", "javascript", "docs"],
+            "method": "consensus_synthesis",
+        }
+
+        with patch.object(
+            self.coordinator.team, "build_consensus", return_value=consensus
+        ):
+            self.coordinator.delegate_task(
+                {"team_task": True, "language": "python", "type": "coding"}
+            )
+
+        role_map = self.coordinator.team.get_role_map()
+        assert role_map[self.python_agent.name] == "Primus"
+        assert role_map[self.js_agent.name] == "Supervisor"
+        assert role_map[self.doc_agent.name] == "Worker"
+
 
 class TestAgentCoordinatorErrorPaths:
     def test_missing_agent_type(self):
@@ -70,3 +111,35 @@ class TestAgentCoordinatorErrorPaths:
 
         with pytest.raises(ValidationError):
             coordinator.delegate_task({"agent_type": "nonexistent"})
+
+    def test_critical_decision_invokes_voting(self):
+        coordinator = AgentCoordinatorImpl({"features": {"wsde_collaboration": True}})
+        agent = MagicMock(spec=Agent)
+        agent.name = "voter"
+        agent.agent_type = "planner"
+        agent.current_role = None
+        coordinator.add_agent(agent)
+
+        task = {
+            "team_task": True,
+            "type": "critical_decision",
+            "is_critical": True,
+            "options": [{"id": "a"}, {"id": "b"}],
+        }
+
+        with patch.object(
+            coordinator.team,
+            "vote_on_critical_decision",
+            return_value={"result": {"winner": "a"}},
+        ) as vote:
+            result = coordinator.delegate_task(task)
+
+        vote.assert_called_once_with(task)
+        assert result["result"]["winner"] == "a"
+
+    def test_delegate_task_no_agents_registered(self):
+        coordinator = AgentCoordinatorImpl({"features": {"wsde_collaboration": True}})
+        task = {"team_task": True}
+
+        with pytest.raises(TeamConfigurationError):
+            coordinator.delegate_task(task)


### PR DESCRIPTION
## Summary
- unit tests for AgentCoordinatorImpl covering consensus, role assignment, voting, and error cases
- ensure critical decision tasks call the WSDE team's voting method
- support voting in `_handle_team_task`

## Testing
- `pytest -q tests/unit/application/collaboration/test_coordinator.py`
- `pytest -q` *(fails: ImportError: httpx)*

------
https://chatgpt.com/codex/tasks/task_e_6861d8ddbf9c833384664faad91ef924