### PR TITLE
Add lmstudio extra and guard LM Studio tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -118,6 +118,7 @@ minimal = [
 retrieval = ["kuzu", "faiss-cpu"]
 dsp = ["dspy-ai"]
 chromadb = ["chromadb"]
+lmstudio = ["lmstudio"]
 memory = ["tinydb", "duckdb", "lmdb", "kuzu", "faiss-cpu", "chromadb"]
 llm = ["tiktoken", "httpx", "dspy-ai"]
 dev = [

--- a/tests/integration/test_lmstudio_provider.py
+++ b/tests/integration/test_lmstudio_provider.py
@@ -2,7 +2,12 @@ import os
 import pytest
 import tempfile
 from unittest.mock import patch, MagicMock
-from devsynth.application.llm.lmstudio_provider import LMStudioProvider, LMStudioConnectionError, LMStudioModelError
+pytest.importorskip("lmstudio")
+from devsynth.application.llm.lmstudio_provider import (
+    LMStudioProvider,
+    LMStudioConnectionError,
+    LMStudioModelError,
+)
 lmstudio_available = pytest.mark.requires_resource('lmstudio')
 
 

--- a/tests/unit/test_lmstudio_provider_unit.py
+++ b/tests/unit/test_lmstudio_provider_unit.py
@@ -2,6 +2,9 @@ import unittest
 from unittest.mock import patch, MagicMock
 import json
 import os
+import pytest
+pytest.importorskip("lmstudio")
+pytestmark = pytest.mark.requires_resource("lmstudio")
 from devsynth.application.llm.lmstudio_provider import LMStudioProvider
 import requests
 from devsynth.application.utils.token_tracker import TokenTracker, TokenLimitExceededError


### PR DESCRIPTION
## Summary
- add `lmstudio` to optional extras
- skip LM Studio provider tests when the dependency is missing

## Testing
- `poetry run pytest` *(fails: 350 failed, 1447 passed, 87 skipped, 29 errors)*

------
https://chatgpt.com/codex/tasks/task_e_687878d0f3208333b408238c56af8873