### PR TITLE
Implement interactive setup wizard

### DIFF
--- a/src/devsynth/application/cli/cli_commands.py
+++ b/src/devsynth/application/cli/cli_commands.py
@@ -97,11 +97,20 @@ def config_key_autocomplete(ctx: typer.Context, incomplete: str):
     return loader_autocomplete(ctx, incomplete)
 
 
-def init_cmd(*, bridge: Optional[UXBridge] = None) -> None:
-    """Interactively initialize a new project."""
+def init_cmd(interactive: bool = False, *, bridge: Optional[UXBridge] = None) -> None:
+    """Initialize a new project.
+
+    If ``interactive`` is True, run the :class:`SetupWizard` for a guided setup.
+    """
 
     bridge = _resolve_bridge(bridge)
     try:
+        if interactive:
+            from .setup_wizard import SetupWizard
+
+            SetupWizard(bridge).run()
+            return
+
         config = load_project_config()
         if config.exists():
             bridge.display_result("Project already initialized")

--- a/src/devsynth/application/cli/setup_wizard.py
+++ b/src/devsynth/application/cli/setup_wizard.py
@@ -1,15 +1,93 @@
-"""Guided Setup Wizard placeholder."""
+"""Interactive setup wizard used by ``devsynth init``."""
 
 from __future__ import annotations
 
+import os
+from typing import Dict, Optional
+
+from devsynth.config import load_project_config, ProjectUnifiedConfig
+from devsynth.interface.cli import CLIUXBridge
+from devsynth.interface.ux_bridge import UXBridge
+
 
 class SetupWizard:
-    """Interactive wizard for project setup.
+    """Guide the user through project initialization."""
 
-    This placeholder provides a minimal interface that will
-    later guide users through configuring a new DevSynth project.
-    """
+    def __init__(self, bridge: Optional[UXBridge] = None) -> None:
+        self.bridge = bridge or CLIUXBridge()
 
-    def run(self) -> None:
-        """Execute the wizard steps."""
-        pass
+    # ------------------------------------------------------------------
+    # Private helpers
+    # ------------------------------------------------------------------
+    def _prompt_features(self, cfg: ProjectUnifiedConfig) -> Dict[str, bool]:
+        features = cfg.config.features or {}
+        for feat in [
+            "wsde_collaboration",
+            "dialectical_reasoning",
+            "code_generation",
+            "test_generation",
+            "documentation_generation",
+            "experimental_features",
+        ]:
+            features[feat] = self.bridge.confirm_choice(
+                f"Enable {feat.replace('_', ' ')}?",
+                default=features.get(feat, False),
+            )
+        return features
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+    def run(self) -> ProjectUnifiedConfig:
+        """Execute the wizard steps and persist configuration."""
+
+        cfg = load_project_config()
+        if cfg.exists():
+            self.bridge.display_result("Project already initialized")
+            return cfg
+
+        root = self.bridge.ask_question("Project root", default=os.getcwd())
+        structure = self.bridge.ask_question(
+            "Project structure",
+            choices=["single_package", "monorepo"],
+            default="single_package",
+        )
+        language = self.bridge.ask_question("Primary language", default="python")
+        constraints = (
+            self.bridge.ask_question(
+                "Path to constraint file (optional)",
+                default="",
+                show_default=False,
+            )
+            or None
+        )
+
+        memory_backend = self.bridge.ask_question(
+            "Select memory backend",
+            choices=["memory", "file", "kuzu", "chromadb"],
+            default=cfg.config.memory_store_type,
+        )
+        offline_mode = self.bridge.confirm_choice(
+            "Enable offline mode?", default=cfg.config.offline_mode
+        )
+
+        features = self._prompt_features(cfg)
+
+        if not self.bridge.confirm_choice("Proceed with initialization?", default=True):
+            self.bridge.display_result("[yellow]Initialization aborted.[/yellow]")
+            return cfg
+
+        cfg.set_root(root)
+        cfg.config.structure = structure
+        cfg.set_language(language)
+        cfg.config.constraints = constraints
+        cfg.config.memory_store_type = memory_backend
+        cfg.config.offline_mode = offline_mode
+        cfg.config.features = features
+        cfg.save()
+
+        self.bridge.display_result("Initialization complete", highlight=True)
+        return cfg
+
+
+__all__ = ["SetupWizard"]

--- a/tests/unit/application/cli/test_setup_wizard.py
+++ b/tests/unit/application/cli/test_setup_wizard.py
@@ -1,6 +1,6 @@
 from importlib.util import module_from_spec, spec_from_file_location
 from pathlib import Path
-
+from devsynth.interface.ux_bridge import UXBridge
 
 MODULE_PATH = (
     Path(__file__).resolve().parents[4]
@@ -17,6 +17,79 @@ spec.loader.exec_module(setup_wizard)
 SetupWizard = setup_wizard.SetupWizard
 
 
+class DummyBridge(UXBridge):
+    def __init__(self, answers, confirms) -> None:
+        self.answers = list(answers)
+        self.confirms = list(confirms)
+        self.messages = []
+
+    def ask_question(self, *a, **k):
+        return self.answers.pop(0)
+
+    def confirm_choice(self, *a, **k):
+        return self.confirms.pop(0)
+
+    def display_result(self, message: str, *, highlight: bool = False) -> None:
+        self.messages.append(message)
+
+
 def test_setup_wizard_instantiation() -> None:
     wizard = SetupWizard()
     assert isinstance(wizard, SetupWizard)
+
+
+def test_setup_wizard_run(tmp_path, monkeypatch) -> None:
+    monkeypatch.chdir(tmp_path)
+    answers = [
+        str(tmp_path),
+        "single_package",
+        "python",
+        "",
+        "kuzu",
+    ]
+    confirms = [
+        True,  # offline mode
+        True,  # wsde_collaboration
+        False,  # dialectical_reasoning
+        False,  # code_generation
+        False,  # test_generation
+        False,  # documentation_generation
+        False,  # experimental_features
+        True,  # proceed
+    ]
+    bridge = DummyBridge(answers, confirms)
+    wizard = SetupWizard(bridge)
+    cfg = wizard.run()
+    cfg_file = tmp_path / ".devsynth" / "project.yaml"
+    assert cfg_file.exists()
+    assert cfg.config.memory_store_type == "kuzu"
+    assert cfg.config.offline_mode is True
+    assert cfg.config.features["wsde_collaboration"] is True
+    assert "Initialization complete" in bridge.messages[-1]
+
+
+def test_setup_wizard_abort(tmp_path, monkeypatch) -> None:
+    monkeypatch.chdir(tmp_path)
+    answers = [
+        str(tmp_path),
+        "single_package",
+        "python",
+        "",
+        "memory",
+    ]
+    confirms = [
+        False,  # offline mode
+        False,  # wsde_collaboration
+        False,  # dialectical_reasoning
+        False,  # code_generation
+        False,  # test_generation
+        False,  # documentation_generation
+        False,  # experimental_features
+        False,  # proceed
+    ]
+    bridge = DummyBridge(answers, confirms)
+    wizard = SetupWizard(bridge)
+    wizard.run()
+    cfg_file = tmp_path / ".devsynth" / "project.yaml"
+    assert not cfg_file.exists()
+    assert "Initialization aborted." in bridge.messages[-1]


### PR DESCRIPTION
## Summary
- implement project initialization wizard per docs
- invoke wizard via `devsynth init --interactive`
- add unit tests for new wizard behaviour

## Testing
- `pytest -q tests/unit/application/cli/test_setup_wizard.py -q`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'langgraph')*

------
https://chatgpt.com/codex/tasks/task_e_6861dcd8169883339eaf8644db1e4f58