### PR TITLE
Update docs on message protocol and test failures

### DIFF
--- a/docs/roadmap/development_status.md
+++ b/docs/roadmap/development_status.md
@@ -351,10 +351,12 @@ This work is planned for after the completion of Month 2.
 ### Completed Tasks
 
 1. **Test Verification**:
-   - Ran all tests to verify functionality
+   - Ran the full test suite to verify functionality
    - Identified and fixed several import errors and missing modules
    - Added missing exception classes to support tests
-   - Most tests now run successfully, with only a few failures related to specific functionality that needs further attention
+   - Numerous tests are still failing, primarily around the Web UI
+     requirements wizard and Kuzu memory integration. Investigation is
+     ongoing and fixes are planned for the next sprint.
 
 2. **Code Fixes**:
    - Added missing `EDRRCoordinatorError` class to exceptions.py
@@ -389,6 +391,14 @@ This work is planned for after the completion of Month 2.
    - Added `alignment_metrics` and `test_metrics` CLI commands
    - Commands generate alignment and test-first development reports
 
+### Remaining Test Failures
+
+Despite the improvements above, several unit and integration tests continue to
+fail. Most failures occur in the Web UI requirements wizard and the Kuzu-backed
+memory system. Planned fixes include refining the wizard navigation logic and
+adjusting initialization steps for the Kuzu vector store. Progress will be
+tracked in upcoming sprint reports.
+
 
 ## Maintenance Strategy
 
@@ -414,5 +424,7 @@ All phases of the DevSynth Repository Harmonization Plan have been successfully 
 - ~~Finalize unit tests for the `MemoryType` enum and resolve any remaining failures.~~
 - ~~Verify that the EDRR coordinator and AST code analysis features fully match their BDD scenarios.~~
 - ~~Complete WSDE agent collaboration capabilities.~~
+- Investigate failing Web UI and Kuzu-related tests; implement fixes for the
+  requirements wizard and memory initialization logic.
 
 For updated scheduling, see the consolidated [ROADMAP](ROADMAP.md).

--- a/docs/technical_debt.md
+++ b/docs/technical_debt.md
@@ -37,17 +37,21 @@ This document identifies and tracks technical debt in the DevSynth project. Tech
 
 ### 2. WSDE Message Passing Protocol
 
-**Description**: The message passing protocol between agents has been specified and has Gherkin scenarios, but lacks implementation.
+**Description**: The message passing protocol is now implemented in
+`application/collaboration/message_protocol.py`. Agents can exchange structured
+messages with JSON persistence and optional memory integration. The current
+implementation covers basic message types and storage but lacks advanced
+features such as priority queues and robust history queries.
 
-**Impact**: Agents cannot effectively communicate in a structured way, limiting multi-agent collaboration.
+**Impact**: Multi-agent collaboration works, though efficiency and rich history
+capabilities are still limited.
 
-**Remediation Steps**:
+**Remaining Improvements**:
 
-1. Implement the message protocol data structures
-2. Develop the message passing infrastructure
-3. Implement message priority handling
-4. Add message history tracking and persistence
-5. Integrate with the memory system for message storage
+1. Enhance message priority handling
+2. Improve history tracking and search features
+3. Expand persistence options and error handling
+4. Tighten integration with the memory system for long-term storage
 
 
 **Priority**: High
@@ -123,6 +127,13 @@ All imports and documentation have been updated accordingly.
 
 **Estimated Effort**: 1-2 days
 
+## Test Failures and Planned Fixes
+
+Recent test runs reveal failures primarily in the Web UI requirements wizard and
+the Kuzu-backed memory system. Planned fixes include refining navigation logic
+in the wizard and adjusting initialization for the Kuzu vector store to ensure
+consistent behavior across environments.
+
 ## Monitoring and Resolution
 
 Technical debt items should be reviewed regularly during sprint planning and prioritized based on their impact and alignment with project goals. Items should be added to this document as they are identified and removed once they are resolved.
@@ -131,4 +142,4 @@ The technical debt backlog should be reviewed at least once per quarter to ensur
 
 ## Last Updated
 
-May 31, 2025
+July 20, 2025


### PR DESCRIPTION
## Summary
- update technical debt doc to note message protocol implementation
- document remaining test failures and planned fixes
- update development status with failing tests and next steps

## Testing
- `poetry run pytest` *(fails: 205 failed, 406 passed, 65 skipped, 3 errors)*

------
https://chatgpt.com/codex/tasks/task_e_687b21be5e2c83338bd15a94bf404ad2