### PR TITLE
Add .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,15 @@
+.git
+__pycache__/
+*.pyc
+*.pyo
+*.pyd
+tests/__pycache__/
+CODEX_ENVIRONMENT_SETUP_FAILED
+docs/
+examples/
+tests/
+deployment/
+templates/
+*.log
+.vscode/
+


### PR DESCRIPTION
## Summary
- keep Docker builds slim by ignoring sources such as tests, docs and examples

## Testing
- `poetry run pytest` *(fails: 140 failed, 293 passed, 61 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_68699984cd1c8333a71124eeefa2dc2c