### PR TITLE
Implement message storage and peer review tracking

### DIFF
--- a/src/devsynth/application/collaboration/peer_review.py
+++ b/src/devsynth/application/collaboration/peer_review.py
@@ -19,6 +19,7 @@ class PeerReview:
 
     reviews: Dict[Any, Dict[str, Any]] = field(default_factory=dict)
     revision: Any = None
+    revision_history: List[Any] = field(default_factory=list)
     status: str = "pending"
 
     def assign_reviews(self) -> None:
@@ -60,6 +61,7 @@ class PeerReview:
         """Submit a revised work product for further review."""
 
         self.revision = revision
+        self.revision_history.append(revision)
         self.status = "revised"
 
     def finalize(self, approved: bool = True) -> Dict[str, Any]:
@@ -67,7 +69,11 @@ class PeerReview:
 
         self.status = "approved" if approved else "rejected"
         feedback = self.aggregate_feedback()
-        return {"status": self.status, "feedback": feedback}
+        return {
+            "status": self.status,
+            "feedback": feedback,
+            "revisions": list(self.revision_history),
+        }
 
 
 @dataclass


### PR DESCRIPTION
## Summary
- connect message protocol with memory manager
- track revision history in peer reviews
- switch memory integration BDD steps to RDF-based knowledge graph

## Testing
- `bash scripts/codex_setup.sh`
- `pytest tests/unit/application/collaboration/test_message_protocol.py::test_send_message_priority -q -o addopts=` *(fails: ModuleNotFoundError: No module named 'argon2')*

------
https://chatgpt.com/codex/tasks/task_e_6863411bf50c8333b38487e81a084f67