### PR TITLE
Complete setup wizard flow

### DIFF
--- a/src/devsynth/application/cli/setup_wizard.py
+++ b/src/devsynth/application/cli/setup_wizard.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from typing import Dict, Optional
 
 from devsynth.config import load_project_config, ProjectUnifiedConfig
+from devsynth.config.unified_loader import UnifiedConfigLoader
 from devsynth.interface.cli import CLIUXBridge
 from devsynth.interface.ux_bridge import UXBridge
 
@@ -103,7 +104,7 @@ class SetupWizard:
         cfg.config.memory_store_type = memory_backend
         cfg.config.offline_mode = offline_mode
         cfg.config.features = features
-        cfg.save()
+        cfg.path = UnifiedConfigLoader.save(cfg)
 
         self.bridge.display_result("Initialization complete", highlight=True)
         return cfg

--- a/tests/behavior/features/setup_wizard.feature
+++ b/tests/behavior/features/setup_wizard.feature
@@ -1,0 +1,14 @@
+Feature: Setup Wizard
+  As a developer
+  I want a guided initialization wizard
+  So that I can configure my project interactively
+
+  Scenario: Run the setup wizard
+    Given the DevSynth CLI is installed
+    When I run the setup wizard
+    Then a project configuration file should include the selected options
+
+  Scenario: Cancel the setup wizard
+    Given the DevSynth CLI is installed
+    When I cancel the setup wizard
+    Then no project configuration file should exist

--- a/tests/behavior/steps/setup_wizard_steps.py
+++ b/tests/behavior/steps/setup_wizard_steps.py
@@ -1,0 +1,114 @@
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Sequence, Optional
+from unittest.mock import MagicMock
+
+from pytest_bdd import scenarios, given, when, then
+
+from devsynth.interface.ux_bridge import UXBridge
+
+
+class DummyBridge(UXBridge):
+    def __init__(self, answers: Sequence[str], confirms: Sequence[bool]):
+        self.answers = list(answers)
+        self.confirms = list(confirms)
+
+    def ask_question(
+        self,
+        message: str,
+        *,
+        choices: Optional[Sequence[str]] = None,
+        default: Optional[str] = None,
+        show_default: bool = True,
+    ) -> str:
+        return self.answers.pop(0)
+
+    def confirm_choice(self, message: str, *, default: bool = False) -> bool:
+        return self.confirms.pop(0)
+
+    def display_result(self, message: str, *, highlight: bool = False) -> None:
+        pass
+
+
+scenarios("../features/setup_wizard.feature")
+
+
+@given("the DevSynth CLI is installed")
+def cli_installed():
+    return True
+
+
+@when("I run the setup wizard")
+def run_setup_wizard(tmp_project_dir, monkeypatch):
+    monkeypatch.setitem(os.sys.modules, "chromadb", MagicMock())
+    monkeypatch.setitem(os.sys.modules, "uvicorn", MagicMock())
+    from devsynth.application.cli.setup_wizard import SetupWizard
+
+    answers = [
+        str(tmp_project_dir),
+        "single_package",
+        "python",
+        "",
+        "demo goals",
+        "kuzu",
+    ]
+    confirms = [
+        True,  # offline mode
+        True,  # wsde_collaboration
+        False,  # dialectical_reasoning
+        False,  # code_generation
+        False,  # test_generation
+        False,  # documentation_generation
+        False,  # experimental_features
+        True,  # proceed
+    ]
+    bridge = DummyBridge(answers, confirms)
+    wizard = SetupWizard(bridge)
+    wizard.run()
+
+
+@when("I cancel the setup wizard")
+def cancel_setup_wizard(tmp_project_dir, monkeypatch):
+    monkeypatch.setitem(os.sys.modules, "chromadb", MagicMock())
+    monkeypatch.setitem(os.sys.modules, "uvicorn", MagicMock())
+    from devsynth.application.cli.setup_wizard import SetupWizard
+
+    answers = [
+        str(tmp_project_dir),
+        "single_package",
+        "python",
+        "",
+        "",
+        "memory",
+    ]
+    confirms = [
+        False,  # offline mode
+        False,  # wsde_collaboration
+        False,  # dialectical_reasoning
+        False,  # code_generation
+        False,  # test_generation
+        False,  # documentation_generation
+        False,  # experimental_features
+        False,  # proceed
+    ]
+    bridge = DummyBridge(answers, confirms)
+    wizard = SetupWizard(bridge)
+    wizard.run()
+
+
+@then("a project configuration file should include the selected options")
+def check_config(tmp_project_dir):
+    from devsynth.config.unified_loader import UnifiedConfigLoader
+
+    cfg = UnifiedConfigLoader.load(tmp_project_dir).config
+    assert cfg.memory_store_type == "kuzu"
+    assert cfg.offline_mode is True
+    assert cfg.features["wsde_collaboration"] is True
+
+
+@then("no project configuration file should exist")
+def no_config(tmp_project_dir):
+    cfg_file = Path(tmp_project_dir) / ".devsynth" / "devsynth.yml"
+    assert not cfg_file.exists()

--- a/tests/behavior/test_setup_wizard.py
+++ b/tests/behavior/test_setup_wizard.py
@@ -1,0 +1,5 @@
+from pytest_bdd import scenarios
+
+from .steps.setup_wizard_steps import *  # noqa: F401,F403
+
+scenarios("features/setup_wizard.feature")

--- a/tests/unit/application/cli/test_setup_wizard.py
+++ b/tests/unit/application/cli/test_setup_wizard.py
@@ -76,7 +76,7 @@ def test_setup_wizard_run(tmp_path, monkeypatch) -> None:
     bridge = DummyBridge(answers, confirms)
     wizard = SetupWizard(bridge)
     cfg = wizard.run()
-    cfg_file = tmp_path / ".devsynth" / "project.yaml"
+    cfg_file = tmp_path / ".devsynth" / "devsynth.yml"
     assert cfg_file.exists()
     assert cfg.config.goals == "do stuff"
     assert cfg.config.memory_store_type == "kuzu"
@@ -108,6 +108,6 @@ def test_setup_wizard_abort(tmp_path, monkeypatch) -> None:
     bridge = DummyBridge(answers, confirms)
     wizard = SetupWizard(bridge)
     wizard.run()
-    cfg_file = tmp_path / ".devsynth" / "project.yaml"
+    cfg_file = tmp_path / ".devsynth" / "devsynth.yml"
     assert not cfg_file.exists()
     assert "Initialization aborted." in bridge.messages[-1]


### PR DESCRIPTION
## Summary
- finalize initialization wizard prompts
- save configuration with `UnifiedConfigLoader.save`
- add BDD scenarios for wizard success and cancellation
- add step definitions and tests using new devsynth.yml path

## Testing
- `poetry run pytest tests/unit/application/cli/test_setup_wizard.py -q`


------
https://chatgpt.com/codex/tasks/task_e_686408bf266883338e0a34a825b9a6eb