### PR TITLE
Add release automation roadmap

### DIFF
--- a/docs/roadmap/index.md
+++ b/docs/roadmap/index.md
@@ -27,6 +27,7 @@ This section outlines the future plans and development trajectory for the DevSyn
 - **[Actionable Roadmap](actionable_roadmap.md)**: Specific, actionable items on the development roadmap.
 - **[Pre-1.0 Release Plan](pre_1.0_release_plan.md)**: Milestones required for the first public release.
 - **[Post-MVP Roadmap](post_mvp_roadmap.md)**: Details the features and enhancements planned after the Minimum Viable Product stage.
+- **[Release Automation Workflow](release_automation.md)**: Describes the CI pipeline for tagging and publishing releases.
 
 ## Documentation and Testing Plans
 

--- a/docs/roadmap/release_automation.md
+++ b/docs/roadmap/release_automation.md
@@ -1,0 +1,42 @@
+---
+author: DevSynth Team
+date: '2025-07-07'
+last_reviewed: '2025-07-10'
+status: published
+tags:
+  - release
+  - ci
+  - automation
+title: DevSynth Release Automation Workflow
+version: 0.1.0
+---
+
+# DevSynth Release Automation Workflow
+
+This document outlines the intended continuous integration workflow for tagging and publishing DevSynth releases. It consolidates the steps described in the archived **RELEASE_PLAN_UPDATE_PLAN** document and reflects the current repository layout.
+
+## Overview
+
+Releases are managed through GitHub Actions. The workflow is stored in `.github/workflows.disabled/release.yml`. When enabled and moved to `.github/workflows/`, it will:
+
+1. Trigger on push of tags matching `v*.*.*`.
+2. Build and publish the package to PyPI using `pypa/gh-action-pypi-publish`.
+3. Build the MkDocs documentation site.
+4. Deploy the site to GitHub Pages using `peaceiris/actions-gh-pages`.
+
+The same workflow also ensures the documentation build succeeds before publication. Documentation validation is covered by a separate `validate_documentation.yml` job.
+
+## Steps for a Release
+
+1. Update `pyproject.toml` with the new version and commit the change.
+2. Tag the commit with the release version using `git tag -s vX.Y.Z` and push the tag.
+3. Once the tag is pushed, GitHub Actions runs the release workflow.
+4. After the workflow completes, verify that the package appears on PyPI and the documentation site is updated.
+
+## Repository Structure Notes
+
+- Workflows are currently stored under `.github/workflows.disabled/`. Move them to `.github/workflows/` when ready to activate automation.
+- Documentation lives in `docs/` and is built using `mkdocs`.
+- Python packaging is managed with Poetry (`pyproject.toml`).
+
+By following this process, DevSynth maintains a consistent release mechanism that automatically publishes packages and documentation whenever a signed tag is pushed.


### PR DESCRIPTION
## Summary
- document the intended CI pipeline
- link the new release plan from the roadmap index

## Testing
- `poetry run pytest -q` *(fails: FileNotFoundError in tests/behavior/test_webui_integration.py)*
- `poetry run mkdocs build -q` *(fails: Command not found: mkdocs)*

------
https://chatgpt.com/codex/tasks/task_e_68743260aba8833381b9631eb8d0cae2