### PR TITLE
Document Semantic Versioning+

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ last_reviewed: "2025-07-10"
 
 DevSynth is an agentic software engineering platform that leverages LLMs, advanced memory systems, and dialectical reasoning to automate and enhance the software development lifecycle. The system is designed for extensibility, resilience, and traceability, supporting both autonomous and collaborative workflows.
 
-**Pre-release notice:** DevSynth is still pre-0.1.0 and no package has been published on PyPI. All versions should be considered experimental. Release milestones are tracked in [docs/roadmap/ROADMAP.md](docs/roadmap/ROADMAP.md).
+**Pre-release notice:** DevSynth is still pre-0.1.0 and no package has been published on PyPI. All versions should be considered experimental. Version labels follow our [Semantic Versioning+ policy](docs/policies/semantic_versioning.md), and release milestones are tracked in [docs/roadmap/ROADMAP.md](docs/roadmap/ROADMAP.md).
 ## Key Features
 - Modular, hexagonal architecture for extensibility and testability
 - Unified memory system with Kuzu, TinyDB, RDFLib, and JSON backends

--- a/docs/policies/semantic_versioning.md
+++ b/docs/policies/semantic_versioning.md
@@ -39,3 +39,33 @@ component. The full version string is `MAJOR.MINOR.PATCH-STABILITY`.
 - `0.1.0-alpha.1` – first alpha iteration of version `0.1.0`.
 - `0.1.0-beta.1` – first beta iteration of version `0.1.0`.
 - `0.1.0-rc.1` – first release candidate of version `0.1.0`.
+
+## Semantic Versioning+
+
+To clarify milestone quality and communicate expectations during the long pre-1.0 period, DevSynth introduces **Semantic Versioning+ (SemVer+)**. The scheme
+extends the standard `MAJOR.MINOR.PATCH` format with an optional stability
+segment and a plus sign for build metadata. The overall pattern is:
+
+```
+MAJOR.MINOR.PATCH[-STABILITY][+BUILD]
+```
+
+- **STABILITY** (`alpha`, `beta`, `rc`) conveys the level of confidence in a
+  release. An incrementing number (e.g., `alpha.2`) denotes successive previews.
+- **BUILD** is optional metadata such as commit hashes or packaging notes. It
+  follows the plus sign defined in the SemVer specification.
+
+SemVer+ is fully compatible with Semantic Versioning and tooling that expects
+`MAJOR.MINOR.PATCH`. The stability label simply provides clearer guidance for
+users evaluating whether a release is experimental or production ready. Build
+metadata is ignored when determining upgrade paths, but helps trace artifacts.
+
+### Practical Guidelines
+
+1. Start new feature lines at `alpha.1` and increment through `beta` and `rc`
+   as quality improves.
+2. Omit the stability label once a release is considered stable.
+3. Use `+<build>` metadata for internal automation or distribution channels.
+
+With Semantic Versioning+ in place, version strings like `0.3.0-beta.2+exp.sha`
+communicate both the development phase and the specific build artifact.

--- a/docs/roadmap/release_plan.md
+++ b/docs/roadmap/release_plan.md
@@ -13,7 +13,7 @@ last_reviewed: "2025-07-10"
 # DevSynth Release Plan
 
 This document consolidates the various roadmap drafts into a single authoritative plan. It outlines the major phases leading to a stable 1.0 release and summarizes key version milestones.
-DevSynth is still pre-0.1.0 and no official release has been published yet. Version references in this plan are provisional and follow the MAJOR.MINOR.PATCH-STABILITY notation defined in our [Semantic Versioning Policy](../policies/semantic_versioning.md). See that policy for the full explanation of the version format and pre-release identifiers.
+DevSynth is still pre-0.1.0 and no official release has been published yet. Version references in this plan are provisional and follow the MAJOR.MINOR.PATCH-STABILITY notation defined in our [Semantic Versioning+ policy](../policies/semantic_versioning.md). See that policy for the full explanation of the version format, stability suffixes, and build metadata.
 
 ## Phased Roadmap
 


### PR DESCRIPTION
## Summary
- elaborate on `Semantic Versioning+` scheme
- reference the new versioning policy in README and Release Plan

## Testing
- `poetry run pytest tests/` *(fails: 354 failed, 1448 passed, 82 skipped, 29 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68766348a9cc8333816ceea3b0549ef8