### PR TITLE
Ensure safe memory retrieval returns dict

### DIFF
--- a/src/devsynth/application/edrr/coordinator.py
+++ b/src/devsynth/application/edrr/coordinator.py
@@ -218,9 +218,20 @@ class EDRRCoordinator:
 
         try:
             if hasattr(self.memory_manager, "retrieve_with_edrr_phase"):
-                return self.memory_manager.retrieve_with_edrr_phase(
+                result = self.memory_manager.retrieve_with_edrr_phase(
                     item_type, edrr_phase, metadata
                 )
+                if isinstance(result, list):
+                    return {"items": result}
+                if isinstance(result, dict):
+                    return result
+                if result is None:
+                    return {}
+                logger.warning(
+                    "Unexpected result type %s from retrieve_with_edrr_phase",
+                    type(result),
+                )
+                return {"items": [result]}
             else:
                 logger.warning(
                     "Memory manager does not support retrieve_with_edrr_phase"

--- a/tests/unit/application/edrr/test_coordinator_phases_simple.py
+++ b/tests/unit/application/edrr/test_coordinator_phases_simple.py
@@ -44,6 +44,7 @@ def test_progress_to_phase_runs_succeeds(coordinator):
 ReqID: N/A"""
     coordinator.task = {'description': 'demo'}
     coordinator.cycle_id = 'cid'
+    coordinator._historical_data = []
     with patch.object(coordinator, '_execute_expand_phase', return_value={
         'done': True}) as ex:
         coordinator.progress_to_phase(Phase.EXPAND)

--- a/tests/unit/application/edrr/test_edrr_coordinator.py
+++ b/tests/unit/application/edrr/test_edrr_coordinator.py
@@ -296,6 +296,7 @@ ReqID: N/A"""
 ReqID: N/A"""
         coordinator.task = {'description': 'Test Task'}
         coordinator.cycle_id = 'test-cycle-id'
+        coordinator._historical_data = []
         with patch.object(coordinator, '_execute_expand_phase'):
             coordinator.progress_to_phase(Phase.EXPAND)
             assert coordinator.current_phase == Phase.EXPAND
@@ -479,3 +480,15 @@ ReqID: N/A"""
         with pytest.raises(EDRRCoordinatorError):
             coordinator.create_micro_cycle(micro_task, Phase.EXPAND)
         assert not coordinator.child_cycles
+
+    def test_safe_retrieve_always_returns_dict_for_list(self, coordinator):
+        """_safe_retrieve_with_edrr_phase converts list results to a dict."""
+        coordinator.memory_manager.retrieve_with_edrr_phase.side_effect = None
+        coordinator.memory_manager.retrieve_with_edrr_phase.return_value = [1, 2]
+        result = coordinator._safe_retrieve_with_edrr_phase(
+            MemoryType.SOLUTION.value,
+            Phase.EXPAND.value,
+            {"cycle_id": "cid"},
+        )
+        assert isinstance(result, dict)
+        assert result == {"items": [1, 2]}


### PR DESCRIPTION
## Summary
- convert lists returned from memory manager to dicts in `_safe_retrieve_with_edrr_phase`
- cover the new behavior with a unit test
- set `_historical_data` in phase tests to avoid AttributeErrors

## Testing
- `poetry run pytest tests/unit/application/edrr/test_edrr_coordinator.py tests/unit/application/edrr/test_coordinator_phases_simple.py -q`

------
https://chatgpt.com/codex/tasks/task_e_687d8d5bb8988333acb7159f9c3c47cd