### PR TITLE
Update README with roadmap reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,10 +18,7 @@ last_reviewed: "2025-07-10"
 
 DevSynth is an agentic software engineering platform that leverages LLMs, advanced memory systems, and dialectical reasoning to automate and enhance the software development lifecycle. The system is designed for extensibility, resilience, and traceability, supporting both autonomous and collaborative workflows.
 
-**Pre-release notice:** DevSynth has not yet reached an official release. All
-current versions are in the `0.1.x` range and should be considered
-experimental. **No version has been officially released yet.**
-
+**Pre-release notice:** DevSynth is still pre-0.1.0 and no package has been published on PyPI. All versions should be considered experimental. Release milestones are tracked in [docs/roadmap/ROADMAP.md](docs/roadmap/ROADMAP.md).
 ## Key Features
 - Modular, hexagonal architecture for extensibility and testability
 - Unified memory system with Kuzu, TinyDB, RDFLib, and JSON backends
@@ -65,7 +62,7 @@ Full documentation is available in the [docs/](docs/index.md) directory and onli
 - [Implementation Status Matrix](docs/implementation/feature_status_matrix.md)
 - [Requirements Traceability Matrix](docs/requirements_traceability.md)
 - [SDLC Policies](docs/policies/index.md)
-- [Roadmap Overview](docs/roadmap/development_plan.md#roadmap-overview)
+- [Project Roadmap](docs/roadmap/ROADMAP.md)
 
 Installation instructions are covered in detail in the [Installation Guide](docs/getting_started/installation.md) and the [Quick Start Guide](docs/getting_started/quick_start_guide.md).
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -28,7 +28,7 @@ Welcome to the DevSynth documentation! This site provides comprehensive guides, 
 - [API Reference](technical_reference/api_reference/index.md)
 - [Project Analysis](analysis/executive_summary.md)
 - [Implementation Status](implementation/feature_status_matrix.md)
-- [Project Roadmap](roadmap/release_plan.md)
+- [Project Roadmap](roadmap/ROADMAP.md)
 
 
 ## Project Policies

--- a/docs/roadmap/ROADMAP.md
+++ b/docs/roadmap/ROADMAP.md
@@ -1,0 +1,16 @@
+---
+title: DevSynth Roadmap
+version: 0.1.0
+status: published
+author: DevSynth Team
+---
+
+# DevSynth Roadmap
+
+This document provides a simplified overview of upcoming release milestones. For full details, see the [Release Plan](release_plan.md).
+
+- **Pre-0.1.0** – Internal iterations and prototype development. No package is published yet.
+- **0.1.x** – Early previews focusing on stabilization and the Worker Self-Directed Enterprise model.
+- **0.2.0** – Expanded agent capabilities, improved memory backends, and API enhancements.
+- **1.0.0** – First stable release with documentation, test coverage, and deployment automation.
+

--- a/docs/roadmap/index.md
+++ b/docs/roadmap/index.md
@@ -26,6 +26,7 @@ This section outlines the future plans and development trajectory for the DevSyn
 - **[Development Status](development_status.md)**: The current status of development efforts.
 - **[Actionable Roadmap](actionable_roadmap.md)**: Specific, actionable items on the development roadmap.
 - **[Release Plan](release_plan.md)**: Milestones required for the first public release.
+- **[ROADMAP](ROADMAP.md)**: Consolidated list of release milestones.
 - **[Post-MVP Roadmap](post_mvp_roadmap.md)**: Details the features and enhancements planned after the Minimum Viable Product stage.
 - **[Release Automation Workflow](release_automation.md)**: Describes the CI pipeline for tagging and publishing releases.
 


### PR DESCRIPTION
## Summary
- clarify pre-release status in README with reference to roadmap
- point quick-start docs and index page to the new roadmap location
- document release milestones in `docs/roadmap/ROADMAP.md`

## Testing
- `poetry run pytest -q` *(fails: 355 failed, 1447 passed, 82 skipped, 29 errors)*

------
https://chatgpt.com/codex/tasks/task_e_6875b3e7a8fc8333ad3e071937bf7bb1