### PR TITLE
Remove obsolete filename references

### DIFF
--- a/docs/DOCUMENTATION_UPDATE_PROGRESS.md
+++ b/docs/DOCUMENTATION_UPDATE_PROGRESS.md
@@ -70,18 +70,18 @@ July 8, 2025
 
 - Reviewed project structure and main components
 - Examined docs directory structure and content
-- Identified potentially redundant files (analysis/executive_summary.md vs analysis/original_executive_summary.md)
+- Identified and removed a redundant analysis summary file
 - Verified that specifications/executive_summary.md serves a different purpose than the analysis versions
 - Examined the analysis directory for potential cleanup needs
 - Reviewed key documentation files (README.md, architecture/overview.md)
 - Checked scripts/agentic_serper_search.py for web search capabilities
-- Deleted redundant file analysis/original_executive_summary.md
+- Removed the outdated analysis summary file
 - Updated analysis/index.md to remove reference to deleted file
 - Examined EDRR-related files in specifications directory and confirmed they serve different purposes:
   - edrr_cycle_specification.md - Technical specification of the EDRR
   - edrr_framework_integration_plan.md - Plan for integrating expanded EDRR Framework (draft)
   - edrr_framework_integration_summary.md - Summary of completed integration (completed)
-- Verified that roadmap/documentation_policies.md and specifications/post_mvp_documentation_plan.md serve different purposes and are not redundant
+- Verified that policies/documentation_policies.md and specifications/documentation_plan.md address distinct topics
 - Enhanced documentation consistency:
   - Added missing metadata to docs/developer_guides/contributing.md
   - Fixed incorrect link in docs/developer_guides/contributing.md
@@ -94,8 +94,8 @@ July 8, 2025
 - Updated all documentation files with consistent metadata headers
 - Verified and updated all internal links between documentation files
 - Ensured consistent terminology throughout all documentation
-- Created a comprehensive documentation_policies.md file in the policies directory that incorporates content from roadmap/documentation_policies.md and provides clear cross-references to the more detailed policy files
-- Updated all references to roadmap/documentation_policies.md to point to the new policies/documentation_policies.md file
+- Created a comprehensive documentation_policies.md file in the policies directory consolidating earlier roadmap content and providing clear cross-references to the detailed policy files
+- Updated all references to point to policies/documentation_policies.md
 - Ensured clear cross-references between the main documentation_policies.md file and the more detailed policy files
 - Updated metadata headers in key documentation files to reflect current date (July 8, 2025):
   - Updated memory_system.md, provider_system.md, quick_start_guide.md, glossary.md, and repo_structure.md
@@ -127,7 +127,7 @@ The project has a well-defined documentation structure organized into directorie
 
 ### Issues Addressed
 
-1. Redundancy between analysis/executive_summary.md and analysis/original_executive_summary.md has been resolved by deleting the outdated version
+1. Redundancy between analysis summary files has been resolved by deleting the outdated version
 2. Redundant content in the analysis directory has been consolidated
 3. All files in the analysis directory have been reviewed and confirmed as necessary
 4. Consistent metadata and formatting has been applied across all documentation files
@@ -154,7 +154,7 @@ The project has a well-defined documentation structure organized into directorie
 
 #### Analysis Directory
 
-- ✅ Deleted `analysis/original_executive_summary.md` as it was marked as "archived" and superseded by `analysis/executive_summary.md`
+- ✅ Removed the archived analysis summary file
 - ✅ Reviewed all analysis documents for relevance and currency:
   - `analysis/codebase_analysis.md` - Kept (contains valuable insights)
   - `analysis/critical_recommendations.md` - Kept (contains actionable recommendations)


### PR DESCRIPTION
## Summary
- drop mentions of removed documentation files in the progress log
- update progress log to reflect consolidated documentation structure

## Testing
- `bash scripts/codex_setup.sh`
- `poetry run pytest tests` *(fails: FileNotFoundError in test_webui_integration)*

------
https://chatgpt.com/codex/tasks/task_e_687423f6c50c83339be7f2ca69a47b36