### PR TITLE
Improve handling of optional dependencies

### DIFF
--- a/src/devsynth/application/llm/providers.py
+++ b/src/devsynth/application/llm/providers.py
@@ -204,7 +204,11 @@ def get_llm_provider(config: Dict[str, Any] | None = None) -> LLMProvider:
 
 
 # Import providers at the end to avoid circular imports
-from .lmstudio_provider import LMStudioProvider
+try:  # pragma: no cover - optional dependency
+    from .lmstudio_provider import LMStudioProvider
+except ImportError as exc:  # pragma: no cover - fallback path
+    LMStudioProvider = None
+    logger.warning("LMStudioProvider not available: %s", exc)
 from .openai_provider import OpenAIProvider
 from .local_provider import LocalProvider
 from .offline_provider import OfflineProvider
@@ -214,7 +218,8 @@ factory = SimpleLLMProviderFactory()
 
 # Register providers
 factory.register_provider_type("anthropic", AnthropicProvider)
-factory.register_provider_type("lmstudio", LMStudioProvider)
+if LMStudioProvider is not None:
+    factory.register_provider_type("lmstudio", LMStudioProvider)
 factory.register_provider_type("openai", OpenAIProvider)
 factory.register_provider_type("local", LocalProvider)
 factory.register_provider_type("offline", OfflineProvider)

--- a/tests/unit/application/llm/test_import_without_lmstudio.py
+++ b/tests/unit/application/llm/test_import_without_lmstudio.py
@@ -1,0 +1,21 @@
+import builtins
+import importlib
+import sys
+
+
+def test_import_lmstudio_provider_without_lmstudio_succeeds(monkeypatch):
+    """Importing providers should succeed without lmstudio installed."""
+    sys.modules.pop("devsynth.application.llm.providers", None)
+    sys.modules.pop("devsynth.application.llm.lmstudio_provider", None)
+    sys.modules.pop("lmstudio", None)
+    real_import = builtins.__import__
+
+    def fake_import(name, globals=None, locals=None, fromlist=(), level=0):
+        if name.startswith("lmstudio"):
+            raise ImportError("No module named 'lmstudio'")
+        return real_import(name, globals, locals, fromlist, level)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+    providers = importlib.import_module("devsynth.application.llm.providers")
+    assert providers.LMStudioProvider is None
+    assert "lmstudio" not in providers.factory.provider_types

--- a/tests/unit/application/memory/test_import_without_duckdb.py
+++ b/tests/unit/application/memory/test_import_without_duckdb.py
@@ -1,0 +1,20 @@
+import builtins
+import importlib
+import sys
+import pytest
+
+
+def test_import_duckdb_store_without_duckdb_fails(monkeypatch):
+    """Importing DuckDBStore should raise ImportError when duckdb is missing."""
+    sys.modules.pop("devsynth.application.memory.duckdb_store", None)
+    sys.modules.pop("duckdb", None)
+    real_import = builtins.__import__
+
+    def fake_import(name, globals=None, locals=None, fromlist=(), level=0):
+        if name == "duckdb":
+            raise ImportError("No module named 'duckdb'")
+        return real_import(name, globals, locals, fromlist, level)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+    with pytest.raises(ImportError, match="duckdb"):
+        importlib.import_module("devsynth.application.memory.duckdb_store")


### PR DESCRIPTION
## Summary
- guard `duckdb` import in `DuckDBStore`
- guard `lmstudio` import in `LMStudioProvider`
- make `LMStudioProvider` registration optional
- test import behaviour when `duckdb` or `lmstudio` are missing

## Testing
- `poetry run pytest tests/unit/application/memory/test_import_without_duckdb.py tests/unit/application/llm/test_import_without_lmstudio.py`
- `poetry run pytest` *(fails: 260 failed, 1683 passed, 92 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_687e685795fc8333b434eacc0045d493