### PR TITLE
Clarify pre-release status in docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,9 @@ All notable changes to the DevSynth project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+DevSynth has not yet reached an official release. Versions in the `0.1.x` range
+represent pre-release milestones leading up to the first stable release.
+
 ## [Unreleased]
 
 ### Added
@@ -36,7 +39,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Improved error handling in the EDRR coordinator
 
-## [Unreleased] - 2025-05-20
+## [0.1.0] - 2025-05-20
 
 ### Added
 - Modular, hexagonal architecture
@@ -46,3 +49,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Provider abstraction for LLM services
 - Comprehensive SDLC policy corpus
 - Automated documentation and testing
+

--- a/README.md
+++ b/README.md
@@ -18,6 +18,10 @@ last_reviewed: "2025-07-10"
 
 DevSynth is an agentic software engineering platform that leverages LLMs, advanced memory systems, and dialectical reasoning to automate and enhance the software development lifecycle. The system is designed for extensibility, resilience, and traceability, supporting both autonomous and collaborative workflows.
 
+**Pre-release notice:** DevSynth has not yet reached an official release. All
+current versions are in the `0.1.x` range and should be considered
+experimental.
+
 ## Key Features
 - Modular, hexagonal architecture for extensibility and testability
 - Unified memory system with Kuzu, TinyDB, RDFLib, and JSON backends

--- a/docs/roadmap/development_plan.md
+++ b/docs/roadmap/development_plan.md
@@ -22,7 +22,10 @@ last_reviewed: "2025-07-10"
 
 # DevSynth Development Plan
 
-**Date:** 2025-06-01  
+**Note:** DevSynth is currently a pre-release project. Versions in the `0.1.x`
+range are unstable and subject to change.
+
+**Date:** 2025-06-01
 **Author:** DevSynth Team
 
 ## Executive Summary

--- a/docs/roadmap/development_status.md
+++ b/docs/roadmap/development_status.md
@@ -17,6 +17,9 @@ version: 0.1.0
 
 # DevSynth Development Status
 
+**Note:** DevSynth is in a pre-release state. Current versions are numbered
+`0.1.x` and do not represent a stable release.
+
 This document serves as the single source of truth for the current development status of the DevSynth project. It consolidates information from various summary documents and provides a clear overview of implementation progress across all phases.
 
 ## Phase 1: Foundation Stabilization

--- a/docs/roadmap/index.md
+++ b/docs/roadmap/index.md
@@ -13,6 +13,10 @@ version: 0.1.0
 
 # DevSynth Roadmap
 
+**Note:** DevSynth has not reached an official release yet. The roadmap
+documents progress toward a future stable version while current builds remain in
+the `0.1.x` pre-release series.
+
 This section outlines the future plans and development trajectory for the DevSynth project.
 
 ## Development Plans

--- a/docs/roadmap/release_plan.md
+++ b/docs/roadmap/release_plan.md
@@ -7,10 +7,13 @@ tags:
 - release-plan
 - roadmap
 title: DevSynth 1.0 Release Plan
-version: 1.0.0
+version: 0.1.0
 ---
 
 # DevSynth 1.0 Release Plan
+
+**Note:** DevSynth is still in pre-release. Current versions are in the `0.1.x`
+series while this document outlines the path toward an eventual 1.0 release.
 
 We propose a multi-phase plan to finalize DevSynth’s UX, architecture, and completeness.  Each phase defines targeted milestones and implementation-ready tasks, emphasizing BDD/TDD practices.  We draw on the current codebase and docs to identify missing features and gaps.
 


### PR DESCRIPTION
## Summary
- update roadmap versions to 0.1.0
- add pre-release note to README and roadmap docs
- clarify changelog pre-release numbering

## Testing
- `bash scripts/codex_setup.sh`
- `poetry run pytest -q` *(fails: FileNotFoundError: webui_integration.feature)*

------
https://chatgpt.com/codex/tasks/task_e_68701f063c408333a8ff197783c0ddcc