### PR TITLE
Update documentation index with all doc entries

### DIFF
--- a/docs/documentation_index.md
+++ b/docs/documentation_index.md
@@ -16,16 +16,52 @@ _This index lists all documentation files, their status, and release phase. It i
 
 | File Path | Title | Status | Release Phase |
 |-----------|-------|--------|---------------|
-| docs/roadmap/release_plan.md | DevSynth Release Plan | published | roadmap |
-| docs/roadmap/post_mvp_roadmap.md | DevSynth Post-MVP Development Roadmap | published | post-mvp |
-| docs/specifications/metrics_system.md | DevSynth Metrics and Analytics System | published | v1 |
-| docs/specifications/documentation_plan.md | DevSynth Documentation Plan | published | consolidation |
-| docs/implementation/* | Implementation examples and pseudocode | draft | implementation |
-| docs/user_guides/* | User guides and CLI references | published | usage |
+| docs/analysis/cli_ui_improvement_plan.md | DevSynth CLI and UI Improvement Plan | draft | analysis |
+| docs/analysis/codebase_analysis.md | DevSynth Codebase Analysis | published | analysis |
+| docs/analysis/critical_recommendations.md | DevSynth Critical Issues and Recommendations Report | published | analysis |
+| docs/analysis/dialectical_evaluation.md | DevSynth Project: Multi-Disciplinary Dialectical Evaluation | published | analysis |
+| docs/analysis/executive_summary.md | DevSynth Project Executive Summary | published | analysis |
+| docs/analysis/index.md | Analysis | published | analysis |
+| docs/analysis/inventory.md | DevSynth Project Comprehensive Inventory & Analysis | published | analysis |
+| docs/analysis/technical_deep_dive.md | DevSynth Technical Deep Dive Analysis | published | analysis |
+| docs/analysis/wide_sweep_analysis.md | DevSynth Project Wide Sweep Analysis | published | analysis |
+| docs/architecture/agent_system.md | DevSynth Agent System Architecture | published | foundation |
+| docs/architecture/cli_webui_mapping.md | CLI to WebUI Command Mapping | draft | foundation |
+| docs/architecture/dialectical_reasoning.md | Dialectical Reasoning System for Requirements Management | published | foundation |
+| docs/architecture/edrr_framework.md | EDRR Framework: Expand, Differentiate, Refine, Retrospect | active | foundation |
+| docs/architecture/hexagonal_architecture.md | Hexagonal Architecture Guide | published | foundation |
+| docs/architecture/index.md | DevSynth Architecture | published | foundation |
+| docs/architecture/init_workflow.md | Init Workflow | draft | foundation |
+| docs/architecture/memory_system.md | DevSynth Memory System Architecture | published | foundation |
+| docs/architecture/multi_disciplinary_dialectical_reasoning.md | Multi-Disciplinary Dialectical Reasoning | published | foundation |
+| docs/architecture/overview.md | DevSynth Architecture Overview | published | foundation |
+| docs/architecture/phase1_overhaul.md | Phase 1 Overhaul Overview | draft | foundation |
+| docs/architecture/provider_system.md | Provider System Architecture | published | foundation |
+| docs/architecture/recursive_edrr_architecture.md | Recursive EDRR Architecture | draft | foundation |
+| docs/architecture/security_design.md | Security Design | published | foundation |
+| docs/architecture/uxbridge.md | UXBridge Abstraction | draft | foundation |
+| docs/architecture/uxbridge_architecture.md | UXBridge Architecture | published | foundation |
+| docs/architecture/webui_implementation_details.md | WebUI Implementation Details | published | foundation |
+| docs/architecture/webui_overview.md | WebUI Architecture Overview | published | foundation |
+| docs/architecture/wsde_agent_model.md | WSDE Agent Model: WSDE | active | foundation |
+| docs/architecture/wsde_edrr_integration.md | WSDE-EDRR Integration Architecture | published | foundation |
 | docs/developer_guides/* | Developer guides and code style | published | development |
-| docs/architecture/* | Architecture and design docs | published | foundation |
+| docs/implementation/* | Implementation examples and pseudocode | draft | implementation |
 | docs/policies/* | SDLC and project policies | published | governance |
-| docs/analysis/* | Project analysis and recommendations | published | analysis |
+| docs/roadmap/FINAL_SUMMARY.md | DevSynth Repository Harmonization Final Summary | published | roadmap |
+| docs/roadmap/PHASE_1_COMPLETION_SUMMARY.md | Phase 1 Completion Summary | published | roadmap |
+| docs/roadmap/PHASE_5_COMPLETION_SUMMARY.md | Phase 5 Completion Summary | published | roadmap |
+| docs/roadmap/actionable_roadmap.md | DevSynth Actionable Implementation Roadmap | published | roadmap |
+| docs/roadmap/development_plan.md | DevSynth Development Plan | published | roadmap |
+| docs/roadmap/development_status.md | DevSynth Development Status | active | roadmap |
+| docs/roadmap/documentation_policies.md | Documentation Policies | published | roadmap |
+| docs/roadmap/index.md | DevSynth Roadmap | published | roadmap |
+| docs/roadmap/post_mvp_roadmap.md | DevSynth Post-MVP Development Roadmap | published | post-mvp |
+| docs/roadmap/pre_1.0_release_plan.md | DevSynth Pre-1.0 Release Plan | published | roadmap |
+| docs/roadmap/release_automation.md | DevSynth Release Automation Workflow | published | roadmap |
+| docs/roadmap/release_plan.md | DevSynth Release Plan | published | roadmap |
+| docs/specifications/documentation_plan.md | DevSynth Documentation Plan | published | consolidation |
+| docs/specifications/metrics_system.md | DevSynth Metrics and Analytics System | published | v1 |
 | docs/testing/* | Behavior feature files index | draft | testing |
-
+| docs/user_guides/* | User guides and CLI references | published | usage |
 > **Note:** Update this table to include any new documentation files. Automate via an indexing script for accuracy.


### PR DESCRIPTION
## Summary
- refresh documentation index to enumerate all docs under analysis, architecture, and roadmap folders
- keep alphabetical ordering and include status and release phase information

## Testing
- `poetry run pytest tests` *(fails: FileNotFoundError for webui_integration.feature)*

------
https://chatgpt.com/codex/tasks/task_e_68744a0131148333b544b4728efe532c