### PR TITLE
Add cache benchmarks and performance plan

### DIFF
--- a/docs/analysis/index.md
+++ b/docs/analysis/index.md
@@ -20,6 +20,7 @@ This section contains various analysis documents related to the DevSynth project
 - **[Technical Deep Dive](technical_deep_dive.md)**: A detailed technical analysis of DevSynth.
 - **[Wide Sweep Analysis](wide_sweep_analysis.md)**: A broad analysis of the DevSynth project.
 - **[CLI and UI Improvement Plan](cli_ui_improvement_plan.md)**: Outline of upcoming usability enhancements.
+- **[Performance Benchmark Plan](performance_plan.md)**: Expected metrics for core components.
 
 ## Related Documentation
 

--- a/docs/analysis/performance_plan.md
+++ b/docs/analysis/performance_plan.md
@@ -1,0 +1,35 @@
+---
+author: DevSynth Team
+date: '2025-07-20'
+last_reviewed: '2025-07-20'
+status: draft
+tags:
+  - analysis
+  - performance
+
+title: DevSynth Performance Benchmark Plan
+version: 0.1.0
+---
+
+# DevSynth Performance Benchmark Plan
+
+This document outlines the expected performance targets for core components of the DevSynth system. Benchmarks are implemented using **pytest-benchmark** under `tests/performance/`.
+
+## Benchmark Targets
+
+| Component | Test | Expected Time |
+|-----------|------|---------------|
+| Memory Manager | Storing 100 items | < 50 ms |
+| Memory Manager | Query by type (100 items) | < 5 ms |
+| OfflineProvider | `generate` call | < 20 ms |
+| OfflineProvider | `get_embedding` call | < 5 ms |
+| Workflow Manager | Simple workflow execution | < 20 ms |
+| TieredCache | Insert 1000 items | < 10 ms |
+| TieredCache | Access cached item | < 1 ms |
+
+These metrics provide a baseline for detecting performance regressions.
+
+## Methodology
+
+Benchmarks run with `pytest --benchmark-only` on a development machine with the specifications defined in [technical_reference/benchmarks_and_performance.md](../technical_reference/benchmarks_and_performance.md). Results are stored in `.benchmarks` and reviewed regularly.
+

--- a/tests/performance/test_cache_benchmarks.py
+++ b/tests/performance/test_cache_benchmarks.py
@@ -1,0 +1,23 @@
+"""Benchmarks for tiered cache operations. ReqID: PERF-04"""
+
+from devsynth.application.memory.tiered_cache import TieredCache
+
+
+def test_cache_put_benchmark(benchmark):
+    """Benchmark inserting 1000 items. ReqID: PERF-04"""
+    cache = TieredCache(max_size=1000)
+
+    def fill_cache() -> None:
+        for i in range(1000):
+            cache.put(f"key{i}", i)
+
+    benchmark(fill_cache)
+
+
+def test_cache_get_benchmark(benchmark):
+    """Benchmark retrieving a cached item. ReqID: PERF-04"""
+    cache = TieredCache(max_size=1000)
+    for i in range(1000):
+        cache.put(f"key{i}", i)
+
+    benchmark(lambda: cache.get("key500"))


### PR DESCRIPTION
## Summary
- document performance metrics
- link the plan in analysis index
- add tiered cache performance benchmarks

## Testing
- `poetry run pytest tests/performance -q`

------
https://chatgpt.com/codex/tasks/task_e_687d1c6f44188333bdd6755a4fbb2713