### PR TITLE
Use lmstudio SDK

### DIFF
--- a/docs/technical_reference/lm_studio_integration.md
+++ b/docs/technical_reference/lm_studio_integration.md
@@ -138,6 +138,10 @@ The LM Studio integration is implemented in the following files:
 - `src/devsynth/application/cli/commands.py`: CLI commands for configuring LLM providers
 - `tests/integration/test_lmstudio_provider.py`: Integration tests for the LM Studio provider
 
+The provider uses the official `lmstudio` Python SDK for all API interactions.  
+`lmstudio.sync_api` is configured with the API host from settings and then used
+to create chat completions and embeddings without relying on raw HTTP requests.
+
 The implementation includes the following features:
 
 - Auto-selection of models from LM Studio


### PR DESCRIPTION
## Summary
- integrate official lmstudio SDK in `LMStudioProvider`
- revise LM Studio provider tests for SDK usage
- document SDK integration details

## Testing
- `poetry run pytest tests/integration/test_lmstudio_provider.py::TestLMStudioProvider::test_generate_with_invalid_response_returns_expected_result -q`
- `poetry run pytest -q` *(fails: Step definition not found)*

------
https://chatgpt.com/codex/tasks/task_e_6873cc635c608333b6d778e35e1ad05d