### PR TITLE
Add memory alias tests and fix setup script

### DIFF
--- a/scripts/codex_setup.sh
+++ b/scripts/codex_setup.sh
@@ -1,7 +1,7 @@
 set -exo pipefail
 
-# Use the Python 3.12 interpreter for the Poetry environment
-poetry env use "$(command -v python3.12)"
+# Use Python 3.12 if available, otherwise fall back to Python 3.11
+poetry env use "$(command -v python3.12 || command -v python3.11)"
 
 # Install all optional extras along with the dev and docs dependency groups.
 # This ensures memory and LLM providers are available for the test suite.

--- a/tests/unit/test_memory_models.py
+++ b/tests/unit/test_memory_models.py
@@ -1,6 +1,6 @@
 import pytest
 from datetime import datetime
-from devsynth.domain.models.memory import MemoryType, MemoryItem
+from devsynth.domain.models.memory import MemoryType, MemoryItem, MemoryItemType
 
 
 class TestMemoryModels:
@@ -44,3 +44,16 @@ ReqID: N/A"""
         assert memory_item.memory_type == MemoryType.LONG_TERM
         assert memory_item.metadata == custom_metadata
         assert memory_item.created_at == custom_time
+
+    def test_memory_type_aliases(self):
+        """Ensure enum aliases reference the same member."""
+
+        # WORKING_MEMORY should refer to the same enum member as WORKING
+        assert MemoryType.WORKING_MEMORY is MemoryType.WORKING
+
+    def test_memory_item_type_alias(self):
+        """Ensure MemoryItemType is an alias of MemoryType."""
+
+        assert MemoryItemType is MemoryType
+        # Spot check a member via the alias
+        assert MemoryItemType.SHORT_TERM is MemoryType.SHORT_TERM


### PR DESCRIPTION
## Summary
- use available Python version in setup script
- confirm memory enum aliases via tests

## Testing
- `poetry run pytest tests/unit/test_memory_models.py::TestMemoryModels::test_memory_type_aliases tests/unit/test_memory_models.py::TestMemoryModels::test_memory_item_type_alias -q`
- `poetry run pytest` *(fails: 318 failed, 1548 passed, 91 skipped, 26 errors)*

------
https://chatgpt.com/codex/tasks/task_e_687a77cd21a0833380ac1c873bc41be9