### PR TITLE
Update roadmap docs with canonical link

### DIFF
--- a/docs/roadmap/FINAL_SUMMARY.md
+++ b/docs/roadmap/FINAL_SUMMARY.md
@@ -13,4 +13,6 @@ last_reviewed: "2025-07-10"
 
 # DevSynth Repository Harmonization Final Summary
 
+**Note:** DevSynth is still in a pre-release stage. The final release plan is tracked in [release_plan.md](release_plan.md).
+
 All phases of the DevSynth Repository Harmonization Plan are complete. The project now features cohesive documentation, validated tests, and a streamlined repository structure. Key achievements include full Anthropic provider integration and a deterministic offline mode. Remaining work focuses on minor test failures, implementing a maintenance strategy, and continuing feature development according to the roadmap.

--- a/docs/roadmap/ROADMAP.md
+++ b/docs/roadmap/ROADMAP.md
@@ -7,6 +7,8 @@ author: DevSynth Team
 
 # DevSynth Roadmap
 
+**Note:** DevSynth is currently in a pre-release stage. Refer to the [Release Plan](release_plan.md) for canonical milestones.
+
 This document provides a simplified overview of upcoming release milestones. For full details, see the [Release Plan](release_plan.md).
 
 - **Pre-0.1.0** – Internal iterations and prototype development. No package is published yet.

--- a/docs/roadmap/actionable_roadmap.md
+++ b/docs/roadmap/actionable_roadmap.md
@@ -13,6 +13,8 @@ version: 0.1.0
 
 # DevSynth Actionable Implementation Roadmap
 
+**Note:** DevSynth is currently in a pre-release stage. The [Release Plan](release_plan.md) is the canonical source for roadmap updates.
+
 **Analysis Date:** May 29, 2025
 **Repository:** https://github.com/ravenoak/devsynth.git
 **Roadmap Timeline:** 24 months with quarterly milestones

--- a/docs/roadmap/development_plan.md
+++ b/docs/roadmap/development_plan.md
@@ -25,6 +25,8 @@ last_reviewed: "2025-07-10"
 **Note:** DevSynth is currently a pre-release project. Versions in the `0.1.x`
 range are unstable and subject to change.
 
+For the authoritative roadmap, see the [Release Plan](release_plan.md).
+
 **Date:** 2025-06-01
 **Author:** DevSynth Team
 

--- a/docs/roadmap/documentation_policies.md
+++ b/docs/roadmap/documentation_policies.md
@@ -11,6 +11,8 @@ version: 0.1.0
 
 # Documentation Policies
 
+**Note:** DevSynth is currently in a pre-release stage. Documentation guidelines may evolve before the 1.0 release.
+
 This document outlines the policies for maintaining high-quality documentation in the DevSynth project.
 
 ## Review Process

--- a/docs/roadmap/post_mvp_roadmap.md
+++ b/docs/roadmap/post_mvp_roadmap.md
@@ -12,6 +12,8 @@ last_reviewed: "2025-07-10"
 
 # DevSynth Post-MVP Development Roadmap
 
+**Note:** DevSynth is currently in a pre-release stage. Plans described here may change before version 1.0.
+
 ## 1. Introduction
 
 This document outlines the roadmap for DevSynth development beyond the Minimum Viable Product (MVP). It focuses on features that would enhance DevSynth's capabilities, allow it to operate on its own codebase, and enable continuous self-improvement. The roadmap is organized into phases, with each phase building upon the previous one to create a more powerful and versatile development tool.

--- a/docs/roadmap/pre_1.0_release_plan.md
+++ b/docs/roadmap/pre_1.0_release_plan.md
@@ -16,6 +16,8 @@ version: 0.1.0
 series while this document outlines the path toward an eventual 1.0 release.
 **No version has been officially released yet.**
 
+For the authoritative roadmap, see the [Release Plan](release_plan.md).
+
 We propose a multi-phase plan to finalize DevSynth’s UX, architecture, and completeness.  Each phase defines targeted milestones and implementation-ready tasks, emphasizing BDD/TDD practices.  We draw on the current codebase and docs to identify missing features and gaps.
 
 For current implementation status, see the

--- a/docs/roadmap/release_automation.md
+++ b/docs/roadmap/release_automation.md
@@ -13,6 +13,8 @@ version: 0.1.0
 
 # DevSynth Release Automation Workflow
 
+**Note:** DevSynth is currently in a pre-release stage. Release automation steps may change until the project reaches 1.0.
+
 This document outlines the intended continuous integration workflow for tagging and publishing DevSynth releases. It consolidates the steps described in the archived **RELEASE_PLAN_UPDATE_PLAN** document and reflects the current repository layout.
 
 ## Overview

--- a/docs/roadmap/release_plan.md
+++ b/docs/roadmap/release_plan.md
@@ -12,8 +12,9 @@ last_reviewed: "2025-07-10"
 
 # DevSynth Release Plan
 
-This document consolidates the various roadmap drafts into a single authoritative plan. It outlines the major phases leading to a stable 1.0 release and summarizes key version milestones.
-DevSynth is still pre-0.1.0 and no official release has been published yet. Version references in this plan are provisional and follow the MAJOR.MINOR.PATCH-STABILITY notation defined in our [Semantic Versioning+ policy](../policies/semantic_versioning.md). See that policy for the full explanation of the version format, stability suffixes, and build metadata.
+This document consolidates the various roadmap drafts into a single authoritative plan. **It is the canonical source for all roadmap updates.** It outlines the major phases leading to a stable 1.0 release and summarizes key version milestones.
+
+DevSynth remains in a pre-release stage. No official release has been published yet and versions in this plan are provisional. They follow the MAJOR.MINOR.PATCH-STABILITY notation defined in our [Semantic Versioning+ policy](../policies/semantic_versioning.md).
 
 ## Phased Roadmap
 


### PR DESCRIPTION
## Summary
- declare release_plan.md as the single canonical roadmap source
- link other roadmap docs back to the release plan
- add pre-release notes across roadmap docs

## Testing
- `poetry run pytest` *(fails: 354 failed, 1448 passed, 82 skipped, 29 errors)*

------
https://chatgpt.com/codex/tasks/task_e_687738659c5883339fbef165ce675dbf