### PR TITLE
Document full semantic version format

### DIFF
--- a/docs/policies/semantic_versioning.md
+++ b/docs/policies/semantic_versioning.md
@@ -22,18 +22,20 @@ DevSynth follows the [Semantic Versioning](https://semver.org/) scheme to commun
 
 ## Pre-release Identifiers
 
-Pre-release versions append an identifier after a hyphen (e.g., `1.2.0-alpha`, `2.0.0-rc.1`) to denote milestones that precede a final release.
+Pre-release versions append an identifier after a hyphen (e.g., `1.2.0-alpha`,
+`2.0.0-rc.1`) to denote milestones that precede a final release.
 
 ## MAJOR.MINOR.PATCH-STABILITY
 
 DevSynth uses an extended scheme that appends a stability label after the patch
-component. The general form is `MAJOR.MINOR.PATCH-STABILITY`.
+component. The full version string is `MAJOR.MINOR.PATCH-STABILITY`.
 
 - **STABILITY** indicates the maturity of the release. Typical values are
   `alpha`, `beta`, and `rc` followed by a dot and an incrementing number.
-- Final releases omit the stability label entirely.
+  - Final releases omit the stability label entirely.
 
 ### Examples
 
 - `0.1.0-alpha.1` – first alpha iteration of version `0.1.0`.
-- `0.1.0-beta.2` – second beta iteration of version `0.1.0`.
+- `0.1.0-beta.1` – first beta iteration of version `0.1.0`.
+- `0.1.0-rc.1` – first release candidate of version `0.1.0`.

--- a/docs/roadmap/release_plan.md
+++ b/docs/roadmap/release_plan.md
@@ -13,7 +13,7 @@ last_reviewed: "2025-07-10"
 # DevSynth Release Plan
 
 This document consolidates the various roadmap drafts into a single authoritative plan. It outlines the major phases leading to a stable 1.0 release and summarizes key version milestones.
-DevSynth is still pre-0.1.0 and no official release has been published yet. Version references in this plan are provisional and will use the MAJOR.MINOR.PATCH-STABILITY notation defined in our [Semantic Versioning Policy](../policies/semantic_versioning.md).
+DevSynth is still pre-0.1.0 and no official release has been published yet. Version references in this plan are provisional and follow the MAJOR.MINOR.PATCH-STABILITY notation defined in our [Semantic Versioning Policy](../policies/semantic_versioning.md). See that policy for the full explanation of the version format and pre-release identifiers.
 
 ## Phased Roadmap
 


### PR DESCRIPTION
## Summary
- clarify `MAJOR.MINOR.PATCH-STABILITY` section of semantic versioning policy
- add examples for `alpha`, `beta`, and `rc`
- mention the policy in the release plan with a link

## Testing
- `pre-commit run --files docs/policies/semantic_versioning.md docs/roadmap/release_plan.md`
- `poetry run pytest` *(fails: 82 failed, 57 passed, 21 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_6875a777fe30833384c320e58eecc218