### PR TITLE
Add simplified tests and coverage options

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,5 +1,5 @@
 [pytest]
-addopts = -p no:warnings
+addopts = -p no:warnings --cov=src/devsynth/application/edrr/coordinator.py --cov=src/devsynth/adapters/agents/agent_adapter.py --cov=src/devsynth/application/agents/unified_agent.py --cov=src/devsynth/application/collaboration/coordinator.py --cov-report=term-missing:skip-covered
 norecursedirs = templates
 # Run tests from the tests directory only
 # This prevents template files from being collected as tests.

--- a/tests/unit/application/agents/test_unified_agent_generic.py
+++ b/tests/unit/application/agents/test_unified_agent_generic.py
@@ -1,0 +1,27 @@
+import sys
+import types
+
+# Stub modules that require optional dependencies
+mem_mod = types.ModuleType('devsynth.adapters.memory.memory_adapter')
+class MemorySystemAdapter:
+    def get_memory_store(self):
+        return {}
+mem_mod.MemorySystemAdapter = MemorySystemAdapter
+sys.modules['devsynth.adapters.memory.memory_adapter'] = mem_mod
+
+am_mod = types.ModuleType('devsynth.application.agents.agent_memory_integration')
+am_mod.AgentMemoryIntegration = object
+sys.modules['devsynth.application.agents.agent_memory_integration'] = am_mod
+
+wsde_mod = types.ModuleType('devsynth.application.agents.wsde_memory_integration')
+wsde_mod.WSDEMemoryIntegration = object
+sys.modules['devsynth.application.agents.wsde_memory_integration'] = wsde_mod
+
+from devsynth.application.agents.unified_agent import UnifiedAgent
+
+
+def test_process_generic_task():
+    agent = UnifiedAgent()
+    result = agent._process_generic_task({"foo": "bar"})
+    assert "result" in result
+    assert result["wsde"].metadata["type"] == "generic"

--- a/tests/unit/application/collaboration/test_delegate_workflows.py
+++ b/tests/unit/application/collaboration/test_delegate_workflows.py
@@ -1,0 +1,44 @@
+import pytest
+
+from devsynth.application.collaboration.coordinator import AgentCoordinatorImpl
+from devsynth.application.collaboration.exceptions import TeamConfigurationError
+from devsynth.exceptions import ValidationError
+
+class DummyAgent:
+    def __init__(self, name, agent_type):
+        self.name = name
+        self.agent_type = agent_type
+    def process(self, task):
+        return {"result": self.name}
+
+
+def make_coord():
+    return AgentCoordinatorImpl({"features": {"wsde_collaboration": True}})
+
+
+def test_delegate_specific_agent():
+    coord = make_coord()
+    agent = DummyAgent("a", "type")
+    coord.add_agent(agent)
+    result = coord.delegate_task({"agent_type": "type"})
+    assert result == {"result": "a"}
+
+
+def test_delegate_team_task(monkeypatch):
+    coord = make_coord()
+    monkeypatch.setattr(coord, "_handle_team_task", lambda task: {"team": True})
+    result = coord.delegate_task({"team_task": True})
+    assert result == {"team": True}
+
+
+def test_missing_agent(monkeypatch):
+    coord = make_coord()
+    with pytest.raises(ValidationError):
+        coord.delegate_task({"agent_type": "none"})
+
+
+def test_team_task_no_agents():
+    coord = make_coord()
+    coord.agents = []
+    with pytest.raises(TeamConfigurationError):
+        coord._handle_team_task({"team_task": True})

--- a/tests/unit/application/edrr/test_coordinator_phases_simple.py
+++ b/tests/unit/application/edrr/test_coordinator_phases_simple.py
@@ -1,0 +1,120 @@
+import types
+import sys
+import pytest
+from unittest.mock import MagicMock, patch
+
+# Stub heavy core module before importing coordinator
+core_stub = types.ModuleType('devsynth.core')
+
+class CoreValues:
+    @classmethod
+    def load(cls, *args, **kwargs):
+        return cls()
+
+    def validate_report(self, report):
+        return []
+def check_report_for_value_conflicts(report, core_values=None):
+    return []
+core_stub.CoreValues = CoreValues
+core_stub.check_report_for_value_conflicts = check_report_for_value_conflicts
+sys.modules['devsynth.core'] = core_stub
+
+from devsynth.application.edrr.coordinator import EDRRCoordinator
+from devsynth.methodology.base import Phase
+
+@pytest.fixture
+def coordinator():
+    mem = MagicMock()
+    mem.retrieve_with_edrr_phase.return_value = {}
+    wsde = MagicMock()
+    code = MagicMock()
+    ast = MagicMock()
+    prompt = MagicMock()
+    doc = MagicMock()
+    return EDRRCoordinator(mem, wsde, code, ast, prompt, doc)
+
+def test_progress_to_phase_runs(coordinator):
+    coordinator.task = {'description': 'demo'}
+    coordinator.cycle_id = 'cid'
+    with patch.object(coordinator, '_execute_expand_phase', return_value={'done': True}) as ex:
+        coordinator.progress_to_phase(Phase.EXPAND)
+    ex.assert_called_once_with({})
+    assert coordinator.results['EXPAND'] == {'done': True}
+    assert coordinator.current_phase == Phase.EXPAND
+
+
+def test_execute_expand_phase(coordinator):
+    coordinator.task = {'description': 'demo'}
+    coordinator.cycle_id = 'cid'
+    coordinator.memory_manager.retrieve_relevant_knowledge.return_value = ['k']
+    coordinator.wsde_team.generate_diverse_ideas.return_value = ['idea']
+    coordinator.code_analyzer.analyze_project_structure.return_value = {'f': 1}
+    res = coordinator._execute_expand_phase({})
+    assert res['ideas'] == ['idea']
+    assert res['knowledge'] == ['k']
+    assert res['code_elements'] == {'f': 1}
+    coordinator.memory_manager.store_with_edrr_phase.assert_called()
+
+
+def test_execute_differentiate_phase(coordinator):
+    coordinator.task = {'description': 'demo'}
+    coordinator.cycle_id = 'cid'
+    coordinator.memory_manager.retrieve_with_edrr_phase.return_value = {'ideas': [1, 2]}
+    coordinator.wsde_team.create_comparison_matrix.return_value = 'cm'
+    coordinator.wsde_team.evaluate_options.return_value = 'eo'
+    coordinator.wsde_team.analyze_trade_offs.return_value = 'to'
+    coordinator.wsde_team.formulate_decision_criteria.return_value = 'dc'
+    res = coordinator._execute_differentiate_phase({})
+    assert res['comparison_matrix'] == 'cm'
+    assert res['evaluated_options'] == 'eo'
+    assert res['trade_offs'] == 'to'
+    assert res['decision_criteria'] == 'dc'
+    coordinator.memory_manager.store_with_edrr_phase.assert_called()
+
+
+def test_execute_refine_phase(coordinator):
+    coordinator.task = {'description': 'demo'}
+    coordinator.cycle_id = 'cid'
+    def ret(item_type, phase, meta):
+        if item_type == 'DIFFERENTIATE_RESULTS':
+            return {'evaluated_options': [1], 'decision_criteria': {}}
+        return {}
+    coordinator.memory_manager.retrieve_with_edrr_phase.side_effect = ret
+    coordinator.wsde_team.select_best_option.return_value = 'best'
+    coordinator.wsde_team.elaborate_details.return_value = 'details'
+    coordinator.wsde_team.create_implementation_plan.return_value = ['p']
+    coordinator.wsde_team.optimize_implementation.return_value = {'opt': True}
+    coordinator.wsde_team.perform_quality_assurance.return_value = {'qa': []}
+    res = coordinator._execute_refine_phase({})
+    assert res['selected_option'] == 'best'
+    assert res['detailed_plan'] == 'details'
+    assert res['implementation_plan'] == ['p']
+    assert res['optimized_plan'] == {'opt': True}
+    assert res['quality_checks'] == {'qa': []}
+    coordinator.memory_manager.store_with_edrr_phase.assert_called()
+
+
+def test_execute_retrospect_phase(coordinator):
+    coordinator.task = {'description': 'demo'}
+    coordinator.cycle_id = 'cid'
+    def ret(item_type, phase, meta):
+        if item_type == 'EXPAND_RESULTS':
+            return {'ideas': []}
+        if item_type == 'DIFFERENTIATE_RESULTS':
+            return {'evaluated_options': []}
+        if item_type == 'REFINE_RESULTS':
+            return {'implementation_plan': [], 'quality_checks': {}}
+        return {}
+    coordinator.memory_manager.retrieve_with_edrr_phase.side_effect = ret
+    coordinator.memory_manager.retrieve_historical_patterns.return_value = []
+    coordinator.wsde_team.extract_learnings.return_value = ['l']
+    coordinator.wsde_team.recognize_patterns.return_value = ['p']
+    coordinator.wsde_team.integrate_knowledge.return_value = {'ik': True}
+    coordinator.wsde_team.generate_improvement_suggestions.return_value = ['s']
+    res = coordinator._execute_retrospect_phase({})
+    assert res['learnings'] == ['l']
+    assert res['patterns'] == ['p']
+    assert res['integrated_knowledge'] == {'ik': True}
+    assert res['improvement_suggestions'] == ['s']
+    assert 'final_report' in res
+    coordinator.memory_manager.store_with_edrr_phase.assert_called()


### PR DESCRIPTION
## Summary
- update `pytest.ini` to enable coverage collection for key modules
- add unit tests for simplified EDRR coordinator phases
- test basic delegate workflow handling
- ensure UnifiedAgent can process generic tasks without optional deps

## Testing
- `poetry run pytest tests/unit/application/edrr/test_coordinator_phases_simple.py tests/unit/application/collaboration/test_delegate_workflows.py tests/unit/application/agents/test_unified_agent_generic.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68632067ae988333b7def43508ad739f