### PR TITLE
Fix streamlit mock for progress tests

### DIFF
--- a/tests/unit/interface/test_webui_enhanced.py
+++ b/tests/unit/interface/test_webui_enhanced.py
@@ -23,6 +23,11 @@ def _mock_streamlit():
     st.container = MagicMock()
     st.container.return_value.__enter__ = MagicMock(return_value=MagicMock())
     st.container.return_value.__exit__ = MagicMock(return_value=None)
+    st.set_page_config = MagicMock()
+    st.components = ModuleType('components')
+    st.components.v1 = ModuleType('v1')
+    st.components.v1.html = MagicMock()
+    st.session_state = {}
     return st
 
 


### PR DESCRIPTION
## Summary
- expand the Streamlit mock used for tests to include `set_page_config`, `components.v1.html`, and `session_state`
- keep `import sys` at the top of progress tests so the fixture can insert the mock module

## Testing
- `poetry run pytest tests/unit/interface/test_webui_progress.py`

------
https://chatgpt.com/codex/tasks/task_e_687dac7e98ac8333a7552ee8bba0c81c