### PR TITLE
Fix teardown path patch conflict

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -303,6 +303,9 @@ def global_test_isolation(monkeypatch, tmp_path):
     os.environ.clear()
     os.environ.update(original_env)
 
+    # Undo any monkeypatches from the test before running cleanup logic
+    monkeypatch.undo()
+
     # Clean up any stray files in real directories
     # Instead of relying on file modification times, we'll use a more reliable approach
     # by checking for specific directories that should never be created during tests


### PR DESCRIPTION
## Summary
- undo monkeypatch effects in global_test_isolation before cleanup
- confirm requirements page error handler test passes

## Testing
- `poetry run pytest tests/unit/interface/test_webui_error_handling.py::test_requirements_page_file_not_found_raises_error -vv`

------
https://chatgpt.com/codex/tasks/task_e_687dc02d325083338d3f985eeaff1b4e