### PR TITLE
Implement setup wizard and update docs

### DIFF
--- a/docs/user_guides/cli_reference.md
+++ b/docs/user_guides/cli_reference.md
@@ -143,6 +143,7 @@ Initialize a new DevSynth project or onboard an existing one.
 devsynth init [--path PATH] [--template TEMPLATE] [--project-root ROOT] [--language LANG]
              [--source-dirs DIRS] [--test-dirs DIRS] [--docs-dirs DIRS]
              [--extra-languages LANGS] [--goals TEXT] [--constraints FILE]
+             [--wizard]
 ```
 
 **Options:**
@@ -156,8 +157,9 @@ devsynth init [--path PATH] [--template TEMPLATE] [--project-root ROOT] [--langu
 - `--extra-languages`: Additional languages used in the project
 - `--goals`: High-level goals or constraints for the project
 - `--constraints`: Path to a constraint configuration file
+- `--wizard`: Launch the guided setup wizard even outside a detected project
 
-This command now detects existing projects and launches an interactive wizard when run inside a directory containing `pyproject.toml` or `devsynth.yml`.
+This command detects existing projects and launches an interactive wizard when run inside a directory containing `pyproject.toml` or `devsynth.yml`. Use the `--wizard` flag to start the wizard explicitly in any directory.
 The wizard reads configuration using the [Unified Config Loader](../implementation/config_loader_workflow.md),
 which prefers the `[tool.devsynth]` table in `pyproject.toml` when both files are present.
 During the wizard you will:
@@ -192,6 +194,9 @@ devsynth init --project-root ./existing --language javascript
 devsynth init --project-root . --language python \
   --source-dirs src --test-dirs tests --docs-dirs docs \
   --extra-languages javascript --goals "demo"
+
+# Start the guided wizard directly
+devsynth init --wizard
 ```
 
 ### inspect

--- a/src/devsynth/application/cli/setup_wizard.py
+++ b/src/devsynth/application/cli/setup_wizard.py
@@ -47,7 +47,20 @@ class SetupWizard:
             return cfg
 
         root = self.bridge.ask_question("Project root", default=os.getcwd())
+        structure = self.bridge.ask_question(
+            "Project structure",
+            choices=["single_package", "monorepo"],
+            default="single_package",
+        )
         language = self.bridge.ask_question("Primary language", default="python")
+        constraints = (
+            self.bridge.ask_question(
+                "Path to constraint file (optional)",
+                default="",
+                show_default=False,
+            )
+            or None
+        )
         goals = (
             self.bridge.ask_question(
                 "Project goals (optional)",
@@ -73,8 +86,10 @@ class SetupWizard:
             return cfg
 
         cfg.set_root(root)
+        cfg.config.structure = structure
         cfg.set_language(language)
         cfg.set_goals(goals or "")
+        cfg.config.constraints = constraints
         cfg.config.memory_store_type = memory_backend
         cfg.config.offline_mode = offline_mode
         cfg.config.features = features

--- a/tests/behavior/features/cli_commands.feature
+++ b/tests/behavior/features/cli_commands.feature
@@ -37,6 +37,11 @@ Feature: CLI Command Execution
     Then the workflow should execute successfully
     And the system should display a success message
 
+  Scenario: Run the wizard via command line
+    When I run the command "devsynth init --wizard"
+    Then the workflow should execute successfully
+    And the system should display a success message
+
   Scenario: Generate specifications with custom requirements file
     When I run the command "devsynth inspect --requirements-file custom-requirements.md"
     Then the system should process the "custom-requirements.md" file


### PR DESCRIPTION
## Summary
- implement missing prompts in SetupWizard
- test CLI wizard flag
- describe wizard option in CLI reference

## Testing
- `poetry run pytest -k wizard -q` *(fails: ModuleNotFoundError: No module named 'yaml')*

------
https://chatgpt.com/codex/tasks/task_e_6862f339bf508333ac2015fe5646920e