### PR TITLE
Standardize lmstudio provider naming

### DIFF
--- a/docs/architecture/provider_system.md
+++ b/docs/architecture/provider_system.md
@@ -328,7 +328,7 @@ class FallbackProvider(BaseProvider):
         config = get_provider_config()
         self.fallback_config = config.get("fallback", {
             "enabled": True,
-            "order": ["openai", "lm_studio"],
+            "order": ["openai", "lmstudio"],
         })
         self.circuit_breaker_config = config.get("circuit_breaker", {
             "enabled": True,
@@ -363,14 +363,14 @@ class FallbackProvider(BaseProvider):
                             )
                     else:
                         logger.info("OpenAI API key missing; skipping OpenAI provider")
-                elif provider_type.lower() == ProviderType.LM_STUDIO.value:
+                elif provider_type.lower() == ProviderType.LMSTUDIO.value:
                     try:
                         providers.append(
-                            ProviderFactory.create_provider(ProviderType.LM_STUDIO.value)
+                            ProviderFactory.create_provider(ProviderType.LMSTUDIO.value)
                         )
                         # Create circuit breaker for this provider
                         if self.circuit_breaker_config["enabled"]:
-                            self.circuit_breakers[ProviderType.LM_STUDIO.value] = CircuitBreaker(
+                            self.circuit_breakers[ProviderType.LMSTUDIO.value] = CircuitBreaker(
                                 failure_threshold=self.circuit_breaker_config["failure_threshold"],
                                 recovery_timeout=self.circuit_breaker_config["recovery_timeout"]
                             )
@@ -609,7 +609,7 @@ class ProviderFactory:
                     logger.warning(
                         "OpenAI API key not found; falling back to LM Studio if available"
                     )
-                    return ProviderFactory.create_provider(ProviderType.LM_STUDIO.value)
+                    return ProviderFactory.create_provider(ProviderType.LMSTUDIO.value)
                 logger.info("Using OpenAI provider")
                 return OpenAIProvider(
                     api_key=config["openai"]["api_key"],
@@ -617,11 +617,11 @@ class ProviderFactory:
                     base_url=config["openai"]["base_url"],
                     tls_config=tls_conf,
                 )
-            elif provider_type.lower() == ProviderType.LM_STUDIO.value:
+            elif provider_type.lower() == ProviderType.LMSTUDIO.value:
                 logger.info("Using LM Studio provider")
                 return LMStudioProvider(
-                    endpoint=config["lm_studio"]["endpoint"],
-                    model=config["lm_studio"]["model"],
+                    endpoint=config["lmstudio"]["endpoint"],
+                    model=config["lmstudio"]["model"],
                     tls_config=tls_conf,
                 )
             else:
@@ -724,7 +724,7 @@ async def acomplete(
 
 # Default Provider Selection
 
-DEVSYNTH_PROVIDER=openai  # Main provider (openai, lm_studio)
+DEVSYNTH_PROVIDER=openai  # Main provider (openai, lmstudio)
 
 # OpenAI Configuration
 
@@ -748,7 +748,7 @@ PROVIDER_JITTER=true
 # Fallback Configuration (Optional)
 
 PROVIDER_FALLBACK_ENABLED=true
-PROVIDER_FALLBACK_ORDER=openai,lm_studio
+PROVIDER_FALLBACK_ORDER=openai,lmstudio
 
 # Circuit Breaker Configuration (Optional)
 
@@ -823,7 +823,7 @@ provider_jitter = True
 # Fallback configuration
 
 provider_fallback_enabled = True
-provider_fallback_order = "openai,lm_studio"
+provider_fallback_order = "openai,lmstudio"
 
 # Circuit breaker configuration
 

--- a/docs/developer_guides/testing.md
+++ b/docs/developer_guides/testing.md
@@ -324,7 +324,7 @@ DEVSYNTH_PROVIDER=openai poetry run pytest
 
 # Use LM Studio provider
 
-DEVSYNTH_PROVIDER=lm_studio poetry run pytest
+DEVSYNTH_PROVIDER=lmstudio poetry run pytest
 ```
 
 ## Enabling Resource-Dependent Tests

--- a/docs/technical_reference/configuration_examples.md
+++ b/docs/technical_reference/configuration_examples.md
@@ -225,7 +225,7 @@ Configure Provider integration with retry mechanisms, fallback strategies, and c
 
 # .devsynth/project.yaml
 
-provider_type: "openai"  # or "lm_studio"
+provider_type: "openai"  # or "lmstudio"
 openai_api_key: "your-api-key"  # or use environment variable
 lm_studio_endpoint: "http://127.0.0.1:1234"  # for local LM Studio
 ```
@@ -256,7 +256,7 @@ Configure fallback strategies for Provider API calls:
 
 provider_fallback_settings:
   enabled: true
-  order: ["openai", "lm_studio"]  # Try OpenAI first, then LM Studio
+  order: ["openai", "lmstudio"]  # Try OpenAI first, then LM Studio
 ```
 
 ## Circuit Breaker Configuration
@@ -294,7 +294,7 @@ provider_retry_settings:
 
 provider_fallback_settings:
   enabled: true
-  order: ["openai", "lm_studio"]
+  order: ["openai", "lmstudio"]
 
 provider_circuit_breaker_settings:
   enabled: true
@@ -326,7 +326,7 @@ export DEVSYNTH_PROVIDER_TYPE=openai
 export OPENAI_API_KEY=your-api-key
 export DEVSYNTH_PROVIDER_MAX_RETRIES=3
 export DEVSYNTH_PROVIDER_FALLBACK_ENABLED=true
-export DEVSYNTH_PROVIDER_FALLBACK_ORDER=openai,lm_studio
+export DEVSYNTH_PROVIDER_FALLBACK_ORDER=openai,lmstudio
 export DEVSYNTH_PROVIDER_CIRCUIT_BREAKER_ENABLED=true
 ```
 

--- a/docs/technical_reference/configuration_reference.md
+++ b/docs/technical_reference/configuration_reference.md
@@ -154,7 +154,7 @@ DevSynth uses the following environment variables for configuration:
 | `DEVSYNTH_PROVIDER_MAX_DELAY` | Maximum delay between retries in seconds | 60.0 |
 | `DEVSYNTH_PROVIDER_JITTER` | Add randomness to retry delays | true |
 | `DEVSYNTH_PROVIDER_FALLBACK_ENABLED` | Enable fallback strategy | true |
-| `DEVSYNTH_PROVIDER_FALLBACK_ORDER` | Provider fallback order (comma-separated) | openai,lm_studio |
+| `DEVSYNTH_PROVIDER_FALLBACK_ORDER` | Provider fallback order (comma-separated) | openai,lmstudio |
 | `DEVSYNTH_PROVIDER_CIRCUIT_BREAKER_ENABLED` | Enable circuit breaker pattern | true |
 | `DEVSYNTH_PROVIDER_FAILURE_THRESHOLD` | Number of failures before opening circuit | 5 |
 | `DEVSYNTH_PROVIDER_RECOVERY_TIMEOUT` | Time in seconds before attempting recovery | 60.0 |
@@ -171,7 +171,7 @@ The `provider` section configures the Provider used by DevSynth.
 
 | Key | Description | Default | Valid Values |
 |-----|-------------|---------|--------------|
-| `name` | Provider name | openai | openai, lm_studio, anthropic, abacus |
+| `name` | Provider name | openai | openai, lmstudio, anthropic, abacus |
 | `model` | Model to use | gpt-4 | Any model supported by the provider |
 | `temperature` | Randomness of responses | 0.7 | 0.0-1.0 |
 | `max_tokens` | Maximum tokens in response | 4000 | 1-32000 (provider-dependent) |
@@ -199,7 +199,7 @@ The `provider.fallback` section configures fallback strategies for Provider API 
 | Key | Description | Default | Valid Values |
 |-----|-------------|---------|--------------|
 | `enabled` | Enable fallback strategy | true | true, false |
-| `order` | Provider fallback order | ["openai", "lm_studio"] | Array of provider names |
+| `order` | Provider fallback order | ["openai", "lmstudio"] | Array of provider names |
 
 #### Circuit Breaker Settings
 

--- a/docs/user_guides/configuration_reference.md
+++ b/docs/user_guides/configuration_reference.md
@@ -37,7 +37,7 @@ DevSynth uses Large Language Models (LLMs) for various tasks. The following opti
 
 | Option | Description | Default Value | Possible Values |
 |--------|-------------|---------------|----------------|
-| `llm.provider` | The Provider to use | `openai` | `openai`, `lm_studio`, `anthropic`, `abacus`, `offline` |
+| `llm.provider` | The Provider to use | `openai` | `openai`, `lmstudio`, `anthropic`, `abacus`, `offline` |
 | `llm.model` | The LLM model to use | `gpt-3.5-turbo` | Any model supported by the selected provider |
 | `llm.temperature` | Creativity level (higher = more creative) | `0.7` | 0.0 - 1.0 |
 | `llm.max_tokens` | Maximum tokens for responses | `2000` | Any positive integer |

--- a/src/devsynth/config/settings.py
+++ b/src/devsynth/config/settings.py
@@ -257,12 +257,14 @@ class Settings(BaseSettings):
         default=True, json_schema_extra={"env": "DEVSYNTH_PROVIDER_FALLBACK_ENABLED"}
     )
     provider_fallback_order: str = Field(
-        default="openai,lm_studio", json_schema_extra={"env": "DEVSYNTH_PROVIDER_FALLBACK_ORDER"}
+        default="openai,lmstudio",
+        json_schema_extra={"env": "DEVSYNTH_PROVIDER_FALLBACK_ORDER"},
     )
 
     # LLM provider circuit breaker settings
     provider_circuit_breaker_enabled: bool = Field(
-        default=True, json_schema_extra={"env": "DEVSYNTH_PROVIDER_CIRCUIT_BREAKER_ENABLED"}
+        default=True,
+        json_schema_extra={"env": "DEVSYNTH_PROVIDER_CIRCUIT_BREAKER_ENABLED"},
     )
     provider_failure_threshold: int = Field(
         default=5, json_schema_extra={"env": "DEVSYNTH_PROVIDER_FAILURE_THRESHOLD"}
@@ -350,28 +352,45 @@ class Settings(BaseSettings):
     def validate_security_bool(cls, v, info):
         return _parse_bool_env(v, info.field_name)
 
-    @field_validator("kuzu_embedded", "provider_jitter", "provider_fallback_enabled", "provider_circuit_breaker_enabled", mode="before")
+    @field_validator(
+        "kuzu_embedded",
+        "provider_jitter",
+        "provider_fallback_enabled",
+        "provider_circuit_breaker_enabled",
+        mode="before",
+    )
     def validate_bool_settings(cls, v, info):
         return _parse_bool_env(v, info.field_name)
 
     @field_validator("provider_max_retries", "provider_failure_threshold", mode="after")
     def validate_positive_int(cls, v, info):
         if v is not None and v < 0:
-            logger.warning(f"{info.field_name} must be a non-negative integer, got {v}. Using default value.")
+            logger.warning(
+                f"{info.field_name} must be a non-negative integer, got {v}. Using default value."
+            )
             return getattr(cls, info.field_name).default
         return v
 
-    @field_validator("provider_initial_delay", "provider_max_delay", "provider_recovery_timeout", mode="after")
+    @field_validator(
+        "provider_initial_delay",
+        "provider_max_delay",
+        "provider_recovery_timeout",
+        mode="after",
+    )
     def validate_positive_float(cls, v, info):
         if v is not None and v <= 0:
-            logger.warning(f"{info.field_name} must be a positive number, got {v}. Using default value.")
+            logger.warning(
+                f"{info.field_name} must be a positive number, got {v}. Using default value."
+            )
             return getattr(cls, info.field_name).default
         return v
 
     @field_validator("provider_exponential_base", mode="after")
     def validate_exponential_base(cls, v, info):
         if v is not None and v <= 1.0:
-            logger.warning(f"{info.field_name} must be greater than 1.0, got {v}. Using default value.")
+            logger.warning(
+                f"{info.field_name} must be greater than 1.0, got {v}. Using default value."
+            )
             return getattr(cls, info.field_name).default
         return v
 
@@ -379,12 +398,16 @@ class Settings(BaseSettings):
     def validate_fallback_order(cls, v, info):
         if v is not None:
             providers = v.split(",")
-            valid_providers = ["openai", "lm_studio"]
+            valid_providers = ["openai", "lmstudio"]
             for provider in providers:
                 if provider.strip().lower() not in valid_providers:
-                    logger.warning(f"Invalid provider in fallback order: {provider}. Valid providers are: {valid_providers}")
+                    logger.warning(
+                        f"Invalid provider in fallback order: {provider}. Valid providers are: {valid_providers}"
+                    )
             if not providers:
-                logger.warning(f"{info.field_name} must not be empty. Using default value.")
+                logger.warning(
+                    f"{info.field_name} must not be empty. Using default value."
+                )
                 return getattr(cls, info.field_name).default
         return v
 

--- a/tests/integration/test_provider_system.py
+++ b/tests/integration/test_provider_system.py
@@ -4,86 +4,123 @@ Integration tests for the provider system.
 These tests verify the provider system can connect to both OpenAI and LM Studio,
 with proper fallback and selection logic.
 """
+
 import os
 import pytest
 from unittest.mock import patch, MagicMock
 import responses
 import json
-from devsynth.adapters.provider_system import get_provider_config, ProviderFactory, OpenAIProvider, LMStudioProvider, FallbackProvider, get_provider, complete, embed, ProviderType, ProviderError
+from devsynth.adapters.provider_system import (
+    get_provider_config,
+    ProviderFactory,
+    OpenAIProvider,
+    LMStudioProvider,
+    FallbackProvider,
+    get_provider,
+    complete,
+    embed,
+    ProviderType,
+    ProviderError,
+)
 
 
 class TestProviderConfig:
     """Test provider configuration loading.
 
-ReqID: N/A"""
+    ReqID: N/A"""
 
     def test_get_provider_config_has_expected(self):
         """Test that provider config can be loaded.
 
-ReqID: N/A"""
+        ReqID: N/A"""
         config = get_provider_config()
-        assert 'default_provider' in config
-        assert 'openai' in config
-        assert 'lm_studio' in config
-        assert config['default_provider'] == os.environ.get('DEVSYNTH_PROVIDER'
-            , 'openai')
-        assert config['openai']['api_key'] == os.environ.get('OPENAI_API_KEY')
-        assert config['openai']['model'] == os.environ.get('OPENAI_MODEL',
-            'gpt-4')
-        assert config['lm_studio']['endpoint'] == os.environ.get(
-            'LM_STUDIO_ENDPOINT', 'http://127.0.0.1:1234')
+        assert "default_provider" in config
+        assert "openai" in config
+        assert "lmstudio" in config
+        assert config["default_provider"] == os.environ.get(
+            "DEVSYNTH_PROVIDER", "openai"
+        )
+        assert config["openai"]["api_key"] == os.environ.get("OPENAI_API_KEY")
+        assert config["openai"]["model"] == os.environ.get("OPENAI_MODEL", "gpt-4")
+        assert config["lmstudio"]["endpoint"] == os.environ.get(
+            "LM_STUDIO_ENDPOINT", "http://127.0.0.1:1234"
+        )
 
 
 class TestProviderFactory:
     """Test provider creation and selection.
 
-ReqID: N/A"""
+    ReqID: N/A"""
 
     def test_create_openai_provider_has_expected(self):
         """Test OpenAI provider creation.
 
-ReqID: N/A"""
-        with patch.dict(os.environ, {'OPENAI_API_KEY': 'test-api-key'}):
-            with patch('devsynth.adapters.provider_system.get_provider_config'
-                ) as mock_config:
-                mock_config.return_value = {'default_provider': 'openai',
-                    'openai': {'api_key': 'test-api-key', 'model': 'gpt-4',
-                    'base_url': 'https://api.openai.com/v1'}, 'lm_studio':
-                    {'endpoint': 'http://127.0.0.1:1234', 'model': 'default'}}
-                provider = ProviderFactory.create_provider(ProviderType.
-                    OPENAI.value)
+        ReqID: N/A"""
+        with patch.dict(os.environ, {"OPENAI_API_KEY": "test-api-key"}):
+            with patch(
+                "devsynth.adapters.provider_system.get_provider_config"
+            ) as mock_config:
+                mock_config.return_value = {
+                    "default_provider": "openai",
+                    "openai": {
+                        "api_key": "test-api-key",
+                        "model": "gpt-4",
+                        "base_url": "https://api.openai.com/v1",
+                    },
+                    "lmstudio": {
+                        "endpoint": "http://127.0.0.1:1234",
+                        "model": "default",
+                    },
+                }
+                provider = ProviderFactory.create_provider(ProviderType.OPENAI.value)
                 assert isinstance(provider, OpenAIProvider)
-                assert provider.api_key == 'test-api-key'
+                assert provider.api_key == "test-api-key"
 
     def test_create_lm_studio_provider_has_expected(self):
         """Test LM Studio provider creation.
 
-ReqID: N/A"""
-        with patch('devsynth.adapters.provider_system.get_provider_config'
-            ) as mock_config:
-            mock_config.return_value = {'default_provider': 'lm_studio',
-                'openai': {'api_key': None, 'model': 'gpt-4', 'base_url':
-                'https://api.openai.com/v1'}, 'lm_studio': {'endpoint':
-                'http://test-endpoint:1234', 'model': 'test-model'}}
-            provider = ProviderFactory.create_provider(ProviderType.
-                LM_STUDIO.value)
+        ReqID: N/A"""
+        with patch(
+            "devsynth.adapters.provider_system.get_provider_config"
+        ) as mock_config:
+            mock_config.return_value = {
+                "default_provider": "lmstudio",
+                "openai": {
+                    "api_key": None,
+                    "model": "gpt-4",
+                    "base_url": "https://api.openai.com/v1",
+                },
+                "lmstudio": {
+                    "endpoint": "http://test-endpoint:1234",
+                    "model": "test-model",
+                },
+            }
+            provider = ProviderFactory.create_provider(ProviderType.LMSTUDIO.value)
             assert isinstance(provider, LMStudioProvider)
-            assert provider.endpoint == 'http://test-endpoint:1234'
-            assert provider.model == 'test-model'
+            assert provider.endpoint == "http://test-endpoint:1234"
+            assert provider.model == "test-model"
 
     def test_fallback_to_lm_studio_succeeds(self):
         """Test fallback to LM Studio if OpenAI API key is missing.
 
-ReqID: N/A"""
-        with patch.dict(os.environ, {'OPENAI_API_KEY': ''}):
-            with patch('devsynth.adapters.provider_system.get_provider_config'
-                ) as mock_config:
-                mock_config.return_value = {'default_provider': 'openai',
-                    'openai': {'api_key': None, 'model': 'gpt-4',
-                    'base_url': 'https://api.openai.com/v1'}, 'lm_studio':
-                    {'endpoint': 'http://127.0.0.1:1234', 'model': 'default'}}
-                provider = ProviderFactory.create_provider(ProviderType.
-                    OPENAI.value)
+        ReqID: N/A"""
+        with patch.dict(os.environ, {"OPENAI_API_KEY": ""}):
+            with patch(
+                "devsynth.adapters.provider_system.get_provider_config"
+            ) as mock_config:
+                mock_config.return_value = {
+                    "default_provider": "openai",
+                    "openai": {
+                        "api_key": None,
+                        "model": "gpt-4",
+                        "base_url": "https://api.openai.com/v1",
+                    },
+                    "lmstudio": {
+                        "endpoint": "http://127.0.0.1:1234",
+                        "model": "default",
+                    },
+                }
+                provider = ProviderFactory.create_provider(ProviderType.OPENAI.value)
                 assert isinstance(provider, LMStudioProvider)
 
 
@@ -91,117 +128,125 @@ ReqID: N/A"""
 class TestProviderIntegration:
     """Integration tests for provider functionality.
 
-These tests make actual API calls and should be run sparingly.
+    These tests make actual API calls and should be run sparingly.
 
-ReqID: N/A"""
+    ReqID: N/A"""
 
     @responses.activate
     def test_openai_complete_succeeds(self):
         """Test OpenAI completion with mocked response.
 
-ReqID: N/A"""
-        responses.add(responses.POST,
-            'https://api.openai.com/v1/chat/completions', json={'choices':
-            [{'message': {'content': 'Test response'}}]}, status=200)
-        provider = OpenAIProvider(api_key='test-api-key', model='gpt-4')
-        response = provider.complete(prompt='Test prompt', system_prompt=
-            'You are a helpful assistant.')
-        assert response == 'Test response'
+        ReqID: N/A"""
+        responses.add(
+            responses.POST,
+            "https://api.openai.com/v1/chat/completions",
+            json={"choices": [{"message": {"content": "Test response"}}]},
+            status=200,
+        )
+        provider = OpenAIProvider(api_key="test-api-key", model="gpt-4")
+        response = provider.complete(
+            prompt="Test prompt", system_prompt="You are a helpful assistant."
+        )
+        assert response == "Test response"
 
     @responses.activate
     def test_lm_studio_complete_succeeds(self):
         """Test LM Studio completion with mocked response.
 
-ReqID: N/A"""
-        responses.add(responses.POST,
-            'http://127.0.0.1:1234/v1/chat/completions', json={'choices': [
-            {'message': {'content': 'Test response from LM Studio'}}]},
-            status=200)
-        provider = LMStudioProvider(endpoint='http://127.0.0.1:1234')
-        response = provider.complete(prompt='Test prompt', system_prompt=
-            'You are a helpful assistant.')
-        assert response == 'Test response from LM Studio'
+        ReqID: N/A"""
+        responses.add(
+            responses.POST,
+            "http://127.0.0.1:1234/v1/chat/completions",
+            json={
+                "choices": [{"message": {"content": "Test response from LM Studio"}}]
+            },
+            status=200,
+        )
+        provider = LMStudioProvider(endpoint="http://127.0.0.1:1234")
+        response = provider.complete(
+            prompt="Test prompt", system_prompt="You are a helpful assistant."
+        )
+        assert response == "Test response from LM Studio"
 
 
 class TestFallbackProvider:
     """Test fallback provider functionality.
 
-ReqID: N/A"""
+    ReqID: N/A"""
 
     def test_fallback_provider_complete_has_expected(self):
         """Test fallback provider tries each provider in sequence.
 
-ReqID: N/A"""
+        ReqID: N/A"""
         mock_provider1 = MagicMock()
-        mock_provider1.complete.side_effect = ProviderError('Provider 1 failed'
-            )
+        mock_provider1.complete.side_effect = ProviderError("Provider 1 failed")
         mock_provider2 = MagicMock()
-        mock_provider2.complete.return_value = 'Response from provider 2'
+        mock_provider2.complete.return_value = "Response from provider 2"
         provider = FallbackProvider(providers=[mock_provider1, mock_provider2])
-        response = provider.complete(prompt='Test prompt', system_prompt=
-            'You are a helpful assistant.')
+        response = provider.complete(
+            prompt="Test prompt", system_prompt="You are a helpful assistant."
+        )
         mock_provider1.complete.assert_called_once()
         mock_provider2.complete.assert_called_once()
-        assert response == 'Response from provider 2'
+        assert response == "Response from provider 2"
 
     def test_fallback_provider_all_fail_fails(self):
         """Test fallback provider raises error if all providers fail.
 
-ReqID: N/A"""
+        ReqID: N/A"""
         mock_provider1 = MagicMock()
-        mock_provider1.complete.side_effect = ProviderError('Provider 1 failed'
-            )
+        mock_provider1.complete.side_effect = ProviderError("Provider 1 failed")
         mock_provider2 = MagicMock()
-        mock_provider2.complete.side_effect = ProviderError('Provider 2 failed'
-            )
+        mock_provider2.complete.side_effect = ProviderError("Provider 2 failed")
         provider = FallbackProvider(providers=[mock_provider1, mock_provider2])
         with pytest.raises(ProviderError):
-            provider.complete(prompt='Test prompt', system_prompt=
-                'You are a helpful assistant.')
+            provider.complete(
+                prompt="Test prompt", system_prompt="You are a helpful assistant."
+            )
 
 
 class TestSimplifiedAPI:
     """Test simplified API functions.
 
-ReqID: N/A"""
+    ReqID: N/A"""
 
     def test_get_provider_has_expected(self):
         """Test get_provider function.
 
-ReqID: N/A"""
+        ReqID: N/A"""
         provider = get_provider(fallback=True)
         assert isinstance(provider, FallbackProvider)
         with patch(
-            'devsynth.adapters.provider_system.ProviderFactory.create_provider'
-            ) as mock_create:
+            "devsynth.adapters.provider_system.ProviderFactory.create_provider"
+        ) as mock_create:
             mock_create.return_value = MagicMock()
-            provider = get_provider(provider_type=ProviderType.OPENAI.value,
-                fallback=False)
+            provider = get_provider(
+                provider_type=ProviderType.OPENAI.value, fallback=False
+            )
             mock_create.assert_called_once_with(ProviderType.OPENAI.value)
 
     def test_complete_function_succeeds(self):
         """Test complete function.
 
-ReqID: N/A"""
-        with patch('devsynth.adapters.provider_system.get_provider'
-            ) as mock_get:
+        ReqID: N/A"""
+        with patch("devsynth.adapters.provider_system.get_provider") as mock_get:
             mock_provider = MagicMock()
-            mock_provider.complete.return_value = 'Test response'
+            mock_provider.complete.return_value = "Test response"
             mock_get.return_value = mock_provider
-            response = complete(prompt='Test prompt', system_prompt=
-                'You are a helpful assistant.')
-            assert response == 'Test response'
+            response = complete(
+                prompt="Test prompt", system_prompt="You are a helpful assistant."
+            )
+            assert response == "Test response"
             mock_provider.complete.assert_called_once()
 
     def test_embed_function_succeeds(self):
         """Test embed function.
 
-ReqID: N/A"""
-        with patch('devsynth.adapters.provider_system.get_provider'
-            ) as mock_get:
+        ReqID: N/A"""
+        with patch("devsynth.adapters.provider_system.get_provider") as mock_get:
             mock_provider = MagicMock()
             mock_provider.embed.return_value = [[0.1, 0.2, 0.3]]
             mock_get.return_value = mock_provider
-            response = embed(text='Test text')
+            response = embed(text="Test text")
             assert response == [[0.1, 0.2, 0.3]]
             mock_provider.embed.assert_called_once()

--- a/tests/integration/test_provider_system_configurations.py
+++ b/tests/integration/test_provider_system_configurations.py
@@ -3,209 +3,294 @@
 This test verifies that the provider system works correctly with different LLM configurations,
 including different models, parameters, and provider combinations.
 """
+
 import pytest
 import os
 from unittest.mock import patch, MagicMock
 import responses
 import json
-from devsynth.adapters.provider_system import get_provider_config, ProviderFactory, OpenAIProvider, LMStudioProvider, FallbackProvider, get_provider, complete, embed, ProviderType, ProviderError
+from devsynth.adapters.provider_system import (
+    get_provider_config,
+    ProviderFactory,
+    OpenAIProvider,
+    LMStudioProvider,
+    FallbackProvider,
+    get_provider,
+    complete,
+    embed,
+    ProviderType,
+    ProviderError,
+)
 
 
 class TestProviderConfigurations:
     """Test the provider system with different LLM configurations.
 
-ReqID: N/A"""
+    ReqID: N/A"""
 
     @pytest.fixture
     def mock_openai_response(self):
         """Mock OpenAI API response."""
-        return {'choices': [{'message': {'content':
-            'This is a mock response from OpenAI'}}]}
+        return {
+            "choices": [{"message": {"content": "This is a mock response from OpenAI"}}]
+        }
 
     @pytest.fixture
     def mock_lm_studio_response(self):
         """Mock LM Studio API response."""
-        return {'choices': [{'text': 'This is a mock response from LM Studio'}]
-            }
+        return {"choices": [{"text": "This is a mock response from LM Studio"}]}
 
     @responses.activate
-    def test_openai_provider_with_different_models_has_expected(self,
-        mock_openai_response):
+    def test_openai_provider_with_different_models_has_expected(
+        self, mock_openai_response
+    ):
         """Test OpenAI provider with different models.
 
-ReqID: N/A"""
-        responses.add(responses.POST,
-            'https://api.openai.com/v1/chat/completions', json=
-            mock_openai_response, status=200)
-        with patch.dict(os.environ, {'OPENAI_API_KEY': 'test_key',
-            'OPENAI_MODEL': 'gpt-4'}):
+        ReqID: N/A"""
+        responses.add(
+            responses.POST,
+            "https://api.openai.com/v1/chat/completions",
+            json=mock_openai_response,
+            status=200,
+        )
+        with patch.dict(
+            os.environ, {"OPENAI_API_KEY": "test_key", "OPENAI_MODEL": "gpt-4"}
+        ):
             provider = ProviderFactory.create_provider(ProviderType.OPENAI)
-            assert provider.model == 'gpt-4'
-            result = provider.complete('Test prompt')
-            assert result == 'This is a mock response from OpenAI'
+            assert provider.model == "gpt-4"
+            result = provider.complete("Test prompt")
+            assert result == "This is a mock response from OpenAI"
         responses.reset()
-        responses.add(responses.POST,
-            'https://api.openai.com/v1/chat/completions', json=
-            mock_openai_response, status=200)
-        with patch.dict(os.environ, {'OPENAI_API_KEY': 'test_key',
-            'OPENAI_MODEL': 'gpt-3.5-turbo'}):
+        responses.add(
+            responses.POST,
+            "https://api.openai.com/v1/chat/completions",
+            json=mock_openai_response,
+            status=200,
+        )
+        with patch.dict(
+            os.environ, {"OPENAI_API_KEY": "test_key", "OPENAI_MODEL": "gpt-3.5-turbo"}
+        ):
             provider = ProviderFactory.create_provider(ProviderType.OPENAI)
-            assert provider.model == 'gpt-3.5-turbo'
-            result = provider.complete('Test prompt')
-            assert result == 'This is a mock response from OpenAI'
+            assert provider.model == "gpt-3.5-turbo"
+            result = provider.complete("Test prompt")
+            assert result == "This is a mock response from OpenAI"
 
     @responses.activate
-    def test_openai_provider_with_different_parameters_has_expected(self,
-        mock_openai_response):
+    def test_openai_provider_with_different_parameters_has_expected(
+        self, mock_openai_response
+    ):
         """Test OpenAI provider with different parameters.
 
-ReqID: N/A"""
-        responses.add(responses.POST,
-            'https://api.openai.com/v1/chat/completions', json=
-            mock_openai_response, status=200)
-        with patch.dict(os.environ, {'OPENAI_API_KEY': 'test_key'}):
+        ReqID: N/A"""
+        responses.add(
+            responses.POST,
+            "https://api.openai.com/v1/chat/completions",
+            json=mock_openai_response,
+            status=200,
+        )
+        with patch.dict(os.environ, {"OPENAI_API_KEY": "test_key"}):
             provider = ProviderFactory.create_provider(ProviderType.OPENAI)
-            result = provider.complete('Test prompt')
-            assert result == 'This is a mock response from OpenAI'
+            result = provider.complete("Test prompt")
+            assert result == "This is a mock response from OpenAI"
         responses.reset()
-        responses.add(responses.POST,
-            'https://api.openai.com/v1/chat/completions', json=
-            mock_openai_response, status=200)
-        with patch.dict(os.environ, {'OPENAI_API_KEY': 'test_key'}):
+        responses.add(
+            responses.POST,
+            "https://api.openai.com/v1/chat/completions",
+            json=mock_openai_response,
+            status=200,
+        )
+        with patch.dict(os.environ, {"OPENAI_API_KEY": "test_key"}):
             provider = ProviderFactory.create_provider(ProviderType.OPENAI)
-            result = provider.complete('Test prompt', parameters={
-                'temperature': 0.7, 'max_tokens': 100, 'top_p': 0.9})
-            assert result == 'This is a mock response from OpenAI'
+            result = provider.complete(
+                "Test prompt",
+                parameters={"temperature": 0.7, "max_tokens": 100, "top_p": 0.9},
+            )
+            assert result == "This is a mock response from OpenAI"
 
     @responses.activate
-    def test_lm_studio_provider_with_different_endpoints_has_expected(self,
-        mock_lm_studio_response):
+    def test_lm_studio_provider_with_different_endpoints_has_expected(
+        self, mock_lm_studio_response
+    ):
         """Test LM Studio provider with different endpoints.
 
-ReqID: N/A"""
-        responses.add(responses.POST,
-            'http://127.0.0.1:1234/v1/completions', json=
-            mock_lm_studio_response, status=200)
-        with patch.dict(os.environ, {'LM_STUDIO_ENDPOINT':
-            'http://127.0.0.1:1234'}):
-            provider = ProviderFactory.create_provider(ProviderType.LM_STUDIO)
-            result = provider.complete('Test prompt')
-            assert result == 'This is a mock response from LM Studio'
+        ReqID: N/A"""
+        responses.add(
+            responses.POST,
+            "http://127.0.0.1:1234/v1/completions",
+            json=mock_lm_studio_response,
+            status=200,
+        )
+        with patch.dict(os.environ, {"LM_STUDIO_ENDPOINT": "http://127.0.0.1:1234"}):
+            provider = ProviderFactory.create_provider(ProviderType.LMSTUDIO)
+            result = provider.complete("Test prompt")
+            assert result == "This is a mock response from LM Studio"
         responses.reset()
-        responses.add(responses.POST,
-            'http://custom-endpoint:5678/v1/completions', json=
-            mock_lm_studio_response, status=200)
-        with patch.dict(os.environ, {'LM_STUDIO_ENDPOINT':
-            'http://custom-endpoint:5678'}):
-            provider = ProviderFactory.create_provider(ProviderType.LM_STUDIO)
-            result = provider.complete('Test prompt')
-            assert result == 'This is a mock response from LM Studio'
+        responses.add(
+            responses.POST,
+            "http://custom-endpoint:5678/v1/completions",
+            json=mock_lm_studio_response,
+            status=200,
+        )
+        with patch.dict(
+            os.environ, {"LM_STUDIO_ENDPOINT": "http://custom-endpoint:5678"}
+        ):
+            provider = ProviderFactory.create_provider(ProviderType.LMSTUDIO)
+            result = provider.complete("Test prompt")
+            assert result == "This is a mock response from LM Studio"
 
     @responses.activate
-    def test_lm_studio_provider_with_different_parameters_has_expected(self,
-        mock_lm_studio_response):
+    def test_lm_studio_provider_with_different_parameters_has_expected(
+        self, mock_lm_studio_response
+    ):
         """Test LM Studio provider with different parameters.
 
-ReqID: N/A"""
-        responses.add(responses.POST,
-            'http://127.0.0.1:1234/v1/completions', json=
-            mock_lm_studio_response, status=200)
-        with patch.dict(os.environ, {'LM_STUDIO_ENDPOINT':
-            'http://127.0.0.1:1234'}):
-            provider = ProviderFactory.create_provider(ProviderType.LM_STUDIO)
-            result = provider.complete('Test prompt')
-            assert result == 'This is a mock response from LM Studio'
+        ReqID: N/A"""
+        responses.add(
+            responses.POST,
+            "http://127.0.0.1:1234/v1/completions",
+            json=mock_lm_studio_response,
+            status=200,
+        )
+        with patch.dict(os.environ, {"LM_STUDIO_ENDPOINT": "http://127.0.0.1:1234"}):
+            provider = ProviderFactory.create_provider(ProviderType.LMSTUDIO)
+            result = provider.complete("Test prompt")
+            assert result == "This is a mock response from LM Studio"
         responses.reset()
-        responses.add(responses.POST,
-            'http://127.0.0.1:1234/v1/completions', json=
-            mock_lm_studio_response, status=200)
-        with patch.dict(os.environ, {'LM_STUDIO_ENDPOINT':
-            'http://127.0.0.1:1234'}):
-            provider = ProviderFactory.create_provider(ProviderType.LM_STUDIO)
-            result = provider.complete('Test prompt', parameters={
-                'temperature': 0.7, 'max_tokens': 100, 'top_p': 0.9})
-            assert result == 'This is a mock response from LM Studio'
+        responses.add(
+            responses.POST,
+            "http://127.0.0.1:1234/v1/completions",
+            json=mock_lm_studio_response,
+            status=200,
+        )
+        with patch.dict(os.environ, {"LM_STUDIO_ENDPOINT": "http://127.0.0.1:1234"}):
+            provider = ProviderFactory.create_provider(ProviderType.LMSTUDIO)
+            result = provider.complete(
+                "Test prompt",
+                parameters={"temperature": 0.7, "max_tokens": 100, "top_p": 0.9},
+            )
+            assert result == "This is a mock response from LM Studio"
 
     @responses.activate
-    def test_fallback_provider_with_different_configurations_has_expected(self,
-        mock_openai_response, mock_lm_studio_response):
+    def test_fallback_provider_with_different_configurations_has_expected(
+        self, mock_openai_response, mock_lm_studio_response
+    ):
         """Test fallback provider with different configurations.
 
-ReqID: N/A"""
-        responses.add(responses.POST,
-            'https://api.openai.com/v1/chat/completions', json=
-            mock_openai_response, status=200)
-        responses.add(responses.POST,
-            'http://127.0.0.1:1234/v1/completions', json=
-            mock_lm_studio_response, status=200)
-        with patch.dict(os.environ, {'OPENAI_API_KEY': 'test_key',
-            'LM_STUDIO_ENDPOINT': 'http://127.0.0.1:1234'}):
-            openai_provider = ProviderFactory.create_provider(ProviderType.
-                OPENAI)
-            lm_studio_provider = ProviderFactory.create_provider(ProviderType
-                .LM_STUDIO)
-            fallback_provider = FallbackProvider(providers=[openai_provider,
-                lm_studio_provider])
-            result = fallback_provider.complete('Test prompt')
-            assert result == 'This is a mock response from OpenAI'
+        ReqID: N/A"""
+        responses.add(
+            responses.POST,
+            "https://api.openai.com/v1/chat/completions",
+            json=mock_openai_response,
+            status=200,
+        )
+        responses.add(
+            responses.POST,
+            "http://127.0.0.1:1234/v1/completions",
+            json=mock_lm_studio_response,
+            status=200,
+        )
+        with patch.dict(
+            os.environ,
+            {
+                "OPENAI_API_KEY": "test_key",
+                "LM_STUDIO_ENDPOINT": "http://127.0.0.1:1234",
+            },
+        ):
+            openai_provider = ProviderFactory.create_provider(ProviderType.OPENAI)
+            lm_studio_provider = ProviderFactory.create_provider(ProviderType.LMSTUDIO)
+            fallback_provider = FallbackProvider(
+                providers=[openai_provider, lm_studio_provider]
+            )
+            result = fallback_provider.complete("Test prompt")
+            assert result == "This is a mock response from OpenAI"
         responses.reset()
-        responses.add(responses.POST,
-            'https://api.openai.com/v1/chat/completions', json={'error':
-            'API error'}, status=500)
-        responses.add(responses.POST,
-            'http://127.0.0.1:1234/v1/completions', json=
-            mock_lm_studio_response, status=200)
-        with patch.dict(os.environ, {'OPENAI_API_KEY': 'test_key',
-            'LM_STUDIO_ENDPOINT': 'http://127.0.0.1:1234'}):
-            openai_provider = ProviderFactory.create_provider(ProviderType.
-                OPENAI)
-            lm_studio_provider = ProviderFactory.create_provider(ProviderType
-                .LM_STUDIO)
-            fallback_provider = FallbackProvider(providers=[openai_provider,
-                lm_studio_provider])
-            result = fallback_provider.complete('Test prompt')
-            assert result == 'This is a mock response from LM Studio'
+        responses.add(
+            responses.POST,
+            "https://api.openai.com/v1/chat/completions",
+            json={"error": "API error"},
+            status=500,
+        )
+        responses.add(
+            responses.POST,
+            "http://127.0.0.1:1234/v1/completions",
+            json=mock_lm_studio_response,
+            status=200,
+        )
+        with patch.dict(
+            os.environ,
+            {
+                "OPENAI_API_KEY": "test_key",
+                "LM_STUDIO_ENDPOINT": "http://127.0.0.1:1234",
+            },
+        ):
+            openai_provider = ProviderFactory.create_provider(ProviderType.OPENAI)
+            lm_studio_provider = ProviderFactory.create_provider(ProviderType.LMSTUDIO)
+            fallback_provider = FallbackProvider(
+                providers=[openai_provider, lm_studio_provider]
+            )
+            result = fallback_provider.complete("Test prompt")
+            assert result == "This is a mock response from LM Studio"
 
     @responses.activate
-    def test_provider_system_with_different_default_providers_has_expected(self
-        , mock_openai_response, mock_lm_studio_response):
+    def test_provider_system_with_different_default_providers_has_expected(
+        self, mock_openai_response, mock_lm_studio_response
+    ):
         """Test provider system with different default providers.
 
-ReqID: N/A"""
-        responses.add(responses.POST,
-            'https://api.openai.com/v1/chat/completions', json=
-            mock_openai_response, status=200)
-        with patch.dict(os.environ, {'DEVSYNTH_PROVIDER': 'openai',
-            'OPENAI_API_KEY': 'test_key'}):
+        ReqID: N/A"""
+        responses.add(
+            responses.POST,
+            "https://api.openai.com/v1/chat/completions",
+            json=mock_openai_response,
+            status=200,
+        )
+        with patch.dict(
+            os.environ, {"DEVSYNTH_PROVIDER": "openai", "OPENAI_API_KEY": "test_key"}
+        ):
             provider = get_provider()
             assert isinstance(provider, OpenAIProvider)
-            result = complete('Test prompt')
-            assert result == 'This is a mock response from OpenAI'
+            result = complete("Test prompt")
+            assert result == "This is a mock response from OpenAI"
         responses.reset()
-        responses.add(responses.POST,
-            'http://127.0.0.1:1234/v1/completions', json=
-            mock_lm_studio_response, status=200)
-        with patch.dict(os.environ, {'DEVSYNTH_PROVIDER': 'lm_studio',
-            'LM_STUDIO_ENDPOINT': 'http://127.0.0.1:1234'}):
+        responses.add(
+            responses.POST,
+            "http://127.0.0.1:1234/v1/completions",
+            json=mock_lm_studio_response,
+            status=200,
+        )
+        with patch.dict(
+            os.environ,
+            {
+                "DEVSYNTH_PROVIDER": "lmstudio",
+                "LM_STUDIO_ENDPOINT": "http://127.0.0.1:1234",
+            },
+        ):
             provider = get_provider()
             assert isinstance(provider, LMStudioProvider)
-            result = complete('Test prompt')
-            assert result == 'This is a mock response from LM Studio'
+            result = complete("Test prompt")
+            assert result == "This is a mock response from LM Studio"
 
     @responses.activate
-    def test_provider_system_with_context_aware_completion_has_expected(self,
-        mock_openai_response):
+    def test_provider_system_with_context_aware_completion_has_expected(
+        self, mock_openai_response
+    ):
         """Test provider system with context-aware completion.
 
-ReqID: N/A"""
-        responses.add(responses.POST,
-            'https://api.openai.com/v1/chat/completions', json=
-            mock_openai_response, status=200)
-        with patch.dict(os.environ, {'OPENAI_API_KEY': 'test_key'}):
+        ReqID: N/A"""
+        responses.add(
+            responses.POST,
+            "https://api.openai.com/v1/chat/completions",
+            json=mock_openai_response,
+            status=200,
+        )
+        with patch.dict(os.environ, {"OPENAI_API_KEY": "test_key"}):
             provider = ProviderFactory.create_provider(ProviderType.OPENAI)
-            result = provider.complete_with_context('Test prompt', [{'role':
-                'system', 'content': 'You are a helpful assistant.'}, {
-                'role': 'user', 'content': 'What is the capital of France?'
-                }, {'role': 'assistant', 'content':
-                'The capital of France is Paris.'}])
-            assert result == 'This is a mock response from OpenAI'
+            result = provider.complete_with_context(
+                "Test prompt",
+                [
+                    {"role": "system", "content": "You are a helpful assistant."},
+                    {"role": "user", "content": "What is the capital of France?"},
+                    {"role": "assistant", "content": "The capital of France is Paris."},
+                ],
+            )
+            assert result == "This is a mock response from OpenAI"

--- a/tests/unit/adapters/providers/test_embeddings.py
+++ b/tests/unit/adapters/providers/test_embeddings.py
@@ -2,20 +2,27 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import httpx
 import pytest
 import requests
-from devsynth.adapters.provider_system import LMStudioProvider, OpenAIProvider, ProviderError, aembed, embed
+from devsynth.adapters.provider_system import (
+    LMStudioProvider,
+    OpenAIProvider,
+    ProviderError,
+    aembed,
+    embed,
+)
 
 
 def test_openai_provider_embed_calls_api_succeeds():
     """Test that openai provider embed calls api succeeds.
 
-ReqID: N/A"""
+    ReqID: N/A"""
     mock_response = MagicMock()
-    mock_response.json.return_value = {'data': [{'embedding': [0.1, 0.2]}]}
+    mock_response.json.return_value = {"data": [{"embedding": [0.1, 0.2]}]}
     mock_response.raise_for_status.return_value = None
-    with patch('devsynth.adapters.provider_system.requests.post',
-        return_value=mock_response) as mock_post:
-        provider = OpenAIProvider(api_key='key')
-        result = provider.embed('hello')
+    with patch(
+        "devsynth.adapters.provider_system.requests.post", return_value=mock_response
+    ) as mock_post:
+        provider = OpenAIProvider(api_key="key")
+        result = provider.embed("hello")
         assert result == [[0.1, 0.2]]
         mock_post.assert_called_once()
 
@@ -23,16 +30,17 @@ ReqID: N/A"""
 @pytest.mark.anyio
 async def test_openai_provider_aembed_calls_api():
     mock_response = MagicMock()
-    mock_response.json.return_value = {'data': [{'embedding': [0.3, 0.4]}]}
+    mock_response.json.return_value = {"data": [{"embedding": [0.3, 0.4]}]}
     mock_response.raise_for_status.return_value = None
     async_client = AsyncMock()
     async_client.__aenter__.return_value = async_client
     async_client.__aexit__.return_value = None
     async_client.post.return_value = mock_response
-    with patch('devsynth.adapters.provider_system.httpx.AsyncClient',
-        return_value=async_client):
-        provider = OpenAIProvider(api_key='key')
-        result = await provider.aembed('world')
+    with patch(
+        "devsynth.adapters.provider_system.httpx.AsyncClient", return_value=async_client
+    ):
+        provider = OpenAIProvider(api_key="key")
+        result = await provider.aembed("world")
         assert result == [[0.3, 0.4]]
         async_client.post.assert_called_once()
 
@@ -40,14 +48,15 @@ async def test_openai_provider_aembed_calls_api():
 def test_lmstudio_provider_embed_calls_api_succeeds():
     """Test that lmstudio provider embed calls api succeeds.
 
-ReqID: N/A"""
+    ReqID: N/A"""
     mock_response = MagicMock()
-    mock_response.json.return_value = {'data': [{'embedding': [0.5, 0.6]}]}
+    mock_response.json.return_value = {"data": [{"embedding": [0.5, 0.6]}]}
     mock_response.raise_for_status.return_value = None
-    with patch('devsynth.adapters.provider_system.requests.post',
-        return_value=mock_response) as mock_post:
-        provider = LMStudioProvider(endpoint='http://localhost:1234')
-        result = provider.embed('text')
+    with patch(
+        "devsynth.adapters.provider_system.requests.post", return_value=mock_response
+    ) as mock_post:
+        provider = LMStudioProvider(endpoint="http://localhost:1234")
+        result = provider.embed("text")
         assert result == [[0.5, 0.6]]
         mock_post.assert_called_once()
 
@@ -55,36 +64,39 @@ ReqID: N/A"""
 def test_embed_function_success_with_lmstudio_succeeds():
     """Test that embed function success with lmstudio succeeds.
 
-ReqID: N/A"""
-    provider = LMStudioProvider(endpoint='http://localhost:1234')
-    with patch('devsynth.adapters.provider_system.get_provider',
-        return_value=provider), patch(
-        'devsynth.adapters.provider_system.requests.post') as mock_post:
+    ReqID: N/A"""
+    provider = LMStudioProvider(endpoint="http://localhost:1234")
+    with (
+        patch("devsynth.adapters.provider_system.get_provider", return_value=provider),
+        patch("devsynth.adapters.provider_system.requests.post") as mock_post,
+    ):
         mock_resp = MagicMock()
-        mock_resp.json.return_value = {'data': [{'embedding': [0.7, 0.8]}]}
+        mock_resp.json.return_value = {"data": [{"embedding": [0.7, 0.8]}]}
         mock_resp.raise_for_status.return_value = None
         mock_post.return_value = mock_resp
-        result = embed('text', provider_type='lm_studio', fallback=False)
+        result = embed("text", provider_type="lmstudio", fallback=False)
         assert result == [[0.7, 0.8]]
         mock_post.assert_called_once()
 
 
 @pytest.mark.anyio
 async def test_aembed_function_success_with_lmstudio():
-    provider = LMStudioProvider(endpoint='http://localhost:1234')
+    provider = LMStudioProvider(endpoint="http://localhost:1234")
     async_client = AsyncMock()
     async_client.__aenter__.return_value = async_client
     async_client.__aexit__.return_value = None
     mock_resp = MagicMock()
-    mock_resp.json.return_value = {'data': [{'embedding': [0.9, 1.0]}]}
+    mock_resp.json.return_value = {"data": [{"embedding": [0.9, 1.0]}]}
     mock_resp.raise_for_status.return_value = None
     async_client.post.return_value = mock_resp
-    with patch('devsynth.adapters.provider_system.get_provider',
-        return_value=provider), patch(
-        'devsynth.adapters.provider_system.httpx.AsyncClient', return_value
-        =async_client):
-        result = await aembed('text', provider_type='lm_studio', fallback=False
-            )
+    with (
+        patch("devsynth.adapters.provider_system.get_provider", return_value=provider),
+        patch(
+            "devsynth.adapters.provider_system.httpx.AsyncClient",
+            return_value=async_client,
+        ),
+    ):
+        result = await aembed("text", provider_type="lmstudio", fallback=False)
         assert result == [[0.9, 1.0]]
         async_client.post.assert_called_once()
 
@@ -92,24 +104,29 @@ async def test_aembed_function_success_with_lmstudio():
 def test_lmstudio_provider_embed_error_succeeds():
     """Test that lmstudio provider embed error succeeds.
 
-ReqID: N/A"""
-    with patch('devsynth.adapters.provider_system.requests.post',
-        side_effect=requests.exceptions.RequestException('boom')):
-        provider = LMStudioProvider(endpoint='http://localhost:1234')
+    ReqID: N/A"""
+    with patch(
+        "devsynth.adapters.provider_system.requests.post",
+        side_effect=requests.exceptions.RequestException("boom"),
+    ):
+        provider = LMStudioProvider(endpoint="http://localhost:1234")
         with pytest.raises(ProviderError):
-            provider.embed('text')
+            provider.embed("text")
 
 
 @pytest.mark.anyio
 async def test_aembed_function_error_propagation():
-    provider = LMStudioProvider(endpoint='http://localhost:1234')
+    provider = LMStudioProvider(endpoint="http://localhost:1234")
     async_client = AsyncMock()
     async_client.__aenter__.return_value = async_client
     async_client.__aexit__.return_value = None
-    async_client.post.side_effect = httpx.HTTPError('fail')
-    with patch('devsynth.adapters.provider_system.get_provider',
-        return_value=provider), patch(
-        'devsynth.adapters.provider_system.httpx.AsyncClient', return_value
-        =async_client):
+    async_client.post.side_effect = httpx.HTTPError("fail")
+    with (
+        patch("devsynth.adapters.provider_system.get_provider", return_value=provider),
+        patch(
+            "devsynth.adapters.provider_system.httpx.AsyncClient",
+            return_value=async_client,
+        ),
+    ):
         with pytest.raises(ProviderError):
-            await aembed('text', provider_type='lm_studio', fallback=False)
+            await aembed("text", provider_type="lmstudio", fallback=False)

--- a/tests/unit/adapters/providers/test_provider_factory.py
+++ b/tests/unit/adapters/providers/test_provider_factory.py
@@ -1,25 +1,44 @@
 import pytest
-from devsynth.adapters.provider_system import ProviderFactory, ProviderType, LMStudioProvider, OpenAIProvider
+from devsynth.adapters.provider_system import (
+    ProviderFactory,
+    ProviderType,
+    LMStudioProvider,
+    OpenAIProvider,
+)
 
 
 def _config_without_openai_key():
-    return {'default_provider': 'openai', 'openai': {'api_key': None,
-        'model': 'gpt-4', 'base_url': 'https://api.openai.com/v1'},
-        'lm_studio': {'endpoint': 'http://localhost:1234', 'model': 'default'}}
+    return {
+        "default_provider": "openai",
+        "openai": {
+            "api_key": None,
+            "model": "gpt-4",
+            "base_url": "https://api.openai.com/v1",
+        },
+        "lmstudio": {"endpoint": "http://localhost:1234", "model": "default"},
+    }
 
 
 def _config_with_openai_key():
-    return {'default_provider': 'openai', 'openai': {'api_key': 'test',
-        'model': 'gpt-4', 'base_url': 'https://api.openai.com/v1'},
-        'lm_studio': {'endpoint': 'http://localhost:1234', 'model': 'default'}}
+    return {
+        "default_provider": "openai",
+        "openai": {
+            "api_key": "test",
+            "model": "gpt-4",
+            "base_url": "https://api.openai.com/v1",
+        },
+        "lmstudio": {"endpoint": "http://localhost:1234", "model": "default"},
+    }
 
 
 def test_create_provider_fallbacks_to_lmstudio_succeeds(monkeypatch):
     """Test that create provider fallbacks to lmstudio succeeds.
 
-ReqID: N/A"""
-    monkeypatch.setattr('devsynth.adapters.provider_system.get_provider_config'
-        , _config_without_openai_key)
+    ReqID: N/A"""
+    monkeypatch.setattr(
+        "devsynth.adapters.provider_system.get_provider_config",
+        _config_without_openai_key,
+    )
     provider = ProviderFactory.create_provider(ProviderType.OPENAI.value)
     assert isinstance(provider, LMStudioProvider)
 
@@ -27,9 +46,11 @@ ReqID: N/A"""
 def test_create_provider_default_with_missing_key_succeeds(monkeypatch):
     """Test that create provider default with missing key succeeds.
 
-ReqID: N/A"""
-    monkeypatch.setattr('devsynth.adapters.provider_system.get_provider_config'
-        , _config_without_openai_key)
+    ReqID: N/A"""
+    monkeypatch.setattr(
+        "devsynth.adapters.provider_system.get_provider_config",
+        _config_without_openai_key,
+    )
     provider = ProviderFactory.create_provider()
     assert isinstance(provider, LMStudioProvider)
 
@@ -37,8 +58,9 @@ ReqID: N/A"""
 def test_create_provider_openai_succeeds(monkeypatch):
     """Test that create provider openai succeeds.
 
-ReqID: N/A"""
-    monkeypatch.setattr('devsynth.adapters.provider_system.get_provider_config'
-        , _config_with_openai_key)
+    ReqID: N/A"""
+    monkeypatch.setattr(
+        "devsynth.adapters.provider_system.get_provider_config", _config_with_openai_key
+    )
     provider = ProviderFactory.create_provider(ProviderType.OPENAI.value)
     assert isinstance(provider, OpenAIProvider)

--- a/tests/unit/adapters/test_provider_factory_env_vars.py
+++ b/tests/unit/adapters/test_provider_factory_env_vars.py
@@ -1,13 +1,18 @@
-from devsynth.adapters.provider_system import ProviderFactory, OpenAIProvider, LMStudioProvider, get_provider_config
+from devsynth.adapters.provider_system import (
+    ProviderFactory,
+    OpenAIProvider,
+    LMStudioProvider,
+    get_provider_config,
+)
 
 
 def test_env_provider_openai_succeeds(monkeypatch):
     """Test that env provider openai succeeds.
 
-ReqID: N/A"""
+    ReqID: N/A"""
     get_provider_config.cache_clear()
-    monkeypatch.setenv('DEVSYNTH_PROVIDER', 'openai')
-    monkeypatch.setenv('OPENAI_API_KEY', 'test-key')
+    monkeypatch.setenv("DEVSYNTH_PROVIDER", "openai")
+    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
     provider = ProviderFactory.create_provider()
     assert isinstance(provider, OpenAIProvider)
 
@@ -15,10 +20,10 @@ ReqID: N/A"""
 def test_env_provider_lmstudio_succeeds(monkeypatch):
     """Test that env provider lmstudio succeeds.
 
-ReqID: N/A"""
+    ReqID: N/A"""
     get_provider_config.cache_clear()
-    monkeypatch.setenv('DEVSYNTH_PROVIDER', 'lm_studio')
-    monkeypatch.setenv('LM_STUDIO_ENDPOINT', 'http://localhost:8888')
-    monkeypatch.delenv('OPENAI_API_KEY', raising=False)
+    monkeypatch.setenv("DEVSYNTH_PROVIDER", "lmstudio")
+    monkeypatch.setenv("LM_STUDIO_ENDPOINT", "http://localhost:8888")
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
     provider = ProviderFactory.create_provider()
     assert isinstance(provider, LMStudioProvider)

--- a/tests/unit/adapters/test_provider_system.py
+++ b/tests/unit/adapters/test_provider_system.py
@@ -5,19 +5,27 @@ import pytest
 import httpx
 import requests
 from devsynth.adapters import provider_system
-from devsynth.adapters.provider_system import ProviderError, ProviderFactory, BaseProvider, OpenAIProvider, LMStudioProvider, FallbackProvider, get_env_or_default, get_provider_config
+from devsynth.adapters.provider_system import (
+    ProviderError,
+    ProviderFactory,
+    BaseProvider,
+    OpenAIProvider,
+    LMStudioProvider,
+    FallbackProvider,
+    get_env_or_default,
+    get_provider_config,
+)
 from devsynth.fallback import retry_with_exponential_backoff
 
 
 def test_embed_success_succeeds():
     """Test that embed success succeeds.
 
-ReqID: N/A"""
+    ReqID: N/A"""
     provider = MagicMock()
     provider.embed.return_value = [[1.0, 2.0]]
-    with patch.object(provider_system, 'get_provider', return_value=provider):
-        result = provider_system.embed('text', provider_type='lm_studio',
-            fallback=False)
+    with patch.object(provider_system, "get_provider", return_value=provider):
+        result = provider_system.embed("text", provider_type="lmstudio", fallback=False)
         assert result == [[1.0, 2.0]]
         provider.embed.assert_called_once()
 
@@ -25,147 +33,180 @@ ReqID: N/A"""
 def test_embed_error_succeeds():
     """Test that embed error succeeds.
 
-ReqID: N/A"""
+    ReqID: N/A"""
     provider = MagicMock()
-    provider.embed.side_effect = ProviderError('fail')
-    with patch.object(provider_system, 'get_provider', return_value=provider):
+    provider.embed.side_effect = ProviderError("fail")
+    with patch.object(provider_system, "get_provider", return_value=provider):
         with pytest.raises(ProviderError):
-            provider_system.embed('text', provider_type='lm_studio',
-                fallback=False)
+            provider_system.embed("text", provider_type="lmstudio", fallback=False)
 
 
 def test_aembed_success_succeeds():
     """Test that aembed success succeeds.
 
-ReqID: N/A"""
+    ReqID: N/A"""
     provider = MagicMock()
     provider.aembed = AsyncMock(return_value=[[3.0, 4.0]])
 
     async def run_test():
-        with patch.object(provider_system, 'get_provider', return_value=
-            provider):
-            result = await provider_system.aembed('text', provider_type=
-                'lm_studio', fallback=False)
+        with patch.object(provider_system, "get_provider", return_value=provider):
+            result = await provider_system.aembed(
+                "text", provider_type="lmstudio", fallback=False
+            )
             assert result == [[3.0, 4.0]]
             provider.aembed.assert_awaited_once()
+
     asyncio.run(run_test())
 
 
 def test_aembed_error_succeeds():
     """Test that aembed error succeeds.
 
-ReqID: N/A"""
+    ReqID: N/A"""
     provider = MagicMock()
-    provider.aembed = AsyncMock(side_effect=ProviderError('boom'))
+    provider.aembed = AsyncMock(side_effect=ProviderError("boom"))
 
     async def run_test():
-        with patch.object(provider_system, 'get_provider', return_value=
-            provider):
+        with patch.object(provider_system, "get_provider", return_value=provider):
             with pytest.raises(ProviderError):
-                await provider_system.aembed('text', provider_type=
-                    'lm_studio', fallback=False)
+                await provider_system.aembed(
+                    "text", provider_type="lmstudio", fallback=False
+                )
+
     asyncio.run(run_test())
 
 
 def test_complete_success_succeeds():
     """Test that complete success succeeds.
 
-ReqID: N/A"""
+    ReqID: N/A"""
     provider = MagicMock()
-    provider.complete.return_value = 'Completed text'
-    with patch.object(provider_system, 'get_provider', return_value=provider):
-        result = provider_system.complete('prompt', system_prompt='system',
-            provider_type='openai', fallback=False)
-        assert result == 'Completed text'
-        provider.complete.assert_called_once_with(prompt='prompt',
-            system_prompt='system', temperature=0.7, max_tokens=2000)
+    provider.complete.return_value = "Completed text"
+    with patch.object(provider_system, "get_provider", return_value=provider):
+        result = provider_system.complete(
+            "prompt", system_prompt="system", provider_type="openai", fallback=False
+        )
+        assert result == "Completed text"
+        provider.complete.assert_called_once_with(
+            prompt="prompt", system_prompt="system", temperature=0.7, max_tokens=2000
+        )
 
 
 def test_complete_error_succeeds():
     """Test that complete error succeeds.
 
-ReqID: N/A"""
+    ReqID: N/A"""
     provider = MagicMock()
-    provider.complete.side_effect = ProviderError('completion failed')
-    with patch.object(provider_system, 'get_provider', return_value=provider):
+    provider.complete.side_effect = ProviderError("completion failed")
+    with patch.object(provider_system, "get_provider", return_value=provider):
         with pytest.raises(ProviderError):
-            provider_system.complete('prompt', provider_type='openai',
-                fallback=False)
+            provider_system.complete("prompt", provider_type="openai", fallback=False)
 
 
 def test_acomplete_success_succeeds():
     """Test that acomplete success succeeds.
 
-ReqID: N/A"""
+    ReqID: N/A"""
     provider = MagicMock()
-    provider.acomplete = AsyncMock(return_value='Async completed text')
+    provider.acomplete = AsyncMock(return_value="Async completed text")
 
     async def run_test():
-        with patch.object(provider_system, 'get_provider', return_value=
-            provider):
-            result = await provider_system.acomplete('prompt',
-                system_prompt='system', provider_type='openai', fallback=False)
-            assert result == 'Async completed text'
-            provider.acomplete.assert_awaited_once_with(prompt='prompt',
-                system_prompt='system', temperature=0.7, max_tokens=2000)
+        with patch.object(provider_system, "get_provider", return_value=provider):
+            result = await provider_system.acomplete(
+                "prompt", system_prompt="system", provider_type="openai", fallback=False
+            )
+            assert result == "Async completed text"
+            provider.acomplete.assert_awaited_once_with(
+                prompt="prompt",
+                system_prompt="system",
+                temperature=0.7,
+                max_tokens=2000,
+            )
+
     asyncio.run(run_test())
 
 
 def test_acomplete_error_succeeds():
     """Test that acomplete error succeeds.
 
-ReqID: N/A"""
+    ReqID: N/A"""
     provider = MagicMock()
-    provider.acomplete = AsyncMock(side_effect=ProviderError(
-        'async completion failed'))
+    provider.acomplete = AsyncMock(side_effect=ProviderError("async completion failed"))
 
     async def run_test():
-        with patch.object(provider_system, 'get_provider', return_value=
-            provider):
+        with patch.object(provider_system, "get_provider", return_value=provider):
             with pytest.raises(ProviderError):
-                await provider_system.acomplete('prompt', provider_type=
-                    'openai', fallback=False)
+                await provider_system.acomplete(
+                    "prompt", provider_type="openai", fallback=False
+                )
+
     asyncio.run(run_test())
 
 
 def test_provider_factory_create_provider_succeeds():
     """Test that provider factory create provider succeeds.
 
-ReqID: N/A"""
-    with patch.object(provider_system, 'get_provider_config') as mock_config:
-        with patch.object(provider_system, 'OpenAIProvider') as mock_openai:
-            with patch.object(provider_system, 'LMStudioProvider'
-                ) as mock_lmstudio:
+    ReqID: N/A"""
+    with patch.object(provider_system, "get_provider_config") as mock_config:
+        with patch.object(provider_system, "OpenAIProvider") as mock_openai:
+            with patch.object(provider_system, "LMStudioProvider") as mock_lmstudio:
                 mock_openai_instance = MagicMock(spec=OpenAIProvider)
                 mock_openai.return_value = mock_openai_instance
                 mock_lmstudio_instance = MagicMock(spec=LMStudioProvider)
                 mock_lmstudio.return_value = mock_lmstudio_instance
-                mock_config.return_value = {'default_provider': 'openai',
-                    'openai': {'api_key': 'test_key', 'model': 'gpt-4',
-                    'base_url': 'https://api.openai.com/v1'}, 'retry': {
-                    'max_retries': 3, 'initial_delay': 1.0,
-                    'exponential_base': 2.0, 'max_delay': 60.0, 'jitter': True}
-                    }
+                mock_config.return_value = {
+                    "default_provider": "openai",
+                    "openai": {
+                        "api_key": "test_key",
+                        "model": "gpt-4",
+                        "base_url": "https://api.openai.com/v1",
+                    },
+                    "retry": {
+                        "max_retries": 3,
+                        "initial_delay": 1.0,
+                        "exponential_base": 2.0,
+                        "max_delay": 60.0,
+                        "jitter": True,
+                    },
+                }
                 factory = ProviderFactory()
-                provider = factory.create_provider('openai')
+                provider = factory.create_provider("openai")
                 mock_openai.assert_called_once()
                 assert provider is mock_openai_instance
                 mock_openai.reset_mock()
-                mock_config.return_value = {'default_provider': 'lm_studio',
-                    'lm_studio': {'endpoint': 'http://test-endpoint',
-                    'model': 'default'}, 'retry': {'max_retries': 3,
-                    'initial_delay': 1.0, 'exponential_base': 2.0,
-                    'max_delay': 60.0, 'jitter': True}}
-                provider = factory.create_provider('lm_studio')
+                mock_config.return_value = {
+                    "default_provider": "lmstudio",
+                    "lmstudio": {
+                        "endpoint": "http://test-endpoint",
+                        "model": "default",
+                    },
+                    "retry": {
+                        "max_retries": 3,
+                        "initial_delay": 1.0,
+                        "exponential_base": 2.0,
+                        "max_delay": 60.0,
+                        "jitter": True,
+                    },
+                }
+                provider = factory.create_provider("lmstudio")
                 mock_lmstudio.assert_called_once()
                 assert provider is mock_lmstudio_instance
                 mock_openai.reset_mock()
-                mock_config.return_value = {'default_provider': 'openai',
-                    'openai': {'api_key': 'default_key', 'model':
-                    'gpt-3.5-turbo', 'base_url':
-                    'https://api.openai.com/v1'}, 'retry': {'max_retries': 
-                    3, 'initial_delay': 1.0, 'exponential_base': 2.0,
-                    'max_delay': 60.0, 'jitter': True}}
+                mock_config.return_value = {
+                    "default_provider": "openai",
+                    "openai": {
+                        "api_key": "default_key",
+                        "model": "gpt-3.5-turbo",
+                        "base_url": "https://api.openai.com/v1",
+                    },
+                    "retry": {
+                        "max_retries": 3,
+                        "initial_delay": 1.0,
+                        "exponential_base": 2.0,
+                        "max_delay": 60.0,
+                        "jitter": True,
+                    },
+                }
                 provider = factory.create_provider()
                 mock_openai.assert_called_once()
                 assert provider is mock_openai_instance
@@ -174,40 +215,42 @@ ReqID: N/A"""
 def test_get_provider_succeeds():
     """Test that get provider succeeds.
 
-ReqID: N/A"""
-    with patch.object(ProviderFactory, 'create_provider') as mock_create:
+    ReqID: N/A"""
+    with patch.object(ProviderFactory, "create_provider") as mock_create:
         mock_create.return_value = MagicMock(spec=OpenAIProvider)
-        provider = provider_system.get_provider(provider_type='openai',
-            fallback=True)
+        provider = provider_system.get_provider(provider_type="openai", fallback=True)
         assert isinstance(provider, FallbackProvider)
-        provider = provider_system.get_provider(provider_type='openai',
-            fallback=False)
+        provider = provider_system.get_provider(provider_type="openai", fallback=False)
         assert not isinstance(provider, FallbackProvider)
-        mock_create.assert_called_with('openai')
+        mock_create.assert_called_with("openai")
 
 
 def test_base_provider_methods_succeeds():
     """Test that base provider methods succeeds.
 
-ReqID: N/A"""
+    ReqID: N/A"""
     provider = BaseProvider()
     with pytest.raises(NotImplementedError):
-        provider.complete('test')
+        provider.complete("test")
     with pytest.raises(NotImplementedError):
-        provider.embed('test')
+        provider.embed("test")
     with pytest.raises(NotImplementedError):
-        asyncio.run(provider.acomplete('test'))
+        asyncio.run(provider.acomplete("test"))
     with pytest.raises(NotImplementedError):
-        asyncio.run(provider.aembed('test'))
+        asyncio.run(provider.aembed("test"))
 
 
-@pytest.mark.parametrize('provider_class,config', [(OpenAIProvider, {
-    'api_key': 'test_key', 'model': 'gpt-4'}), (LMStudioProvider, {
-    'endpoint': 'http://test-endpoint'})])
+@pytest.mark.parametrize(
+    "provider_class,config",
+    [
+        (OpenAIProvider, {"api_key": "test_key", "model": "gpt-4"}),
+        (LMStudioProvider, {"endpoint": "http://test-endpoint"}),
+    ],
+)
 def test_provider_initialization_succeeds(provider_class, config):
     """Test that provider initialization succeeds.
 
-ReqID: N/A"""
+    ReqID: N/A"""
     provider = provider_class(**config)
     assert provider is not None
     retry_decorator = provider.get_retry_decorator()
@@ -217,242 +260,252 @@ ReqID: N/A"""
 def test_fallback_provider_succeeds():
     """Test that fallback provider succeeds.
 
-ReqID: N/A"""
+    ReqID: N/A"""
     provider1 = MagicMock(spec=BaseProvider)
     provider2 = MagicMock(spec=BaseProvider)
-    provider1.complete.side_effect = ProviderError('Provider 1 failed')
-    provider2.complete.return_value = 'Success from provider 2'
+    provider1.complete.side_effect = ProviderError("Provider 1 failed")
+    provider2.complete.return_value = "Success from provider 2"
     fallback = FallbackProvider(providers=[provider1, provider2])
-    result = fallback.complete('test prompt')
-    assert result == 'Success from provider 2'
+    result = fallback.complete("test prompt")
+    assert result == "Success from provider 2"
     provider1.complete.assert_called_once()
     provider2.complete.assert_called_once()
-    provider2.complete.side_effect = ProviderError('Provider 2 failed')
+    provider2.complete.side_effect = ProviderError("Provider 2 failed")
     with pytest.raises(ProviderError):
-        fallback.complete('test prompt')
+        fallback.complete("test prompt")
 
 
 def test_get_env_or_default_succeeds():
     """Test the get_env_or_default function.
 
-ReqID: N/A"""
-    with patch.dict('os.environ', {'TEST_VAR': 'test_value'}):
-        assert get_env_or_default('TEST_VAR', 'default') == 'test_value'
-    with patch.dict('os.environ', {}, clear=True):
-        assert get_env_or_default('TEST_VAR', 'default') == 'default'
-    with patch.dict('os.environ', {}, clear=True):
-        assert get_env_or_default('TEST_VAR') is None
+    ReqID: N/A"""
+    with patch.dict("os.environ", {"TEST_VAR": "test_value"}):
+        assert get_env_or_default("TEST_VAR", "default") == "test_value"
+    with patch.dict("os.environ", {}, clear=True):
+        assert get_env_or_default("TEST_VAR", "default") == "default"
+    with patch.dict("os.environ", {}, clear=True):
+        assert get_env_or_default("TEST_VAR") is None
 
 
 def test_get_provider_config_has_expected():
     """Test the get_provider_config function.
 
-ReqID: N/A"""
+    ReqID: N/A"""
     get_provider_config.cache_clear()
-    env_vars = {'DEVSYNTH_PROVIDER': 'openai', 'OPENAI_API_KEY': 'test_key',
-        'OPENAI_MODEL': 'gpt-4', 'LM_STUDIO_ENDPOINT': 'http://test-endpoint'}
-    with patch.dict('os.environ', env_vars, clear=True):
+    env_vars = {
+        "DEVSYNTH_PROVIDER": "openai",
+        "OPENAI_API_KEY": "test_key",
+        "OPENAI_MODEL": "gpt-4",
+        "LM_STUDIO_ENDPOINT": "http://test-endpoint",
+    }
+    with patch.dict("os.environ", env_vars, clear=True):
         config = get_provider_config()
-        assert config['default_provider'] == 'openai'
-        assert config['openai']['api_key'] == 'test_key'
-        assert config['openai']['model'] == 'gpt-4'
-        assert config['lm_studio']['endpoint'] == 'http://test-endpoint'
+        assert config["default_provider"] == "openai"
+        assert config["openai"]["api_key"] == "test_key"
+        assert config["openai"]["model"] == "gpt-4"
+        assert config["lmstudio"]["endpoint"] == "http://test-endpoint"
     get_provider_config.cache_clear()
-    with patch.dict('os.environ', {'OPENAI_API_KEY': 'test_key'}, clear=True):
+    with patch.dict("os.environ", {"OPENAI_API_KEY": "test_key"}, clear=True):
         config = get_provider_config()
-        assert config['default_provider'] == 'openai'
-        assert config['openai']['api_key'] == 'test_key'
-        assert 'model' in config['openai']
+        assert config["default_provider"] == "openai"
+        assert config["openai"]["api_key"] == "test_key"
+        assert "model" in config["openai"]
 
 
-@patch('requests.post')
+@patch("requests.post")
 def test_openai_provider_complete_has_expected(mock_post):
     """Test the complete method of OpenAIProvider.
 
-ReqID: N/A"""
+    ReqID: N/A"""
     mock_response = MagicMock()
     mock_response.status_code = 200
-    mock_response.json.return_value = {'choices': [{'message': {'content':
-        'Test completion'}}]}
+    mock_response.json.return_value = {
+        "choices": [{"message": {"content": "Test completion"}}]
+    }
     mock_post.return_value = mock_response
-    provider = OpenAIProvider(api_key='test_key', model='gpt-4')
-    result = provider.complete('Test prompt', system_prompt='System prompt')
-    assert result == 'Test completion'
+    provider = OpenAIProvider(api_key="test_key", model="gpt-4")
+    result = provider.complete("Test prompt", system_prompt="System prompt")
+    assert result == "Test completion"
     mock_post.assert_called_once()
     args, kwargs = mock_post.call_args
-    assert args[0] == 'https://api.openai.com/v1/chat/completions'
-    assert kwargs['headers']['Authorization'] == 'Bearer test_key'
-    assert kwargs['json']['model'] == 'gpt-4'
-    assert kwargs['json']['messages'][0]['content'] == 'System prompt'
-    assert kwargs['json']['messages'][1]['content'] == 'Test prompt'
+    assert args[0] == "https://api.openai.com/v1/chat/completions"
+    assert kwargs["headers"]["Authorization"] == "Bearer test_key"
+    assert kwargs["json"]["model"] == "gpt-4"
+    assert kwargs["json"]["messages"][0]["content"] == "System prompt"
+    assert kwargs["json"]["messages"][1]["content"] == "Test prompt"
 
 
-@patch('requests.post')
+@patch("requests.post")
 def test_openai_provider_complete_error_raises_error(mock_post):
     """Test error handling in the complete method of OpenAIProvider.
 
-ReqID: N/A"""
+    ReqID: N/A"""
     mock_response = MagicMock()
     mock_response.status_code = 400
-    mock_response.json.return_value = {'error': {'message': 'Bad request'}}
+    mock_response.json.return_value = {"error": {"message": "Bad request"}}
     mock_post.return_value = mock_response
-    provider = OpenAIProvider(api_key='test_key', model='gpt-4')
+    provider = OpenAIProvider(api_key="test_key", model="gpt-4")
     with pytest.raises(ProviderError) as excinfo:
-        provider.complete('Test prompt')
-    assert 'Bad request' in str(excinfo.value)
+        provider.complete("Test prompt")
+    assert "Bad request" in str(excinfo.value)
 
 
-@patch('requests.post')
+@patch("requests.post")
 def test_openai_provider_complete_retry_has_expected(mock_post):
     """Test retry mechanism in the complete method of OpenAIProvider.
 
-ReqID: N/A"""
+    ReqID: N/A"""
     with patch(
-        'devsynth.adapters.provider_system.retry_with_exponential_backoff'
-        ) as mock_retry:
+        "devsynth.adapters.provider_system.retry_with_exponential_backoff"
+    ) as mock_retry:
         mock_retry.return_value = lambda func: func
         error_response = MagicMock()
         error_response.status_code = 429
-        error_response.json.return_value = {'error': {'message':
-            'Rate limit exceeded'}}
-        error_response.raise_for_status.side_effect = (requests.exceptions.
-            HTTPError('429 Client Error'))
+        error_response.json.return_value = {"error": {"message": "Rate limit exceeded"}}
+        error_response.raise_for_status.side_effect = requests.exceptions.HTTPError(
+            "429 Client Error"
+        )
         success_response = MagicMock()
         success_response.status_code = 200
-        success_response.json.return_value = {'choices': [{'message': {
-            'content': 'Test completion'}}]}
+        success_response.json.return_value = {
+            "choices": [{"message": {"content": "Test completion"}}]
+        }
         mock_post.side_effect = [error_response, success_response]
-        provider = OpenAIProvider(api_key='test_key', model='gpt-4')
+        provider = OpenAIProvider(api_key="test_key", model="gpt-4")
         try:
-            provider.complete('Test prompt')
+            provider.complete("Test prompt")
         except ProviderError:
             mock_post.side_effect = [success_response]
-            result = provider.complete('Test prompt')
-            assert result == 'Test completion'
+            result = provider.complete("Test prompt")
+            assert result == "Test completion"
         assert mock_retry.call_count >= 1
-        retry_calls_with_correct_params = [call for call in mock_retry.
-            call_args_list if call[1].get('retryable_exceptions') == (
-            requests.exceptions.RequestException,)]
+        retry_calls_with_correct_params = [
+            call
+            for call in mock_retry.call_args_list
+            if call[1].get("retryable_exceptions")
+            == (requests.exceptions.RequestException,)
+        ]
         assert len(retry_calls_with_correct_params) >= 1
 
 
-@patch('httpx.AsyncClient.post')
+@patch("httpx.AsyncClient.post")
 def test_openai_provider_acomplete_has_expected(mock_post):
     """Test the acomplete method of OpenAIProvider.
 
-ReqID: N/A"""
+    ReqID: N/A"""
     mock_response = MagicMock()
     mock_response.status_code = 200
-    mock_response.json.return_value = {'choices': [{'message': {'content':
-        'Async test completion'}}]}
+    mock_response.json.return_value = {
+        "choices": [{"message": {"content": "Async test completion"}}]
+    }
     mock_post.return_value = mock_response
-    provider = OpenAIProvider(api_key='test_key', model='gpt-4')
+    provider = OpenAIProvider(api_key="test_key", model="gpt-4")
 
     async def run_test():
-        result = await provider.acomplete('Test prompt', system_prompt=
-            'System prompt')
-        assert result == 'Async test completion'
+        result = await provider.acomplete("Test prompt", system_prompt="System prompt")
+        assert result == "Async test completion"
         mock_post.assert_called_once()
         args, kwargs = mock_post.call_args
-        assert args[0] == 'https://api.openai.com/v1/chat/completions'
-        assert kwargs['headers']['Authorization'] == 'Bearer test_key'
-        assert kwargs['json']['model'] == 'gpt-4'
-        assert kwargs['json']['messages'][0]['content'] == 'System prompt'
-        assert kwargs['json']['messages'][1]['content'] == 'Test prompt'
+        assert args[0] == "https://api.openai.com/v1/chat/completions"
+        assert kwargs["headers"]["Authorization"] == "Bearer test_key"
+        assert kwargs["json"]["model"] == "gpt-4"
+        assert kwargs["json"]["messages"][0]["content"] == "System prompt"
+        assert kwargs["json"]["messages"][1]["content"] == "Test prompt"
+
     asyncio.run(run_test())
 
 
-@patch('requests.post')
+@patch("requests.post")
 def test_openai_provider_embed_has_expected(mock_post):
     """Test the embed method of OpenAIProvider.
 
-ReqID: N/A"""
+    ReqID: N/A"""
     mock_response = MagicMock()
     mock_response.status_code = 200
-    mock_response.json.return_value = {'data': [{'embedding': [0.1, 0.2, 0.3]}]
-        }
+    mock_response.json.return_value = {"data": [{"embedding": [0.1, 0.2, 0.3]}]}
     mock_post.return_value = mock_response
-    provider = OpenAIProvider(api_key='test_key', model='gpt-4')
-    result = provider.embed('Test text')
+    provider = OpenAIProvider(api_key="test_key", model="gpt-4")
+    result = provider.embed("Test text")
     assert result == [[0.1, 0.2, 0.3]]
     mock_post.assert_called_once()
     args, kwargs = mock_post.call_args
-    assert args[0] == 'https://api.openai.com/v1/embeddings'
-    assert kwargs['headers']['Authorization'] == 'Bearer test_key'
-    assert kwargs['json']['input'] == ['Test text']
+    assert args[0] == "https://api.openai.com/v1/embeddings"
+    assert kwargs["headers"]["Authorization"] == "Bearer test_key"
+    assert kwargs["json"]["input"] == ["Test text"]
 
 
-@patch('requests.post')
+@patch("requests.post")
 def test_lmstudio_provider_complete_has_expected(mock_post):
     """Test the complete method of LMStudioProvider.
 
-ReqID: N/A"""
+    ReqID: N/A"""
     mock_response = MagicMock()
     mock_response.status_code = 200
-    mock_response.json.return_value = {'choices': [{'message': {'content':
-        'LM Studio completion'}}]}
+    mock_response.json.return_value = {
+        "choices": [{"message": {"content": "LM Studio completion"}}]
+    }
     mock_post.return_value = mock_response
-    provider = LMStudioProvider(endpoint='http://test-endpoint')
-    result = provider.complete('Test prompt', system_prompt='System prompt')
-    assert result == 'LM Studio completion'
+    provider = LMStudioProvider(endpoint="http://test-endpoint")
+    result = provider.complete("Test prompt", system_prompt="System prompt")
+    assert result == "LM Studio completion"
     mock_post.assert_called_once()
     args, kwargs = mock_post.call_args
-    assert args[0] == 'http://test-endpoint/v1/chat/completions'
-    assert kwargs['json']['messages'][0]['content'] == 'System prompt'
-    assert kwargs['json']['messages'][1]['content'] == 'Test prompt'
+    assert args[0] == "http://test-endpoint/v1/chat/completions"
+    assert kwargs["json"]["messages"][0]["content"] == "System prompt"
+    assert kwargs["json"]["messages"][1]["content"] == "Test prompt"
 
 
 def test_fallback_provider_async_methods_has_expected():
     """Test the async methods of FallbackProvider.
 
-ReqID: N/A"""
+    ReqID: N/A"""
     provider1 = MagicMock(spec=BaseProvider)
     provider2 = MagicMock(spec=BaseProvider)
-    provider1.acomplete = AsyncMock(side_effect=ProviderError(
-        'Provider 1 failed'))
-    provider2.acomplete = AsyncMock(return_value=
-        'Async success from provider 2')
-    provider1.aembed = AsyncMock(side_effect=ProviderError('Provider 1 failed')
-        )
+    provider1.acomplete = AsyncMock(side_effect=ProviderError("Provider 1 failed"))
+    provider2.acomplete = AsyncMock(return_value="Async success from provider 2")
+    provider1.aembed = AsyncMock(side_effect=ProviderError("Provider 1 failed"))
     provider2.aembed = AsyncMock(return_value=[[0.1, 0.2, 0.3]])
     fallback = FallbackProvider(providers=[provider1, provider2])
 
     async def run_test():
-        result = await fallback.acomplete('test prompt')
-        assert result == 'Async success from provider 2'
+        result = await fallback.acomplete("test prompt")
+        assert result == "Async success from provider 2"
         provider1.acomplete.assert_awaited_once()
         provider2.acomplete.assert_awaited_once()
-        result = await fallback.aembed('test text')
+        result = await fallback.aembed("test text")
         assert result == [[0.1, 0.2, 0.3]]
         provider1.aembed.assert_awaited_once()
         provider2.aembed.assert_awaited_once()
-        provider2.acomplete.side_effect = ProviderError('Provider 2 failed')
+        provider2.acomplete.side_effect = ProviderError("Provider 2 failed")
         with pytest.raises(ProviderError):
-            await fallback.acomplete('test prompt')
+            await fallback.acomplete("test prompt")
+
     asyncio.run(run_test())
 
 
 def test_provider_with_empty_inputs_has_expected():
     """Test providers with empty inputs.
 
-ReqID: N/A"""
-    with patch('requests.post') as mock_post:
+    ReqID: N/A"""
+    with patch("requests.post") as mock_post:
         mock_response = MagicMock()
         mock_response.status_code = 200
-        mock_response.json.return_value = {'choices': [{'message': {
-            'content': 'Empty prompt response'}}]}
+        mock_response.json.return_value = {
+            "choices": [{"message": {"content": "Empty prompt response"}}]
+        }
         mock_post.return_value = mock_response
-        provider = OpenAIProvider(api_key='test_key')
-        result = provider.complete('')
-        assert result == 'Empty prompt response'
+        provider = OpenAIProvider(api_key="test_key")
+        result = provider.complete("")
+        assert result == "Empty prompt response"
         args, kwargs = mock_post.call_args
-        assert kwargs['json']['messages'][0]['content'] == ''
-    with patch('requests.post') as mock_post:
+        assert kwargs["json"]["messages"][0]["content"] == ""
+    with patch("requests.post") as mock_post:
         mock_response = MagicMock()
         mock_response.status_code = 200
-        mock_response.json.return_value = {'choices': [{'message': {
-            'content': 'Empty prompt response'}}]}
+        mock_response.json.return_value = {
+            "choices": [{"message": {"content": "Empty prompt response"}}]
+        }
         mock_post.return_value = mock_response
         provider = LMStudioProvider()
-        result = provider.complete('')
-        assert result == 'Empty prompt response'
+        result = provider.complete("")
+        assert result == "Empty prompt response"


### PR DESCRIPTION
## Summary
- rename ProviderType.LM_STUDIO -> ProviderType.LMSTUDIO
- align config and factory with `lmstudio` key
- update fallback order default and validation
- adjust script and tests to use new provider name
- refresh docs for consistent `lmstudio` spelling

## Testing
- `poetry run pytest -q tests` *(fails: FileNotFoundError in test collection)*

------
https://chatgpt.com/codex/tasks/task_e_6873d354053c8333a523d69f8a34f186