### PR TITLE
Add agent memory utilities

### DIFF
--- a/src/devsynth/application/agents/unified_agent.py
+++ b/src/devsynth/application/agents/unified_agent.py
@@ -15,6 +15,7 @@ import os
 from typing import Any, Dict, List
 from .base import BaseAgent
 from ..prompts.auto_tuning import BasicPromptTuner
+from ...domain.models.agent import AgentConfig, AgentType
 
 # Define MVP capabilities
 MVP_CAPABILITIES = [
@@ -35,9 +36,29 @@ class UnifiedAgent(BaseAgent):
     into a single agent for the MVP. It preserves extension points for future multi-agent capabilities.
     """
 
-    def __init__(self) -> None:
+    def __init__(
+        self,
+        name: str | None = None,
+        agent_type: AgentType = AgentType.ORCHESTRATOR,
+        config: AgentConfig | None = None,
+        **kwargs: Any,
+    ) -> None:
         super().__init__()
         self.prompt_tuner = BasicPromptTuner()
+
+        if config is None:
+            config = AgentConfig(
+                name=name or self.__class__.__name__,
+                agent_type=agent_type,
+                description="",
+                capabilities=[],
+            )
+        else:
+            if name is not None:
+                config.name = name
+            config.agent_type = agent_type
+
+        self.initialize(config)
 
     def record_prompt_feedback(
         self, success: bool | None = None, feedback_score: float | None = None

--- a/src/devsynth/domain/models/agent.py
+++ b/src/devsynth/domain/models/agent.py
@@ -35,21 +35,25 @@ class AgentType(Enum):
     DOCUMENTATION = "documentation"
     DIAGRAM = "diagram"
     CRITIC = "critic"
+    WSDE = "wsde"
 
 
 @dataclass
 class AgentConfig:
     """Configuration for an agent."""
 
-    name: str
-    agent_type: AgentType
-    description: str
-    capabilities: List[str]
-    parameters: Dict[str, Any] = None
+    name: str = "UnnamedAgent"
+    agent_type: AgentType = AgentType.EXPERT
+    description: str = ""
+    capabilities: List[str] | None = None
+    expertise: List[str] | None = None
+    parameters: Dict[str, Any] | None = None
 
     def __post_init__(self):
         if self.parameters is None:
             self.parameters = {}
+        if self.capabilities is None:
+            self.capabilities = []
 
 
 # Define MVP capabilities


### PR DESCRIPTION
## Summary
- implement storage operations in AgentMemoryIntegration
- support MemoryManager and private memory filtering
- extend AgentConfig and UnifiedAgent to handle optional params
- cover new functionality with unit tests
- ensure memory agent integration works via integration tests

## Testing
- `poetry run pytest tests/unit/application/agents/test_agent_memory_integration.py -q`
- `poetry run pytest tests/unit/test_unified_agent.py -q`
- `poetry run pytest tests/integration/test_memory_agent_integration.py -q`

------
https://chatgpt.com/codex/tasks/task_e_687b1453510c833397da7e4e233992e6