### PR TITLE
Add EXPERT AgentType and update integration tests

### DIFF
--- a/src/devsynth/domain/models/agent.py
+++ b/src/devsynth/domain/models/agent.py
@@ -1,4 +1,3 @@
-
 from dataclasses import dataclass
 from typing import Dict, List, Any, Optional
 from enum import Enum
@@ -9,11 +8,16 @@ from devsynth.logging_setup import DevSynthLogger
 logger = DevSynthLogger(__name__)
 from devsynth.exceptions import DevSynthError
 
+
 class AgentType(Enum):
     """Types of agents in the DevSynth system."""
+
     # MVP agent type
     ORCHESTRATOR = "orchestrator"  # Single unified agent for MVP
-    
+
+    # Generic expert agent used for specialized test agents
+    EXPERT = "expert"
+
     # Future agent types (retained for future multi-agent implementation)
     # These are commented in the enum definition but kept as values for backward compatibility
     PLANNER = "planner"
@@ -21,7 +25,7 @@ class AgentType(Enum):
     TESTER = "tester"
     REVIEWER = "reviewer"
     DOCUMENTER = "documenter"
-    
+
     # Original types (retained for backward compatibility)
     SPECIFICATION = "specification"
     TEST = "test"
@@ -32,18 +36,21 @@ class AgentType(Enum):
     DIAGRAM = "diagram"
     CRITIC = "critic"
 
+
 @dataclass
 class AgentConfig:
     """Configuration for an agent."""
+
     name: str
     agent_type: AgentType
     description: str
     capabilities: List[str]
     parameters: Dict[str, Any] = None
-    
+
     def __post_init__(self):
         if self.parameters is None:
             self.parameters = {}
+
 
 # Define MVP capabilities
 MVP_CAPABILITIES = [
@@ -53,7 +60,7 @@ MVP_CAPABILITIES = [
     "generate_tests",
     "generate_code",
     "validate_implementation",
-    "track_token_usage"
+    "track_token_usage",
 ]
 
 # Define future capabilities
@@ -66,5 +73,5 @@ FUTURE_CAPABILITIES = [
     "code_review",
     "style_checking",
     "best_practice_enforcement",
-    "multi_agent_collaboration"
+    "multi_agent_collaboration",
 ]

--- a/tests/integration/test_code_analysis_edrr_integration.py
+++ b/tests/integration/test_code_analysis_edrr_integration.py
@@ -5,6 +5,7 @@ This test verifies that the code analysis components (ProjectStateAnalyzer,
 SelfAnalyzer, CodeTransformer, AstWorkflowIntegration) can be used effectively
 within the EDRR framework to analyze and transform code during the development process.
 """
+
 import os
 import pytest
 from unittest.mock import MagicMock, patch
@@ -13,27 +14,55 @@ from devsynth.domain.models.wsde import WSDETeam
 from devsynth.application.memory.memory_manager import MemoryManager
 from devsynth.application.code_analysis.analyzer import CodeAnalyzer
 from devsynth.application.code_analysis.ast_transformer import AstTransformer
-from devsynth.application.code_analysis.project_state_analyzer import ProjectStateAnalyzer
+from devsynth.application.code_analysis.project_state_analyzer import (
+    ProjectStateAnalyzer,
+)
 from devsynth.application.code_analysis.self_analyzer import SelfAnalyzer
 from devsynth.application.code_analysis.transformer import CodeTransformer
-from devsynth.application.code_analysis.ast_workflow_integration import AstWorkflowIntegration
+from devsynth.application.code_analysis.ast_workflow_integration import (
+    AstWorkflowIntegration,
+)
 from devsynth.application.prompts.prompt_manager import PromptManager
-from devsynth.application.documentation.documentation_manager import DocumentationManager
+from devsynth.application.documentation.documentation_manager import (
+    DocumentationManager,
+)
 from devsynth.methodology.base import Phase
 from devsynth.domain.models.agent import AgentConfig, AgentType
 from devsynth.application.agents.unified_agent import UnifiedAgent
 from devsynth.domain.models.memory import MemoryType
 
 
+def test_agent_type_expert_exists():
+    """Ensure the EXPERT enum is defined."""
+    assert AgentType.EXPERT.value == "expert"
+
+
 class CodeAnalysisAgent(UnifiedAgent):
     """An agent that uses code analysis components to analyze and transform code."""
 
-    def __init__(self, name, code_analyzer, ast_transformer,
-        project_analyzer, self_analyzer, code_transformer, ast_workflow):
+    def __init__(
+        self,
+        name,
+        code_analyzer,
+        ast_transformer,
+        project_analyzer,
+        self_analyzer,
+        code_transformer,
+        ast_workflow,
+    ):
         """Initialize the agent with code analysis components."""
-        super().__init__(config=AgentConfig(name=name, agent_type=AgentType
-            .EXPERT, expertise=['code analysis', 'refactoring',
-            'architecture']))
+        super().__init__()
+        self.initialize(
+            AgentConfig(
+                name=name,
+                agent_type=AgentType.EXPERT,
+                description="Code analysis expert agent",
+                capabilities=["code analysis", "refactoring", "architecture"],
+                parameters={
+                    "expertise": ["code analysis", "refactoring", "architecture"]
+                },
+            )
+        )
         self.code_analyzer = code_analyzer
         self.ast_transformer = ast_transformer
         self.project_analyzer = project_analyzer
@@ -43,29 +72,35 @@ class CodeAnalysisAgent(UnifiedAgent):
 
     def process(self, task):
         """Process a task using code analysis components."""
-        if 'analyze_code' in task:
-            code = task['analyze_code']
-            return {'analysis': self.code_analyzer.analyze_code(code),
-                'quality_metrics': self.ast_workflow._calculate_complexity(
-                self.code_analyzer.analyze_code(code))}
-        elif 'transform_code' in task:
-            code = task['transform_code']
-            transformations = task.get('transformations', [
-                'remove_unused_imports', 'remove_unused_variables'])
-            return {'transformed': self.code_transformer.transform_code(
-                code, transformations)}
-        elif 'analyze_project' in task:
-            project_path = task['analyze_project']
-            return {'project_analysis': self.project_analyzer.analyze()}
-        elif 'analyze_self' in task:
-            return {'self_analysis': self.self_analyzer.analyze()}
-        elif 'refine_implementation' in task:
-            code = task['refine_implementation']
-            task_id = task.get('task_id', 'test_task')
-            return {'refined': self.ast_workflow.refine_implementation(code,
-                task_id)}
+        if "analyze_code" in task:
+            code = task["analyze_code"]
+            return {
+                "analysis": self.code_analyzer.analyze_code(code),
+                "quality_metrics": self.ast_workflow._calculate_complexity(
+                    self.code_analyzer.analyze_code(code)
+                ),
+            }
+        elif "transform_code" in task:
+            code = task["transform_code"]
+            transformations = task.get(
+                "transformations", ["remove_unused_imports", "remove_unused_variables"]
+            )
+            return {
+                "transformed": self.code_transformer.transform_code(
+                    code, transformations
+                )
+            }
+        elif "analyze_project" in task:
+            project_path = task["analyze_project"]
+            return {"project_analysis": self.project_analyzer.analyze()}
+        elif "analyze_self" in task:
+            return {"self_analysis": self.self_analyzer.analyze()}
+        elif "refine_implementation" in task:
+            code = task["refine_implementation"]
+            task_id = task.get("task_id", "test_task")
+            return {"refined": self.ast_workflow.refine_implementation(code, task_id)}
         else:
-            return {'error': 'Unknown task type'}
+            return {"error": "Unknown task type"}
 
 
 @pytest.fixture
@@ -76,59 +111,68 @@ def code_analysis_coordinator(tmp_path_factory):
     ast_transformer = AstTransformer()
     with pytest.MonkeyPatch.context() as mp:
         temp_dir = tmp_path_factory.getbasetemp()
-        project_file = temp_dir.joinpath('test_project')
-        project_file.write_text('# Test project')
+        project_file = temp_dir.joinpath("test_project")
+        project_file.write_text("# Test project")
         project_path = str(project_file)
-        mp.setenv('DEVSYNTH_PROJECT_DIR', project_path)
+        mp.setenv("DEVSYNTH_PROJECT_DIR", project_path)
         project_analyzer = ProjectStateAnalyzer(project_path)
         self_analyzer = SelfAnalyzer(project_path)
         code_transformer = CodeTransformer()
         ast_workflow = AstWorkflowIntegration(memory_manager)
-        code_analysis_agent = CodeAnalysisAgent('code_analyst',
-            code_analyzer, ast_transformer, project_analyzer, self_analyzer,
-            code_transformer, ast_workflow)
-        wsde_team = WSDETeam(name='TestCodeAnalysisEdrrIntegrationTeam')
+        code_analysis_agent = CodeAnalysisAgent(
+            "code_analyst",
+            code_analyzer,
+            ast_transformer,
+            project_analyzer,
+            self_analyzer,
+            code_transformer,
+            ast_workflow,
+        )
+        wsde_team = WSDETeam(name="TestCodeAnalysisEdrrIntegrationTeam")
         wsde_team.add_agent(code_analysis_agent)
         prompt_manager = PromptManager()
         doc_manager = DocumentationManager()
-        coordinator = EnhancedEDRRCoordinator(wsde_team=wsde_team,
-            memory_manager=memory_manager, prompt_manager=prompt_manager,
-            documentation_manager=doc_manager)
+        coordinator = EnhancedEDRRCoordinator(
+            wsde_team=wsde_team,
+            memory_manager=memory_manager,
+            prompt_manager=prompt_manager,
+            documentation_manager=doc_manager,
+        )
         yield coordinator
 
 
 def test_code_analysis_in_edrr_workflow_succeeds(code_analysis_coordinator):
     """Test that code analysis components can be used in an EDRR workflow.
 
-ReqID: N/A"""
-    task = {'analyze_code':
-        """
+    ReqID: N/A"""
+    task = {
+        "analyze_code": """
 def calculate_sum(a, b):
     result = a + b
     return result
         """
-        }
+    }
     with patch(
-        'devsynth.application.edrr.edrr_coordinator_enhanced.EnhancedEDRRCoordinator._get_llm_response'
-        ) as mock_llm:
-        mock_llm.return_value = 'This code looks good.'
-        result = code_analysis_coordinator.execute_single_agent_task(task=
-            task, agent_name='code_analyst', phase=Phase.ANALYSIS)
-        assert 'analysis' in result
-        assert 'quality_metrics' in result
-        analysis = result['analysis']
-        assert analysis.get_functions()[0]['name'] == 'calculate_sum'
-        quality_metrics = result['quality_metrics']
+        "devsynth.application.edrr.edrr_coordinator_enhanced.EnhancedEDRRCoordinator._get_llm_response"
+    ) as mock_llm:
+        mock_llm.return_value = "This code looks good."
+        result = code_analysis_coordinator.execute_single_agent_task(
+            task=task, agent_name="code_analyst", phase=Phase.ANALYSIS
+        )
+        assert "analysis" in result
+        assert "quality_metrics" in result
+        analysis = result["analysis"]
+        assert analysis.get_functions()[0]["name"] == "calculate_sum"
+        quality_metrics = result["quality_metrics"]
         assert 0 <= quality_metrics <= 1
 
 
-def test_code_transformation_in_edrr_workflow_succeeds(
-    code_analysis_coordinator):
+def test_code_transformation_in_edrr_workflow_succeeds(code_analysis_coordinator):
     """Test that code transformation can be performed in an EDRR workflow.
 
-ReqID: N/A"""
-    task = {'transform_code':
-        """
+    ReqID: N/A"""
+    task = {
+        "transform_code": """
 import os
 import sys
 import re  # This import is unused
@@ -144,41 +188,44 @@ def main():
     z = 15  # This variable is unused
     total = calculate_sum(x, y)
     print(f"The sum is {total}")
-        """
-        , 'transformations': ['remove_unused_imports',
-        'remove_unused_variables']}
+        """,
+        "transformations": ["remove_unused_imports", "remove_unused_variables"],
+    }
     with patch(
-        'devsynth.application.edrr.edrr_coordinator_enhanced.EnhancedEDRRCoordinator._get_llm_response'
-        ) as mock_llm:
-        mock_llm.return_value = 'Code has been transformed.'
-        result = code_analysis_coordinator.execute_single_agent_task(task=
-            task, agent_name='code_analyst', phase=Phase.IMPLEMENTATION)
-        assert 'transformed' in result
-        transformed = result['transformed']
-        assert 'import re' not in transformed.transformed_code
-        assert 'z = 15' not in transformed.transformed_code
+        "devsynth.application.edrr.edrr_coordinator_enhanced.EnhancedEDRRCoordinator._get_llm_response"
+    ) as mock_llm:
+        mock_llm.return_value = "Code has been transformed."
+        result = code_analysis_coordinator.execute_single_agent_task(
+            task=task, agent_name="code_analyst", phase=Phase.IMPLEMENTATION
+        )
+        assert "transformed" in result
+        transformed = result["transformed"]
+        assert "import re" not in transformed.transformed_code
+        assert "z = 15" not in transformed.transformed_code
 
 
 def test_code_refinement_in_edrr_workflow_succeeds(code_analysis_coordinator):
     """Test that code refinement can be performed in an EDRR workflow.
 
-ReqID: N/A"""
-    task = {'refine_implementation':
-        """
+    ReqID: N/A"""
+    task = {
+        "refine_implementation": """
 def calculate(a, b):
     # Redundant variable
     result = a + b
     return result
-        """
-        , 'task_id': 'test_refinement'}
+        """,
+        "task_id": "test_refinement",
+    }
     with patch(
-        'devsynth.application.edrr.edrr_coordinator_enhanced.EnhancedEDRRCoordinator._get_llm_response'
-        ) as mock_llm:
-        mock_llm.return_value = 'Code has been refined.'
-        result = code_analysis_coordinator.execute_single_agent_task(task=
-            task, agent_name='code_analyst', phase=Phase.REFINEMENT)
-        assert 'refined' in result
-        refined = result['refined']
-        assert 'original_code' in refined
-        assert 'refined_code' in refined
-        assert 'improvements' in refined
+        "devsynth.application.edrr.edrr_coordinator_enhanced.EnhancedEDRRCoordinator._get_llm_response"
+    ) as mock_llm:
+        mock_llm.return_value = "Code has been refined."
+        result = code_analysis_coordinator.execute_single_agent_task(
+            task=task, agent_name="code_analyst", phase=Phase.REFINEMENT
+        )
+        assert "refined" in result
+        refined = result["refined"]
+        assert "original_code" in refined
+        assert "refined_code" in refined
+        assert "improvements" in refined

--- a/tests/integration/test_code_analysis_wsde_integration.py
+++ b/tests/integration/test_code_analysis_wsde_integration.py
@@ -5,6 +5,7 @@ This test verifies that the code analysis components (ProjectStateAnalyzer,
 SelfAnalyzer, CodeTransformer, AstWorkflowIntegration) can be used effectively
 within the WSDE framework to analyze and transform code during the development process.
 """
+
 import os
 import pytest
 from unittest.mock import MagicMock, patch
@@ -12,25 +13,51 @@ from devsynth.domain.models.wsde import WSDETeam
 from devsynth.application.memory.memory_manager import MemoryManager
 from devsynth.application.code_analysis.analyzer import CodeAnalyzer
 from devsynth.application.code_analysis.ast_transformer import AstTransformer
-from devsynth.application.code_analysis.project_state_analyzer import ProjectStateAnalyzer
+from devsynth.application.code_analysis.project_state_analyzer import (
+    ProjectStateAnalyzer,
+)
 from devsynth.application.code_analysis.self_analyzer import SelfAnalyzer
 from devsynth.application.code_analysis.transformer import CodeTransformer
-from devsynth.application.code_analysis.ast_workflow_integration import AstWorkflowIntegration
+from devsynth.application.code_analysis.ast_workflow_integration import (
+    AstWorkflowIntegration,
+)
 from devsynth.domain.models.agent import AgentConfig, AgentType
 from devsynth.application.agents.unified_agent import UnifiedAgent
 from devsynth.domain.models.memory import MemoryType
 from devsynth.domain.models.task import Task, TaskStatus
 
 
+def test_agent_type_expert_exists():
+    """Ensure the EXPERT enum is defined."""
+    assert AgentType.EXPERT.value == "expert"
+
+
 class CodeAnalysisAgent(UnifiedAgent):
     """An agent that uses code analysis components to analyze and transform code."""
 
-    def __init__(self, name, code_analyzer, ast_transformer,
-        project_analyzer, self_analyzer, code_transformer, ast_workflow):
+    def __init__(
+        self,
+        name,
+        code_analyzer,
+        ast_transformer,
+        project_analyzer,
+        self_analyzer,
+        code_transformer,
+        ast_workflow,
+    ):
         """Initialize the agent with code analysis components."""
-        super().__init__(config=AgentConfig(name=name, agent_type=AgentType
-            .EXPERT, expertise=['code analysis', 'refactoring',
-            'architecture']))
+        super().__init__()
+        self.initialize(
+            AgentConfig(
+                name=name,
+                agent_type=AgentType.EXPERT,
+                description="Code analysis expert agent",
+                capabilities=["code analysis", "refactoring", "architecture"],
+                parameters={
+                    "expertise": ["code analysis", "refactoring", "architecture"]
+                },
+            )
+        )
         self.code_analyzer = code_analyzer
         self.ast_transformer = ast_transformer
         self.project_analyzer = project_analyzer
@@ -41,58 +68,71 @@ class CodeAnalysisAgent(UnifiedAgent):
     def process(self, task):
         """Process a task using code analysis components."""
         if isinstance(task, dict):
-            if 'analyze_code' in task:
-                code = task['analyze_code']
-                return {'analysis': self.code_analyzer.analyze_code(code),
-                    'quality_metrics': self.ast_workflow.
-                    _calculate_complexity(self.code_analyzer.analyze_code(
-                    code))}
-            elif 'transform_code' in task:
-                code = task['transform_code']
-                transformations = task.get('transformations', [
-                    'remove_unused_imports', 'remove_unused_variables'])
-                return {'transformed': self.code_transformer.transform_code
-                    (code, transformations)}
-            elif 'analyze_project' in task:
-                project_path = task['analyze_project']
-                return {'project_analysis': self.project_analyzer.analyze()}
-            elif 'analyze_self' in task:
-                return {'self_analysis': self.self_analyzer.analyze()}
-            elif 'refine_implementation' in task:
-                code = task['refine_implementation']
-                task_id = task.get('task_id', 'test_task')
-                return {'refined': self.ast_workflow.refine_implementation(
-                    code, task_id)}
+            if "analyze_code" in task:
+                code = task["analyze_code"]
+                return {
+                    "analysis": self.code_analyzer.analyze_code(code),
+                    "quality_metrics": self.ast_workflow._calculate_complexity(
+                        self.code_analyzer.analyze_code(code)
+                    ),
+                }
+            elif "transform_code" in task:
+                code = task["transform_code"]
+                transformations = task.get(
+                    "transformations",
+                    ["remove_unused_imports", "remove_unused_variables"],
+                )
+                return {
+                    "transformed": self.code_transformer.transform_code(
+                        code, transformations
+                    )
+                }
+            elif "analyze_project" in task:
+                project_path = task["analyze_project"]
+                return {"project_analysis": self.project_analyzer.analyze()}
+            elif "analyze_self" in task:
+                return {"self_analysis": self.self_analyzer.analyze()}
+            elif "refine_implementation" in task:
+                code = task["refine_implementation"]
+                task_id = task.get("task_id", "test_task")
+                return {
+                    "refined": self.ast_workflow.refine_implementation(code, task_id)
+                }
             else:
-                return {'error': 'Unknown task type'}
+                return {"error": "Unknown task type"}
         elif isinstance(task, Task):
             task_data = task.data or {}
-            if 'code' in task_data:
-                code = task_data['code']
-                if task.task_type == 'analyze':
+            if "code" in task_data:
+                code = task_data["code"]
+                if task.task_type == "analyze":
                     analysis = self.code_analyzer.analyze_code(code)
-                    quality_metrics = self.ast_workflow._calculate_complexity(
-                        analysis)
-                    task.result = {'analysis': analysis, 'quality_metrics':
-                        quality_metrics}
-                elif task.task_type == 'transform':
-                    transformations = task_data.get('transformations', [
-                        'remove_unused_imports', 'remove_unused_variables'])
-                    transformed = self.code_transformer.transform_code(code,
-                        transformations)
-                    task.result = {'transformed': transformed}
-                elif task.task_type == 'refine':
-                    refined = self.ast_workflow.refine_implementation(code,
-                        str(task.id))
-                    task.result = {'refined': refined}
+                    quality_metrics = self.ast_workflow._calculate_complexity(analysis)
+                    task.result = {
+                        "analysis": analysis,
+                        "quality_metrics": quality_metrics,
+                    }
+                elif task.task_type == "transform":
+                    transformations = task_data.get(
+                        "transformations",
+                        ["remove_unused_imports", "remove_unused_variables"],
+                    )
+                    transformed = self.code_transformer.transform_code(
+                        code, transformations
+                    )
+                    task.result = {"transformed": transformed}
+                elif task.task_type == "refine":
+                    refined = self.ast_workflow.refine_implementation(
+                        code, str(task.id)
+                    )
+                    task.result = {"refined": refined}
                 else:
-                    task.result = {'error': 'Unknown task type'}
+                    task.result = {"error": "Unknown task type"}
             else:
-                task.result = {'error': 'No code provided'}
+                task.result = {"error": "No code provided"}
             task.status = TaskStatus.COMPLETED
             return task
         else:
-            return {'error': 'Unsupported task format'}
+            return {"error": "Unsupported task format"}
 
 
 @pytest.fixture
@@ -103,21 +143,33 @@ def wsde_team_with_code_analysis(tmp_path_factory):
     ast_transformer = AstTransformer()
     with pytest.MonkeyPatch.context() as mp:
         temp_dir = tmp_path_factory.getbasetemp()
-        project_file = temp_dir.joinpath('test_project')
-        project_file.write_text('# Test project')
+        project_file = temp_dir.joinpath("test_project")
+        project_file.write_text("# Test project")
         project_path = str(project_file)
-        mp.setenv('DEVSYNTH_PROJECT_DIR', project_path)
+        mp.setenv("DEVSYNTH_PROJECT_DIR", project_path)
         project_analyzer = ProjectStateAnalyzer(project_path)
         self_analyzer = SelfAnalyzer(project_path)
         code_transformer = CodeTransformer()
         ast_workflow = AstWorkflowIntegration(memory_manager)
-        code_analysis_agent = CodeAnalysisAgent('code_analyst',
-            code_analyzer, ast_transformer, project_analyzer, self_analyzer,
-            code_transformer, ast_workflow)
-        code_reviewer_agent = CodeAnalysisAgent('code_reviewer',
-            code_analyzer, ast_transformer, project_analyzer, self_analyzer,
-            code_transformer, ast_workflow)
-        wsde_team = WSDETeam(name='TestCodeAnalysisWsdeIntegrationTeam')
+        code_analysis_agent = CodeAnalysisAgent(
+            "code_analyst",
+            code_analyzer,
+            ast_transformer,
+            project_analyzer,
+            self_analyzer,
+            code_transformer,
+            ast_workflow,
+        )
+        code_reviewer_agent = CodeAnalysisAgent(
+            "code_reviewer",
+            code_analyzer,
+            ast_transformer,
+            project_analyzer,
+            self_analyzer,
+            code_transformer,
+            ast_workflow,
+        )
+        wsde_team = WSDETeam(name="TestCodeAnalysisWsdeIntegrationTeam")
         wsde_team.add_agent(code_analysis_agent)
         wsde_team.add_agent(code_reviewer_agent)
         yield wsde_team
@@ -126,31 +178,30 @@ def wsde_team_with_code_analysis(tmp_path_factory):
 def test_code_analysis_in_wsde_team_succeeds(wsde_team_with_code_analysis):
     """Test that code analysis can be performed by a WSDE team.
 
-ReqID: N/A"""
-    task_data = {'analyze_code':
-        """
+    ReqID: N/A"""
+    task_data = {
+        "analyze_code": """
 def calculate_sum(a, b):
     result = a + b
     return result
         """
-        }
-    code_analyst = wsde_team_with_code_analysis.get_agent('code_analyst')
+    }
+    code_analyst = wsde_team_with_code_analysis.get_agent("code_analyst")
     result = code_analyst.process(task_data)
-    assert 'analysis' in result
-    assert 'quality_metrics' in result
-    analysis = result['analysis']
-    assert analysis.get_functions()[0]['name'] == 'calculate_sum'
-    quality_metrics = result['quality_metrics']
+    assert "analysis" in result
+    assert "quality_metrics" in result
+    analysis = result["analysis"]
+    assert analysis.get_functions()[0]["name"] == "calculate_sum"
+    quality_metrics = result["quality_metrics"]
     assert 0 <= quality_metrics <= 1
 
 
-def test_code_transformation_in_wsde_team_succeeds(wsde_team_with_code_analysis
-    ):
+def test_code_transformation_in_wsde_team_succeeds(wsde_team_with_code_analysis):
     """Test that code transformation can be performed by a WSDE team.
 
-ReqID: N/A"""
-    task_data = {'transform_code':
-        """
+    ReqID: N/A"""
+    task_data = {
+        "transform_code": """
 import os
 import sys
 import re  # This import is unused
@@ -166,22 +217,21 @@ def main():
     z = 15  # This variable is unused
     total = calculate_sum(x, y)
     print(f"The sum is {total}")
-        """
-        , 'transformations': ['remove_unused_imports',
-        'remove_unused_variables']}
-    code_analyst = wsde_team_with_code_analysis.get_agent('code_analyst')
+        """,
+        "transformations": ["remove_unused_imports", "remove_unused_variables"],
+    }
+    code_analyst = wsde_team_with_code_analysis.get_agent("code_analyst")
     result = code_analyst.process(task_data)
-    assert 'transformed' in result
-    transformed = result['transformed']
-    assert 'import re' not in transformed.transformed_code
-    assert 'z = 15' not in transformed.transformed_code
+    assert "transformed" in result
+    transformed = result["transformed"]
+    assert "import re" not in transformed.transformed_code
+    assert "z = 15" not in transformed.transformed_code
 
 
-def test_code_review_collaboration_in_wsde_team_succeeds(
-    wsde_team_with_code_analysis):
+def test_code_review_collaboration_in_wsde_team_succeeds(wsde_team_with_code_analysis):
     """Test that code analysis agents can collaborate in a WSDE team.
 
-ReqID: N/A"""
+    ReqID: N/A"""
     code = """
 def calculate_sum(a, b):
     # Redundant assignment
@@ -195,38 +245,43 @@ def main():
     total = calculate_sum(x, y)
     print(f"The sum is {total}")
     """
-    analysis_task = Task(id='task1', task_type='analyze', data={'code':
-        code}, assigned_to='code_analyst')
-    review_task = Task(id='task2', task_type='transform', data={'code':
-        code, 'transformations': ['remove_unused_variables']}, assigned_to=
-        'code_reviewer')
+    analysis_task = Task(
+        id="task1", task_type="analyze", data={"code": code}, assigned_to="code_analyst"
+    )
+    review_task = Task(
+        id="task2",
+        task_type="transform",
+        data={"code": code, "transformations": ["remove_unused_variables"]},
+        assigned_to="code_reviewer",
+    )
     wsde_team_with_code_analysis.process_task(analysis_task)
     wsde_team_with_code_analysis.process_task(review_task)
     assert analysis_task.status == TaskStatus.COMPLETED
     assert review_task.status == TaskStatus.COMPLETED
-    assert 'analysis' in analysis_task.result
-    assert 'quality_metrics' in analysis_task.result
-    assert 'transformed' in review_task.result
-    transformed = review_task.result['transformed']
-    assert 'z = 15' not in transformed.transformed_code
+    assert "analysis" in analysis_task.result
+    assert "quality_metrics" in analysis_task.result
+    assert "transformed" in review_task.result
+    transformed = review_task.result["transformed"]
+    assert "z = 15" not in transformed.transformed_code
 
 
 def test_code_refinement_in_wsde_team_succeeds(wsde_team_with_code_analysis):
     """Test that code refinement can be performed by a WSDE team.
 
-ReqID: N/A"""
-    task_data = {'refine_implementation':
-        """
+    ReqID: N/A"""
+    task_data = {
+        "refine_implementation": """
 def calculate(a, b):
     # Redundant variable
     result = a + b
     return result
-        """
-        , 'task_id': 'test_refinement'}
-    code_analyst = wsde_team_with_code_analysis.get_agent('code_analyst')
+        """,
+        "task_id": "test_refinement",
+    }
+    code_analyst = wsde_team_with_code_analysis.get_agent("code_analyst")
     result = code_analyst.process(task_data)
-    assert 'refined' in result
-    refined = result['refined']
-    assert 'original_code' in refined
-    assert 'refined_code' in refined
-    assert 'improvements' in refined
+    assert "refined" in result
+    refined = result["refined"]
+    assert "original_code" in refined
+    assert "refined_code" in refined
+    assert "improvements" in refined


### PR DESCRIPTION
## Summary
- extend `AgentType` enum with `EXPERT`
- adjust `CodeAnalysisAgent` fixtures to initialize using `AgentType.EXPERT`
- add simple tests verifying the new enum

## Testing
- `poetry run pytest` *(fails: 330 failed, 1551 passed, 91 skipped, 13 errors)*

------
https://chatgpt.com/codex/tasks/task_e_687b0e643ca88333b4a32b65077776e8