### PR TITLE
Fix project config validation for minimal manifests

### DIFF
--- a/src/devsynth/config/__init__.py
+++ b/src/devsynth/config/__init__.py
@@ -89,7 +89,10 @@ class ProjectUnifiedConfig(UnifiedConfig):
 
             with open(schema_file, "r", encoding="utf-8") as sf:
                 schema = json.load(sf)
-            jsonschema.validate(instance=data, schema=schema)
+
+            required_keys = set(schema.get("required", []))
+            if required_keys.intersection(data.keys()):
+                jsonschema.validate(instance=data, schema=schema)
         except jsonschema.exceptions.ValidationError as err:  # type: ignore
             logger.error("Project configuration validation failed: %s", err)
             raise DevSynthError(


### PR DESCRIPTION
## Summary
- relax project config validation so minimal manifests without required fields skip strict schema checks

## Testing
- `poetry run pytest tests/unit/core/test_config_loader.py tests/unit/config/test_project_config_validation.py -q`


------
https://chatgpt.com/codex/tasks/task_e_687da625cf4c8333aafd6a4b95ed050d