### PR TITLE
Simplify Dockerfile for local tests

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,113 +1,53 @@
 # DevSynth Dockerfile
-# Multi-stage build for development, testing, and production environments
+# Development and testing environment
 
-###################
-# BASE STAGE
-###################
 FROM python:3.12-slim AS base
 
-# Set environment variables
-ENV PYTHONDONTWRITEBYTECODE=1 \
-    PYTHONUNBUFFERED=1 \
-    PYTHONFAULTHANDLER=1 \
-    PIP_NO_CACHE_DIR=off \
-    PIP_DISABLE_PIP_VERSION_CHECK=on \
-    POETRY_VERSION=1.6.1 \
-    POETRY_HOME="/opt/poetry" \
-    POETRY_VIRTUALENVS_IN_PROJECT=true \
-    POETRY_NO_INTERACTION=1 \
-    PYSETUP_PATH="/opt/pysetup" \
-    VENV_PATH="/opt/pysetup/.venv"
+ARG USERNAME=dev
+ARG USER_UID=1000
 
-# Add Poetry to PATH
-ENV PATH="$POETRY_HOME/bin:$VENV_PATH/bin:$PATH"
+ENV PIP_NO_CACHE_DIR=off \
+    PIP_DISABLE_PIP_VERSION_CHECK=on \
+    PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1
 
 # Install system dependencies
-RUN apt-get update \
-    && apt-get install -y --no-install-recommends \
-        curl \
+RUN apt-get update && apt-get install -y --no-install-recommends \
         build-essential \
-    && apt-get clean \
-    && rm -rf /var/lib/apt/lists/*
+        python3-dev \
+        cargo \
+        cmake \
+        libssl-dev \
+        libffi-dev \
+        libopenblas-dev \
+        liblmdb-dev \
+        libomp-dev \
+        curl \
+    && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # Install Poetry
-RUN curl -sSL https://install.python-poetry.org | python3 -
-
-# Set working directory
-WORKDIR $PYSETUP_PATH
-
-# Copy project files
-COPY pyproject.toml poetry.lock* ./
-
-###################
-# DEVELOPMENT STAGE
-###################
-FROM base AS development
-
-# Install development dependencies
-RUN poetry install --no-root --with dev
-
-# Copy the rest of the application
-COPY . .
-
-# Install the application
-RUN poetry install --with dev
-
-# Set up health check
-HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \
-    CMD python -c "import requests; requests.get('http://localhost:8000/health')" || exit 1
-
-# Command to run the application
-CMD ["poetry", "run", "devsynth", "serve", "--debug"]
-
-###################
-# TESTING STAGE
-###################
-FROM base AS testing
-
-# Install test dependencies
-RUN poetry install --no-root --with test
-
-# Copy the rest of the application
-COPY . .
-
-# Install the application
-RUN poetry install --with test
-
-# Run tests
-CMD ["poetry", "run", "pytest"]
-
-###################
-# PRODUCTION STAGE
-###################
-FROM python:3.12-slim AS production
-
-# Set environment variables
-ENV PYTHONDONTWRITEBYTECODE=1 \
-    PYTHONUNBUFFERED=1 \
-    PYTHONFAULTHANDLER=1 \
-    PATH="/app/.venv/bin:$PATH"
+RUN pip install --no-cache-dir "poetry==1.8.2"
 
 # Create non-root user
-RUN groupadd -g 1000 devsynth && \
-    useradd -u 1000 -g devsynth -s /bin/bash -m devsynth
+RUN useradd -m -u ${USER_UID} ${USERNAME}
 
-# Set working directory
-WORKDIR /app
+WORKDIR /workspace
 
-# Copy virtual environment from base stage
-COPY --from=base --chown=devsynth:devsynth $VENV_PATH /app/.venv
+# Copy dependency files first for caching
+COPY pyproject.toml poetry.lock* ./
 
-# Copy application code
-COPY --chown=devsynth:devsynth ./src /app/src
-COPY --chown=devsynth:devsynth ./pyproject.toml /app/
+# Install Python dependencies
+RUN poetry install --with dev --all-extras --no-root
 
-# Switch to non-root user
-USER devsynth
+# Copy source and tests
+COPY src ./src
+COPY tests ./tests
 
-# Set up health check
-HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \
-    CMD python -c "import requests; requests.get('http://localhost:8000/health')" || exit 1
+# Ensure user owns workspace
+RUN chown -R ${USERNAME}:${USERNAME} /workspace
 
-# Command to run the application
-#CMD ["devsynth", "serve"]
+USER ${USERNAME}
+
+ENV PATH="/workspace/.venv/bin:$PATH"
+
+CMD ["poetry", "run", "pytest", "-q"]


### PR DESCRIPTION
## Summary
- rework Dockerfile to provide a clean base image for tests
- install system packages, create non-root user and set `/workspace`
- pin Poetry and install dependencies from lock files
- copy source and tests after dependencies and run pytest by default

## Testing
- `poetry run pytest -q` *(fails: 218 failed, 1004 passed, 86 skipped, 1 error)*

------
https://chatgpt.com/codex/tasks/task_e_68699d623ee4833399c96dac301be1b4