### PR TITLE
Clarify upcoming 0.1.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,16 @@ represent pre-release milestones leading up to the first stable release.
 
 ## [Unreleased]
 
+Changes below will be included in the upcoming **0.1.0** release.
+
 ### Added
+- Modular, hexagonal architecture
+- Unified memory system with multiple backends
+- Agent system powered by LangGraph
+- Advanced code analysis using NetworkX
+- Provider abstraction for LLM services
+- Comprehensive SDLC policy corpus
+- Automated documentation and testing
 - Recursive EDRR framework implementation
 - Documentation cleansing and organization
 - Behavior-driven tests for the EDRR coordinator
@@ -41,13 +50,5 @@ represent pre-release milestones leading up to the first stable release.
 - Improved error handling in the EDRR coordinator
 
 ## [0.1.0] - 2025-05-20
-
-### Added
-- Modular, hexagonal architecture
-- Unified memory system with multiple backends
-- Agent system powered by LangGraph
-- Advanced code analysis using NetworkX
-- Provider abstraction for LLM services
-- Comprehensive SDLC policy corpus
-- Automated documentation and testing
+Released concurrently with this changelog.
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ DevSynth is an agentic software engineering platform that leverages LLMs, advanc
 
 **Pre-release notice:** DevSynth has not yet reached an official release. All
 current versions are in the `0.1.x` range and should be considered
-experimental.
+experimental. **No version has been officially released yet.**
 
 ## Key Features
 - Modular, hexagonal architecture for extensibility and testability

--- a/docs/roadmap/pre_1.0_release_plan.md
+++ b/docs/roadmap/pre_1.0_release_plan.md
@@ -14,6 +14,7 @@ version: 0.1.0
 
 **Note:** DevSynth is still in pre-release. Current versions are in the `0.1.x`
 series while this document outlines the path toward an eventual 1.0 release.
+**No version has been officially released yet.**
 
 We propose a multi-phase plan to finalize DevSynth’s UX, architecture, and completeness.  Each phase defines targeted milestones and implementation-ready tasks, emphasizing BDD/TDD practices.  We draw on the current codebase and docs to identify missing features and gaps.
 
@@ -145,7 +146,7 @@ workflows operate without network access.
 
 ## Roadmap from 0.1.0 to 1.0.0
 
-### Version 0.1.0 (Initial Release)
+### Version 0.1.0 (Upcoming Initial Release)
 
 #### 0.1.0-alpha.1 (Foundation)
 - Core architecture stabilization
@@ -185,7 +186,7 @@ workflows operate without network access.
 - Comprehensive testing
 - Release preparation
 
-#### 0.1.0 (Stable Release)
+#### 0.1.0 (Stable Release - Upcoming)
 - Production-ready initial release
 - Complete documentation
 - Verified installation process


### PR DESCRIPTION
## Summary
- clarify in README that no version is released
- clarify in pre-1.0 release plan that no version is released
- mark 0.1.0 as upcoming in roadmap headings
- move 0.1.0 changelog entry under Unreleased

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_68743986693c8333ac0bd9d3bf1abaa4