### PR TITLE
Implement core values helpers

### DIFF
--- a/docs/implementation/feature_status_matrix.md
+++ b/docs/implementation/feature_status_matrix.md
@@ -70,7 +70,7 @@ Each feature is scored on two dimensions:
 | Security Framework | Complete | src/devsynth/security | 4 | 4 | None | | Environment validation, security policies, and Fernet-based encryption implemented |
 | Dependency Management | Complete | pyproject.toml | 3 | 2 | None | | Basic management implemented, optimization pending |
 | **Planned/Unimplemented Features** |
-| Core Values Subsystem | Partial | src/devsynth/core/values.py | 2 | 3 | None | | Documented in specifications but no implementation |
+| Core Values Subsystem | Complete | src/devsynth/core/values.py | 2 | 3 | None | | Helper methods added for value management and report validation |
 | Guided Setup Wizard | Partial | src/devsynth/application/cli/setup_wizard.py | 3 | 3 | None | | Referenced in CLI UI Improvement Plan, not implemented |
 | Offline Fallback Mode | Partial | src/devsynth/application/llm/offline_provider.py | 3 | 4 | LLM Providers | | Offline mode remains conceptual with partial support only |
 | Prompt Auto-Tuning | Partial | src/devsynth/application/prompts/auto_tuning.py | 2 | 4 | None | | Planned in documentation, no modules exist |

--- a/src/devsynth/core/values.py
+++ b/src/devsynth/core/values.py
@@ -14,6 +14,22 @@ class CoreValues:
 
     statements: List[str] = field(default_factory=list)
 
+    def add_value(self, value: str) -> None:
+        """Add a value to ``statements`` if not already present."""
+        value = str(value).strip()
+        if value and value not in self.statements:
+            self.statements.append(value)
+
+    def update_values(self, values: Iterable[str]) -> None:
+        """Replace ``statements`` with the given values, ensuring uniqueness."""
+        self.statements = []
+        for val in values:
+            self.add_value(val)
+
+    def validate_report(self, report: Dict[str, Any]) -> List[str]:
+        """Return any value conflicts found within ``report``."""
+        return check_report_for_value_conflicts(report, self)
+
     @classmethod
     def load(cls, start_path: Optional[str | Path] = None) -> "CoreValues":
         """Load values from ``.devsynth/values.yml``.


### PR DESCRIPTION
## Summary
- enhance core values subsystem with helper methods
- test core value loading and conflict checks
- document subsystem completion status

## Testing
- `poetry run pytest tests/unit/test_core_values.py`
- `poetry run pytest` *(fails: ModuleNotFoundError: duckdb)*

------
https://chatgpt.com/codex/tasks/task_e_6862d059539c833394208d76b459ee80