### PR TITLE
Implement unified config loader

### DIFF
--- a/docs/user_guides/cli_reference.md
+++ b/docs/user_guides/cli_reference.md
@@ -158,6 +158,8 @@ devsynth init [--path PATH] [--template TEMPLATE] [--project-root ROOT] [--langu
 - `--constraints`: Path to a constraint configuration file
 
 This command now detects existing projects and launches an interactive wizard when run inside a directory containing `pyproject.toml` or `devsynth.yml`.
+The wizard reads configuration using the [Unified Config Loader](../implementation/config_loader_workflow.md),
+which prefers the `[tool.devsynth]` table in `pyproject.toml` when both files are present.
 During the wizard you will:
 
 1. Select the memory backend (``memory``, ``file``, ``kuzu`` or ``chromadb``).

--- a/tests/unit/test_unified_config_loader.py
+++ b/tests/unit/test_unified_config_loader.py
@@ -1,5 +1,7 @@
 import logging
 from pathlib import Path
+import yaml
+import toml
 
 from devsynth.config.unified_loader import UnifiedConfigLoader
 
@@ -62,3 +64,22 @@ def test_version_mismatch_warning(tmp_path: Path, caplog) -> None:
     UnifiedConfigLoader.load(tmp_path)
 
     assert any("version" in rec.message for rec in caplog.records)
+
+
+def test_loader_save_function_yaml(tmp_path: Path) -> None:
+    cfg = UnifiedConfigLoader.load(tmp_path)
+    cfg.set_language("go")
+    path = UnifiedConfigLoader.save(cfg)
+    data = yaml.safe_load(path.read_text())
+    assert data["language"] == "go"
+
+
+def test_loader_save_function_pyproject(tmp_path: Path) -> None:
+    toml_path = tmp_path / "pyproject.toml"
+    toml_path.write_text("[tool.devsynth]\n")
+
+    cfg = UnifiedConfigLoader.load(tmp_path)
+    cfg.set_language("rust")
+    path = UnifiedConfigLoader.save(cfg)
+    data = toml.load(path)
+    assert data["tool"]["devsynth"]["language"] == "rust"


### PR DESCRIPTION
## Summary
- implement `UnifiedConfig.exists` checks and add `UnifiedConfigLoader.save`
- extend tests for unified loader
- mention unified loader in CLI docs

## Testing
- `bash scripts/codex_setup.sh`
- `pytest tests/unit/test_unified_config_loader.py tests/unit/core/test_unified_config_loader.py -q`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'langgraph')*

------
https://chatgpt.com/codex/tasks/task_e_6862c4a6eee08333b1d1ff3b4356881c