### PR TITLE
Fix MkDocs link for testing infrastructure

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -103,7 +103,7 @@ nav:
     - Development Plan: roadmap/development_plan.md
     - Development Status: roadmap/development_status.md
     - Documentation Policies: roadmap/documentation_policies.md
-    - Testing Infrastructure: roadmap/testing_infrastructure.md
+    - Testing Infrastructure: specifications/testing_infrastructure.md
   - Changelog: CHANGELOG.md
 
 markdown_extensions:


### PR DESCRIPTION
## Summary
- update MkDocs nav to point Testing Infrastructure page to `specifications/`

## Testing
- `poetry run mkdocs build`
- `poetry run pytest -q` *(fails: KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_687827e4231483339baf861dff38f653