### PR TITLE
Fix WebUI tests and config loader

### DIFF
--- a/src/devsynth/config/loader.py
+++ b/src/devsynth/config/loader.py
@@ -137,9 +137,9 @@ def _find_config_path(start: Path) -> Optional[Path]:
     return None
 
 
-def load_config(path: Optional[Path] = None) -> ConfigModel:
+def load_config(path: Optional[str | Path] = None) -> ConfigModel:
     """Load configuration from YAML or TOML."""
-    root = path or Path(os.getcwd())
+    root = Path(path) if path is not None else Path(os.getcwd())
     cfg_path = _find_config_path(root)
 
     defaults = ConfigModel(project_root=str(root))

--- a/tests/integration/general/test_webui_pages.py
+++ b/tests/integration/general/test_webui_pages.py
@@ -3,7 +3,10 @@ import sys
 from types import ModuleType
 from unittest.mock import MagicMock
 import pytest
-from tests.integration.test_webui_setup import _setup_streamlit
+try:  # Compatibility with older test layout
+    from tests.integration.test_webui_setup import _setup_streamlit
+except ModuleNotFoundError:  # pragma: no cover - fallback path
+    from tests.integration.general.test_webui_setup import _setup_streamlit
 
 
 @pytest.fixture

--- a/tests/unit/interface/test_webui_requirements.py
+++ b/tests/unit/interface/test_webui_requirements.py
@@ -39,6 +39,7 @@ def mock_streamlit(monkeypatch):
     st.expander.return_value.__enter__ = MagicMock(return_value=MagicMock())
     st.expander.return_value.__exit__ = MagicMock(return_value=None)
     st.spinner = MagicMock()
+    monkeypatch.setattr('pathlib.Path.exists', lambda self: True)
     monkeypatch.setitem(sys.modules, 'streamlit', st)
     return st
 
@@ -47,8 +48,10 @@ def mock_streamlit(monkeypatch):
 def mock_spec_cmd(monkeypatch):
     """Fixture to mock spec_cmd for testing."""
     spec_cmd = MagicMock()
+    inspect_cmd = MagicMock()
     cli_module = ModuleType('devsynth.application.cli')
     cli_module.spec_cmd = spec_cmd
+    cli_module.inspect_cmd = inspect_cmd
     monkeypatch.setitem(sys.modules, 'devsynth.application.cli', cli_module)
     return spec_cmd
 
@@ -59,17 +62,22 @@ def mock_requirement_types(monkeypatch):
     req_module = ModuleType('devsynth.domain.models.requirement')
 
 
+    class _Enum:
+        def __init__(self, value):
+            self.value = value
+
     class MockRequirementType:
-        FUNCTIONAL = 'functional'
-        NON_FUNCTIONAL = 'non_functional'
-        CONSTRAINT = 'constraint'
+        FUNCTIONAL = _Enum("functional")
+        NON_FUNCTIONAL = _Enum("non_functional")
+        CONSTRAINT = _Enum("constraint")
 
 
     class MockRequirementPriority:
-        MUST_HAVE = 'must_have'
-        SHOULD_HAVE = 'should_have'
-        COULD_HAVE = 'could_have'
-        WONT_HAVE = 'wont_have'
+        MUST_HAVE = _Enum("must_have")
+        SHOULD_HAVE = _Enum("should_have")
+        COULD_HAVE = _Enum("could_have")
+        WONT_HAVE = _Enum("wont_have")
+        MEDIUM = _Enum("medium")
     req_module.RequirementType = MockRequirementType
     req_module.RequirementPriority = MockRequirementPriority
     monkeypatch.setitem(sys.modules, 'devsynth.domain.models.requirement',


### PR DESCRIPTION
## Summary
- fix compatibility import in WebUI page tests
- ensure `load_config` accepts string paths
- update WebUI requirements test stubs

## Testing
- `poetry run pytest tests/integration/general/test_webui_setup.py tests/integration/general/test_webui_pages.py tests/unit/interface/test_webui_requirements.py tests/unit/general/test_kuzu_store.py -q`

------
https://chatgpt.com/codex/tasks/task_e_687ee6d34b44833396fa80b14bc95bf8