### PR TITLE
Switch CLI config loading to core loader

### DIFF
--- a/src/devsynth/adapters/cli/typer_adapter.py
+++ b/src/devsynth/adapters/cli/typer_adapter.py
@@ -1,6 +1,6 @@
 import typer
 from devsynth.logging_setup import DevSynthLogger
-from devsynth.config import load_project_config
+from devsynth.core.config_loader import load_config
 
 from devsynth.application.cli import (
     init_cmd,
@@ -179,7 +179,7 @@ app = build_app()
 def _warn_if_features_disabled() -> None:
     """Emit a notice when all feature flags are disabled."""
     try:
-        cfg = load_project_config().config
+        cfg = load_config()
         features = cfg.features or {}
         if features and not any(features.values()):
             typer.echo(

--- a/src/devsynth/application/cli/commands/doctor_cmd.py
+++ b/src/devsynth/application/cli/commands/doctor_cmd.py
@@ -1,7 +1,7 @@
 from pathlib import Path
 from rich.console import Console
 from devsynth.logging_setup import DevSynthLogger
-from devsynth.config.unified_loader import UnifiedConfigLoader
+from devsynth.core.config_loader import load_config, _find_project_config
 from devsynth.interface.cli import CLIUXBridge
 from devsynth.interface.ux_bridge import UXBridge
 import importlib.util
@@ -20,8 +20,8 @@ def doctor_cmd(config_dir: str = "config") -> None:
         `devsynth doctor --config-dir ./config`
     """
     try:
-        config = UnifiedConfigLoader.load()
-        if not config.exists():
+        config = load_config()
+        if _find_project_config(Path.cwd()) is None:
             bridge.print(
                 "[yellow]No project configuration found. Run 'devsynth init' to create it.[/yellow]"
             )

--- a/src/devsynth/application/cli/commands/edrr_cycle_cmd.py
+++ b/src/devsynth/application/cli/commands/edrr_cycle_cmd.py
@@ -18,7 +18,7 @@ from devsynth.core import run_pipeline
 from devsynth.methodology.base import Phase
 from devsynth.logging_setup import DevSynthLogger
 from devsynth.exceptions import DevSynthError
-from devsynth.config import load_project_config
+from devsynth.core.config_loader import load_config
 
 logger = DevSynthLogger(__name__)
 bridge: UXBridge = CLIUXBridge()
@@ -50,7 +50,7 @@ def edrr_cycle_cmd(manifest: str, auto: bool = True) -> None:
         prompt_manager = PromptManager()
         documentation_manager = DocumentationManager(memory_manager)
 
-        project_cfg = load_project_config().config.as_dict()
+        project_cfg = load_config().as_dict()
         edrr_cfg = project_cfg.get("edrr", {})
         edrr_cfg.setdefault("phase_transition", {})["auto"] = auto
         project_cfg["edrr"] = edrr_cfg

--- a/src/devsynth/application/llm/providers.py
+++ b/src/devsynth/application/llm/providers.py
@@ -2,7 +2,8 @@ from typing import Any, Dict, List, Optional
 import httpx
 from ...domain.interfaces.llm import LLMProvider, LLMProviderFactory
 import os
-from devsynth.config import load_project_config, get_llm_settings
+from devsynth.core.config_loader import load_config
+from devsynth.config import get_llm_settings
 
 # Create a logger for this module
 from devsynth.logging_setup import DevSynthLogger
@@ -191,7 +192,7 @@ class SimpleLLMProviderFactory(LLMProviderFactory):
 def get_llm_provider(config: Dict[str, Any] | None = None) -> LLMProvider:
     """Return an LLM provider based on configuration."""
 
-    cfg = config or load_project_config().config.as_dict()
+    cfg = config or load_config().as_dict()
     offline = cfg.get("offline_mode", False)
 
     llm_cfg = get_llm_settings()

--- a/tests/behavior/steps/edrr_cycle_steps.py
+++ b/tests/behavior/steps/edrr_cycle_steps.py
@@ -34,9 +34,9 @@ def run_edrr_cycle(context):
     with patch('devsynth.application.cli.commands.edrr_cycle_cmd.bridge') as mock_bridge, \
          patch('devsynth.application.cli.commands.edrr_cycle_cmd.EDRRCoordinator') as coord_cls, \
          patch('devsynth.application.cli.commands.edrr_cycle_cmd.MemoryManager') as manager_cls, \
-         patch('devsynth.application.cli.commands.edrr_cycle_cmd.load_project_config') as cfg_loader:
+         patch('devsynth.core.config_loader.load_config') as cfg_loader:
         cfg = MagicMock()
-        cfg.config.as_dict.return_value = {}
+        cfg.as_dict.return_value = {}
         cfg_loader.return_value = cfg
         coordinator = MagicMock()
         coordinator.generate_report.return_value = {'ok': True}

--- a/tests/unit/application/cli/test_config_validation.py
+++ b/tests/unit/application/cli/test_config_validation.py
@@ -42,7 +42,7 @@ def test_config_warnings(tmp_path, monkeypatch):
         patch.object(
             doctor_cmd.importlib.util, "spec_from_file_location", side_effect=fake_spec
         ),
-        patch.object(doctor_cmd.UnifiedConfigLoader, "load"),
+        patch.object(doctor_cmd, "load_config"),
         patch.object(doctor_cmd.bridge, "print") as mock_print,
     ):
         doctor_cmd.doctor_cmd(str(config_dir))
@@ -107,7 +107,7 @@ def test_config_success(tmp_path, monkeypatch):
         patch.object(
             doctor_cmd.importlib.util, "spec_from_file_location", side_effect=fake_spec
         ),
-        patch.object(doctor_cmd.UnifiedConfigLoader, "load"),
+        patch.object(doctor_cmd, "load_config"),
         patch.object(doctor_cmd.bridge, "print") as mock_print,
     ):
         doctor_cmd.doctor_cmd(str(config_dir))

--- a/tests/unit/application/cli/test_doctor_cmd.py
+++ b/tests/unit/application/cli/test_doctor_cmd.py
@@ -53,7 +53,7 @@ def test_doctor_cmd_old_python_and_missing_env_warn(monkeypatch):
 
     with (
         _patch_validation_loader(),
-        patch.object(doctor_cmd.UnifiedConfigLoader, "load", return_value=cfg),
+        patch.object(doctor_cmd, "load_config", return_value=cfg),
         patch.object(doctor_cmd.bridge, "print") as mock_print,
     ):
         doctor_cmd.doctor_cmd("config")
@@ -117,7 +117,7 @@ def test_doctor_cmd_success(tmp_path, monkeypatch):
 
     with (
         _patch_validation_loader(),
-        patch.object(doctor_cmd.UnifiedConfigLoader, "load", return_value=cfg),
+        patch.object(doctor_cmd, "load_config", return_value=cfg),
         patch.object(doctor_cmd.bridge, "print") as mock_print,
     ):
         doctor_cmd.doctor_cmd(str(config_dir))
@@ -141,7 +141,7 @@ def test_doctor_cmd_invalid_config(tmp_path, monkeypatch):
 
     with (
         _patch_validation_loader(),
-        patch.object(doctor_cmd.UnifiedConfigLoader, "load", return_value=cfg),
+        patch.object(doctor_cmd, "load_config", return_value=cfg),
         patch.object(doctor_cmd.bridge, "print") as mock_print,
     ):
         doctor_cmd.doctor_cmd(str(config_dir))
@@ -163,7 +163,7 @@ def test_doctor_cmd_missing_env_vars(monkeypatch, missing):
 
     with (
         _patch_validation_loader(),
-        patch.object(doctor_cmd.UnifiedConfigLoader, "load", return_value=cfg),
+        patch.object(doctor_cmd, "load_config", return_value=cfg),
         patch.object(doctor_cmd.bridge, "print") as mock_print,
     ):
         doctor_cmd.doctor_cmd("config")

--- a/tests/unit/application/llm/test_offline_provider.py
+++ b/tests/unit/application/llm/test_offline_provider.py
@@ -6,14 +6,13 @@ from devsynth.application.llm.offline_provider import OfflineProvider
 
 def _mock_config():
     cfg = types.SimpleNamespace()
-    cfg.config = types.SimpleNamespace()
-    cfg.config.as_dict = lambda: {"offline_mode": True}
+    cfg.as_dict = lambda: {"offline_mode": True}
     return cfg
 
 
 def test_get_llm_provider_returns_offline(monkeypatch):
     monkeypatch.setattr(
-        "devsynth.application.llm.providers.load_project_config",
+        "devsynth.application.llm.providers.load_config",
         lambda: _mock_config(),
     )
     monkeypatch.setattr(

--- a/tests/unit/test_edrr_cycle_cmd.py
+++ b/tests/unit/test_edrr_cycle_cmd.py
@@ -37,11 +37,11 @@ def mock_components():
 
 @pytest.fixture
 def mock_config():
-    """Patch load_project_config to return an empty config."""
+    """Patch config loader to return an empty config."""
     cfg = MagicMock()
-    cfg.config.as_dict.return_value = {}
+    cfg.as_dict.return_value = {}
     with patch(
-        "devsynth.application.cli.commands.edrr_cycle_cmd.load_project_config",
+        "devsynth.core.config_loader.load_config",
         return_value=cfg,
     ) as mock_loader:
         yield mock_loader

--- a/tests/unit/test_llm_provider_selection.py
+++ b/tests/unit/test_llm_provider_selection.py
@@ -7,8 +7,7 @@ from devsynth.application.llm.openai_provider import OpenAIProvider
 
 def _mock_config(offline: bool):
     cfg = types.SimpleNamespace()
-    cfg.config = types.SimpleNamespace()
-    cfg.config.as_dict = lambda: {"offline_mode": offline}
+    cfg.as_dict = lambda: {"offline_mode": offline}
     return cfg
 
 
@@ -17,7 +16,7 @@ def test_offline_mode_selects_offline_provider(monkeypatch):
         "devsynth.application.utils.token_tracker.TIKTOKEN_AVAILABLE", False
     )
     monkeypatch.setattr(
-        "devsynth.application.llm.providers.load_project_config",
+        "devsynth.application.llm.providers.load_config",
         lambda: _mock_config(True),
     )
     monkeypatch.setattr(
@@ -37,7 +36,7 @@ def test_online_mode_uses_configured_provider(monkeypatch):
         "devsynth.application.utils.token_tracker.TIKTOKEN_AVAILABLE", False
     )
     monkeypatch.setattr(
-        "devsynth.application.llm.providers.load_project_config",
+        "devsynth.application.llm.providers.load_config",
         lambda: _mock_config(False),
     )
     monkeypatch.setattr(


### PR DESCRIPTION
## Summary
- use `core.config_loader.load_config` across CLI modules
- replace project loader usage in initialization wizard and commands
- update unit tests to mock `load_config`

## Testing
- `poetry run pytest -q` *(fails: ModuleNotFoundError for chromadb_store)*

------
https://chatgpt.com/codex/tasks/task_e_6861e7febde883338f3f3bdb007566e1