### PR TITLE
Add UXBridge invariants tests

### DIFF
--- a/docs/architecture/uxbridge.md
+++ b/docs/architecture/uxbridge.md
@@ -112,3 +112,14 @@ agnostic:
 These expectations are enforced by unit tests in
 ``tests/unit/interface/test_uxbridge_consistency.py`` which instantiate each
 bridge and verify consistent behaviour.
+
+## Bridge Invariants
+
+Regardless of implementation, all bridges guarantee a few key invariants:
+
+- **Consistent return types** – `ask_question` always yields a string and
+  `confirm_choice` always yields a boolean.
+- **Output sanitization** – messages passed to `display_result` and progress
+  descriptions are sanitized with `sanitize_output` before presentation.
+- **Safe CLI input** – the CLI bridge validates user responses with
+  `validate_safe_input` so unsafe content is rejected early.

--- a/src/devsynth/interface/cli.py
+++ b/src/devsynth/interface/cli.py
@@ -11,6 +11,7 @@ from devsynth.interface.ux_bridge import (
     ProgressIndicator,
     sanitize_output,
 )
+from devsynth.security import validate_safe_input
 
 
 class CLIProgressIndicator(ProgressIndicator):
@@ -53,12 +54,13 @@ class CLIUXBridge(UXBridge):
         default: Optional[str] = None,
         show_default: bool = True,
     ) -> str:
-        return Prompt.ask(
+        answer = Prompt.ask(
             message,
             choices=list(choices) if choices else None,
             default=default,
             show_default=show_default,
         )
+        return validate_safe_input(str(answer))
 
     def confirm_choice(self, message: str, *, default: bool = False) -> bool:
         return Confirm.ask(message, default=default)

--- a/tests/unit/interface/test_cliuxbridge.py
+++ b/tests/unit/interface/test_cliuxbridge.py
@@ -23,3 +23,23 @@ def test_cliuxbridge_display_result():
     with patch("rich.console.Console.print") as out:
         bridge.display_result("done", highlight=True)
         out.assert_called_once_with("done", highlight=True)
+
+
+def test_cliuxbridge_ask_question_validates_input():
+    bridge = CLIUXBridge()
+    with (
+        patch("rich.prompt.Prompt.ask", return_value="bad") as ask,
+        patch(
+            "devsynth.interface.cli.validate_safe_input",
+            side_effect=lambda x: f"clean-{x}",
+        ) as validate,
+    ):
+        result = bridge.ask_question("msg")
+        ask.assert_called_once_with(
+            "msg",
+            choices=None,
+            default=None,
+            show_default=True,
+        )
+        validate.assert_called_once_with("bad")
+        assert result == "clean-bad"


### PR DESCRIPTION
## Summary
- enforce safe input validation in CLIUXBridge
- test bridge invariant behaviour across CLI, API, and WebUI
- regression test that CLIUXBridge validates user input
- document UXBridge invariants

## Testing
- `poetry run pytest tests/unit/interface/test_cliuxbridge.py tests/unit/interface/test_uxbridge_consistency.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6862a0a16f9883339dd696d299152cba