### PR TITLE
Fix integration tests for refactor workflow

### DIFF
--- a/src/devsynth/core/workflows.py
+++ b/src/devsynth/core/workflows.py
@@ -5,14 +5,20 @@ from pathlib import Path
 import json
 import yaml
 
-from devsynth.application.orchestration.workflow import workflow_manager
 from devsynth.interface.ux_bridge import UXBridge
 from devsynth.config import get_project_config, save_config
 
 
+def _get_workflow_manager():
+    """Return the global ``WorkflowManager`` instance lazily."""
+    from devsynth.application.orchestration.workflow import workflow_manager
+
+    return workflow_manager
+
+
 def execute_command(command: str, args: Dict[str, Any]) -> Dict[str, Any]:
     """Execute a workflow command through the application workflow manager."""
-    return workflow_manager.execute_command(command, args)
+    return _get_workflow_manager().execute_command(command, args)
 
 
 def filter_args(args: Dict[str, Any]) -> Dict[str, Any]:

--- a/tests/integration/test_refactor_workflow.py
+++ b/tests/integration/test_refactor_workflow.py
@@ -10,6 +10,7 @@ import pytest
 import tempfile
 import shutil
 from pathlib import Path
+from unittest.mock import patch
 from devsynth.application.orchestration.refactor_workflow import RefactorWorkflowManager
 from devsynth.application.cli.cli_commands import init_cmd
 
@@ -33,7 +34,7 @@ ReqID: N/A"""
 
 ReqID: N/A"""
         with patch('devsynth.application.cli.cli_commands.bridge.ask_question',
-            side_effect=[temp_project_dir, 'python', '']), patch(
+            side_effect=[temp_project_dir, 'python', '', 'memory']), patch(
             'devsynth.application.cli.cli_commands.bridge.confirm_choice',
             return_value=True):
             init_cmd()
@@ -75,7 +76,7 @@ ReqID: N/A"""
 
 ReqID: N/A"""
         with patch('devsynth.application.cli.cli_commands.bridge.ask_question',
-            side_effect=[temp_project_dir, 'python', '']), patch(
+            side_effect=[temp_project_dir, 'python', '', 'memory']), patch(
             'devsynth.application.cli.cli_commands.bridge.confirm_choice',
             return_value=True):
             init_cmd()
@@ -168,7 +169,7 @@ ReqID: N/A"""
 
 ReqID: N/A"""
         with patch('devsynth.application.cli.cli_commands.bridge.ask_question',
-            side_effect=[temp_project_dir, 'python', '']), patch(
+            side_effect=[temp_project_dir, 'python', '', 'memory']), patch(
             'devsynth.application.cli.cli_commands.bridge.confirm_choice',
             return_value=True):
             init_cmd()
@@ -204,7 +205,7 @@ ReqID: N/A"""
 
 ReqID: N/A"""
         with patch('devsynth.application.cli.cli_commands.bridge.ask_question',
-            side_effect=[temp_project_dir, 'python', '']), patch(
+            side_effect=[temp_project_dir, 'python', '', 'memory']), patch(
             'devsynth.application.cli.cli_commands.bridge.confirm_choice',
             return_value=True):
             init_cmd()
@@ -239,7 +240,7 @@ ReqID: N/A"""
 
 ReqID: N/A"""
         with patch('devsynth.application.cli.cli_commands.bridge.ask_question',
-            side_effect=[temp_project_dir, 'python', '']), patch(
+            side_effect=[temp_project_dir, 'python', '', 'memory']), patch(
             'devsynth.application.cli.cli_commands.bridge.confirm_choice',
             return_value=True):
             init_cmd()

--- a/tests/integration/test_requirements_gathering.py
+++ b/tests/integration/test_requirements_gathering.py
@@ -1,5 +1,6 @@
 import os
 import yaml
+from unittest.mock import patch
 from devsynth.application.cli.cli_commands import init_cmd, gather_cmd
 
 
@@ -9,7 +10,7 @@ def test_gather_updates_config_succeeds(tmp_path):
 ReqID: N/A"""
     os.chdir(tmp_path)
     with patch('devsynth.application.cli.cli_commands.bridge.ask_question',
-        side_effect=[str(tmp_path), 'python', '']), patch(
+        side_effect=[str(tmp_path), 'python', '', 'memory']), patch(
         'devsynth.application.cli.cli_commands.bridge.confirm_choice',
         return_value=True):
         init_cmd()
@@ -26,7 +27,13 @@ ReqID: N/A"""
             self.i += 1
             return val
 
+        def prompt(self, *a, **k):
+            return self.ask_question(*a, **k)
+
         def confirm_choice(self, *a, **k):
+            return True
+
+        def confirm(self, *a, **k):
             return True
 
         def display_result(self, *a, **k):


### PR DESCRIPTION
## Summary
- avoid circular import by lazy-loading workflow manager
- include health report fields in `analyze_project_state`
- simplify workflow determination and suggestions
- expose success metadata from `execute_refactor_workflow`
- update integration tests accordingly

## Testing
- `poetry run pytest tests/integration/test_refactor_workflow.py -vv`
- `poetry run pytest tests/integration/test_requirements_gathering.py -vv`


------
https://chatgpt.com/codex/tasks/task_e_687ac86f13b48333a568f5f70a60039c