### PR TITLE
Implement persistence for KuzuAdapter

### DIFF
--- a/src/devsynth/adapters/memory/kuzu_adapter.py
+++ b/src/devsynth/adapters/memory/kuzu_adapter.py
@@ -1,7 +1,15 @@
-"""Simple in-memory vector store used when KuzuDB is unavailable."""
+"""Simple vector store used as a fallback when KuzuDB is unavailable.
+
+The adapter stores vectors in memory but also persists them to disk so that
+subsequent adapter instances created with the same ``persist_directory`` can
+retrieve previously stored vectors.  This mirrors the behaviour of other vector
+stores used throughout the codebase and keeps the tests deterministic.
+"""
+
 from __future__ import annotations
 
 import os
+import json
 import uuid
 from typing import Any, Dict, List, Optional
 
@@ -17,22 +25,67 @@ logger = DevSynthLogger(__name__)
 class KuzuAdapter(VectorStore):
     """Vector store interface mimicking ``ChromaDBAdapter``."""
 
-    def __init__(self, persist_directory: str, collection_name: str = "devsynth_vectors") -> None:
+    def __init__(
+        self, persist_directory: str, collection_name: str = "devsynth_vectors"
+    ) -> None:
         self.persist_directory = persist_directory
         self.collection_name = collection_name
         os.makedirs(persist_directory, exist_ok=True)
+        self._data_file = os.path.join(persist_directory, f"{collection_name}.json")
         self._store: Dict[str, MemoryVector] = {}
+        self._load()
+
+    # ------------------------------------------------------------------
+    def _load(self) -> None:
+        """Load persisted vectors from disk if available."""
+        if not os.path.exists(self._data_file):
+            return
+        try:
+            with open(self._data_file, "r", encoding="utf-8") as f:
+                raw = json.load(f)
+        except Exception as exc:  # pragma: no cover - defensive
+            logger.warning("Failed to load persisted vectors: %s", exc)
+            return
+
+        for item in raw:
+            try:
+                vec = MemoryVector(**item)
+                self._store[vec.id] = vec
+            except Exception:  # pragma: no cover - defensive
+                logger.warning("Invalid vector record skipped: %s", item)
+
+    def _persist(self) -> None:
+        """Persist the vector store to disk."""
+        try:
+            with open(self._data_file, "w", encoding="utf-8") as f:
+                json.dump(
+                    [
+                        {
+                            "id": v.id,
+                            "content": v.content,
+                            "embedding": v.embedding,
+                            "metadata": v.metadata,
+                        }
+                        for v in self._store.values()
+                    ],
+                    f,
+                )
+        except Exception as exc:  # pragma: no cover - defensive
+            logger.error("Failed to persist vectors: %s", exc)
 
     def store_vector(self, vector: MemoryVector) -> str:
         if not vector.id:
             vector.id = str(uuid.uuid4())
         self._store[vector.id] = vector
+        self._persist()
         return vector.id
 
     def retrieve_vector(self, vector_id: str) -> Optional[MemoryVector]:
         return self._store.get(vector_id)
 
-    def similarity_search(self, query_embedding: List[float], top_k: int = 5) -> List[MemoryVector]:
+    def similarity_search(
+        self, query_embedding: List[float], top_k: int = 5
+    ) -> List[MemoryVector]:
         results = []
         q = np.array(query_embedding, dtype=float)
         for vec in self._store.values():
@@ -42,7 +95,10 @@ class KuzuAdapter(VectorStore):
         return [v for _, v in results[:top_k]]
 
     def delete_vector(self, vector_id: str) -> bool:
-        return self._store.pop(vector_id, None) is not None
+        existed = self._store.pop(vector_id, None) is not None
+        if existed:
+            self._persist()
+        return existed
 
     def get_collection_stats(self) -> Dict[str, Any]:
         dim = 0

--- a/tests/unit/test_kuzu_adapter.py
+++ b/tests/unit/test_kuzu_adapter.py
@@ -1,4 +1,5 @@
 """Tests for the ``KuzuAdapter`` vector store."""
+
 import tempfile
 import shutil
 from devsynth.domain.models.memory import MemoryVector
@@ -8,28 +9,43 @@ from devsynth.adapters.memory.kuzu_adapter import KuzuAdapter
 def test_store_and_retrieve_vector_succeeds():
     """Test that store and retrieve vector succeeds.
 
-ReqID: N/A"""
+    ReqID: N/A"""
     temp_dir = tempfile.mkdtemp()
     adapter = KuzuAdapter(temp_dir)
-    vec = MemoryVector(id='v1', content='text', embedding=[0.1, 0.2, 0.3])
+    vec = MemoryVector(id="v1", content="text", embedding=[0.1, 0.2, 0.3])
     adapter.store_vector(vec)
-    retrieved = adapter.retrieve_vector('v1')
+    retrieved = adapter.retrieve_vector("v1")
     shutil.rmtree(temp_dir)
     assert retrieved is not None
-    assert retrieved.id == 'v1'
+    assert retrieved.id == "v1"
 
 
 def test_similarity_search_succeeds():
     """Test that similarity search succeeds.
 
-ReqID: N/A"""
+    ReqID: N/A"""
     temp_dir = tempfile.mkdtemp()
     adapter = KuzuAdapter(temp_dir)
-    vectors = [MemoryVector(id=f'v{i}', content='x', embedding=[i, i, i]) for
-        i in range(3)]
+    vectors = [
+        MemoryVector(id=f"v{i}", content="x", embedding=[i, i, i]) for i in range(3)
+    ]
     for v in vectors:
         adapter.store_vector(v)
     res = adapter.similarity_search([0.0, 0.0, 0.0], top_k=2)
     shutil.rmtree(temp_dir)
     assert len(res) == 2
-    assert res[0].id == 'v0'
+    assert res[0].id == "v0"
+
+
+def test_persistence_between_instances_succeeds():
+    """Vectors should persist to disk across adapter instances."""
+    temp_dir = tempfile.mkdtemp()
+    adapter1 = KuzuAdapter(temp_dir)
+    adapter1.store_vector(
+        MemoryVector(id="v1", content="text", embedding=[0.1, 0.2, 0.3])
+    )
+    # Recreate adapter to trigger loading from disk
+    adapter2 = KuzuAdapter(temp_dir)
+    retrieved = adapter2.retrieve_vector("v1")
+    shutil.rmtree(temp_dir)
+    assert retrieved is not None


### PR DESCRIPTION
## Summary
- persist vectors to disk in `KuzuAdapter`
- add tests for persistent behaviour

## Testing
- `poetry run pytest tests/unit/test_kuzu_adapter.py tests/unit/test_kuzu_store.py tests/unit/test_memory_system_with_kuzu.py`
- `poetry run pytest` *(fails: test_webui_progress_add_subtask_succeeds, test_ui_progress_update_subtask_succeeds, test_ui_progress_complete_subtask_succeeds, ...)*

------
https://chatgpt.com/codex/tasks/task_e_687c69714f7083338a4eefa4a382f72c