### PR TITLE
Fix OfflineProvider test import path

### DIFF
--- a/tests/unit/test_llm_provider_selection.py
+++ b/tests/unit/test_llm_provider_selection.py
@@ -1,6 +1,8 @@
 import types
 from devsynth.application.llm import get_llm_provider
-from devsynth.application.llm.offline_provider import OfflineProvider
+# Import the provider from the same module used by ``get_llm_provider`` to
+# avoid type mismatches if ``offline_provider`` is reloaded in other tests.
+from devsynth.application.llm.providers import OfflineProvider
 from devsynth.application.llm.openai_provider import OpenAIProvider
 
 


### PR DESCRIPTION
## Summary
- ensure OfflineProvider used in tests matches factory-registered class

## Testing
- `poetry run pytest tests/unit/test_llm_provider_selection.py -vv`

------
https://chatgpt.com/codex/tasks/task_e_687b25a2137c8333afbbbe51f479343c