### PR TITLE
Ensure offline provider is selected in offline mode

### DIFF
--- a/docs/analysis/cli_ui_improvement_plan.md
+++ b/docs/analysis/cli_ui_improvement_plan.md
@@ -47,8 +47,12 @@ This document summarizes the current operating modes of the DevSynth tool and ou
    - Simple interface for EDRR cycle status and sprint metrics.
    - CLI remains primary; GUI provides at-a-glance information.
 5. **Support Offline/Minimal Modes**
-   - Local LLM fallback when internet is unavailable.
-   - Document limitations of offline mode.
+ - Local LLM fallback when internet is unavailable.
+ - Document limitations of offline mode.
+    - Offline mode disables remote LLM calls, so advanced model features such
+      as streaming completions or external search integrations are not
+      available. The built-in provider offers deterministic but lower quality
+      responses suitable for testing and repeatable pipelines.
 6. **Expose EDRR Metrics**
    - Commands like `devsynth metrics` and `devsynth report` to surface history.
    - Export results to HTML or Markdown.

--- a/docs/user_guides/cli_reference.md
+++ b/docs/user_guides/cli_reference.md
@@ -172,7 +172,10 @@ manifest.
 
 When offline mode is enabled the CLI uses the settings under
 `offline_provider`. Set `offline_provider.model_path` to a local HuggingFace
-model so generation commands work without network access.
+model so generation commands work without network access. Be aware that offline
+mode disables remote LLM capabilities including streaming responses and
+third-party integrations. The built-in provider focuses on deterministic output
+for testing rather than high quality completions.
 
 **Examples:**
 ```bash

--- a/tests/unit/application/test_offline_provider.py
+++ b/tests/unit/application/test_offline_provider.py
@@ -1,0 +1,35 @@
+import types
+
+import httpx
+from devsynth.application.llm import get_llm_provider
+from devsynth.application.llm.offline_provider import OfflineProvider
+
+
+def _mock_config():
+    cfg = types.SimpleNamespace()
+    cfg.as_dict = lambda: {"offline_mode": True}
+    return cfg
+
+
+def _llm_settings():
+    return {"provider": "openai"}
+
+
+def test_generate_does_not_call_external(monkeypatch):
+    called = {}
+
+    def fake_post(*args, **kwargs):
+        called["called"] = True
+        raise AssertionError("external call")
+
+    monkeypatch.setattr("devsynth.application.llm.load_config", _mock_config)
+    monkeypatch.setattr("devsynth.application.llm.get_llm_settings", _llm_settings)
+    monkeypatch.setattr(httpx, "post", fake_post)
+
+    provider = get_llm_provider()
+    assert isinstance(provider, OfflineProvider)
+
+    result = provider.generate("hello")
+
+    assert result == "[offline] hello"
+    assert "called" not in called

--- a/tests/unit/test_llm_provider_selection.py
+++ b/tests/unit/test_llm_provider_selection.py
@@ -16,11 +16,11 @@ def test_offline_mode_selects_offline_provider(monkeypatch):
         "devsynth.application.utils.token_tracker.TIKTOKEN_AVAILABLE", False
     )
     monkeypatch.setattr(
-        "devsynth.application.llm.providers.load_config",
+        "devsynth.application.llm.load_config",
         lambda: _mock_config(True),
     )
     monkeypatch.setattr(
-        "devsynth.application.llm.providers.get_llm_settings",
+        "devsynth.application.llm.get_llm_settings",
         lambda: {
             "provider": "openai",
             "openai_api_key": "key",
@@ -36,11 +36,11 @@ def test_online_mode_uses_configured_provider(monkeypatch):
         "devsynth.application.utils.token_tracker.TIKTOKEN_AVAILABLE", False
     )
     monkeypatch.setattr(
-        "devsynth.application.llm.providers.load_config",
+        "devsynth.application.llm.load_config",
         lambda: _mock_config(False),
     )
     monkeypatch.setattr(
-        "devsynth.application.llm.providers.get_llm_settings",
+        "devsynth.application.llm.get_llm_settings",
         lambda: {
             "provider": "openai",
             "openai_api_key": "key",


### PR DESCRIPTION
## Summary
- select OfflineProvider when offline_mode is enabled
- adjust provider selection unit tests and add new offline provider test
- document offline mode limitations

## Testing
- `poetry run pytest tests/unit/test_llm_provider_selection.py tests/unit/application/test_offline_provider.py tests/unit/application/test_offline_provider_unit.py`

------
https://chatgpt.com/codex/tasks/task_e_6862d0513d68833393bf4b240ef93b03