### PR TITLE
Fix test isolation for UnifiedAgent stubs

### DIFF
--- a/tests/unit/application/agents/test_unified_agent_generic.py
+++ b/tests/unit/application/agents/test_unified_agent_generic.py
@@ -1,31 +1,57 @@
 import sys
 import types
-mem_mod = types.ModuleType('devsynth.adapters.memory.memory_adapter')
+import pytest
 
 
-class MemorySystemAdapter:
+@pytest.fixture(autouse=True)
+def stub_agent_dependencies(monkeypatch):
+    """Stub heavy agent dependencies to avoid imports during testing."""
 
-    def get_memory_store(self):
-        return {}
+    mem_mod = types.ModuleType("devsynth.adapters.memory.memory_adapter")
+
+    class MemorySystemAdapter:
+        def get_memory_store(self):
+            return {}
+
+    mem_mod.MemorySystemAdapter = MemorySystemAdapter
+    monkeypatch.setitem(
+        sys.modules, "devsynth.adapters.memory.memory_adapter", mem_mod
+    )
+
+    am_mod = types.ModuleType(
+        "devsynth.application.agents.agent_memory_integration"
+    )
+    am_mod.AgentMemoryIntegration = object
+    monkeypatch.setitem(
+        sys.modules,
+        "devsynth.application.agents.agent_memory_integration",
+        am_mod,
+    )
+
+    wsde_mod = types.ModuleType(
+        "devsynth.application.agents.wsde_memory_integration"
+    )
+    wsde_mod.WSDEMemoryIntegration = object
+    monkeypatch.setitem(
+        sys.modules,
+        "devsynth.application.agents.wsde_memory_integration",
+        wsde_mod,
+    )
+    yield
 
 
-mem_mod.MemorySystemAdapter = MemorySystemAdapter
-sys.modules['devsynth.adapters.memory.memory_adapter'] = mem_mod
-am_mod = types.ModuleType(
-    'devsynth.application.agents.agent_memory_integration')
-am_mod.AgentMemoryIntegration = object
-sys.modules['devsynth.application.agents.agent_memory_integration'] = am_mod
-wsde_mod = types.ModuleType(
-    'devsynth.application.agents.wsde_memory_integration')
-wsde_mod.WSDEMemoryIntegration = object
-sys.modules['devsynth.application.agents.wsde_memory_integration'] = wsde_mod
-from devsynth.application.agents.unified_agent import UnifiedAgent
+def import_unified_agent():
+    """Import the ``UnifiedAgent`` after stubbing its dependencies."""
+    from devsynth.application.agents.unified_agent import UnifiedAgent
+
+    return UnifiedAgent
 
 
 def test_process_generic_task_succeeds():
     """Test that process generic task succeeds.
 
-ReqID: N/A"""
+    ReqID: N/A"""
+    UnifiedAgent = import_unified_agent()
     agent = UnifiedAgent()
     result = agent._process_generic_task({'foo': 'bar'})
     assert 'result' in result


### PR DESCRIPTION
## Summary
- isolate stubbed modules in `test_unified_agent_generic`
- expose helper to import `UnifiedAgent` only after patches are applied

## Testing
- `poetry run pytest tests/unit/application/agents/test_unified_agent_generic.py tests/unit/test_memory_system_with_kuzu.py -vv`
- `poetry run pytest tests/unit/test_memory_system_with_kuzu.py`

------
https://chatgpt.com/codex/tasks/task_e_687b25825f08833387da0a8eace65e3c