### PR TITLE
Ensure poetry test setup

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,8 +28,9 @@ manually to make it succeed. To fix your environment:
 2. Run `bash scripts/codex_setup.sh` (without network access) until it completes
    without errors.
 3. Remove the failure marker with `rm CODEX_ENVIRONMENT_SETUP_FAILED`.
+4. Execute `poetry run pytest` to verify the environment.
 
-Development and test commands may fail until the setup script completes successfully and the marker file is removed.
+Development and test commands may fail until the setup script completes successfully, the marker file is removed, and the tests pass.
 
 ## Project Structure
 

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ Installation instructions are covered in detail in the [Installation Guide](docs
 
 DevSynth requires **Python 3.12 or higher**. Using [Poetry](https://python-poetry.org/) is recommended for managing dependencies during development.
 
-The initial workspace setup runs [`scripts/codex_setup.sh`](scripts/codex_setup.sh) with network access enabled. If the script fails, a file named `CODEX_ENVIRONMENT_SETUP_FAILED` will appear in the repository root. After provisioning, network access is disabled. See [AGENTS.md#environment-setup](AGENTS.md#environment-setup) for instructions on fixing and rerunning the setup offline.
+The initial workspace setup runs [`scripts/codex_setup.sh`](scripts/codex_setup.sh) with network access enabled. If the script fails, a file named `CODEX_ENVIRONMENT_SETUP_FAILED` will appear in the repository root. After provisioning, network access is disabled. See [AGENTS.md#environment-setup](AGENTS.md#environment-setup) for instructions on fixing and rerunning the setup offline. Once the script completes successfully and the marker file is removed, run `poetry run pytest` to verify your environment.
 
 ## Installation
 
@@ -172,8 +172,9 @@ The repository includes runnable examples that walk through common workflows:
 
 ## Running Tests
 
+Run `scripts/codex_setup.sh` first to provision the environment. Once it finishes without errors, execute the test suite with `poetry run pytest`.
 
-Before running the test suite, you **must** install DevSynth with its development extras:
+Before running the test suite manually, you **must** install DevSynth with its development extras:
 
 ```bash
 poetry install --with dev

--- a/scripts/codex_setup.sh
+++ b/scripts/codex_setup.sh
@@ -1,16 +1,13 @@
 set -exo pipefail
 
-# Install the minimal runtime and development packages needed for tests.
-# Optional extras enable memory and LLM providers so pytest can run
-# without manual intervention in the offline environment.
+# Use the Python 3.12 interpreter for the Poetry environment
+poetry env use "$(command -v python3.12)"
+
+# Install all optional extras along with the dev and docs dependency groups.
+# This ensures memory and LLM providers are available for the test suite.
 poetry install \
-  --with dev \
-  --with docs \
-  --extras docs \
-  --extras minimal \
-  --extras memory \
-  --extras llm \
-  --extras dev \
+  --with dev,docs \
+  --all-extras \
   --no-interaction
 
 # Verify key packages are present


### PR DESCRIPTION
## Summary
- use Python 3.12 and install all extras in `codex_setup.sh`
- note running `poetry run pytest` after setup in AGENTS.md and README

## Testing
- `bash scripts/codex_setup.sh`
- `poetry run pytest` *(fails: 354 failed, 1448 passed, 82 skipped, 29 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68787651da548333b44c358dadd4c2ff