### PR TITLE
Ensure vector store stats retrieved before integration

### DIFF
--- a/src/devsynth/application/memory/adapters/graph_memory_adapter.py
+++ b/src/devsynth/application/memory/adapters/graph_memory_adapter.py
@@ -992,6 +992,15 @@ class GraphMemoryAdapter(MemoryStore):
                 other_store, "retrieve_vector"
             )
 
+            if has_vector_store_methods and hasattr(
+                other_store, "get_collection_stats"
+            ):
+                try:
+                    stats = other_store.get_collection_stats()
+                    logger.info(f"Vector store stats before integration: {stats}")
+                except Exception as e:  # pragma: no cover - logging
+                    logger.warning(f"Failed to retrieve vector store stats: {e}")
+
             if has_vector_store_methods and self.use_rdflib_store and self.rdflib_store:
                 # Import vectors from the other store
                 if sync_mode in ["import", "bidirectional"]:


### PR DESCRIPTION
## Summary
- gather vector store stats using `get_collection_stats` in `integrate_with_store`
- log the statistics before importing or exporting vectors

## Testing
- `poetry run pytest tests/unit/application/memory/test_graph_memory_adapter.py::TestGraphMemoryAdapter::test_integrate_with_vector_store_succeeds -q`
- `poetry run pytest -q` *(fails: Step definition not found)*

------
https://chatgpt.com/codex/tasks/task_e_687e4d33baf483338d7295312cfe358c