### PR TITLE
Add unified loader tests and doc update

### DIFF
--- a/docs/technical_reference/configuration_reference.md
+++ b/docs/technical_reference/configuration_reference.md
@@ -34,6 +34,14 @@ This document provides a comprehensive reference for configuring DevSynth. It co
 
 DevSynth uses a YAML configuration file located at `~/.devsynth/config.yaml` by default. You can specify a different location using the `--config-file` CLI option or the `DEVSYNTH_CONFIG_PATH` environment variable.
 
+For project configuration DevSynth relies on a *unified loader* that searches the
+project root for either a `[tool.devsynth]` table in `pyproject.toml` or the file
+`.devsynth/devsynth.yml`. When both are present the TOML entry takes precedence.
+Saving a configuration writes back to whichever file was originally loaded. The
+loader also checks the `version` field against the CLI's expected
+`ConfigModel.version` and logs a warning if they differ, providing a simple form
+of version locking.
+
 ### Example Configuration File
 
 ```yaml

--- a/tests/unit/config/test_unified_loader.py
+++ b/tests/unit/config/test_unified_loader.py
@@ -1,0 +1,58 @@
+import toml
+import yaml
+from pathlib import Path
+
+from devsynth.config.unified_loader import UnifiedConfigLoader
+from devsynth.config.loader import ConfigModel
+
+
+def test_loads_from_pyproject(tmp_path: Path) -> None:
+    pyproject = tmp_path / "pyproject.toml"
+    pyproject.write_text(f"[tool.devsynth]\nversion = '{ConfigModel.version}'\n")
+
+    unified = UnifiedConfigLoader.load(tmp_path)
+
+    assert unified.use_pyproject is True
+    assert unified.path == pyproject
+    assert unified.config.version == ConfigModel.version
+
+
+def test_loads_from_yaml(tmp_path: Path) -> None:
+    cfg_dir = tmp_path / ".devsynth"
+    cfg_dir.mkdir()
+    yaml_file = cfg_dir / "devsynth.yml"
+    yaml_file.write_text(f"version: '{ConfigModel.version}'\n")
+
+    unified = UnifiedConfigLoader.load(tmp_path)
+
+    assert unified.use_pyproject is False
+    assert unified.path == yaml_file
+    assert unified.config.version == ConfigModel.version
+
+
+def test_save_round_trip_yaml(tmp_path: Path) -> None:
+    cfg_dir = tmp_path / ".devsynth"
+    cfg_dir.mkdir()
+    yaml_file = cfg_dir / "devsynth.yml"
+    yaml_file.write_text(f"version: '{ConfigModel.version}'\n")
+
+    unified = UnifiedConfigLoader.load(tmp_path)
+    unified.config.language = "python"
+    saved = UnifiedConfigLoader.save(unified)
+
+    assert saved == yaml_file
+    data = yaml.safe_load(yaml_file.read_text())
+    assert data["language"] == "python"
+
+
+def test_save_round_trip_pyproject(tmp_path: Path) -> None:
+    pyproject = tmp_path / "pyproject.toml"
+    pyproject.write_text(f"[tool.devsynth]\nversion = '{ConfigModel.version}'\n")
+
+    unified = UnifiedConfigLoader.load(tmp_path)
+    unified.config.language = "python"
+    saved = UnifiedConfigLoader.save(unified)
+
+    assert saved == pyproject
+    content = toml.load(pyproject)
+    assert content["tool"]["devsynth"]["language"] == "python"


### PR DESCRIPTION
## Summary
- add unit tests for UnifiedConfigLoader covering pyproject and YAML cases
- ensure config saves back to the right file
- document unified loader paths and version locking

## Testing
- `poetry run pytest tests/unit/config/test_unified_loader.py -q`
- `poetry run pytest tests/unit/config/test_project_config_validation.py -q`


------
https://chatgpt.com/codex/tasks/task_e_686435901c588333b482ef5e7a9f1b59