### PR TITLE
Remove codex setup references

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,8 +70,6 @@ Installation instructions are covered in detail in the [Installation Guide](docs
 
 DevSynth requires **Python 3.12 or higher**. Using [Poetry](https://python-poetry.org/) is recommended for managing dependencies during development.
 
-The initial workspace setup runs [`scripts/codex_setup.sh`](scripts/codex_setup.sh) with network access enabled. If the script fails, a file named `CODEX_ENVIRONMENT_SETUP_FAILED` will appear in the repository root. After provisioning, network access is disabled. See [AGENTS.md#environment-setup](AGENTS.md#environment-setup) for instructions on fixing and rerunning the setup offline. Once the script completes successfully and the marker file is removed, run `poetry run pytest` to verify your environment.
-
 ## Installation
 
 You can install DevSynth in a few different ways:
@@ -174,7 +172,7 @@ The repository includes runnable examples that walk through common workflows:
 
 ## Running Tests
 
-Run `scripts/codex_setup.sh` first to provision the environment. Once it finishes without errors, execute the test suite with `poetry run pytest`.
+Run `poetry run pytest` to execute the test suite.
 
 Before running the test suite manually, you **must** install DevSynth with its development extras:
 

--- a/docs/developer_guides/development_setup.md
+++ b/docs/developer_guides/development_setup.md
@@ -59,8 +59,6 @@ Before setting up the development environment, ensure you have the following ins
 
 ## Development Environment Setup
 
-The workspace automatically runs [`scripts/codex_setup.sh`](../../scripts/codex_setup.sh) with network access enabled during provisioning. If the script fails, a `CODEX_ENVIRONMENT_SETUP_FAILED` file will appear in the project root. Network access is disabled afterward. Follow the steps in [AGENTS.md#environment-setup](../../AGENTS.md#environment-setup) to repair the environment and remove the marker offline.
-
 ### 1. Clone the Repository
 
 ```bash

--- a/tests/README.md
+++ b/tests/README.md
@@ -247,8 +247,6 @@ poetry run pytest
 
 ### Environment Setup
 
-The test environment relies on [`scripts/codex_setup.sh`](../scripts/codex_setup.sh) being executed successfully during provisioning (with network access). If the script fails, a `CODEX_ENVIRONMENT_SETUP_FAILED` file will be present in the repository root. Network access is disabled when you run the tests manually. See [AGENTS.md#environment-setup](../AGENTS.md#environment-setup) for instructions on how to resolve the failure and remove the marker offline.
-
 Before running tests, you **must** install DevSynth with the development extras:
 
 ```bash


### PR DESCRIPTION
## Summary
- drop references to `scripts/codex_setup.sh` in docs
- remove setup script notes from tests guide
- update running tests section

## Testing
- `poetry run pytest -q` *(fails: FileNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_687fa2d627388333884dc7ca8fdee801