### PR TITLE
Implement ChromaDB vector adapter

### DIFF
--- a/src/devsynth/application/memory/adapters/chromadb_vector_adapter.py
+++ b/src/devsynth/application/memory/adapters/chromadb_vector_adapter.py
@@ -4,176 +4,190 @@ ChromaDB Vector Adapter Module
 This module provides a memory adapter that handles vector-based operations
 for similarity search using ChromaDB as the backend.
 """
+
+"""
+Adapter for using ChromaDB as a simple vector store.
+
+The previous implementation only stored vectors in a local dictionary.  This
+update provides real interactions with ChromaDB using its client API so that
+vectors are persisted and retrieved from a ChromaDB collection.
+"""
+
+from typing import Any, Dict, List, Optional
+
 import numpy as np
-from typing import Dict, List, Any, Optional
+
+try:  # pragma: no cover - optional dependency
+    import chromadb
+    from chromadb.config import Settings
+except Exception as e:  # pragma: no cover - if chromadb is missing the tests skip
+    raise ImportError(
+        "ChromaDBVectorAdapter requires the 'chromadb' package. Install it with 'pip install chromadb' or use the dev extras."
+    ) from e
+
 from ....domain.models.memory import MemoryVector
 from ....domain.interfaces.memory import VectorStore
 from ....logging_setup import DevSynthLogger
 
 logger = DevSynthLogger(__name__)
 
+
 class ChromaDBVectorAdapter(VectorStore):
     """
     ChromaDB Vector Adapter handles vector-based operations for similarity search using ChromaDB.
-    
+
     It implements the VectorStore interface and provides methods for storing,
     retrieving, and searching vectors using ChromaDB as the backend.
     """
-    
-    def __init__(self, collection_name: str = "default", persist_directory: Optional[str] = None):
+
+    def __init__(
+        self, collection_name: str = "default", persist_directory: Optional[str] = None
+    ):
         """
         Initialize the ChromaDB Vector Adapter.
-        
+
         Args:
             collection_name: Name of the ChromaDB collection
             persist_directory: Directory to persist ChromaDB data (if None, in-memory only)
         """
         self.collection_name = collection_name
         self.persist_directory = persist_directory
-        self.vectors = {}  # Dictionary of memory vectors by ID (for local caching)
-        logger.info(f"ChromaDB Vector Adapter initialized with collection '{collection_name}'")
-        
-        # Note: In a real implementation, we would initialize ChromaDB client here
-        # self.client = chromadb.Client()
-        # self.collection = self.client.get_or_create_collection(collection_name)
-    
+        self.vectors: Dict[str, MemoryVector] = {}
+
+        if persist_directory:
+            self.client = chromadb.PersistentClient(path=persist_directory)
+        else:
+            # Use an in-memory client when no directory is provided
+            settings = Settings(anonymized_telemetry=False)
+            self.client = chromadb.EphemeralClient(settings)
+
+        self.collection = self.client.get_or_create_collection(collection_name)
+        logger.info(
+            "ChromaDB Vector Adapter initialized with collection '%s'", collection_name
+        )
+
     def store_vector(self, vector: MemoryVector) -> str:
         """
         Store a vector in the vector store.
-        
+
         Args:
             vector: The memory vector to store
-            
+
         Returns:
             The ID of the stored vector
         """
-        # Generate an ID if not provided
         if not vector.id:
             vector.id = f"vector_{len(self.vectors) + 1}"
-        
-        # Store the vector locally
+
+        self.collection.add(
+            ids=[vector.id],
+            embeddings=[vector.embedding],
+            metadatas=[vector.metadata or {}],
+            documents=[vector.content],
+        )
+
         self.vectors[vector.id] = vector
-        
-        # Note: In a real implementation, we would store in ChromaDB
-        # self.collection.add(
-        #     ids=[vector.id],
-        #     embeddings=[vector.embedding],
-        #     metadatas=[vector.metadata]
-        # )
-        
-        logger.info(f"Stored memory vector with ID {vector.id} in ChromaDB Vector Adapter")
+        logger.info("Stored memory vector with ID %s in ChromaDB", vector.id)
         return vector.id
-    
+
     def retrieve_vector(self, vector_id: str) -> Optional[MemoryVector]:
         """
         Retrieve a vector from the vector store.
-        
+
         Args:
             vector_id: The ID of the vector to retrieve
-            
+
         Returns:
             The retrieved vector, or None if not found
         """
-        # Note: In a real implementation, we would retrieve from ChromaDB
-        # result = self.collection.get(ids=[vector_id])
-        # if result and result['ids']:
-        #     return MemoryVector(
-        #         id=result['ids'][0],
-        #         embedding=result['embeddings'][0],
-        #         metadata=result['metadatas'][0]
-        #     )
-        # return None
-        
-        return self.vectors.get(vector_id)
-    
-    def similarity_search(self, query_embedding: List[float], top_k: int = 5) -> List[MemoryVector]:
+        result = self.collection.get(
+            ids=[vector_id], include=["embeddings", "metadatas", "documents"]
+        )
+        if result and result.get("ids"):
+            vector = MemoryVector(
+                id=result["ids"][0],
+                content=result.get("documents", [None])[0],
+                embedding=result.get("embeddings", [[None]])[0],
+                metadata=result.get("metadatas", [{}])[0],
+            )
+            self.vectors[vector_id] = vector
+            return vector
+        return None
+
+    def similarity_search(
+        self, query_embedding: List[float], top_k: int = 5
+    ) -> List[MemoryVector]:
         """
         Search for vectors similar to the query embedding.
-        
+
         Args:
             query_embedding: The query embedding
             top_k: The number of results to return
-            
+
         Returns:
             A list of similar memory vectors
         """
-        if not self.vectors:
+        results = self.collection.query(
+            query_embeddings=[query_embedding],
+            n_results=top_k,
+            include=["embeddings", "metadatas", "documents"],
+        )
+
+        if not results or not results.get("ids") or not results["ids"][0]:
             return []
-        
-        # Note: In a real implementation, we would use ChromaDB's query method
-        # results = self.collection.query(
-        #     query_embeddings=[query_embedding],
-        #     n_results=top_k
-        # )
-        # 
-        # return [
-        #     MemoryVector(
-        #         id=id,
-        #         embedding=embedding,
-        #         metadata=metadata
-        #     )
-        #     for id, embedding, metadata in zip(
-        #         results['ids'][0],
-        #         results['embeddings'][0],
-        #         results['metadatas'][0]
-        #     )
-        # ]
-        
-        # Simplified implementation for placeholder
-        query_embedding_np = np.array(query_embedding)
-        similarities = {}
-        
-        for vector_id, vector in self.vectors.items():
-            embedding = np.array(vector.embedding)
-            query_norm = np.linalg.norm(query_embedding_np)
-            embedding_norm = np.linalg.norm(embedding)
-            
-            if query_norm == 0 or embedding_norm == 0:
-                similarities[vector_id] = 0
-            else:
-                similarity = np.dot(query_embedding_np, embedding) / (query_norm * embedding_norm)
-                similarities[vector_id] = similarity
-        
-        sorted_ids = sorted(similarities.keys(), key=lambda x: similarities[x], reverse=True)
-        top_k_ids = sorted_ids[:top_k]
-        
-        return [self.vectors[vector_id] for vector_id in top_k_ids]
-    
+
+        vectors = []
+        for i, vid in enumerate(results["ids"][0]):
+            vector = MemoryVector(
+                id=vid,
+                content=results.get("documents", [[None]])[0][i],
+                embedding=results.get("embeddings", [[None]])[0][i],
+                metadata=results.get("metadatas", [[{}]])[0][i],
+            )
+            self.vectors[vid] = vector
+            vectors.append(vector)
+
+        return vectors
+
     def delete_vector(self, vector_id: str) -> bool:
         """
         Delete a vector from the vector store.
-        
+
         Args:
             vector_id: The ID of the vector to delete
-            
+
         Returns:
             True if the vector was deleted, False otherwise
         """
-        if vector_id in self.vectors:
-            # Remove from local cache
-            del self.vectors[vector_id]
-            
-            # Note: In a real implementation, we would delete from ChromaDB
-            # self.collection.delete(ids=[vector_id])
-            
-            logger.info(f"Deleted memory vector with ID {vector_id} from ChromaDB Vector Adapter")
-            return True
-        
-        return False
-    
+        result = self.collection.get(ids=[vector_id])
+        if not result or not result.get("ids"):
+            return False
+
+        self.collection.delete(ids=[vector_id])
+        self.vectors.pop(vector_id, None)
+        logger.info("Deleted memory vector with ID %s from ChromaDB", vector_id)
+        return True
+
     def get_collection_stats(self) -> Dict[str, Any]:
         """
         Get statistics about the vector store collection.
-        
+
         Returns:
             A dictionary of statistics
         """
         # Note: In a real implementation, we would get stats from ChromaDB
         # count = self.collection.count()
-        
+
+        result = self.collection.get(include=["embeddings"])
+        count = len(result.get("ids", [])) if result else 0
+        dimension = 0
+        if count > 0 and result.get("embeddings"):
+            first = result["embeddings"][0]
+            dimension = len(first) if not hasattr(first, "shape") else first.shape[0]
+
         return {
-            "vector_count": len(self.vectors),
+            "vector_count": count,
             "collection_name": self.collection_name,
             "persist_directory": self.persist_directory,
-            "embedding_dimensions": len(next(iter(self.vectors.values())).embedding) if self.vectors else 0
+            "embedding_dimensions": dimension,
         }

--- a/tests/unit/adapters/test_chromadb_vector_adapter.py
+++ b/tests/unit/adapters/test_chromadb_vector_adapter.py
@@ -1,0 +1,102 @@
+import os
+import tempfile
+import uuid
+from unittest.mock import patch, MagicMock, create_autospec
+
+import pytest
+
+from devsynth.application.memory.adapters.chromadb_vector_adapter import (
+    ChromaDBVectorAdapter,
+)
+from devsynth.domain.models.memory import MemoryVector
+
+try:
+    import chromadb
+    from chromadb.api.models.Collection import Collection
+except Exception:  # pragma: no cover - optional dependency
+    chromadb = None
+    Collection = object
+
+pytestmark = pytest.mark.requires_resource("chromadb")
+
+
+@pytest.fixture
+def mock_chromadb_client():
+    client = create_autospec(chromadb.Client if chromadb else object)
+    collection = create_autospec(Collection)
+    client.get_or_create_collection.return_value = collection
+    return client, collection
+
+
+@pytest.fixture
+def temp_dir(tmp_path):
+    return str(tmp_path)
+
+
+@pytest.fixture
+def vector_adapter(temp_dir, mock_chromadb_client):
+    mock_client, mock_collection = mock_chromadb_client
+    with patch(
+        "devsynth.application.memory.adapters.chromadb_vector_adapter.chromadb.PersistentClient",
+        return_value=mock_client,
+    ):
+        adapter = ChromaDBVectorAdapter(
+            collection_name="test", persist_directory=temp_dir
+        )
+        adapter.collection = mock_collection
+        yield adapter
+
+
+def test_store_and_retrieve_vector(vector_adapter, mock_chromadb_client):
+    _, collection = mock_chromadb_client
+    collection.get.return_value = {
+        "ids": ["v1"],
+        "embeddings": [[0.1, 0.2]],
+        "metadatas": [{"foo": "bar"}],
+        "documents": ["content"],
+    }
+    vec = MemoryVector(
+        id="v1", content="content", embedding=[0.1, 0.2], metadata={"foo": "bar"}
+    )
+    vid = vector_adapter.store_vector(vec)
+    assert vid == "v1"
+    collection.add.assert_called_once_with(
+        ids=["v1"],
+        embeddings=[[0.1, 0.2]],
+        metadatas=[{"foo": "bar"}],
+        documents=["content"],
+    )
+    out = vector_adapter.retrieve_vector("v1")
+    collection.get.assert_called_with(
+        ids=["v1"], include=["embeddings", "metadatas", "documents"]
+    )
+    assert out is not None and out.id == "v1"
+    assert out.content == "content"
+
+
+def test_similarity_search(vector_adapter, mock_chromadb_client):
+    _, collection = mock_chromadb_client
+    collection.query.return_value = {
+        "ids": [["v1", "v2"]],
+        "embeddings": [
+            [
+                [0.1, 0.2],
+                [0.2, 0.3],
+            ]
+        ],
+        "metadatas": [[{"a": 1}, {"a": 2}]],
+        "documents": [["c1", "c2"]],
+    }
+    results = vector_adapter.similarity_search([0.1, 0.2], top_k=2)
+    collection.query.assert_called_once()
+    assert len(results) == 2
+    assert {r.id for r in results} == {"v1", "v2"}
+
+
+def test_delete_vector(vector_adapter, mock_chromadb_client):
+    _, collection = mock_chromadb_client
+    collection.get.return_value = {"ids": ["v1"]}
+    assert vector_adapter.delete_vector("v1") is True
+    collection.delete.assert_called_with(ids=["v1"])
+    collection.get.return_value = {"ids": []}
+    assert vector_adapter.delete_vector("v1") is False


### PR DESCRIPTION
## Summary
- implement real ChromaDB interactions for `ChromaDBVectorAdapter`
- add unit tests exercising store, retrieve, search and delete

## Testing
- `poetry run pytest tests/unit/adapters/test_chromadb_vector_adapter.py`

------
https://chatgpt.com/codex/tasks/task_e_687a56a250a483339dd2eb07d5e1260c