### PR TITLE
Fix Setup wizard reset and kuzu store path

### DIFF
--- a/src/devsynth/interface/webui.py
+++ b/src/devsynth/interface/webui.py
@@ -818,6 +818,17 @@ class WebUI(UXBridge):
             self.display_result(
                 "[green]Requirements saved to requirements_wizard.json[/green]"
             )
+            # Reset wizard state so subsequent interactions start from the
+            # beginning.  This mirrors typical form wizard behaviour and avoids
+            # cross-test contamination when the page persists across runs.
+            st.session_state.wizard_step = 0
+            st.session_state.wizard_data = {
+                "title": "",
+                "description": "",
+                "type": RequirementType.FUNCTIONAL.value,
+                "priority": RequirementPriority.MEDIUM.value,
+                "constraints": "",
+            }
 
     def _gather_wizard(self) -> None:
         """Run the requirements gathering workflow via :mod:`core.workflows`."""


### PR DESCRIPTION
## Summary
- ensure KuzuStore always creates its working directory
- reset requirements wizard state after saving

## Testing
- `poetry run pytest tests/unit/test_kuzu_store.py tests/integration/test_kuzu_memory_integration.py tests/integration/test_webui_setup.py -q`
- `poetry run pytest tests/behavior -k webui -q`

------
https://chatgpt.com/codex/tasks/task_e_687c366737d08333972e22f430ed57a5