### PR TITLE
Add roadmap completion summaries

### DIFF
--- a/docs/roadmap/FINAL_SUMMARY.md
+++ b/docs/roadmap/FINAL_SUMMARY.md
@@ -1,0 +1,16 @@
+---
+title: "DevSynth Repository Harmonization Final Summary"
+date: "2025-07-10"
+version: "0.1.0"
+status: "published"
+tags:
+  - roadmap
+  - summary
+  - final
+author: "DevSynth Team"
+last_reviewed: "2025-07-10"
+---
+
+# DevSynth Repository Harmonization Final Summary
+
+All phases of the DevSynth Repository Harmonization Plan are complete. The project now features cohesive documentation, validated tests, and a streamlined repository structure. Remaining work focuses on minor test failures, implementing a maintenance strategy, and continuing feature development according to the roadmap.

--- a/docs/roadmap/PHASE_1_COMPLETION_SUMMARY.md
+++ b/docs/roadmap/PHASE_1_COMPLETION_SUMMARY.md
@@ -1,0 +1,24 @@
+---
+title: "Phase 1 Completion Summary"
+date: "2025-07-10"
+version: "0.1.0"
+status: "published"
+tags:
+  - roadmap
+  - phase1
+  - summary
+author: "DevSynth Team"
+last_reviewed: "2025-07-10"
+---
+
+# Phase 1 Completion Summary
+
+Phase 1 focused on **Foundation Stabilization**. Key accomplishments include:
+
+- Completed a comprehensive implementation audit and alignment effort.
+- Performed an in-depth assessment of the EDRR framework and identified integration gaps.
+- Validated the WSDE model with gap analysis and prepared integration plans.
+- Established a secure multi-stage Docker build and local development environment.
+- Implemented environment-specific configuration validation and deployment documentation.
+
+With these objectives achieved, the project established a solid baseline for subsequent phases.

--- a/docs/roadmap/PHASE_5_COMPLETION_SUMMARY.md
+++ b/docs/roadmap/PHASE_5_COMPLETION_SUMMARY.md
@@ -1,0 +1,22 @@
+---
+title: "Phase 5 Completion Summary"
+date: "2025-07-10"
+version: "0.1.0"
+status: "published"
+tags:
+  - roadmap
+  - phase5
+  - summary
+author: "DevSynth Team"
+last_reviewed: "2025-07-10"
+---
+
+# Phase 5 Completion Summary
+
+Phase 5 centered on **Verification and Validation**. Major outcomes:
+
+- Executed the full test suite to verify functionality and fixed import issues.
+- Added missing exception classes and adapter stubs to support testing.
+- Standardized the package structure and corrected import paths across tests.
+- Reviewed all documentation for accuracy and ensured bidirectional traceability between requirements, code, and tests.
+- Produced this phase summary to capture lessons learned and recommendations for ongoing maintenance.

--- a/docs/roadmap/development_status.md
+++ b/docs/roadmap/development_status.md
@@ -287,12 +287,12 @@ This work is planned for after the completion of Month 2.
 1. **Documentation Consolidation**:
    - Consolidated overlapping summary documents into development_status.md (this file)
    - Archived redundant files to docs/archived/harmonization directory:
-     - PHASE_1_COMPLETION_SUMMARY.md
+    - [PHASE_1_COMPLETION_SUMMARY](PHASE_1_COMPLETION_SUMMARY.md)
      - IMPLEMENTATION_STATUS.md
      - IMPLEMENTATION_PLAN.md
      - IMPLEMENTATION_ENHANCEMENT_PLAN.md
      - FEATURE_IMPLEMENTATION_STATUS.md
-     - FINAL_SUMMARY.md
+    - [FINAL_SUMMARY](FINAL_SUMMARY.md)
      - NEXT_ITERATIONS_UPDATED.md
 
 2. **Documentation Standardization**:
@@ -404,7 +404,7 @@ This work is planned for after the completion of Month 2.
    - Complete bidirectional traceability between requirements, code, and tests
 
 6. **Final Report**:
-   - Created PHASE_5_COMPLETION_SUMMARY.md to document the completion of Phase 5
+   - Created [PHASE_5_COMPLETION_SUMMARY](PHASE_5_COMPLETION_SUMMARY.md) to document the completion of Phase 5
    - Documented key achievements and lessons learned
    - Provided recommendations for future maintenance
 


### PR DESCRIPTION
## Summary
- add Phase 1 Completion Summary, Phase 5 Completion Summary and Final Summary docs
- link these summaries from `development_status.md`

## Testing
- `poetry run python scripts/validate_metadata.py docs/roadmap/PHASE_1_COMPLETION_SUMMARY.md docs/roadmap/PHASE_5_COMPLETION_SUMMARY.md docs/roadmap/FINAL_SUMMARY.md`
- `poetry run pytest -k "" -q` *(fails: FileNotFoundError in `test_webui_integration.py`)*

------
https://chatgpt.com/codex/tasks/task_e_68743233b078833386d4543ac900953b