### PR TITLE
Implement bridge utilities and doctor command wrapper

### DIFF
--- a/src/devsynth/application/cli/__init__.py
+++ b/src/devsynth/application/cli/__init__.py
@@ -24,13 +24,11 @@ from .cli_commands import (
     webapp_cmd,
     webui_cmd,
     dbschema_cmd,
+    doctor_cmd,
     check_cmd,
     refactor_cmd,
     serve_cmd,
 )
-
-# Doctor command now lives in the commands package
-from .commands.doctor_cmd import doctor_cmd
 
 # Import commands from the commands directory
 from .commands.inspect_code_cmd import inspect_code_cmd

--- a/src/devsynth/application/cli/cli_commands.py
+++ b/src/devsynth/application/cli/cli_commands.py
@@ -33,7 +33,7 @@ from devsynth.config import (
 from devsynth.config.unified_loader import UnifiedConfigLoader
 from devsynth.config.loader import ConfigModel, save_config, _find_config_path
 from .commands.edrr_cycle_cmd import edrr_cycle_cmd
-from .commands.doctor_cmd import doctor_cmd
+from .commands.doctor_cmd import doctor_cmd as _doctor_impl
 
 logger = DevSynthLogger(__name__)
 bridge: UXBridge = CLIUXBridge()
@@ -1683,6 +1683,12 @@ def dbschema_cmd(
                 border_style="red",
             )
         )
+
+
+def doctor_cmd(config_dir: str = "config", *, bridge: Optional[UXBridge] = None) -> None:
+    """Validate environment configuration files."""
+
+    _doctor_impl(config_dir=config_dir, bridge=_resolve_bridge(bridge))
 
 
 def check_cmd(config_dir: str = "config") -> None:

--- a/src/devsynth/application/server/bridge.py
+++ b/src/devsynth/application/server/bridge.py
@@ -1,0 +1,45 @@
+"""Global UXBridge accessor for server components.
+
+This module exposes helper functions to share a single
+:class:`~devsynth.interface.ux_bridge.UXBridge` instance
+between the CLI, WebUI and Agent API.  The default
+bridge implementation is chosen based on project
+configuration via :func:`devsynth.interface.uxbridge_config.get_default_bridge`.
+"""
+
+from __future__ import annotations
+
+from typing import Optional
+
+from devsynth.logging_setup import DevSynthLogger
+from devsynth.interface.ux_bridge import UXBridge
+from devsynth.interface.uxbridge_config import get_default_bridge
+
+logger = DevSynthLogger(__name__)
+
+_bridge: Optional[UXBridge] = None
+
+
+def get_bridge() -> UXBridge:
+    """Return the active :class:`UXBridge` instance.
+
+    If no bridge has been set explicitly, the default
+    implementation from configuration is created lazily.
+    """
+
+    global _bridge
+    if _bridge is None:
+        _bridge = get_default_bridge()
+        logger.debug("Initialized UXBridge %s", _bridge.__class__.__name__)
+    return _bridge
+
+
+def set_bridge(bridge: UXBridge) -> None:
+    """Override the active :class:`UXBridge` instance."""
+
+    global _bridge
+    _bridge = bridge
+    logger.debug("UXBridge overridden with %s", bridge.__class__.__name__)
+
+
+__all__ = ["get_bridge", "set_bridge"]


### PR DESCRIPTION
## Summary
- add `server.bridge` module providing global UXBridge access
- extend doctor command to accept a UXBridge parameter
- expose a wrapper `doctor_cmd` in cli_commands
- export updated doctor command in CLI package

## Testing
- `poetry run pytest tests/behavior/test_uxbridge_cli_webui.py tests/behavior/test_doctor_command.py -q`

------
https://chatgpt.com/codex/tasks/task_e_687c3ad9dd28833399fca3f624e164d1