### PR TITLE
Add memory enum and workflow tests

### DIFF
--- a/tests/integration/test_wsde_peer_review_workflow.py
+++ b/tests/integration/test_wsde_peer_review_workflow.py
@@ -1,0 +1,23 @@
+import pytest
+from devsynth.domain.models.wsde import WSDETeam
+from devsynth.application.collaboration.peer_review import run_peer_review
+
+class DummyAgent:
+    def __init__(self, name):
+        self.name = name
+
+@pytest.fixture
+def wsde_team():
+    team = WSDETeam(name='PeerReviewTeam')
+    team.add_agent(DummyAgent('author'))
+    team.add_agent(DummyAgent('reviewer1'))
+    team.add_agent(DummyAgent('reviewer2'))
+    return team
+
+def test_run_peer_review_workflow(wsde_team):
+    author = wsde_team.agents[0]
+    reviewers = wsde_team.agents[1:]
+    result = run_peer_review({'text': 'demo'}, author, reviewers)
+    assert result['status'] in {'approved', 'rejected'}
+    assert 'workflow' in result
+    assert 'revision_cycles' in result['workflow']

--- a/tests/unit/application/code_analysis/test_ast_workflow_integration.py
+++ b/tests/unit/application/code_analysis/test_ast_workflow_integration.py
@@ -5,6 +5,7 @@ from devsynth.application.code_analysis.ast_workflow_integration import AstWorkf
 from devsynth.application.memory.memory_manager import MemoryManager
 from devsynth.application.code_analysis.analyzer import CodeAnalyzer
 from devsynth.domain.models.memory import MemoryItem, MemoryType
+from devsynth.methodology.base import Phase
 
 
 class MockMemoryStore:
@@ -79,8 +80,14 @@ class Calculator:
         options = [{'name': 'no_docs', 'description': '', 'code':
             code_no_docs}, {'name': 'with_docs', 'description': '', 'code':
             code_with_docs}]
-        selected = self.integration.differentiate_implementation_quality(
-            options, 'task')
+        with patch.object(self.memory_manager, 'store_with_edrr_phase') as store:
+            store.return_value = 'id1'
+            selected = self.integration.differentiate_implementation_quality(
+                options, 'task')
+            store.assert_called()
+            kwargs = store.call_args.kwargs
+            assert kwargs['memory_type'] == MemoryType.CODE_ANALYSIS
+            assert kwargs['edrr_phase'] == Phase.DIFFERENTIATE.value
         self.assertEqual(selected['name'], 'with_docs')
         metrics = selected['metrics']
         for key in ['complexity', 'readability', 'maintainability']:

--- a/tests/unit/application/edrr/test_edrr_coordinator.py
+++ b/tests/unit/application/edrr/test_edrr_coordinator.py
@@ -6,6 +6,7 @@ from devsynth.application.edrr.coordinator import EDRRCoordinator, EDRRCoordinat
 from devsynth.methodology.base import Phase
 from devsynth.application.memory.memory_manager import MemoryManager
 from devsynth.domain.models.wsde import WSDETeam
+from devsynth.domain.models.memory import MemoryType
 from devsynth.application.code_analysis.analyzer import CodeAnalyzer
 from devsynth.application.code_analysis.ast_transformer import AstTransformer
 from devsynth.application.prompts.prompt_manager import PromptManager
@@ -145,6 +146,10 @@ ReqID: N/A"""
         assert code_analyzer.analyze_project_structure.call_count == 1
         assert memory_manager.store_with_edrr_phase.call_count >= 1
         assert f'EXPAND_{coordinator.cycle_id}' in coordinator._execution_traces
+        stored = memory_manager.stored_items[MemoryType.SOLUTION]
+        assert stored['phase'] == 'EXPAND'
+        assert stored['metadata']['cycle_id'] == 'test-cycle-id'
+        assert stored['item'] == results
 
     def test_differentiate_phase_execution_has_expected(self, coordinator,
         memory_manager, wsde_team):
@@ -168,6 +173,10 @@ ReqID: N/A"""
         assert wsde_team.formulate_decision_criteria.call_count == 1
         assert memory_manager.store_with_edrr_phase.call_count >= 1
         assert f'DIFFERENTIATE_{coordinator.cycle_id}' in coordinator._execution_traces
+        stored = memory_manager.stored_items[MemoryType.SOLUTION]
+        assert stored['phase'] == 'DIFFERENTIATE'
+        assert stored['metadata']['cycle_id'] == 'test-cycle-id'
+        assert stored['item'] == results
 
     def test_refine_phase_execution_has_expected(self, coordinator,
         memory_manager, wsde_team):
@@ -195,6 +204,10 @@ ReqID: N/A"""
         assert wsde_team.perform_quality_assurance.call_count == 1
         assert memory_manager.store_with_edrr_phase.call_count >= 1
         assert f'REFINE_{coordinator.cycle_id}' in coordinator._execution_traces
+        stored = memory_manager.stored_items[MemoryType.SOLUTION]
+        assert stored['phase'] == 'REFINE'
+        assert stored['metadata']['cycle_id'] == 'test-cycle-id'
+        assert stored['item'] == results
 
     def test_retrospect_phase_execution_has_expected(self, coordinator,
         memory_manager, wsde_team):
@@ -226,6 +239,10 @@ ReqID: N/A"""
         assert wsde_team.generate_improvement_suggestions.call_count == 1
         assert memory_manager.store_with_edrr_phase.call_count >= 2
         assert f'RETROSPECT_{coordinator.cycle_id}' in coordinator._execution_traces
+        stored = memory_manager.stored_items["RETROSPECT_RESULTS"]
+        assert stored['phase'] == 'RETROSPECT'
+        assert stored['metadata']['cycle_id'] == 'test-cycle-id'
+        assert stored['item'] == results
 
     def test_generate_final_report_succeeds(self, coordinator):
         """Test generating the final report.

--- a/tests/unit/domain/test_memory_type.py
+++ b/tests/unit/domain/test_memory_type.py
@@ -1,4 +1,5 @@
 import json
+import pytest
 from devsynth.domain.models.memory import MemoryType
 
 
@@ -14,3 +15,34 @@ def test_memory_type_serialization_deserialization():
 def test_working_memory_alias():
     """Alias WORKING_MEMORY should reference the same member as WORKING."""
     assert MemoryType.WORKING_MEMORY is MemoryType.WORKING
+
+
+def test_memory_type_members_complete():
+    """Verify that all expected memory types are present."""
+    expected = [
+        "SHORT_TERM",
+        "LONG_TERM",
+        "WORKING",
+        "EPISODIC",
+        "SOLUTION",
+        "DIALECTICAL_REASONING",
+        "TEAM_STATE",
+        "KNOWLEDGE_GRAPH",
+        "RELATIONSHIP",
+        "CODE_ANALYSIS",
+        "CODE",
+        "CODE_TRANSFORMATION",
+        "DOCUMENTATION",
+        "CONTEXT",
+        "CONVERSATION",
+        "TASK_HISTORY",
+        "KNOWLEDGE",
+        "ERROR_LOG",
+    ]
+    assert [member.name for member in MemoryType] == expected
+
+
+@pytest.mark.parametrize("value", [m.value for m in MemoryType])
+def test_memory_type_lookup_by_value(value):
+    """Ensure enum members can be retrieved from their values."""
+    assert MemoryType(value).value == value


### PR DESCRIPTION
## Summary
- expand MemoryType tests for complete coverage and lookup
- verify EDRRCoordinator stores results with correct tags
- ensure AST workflow stores analysis with EDRR phase
- add integration test for WSDE peer review workflow

## Testing
- `poetry run pytest -q tests/unit/domain/test_memory_type.py tests/unit/application/edrr/test_edrr_coordinator.py::TestEDRRCoordinator::test_expand_phase_execution_has_expected tests/unit/application/edrr/test_edrr_coordinator.py::TestEDRRCoordinator::test_differentiate_phase_execution_has_expected tests/unit/application/edrr/test_edrr_coordinator.py::TestEDRRCoordinator::test_refine_phase_execution_has_expected tests/unit/application/edrr/test_edrr_coordinator.py::TestEDRRCoordinator::test_retrospect_phase_execution_has_expected tests/unit/application/code_analysis/test_ast_workflow_integration.py::TestAstWorkflowIntegration::test_differentiate_selects_best_option_succeeds tests/integration/test_wsde_peer_review_workflow.py::test_run_peer_review_workflow -q`

------
https://chatgpt.com/codex/tasks/task_e_687a6ba9cd288333911723d3d88e2e99