### PR TITLE
Add vector sync between GraphMemoryAdapter and ChromaDB

### DIFF
--- a/src/devsynth/application/memory/adapters/chromadb_vector_adapter.py
+++ b/src/devsynth/application/memory/adapters/chromadb_vector_adapter.py
@@ -191,3 +191,23 @@ class ChromaDBVectorAdapter(VectorStore):
             "persist_directory": self.persist_directory,
             "embedding_dimensions": dimension,
         }
+
+    def get_all_vectors(self) -> List[MemoryVector]:
+        """Return all vectors stored in the adapter."""
+        if self.vectors:
+            return list(self.vectors.values())
+
+        result = self.collection.get(include=["embeddings", "metadatas", "documents"])
+        vectors: List[MemoryVector] = []
+        for i, vid in enumerate(result.get("ids", [])):
+            vectors.append(
+                MemoryVector(
+                    id=vid,
+                    content=result.get("documents", [[None]])[0][i],
+                    embedding=result.get("embeddings", [[None]])[0][i],
+                    metadata=result.get("metadatas", [[{}]])[0][i],
+                )
+            )
+        for vec in vectors:
+            self.vectors[vec.id] = vec
+        return vectors

--- a/src/devsynth/application/memory/rdflib_store.py
+++ b/src/devsynth/application/memory/rdflib_store.py
@@ -777,3 +777,23 @@ class RDFLibStore(MemoryStore, VectorStore):
                 operation="get_collection_stats",
                 original_error=e,
             )
+
+    def get_all_vectors(self) -> List[MemoryVector]:
+        """Return all vectors stored in the graph."""
+        vectors: List[MemoryVector] = []
+        try:
+            sparql_query = """
+                SELECT ?vector
+                WHERE {
+                    ?vector a <https://github.com/ravenoak/devsynth/ontology/memory#MemoryVector> .
+                }
+            """
+            results = self.graph.query(sparql_query)
+            for row in results:
+                vector_uri = row[0]
+                vector = self._triples_to_memory_vector(vector_uri)
+                if vector:
+                    vectors.append(vector)
+        except Exception as e:  # pragma: no cover - safe fallback
+            logger.error(f"Failed to retrieve vectors: {e}")
+        return vectors


### PR DESCRIPTION
## Summary
- support retrieving all vectors from RDFLib store
- expose `get_all_vectors` for GraphMemoryAdapter and ChromaDBVectorAdapter
- implement import/export of vectors when integrating stores
- test `advanced_graph_memory_features` scenario

## Testing
- `poetry run pytest -k advanced_graph_memory_features -q`
- `poetry run pytest -q` *(fails: web UI tests)*

------
https://chatgpt.com/codex/tasks/task_e_687da613120c8333ba0d8e74491dd74c