### PR TITLE
Expand multi-language support

### DIFF
--- a/docs/user_guides/cli_reference.md
+++ b/docs/user_guides/cli_reference.md
@@ -160,11 +160,14 @@ devsynth init [--path PATH] [--template TEMPLATE] [--project-root ROOT] [--langu
 - `--path`, `-p`: Path to initialize the project (default: current directory)
 - `--template`, `-t`: Template to use for initialization (default: basic)
 - `--project-root`: Root directory of an existing project to onboard
-- `--language`: Primary language of the project (default: python)
+- `--language`: Primary language of the project (default: python). Supported
+  values: `python`, `javascript`, `typescript`, `go`, `rust`, `haskell`, `julia`,
+  or `polyglot` for multi-language projects.
 - `--source-dirs`: Comma separated list of source directories (default: src)
 - `--test-dirs`: Comma separated list of test directories (default: tests)
 - `--docs-dirs`: Comma separated list of documentation directories (default: docs)
-- `--extra-languages`: Additional languages used in the project
+- `--extra-languages`: Additional languages used in the project (comma-separated)
+  using the same language names as `--language`.
 - `--goals`: High-level goals or constraints for the project
 - `--constraints`: Path to a constraint configuration file
 - `--wizard`: Launch the guided setup wizard even outside a detected project
@@ -205,13 +208,13 @@ devsynth init --path ./my-project --template web-app
 
 # Onboard an existing project using custom language
 
-devsynth init --project-root ./existing --language javascript
+devsynth init --project-root ./existing --language typescript
 
 # Provide directories and project goals via flags
 
 devsynth init --project-root . --language python \
   --source-dirs src --test-dirs tests --docs-dirs docs \
-  --extra-languages javascript --goals "demo"
+  --extra-languages javascript,go --goals "demo"
 
 # Start the guided wizard directly
 
@@ -286,7 +289,9 @@ devsynth refactor [--test-dir DIR] [--spec-file FILE] [--output-dir DIR]
 - `--test-dir`, `-t`: Directory containing test files (default: tests/)
 - `--spec-file`, `-s`: Path to specification file (default: specifications.md)
 - `--output-dir`, `-o`: Directory to output code files (default: src/)
-- `--language`, `-l`: Target language for generated code (python or javascript)
+- `--language`, `-l`: Target language for generated code. Supported values are
+  `python`, `javascript`, `typescript`, `go`, `rust`, `haskell`, `julia`, or
+  `polyglot`.
 
 
 **Examples:**
@@ -301,9 +306,9 @@ devsynth refactor
 
 devsynth refactor --spec-file custom_specs.md --output-dir custom_src/
 
-# Generate JavaScript code
+# Generate TypeScript code
 
-devsynth refactor --language javascript
+devsynth refactor --language typescript
 ```
 
 ## run-pipeline

--- a/src/devsynth/application/agents/multi_language_code.py
+++ b/src/devsynth/application/agents/multi_language_code.py
@@ -17,12 +17,76 @@ class MultiLanguageCodeAgent(BaseAgent):
     SUPPORTED_LANGUAGES = {
         "python": "print('Hello from Python')\n",
         "javascript": "console.log('Hello from JavaScript');\n",
+        "typescript": "console.log('Hello from TypeScript');\n",
+        "go": (
+            'package main\n\nimport "fmt"\n\nfunc main() {\n    fmt.Println("Hello from Go")\n}\n'
+        ),
+        "rust": 'fn main() {\n    println!("Hello from Rust");\n}\n',
+        "haskell": 'main = putStrLn "Hello from Haskell"\n',
+        "julia": 'println("Hello from Julia")\n',
     }
 
     def process(self, inputs: Dict[str, Any]) -> Dict[str, Any]:
         """Generate code in the requested language."""
         role_prompt = self.get_role_prompt()
         language = str(inputs.get("language", "python")).lower()
+
+        if language == "polyglot":
+            languages = inputs.get("languages") or list(self.SUPPORTED_LANGUAGES.keys())
+            languages = [str(l).lower() for l in languages]
+            for lang in languages:
+                if lang not in self.SUPPORTED_LANGUAGES:
+                    raise ValueError(f"Unsupported language: {lang}")
+
+            code_results = {}
+            wsde_results = {}
+            for lang in languages:
+                prompt = f"""
+        {role_prompt}
+
+        You are a coding expert. Generate {lang} code based on the following inputs.
+
+        Project context:
+        {inputs.get('context', '')}
+
+        Specifications:
+        {inputs.get('specifications', '')}
+
+        Tests:
+        {inputs.get('tests', '')}
+        """
+                try:
+                    code = self.generate_text(prompt)
+                except Exception as e:  # pragma: no cover - defensive
+                    logger.error(f"Error generating text: {str(e)}")
+                    code = self.SUPPORTED_LANGUAGES[lang]
+
+                wsde = None
+                try:
+                    wsde = self.create_wsde(
+                        content=code,
+                        content_type="code",
+                        metadata={
+                            "agent": self.name,
+                            "role": self.current_role,
+                            "language": lang,
+                            "type": "code",
+                        },
+                    )
+                except Exception as e:  # pragma: no cover - defensive
+                    logger.error(f"Error creating WSDE: {str(e)}")
+
+                code_results[lang] = code
+                wsde_results[lang] = wsde
+
+            return {
+                "code": code_results,
+                "wsde": wsde_results,
+                "agent": self.name,
+                "role": self.current_role,
+                "language": "polyglot",
+                "languages": languages,
+            }
 
         if language not in self.SUPPORTED_LANGUAGES:
             raise ValueError(f"Unsupported language: {language}")
@@ -45,7 +109,7 @@ class MultiLanguageCodeAgent(BaseAgent):
         # In a real implementation this would query the LLM. Use placeholder text for now.
         try:
             code = self.generate_text(prompt)
-        except Exception as e:
+        except Exception as e:  # pragma: no cover - defensive
             logger.error(f"Error generating text: {str(e)}")
             code = self.SUPPORTED_LANGUAGES[language]
 
@@ -55,9 +119,14 @@ class MultiLanguageCodeAgent(BaseAgent):
             code_wsde = self.create_wsde(
                 content=code,
                 content_type="code",
-                metadata={"agent": self.name, "role": self.current_role, "language": language, "type": "code"},
+                metadata={
+                    "agent": self.name,
+                    "role": self.current_role,
+                    "language": language,
+                    "type": "code",
+                },
             )
-        except Exception as e:
+        except Exception as e:  # pragma: no cover - defensive
             logger.error(f"Error creating WSDE: {str(e)}")
 
         return {
@@ -72,5 +141,8 @@ class MultiLanguageCodeAgent(BaseAgent):
         """Return the capabilities for this agent."""
         capabilities = super().get_capabilities()
         if not capabilities:
-            capabilities = [f"generate_{lang}_code" for lang in self.SUPPORTED_LANGUAGES.keys()]
+            capabilities = [
+                f"generate_{lang}_code" for lang in self.SUPPORTED_LANGUAGES.keys()
+            ]
+            capabilities.append("generate_polyglot_code")
         return capabilities

--- a/tests/unit/application/agents/test_multi_language_code.py
+++ b/tests/unit/application/agents/test_multi_language_code.py
@@ -9,17 +9,17 @@ class TestMultiLanguageCodeAgent:
     @pytest.fixture
     def mock_llm_port(self):
         mock = MagicMock(spec=LLMPort)
-        mock.generate.return_value = 'generated code'
-        mock.generate_with_context.return_value = 'generated code with context'
+        mock.generate.return_value = "generated code"
+        mock.generate_with_context.return_value = "generated code with context"
         return mock
 
     @pytest.fixture
     def agent(self, mock_llm_port):
         agent = MultiLanguageCodeAgent()
         config = AgentConfig(
-            name='MultiLangAgent',
+            name="MultiLangAgent",
             agent_type=AgentType.CODE,
-            description='Test multi language agent',
+            description="Test multi language agent",
             capabilities=[],
         )
         agent.initialize(config)
@@ -27,34 +27,54 @@ class TestMultiLanguageCodeAgent:
         return agent
 
     def test_initialization_succeeds(self, agent):
-        assert agent.name == 'MultiLangAgent'
+        assert agent.name == "MultiLangAgent"
         assert agent.agent_type == AgentType.CODE.value
         capabilities = agent.get_capabilities()
-        assert 'generate_python_code' in capabilities
-        assert 'generate_javascript_code' in capabilities
+        assert "generate_python_code" in capabilities
+        assert "generate_javascript_code" in capabilities
+        assert "generate_go_code" in capabilities
+        assert "generate_polyglot_code" in capabilities
 
-    def test_process_python_succeeds(self, agent):
-        result = agent.process({'language': 'python'})
-        assert result['language'] == 'python'
-        assert 'code' in result
-        assert 'wsde' in result
-        wsde = result['wsde']
-        assert wsde.content == result['code']
-        assert wsde.metadata['language'] == 'python'
+    @pytest.mark.parametrize(
+        "lang",
+        [
+            "python",
+            "javascript",
+            "typescript",
+            "go",
+            "rust",
+            "haskell",
+            "julia",
+        ],
+    )
+    def test_process_supported_languages_succeed(self, agent, lang):
+        result = agent.process({"language": lang})
+        assert result["language"] == lang
+        wsde = result["wsde"]
+        assert wsde.content == result["code"]
+        assert wsde.metadata["language"] == lang
 
-    def test_process_javascript_succeeds(self, agent):
-        result = agent.process({'language': 'javascript'})
-        assert result['language'] == 'javascript'
-        wsde = result['wsde']
-        assert wsde.metadata['language'] == 'javascript'
+    def test_process_polyglot_succeeds(self, agent):
+        result = agent.process(
+            {"language": "polyglot", "languages": ["python", "javascript"]}
+        )
+        assert result["language"] == "polyglot"
+        assert set(result["languages"]) == {"python", "javascript"}
+        assert "python" in result["code"] and "javascript" in result["code"]
+        assert result["wsde"]["python"].metadata["language"] == "python"
+        assert result["wsde"]["javascript"].metadata["language"] == "javascript"
+
+    def test_process_polyglot_with_invalid_language(self, agent):
+        with pytest.raises(ValueError):
+            agent.process({"language": "polyglot", "languages": ["python", "ruby"]})
 
     def test_process_unsupported_language_raises_error(self, agent):
         with pytest.raises(ValueError):
-            agent.process({'language': 'ruby'})
+            agent.process({"language": "ruby"})
 
-    @patch('devsynth.application.agents.multi_language_code.logger')
+    @patch("devsynth.application.agents.multi_language_code.logger")
     def test_process_wsde_creation_error_logs_and_returns(self, mock_logger, agent):
-        with patch.object(agent, 'create_wsde', side_effect=Exception('fail')):
-            result = agent.process({'language': 'python'})
+        with patch.object(agent, "create_wsde", side_effect=Exception("fail")):
+            result = agent.process({"language": "python"})
             mock_logger.error.assert_called_once()
-            assert result['wsde'] is None
+            assert result["wsde"] is None


### PR DESCRIPTION
## Summary
- extend `MultiLanguageCodeAgent` with more languages and polyglot mode
- broaden unit tests to cover new languages and polyglot behavior
- document new language options in CLI reference

## Testing
- `poetry run pytest tests/unit/application/agents/test_multi_language_code.py -q`

------
https://chatgpt.com/codex/tasks/task_e_687c69f0edf48333af1d9fb3411bd649