### PR TITLE
Update changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ version has been published yet.
 - Behavior-driven tests for the EDRR coordinator
 - Basic security utilities for authentication, authorization, and input sanitization
 - Doctor command for configuration validation
+- Anthropic API support and deterministic offline provider implementation
 
 ### Changed
 - Moved development documents to appropriate locations in the docs/ directory


### PR DESCRIPTION
## Summary
- add bullet for Anthropic API support and offline provider implementation

## Testing
- `poetry run pytest -q` *(fails: 237 failed, 317 passed, 64 skipped, 27 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68756cfc93948333b1050b3250639530