### PR TITLE
Rename analyze/adaptive terms

### DIFF
--- a/docs/architecture/cli_webui_mapping.md
+++ b/docs/architecture/cli_webui_mapping.md
@@ -31,7 +31,7 @@ backend functions.
 | `inspect`                 | **Requirements** – Inspect Requirements form         |
 | `gather`                  | **Requirements** – Requirements Plan Wizard          |
 | `wizard`                  | **Requirements** – Requirements Wizard               |
-| `analyze-code`            | **Analysis** – Analyze Code form                     |
+| `inspect-code`            | **Analysis** – Inspect Code form                     |
 | `refactor`                | N/A (planned **Analysis** workflow suggestions)      |
 | `webapp`                  | N/A (planned **Database/Web App** helper page)       |
 | `serve`                   | N/A (planned server management page; currently runs API server from CLI)                       |

--- a/docs/roadmap/actionable_roadmap.md
+++ b/docs/roadmap/actionable_roadmap.md
@@ -689,7 +689,7 @@ This roadmap transforms the comprehensive analysis findings into a practical, ph
 - [ ] **Continuous Learning Implementation**
   - Implement online learning from user interactions
   - Add personalized AI behavior and recommendations
-  - Create adaptive workflow optimization
+  - Create refactor workflow optimization
   - Implement knowledge transfer between projects
 
 - [ ] **Predictive Development Analytics**

--- a/docs/specifications/devsynth_specification_mvp_updated.md
+++ b/docs/specifications/devsynth_specification_mvp_updated.md
@@ -119,7 +119,7 @@ The MVP architecture follows a simplified layered approach with clear separation
 - Command parser using Click or Typer library
  - Core command set: `init`, `spec`, `test`, `code`, `run-pipeline`, `inspect`,
    `refactor`, `retrace`, `doctor`/`check`, `ingest`, `apispec`, `webapp`,
-  `dbschema`, `analyze-code`, `edrr-cycle`, `align`, `alignment-metrics`,
+  `dbschema`, `inspect-code`, `edrr-cycle`, `align`, `alignment-metrics`,
   `inspect-config`, `validate-manifest`,
    `validate-metadata`, `test-metrics`, `generate-docs`, `serve`, and the
    `config` subcommands (including `enable-feature`).

--- a/docs/user_guides/case_studies.md
+++ b/docs/user_guides/case_studies.md
@@ -25,7 +25,7 @@ The `examples/full_workflow` project demonstrates the complete DevSynth process:
 
 ### Lessons Learned
 
-- Ensure optional dependencies such as `langgraph` are installed when running examples that rely on the adaptive workflow.
+- Ensure optional dependencies such as `langgraph` are installed when running examples that rely on the refactor workflow.
 - When packaging code in `examples/`, update test modules to adjust `sys.path` so that imports resolve correctly when running `pytest` from the repository root.
  - The command `python src/main.py <file>` runs the word counter. Using `devsynth run-pipeline` executes the configured entrypoint but requires all dependencies to be available.
 

--- a/docs/user_guides/cli_reference.md
+++ b/docs/user_guides/cli_reference.md
@@ -36,7 +36,7 @@ This document provides a comprehensive reference for the DevSynth Command Line I
   - [doctor](#doctor-check)
   - [check](#doctor-check)
   - [refactor](#refactor)
-  - [analyze-code](#analyze-code)
+  - [inspect-code](#inspect-code)
   - [edrr-cycle](#edrr-cycle)
   - [align](#align)
   - [alignment-metrics](#alignment-metrics)
@@ -101,7 +101,7 @@ webui
 dbschema
 doctor (alias: check)
 refactor
-analyze-code
+inspect-code
 edrr-cycle
 align
 alignment-metrics
@@ -515,7 +515,7 @@ These commands mirror the names reported by `devsynth --help`:
 
 ```
 gather
-analyze-code
+inspect-code
 edrr-cycle
 align
 alignment-metrics

--- a/docs/user_guides/cli_usage.md
+++ b/docs/user_guides/cli_usage.md
@@ -11,7 +11,7 @@ tags:
 This short reference outlines the most common DevSynth commands. Recent releases renamed some commands for clarity:
 
 - `init` – initialize a project directory
-- `inspect` – analyze requirements interactively or from a file
+- `inspect` – inspect requirements interactively or from a file
 - `run-pipeline` – execute generated code or tests
 - `refactor` – suggest the next workflow steps
 

--- a/docs/user_guides/user_guide.md
+++ b/docs/user_guides/user_guide.md
@@ -78,16 +78,16 @@ devsynth inspect --input requirements.md
 **Details:**
 This command processes requirements and provides insights about their completeness, consistency, and clarity. It helps identify potential issues before proceeding to specification generation.
 
-### `analyze-code`
+### `inspect-code`
 
-Analyzes a codebase to understand its architecture, structure, and quality.
+Inspects a codebase to understand its architecture, structure, and quality.
 
 ```bash
 devsynth inspect-code [--path PATH]
 ```
 
 **Options:**
-- `--path PATH`: Path to the codebase to analyze (default: current directory)
+- `--path PATH`: Path to the codebase to inspect (default: current directory)
 
 **Example:**
 ```bash

--- a/docs/user_guides/webui_reference.md
+++ b/docs/user_guides/webui_reference.md
@@ -23,7 +23,7 @@ The sidebar offers the following pages:
 
 1. **Onboarding** – initialize projects.
 2. **Requirements** – generate and inspect specifications.
-3. **Analysis** – analyze project code.
+3. **Analysis** – inspect project code.
 4. **Synthesis** – generate tests and code then run the pipeline.
 5. **Config** – edit configuration values.
 6. **Diagnostics** – run environment checks via the doctor command.

--- a/src/devsynth/adapters/cli/typer_adapter.py
+++ b/src/devsynth/adapters/cli/typer_adapter.py
@@ -19,7 +19,7 @@ from devsynth.application.cli import (
     dbschema_cmd,
     doctor_cmd,
     refactor_cmd,
-    analyze_code_cmd,
+    inspect_code_cmd,
     edrr_cycle_cmd,
     serve_cmd,
 )
@@ -110,12 +110,12 @@ def build_app() -> typer.Typer:
         help="Suggest next workflow steps. Example: devsynth refactor",
     )(refactor_cmd)
     app.command(
-        name="analyze-code",
+        name="inspect-code",
         help=(
-            "Analyze a codebase and report architecture, quality and health "
-            "metrics. Example: devsynth analyze-code --path ./src"
+            "Inspect a codebase and report architecture, quality and health "
+            "metrics. Example: devsynth inspect-code --path ./src"
         ),
-    )(analyze_code_cmd)
+    )(inspect_code_cmd)
     app.command(
         name="edrr-cycle",
         help="Run an EDRR cycle. Example: devsynth edrr-cycle manifest.yaml",

--- a/src/devsynth/application/cli/__init__.py
+++ b/src/devsynth/application/cli/__init__.py
@@ -33,7 +33,7 @@ from .cli_commands import (
 from .commands.doctor_cmd import doctor_cmd
 
 # Import commands from the commands directory
-from .commands.analyze_code_cmd import analyze_code_cmd
+from .commands.inspect_code_cmd import inspect_code_cmd
 from .commands.edrr_cycle_cmd import edrr_cycle_cmd
 
 __all__ = [
@@ -54,6 +54,6 @@ __all__ = [
     "check_cmd",
     "refactor_cmd",
     "serve_cmd",
-    "analyze_code_cmd",
+    "inspect_code_cmd",
     "edrr_cycle_cmd",
 ]

--- a/src/devsynth/application/cli/cli_commands.py
+++ b/src/devsynth/application/cli/cli_commands.py
@@ -24,7 +24,7 @@ from devsynth.core.workflows import (
 )
 import uvicorn
 from devsynth.logging_setup import configure_logging
-from ..orchestration.adaptive_workflow import adaptive_workflow_manager
+from ..orchestration.refactor_workflow import refactor_workflow_manager
 from devsynth.logging_setup import DevSynthLogger
 from devsynth.exceptions import DevSynthError
 from devsynth.config import (
@@ -390,7 +390,7 @@ def refactor_cmd(
         project_path = path or os.getcwd()
 
         # Execute the refactor workflow
-        result = adaptive_workflow_manager.execute_adaptive_workflow(project_path)
+        result = refactor_workflow_manager.execute_refactor_workflow(project_path)
 
         if result.get("success", False):
             # Display the workflow information

--- a/src/devsynth/application/cli/commands/__init__.py
+++ b/src/devsynth/application/cli/commands/__init__.py
@@ -2,8 +2,8 @@
 Command modules for the CLI application.
 """
 
-# Import the analyze_code_cmd function to make it available from this package
-from .analyze_code_cmd import analyze_code_cmd
+# Import the inspect_code_cmd function to make it available from this package
+from .inspect_code_cmd import inspect_code_cmd
 from .inspect_config_cmd import inspect_config_cmd
 
-__all__ = ["analyze_code_cmd", "inspect_config_cmd"]
+__all__ = ["inspect_code_cmd", "inspect_config_cmd"]

--- a/src/devsynth/application/cli/commands/inspect_code_cmd.py
+++ b/src/devsynth/application/cli/commands/inspect_code_cmd.py
@@ -1,5 +1,5 @@
 """
-Command to analyze a codebase and provide insights about its architecture, structure, and quality.
+Command to inspect a codebase and provide insights about its architecture, structure, and quality.
 """
 
 import os
@@ -20,46 +20,46 @@ logger = DevSynthLogger(__name__)
 bridge: UXBridge = CLIUXBridge()
 
 
-def analyze_code_cmd(path: Optional[str] = None) -> None:
-    """Analyze a codebase to understand its architecture and quality.
+def inspect_code_cmd(path: Optional[str] = None) -> None:
+    """Inspect a codebase to understand its architecture and quality.
 
     Example:
-        `devsynth analyze-code --path ./my-project`
+        `devsynth inspect-code --path ./my-project`
 
     Args:
-        path: Path to the codebase to analyze (default: current directory)
+        path: Path to the codebase to inspect (default: current directory)
     """
     console = Console()
 
     try:
-        # Show a welcome message for the analyze-code command
+        # Show a welcome message for the inspect-code command
         bridge.print(
             Panel(
-                "[bold blue]DevSynth Code Analysis[/bold blue]\n\n"
-                "This command will analyze a codebase and provide insights about its architecture, structure, and quality.",
-                title="Code Analysis",
+                "[bold blue]DevSynth Code Inspection[/bold blue]\n\n"
+                "This command will inspect a codebase and provide insights about its architecture, structure, and quality.",
+                title="Code Inspection",
                 border_style="blue",
             )
         )
 
-        # Determine the path to analyze
+        # Determine the path to inspect
         if path is None:
             path = os.getcwd()
 
-        bridge.print(f"[bold]Analyzing codebase at:[/bold] {path}")
+        bridge.print(f"[bold]Inspecting codebase at:[/bold] {path}")
 
         # Create a progress panel
-        with console.status("[bold green]Analyzing codebase...[/bold green]"):
-            # Analyze the codebase using SelfAnalyzer
+        with console.status("[bold green]Inspecting codebase...[/bold green]"):
+            # Inspect the codebase using SelfAnalyzer
             analyzer = SelfAnalyzer(path)
             result = analyzer.analyze()
 
-            # Analyze the project state using ProjectStateAnalyzer
+            # Inspect the project state using ProjectStateAnalyzer
             project_analyzer = ProjectStateAnalyzer(path)
             project_state = project_analyzer.analyze()
 
         # Display the analysis results
-        bridge.print("\n[bold]Analysis Results:[/bold]")
+        bridge.print("\n[bold]Inspection Results:[/bold]")
 
         # Display architecture information
         architecture = result["insights"]["architecture"]
@@ -169,7 +169,7 @@ def analyze_code_cmd(path: Optional[str] = None) -> None:
             for recommendation in project_state["recommendations"]:
                 bridge.print(f"- {recommendation}")
 
-        bridge.print("\n[green]Analysis completed successfully![/green]")
+        bridge.print("\n[green]Inspection completed successfully![/green]")
 
     except Exception as e:
         logger.error(f"Error analyzing codebase: {str(e)}")

--- a/src/devsynth/application/orchestration/refactor_workflow.py
+++ b/src/devsynth/application/orchestration/refactor_workflow.py
@@ -1,5 +1,5 @@
 """
-Adaptive Workflow Engine for DevSynth.
+Refactor Workflow Engine for DevSynth.
 
 This module provides an enhanced workflow engine that can adapt to projects
 in any state, detect the current project state automatically, and suggest
@@ -19,16 +19,16 @@ from ...domain.models.workflow import Workflow, WorkflowStep, WorkflowStatus
 from ...application.code_analysis.project_state_analyzer import ProjectStateAnalyzer
 from .workflow import WorkflowManager
 
-class AdaptiveWorkflowManager:
+class RefactorWorkflowManager:
     """
-    Enhanced workflow manager with adaptive capabilities.
+    Enhanced workflow manager with refactor capabilities.
 
     This class extends the standard workflow manager to handle projects in any state,
     detect the current project state automatically, and suggest appropriate next steps.
     """
 
     def __init__(self):
-        """Initialize the adaptive workflow manager."""
+        """Initialize the refactor workflow manager."""
         self.workflow_manager = WorkflowManager()
 
     def analyze_project_state(self, project_path: str) -> Dict[str, Any]:
@@ -244,9 +244,9 @@ class AdaptiveWorkflowManager:
 
         return result
 
-    def execute_adaptive_workflow(self, project_path: str, max_steps: int = 3) -> Dict[str, Any]:
+    def execute_refactor_workflow(self, project_path: str, max_steps: int = 3) -> Dict[str, Any]:
         """
-        Execute an adaptive workflow based on the current project state.
+        Execute a refactor workflow based on the current project state.
 
         This method executes a multi-step workflow that adapts based on the project state.
         It will execute up to max_steps commands, analyzing the project state after each step
@@ -265,7 +265,7 @@ class AdaptiveWorkflowManager:
             - suggestions: Suggestions for next steps
             - final_state: Summary of the final project state
         """
-        logger.info(f"Executing adaptive workflow for {project_path} with max_steps={max_steps}")
+        logger.info(f"Executing refactor workflow for {project_path} with max_steps={max_steps}")
 
         # Initialize the workflow
         workflow, entry_point, suggestions = self.initialize_workflow(project_path)
@@ -345,5 +345,5 @@ class AdaptiveWorkflowManager:
 
         return result
 
-# Create a singleton instance of the adaptive workflow manager
-adaptive_workflow_manager = AdaptiveWorkflowManager()
+# Create a singleton instance of the refactor workflow manager
+refactor_workflow_manager = RefactorWorkflowManager()

--- a/src/devsynth/interface/webui.py
+++ b/src/devsynth/interface/webui.py
@@ -42,7 +42,7 @@ from devsynth.application.cli import (
     spec_cmd,
     test_cmd,
 )
-from devsynth.application.cli.commands.analyze_code_cmd import analyze_code_cmd
+from devsynth.application.cli.commands.inspect_code_cmd import inspect_code_cmd
 from devsynth.application.cli.commands.doctor_cmd import doctor_cmd
 from devsynth.application.cli.commands.edrr_cycle_cmd import edrr_cycle_cmd
 from devsynth.application.cli.commands.align_cmd import align_cmd
@@ -263,13 +263,13 @@ class WebUI(UXBridge):
     def analysis_page(self) -> None:
         """Render the code analysis page."""
         st.header("Code Analysis")
-        with st.expander("Analyze Code", expanded=True):
+        with st.expander("Inspect Code", expanded=True):
             with st.form("analysis"):
                 path = st.text_input("Path", ".")
-                submitted = st.form_submit_button("Analyze")
+                submitted = st.form_submit_button("Inspect")
                 if submitted:
-                    with st.spinner("Analyzing code..."):
-                        analyze_code_cmd(path=path)
+                    with st.spinner("Inspecting code..."):
+                        inspect_code_cmd(path=path)
 
     def synthesis_page(self) -> None:
         """Render the synthesis execution page."""

--- a/tests/behavior/features/analyze_commands.feature
+++ b/tests/behavior/features/analyze_commands.feature
@@ -1,6 +1,6 @@
-Feature: Analyze Commands
+Feature: Inspect Commands
   As a developer using DevSynth
-  I want to use the analyze commands
+  I want to use the inspect commands
   So that I can gain insights about my codebase and project configuration
 
   Background:
@@ -8,8 +8,8 @@ Feature: Analyze Commands
     And I have a valid DevSynth project
 
   @code-analysis
-  Scenario: Analyze code in the current directory
-    When I run the command "devsynth analyze-code"
+  Scenario: Inspect code in the current directory
+    When I run the command "devsynth inspect-code"
     Then the system should analyze the codebase in the current directory
     And the output should include architecture information
     And the output should include code quality metrics
@@ -18,8 +18,8 @@ Feature: Analyze Commands
     And the workflow should execute successfully
 
   @code-analysis
-  Scenario: Analyze code in a specific directory
-    When I run the command "devsynth analyze-code --path ./src"
+  Scenario: Inspect code in a specific directory
+    When I run the command "devsynth inspect-code --path ./src"
     Then the system should analyze the codebase at "./src"
     And the output should include architecture information
     And the output should include code quality metrics
@@ -28,9 +28,9 @@ Feature: Analyze Commands
     And the workflow should execute successfully
 
   @code-analysis
-  Scenario: Handle errors during code analysis
+  Scenario: Handle errors during code inspection
     Given a project with invalid code structure
-    When I run the command "devsynth analyze-code"
+    When I run the command "devsynth inspect-code"
     Then the system should display an error message
     And the error message should indicate the analysis problem
 

--- a/tests/behavior/steps/analyze_commands_steps.py
+++ b/tests/behavior/steps/analyze_commands_steps.py
@@ -11,7 +11,7 @@ from io import StringIO
 
 # Import the CLI modules
 from devsynth.adapters.cli.typer_adapter import run_cli, show_help, parse_args
-from devsynth.application.cli.commands.analyze_code_cmd import analyze_code_cmd
+from devsynth.application.cli.commands.inspect_code_cmd import inspect_code_cmd
 from devsynth.application.cli.commands.inspect_config_cmd import inspect_config_cmd
 
 # Register the scenarios
@@ -95,14 +95,14 @@ def run_command(command, monkeypatch, mock_workflow_manager, command_context):
     # Directly call the appropriate command function based on the first argument
     with patch("sys.stdout", new=captured_output):
         try:
-            if args[0] == "analyze-code":
+            if args[0] == "inspect-code":
                 # Parse the path argument
                 path = None
                 if len(args) > 2 and args[1] == "--path":
                     path = args[2]
 
-                # Call the analyze-code command
-                analyze_code_cmd(path)
+                # Call the inspect-code command
+                inspect_code_cmd(path)
 
                 # For testing purposes, we need to manually set the call args on the mock
                 mock_workflow_manager.execute_command.reset_mock()
@@ -111,11 +111,11 @@ def run_command(command, monkeypatch, mock_workflow_manager, command_context):
                 analyze_code_args = {"path": path}
 
                 # Manually set the call args on the mock
-                mock_workflow_manager.execute_command("analyze-code", analyze_code_args)
+                mock_workflow_manager.execute_command("inspect-code", analyze_code_args)
 
                 # Ensure the mock is called with the correct arguments
                 mock_workflow_manager.execute_command.assert_called_with(
-                    "analyze-code", analyze_code_args
+                    "inspect-code", analyze_code_args
                 )
             elif args[0] == "inspect-config":
                 # Parse the arguments
@@ -277,9 +277,9 @@ def check_analyze_code_current_dir(mock_workflow_manager, command_context):
     """
     Verify that the system analyzed the codebase in the current directory.
     """
-    # Check that the analyze-code command was called
+    # Check that the inspect-code command was called
     mock_workflow_manager.execute_command.assert_any_call(
-        "analyze-code", {"path": None}
+        "inspect-code", {"path": None}
     )
 
 
@@ -288,9 +288,9 @@ def check_analyze_code_path(path, mock_workflow_manager):
     """
     Verify that the system analyzed the codebase at the specified path.
     """
-    # Check that the analyze-code command was called with the correct path
+    # Check that the inspect-code command was called with the correct path
     mock_workflow_manager.execute_command.assert_any_call(
-        "analyze-code", {"path": path}
+        "inspect-code", {"path": path}
     )
 
 

--- a/tests/behavior/steps/cli_commands_steps.py
+++ b/tests/behavior/steps/cli_commands_steps.py
@@ -30,7 +30,7 @@ from devsynth.application.cli.commands.validate_metadata_cmd import (
 from devsynth.application.cli.commands.alignment_metrics_cmd import (
     alignment_metrics_cmd,
 )
-from devsynth.application.cli.commands.analyze_code_cmd import analyze_code_cmd
+from devsynth.application.cli.commands.inspect_code_cmd import inspect_code_cmd
 from devsynth.application.cli.commands.inspect_config_cmd import inspect_config_cmd
 
 
@@ -257,14 +257,14 @@ def run_command(command, monkeypatch, mock_workflow_manager, command_context):
                 mock_workflow_manager.execute_command.assert_called_with(
                     "config", {"key": key, "value": value}
                 )
-            elif args[0] == "analyze-code":
+            elif args[0] == "inspect-code":
                 # Parse the path argument
                 path = None
                 if len(args) > 2 and args[1] == "--path":
                     path = args[2]
 
-                # Call the analyze-code command
-                analyze_code_cmd(path)
+                # Call the inspect-code command
+                inspect_code_cmd(path)
 
                 # For testing purposes, we need to manually set the call args on the mock
                 mock_workflow_manager.execute_command.reset_mock()
@@ -273,11 +273,11 @@ def run_command(command, monkeypatch, mock_workflow_manager, command_context):
                 analyze_code_args = {"path": path}
 
                 # Manually set the call args on the mock
-                mock_workflow_manager.execute_command("analyze-code", analyze_code_args)
+                mock_workflow_manager.execute_command("inspect-code", analyze_code_args)
 
                 # Ensure the mock is called with the correct arguments
                 mock_workflow_manager.execute_command.assert_called_with(
-                    "analyze-code", analyze_code_args
+                    "inspect-code", analyze_code_args
                 )
             elif args[0] == "edrr-cycle":
                 manifest = args[1] if len(args) > 1 else None

--- a/tests/behavior/steps/webui_onboarding_steps.py
+++ b/tests/behavior/steps/webui_onboarding_steps.py
@@ -64,10 +64,10 @@ def webui_context(monkeypatch):
         setattr(cli_stub, name, MagicMock())
     monkeypatch.setitem(sys.modules, "devsynth.application.cli", cli_stub)
 
-    analyze_stub = ModuleType("devsynth.application.cli.commands.analyze_code_cmd")
-    analyze_stub.analyze_code_cmd = MagicMock()
+    analyze_stub = ModuleType("devsynth.application.cli.commands.inspect_code_cmd")
+    analyze_stub.inspect_code_cmd = MagicMock()
     monkeypatch.setitem(
-        sys.modules, "devsynth.application.cli.commands.analyze_code_cmd", analyze_stub
+        sys.modules, "devsynth.application.cli.commands.inspect_code_cmd", analyze_stub
     )
 
     import devsynth.interface.webui as webui

--- a/tests/behavior/steps/webui_steps.py
+++ b/tests/behavior/steps/webui_steps.py
@@ -74,10 +74,10 @@ def webui_context(monkeypatch):
         setattr(cli_stub, name, MagicMock())
     monkeypatch.setitem(sys.modules, "devsynth.application.cli", cli_stub)
 
-    analyze_stub = ModuleType("devsynth.application.cli.commands.analyze_code_cmd")
-    analyze_stub.analyze_code_cmd = MagicMock()
+    analyze_stub = ModuleType("devsynth.application.cli.commands.inspect_code_cmd")
+    analyze_stub.inspect_code_cmd = MagicMock()
     monkeypatch.setitem(
-        sys.modules, "devsynth.application.cli.commands.analyze_code_cmd", analyze_stub
+        sys.modules, "devsynth.application.cli.commands.inspect_code_cmd", analyze_stub
     )
 
     doctor_stub = ModuleType("devsynth.application.cli.commands.doctor_cmd")

--- a/tests/behavior/test_cli_webui_parity.py
+++ b/tests/behavior/test_cli_webui_parity.py
@@ -74,10 +74,10 @@ def parity_env(monkeypatch):
     cli_stub.doctor_cmd = doctor_mod.doctor_cmd
 
     # Additional stub command modules required by the WebUI import
-    analyze_mod = ModuleType("devsynth.application.cli.commands.analyze_code_cmd")
-    analyze_mod.analyze_code_cmd = MagicMock()
+    analyze_mod = ModuleType("devsynth.application.cli.commands.inspect_code_cmd")
+    analyze_mod.inspect_code_cmd = MagicMock()
     monkeypatch.setitem(
-        sys.modules, "devsynth.application.cli.commands.analyze_code_cmd", analyze_mod
+        sys.modules, "devsynth.application.cli.commands.inspect_code_cmd", analyze_mod
     )
 
     edrr_mod = ModuleType("devsynth.application.cli.commands.edrr_cycle_cmd")

--- a/tests/integration/test_complex_workflow.py
+++ b/tests/integration/test_complex_workflow.py
@@ -15,7 +15,7 @@ from pathlib import Path
 from devsynth.application.code_analysis.project_state_analyzer import (
     ProjectStateAnalyzer,
 )
-from devsynth.application.orchestration.adaptive_workflow import AdaptiveWorkflowManager
+from devsynth.application.orchestration.refactor_workflow import RefactorWorkflowManager
 from devsynth.application.cli.cli_commands import (
     init_cmd,
     inspect_cmd,
@@ -253,8 +253,8 @@ class TestComplexWorkflow:
             )
             assert initial_report["spec_code_alignment"]["implementation_score"] < 1.0
 
-            # Step 6: Use the adaptive workflow manager to determine the optimal workflow
-            adaptive_manager = AdaptiveWorkflowManager()
+            # Step 6: Use the refactor workflow manager to determine the optimal workflow
+            adaptive_manager = RefactorWorkflowManager()
             workflow = adaptive_manager.determine_optimal_workflow(initial_report)
 
             # The optimal workflow should be either "specifications" or "code" due to the partial coverage
@@ -353,8 +353,8 @@ class TestComplexWorkflow:
                 adaptive_manager, "execute_command", mock_execute_command
             )
 
-            # Step 9: Execute the adaptive workflow
-            result = adaptive_manager.execute_adaptive_workflow(temp_project_dir)
+            # Step 9: Execute the refactor workflow
+            result = adaptive_manager.execute_refactor_workflow(temp_project_dir)
 
             # Verify that the workflow execution was successful
             assert result["status"] == "success"

--- a/tests/integration/test_comprehensive_workflow.py
+++ b/tests/integration/test_comprehensive_workflow.py
@@ -6,7 +6,7 @@ from pathlib import Path
 
 from devsynth.application.code_analysis.project_state_analyzer import ProjectStateAnalyzer
 from devsynth.application.code_analysis.self_analyzer import SelfAnalyzer
-from devsynth.application.orchestration.adaptive_workflow import AdaptiveWorkflowManager
+from devsynth.application.orchestration.refactor_workflow import RefactorWorkflowManager
 from devsynth.application.orchestration.workflow import WorkflowManager
 
 
@@ -204,10 +204,10 @@ class TestUser(unittest.TestCase):
         print(f"File Count: {report['file_count']}")
         print(f"Requirements Count: {report['requirements_count']}")
 
-    def test_adaptive_workflow_with_external_codebase(self, sample_project):
-        """Test that AdaptiveWorkflowManager can work with an external codebase."""
-        # Create an AdaptiveWorkflowManager instance
-        workflow_manager = AdaptiveWorkflowManager()
+    def test_refactor_workflow_with_external_codebase(self, sample_project):
+        """Test that RefactorWorkflowManager can work with an external codebase."""
+        # Create a RefactorWorkflowManager instance
+        workflow_manager = RefactorWorkflowManager()
 
         # Get suggestions for next steps
         suggestions = workflow_manager.suggest_next_steps(sample_project)
@@ -248,7 +248,7 @@ class TestUser(unittest.TestCase):
         code_analysis = code_analyzer.analyze()
 
         # Step 3: Determine the optimal workflow
-        workflow_manager = AdaptiveWorkflowManager()
+        workflow_manager = RefactorWorkflowManager()
         workflow = workflow_manager.determine_optimal_workflow(project_state)
         entry_point = workflow_manager.determine_entry_point(project_state, workflow)
 

--- a/tests/integration/test_refactor_workflow.py
+++ b/tests/integration/test_refactor_workflow.py
@@ -1,7 +1,7 @@
 """
-Integration tests for the AdaptiveWorkflowManager class.
+Integration tests for the RefactorWorkflowManager class.
 
-These tests verify that the AdaptiveWorkflowManager can correctly analyze
+These tests verify that the RefactorWorkflowManager can correctly analyze
 a project's state, determine the optimal workflow, and suggest appropriate
 next steps.
 """
@@ -12,12 +12,12 @@ import tempfile
 import shutil
 from pathlib import Path
 
-from devsynth.application.orchestration.adaptive_workflow import AdaptiveWorkflowManager
+from devsynth.application.orchestration.refactor_workflow import RefactorWorkflowManager
 from devsynth.application.cli.cli_commands import init_cmd
 
 
-class TestAdaptiveWorkflowManager:
-    """Tests for the AdaptiveWorkflowManager class."""
+class TestRefactorWorkflowManager:
+    """Tests for the RefactorWorkflowManager class."""
 
     @pytest.fixture
     def temp_project_dir(self):
@@ -59,8 +59,8 @@ class TestAdaptiveWorkflowManager:
         with open(os.path.join(requirements_dir, "requirements.md"), "w") as f:
             f.write(requirements_content)
 
-        # Create an AdaptiveWorkflowManager
-        manager = AdaptiveWorkflowManager()
+        # Create a RefactorWorkflowManager
+        manager = RefactorWorkflowManager()
 
         # Analyze the project state
         project_state = manager.analyze_project_state(temp_project_dir)
@@ -121,8 +121,8 @@ class TestAdaptiveWorkflowManager:
         with open(os.path.join(requirements_dir, "requirements.md"), "w") as f:
             f.write(requirements_content)
 
-        # Create an AdaptiveWorkflowManager
-        manager = AdaptiveWorkflowManager()
+        # Create a RefactorWorkflowManager
+        manager = RefactorWorkflowManager()
 
         # Analyze the project state
         project_state = manager.analyze_project_state(temp_project_dir)
@@ -238,8 +238,8 @@ class TestAdaptiveWorkflowManager:
         ):
             init_cmd()
 
-        # Create an AdaptiveWorkflowManager
-        manager = AdaptiveWorkflowManager()
+        # Create a RefactorWorkflowManager
+        manager = RefactorWorkflowManager()
 
         # Suggest next steps
         suggestions = manager.suggest_next_steps(temp_project_dir)
@@ -313,8 +313,8 @@ class TestAdaptiveWorkflowManager:
         with open(os.path.join(requirements_dir, "requirements.md"), "w") as f:
             f.write(requirements_content)
 
-        # Create an AdaptiveWorkflowManager
-        manager = AdaptiveWorkflowManager()
+        # Create a RefactorWorkflowManager
+        manager = RefactorWorkflowManager()
 
         # Initialize the workflow
         workflow, entry_point, suggestions = manager.initialize_workflow(
@@ -335,8 +335,8 @@ class TestAdaptiveWorkflowManager:
         assert "specifications" in suggestions[0]["description"].lower()
         assert suggestions[0]["priority"] == "high"
 
-    def test_execute_adaptive_workflow(self, temp_project_dir, monkeypatch):
-        """Test executing an adaptive workflow."""
+    def test_execute_refactor_workflow(self, temp_project_dir, monkeypatch):
+        """Test executing a refactor workflow."""
         # Initialize a new project
         with patch(
             "devsynth.application.cli.cli_commands.bridge.ask_question",
@@ -366,8 +366,8 @@ class TestAdaptiveWorkflowManager:
         with open(os.path.join(requirements_dir, "requirements.md"), "w") as f:
             f.write(requirements_content)
 
-        # Create an AdaptiveWorkflowManager
-        manager = AdaptiveWorkflowManager()
+        # Create a RefactorWorkflowManager
+        manager = RefactorWorkflowManager()
 
         # Mock the execute_command method to avoid actually executing commands
         def mock_execute_command(command, args):
@@ -379,8 +379,8 @@ class TestAdaptiveWorkflowManager:
 
         monkeypatch.setattr(manager, "execute_command", mock_execute_command)
 
-        # Execute the adaptive workflow
-        result = manager.execute_adaptive_workflow(temp_project_dir)
+        # Execute the refactor workflow
+        result = manager.execute_refactor_workflow(temp_project_dir)
 
         # Verify that the result contains the expected fields
         assert "success" in result
@@ -400,4 +400,4 @@ class TestAdaptiveWorkflowManager:
 
 
 if __name__ == "__main__":
-    pytest.main(["-v", "test_adaptive_workflow.py"])
+    pytest.main(["-v", "test_refactor_workflow.py"])

--- a/tests/unit/interface/test_uxbridge_consistency.py
+++ b/tests/unit/interface/test_uxbridge_consistency.py
@@ -128,10 +128,10 @@ def _web_bridge(monkeypatch):
         sys.modules, "devsynth.application.cli.commands.align_cmd", align_module
     )
 
-    analyze_stub = ModuleType("devsynth.application.cli.commands.analyze_code_cmd")
-    analyze_stub.analyze_code_cmd = MagicMock()
+    analyze_stub = ModuleType("devsynth.application.cli.commands.inspect_code_cmd")
+    analyze_stub.inspect_code_cmd = MagicMock()
     monkeypatch.setitem(
-        sys.modules, "devsynth.application.cli.commands.analyze_code_cmd", analyze_stub
+        sys.modules, "devsynth.application.cli.commands.inspect_code_cmd", analyze_stub
     )
 
     import importlib

--- a/tests/unit/interface/test_webui.py
+++ b/tests/unit/interface/test_webui.py
@@ -65,11 +65,11 @@ def stub_streamlit(monkeypatch):
         setattr(cli_stub, name, MagicMock())
     monkeypatch.setitem(sys.modules, "devsynth.application.cli", cli_stub)
 
-    analyze_stub = ModuleType("devsynth.application.cli.commands.analyze_code_cmd")
-    analyze_stub.analyze_code_cmd = MagicMock()
+    analyze_stub = ModuleType("devsynth.application.cli.commands.inspect_code_cmd")
+    analyze_stub.inspect_code_cmd = MagicMock()
     monkeypatch.setitem(
         sys.modules,
-        "devsynth.application.cli.commands.analyze_code_cmd",
+        "devsynth.application.cli.commands.inspect_code_cmd",
         analyze_stub,
     )
 
@@ -122,7 +122,7 @@ def test_requirements_calls_spec(monkeypatch, stub_streamlit):
 def test_analysis_calls_analyze(monkeypatch, stub_streamlit):
     analyze = _patch_cmd(
         monkeypatch,
-        "devsynth.application.cli.commands.analyze_code_cmd.analyze_code_cmd",
+        "devsynth.application.cli.commands.inspect_code_cmd.inspect_code_cmd",
     )
     import importlib
     import devsynth.interface.webui as webui

--- a/tests/unit/test_cli_commands.py
+++ b/tests/unit/test_cli_commands.py
@@ -49,7 +49,7 @@ class TestCLIHelpOutput:
             "doctor",
             "check",
             "refactor",
-            "analyze-code",
+            "inspect-code",
             "edrr-cycle",
             "align",
             "alignment-metrics",

--- a/tests/unit/test_ux_bridge.py
+++ b/tests/unit/test_ux_bridge.py
@@ -41,11 +41,11 @@ def test_webui_bridge_methods(monkeypatch):
         setattr(cli_stub, name, MagicMock())
     monkeypatch.setitem(sys.modules, "devsynth.application.cli", cli_stub)
 
-    analyze_stub = ModuleType("devsynth.application.cli.commands.analyze_code_cmd")
-    analyze_stub.analyze_code_cmd = MagicMock()
+    analyze_stub = ModuleType("devsynth.application.cli.commands.inspect_code_cmd")
+    analyze_stub.inspect_code_cmd = MagicMock()
     monkeypatch.setitem(
         sys.modules,
-        "devsynth.application.cli.commands.analyze_code_cmd",
+        "devsynth.application.cli.commands.inspect_code_cmd",
         analyze_stub,
     )
 


### PR DESCRIPTION
## Summary
- rename adaptive workflow to refactor workflow
- rename analyze-code command to inspect-code
- update tests and docs for new names

## Testing
- `poetry run pytest -q tests` *(fails: Typer.command() got an unexpected keyword argument 'aliases')*

------
https://chatgpt.com/codex/tasks/task_e_686408953cb083338ed80c995f8938b1