### PR TITLE
Update unified loader and project YAML tests

### DIFF
--- a/src/devsynth/config/loader.py
+++ b/src/devsynth/config/loader.py
@@ -83,6 +83,10 @@ def _find_config_path(start: Path) -> Optional[Path]:
                 "Malformed TOML configuration", config_key=str(toml_path)
             ) from exc
 
+    proj_yaml = start / ".devsynth" / "project.yaml"
+    if proj_yaml.exists():
+        return proj_yaml
+
     yaml_path = start / ".devsynth" / "devsynth.yml"
     if yaml_path.exists():
         return yaml_path

--- a/src/devsynth/config/unified_loader.py
+++ b/src/devsynth/config/unified_loader.py
@@ -51,10 +51,11 @@ class UnifiedConfigLoader:
         root = Path(path or Path.cwd())
         cfg_path = _find_config_path(root)
         use_pyproject = False
-        if cfg_path is not None and cfg_path.name == "pyproject.toml":
-            use_pyproject = True
+        if cfg_path is not None:
+            if cfg_path.name == "pyproject.toml":
+                use_pyproject = True
         else:
-            cfg_path = root / ".devsynth" / "devsynth.yml"
+            cfg_path = root / ".devsynth" / "project.yaml"
 
         cfg = load_config(root)
         return UnifiedConfig(cfg, cfg_path, use_pyproject)

--- a/tests/unit/test_project_yaml.py
+++ b/tests/unit/test_project_yaml.py
@@ -74,3 +74,26 @@ class TestProjectYamlLoading:
 
                 # Verify open was called with the new path
                 mock_open.assert_called_once_with(Path(".devsynth/project.yaml"), "r")
+
+    @patch('builtins.open')
+    @patch('yaml.safe_load')
+    def test_manifest_version_locking(self, mock_yaml_load, mock_open):
+        """Version field is preserved when loading project.yaml."""
+        mock_yaml_load.return_value = {"metadata": {"version": "9.9.9"}}
+
+        result = load_manifest(Path(".devsynth/project.yaml"))
+
+        assert result["metadata"]["version"] == "9.9.9"
+        mock_open.assert_called_once_with(Path(".devsynth/project.yaml"), "r")
+        mock_yaml_load.assert_called_once()
+
+    @patch('os.path.exists')
+    def test_default_manifest_returned_when_missing(self, mock_exists):
+        """load_manifest returns minimal default manifest when no file is present."""
+        mock_exists.return_value = False
+
+        manifest = load_manifest(None)
+
+        assert manifest["metadata"]["name"] == "Unmanaged Project"
+        assert manifest["metadata"]["version"] == "0.1.0"
+        assert manifest["structure"]["type"] == "standard"


### PR DESCRIPTION
## Summary
- extend `_find_config_path` to look for `.devsynth/project.yaml`
- default unified loader path to `project.yaml`
- add version and default-value checks to project YAML tests

## Testing
- `poetry run pytest tests/unit/test_project_yaml.py -q` *(fails: ModuleNotFoundError: No module named 'cryptography')*

------
https://chatgpt.com/codex/tasks/task_e_68635be0db608333986b43a5b196c698