### PR TITLE
Fix memory adapter search/update logic

### DIFF
--- a/src/devsynth/application/agents/base.py
+++ b/src/devsynth/application/agents/base.py
@@ -1,4 +1,3 @@
-
 """
 Base agent class for the DevSynth system.
 """
@@ -16,12 +15,15 @@ from devsynth.logging_setup import DevSynthLogger
 logger = DevSynthLogger(__name__)
 from devsynth.exceptions import DevSynthError
 
+
 class BaseAgent(Agent, ABC):
     """Base class for all agents in the DevSynth system."""
 
     def __init__(self):
         self.config = None
-        self.current_role = None  # Current WSDE role (Worker, Supervisor, Designer, Evaluator, Primus)
+        self.current_role = (
+            None  # Current WSDE role (Worker, Supervisor, Designer, Evaluator, Primus)
+        )
         self.llm_port = None
 
     def initialize(self, config: AgentConfig) -> None:
@@ -44,7 +46,12 @@ class BaseAgent(Agent, ABC):
             logger.error(f"Error generating text: {str(e)}")
             return f"Error generating text: {str(e)}"
 
-    def generate_text_with_context(self, prompt: str, context: List[Dict[str, str]], parameters: Dict[str, Any] = None) -> str:
+    def generate_text_with_context(
+        self,
+        prompt: str,
+        context: List[Dict[str, str]],
+        parameters: Dict[str, Any] = None,
+    ) -> str:
         """Generate text with conversation context using the LLM port."""
         if self.llm_port is None:
             logger.warning("LLM port not set. Using placeholder text.")
@@ -74,6 +81,14 @@ class BaseAgent(Agent, ABC):
             return self.config.name
         return self.__class__.__name__
 
+    @name.setter
+    def name(self, value: str) -> None:
+        """Set the agent name, updating :class:`AgentConfig` if necessary."""
+        if self.config:
+            self.config.name = value
+        else:  # pragma: no cover - defensive
+            self.config = AgentConfig(name=value)
+
     @property
     def agent_type(self) -> str:
         """Get the type of this agent."""
@@ -88,15 +103,15 @@ class BaseAgent(Agent, ABC):
             return self.config.description
         return "Base agent"
 
-    def create_wsde(self, content: str, content_type: str = "text", metadata: Dict[str, Any] = None) -> WSDE:
+    def create_wsde(
+        self, content: str, content_type: str = "text", metadata: Dict[str, Any] = None
+    ) -> WSDE:
         """Create a new WSDE with the given content."""
-        return WSDE(
-            content=content,
-            content_type=content_type,
-            metadata=metadata or {}
-        )
+        return WSDE(content=content, content_type=content_type, metadata=metadata or {})
 
-    def update_wsde(self, wsde: WSDE, content: str = None, metadata: Dict[str, Any] = None) -> WSDE:
+    def update_wsde(
+        self, wsde: WSDE, content: str = None, metadata: Dict[str, Any] = None
+    ) -> WSDE:
         """Update an existing WSDE."""
         if content is not None:
             wsde.content = content

--- a/tests/unit/application/agents/test_agent_memory_integration.py
+++ b/tests/unit/application/agents/test_agent_memory_integration.py
@@ -10,7 +10,7 @@ from devsynth.application.agents.agent_memory_integration import AgentMemoryInte
 class TestAgentMemoryIntegration(unittest.TestCase):
     """Test the integration between agents and the memory system.
 
-ReqID: N/A"""
+    ReqID: N/A"""
 
     def setUp(self):
         """Set up the test environment."""
@@ -19,48 +19,55 @@ ReqID: N/A"""
         self.context_manager = MagicMock()
         self.vector_store = MagicMock()
         self.memory_adapter.get_memory_store.return_value = self.memory_store
-        self.memory_adapter.get_context_manager.return_value = (self.
-            context_manager)
+        self.memory_adapter.get_context_manager.return_value = self.context_manager
         self.memory_adapter.get_vector_store.return_value = self.vector_store
         self.memory_adapter.has_vector_store.return_value = True
         self.wsde_team = MagicMock(spec=WSDETeam)
         self.wsde_team.name = "TestAgent"
-        self.agent_memory = AgentMemoryIntegration(memory_adapter=self.
-            memory_adapter, wsde_team=self.wsde_team)
+        self.agent_memory = AgentMemoryIntegration(
+            memory_adapter=self.memory_adapter, wsde_team=self.wsde_team
+        )
 
     def test_store_agent_solution_succeeds(self):
         """Test storing an agent solution in memory.
 
-ReqID: N/A"""
-        agent_id = 'agent1'
-        task = {'id': 'task1', 'description': 'Test task'}
-        solution = {'id': 'solution1', 'content': 'Test solution'}
-        result = self.agent_memory.store_agent_solution(agent_id, task,
-            solution)
+        ReqID: N/A"""
+        agent_id = "agent1"
+        task = {"id": "task1", "description": "Test task"}
+        solution = {"id": "solution1", "content": "Test solution"}
+        result = self.agent_memory.store_agent_solution(agent_id, task, solution)
         self.memory_store.store.assert_called_once()
         stored_item = self.memory_store.store.call_args[0][0]
         self.assertEqual(stored_item.memory_type, MemoryType.SOLUTION)
-        self.assertEqual(stored_item.metadata.get('agent_id'), agent_id)
-        self.assertEqual(stored_item.metadata.get('task_id'), task['id'])
-        self.assertEqual(stored_item.metadata.get('solution_id'), solution[
-            'id'])
+        self.assertEqual(stored_item.metadata.get("agent_id"), agent_id)
+        self.assertEqual(stored_item.metadata.get("task_id"), task["id"])
+        self.assertEqual(stored_item.metadata.get("solution_id"), solution["id"])
         self.assertEqual(result, self.memory_store.store.return_value)
 
     def test_retrieve_agent_solutions_succeeds(self):
         """Test retrieving agent solutions from memory.
 
-ReqID: N/A"""
-        task_id = 'task1'
-        mock_items = [MemoryItem(id='item1', content='Solution 1',
-            memory_type=MemoryType.SOLUTION, metadata={'task_id': task_id,
-            'agent_id': 'agent1'}), MemoryItem(id='item2', content=
-            'Solution 2', memory_type=MemoryType.SOLUTION, metadata={
-            'task_id': task_id, 'agent_id': 'agent2'})]
+        ReqID: N/A"""
+        task_id = "task1"
+        mock_items = [
+            MemoryItem(
+                id="item1",
+                content="Solution 1",
+                memory_type=MemoryType.SOLUTION,
+                metadata={"task_id": task_id, "agent_id": "agent1"},
+            ),
+            MemoryItem(
+                id="item2",
+                content="Solution 2",
+                memory_type=MemoryType.SOLUTION,
+                metadata={"task_id": task_id, "agent_id": "agent2"},
+            ),
+        ]
 
         # Remove the 'items' attribute from memory_store
         # so the method will use search
-        if hasattr(type(self.memory_store), 'items'):
-            delattr(type(self.memory_store), 'items')
+        if hasattr(type(self.memory_store), "items"):
+            delattr(type(self.memory_store), "items")
 
         # Mock the search method to return our mock items
         self.memory_store.search.return_value = mock_items
@@ -71,84 +78,87 @@ ReqID: N/A"""
         # Verify that search was called with the correct memory_type
         self.memory_store.search.assert_called_once()
         search_query = self.memory_store.search.call_args[0][0]
-        self.assertEqual(search_query['memory_type'], MemoryType.SOLUTION)
+        self.assertEqual(search_query["memory_type"], MemoryType.SOLUTION)
 
         # Verify the results
         self.assertEqual(len(results), 2)
-        self.assertEqual(results[0].content, 'Solution 1')
-        self.assertEqual(results[1].content, 'Solution 2')
+        self.assertEqual(results[0].content, "Solution 1")
+        self.assertEqual(results[1].content, "Solution 2")
 
     def test_store_dialectical_reasoning_succeeds(self):
         """Test storing dialectical reasoning in memory.
 
-ReqID: N/A"""
-        task_id = 'task1'
-        thesis = {'id': 'thesis1', 'content': 'Thesis content'}
-        antithesis = {'id': 'antithesis1', 'content': 'Antithesis content'}
-        synthesis = {'id': 'synthesis1', 'content': 'Synthesis content'}
-        result = self.agent_memory.store_dialectical_reasoning(task_id,
-            thesis, antithesis, synthesis)
+        ReqID: N/A"""
+        task_id = "task1"
+        thesis = {"id": "thesis1", "content": "Thesis content"}
+        antithesis = {"id": "antithesis1", "content": "Antithesis content"}
+        synthesis = {"id": "synthesis1", "content": "Synthesis content"}
+        result = self.agent_memory.store_dialectical_reasoning(
+            task_id, thesis, antithesis, synthesis
+        )
         self.memory_store.store.assert_called_once()
         stored_item = self.memory_store.store.call_args[0][0]
-        self.assertEqual(stored_item.memory_type, MemoryType.
-            DIALECTICAL_REASONING)
-        self.assertEqual(stored_item.metadata.get('task_id'), task_id)
-        self.assertEqual(stored_item.metadata.get('thesis_id'), thesis['id'])
-        self.assertEqual(stored_item.metadata.get('antithesis_id'),
-            antithesis['id'])
-        self.assertEqual(stored_item.metadata.get('synthesis_id'),
-            synthesis['id'])
+        self.assertEqual(stored_item.memory_type, MemoryType.DIALECTICAL_REASONING)
+        self.assertEqual(stored_item.metadata.get("task_id"), task_id)
+        self.assertEqual(stored_item.metadata.get("thesis_id"), thesis["id"])
+        self.assertEqual(stored_item.metadata.get("antithesis_id"), antithesis["id"])
+        self.assertEqual(stored_item.metadata.get("synthesis_id"), synthesis["id"])
         self.assertEqual(result, self.memory_store.store.return_value)
 
     def test_retrieve_dialectical_reasoning_succeeds(self):
         """Test retrieving dialectical reasoning from memory.
 
-ReqID: N/A"""
-        task_id = 'task1'
-        mock_item = MemoryItem(id='item1', content=
-            'Dialectical reasoning content', memory_type=MemoryType.
-            DIALECTICAL_REASONING, metadata={'task_id': task_id,
-            'thesis_id': 'thesis1', 'antithesis_id': 'antithesis1',
-            'synthesis_id': 'synthesis1'})
+        ReqID: N/A"""
+        task_id = "task1"
+        mock_item = MemoryItem(
+            id="item1",
+            content="Dialectical reasoning content",
+            memory_type=MemoryType.DIALECTICAL_REASONING,
+            metadata={
+                "task_id": task_id,
+                "thesis_id": "thesis1",
+                "antithesis_id": "antithesis1",
+                "synthesis_id": "synthesis1",
+            },
+        )
         self.memory_store.search.return_value = [mock_item]
         result = self.agent_memory.retrieve_dialectical_reasoning(task_id)
         self.memory_store.search.assert_called_once()
         search_query = self.memory_store.search.call_args[0][0]
-        self.assertEqual(search_query['memory_type'], MemoryType.
-            DIALECTICAL_REASONING)
-        self.assertEqual(search_query['metadata.task_id'], task_id)
+        self.assertEqual(search_query["memory_type"], MemoryType.DIALECTICAL_REASONING)
+        self.assertEqual(search_query["metadata.task_id"], task_id)
         self.assertEqual(result, mock_item)
 
     def test_store_agent_context_succeeds(self):
         """Test storing agent context in memory.
 
-ReqID: N/A"""
-        agent_id = 'agent1'
-        context_data = {'key': 'value', 'nested': {'data': 'nested value'}}
+        ReqID: N/A"""
+        agent_id = "agent1"
+        context_data = {"key": "value", "nested": {"data": "nested value"}}
         self.agent_memory.store_agent_context(agent_id, context_data)
         self.context_manager.add_to_context.assert_called_once()
-        context_key, context_value = (self.context_manager.add_to_context.
-            call_args[0])
-        self.assertEqual(context_key, f'agent:{agent_id}')
+        context_key, context_value = self.context_manager.add_to_context.call_args[0]
+        self.assertEqual(context_key, f"agent:{agent_id}")
         self.assertEqual(context_value, context_data)
 
     def test_retrieve_agent_context_succeeds(self):
         """Test retrieving agent context from memory.
 
-ReqID: N/A"""
-        agent_id = 'agent1'
-        context_data = {'key': 'value', 'nested': {'data': 'nested value'}}
+        ReqID: N/A"""
+        agent_id = "agent1"
+        context_data = {"key": "value", "nested": {"data": "nested value"}}
         self.context_manager.get_from_context.return_value = context_data
         result = self.agent_memory.retrieve_agent_context(agent_id)
         self.context_manager.get_from_context.assert_called_once_with(
-            f'agent:{agent_id}')
+            f"agent:{agent_id}"
+        )
         self.assertEqual(result, context_data)
 
     def test_search_similar_solutions_succeeds(self):
         """Test searching for similar solutions using vector similarity.
 
-ReqID: N/A"""
-        query = 'How to implement a feature'
+        ReqID: N/A"""
+        query = "How to implement a feature"
         mock_vectors = [MagicMock(), MagicMock()]
         self.vector_store.similarity_search.return_value = mock_vectors
         results = self.agent_memory.search_similar_solutions(query)
@@ -158,8 +168,8 @@ ReqID: N/A"""
     def test_search_similar_solutions_no_vector_store_succeeds(self):
         """Test searching for similar solutions when no vector store is available.
 
-ReqID: N/A"""
-        query = 'How to implement a feature'
+        ReqID: N/A"""
+        query = "How to implement a feature"
         self.memory_adapter.has_vector_store.return_value = False
         self.agent_memory.vector_store = None
         results = self.agent_memory.search_similar_solutions(query)
@@ -201,12 +211,14 @@ ReqID: N/A"""
 
         query = {"field": "value"}
         items = [
-            MemoryItem(id="1", content={"field": "value"}, memory_type=MemoryType.KNOWLEDGE)
+            MemoryItem(
+                id="1", content={"field": "value"}, memory_type=MemoryType.KNOWLEDGE
+            )
         ]
         self.memory_store.search.return_value = items
 
         result = self.agent_memory.search_memory(query)
-        self.memory_store.search.assert_called_once_with({})
+        self.memory_store.search.assert_called_once_with(query)
         self.assertEqual(result, items)
 
     def test_update_memory_succeeds(self):
@@ -240,7 +252,9 @@ ReqID: N/A"""
         """Test storing memory with context."""
 
         context = {"task": "t"}
-        self.agent_memory.store_memory_with_context("c", MemoryType.KNOWLEDGE, {}, context)
+        self.agent_memory.store_memory_with_context(
+            "c", MemoryType.KNOWLEDGE, {}, context
+        )
         self.memory_store.store.assert_called_once()
         item = self.memory_store.store.call_args[0][0]
         self.assertEqual(item.metadata["context"], context)

--- a/tests/unit/application/memory/test_memory_adapters_regression.py
+++ b/tests/unit/application/memory/test_memory_adapters_regression.py
@@ -1,0 +1,51 @@
+import tempfile
+import pytest
+
+from devsynth.application.memory.adapters.tinydb_memory_adapter import (
+    TinyDBMemoryAdapter,
+)
+from devsynth.application.memory.adapters.graph_memory_adapter import GraphMemoryAdapter
+from devsynth.application.memory.adapters.vector_memory_adapter import (
+    VectorMemoryAdapter,
+)
+from devsynth.domain.models.memory import MemoryItem, MemoryType, MemoryVector
+
+
+@pytest.mark.parametrize("adapter_cls", [TinyDBMemoryAdapter, GraphMemoryAdapter])
+def test_store_retrieve_search_update(adapter_cls, tmp_path):
+    if adapter_cls is GraphMemoryAdapter:
+        adapter = adapter_cls(base_path=tmp_path)
+    else:
+        adapter = adapter_cls(db_path=str(tmp_path / "db.json"))
+
+    item = MemoryItem(
+        id="",
+        content={"foo": "bar"},
+        memory_type=MemoryType.KNOWLEDGE,
+        metadata={"tag": "t"},
+    )
+    item_id = adapter.store(item)
+    retrieved = adapter.retrieve(item_id)
+    assert retrieved is not None
+    assert retrieved.content["foo"] == "bar"
+
+    results = adapter.search({"tag": "t"})
+    assert any(r.id == item_id for r in results)
+
+    item.content = {"foo": "baz"}
+    adapter.store(item)
+    updated = adapter.retrieve(item_id)
+    assert updated.content["foo"] == "baz"
+
+
+def test_vector_adapter_operations():
+    adapter = VectorMemoryAdapter()
+    vector = MemoryVector(
+        id="", content="doc", embedding=[0.1, 0.2, 0.3], metadata={"kind": "test"}
+    )
+    vid = adapter.store_vector(vector)
+    retrieved = adapter.retrieve_vector(vid)
+    assert retrieved is not None
+    assert retrieved.content == "doc"
+    results = adapter.similarity_search([0.1, 0.2, 0.3], top_k=1)
+    assert results and results[0].id == vid


### PR DESCRIPTION
## Summary
- allow setting BaseAgent name via property setter
- fix AgentMemoryIntegration.search_memory to pass queries through
- update GraphMemoryAdapter.store to overwrite existing items
- adjust AgentMemoryIntegration unit test for new behavior
- add regression tests covering memory adapters

## Testing
- `poetry run pytest tests/integration/test_memory_agent_integration.py tests/unit/application/memory/test_memory_adapters_regression.py tests/unit/application/agents/test_agent_memory_integration.py::TestAgentMemoryIntegration::test_search_memory_succeeds -q`

------
https://chatgpt.com/codex/tasks/task_e_687b1ccb22108333a7538588a12e6eb6