### PR TITLE
Fix show_help group listing

### DIFF
--- a/src/devsynth/adapters/cli/typer_adapter.py
+++ b/src/devsynth/adapters/cli/typer_adapter.py
@@ -525,10 +525,10 @@ def show_help() -> None:
         command_table.add_row(command.name, command.help or "")
 
     # Add rows for each subcommand group
-    for typer_instance in app.registered_typers:
+    for group in app.registered_groups:
         command_table.add_row(
-            f"{typer_instance.name} [subcommands]",
-            typer_instance.typer_instance.info.help or ""
+            f"{group.name} [subcommands]",
+            (group.help or group.typer_instance.info.help or "")
         )
 
     console.print(command_table)

--- a/tests/unit/adapters/cli/test_typer_adapter.py
+++ b/tests/unit/adapters/cli/test_typer_adapter.py
@@ -82,7 +82,7 @@ ReqID: N/A"""
     mock_app.info = MagicMock()
     mock_app.info.help = "Test help text"
     mock_app.registered_commands = []
-    mock_app.registered_typers = []
+    mock_app.registered_groups = []
 
     # Set up the mock build_app to return our mock app
     mock_build_app.return_value = mock_app


### PR DESCRIPTION
## Summary
- iterate over `registered_groups` for subcommand groups
- update unit test to mock `registered_groups`

## Testing
- `PYTHONPATH=. poetry run pytest -q -p tests.conftest_extensions --speed=fast`

------
https://chatgpt.com/codex/tasks/task_e_687c6f72ba3c8333851f91a7272c00cf