### PR TITLE
Fix WebUI wizard navigation and Kuzu init

### DIFF
--- a/src/devsynth/interface/webui.py
+++ b/src/devsynth/interface/webui.py
@@ -847,11 +847,22 @@ class WebUI(UXBridge):
                 "constraints": "",
             }
 
+        data = st.session_state.wizard_data
+        defaults = {
+            "title": "",
+            "description": "",
+            "type": RequirementType.FUNCTIONAL.value,
+            "priority": RequirementPriority.MEDIUM.value,
+            "constraints": "",
+        }
+        for key, val in defaults.items():
+            if key not in data:
+                data[key] = val
+
         steps = ["Title", "Description", "Type", "Priority", "Constraints"]
         step = st.session_state.wizard_step
         st.write(f"Step {step + 1} of {len(steps)}: {steps[step]}")
         st.progress((step + 1) / len(steps))
-        data = st.session_state.wizard_data
 
         if step == len(steps) - 1 and st.button("Save Requirements"):
             try:

--- a/tests/behavior/steps/test_requirements_wizard_navigation_steps.py
+++ b/tests/behavior/steps/test_requirements_wizard_navigation_steps.py
@@ -8,7 +8,7 @@ from pytest_bdd import given, when, then, scenarios
 
 from devsynth.interface.webui import WebUI
 
-scenarios("../features/requirements_wizard_navigation.feature")
+scenarios("../features/general/requirements_wizard_navigation.feature")
 
 
 class DummyForm:
@@ -28,8 +28,10 @@ class DummyForm:
 @pytest.fixture
 def wizard_context(monkeypatch):
     st = ModuleType("streamlit")
+
     class SS(dict):
         pass
+
     st.session_state = SS()
     st.session_state.wizard_step = 0
     st.session_state.wizard_data = {}
@@ -48,13 +50,19 @@ def wizard_context(monkeypatch):
     st.button = MagicMock(side_effect=[False, True, False])
     st.spinner = DummyForm
     st.divider = MagicMock()
-    st.columns = MagicMock(return_value=(MagicMock(button=lambda *a, **k: False), MagicMock(button=lambda *a, **k: False)))
+    st.columns = MagicMock(
+        return_value=(
+            MagicMock(button=lambda *a, **k: False),
+            MagicMock(button=lambda *a, **k: False),
+        )
+    )
     st.progress = MagicMock()
     st.write = MagicMock()
     st.markdown = MagicMock()
     monkeypatch.setitem(sys.modules, "streamlit", st)
 
     import devsynth.interface.webui as webui
+
     importlib.reload(webui)
 
     ctx = {"st": st, "ui": webui.WebUI()}

--- a/tests/behavior/steps/test_requirements_wizard_steps.py
+++ b/tests/behavior/steps/test_requirements_wizard_steps.py
@@ -55,7 +55,7 @@ def _run_wizard(output: Path, bridge: DummyBridge) -> None:
         wizard.bridge.display_result("Cancelled")
 
 
-scenarios("../features/requirements_wizard.feature")
+scenarios("../features/general/requirements_wizard.feature")
 
 
 @given("the DevSynth CLI is installed")
@@ -65,7 +65,7 @@ def cli_installed():
 
 @when("I run the requirements wizard")
 def run_requirements_wizard(tmp_project_dir, monkeypatch):
-    monkeypatch.setitem(Path, "home", lambda: Path(tmp_project_dir))
+    monkeypatch.setattr(Path, "home", lambda: Path(tmp_project_dir))
     answers = ["My Project", "python", "feature1,feature2"]
     confirms = [True]
     bridge = DummyBridge(answers, confirms)
@@ -75,7 +75,7 @@ def run_requirements_wizard(tmp_project_dir, monkeypatch):
 
 @when("I cancel the requirements wizard")
 def cancel_requirements_wizard(tmp_project_dir, monkeypatch):
-    monkeypatch.setitem(Path, "home", lambda: Path(tmp_project_dir))
+    monkeypatch.setattr(Path, "home", lambda: Path(tmp_project_dir))
     answers = ["My Project", "python", "feature1,feature2"]
     confirms = [False]
     bridge = DummyBridge(answers, confirms)

--- a/tests/behavior/test_requirements_wizard.py
+++ b/tests/behavior/test_requirements_wizard.py
@@ -1,10 +1,12 @@
 import os
 from pytest_bdd import scenarios
 
-from .steps.requirements_wizard_steps import *  # noqa: F401,F403
+from .steps.test_requirements_wizard_steps import *  # noqa: F401,F403
 
 # Get the absolute path to the feature file
-feature_file = os.path.join(os.path.dirname(__file__), "features", "requirements_wizard.feature")
+feature_file = os.path.join(
+    os.path.dirname(__file__), "features", "general", "requirements_wizard.feature"
+)
 
 # Load the scenarios from the feature file
 scenarios(feature_file)

--- a/tests/behavior/test_requirements_wizard_navigation.py
+++ b/tests/behavior/test_requirements_wizard_navigation.py
@@ -1,10 +1,15 @@
 import os
 from pytest_bdd import scenarios
 
-from .steps.requirements_wizard_navigation_steps import *  # noqa: F401,F403
+from .steps.test_requirements_wizard_navigation_steps import *  # noqa: F401,F403
 
 # Get the absolute path to the feature file
-feature_file = os.path.join(os.path.dirname(__file__), "features", "requirements_wizard_navigation.feature")
+feature_file = os.path.join(
+    os.path.dirname(__file__),
+    "features",
+    "general",
+    "requirements_wizard_navigation.feature",
+)
 
 # Load the scenarios from the feature file
 scenarios(feature_file)

--- a/tests/integration/general/test_kuzu_memory_integration.py
+++ b/tests/integration/general/test_kuzu_memory_integration.py
@@ -47,3 +47,13 @@ def test_kuzu_memory_vector_integration_succeeds(temp_dir):
     results = adapter.vector_store.similarity_search([0.1, 0.2, 0.3], top_k=1)
     assert results
     assert results[0].id == item_id
+
+
+def test_create_for_testing_with_kuzu(temp_dir):
+    adapter = MemorySystemAdapter.create_for_testing(
+        storage_type="kuzu", memory_path=temp_dir
+    )
+    assert adapter.storage_type == "kuzu"
+    assert adapter.memory_store is not None
+    assert adapter.context_manager is not None
+    assert adapter.vector_store is not None


### PR DESCRIPTION
## Summary
- normalize wizard data defaults in WebUI so navigation works
- point requirements wizard step files at the correct feature paths
- fix Path monkeypatching in wizard steps
- test WebUI requirements wizard navigation
- verify create_for_testing with kuzu backends

## Testing
- `poetry run pytest tests/integration/general/test_kuzu_memory_integration.py tests/behavior/test_requirements_wizard_navigation.py tests/behavior/test_requirements_wizard.py -vv`

------
https://chatgpt.com/codex/tasks/task_e_687ebcb9c9bc8333b20177744a2c2b80