### PR TITLE
Refactor test Streamlit mocks

### DIFF
--- a/tests/unit/interface/streamlit_mocks.py
+++ b/tests/unit/interface/streamlit_mocks.py
@@ -1,0 +1,76 @@
+from types import ModuleType
+from unittest.mock import MagicMock
+
+
+class DummyContext:
+    """Simple context manager used for streamlit forms/spinners."""
+
+    def __init__(self, submitted: bool = True):
+        self.submitted = submitted
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+    def form_submit_button(self, *_args, **_kwargs):
+        return self.submitted
+
+
+def make_streamlit_mock(submitted: bool = True) -> ModuleType:
+    """Return a mocked ``streamlit`` module with common APIs used in WebUI."""
+    st = ModuleType("streamlit")
+
+    class SS(dict):
+        pass
+
+    st.session_state = SS()
+    st.session_state.wizard_step = 0
+
+    st.header = MagicMock()
+    st.subheader = MagicMock()
+    st.text_input = MagicMock(return_value="text")
+    st.text_area = MagicMock(return_value="desc")
+    st.selectbox = MagicMock(return_value="choice")
+    st.checkbox = MagicMock(return_value=True)
+    st.number_input = MagicMock(return_value=30)
+    st.toggle = MagicMock(return_value=False)
+    st.radio = MagicMock(return_value="choice")
+    st.button = MagicMock(return_value=False)
+    st.form_submit_button = MagicMock(return_value=submitted)
+    st.expander = lambda *_a, **_k: DummyContext(submitted)
+    st.form = lambda *_a, **_k: DummyContext(submitted)
+    st.spinner = lambda *_a, **_k: DummyContext(submitted)
+    st.divider = MagicMock()
+    st.columns = MagicMock(
+        return_value=(MagicMock(button=lambda *a, **k: False), MagicMock(button=lambda *a, **k: False))
+    )
+    st.progress = MagicMock()
+    st.write = MagicMock()
+    st.markdown = MagicMock()
+    st.code = MagicMock()
+    st.error = MagicMock()
+    st.info = MagicMock()
+    st.success = MagicMock()
+    st.warning = MagicMock()
+    st.set_page_config = MagicMock()
+    st.empty = MagicMock(return_value=MagicMock(markdown=MagicMock(), empty=MagicMock()))
+    st.container = lambda *_a, **_k: DummyContext(submitted)
+    st.components = ModuleType("components")
+    st.components.v1 = ModuleType("v1")
+    st.components.v1.html = MagicMock()
+
+    sidebar = MagicMock()
+    sidebar.title = MagicMock()
+    sidebar.markdown = MagicMock()
+    sidebar.radio = MagicMock(return_value="Onboarding")
+    sidebar.button = MagicMock(return_value=False)
+    sidebar.selectbox = MagicMock(return_value="test")
+    sidebar.checkbox = MagicMock(return_value=False)
+    sidebar.text_input = MagicMock(return_value="test")
+    sidebar.text_area = MagicMock(return_value="test")
+    sidebar.expander = lambda *_a, **_k: DummyContext(submitted)
+    st.sidebar = sidebar
+
+    return st

--- a/tests/unit/interface/test_webui.py
+++ b/tests/unit/interface/test_webui.py
@@ -2,64 +2,12 @@ import sys
 from types import ModuleType
 from unittest.mock import MagicMock
 import pytest
-
-
-class DummyForm:
-
-    def __init__(self, submitted: bool = True):
-        self.submitted = submitted
-
-    def __enter__(self):
-        return self
-
-    def __exit__(self, exc_type, exc, tb):
-        return False
-
-    def form_submit_button(self, *_args, **_kwargs):
-        return self.submitted
+from tests.unit.interface.streamlit_mocks import make_streamlit_mock
 
 
 @pytest.fixture(autouse=True)
 def stub_streamlit(monkeypatch):
-    st = ModuleType("streamlit")
-
-    class SS(dict):
-        pass
-
-    st.session_state = SS()
-    st.session_state.wizard_step = 0
-    st.header = MagicMock()
-    st.expander = lambda *_a, **_k: DummyForm(True)
-    st.form = lambda *_a, **_k: DummyForm(True)
-    st.form_submit_button = MagicMock(return_value=True)
-    st.text_input = MagicMock(return_value="text")
-    st.text_area = MagicMock(return_value="desc")
-    st.selectbox = MagicMock(return_value="choice")
-    st.checkbox = MagicMock(return_value=True)
-    st.button = MagicMock(return_value=False)
-    st.error = MagicMock()
-    st.info = MagicMock()
-    st.success = MagicMock()
-    st.warning = MagicMock()
-    st.spinner = DummyForm
-    st.divider = MagicMock()
-    st.columns = MagicMock(
-        return_value=(
-            MagicMock(button=lambda *a, **k: False),
-            MagicMock(button=lambda *a, **k: False),
-        )
-    )
-    st.progress = MagicMock()
-    st.write = MagicMock()
-    st.markdown = MagicMock()
-    st.subheader = MagicMock()
-    st.set_page_config = MagicMock()
-    st.sidebar = MagicMock()
-    st.sidebar.title = MagicMock()
-    st.sidebar.markdown = MagicMock()
-    st.sidebar.radio = MagicMock(return_value="Onboarding")
-    st.number_input = MagicMock(return_value=30)
-    st.toggle = MagicMock(return_value=False)
+    st = make_streamlit_mock()
     monkeypatch.setitem(sys.modules, "streamlit", st)
     monkeypatch.setattr("pathlib.Path.exists", lambda self: True)
     cli_stub = ModuleType("devsynth.application.cli")

--- a/tests/unit/interface/test_webui_error_handling.py
+++ b/tests/unit/interface/test_webui_error_handling.py
@@ -1,58 +1,14 @@
 import sys
-from types import ModuleType
 from unittest.mock import MagicMock, patch
 import pytest
 from pathlib import Path
+from tests.unit.interface.streamlit_mocks import make_streamlit_mock
 
 
 @pytest.fixture
 def stub_streamlit(monkeypatch):
-    """Create a stub streamlit module for testing."""
-    st = ModuleType('streamlit')
-
-
-    class SS(dict):
-        pass
-    st.session_state = SS()
-    st.header = MagicMock()
-    st.expander = MagicMock()
-    st.expander.return_value.__enter__ = MagicMock(return_value=None)
-    st.expander.return_value.__exit__ = MagicMock(return_value=None)
-    st.form = MagicMock()
-    st.form.return_value.__enter__ = MagicMock(return_value=None)
-    st.form.return_value.__exit__ = MagicMock(return_value=None)
-    st.form_submit_button = MagicMock(return_value=True)
-    st.text_input = MagicMock(return_value='test')
-    st.button = MagicMock(return_value=False)
-    st.spinner = MagicMock()
-    st.spinner.return_value.__enter__ = MagicMock(return_value=None)
-    st.spinner.return_value.__exit__ = MagicMock(return_value=None)
-
-    # Add missing methods that are used in the WebUI implementation
-    st.error = MagicMock()
-    st.info = MagicMock()
-    st.success = MagicMock()
-    st.write = MagicMock()
-    st.progress = MagicMock()
-    st.text_area = MagicMock(return_value='test')
-    st.columns = MagicMock(return_value=[MagicMock(), MagicMock()])
-    st.divider = MagicMock()
-    st.markdown = MagicMock()
-    st.toggle = MagicMock(return_value=False)
-    st.selectbox = MagicMock(return_value='test')
-    st.radio = MagicMock(return_value='test')
-    st.checkbox = MagicMock(return_value=False)
-    st.sidebar = MagicMock()
-    st.sidebar.button = MagicMock(return_value=False)
-    st.sidebar.selectbox = MagicMock(return_value='test')
-    st.sidebar.radio = MagicMock(return_value='test')
-    st.sidebar.checkbox = MagicMock(return_value=False)
-    st.sidebar.text_input = MagicMock(return_value='test')
-    st.sidebar.text_area = MagicMock(return_value='test')
-    st.sidebar.expander = MagicMock()
-    st.sidebar.expander.return_value.__enter__ = MagicMock(return_value=None)
-    st.sidebar.expander.return_value.__exit__ = MagicMock(return_value=None)
-
+    """Provide a shared Streamlit mock for WebUI tests."""
+    st = make_streamlit_mock()
     monkeypatch.setitem(sys.modules, 'streamlit', st)
     return st
 


### PR DESCRIPTION
## Summary
- add `make_streamlit_mock` helper for reusable Streamlit mocks
- use helper in `test_webui.py`
- use helper in `test_webui_error_handling.py`

## Testing
- `poetry run pytest tests/unit/interface/test_webui.py::test_onboarding_calls_init_succeeds tests/unit/interface/test_webui_error_handling.py::test_onboarding_page_init_cmd_error_raises_error -q` *(fails: init_cmd() got an unexpected keyword argument 'path')*

------
https://chatgpt.com/codex/tasks/task_e_687e51ded06083339be819bb3b93c8d9