### PR TITLE
Add guided setup and offline toggle

### DIFF
--- a/src/devsynth/interface/webui.py
+++ b/src/devsynth/interface/webui.py
@@ -36,6 +36,8 @@ from devsynth.application.cli.commands.analyze_code_cmd import analyze_code_cmd
 from devsynth.application.cli.commands.doctor_cmd import doctor_cmd
 from devsynth.application.cli.commands.edrr_cycle_cmd import edrr_cycle_cmd
 from devsynth.application.cli.commands.align_cmd import align_cmd
+from devsynth.application.cli.setup_wizard import SetupWizard
+from devsynth.config import load_project_config, save_config
 from devsynth.domain.models.requirement import RequirementPriority, RequirementType
 from devsynth.interface.ux_bridge import ProgressIndicator, UXBridge, sanitize_output
 
@@ -114,6 +116,9 @@ class WebUI(UXBridge):
                             goals=goals or None,
                             bridge=self,
                         )
+            if st.button("Guided Setup", key="guided_setup"):
+                with st.spinner("Starting guided setup..."):
+                    SetupWizard(self).run()
 
     def requirements_page(self) -> None:
         """Render the requirements gathering page."""
@@ -264,6 +269,20 @@ class WebUI(UXBridge):
     def config_page(self) -> None:
         """Render the configuration editing page."""
         st.header("Configuration Editing")
+        cfg = load_project_config()
+        offline_toggle = st.toggle(
+            "Offline Mode",
+            value=cfg.config.offline_mode,
+            key="offline_mode_toggle",
+        )
+        if st.button("Save Offline Mode", key="offline_mode_save"):
+            cfg.config.offline_mode = offline_toggle
+            with st.spinner("Saving configuration..."):
+                save_config(
+                    cfg.config,
+                    use_pyproject=cfg.use_pyproject,
+                    path=cfg.config.project_root,
+                )
         with st.expander("Update Settings", expanded=True):
             with st.form("config"):
                 key = st.text_input("Key")

--- a/tests/integration/test_webui_setup.py
+++ b/tests/integration/test_webui_setup.py
@@ -1,0 +1,149 @@
+import importlib
+import sys
+from types import ModuleType
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+
+def _setup_streamlit(monkeypatch, button_return=False, toggle_return=False):
+    st = ModuleType("streamlit")
+
+    class SS(dict):
+        pass
+
+    st.session_state = SS()
+    st.session_state.wizard_step = 0
+    st.session_state.wizard_data = {}
+    st.sidebar = ModuleType("sidebar")
+    st.sidebar.radio = MagicMock(return_value="Onboarding")
+    st.sidebar.title = MagicMock()
+    st.set_page_config = MagicMock()
+    st.header = MagicMock()
+    st.expander = lambda *_a, **_k: DummyForm(True)
+    st.form = lambda *_a, **_k: DummyForm(True)
+    st.form_submit_button = MagicMock(return_value=False)
+    st.text_input = MagicMock(return_value="text")
+    st.text_area = MagicMock(return_value="text")
+    st.selectbox = MagicMock(return_value="choice")
+    st.checkbox = MagicMock(return_value=False)
+    st.toggle = MagicMock(return_value=toggle_return)
+    st.button = MagicMock(return_value=button_return)
+    st.spinner = DummyForm
+    st.divider = MagicMock()
+    st.columns = MagicMock(
+        return_value=(
+            MagicMock(button=lambda *a, **k: False),
+            MagicMock(button=lambda *a, **k: False),
+        )
+    )
+    st.progress = MagicMock()
+    st.write = MagicMock()
+    st.markdown = MagicMock()
+    monkeypatch.setitem(sys.modules, "streamlit", st)
+    # stub heavy optional dependencies
+    modules = [
+        "langgraph",
+        "langgraph.checkpoint",
+        "langgraph.checkpoint.base",
+        "langgraph.graph",
+        "langchain",
+        "langchain_openai",
+        "langchain_community",
+        "tiktoken",
+        "tinydb",
+        "tinydb.storages",
+        "tinydb.middlewares",
+        "duckdb",
+        "lmdb",
+        "faiss",
+        "httpx",
+        "openai",
+        "openai.types",
+        "openai.types.chat",
+        "torch",
+        "transformers",
+        "astor",
+    ]
+    for name in modules:
+        module = ModuleType(name)
+        if name == "langgraph.checkpoint.base":
+            module.BaseCheckpointSaver = object
+            module.empty_checkpoint = object()
+        if name == "langgraph.graph":
+            module.END = None
+            module.StateGraph = object
+        if name == "tinydb":
+            module.TinyDB = object
+            module.Query = object
+        if name == "tinydb.storages":
+            module.JSONStorage = object
+            module.MemoryStorage = object
+        if name == "tinydb.middlewares":
+            module.CachingMiddleware = object
+        if name == "openai":
+            module.OpenAI = object
+            module.AsyncOpenAI = object
+        if name == "openai.types.chat":
+            module.ChatCompletion = object
+            module.ChatCompletionChunk = object
+        if name == "transformers":
+            module.AutoModelForCausalLM = object
+            module.AutoTokenizer = object
+        monkeypatch.setitem(sys.modules, name, module)
+    return st
+
+
+class DummyForm:
+    def __init__(self, submitted: bool = True) -> None:
+        self.submitted = submitted
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+    def form_submit_button(self, *_args, **_kwargs):
+        return self.submitted
+
+
+def test_guided_setup_button_invokes_wizard(monkeypatch):
+    st = _setup_streamlit(monkeypatch, button_return=True)
+    import devsynth.interface.webui as webui
+
+    importlib.reload(webui)
+
+    mock_run = MagicMock()
+    monkeypatch.setattr(
+        webui, "SetupWizard", MagicMock(return_value=MagicMock(run=mock_run))
+    )
+
+    webui.WebUI().onboarding_page()
+    assert mock_run.called
+
+
+def test_offline_toggle_saves_config(monkeypatch, tmp_path):
+    st = _setup_streamlit(monkeypatch, button_return=True, toggle_return=True)
+    import devsynth.interface.webui as webui
+
+    importlib.reload(webui)
+
+    from devsynth.config import ProjectUnifiedConfig, ConfigModel
+
+    cfg = ProjectUnifiedConfig(
+        ConfigModel(project_root=str(tmp_path)), tmp_path / "project.yaml", False
+    )
+    monkeypatch.setattr(webui, "load_project_config", lambda: cfg)
+    saved = {}
+    monkeypatch.setattr(
+        webui,
+        "save_config",
+        lambda conf, *, use_pyproject, path: saved.update(
+            {"offline": conf.offline_mode}
+        ),
+    )
+
+    webui.WebUI().config_page()
+    assert saved.get("offline") is True


### PR DESCRIPTION
## Summary
- add Guided Setup button to onboarding page
- add offline mode toggle on config page
- integrate SetupWizard with WebUI
- add integration tests for WebUI setup actions

## Testing
- `pytest tests/integration/test_webui_setup.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6862ab5f7c1c833399e44773a5a11564