### PR TITLE
Document offline mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,15 @@ pip install 'devsynth[retrieval,memory,llm]'
 
 These packages enable the Kuzu, FAISS, and LMDB memory stores along with optional LLM provider helpers. ChromaDB can be enabled later, but only the embedded backend is currently supported.
 
+### Offline Mode
+
+Set `offline_mode: true` in your project configuration to run DevSynth without
+network access. When enabled the CLI automatically uses the built-in
+OfflineProvider, which generates deterministic text and embeddings or loads a
+local model defined by `offline_provider.model_path`. See
+[Offline Provider details](docs/technical_reference/llm_integration.md#offline-provider)
+for more information.
+
 ## Minimal Project Example
 
 Follow these steps to try DevSynth on a small project:

--- a/docs/technical_reference/llm_integration.md
+++ b/docs/technical_reference/llm_integration.md
@@ -85,6 +85,16 @@ context = [
 response = provider.generate_with_context("Tell me a joke", context)
 ```
 
+## Offline Provider
+
+When `offline_mode` is enabled in the project configuration, DevSynth selects
+the **OfflineProvider**. This provider avoids all remote API calls and either
+loads a local Hugging Face model specified via
+`offline_provider.model_path` or falls back to deterministic text generation and
+hash-based embeddings. Offline mode ensures repeatable results for testing and
+continuous integration. See the configuration guide for details on the relevant
+flags.
+
 ## Token Tracking and Optimization
 
 DevSynth includes a `TokenTracker` utility for tracking and optimizing token usage in LLM interactions.

--- a/docs/user_guides/user_guide.md
+++ b/docs/user_guides/user_guide.md
@@ -249,6 +249,15 @@ DevSynth can be configured using the `config` command or by editing the configur
 | `serper_api_key` | Serper API key for web search functionality | None | Valid Serper API key |
 | `memory_store_type` | Type of memory store to use | `memory` | `memory`, `file`, `Kuzu` |
 
+### Offline Mode
+
+Enable `offline_mode` in your configuration to avoid all remote LLM calls.
+When this flag is `true` the CLI selects the OfflineProvider, which returns
+deterministic text and embeddings or loads a local model from
+`offline_provider.model_path`. See
+[Offline Provider details](../technical_reference/llm_integration.md#offline-provider)
+for more information.
+
 ### Environment Variables and .env Files
 
 DevSynth supports loading configuration from environment variables and `.env` files. This is especially useful for sensitive information like API keys.


### PR DESCRIPTION
## Summary
- describe offline mode configuration and provider
- explain offline mode in the user guide
- add offline provider notes to the technical reference

## Testing
- `poetry run pytest -q` *(fails: ModuleNotFoundError: No module named 'pytest_bdd')*

------
https://chatgpt.com/codex/tasks/task_e_6870b6db9ac88333afb96e96775b06ec