### PR TITLE
Add BDD scenarios for new CLI commands

### DIFF
--- a/tests/behavior/features/alignment_metrics_command.feature
+++ b/tests/behavior/features/alignment_metrics_command.feature
@@ -1,0 +1,18 @@
+Feature: Alignment Metrics Command
+  As a developer
+  I want to collect alignment metrics
+  So that I can measure coverage between requirements, specifications, tests and code
+
+  Background:
+    Given the DevSynth CLI is installed
+    And I have a valid DevSynth project
+
+  Scenario: Collect metrics successfully
+    When I run the command "devsynth alignment-metrics"
+    Then the system should display alignment metrics
+    And the workflow should execute successfully
+
+  Scenario: Handle failure during metrics collection
+    Given alignment metrics calculation fails
+    When I run the command "devsynth alignment-metrics"
+    Then the system should display an error message

--- a/tests/behavior/features/validate_manifest_command.feature
+++ b/tests/behavior/features/validate_manifest_command.feature
@@ -1,0 +1,18 @@
+Feature: Validate Manifest Command
+  As a developer
+  I want to validate my project manifest
+  So that I can ensure it is well formed
+
+  Background:
+    Given the DevSynth CLI is installed
+    And I have a valid DevSynth project
+
+  Scenario: Validate manifest successfully
+    When I run the command "devsynth validate-manifest"
+    Then the output should indicate the project configuration is valid
+    And the workflow should execute successfully
+
+  Scenario: Handle missing manifest file
+    Given no manifest file exists at the provided path
+    When I run the command "devsynth validate-manifest --config missing.yaml"
+    Then the system should display an error message

--- a/tests/behavior/features/validate_metadata_command.feature
+++ b/tests/behavior/features/validate_metadata_command.feature
@@ -1,0 +1,17 @@
+Feature: Validate Metadata Command
+  As a documentation maintainer
+  I want to validate metadata in Markdown files
+  So that the documentation meets standards
+
+  Background:
+    Given the DevSynth CLI is installed
+    And I have a valid DevSynth project
+
+  Scenario: Validate metadata successfully
+    Given a documentation file with valid metadata
+    When I run the command "devsynth validate-metadata --directory docs"
+    Then the output should indicate the metadata is valid
+
+  Scenario: Handle missing documentation directory
+    When I run the command "devsynth validate-metadata --directory ./missing-dir"
+    Then the system should display an error message

--- a/tests/behavior/steps/alignment_metrics_steps.py
+++ b/tests/behavior/steps/alignment_metrics_steps.py
@@ -1,0 +1,26 @@
+"""Steps for the alignment metrics command feature."""
+
+from pytest_bdd import scenarios, given, then
+
+from .cli_commands_steps import run_command  # noqa: F401
+
+scenarios("../features/alignment_metrics_command.feature")
+
+
+@given("alignment metrics calculation fails")
+def metrics_fail(monkeypatch):
+    """Force the alignment metrics command to raise an exception."""
+    def _raise(*_args, **_kwargs):
+        raise Exception("metrics failure")
+
+    monkeypatch.setattr(
+        "devsynth.application.cli.commands.alignment_metrics_cmd.calculate_alignment_coverage",
+        _raise,
+    )
+
+
+@then("the system should display alignment metrics")
+def check_metrics_output(command_context):
+    """Verify that alignment metrics were printed."""
+    output = command_context.get("output", "")
+    assert "Alignment Metrics" in output or "Metrics report" in output

--- a/tests/behavior/steps/cli_commands_steps.py
+++ b/tests/behavior/steps/cli_commands_steps.py
@@ -24,6 +24,12 @@ from devsynth.application.cli.cli_commands import (
 from devsynth.application.cli.commands.validate_manifest_cmd import (
     validate_manifest_cmd,
 )
+from devsynth.application.cli.commands.validate_metadata_cmd import (
+    validate_metadata_cmd,
+)
+from devsynth.application.cli.commands.alignment_metrics_cmd import (
+    alignment_metrics_cmd,
+)
 from devsynth.application.cli.commands.analyze_code_cmd import analyze_code_cmd
 from devsynth.application.cli.commands.analyze_manifest_cmd import analyze_manifest_cmd
 
@@ -310,6 +316,37 @@ def run_command(command, monkeypatch, mock_workflow_manager, command_context):
                 mock_workflow_manager.execute_command.assert_called_with(
                     "analyze-manifest", analyze_manifest_args
                 )
+            elif args[0] == "alignment-metrics":
+                path = "."
+                metrics_file = ".devsynth/alignment_metrics.json"
+                output_file = None
+                i = 1
+                while i < len(args):
+                    if args[i] == "--path" and i + 1 < len(args):
+                        path = args[i + 1]
+                        i += 2
+                    elif args[i] == "--metrics-file" and i + 1 < len(args):
+                        metrics_file = args[i + 1]
+                        i += 2
+                    elif args[i] == "--output" and i + 1 < len(args):
+                        output_file = args[i + 1]
+                        i += 2
+                    else:
+                        i += 1
+
+                alignment_metrics_cmd(path, metrics_file, output_file)
+                mock_workflow_manager.execute_command.reset_mock()
+                metrics_args = {
+                    "path": path,
+                    "metrics_file": metrics_file,
+                    "output": output_file,
+                }
+                mock_workflow_manager.execute_command(
+                    "alignment-metrics", metrics_args
+                )
+                mock_workflow_manager.execute_command.assert_called_with(
+                    "alignment-metrics", metrics_args
+                )
             elif args[0] == "validate-manifest":
                 manifest = None
                 schema = None
@@ -332,6 +369,37 @@ def run_command(command, monkeypatch, mock_workflow_manager, command_context):
                 )
                 mock_workflow_manager.execute_command.assert_called_with(
                     "validate-manifest", validate_args
+                )
+            elif args[0] == "validate-metadata":
+                directory = None
+                file = None
+                verbose = False
+                i = 1
+                while i < len(args):
+                    if args[i] == "--directory" and i + 1 < len(args):
+                        directory = args[i + 1]
+                        i += 2
+                    elif args[i] == "--file" and i + 1 < len(args):
+                        file = args[i + 1]
+                        i += 2
+                    elif args[i] == "--verbose":
+                        verbose = True
+                        i += 1
+                    else:
+                        i += 1
+
+                validate_metadata_cmd(directory, file, verbose)
+                mock_workflow_manager.execute_command.reset_mock()
+                metadata_args = {
+                    "directory": directory,
+                    "file": file,
+                    "verbose": verbose,
+                }
+                mock_workflow_manager.execute_command(
+                    "validate-metadata", metadata_args
+                )
+                mock_workflow_manager.execute_command.assert_called_with(
+                    "validate-metadata", metadata_args
                 )
             elif args[0] == "serve":
                 host = "0.0.0.0"

--- a/tests/behavior/steps/validate_manifest_command_steps.py
+++ b/tests/behavior/steps/validate_manifest_command_steps.py
@@ -1,0 +1,14 @@
+"""Steps for the validate manifest command feature."""
+
+from pytest_bdd import scenarios, then
+
+from .cli_commands_steps import run_command  # noqa: F401
+
+scenarios("../features/validate_manifest_command.feature")
+
+
+@then("the output should indicate the project configuration is valid")
+def manifest_valid(command_context):
+    """Check for a success message from validate-manifest."""
+    output = command_context.get("output", "")
+    assert "Project configuration is valid" in output

--- a/tests/behavior/steps/validate_metadata_command_steps.py
+++ b/tests/behavior/steps/validate_metadata_command_steps.py
@@ -1,0 +1,25 @@
+"""Steps for the validate metadata command feature."""
+
+from pathlib import Path
+from pytest_bdd import scenarios, given, then
+
+from .cli_commands_steps import run_command  # noqa: F401
+
+scenarios("../features/validate_metadata_command.feature")
+
+
+@given("a documentation file with valid metadata")
+def doc_with_metadata(tmp_project_dir):
+    """Create a markdown file with front matter for validation."""
+    docs_dir = Path(tmp_project_dir) / "docs"
+    docs_dir.mkdir(exist_ok=True)
+    file = docs_dir / "index.md"
+    file.write_text("""---\ntitle: Test Doc\ndate: 2024-01-01\nversion: 1.0.0\n---\n""")
+    return file
+
+
+@then("the output should indicate the metadata is valid")
+def metadata_valid(command_context):
+    """Check for a success message from validate-metadata."""
+    output = command_context.get("output", "")
+    assert "All metadata is valid" in output

--- a/tests/behavior/test_alignment_metrics_command.py
+++ b/tests/behavior/test_alignment_metrics_command.py
@@ -1,0 +1,9 @@
+import pytest
+from pytest_bdd import scenarios
+
+from .steps.cli_commands_steps import *  # noqa: F401,F403
+from .steps.alignment_metrics_steps import *  # noqa: F401,F403
+
+pytestmark = pytest.mark.requires_resource("cli")
+
+scenarios("features/alignment_metrics_command.feature")

--- a/tests/behavior/test_validate_manifest_command.py
+++ b/tests/behavior/test_validate_manifest_command.py
@@ -1,0 +1,10 @@
+import pytest
+from pytest_bdd import scenarios
+
+from .steps.cli_commands_steps import *  # noqa: F401,F403
+from .steps.validate_manifest_command_steps import *  # noqa: F401,F403
+from .steps.edrr_cycle_steps import *  # noqa: F401,F403
+
+pytestmark = pytest.mark.requires_resource("cli")
+
+scenarios("features/validate_manifest_command.feature")

--- a/tests/behavior/test_validate_metadata_command.py
+++ b/tests/behavior/test_validate_metadata_command.py
@@ -1,0 +1,9 @@
+import pytest
+from pytest_bdd import scenarios
+
+from .steps.cli_commands_steps import *  # noqa: F401,F403
+from .steps.validate_metadata_command_steps import *  # noqa: F401,F403
+
+pytestmark = pytest.mark.requires_resource("cli")
+
+scenarios("features/validate_metadata_command.feature")


### PR DESCRIPTION
## Summary
- add behaviour features for `alignment-metrics`, `validate-manifest` and `validate-metadata`
- implement step definitions for new scenarios
- extend CLI command helper to exercise new commands
- register new scenario tests

## Testing
- `pytest tests/behavior/test_alignment_metrics_command.py -q`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'psutil')*

------
https://chatgpt.com/codex/tasks/task_e_686205a50df0833396b6cafb757db5b2