### PR TITLE
Add MemoryType tests

### DIFF
--- a/docs/roadmap/development_status.md
+++ b/docs/roadmap/development_status.md
@@ -411,7 +411,7 @@ All phases of the DevSynth Repository Harmonization Plan have been successfully 
 
 ### Outstanding Tasks
 
-- Finalize unit tests for the `MemoryType` enum and resolve any remaining failures.
+- ~~Finalize unit tests for the `MemoryType` enum and resolve any remaining failures.~~
 - Verify that the EDRR coordinator and AST code analysis features fully match their BDD scenarios.
 - Complete WSDE agent collaboration capabilities.
 

--- a/tests/unit/domain/test_memory_type.py
+++ b/tests/unit/domain/test_memory_type.py
@@ -1,0 +1,16 @@
+import json
+from devsynth.domain.models.memory import MemoryType
+
+
+def test_memory_type_serialization_deserialization():
+    """Ensure all MemoryType members serialize and deserialize correctly."""
+    for name, member in MemoryType.__members__.items():
+        serialized = json.dumps(member.value)
+        deserialized_value = json.loads(serialized)
+        assert deserialized_value == member.value
+        assert MemoryType(deserialized_value) is member
+
+
+def test_working_memory_alias():
+    """Alias WORKING_MEMORY should reference the same member as WORKING."""
+    assert MemoryType.WORKING_MEMORY is MemoryType.WORKING


### PR DESCRIPTION
## Summary
- create unit tests for MemoryType enum covering all members
- mark outstanding task complete in roadmap

## Testing
- `poetry run pytest tests/unit/domain/test_memory_type.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68799f78c87c8333937681cf6b1ee571