### PR TITLE
Add feature dependency roadmap

### DIFF
--- a/docs/roadmap/development_status.md
+++ b/docs/roadmap/development_status.md
@@ -21,6 +21,7 @@ version: 0.1.0
 `0.1.x` and do not represent a stable release.
 
 This document serves as the single source of truth for the current development status of the DevSynth project. It consolidates information from various summary documents and provides a clear overview of implementation progress across all phases. Major milestones are tracked in the [Release Plan](release_plan.md).
+For the ordering of upcoming releases, see [Feature Dependencies](feature_dependencies.md) which outlines how key components build on each other.
 
 ## Provider Completion Summary
 

--- a/docs/roadmap/feature_dependencies.md
+++ b/docs/roadmap/feature_dependencies.md
@@ -1,0 +1,24 @@
+---
+author: DevSynth Team
+date: '2025-07-17'
+last_reviewed: '2025-07-17'
+status: active
+tags:
+- roadmap
+- dependencies
+title: Feature Dependencies
+version: 0.1.0
+---
+
+# Feature Dependencies
+
+This document summarizes how major DevSynth features depend on one another. Understanding these relationships helps plan releases in a logical order.
+
+| Feature | Depends On | Notes |
+|---------|------------|-------|
+| Providers | Core configuration, offline mode | Foundation for all LLM interactions. Needed before memory backends can generate embeddings. |
+| Memory backends | Providers | Vector stores require embeddings from a provider. Stable provider APIs must be available first. |
+| Multi-language support | Providers, Memory backends | Requires reliable provider completions and memory storage for multi-language code. Introduced after memory is stable. |
+| DSPy integration | Providers, Memory backends, Multi-language support | DSPy relies on consistent provider interfaces and memory persistence. Planned for later releases once multi-language features are in place. |
+
+These dependencies influence the sequence of upcoming releases. Providers and memory backends are addressed in early versions, followed by multi-language features and eventually DSPy integration.

--- a/docs/roadmap/release_plan.md
+++ b/docs/roadmap/release_plan.md
@@ -15,6 +15,7 @@ last_reviewed: "2025-07-10"
 This document consolidates the various roadmap drafts into a single authoritative plan. **It is the canonical source for all roadmap updates.** It outlines the major phases leading to a stable 1.0 release and summarizes key version milestones.
 
 DevSynth remains in a pre-release stage. No official release has been published yet and versions in this plan are provisional. They follow the MAJOR.MINOR.PATCH-STABILITY notation defined in our [Semantic Versioning+ policy](../policies/semantic_versioning.md).
+Dependencies among major features are summarized in [Feature Dependencies](feature_dependencies.md) to clarify how releases build on each other.
 
 ## Phased Roadmap
 


### PR DESCRIPTION
## Summary
- document how major features depend on each other
- reference the dependency map from `release_plan.md`
- reference the dependency map from `development_status.md`

## Testing
- `poetry run pytest -q` *(fails: 215 failed, 264 passed, 61 skipped, 15 errors)*

------
https://chatgpt.com/codex/tasks/task_e_6877e9e8c5d083339744f780ca182026