### PR TITLE
Add knowledge graph/standards setters

### DIFF
--- a/docs/architecture/wsde_agent_model.md
+++ b/docs/architecture/wsde_agent_model.md
@@ -287,6 +287,10 @@ team.add_agents([agent_a, agent_b])
 task = {"type": "documentation", "description": "Write API docs"}
 team.dynamic_role_reassignment(task)
 
+# Optionally attach shared resources
+team.set_knowledge_graph(my_knowledge_graph)
+team.set_standards(my_standards)
+
 # Agents contribute solutions
 
 team.add_solution(task, {"agent": agent_a.name, "content": "Initial draft"})

--- a/src/devsynth/domain/models/wsde_base.py
+++ b/src/devsynth/domain/models/wsde_base.py
@@ -22,16 +22,17 @@ logger = DevSynthLogger(__name__)
 class WSDE:
     """
     Base class for Worker Self-Directed Enterprise (WSDE) components.
-    
+
     This class serves as a foundation for WSDE-related classes and provides
     basic functionality for tracking metadata and timestamps.
     """
+
     name: str
     description: Optional[str] = None
     metadata: Optional[Dict[str, Any]] = None
     created_at: datetime = None
     updated_at: datetime = None
-    
+
     def __post_init__(self):
         """Initialize timestamps if not provided."""
         if self.created_at is None:
@@ -86,6 +87,8 @@ class WSDETeam:
         self.solutions = []
         self.dialectical_hooks = []
         self.voting_history = []
+        self.knowledge_graph = None
+        self.standards = None
         self.created_at = datetime.now()
         self.updated_at = self.created_at
         self.team_id = str(uuid4())
@@ -105,37 +108,43 @@ class WSDETeam:
         additional setup tasks.
         """
         # Ensure all required attributes are initialized
-        if not hasattr(self, 'agents'):
+        if not hasattr(self, "agents"):
             self.agents = []
 
-        if not hasattr(self, 'roles'):
+        if not hasattr(self, "roles"):
             self.roles = {
                 "primus": None,
                 "worker": None,
                 "supervisor": None,
                 "designer": None,
-                "evaluator": None
+                "evaluator": None,
             }
 
-        if not hasattr(self, 'messages'):
+        if not hasattr(self, "messages"):
             self.messages = []
 
-        if not hasattr(self, 'solutions'):
+        if not hasattr(self, "solutions"):
             self.solutions = []
 
-        if not hasattr(self, 'dialectical_hooks'):
+        if not hasattr(self, "dialectical_hooks"):
             self.dialectical_hooks = []
 
-        if not hasattr(self, 'voting_history'):
+        if not hasattr(self, "voting_history"):
             self.voting_history = []
 
-        if not hasattr(self, 'team_id'):
+        if not hasattr(self, "team_id"):
             self.team_id = str(uuid4())
+
+        if not hasattr(self, "knowledge_graph"):
+            self.knowledge_graph = None
+
+        if not hasattr(self, "standards"):
+            self.standards = None
 
     def add_agent(self, agent: Any):
         """
         Add an agent to the team.
-        
+
         Args:
             agent: The agent to add to the team
         """
@@ -145,29 +154,37 @@ class WSDETeam:
     def add_agents(self, agents: List[Any]):
         """
         Add multiple agents to the team.
-        
+
         Args:
             agents: List of agents to add to the team
         """
         for agent in agents:
             self.add_agent(agent)
 
-    def register_dialectical_hook(self, hook: Callable[[Dict[str, Any], List[Dict[str, Any]]], None]):
+    def register_dialectical_hook(
+        self, hook: Callable[[Dict[str, Any], List[Dict[str, Any]]], None]
+    ):
         """
         Register a hook to be called when dialectical reasoning is applied.
-        
+
         Args:
             hook: A callable that takes a task and a list of solutions
         """
         self.dialectical_hooks.append(hook)
         self.logger.info(f"Registered dialectical hook in team {self.name}")
 
-    def send_message(self, sender: str, recipients: List[str], message_type: str, 
-                    subject: str = "", content: Any = None, 
-                    metadata: Optional[Dict[str, Any]] = None):
+    def send_message(
+        self,
+        sender: str,
+        recipients: List[str],
+        message_type: str,
+        subject: str = "",
+        content: Any = None,
+        metadata: Optional[Dict[str, Any]] = None,
+    ):
         """
         Send a message from one agent to specific recipients.
-        
+
         Args:
             sender: The name of the sending agent
             recipients: List of recipient agent names
@@ -184,18 +201,23 @@ class WSDETeam:
             "type": message_type,
             "subject": subject,
             "content": content,
-            "metadata": metadata or {}
+            "metadata": metadata or {},
         }
         self.messages.append(message)
         self.logger.debug(f"Message sent from {sender} to {recipients}: {subject}")
         return message
 
-    def broadcast_message(self, sender: str, message_type: str, 
-                         subject: str = "", content: Any = None, 
-                         metadata: Optional[Dict[str, Any]] = None):
+    def broadcast_message(
+        self,
+        sender: str,
+        message_type: str,
+        subject: str = "",
+        content: Any = None,
+        metadata: Optional[Dict[str, Any]] = None,
+    ):
         """
         Broadcast a message from one agent to all team members.
-        
+
         Args:
             sender: The name of the sending agent
             message_type: Type of message (e.g., "announcement", "notification")
@@ -210,45 +232,52 @@ class WSDETeam:
             message_type=message_type,
             subject=subject,
             content=content,
-            metadata=metadata
+            metadata=metadata,
         )
         self.logger.debug(f"Broadcast message sent from {sender}: {subject}")
         return message
 
-    def get_messages(self, agent: Optional[str] = None, 
-                    filters: Optional[Dict[str, Any]] = None):
+    def get_messages(
+        self, agent: Optional[str] = None, filters: Optional[Dict[str, Any]] = None
+    ):
         """
         Get messages for a specific agent or with specific filters.
-        
+
         Args:
             agent: Optional agent name to filter messages for
             filters: Optional dictionary of filters to apply
-        
+
         Returns:
             List of messages matching the criteria
         """
         filtered_messages = self.messages
 
         if agent:
-            filtered_messages = [m for m in filtered_messages 
-                               if agent in m["recipients"] or m["sender"] == agent]
+            filtered_messages = [
+                m
+                for m in filtered_messages
+                if agent in m["recipients"] or m["sender"] == agent
+            ]
 
         if filters:
             for key, value in filters.items():
-                filtered_messages = [m for m in filtered_messages if m.get(key) == value]
+                filtered_messages = [
+                    m for m in filtered_messages if m.get(key) == value
+                ]
 
         return filtered_messages
 
-    def request_peer_review(self, work_product: Any, author: Any, 
-                           reviewer_agents: List[Any]):
+    def request_peer_review(
+        self, work_product: Any, author: Any, reviewer_agents: List[Any]
+    ):
         """
         Request peer review for a work product.
-        
+
         Args:
             work_product: The work product to be reviewed
             author: The agent who created the work product
             reviewer_agents: List of agents to review the work product
-        
+
         Returns:
             Dictionary containing the review request details
         """
@@ -259,7 +288,7 @@ class WSDETeam:
             "author": author.name,
             "reviewers": [agent.name for agent in reviewer_agents],
             "status": "requested",
-            "reviews": []
+            "reviews": [],
         }
 
         # Send messages to reviewers
@@ -270,35 +299,40 @@ class WSDETeam:
                 message_type="review_request",
                 subject=f"Review request for {work_product.get('title', 'work product')}",
                 content=work_product,
-                metadata={"review_id": review_request["id"]}
+                metadata={"review_id": review_request["id"]},
             )
 
-        self.logger.info(f"Peer review requested by {author.name} for {len(reviewer_agents)} reviewers")
+        self.logger.info(
+            f"Peer review requested by {author.name} for {len(reviewer_agents)} reviewers"
+        )
         return review_request
 
-    def conduct_peer_review(self, work_product: Any, author: Any, 
-                           reviewer_agents: List[Any]):
+    def conduct_peer_review(
+        self, work_product: Any, author: Any, reviewer_agents: List[Any]
+    ):
         """
         Conduct a peer review process for a work product.
-        
+
         Args:
             work_product: The work product to be reviewed
             author: The agent who created the work product
             reviewer_agents: List of agents to review the work product
-        
+
         Returns:
             Dictionary containing the review results
         """
         review_request = self.request_peer_review(work_product, author, reviewer_agents)
         # In a real implementation, this would wait for reviews to be submitted
         # For now, we'll just return the review request
-        self.logger.info(f"Peer review process initiated for work product from {author.name}")
+        self.logger.info(
+            f"Peer review process initiated for work product from {author.name}"
+        )
         return review_request
 
     def rotate_primus(self):
         """
         Rotate the primus role to the next agent in the team.
-        
+
         Returns:
             The new primus agent or None if no agents are available
         """
@@ -321,7 +355,7 @@ class WSDETeam:
     def get_primus(self):
         """
         Get the current primus agent.
-        
+
         Returns:
             The current primus agent or None if not assigned
         """
@@ -330,7 +364,7 @@ class WSDETeam:
     def get_worker(self):
         """
         Get the current worker agent.
-        
+
         Returns:
             The current worker agent or None if not assigned
         """
@@ -339,7 +373,7 @@ class WSDETeam:
     def get_supervisor(self):
         """
         Get the current supervisor agent.
-        
+
         Returns:
             The current supervisor agent or None if not assigned
         """
@@ -348,7 +382,7 @@ class WSDETeam:
     def get_designer(self):
         """
         Get the current designer agent.
-        
+
         Returns:
             The current designer agent or None if not assigned
         """
@@ -357,8 +391,18 @@ class WSDETeam:
     def get_evaluator(self):
         """
         Get the current evaluator agent.
-        
+
         Returns:
             The current evaluator agent or None if not assigned
         """
         return self.roles.get("evaluator")
+
+    def set_knowledge_graph(self, graph: Any) -> None:
+        """Attach a knowledge graph to the team for later use."""
+        self.knowledge_graph = graph
+        self.logger.info("Knowledge graph set for team %s", self.name)
+
+    def set_standards(self, standards: Any) -> None:
+        """Attach standards and best practices to the team."""
+        self.standards = standards
+        self.logger.info("Standards set for team %s", self.name)


### PR DESCRIPTION
## Summary
- allow WSDETeam to store a knowledge graph and standards via new setters
- show usage of the new API in docs

## Testing
- `poetry run pytest` *(fails: test suite errors)*

------
https://chatgpt.com/codex/tasks/task_e_687b0e1f33b88333a9f679e35810bcbf