### PR TITLE
Return wizard result on save

### DIFF
--- a/src/devsynth/interface/webui.py
+++ b/src/devsynth/interface/webui.py
@@ -792,27 +792,30 @@ class WebUI(UXBridge):
         data = st.session_state.wizard_data
 
         if step == len(steps) - 1 and st.button("Save Requirements"):
-            result = {
-                "title": data["title"],
-                "description": data["description"],
-                "type": data["type"],
-                "priority": data["priority"],
-                "constraints": [
-                    c.strip() for c in data["constraints"].split(",") if c.strip()
-                ],
-            }
             try:
+                result = {
+                    "title": data["title"],
+                    "description": data["description"],
+                    "type": data["type"],
+                    "priority": data["priority"],
+                    "constraints": [
+                        c.strip()
+                        for c in data["constraints"].split(",")
+                        if c.strip()
+                    ],
+                }
                 with open("requirements_wizard.json", "w", encoding="utf-8") as f:
                     f.write(json.dumps(result, indent=2))
                 self.display_result(
                     "[green]Requirements saved to requirements_wizard.json[/green]"
                 )
+                return result
             except Exception as exc:  # pragma: no cover - error path tested
                 self.display_result(
                     f"[red]ERROR saving requirements: {exc}[/red]",
                     highlight=False,
                 )
-            return
+                return None
 
         if step == 0:
             data["title"] = st.text_input("Requirement Title", data["title"])

--- a/tests/unit/interface/test_webui_requirements_wizard.py
+++ b/tests/unit/interface/test_webui_requirements_wizard.py
@@ -129,7 +129,7 @@ def test_requirements_wizard_save_requirements_succeeds(stub_streamlit, monkeypa
     stub_streamlit.button.return_value = True
     m = mock_open()
     with patch("builtins.open", m):
-        WebUI()._requirements_wizard()
+        result = WebUI()._requirements_wizard()
     m.assert_called_once_with("requirements_wizard.json", "w", encoding="utf-8")
     handle = m()
     expected_data = {
@@ -140,12 +140,14 @@ def test_requirements_wizard_save_requirements_succeeds(stub_streamlit, monkeypa
         "constraints": ["constraint1", "constraint2"],
     }
     handle.write.assert_called_once_with(json.dumps(expected_data, indent=2))
+    assert result == expected_data
     webui_instance = WebUI()
     webui_instance.display_result = MagicMock()
     with patch("builtins.open", m):
-        webui_instance._requirements_wizard()
+        result = webui_instance._requirements_wizard()
     webui_instance.display_result.assert_called_once()
     assert "[green]" in webui_instance.display_result.call_args[0][0]
+    assert result == expected_data
 
 
 def test_requirements_wizard_different_steps_succeeds(stub_streamlit):


### PR DESCRIPTION
## Summary
- return the requirements data from `_requirements_wizard`
- update wizard error handling
- expect returned result in requirements wizard tests
- adjust requirements tests to use updated fixture

## Testing
- `poetry run pytest tests/unit/interface/test_webui_requirements_wizard.py::test_requirements_wizard_save_requirements_succeeds -q`
- `poetry run pytest tests/unit/interface/test_webui_requirements.py::test_requirements_wizard_succeeds -q`
- `poetry run pytest` *(fails: 282 failed, 1654 passed, 92 skipped, 4 errors)*

------
https://chatgpt.com/codex/tasks/task_e_687d714d8cc883339dbded862430aed3