### PR TITLE
Fix BDD feature paths

### DIFF
--- a/tests/behavior/steps/test_additional_storage_backends_steps.py
+++ b/tests/behavior/steps/test_additional_storage_backends_steps.py
@@ -25,7 +25,7 @@ pytestmark = [
 ]
 
 # Register the scenarios from the feature file
-scenarios('../features/additional_storage_backends.feature')
+scenarios('../features/general/additional_storage_backends.feature')
 
 
 @pytest.fixture

--- a/tests/behavior/steps/test_advanced_graph_memory_features_steps.py
+++ b/tests/behavior/steps/test_advanced_graph_memory_features_steps.py
@@ -15,7 +15,7 @@ from devsynth.application.memory.adapters.tinydb_memory_adapter import TinyDBMem
 from devsynth.application.memory.adapters.chromadb_vector_adapter import ChromaDBVectorAdapter
 
 # Register scenarios
-scenarios('../features/advanced_graph_memory_features.feature')
+scenarios('../features/general/advanced_graph_memory_features.feature')
 
 @pytest.fixture
 def context():

--- a/tests/behavior/steps/test_agent_adapter_steps.py
+++ b/tests/behavior/steps/test_agent_adapter_steps.py
@@ -17,7 +17,7 @@ def adapter_context(monkeypatch):
     return {"cls": mock_cls, "instance": mock_coord}
 
 
-scenarios("../features/agent_adapter.feature")
+scenarios("../features/general/agent_adapter.feature")
 
 
 @given("the agent_adapter feature context")

--- a/tests/behavior/steps/test_agent_api_health_metrics_steps.py
+++ b/tests/behavior/steps/test_agent_api_health_metrics_steps.py
@@ -9,7 +9,7 @@ import pytest
 from fastapi.testclient import TestClient
 from pytest_bdd import given, when, then, scenarios, parsers
 
-scenarios("../features/agent_api_health_metrics.feature")
+scenarios("../features/general/agent_api_health_metrics.feature")
 
 
 @pytest.fixture

--- a/tests/behavior/steps/test_agent_api_steps.py
+++ b/tests/behavior/steps/test_agent_api_steps.py
@@ -9,7 +9,7 @@ import pytest
 from fastapi.testclient import TestClient
 from pytest_bdd import given, when, then, scenarios, parsers
 
-scenarios("../features/agent_api_interactions.feature")
+scenarios("../features/general/agent_api_interactions.feature")
 
 
 @pytest.fixture

--- a/tests/behavior/steps/test_alignment_metrics_steps.py
+++ b/tests/behavior/steps/test_alignment_metrics_steps.py
@@ -4,7 +4,7 @@ from pytest_bdd import scenarios, given, then
 
 from .cli_commands_steps import run_command  # noqa: F401
 
-scenarios("../features/alignment_metrics_command.feature")
+scenarios("../features/general/alignment_metrics_command.feature")
 
 
 @given("alignment metrics calculation fails")

--- a/tests/behavior/steps/test_analyze_commands_steps.py
+++ b/tests/behavior/steps/test_analyze_commands_steps.py
@@ -15,7 +15,7 @@ from devsynth.application.cli.commands.inspect_code_cmd import inspect_code_cmd
 from devsynth.application.cli.commands.inspect_config_cmd import inspect_config_cmd
 
 # Register the scenarios
-scenarios("../features/analyze_commands.feature")
+scenarios("../features/general/analyze_commands.feature")
 
 
 # Define fixtures and step definitions

--- a/tests/behavior/steps/test_api_stub_steps.py
+++ b/tests/behavior/steps/test_api_stub_steps.py
@@ -6,7 +6,7 @@ import importlib
 import pytest
 from pytest_bdd import given, when, then, scenarios
 
-scenarios("../features/api_stub_usage.feature")
+scenarios("../features/general/api_stub_usage.feature")
 
 
 @pytest.fixture

--- a/tests/behavior/steps/test_apispec_generation_steps.py
+++ b/tests/behavior/steps/test_apispec_generation_steps.py
@@ -19,7 +19,7 @@ def apispec_context(monkeypatch):
     return {"cmd": mock_cmd}
 
 
-scenarios("../features/apispec_generation.feature")
+scenarios("../features/general/apispec_generation.feature")
 
 
 @given("the apispec_generation feature context")

--- a/tests/behavior/steps/test_ast_code_analysis_steps.py
+++ b/tests/behavior/steps/test_ast_code_analysis_steps.py
@@ -9,7 +9,7 @@ import uuid
 from pytest_bdd import given, when, then, parsers, scenarios
 
 # Import the feature file
-scenarios('../features/ast_code_analysis.feature')
+scenarios('../features/general/ast_code_analysis.feature')
 
 # Import the modules needed for the steps
 from devsynth.application.code_analysis.analyzer import CodeAnalyzer

--- a/tests/behavior/steps/test_chromadb_integration_steps.py
+++ b/tests/behavior/steps/test_chromadb_integration_steps.py
@@ -17,7 +17,7 @@ def chroma_context(monkeypatch, tmp_path):
     return {"cls": mock_cls, "store": mock_store, "path": tmp_path}
 
 
-scenarios("../features/chromadb_integration.feature")
+scenarios("../features/general/chromadb_integration.feature")
 
 
 @given("the chromadb_integration feature context")

--- a/tests/behavior/steps/test_cli_ux_enhancements_steps.py
+++ b/tests/behavior/steps/test_cli_ux_enhancements_steps.py
@@ -8,7 +8,7 @@ from rich.console import Console
 from rich.progress import Progress
 
 # The scenarios function is called in the test file, so we don't need to call it here
-# scenarios("../features/cli_ux_enhancements.feature")
+# scenarios("../features/general/cli_ux_enhancements.feature")
 
 # Mock the CLI bridge and related components
 @pytest.fixture

--- a/tests/behavior/steps/test_code_generation_steps.py
+++ b/tests/behavior/steps/test_code_generation_steps.py
@@ -10,7 +10,7 @@ from pytest_bdd import scenarios, given, when, then, parsers
 from .cli_commands_steps import run_command
 from .test_generation_steps import have_analyzed_project
 
-scenarios("../features/code_generation.feature")
+scenarios("../features/general/code_generation.feature")
 
 
 @pytest.fixture

--- a/tests/behavior/steps/test_code_transformer_steps.py
+++ b/tests/behavior/steps/test_code_transformer_steps.py
@@ -18,7 +18,7 @@ from devsynth.methodology.base import Phase
 
 
 # Import the feature file
-scenarios = pytest.importorskip("pytest_bdd").scenarios("features/code_transformer.feature")
+scenarios = pytest.importorskip("pytest_bdd").scenarios("../features/general/code_transformer.feature")
 
 
 @pytest.fixture

--- a/tests/behavior/steps/test_config_enable_feature_steps.py
+++ b/tests/behavior/steps/test_config_enable_feature_steps.py
@@ -8,7 +8,7 @@ from pytest_bdd import given, scenarios, when, then
 from devsynth.config.loader import ConfigModel, save_config, load_config
 from .cli_commands_steps import run_command
 
-scenarios("../features/config_enable_feature.feature")
+scenarios("../features/general/config_enable_feature.feature")
 
 
 @given('a project configuration without the "code_generation" feature enabled')

--- a/tests/behavior/steps/test_consensus_building_steps.py
+++ b/tests/behavior/steps/test_consensus_building_steps.py
@@ -13,7 +13,7 @@ from devsynth.application.agents.unified_agent import UnifiedAgent
 from devsynth.domain.models.agent import AgentConfig, AgentType
 
 # Import the feature file
-scenarios('../features/consensus_building.feature')
+scenarios('../features/general/consensus_building.feature')
 
 # Define a fixture for the context
 @pytest.fixture

--- a/tests/behavior/steps/test_dbschema_generation_steps.py
+++ b/tests/behavior/steps/test_dbschema_generation_steps.py
@@ -3,7 +3,7 @@
 import pytest
 from pytest_bdd import scenarios, given, when, then
 
-scenarios("../features/dbschema_generation.feature")
+scenarios("../features/general/dbschema_generation.feature")
 
 
 @pytest.fixture

--- a/tests/behavior/steps/test_delegate_task_consensus_steps.py
+++ b/tests/behavior/steps/test_delegate_task_consensus_steps.py
@@ -7,7 +7,7 @@ from pytest_bdd import scenarios, given, when, then
 from devsynth.adapters.agents.agent_adapter import WSDETeamCoordinator
 from devsynth.domain.interfaces.agent import Agent
 
-scenarios("../features/delegate_task_consensus.feature")
+scenarios("../features/general/delegate_task_consensus.feature")
 
 
 @pytest.fixture

--- a/tests/behavior/steps/test_delegate_task_steps.py
+++ b/tests/behavior/steps/test_delegate_task_steps.py
@@ -11,7 +11,7 @@ from pytest_bdd import given, scenarios, then, when
 from devsynth.application.collaboration.coordinator import AgentCoordinatorImpl
 from devsynth.domain.models.wsde import WSDETeam
 
-scenarios("../features/delegate_task.feature")
+scenarios("../features/general/delegate_task.feature")
 
 
 class SimpleTeam(WSDETeam):

--- a/tests/behavior/steps/test_docs_fetch_steps.py
+++ b/tests/behavior/steps/test_docs_fetch_steps.py
@@ -3,7 +3,7 @@
 import pytest
 from pytest_bdd import scenarios, given, when, then
 
-scenarios("../features/docs_fetch.feature")
+scenarios("../features/general/docs_fetch.feature")
 
 
 @pytest.fixture

--- a/tests/behavior/steps/test_doctor_missing_env_steps.py
+++ b/tests/behavior/steps/test_doctor_missing_env_steps.py
@@ -2,7 +2,7 @@
 
 from pytest_bdd import scenarios, given, then
 
-scenarios("../features/doctor_missing_env.feature")
+scenarios("../features/general/doctor_missing_env.feature")
 
 
 @given("essential environment variables are missing")

--- a/tests/behavior/steps/test_documentation_ingestion_steps.py
+++ b/tests/behavior/steps/test_documentation_ingestion_steps.py
@@ -16,7 +16,7 @@ from devsynth.application.memory.memory_manager import MemoryManager
 from devsynth.domain.models.memory import MemoryType
 
 # Register scenarios
-scenarios('../features/documentation_ingestion.feature')
+scenarios('../features/general/documentation_ingestion.feature')
 
 @pytest.fixture
 def context():

--- a/tests/behavior/steps/test_documentation_utility_functions_steps.py
+++ b/tests/behavior/steps/test_documentation_utility_functions_steps.py
@@ -6,7 +6,7 @@ from devsynth.application.memory.memory_manager import MemoryManager
 from devsynth.application.documentation.documentation_manager import DocumentationManager
 
 # Import the feature file
-scenarios('../features/documentation_utility_functions.feature')
+scenarios('../features/general/documentation_utility_functions.feature')
 
 # Define a fixture for the context
 @pytest.fixture

--- a/tests/behavior/steps/test_edrr_coordinator_steps.py
+++ b/tests/behavior/steps/test_edrr_coordinator_steps.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from pytest_bdd import given, when, then, parsers
 from pytest_bdd import scenarios
 import pytest
-scenarios('../features/edrr_coordinator.feature')
+scenarios('../features/general/edrr_coordinator.feature')
 import os
 import json
 import tempfile

--- a/tests/behavior/steps/test_edrr_cycle_steps.py
+++ b/tests/behavior/steps/test_edrr_cycle_steps.py
@@ -9,7 +9,7 @@ from typing import Dict
 import pytest
 from pytest_bdd import given, scenarios, then, when
 
-scenarios("../features/edrr_cycle.feature")
+scenarios("../features/general/edrr_cycle.feature")
 
 
 @pytest.fixture

--- a/tests/behavior/steps/test_edrr_enhanced_memory_integration_steps.py
+++ b/tests/behavior/steps/test_edrr_enhanced_memory_integration_steps.py
@@ -5,7 +5,7 @@ from pytest_bdd import scenarios
 import pytest
 
 # Import the scenarios from the feature file
-scenarios('../features/edrr_enhanced_memory_integration.feature')
+scenarios('../features/general/edrr_enhanced_memory_integration.feature')
 
 # Import the necessary components
 from unittest.mock import MagicMock, patch

--- a/tests/behavior/steps/test_edrr_enhanced_phase_transitions_steps.py
+++ b/tests/behavior/steps/test_edrr_enhanced_phase_transitions_steps.py
@@ -8,7 +8,7 @@ from unittest.mock import MagicMock, patch
 import time
 from datetime import datetime, timedelta
 
-scenarios("../features/edrr_enhanced_phase_transitions.feature")
+scenarios("../features/general/edrr_enhanced_phase_transitions.feature")
 from devsynth.methodology.base import Phase
 from devsynth.application.memory.memory_manager import MemoryManager
 from devsynth.domain.models.wsde import WSDETeam

--- a/tests/behavior/steps/test_edrr_enhanced_recursion_steps.py
+++ b/tests/behavior/steps/test_edrr_enhanced_recursion_steps.py
@@ -10,7 +10,7 @@ import time
 from datetime import datetime, timedelta
 
 # Import the scenarios from the feature file
-scenarios('../features/edrr_enhanced_recursion.feature')
+scenarios('../features/general/edrr_enhanced_recursion.feature')
 
 # Import the necessary components
 from devsynth.methodology.base import Phase

--- a/tests/behavior/steps/test_enhanced_chromadb_integration_steps.py
+++ b/tests/behavior/steps/test_enhanced_chromadb_integration_steps.py
@@ -3,7 +3,7 @@
 import pytest
 from pytest_bdd import scenarios, given, when, then
 
-scenarios("../features/enhanced_chromadb_integration.feature")
+scenarios("../features/general/enhanced_chromadb_integration.feature")
 
 
 @pytest.fixture

--- a/tests/behavior/steps/test_enhanced_dialectical_reasoning_steps.py
+++ b/tests/behavior/steps/test_enhanced_dialectical_reasoning_steps.py
@@ -10,7 +10,7 @@ from pytest_bdd import given, when, then, parsers, scenarios
 from unittest.mock import MagicMock, patch
 
 # Import the feature file
-scenarios("../features/enhanced_dialectical_reasoning.feature")
+scenarios("../features/general/enhanced_dialectical_reasoning.feature")
 
 # Import the modules needed for the steps
 from devsynth.domain.models.wsde import WSDETeam

--- a/tests/behavior/steps/test_environment_variables_steps.py
+++ b/tests/behavior/steps/test_environment_variables_steps.py
@@ -9,7 +9,7 @@ from pytest_bdd import given, when, then, parsers
 from pytest_bdd import scenarios
 
 # Import the feature file
-scenarios('../environment_variables.feature')
+scenarios('../features/general/environment_variables.feature')
 
 @given(parsers.parse('I have a .env file with the following content:\n{content}'))
 def create_env_file(content, monkeypatch):

--- a/tests/behavior/steps/test_error_handling_steps.py
+++ b/tests/behavior/steps/test_error_handling_steps.py
@@ -3,7 +3,7 @@
 import pytest
 from pytest_bdd import scenarios, given, when, then
 
-scenarios("../features/error_handling.feature")
+scenarios("../features/general/error_handling.feature")
 
 
 @pytest.fixture

--- a/tests/behavior/steps/test_generate_docs_steps.py
+++ b/tests/behavior/steps/test_generate_docs_steps.py
@@ -18,7 +18,7 @@ def docs_context(monkeypatch):
     importlib.reload(docs_module)
     return {"cmd": mock_cmd}
 
-scenarios("../features/generate_docs.feature")
+scenarios("../features/general/generate_docs.feature")
 
 
 @given("the generate_docs feature context")

--- a/tests/behavior/steps/test_generation_steps.py
+++ b/tests/behavior/steps/test_generation_steps.py
@@ -7,7 +7,7 @@ from unittest.mock import MagicMock, patch
 from pytest_bdd import scenarios, given, when, then, parsers
 
 # Register scenarios from the feature file
-scenarios("../features/test_generation.feature")
+scenarios("../features/general/test_generation.feature")
 
 
 @given("I have a DevSynth project with analyzed requirements")

--- a/tests/behavior/steps/test_hybrid_memory_query_patterns_steps.py
+++ b/tests/behavior/steps/test_hybrid_memory_query_patterns_steps.py
@@ -17,7 +17,7 @@ from devsynth.application.memory.adapters.tinydb_memory_adapter import (
 )
 from devsynth.application.memory.json_file_store import JSONFileStore
 
-scenarios("../features/hybrid_memory_query_patterns.feature")
+scenarios("../features/general/hybrid_memory_query_patterns.feature")
 
 
 @pytest.fixture

--- a/tests/behavior/steps/test_ingest_command_steps.py
+++ b/tests/behavior/steps/test_ingest_command_steps.py
@@ -5,7 +5,7 @@ from pytest_bdd import given, when, then, parsers, scenarios
 from unittest.mock import patch, MagicMock
 
 # Import the scenarios from the feature file
-scenarios('../features/ingest_command.feature')
+scenarios('../features/general/ingest_command.feature')
 
 # Fixtures for test isolation
 @pytest.fixture

--- a/tests/behavior/steps/test_inspect_code_command_steps.py
+++ b/tests/behavior/steps/test_inspect_code_command_steps.py
@@ -6,7 +6,7 @@ from pytest_bdd import given, when, then, parsers, scenarios
 from unittest.mock import patch, MagicMock
 
 # Import the scenarios from the feature file
-scenarios('../features/inspect_code_command.feature')
+scenarios('../features/general/inspect_code_command.feature')
 
 # Fixtures for test isolation
 @pytest.fixture

--- a/tests/behavior/steps/test_interactive_flow_steps.py
+++ b/tests/behavior/steps/test_interactive_flow_steps.py
@@ -36,8 +36,8 @@ class DummyBridge(UXBridge):
         pass
 
 
-scenarios("../features/interactive_flow_cli.feature")
-scenarios("../features/interactive_flow_webui.feature")
+scenarios("../features/general/interactive_flow_cli.feature")
+scenarios("../features/general/interactive_flow_webui.feature")
 
 
 @given("the DevSynth CLI is installed")

--- a/tests/behavior/steps/test_interactive_init_wizard_steps.py
+++ b/tests/behavior/steps/test_interactive_init_wizard_steps.py
@@ -37,7 +37,7 @@ class DummyBridge(UXBridge):
         pass
 
 
-scenarios("../features/interactive_init_wizard.feature")
+scenarios("../features/general/interactive_init_wizard.feature")
 
 
 @given("the DevSynth CLI is installed")

--- a/tests/behavior/steps/test_interactive_requirements_steps.py
+++ b/tests/behavior/steps/test_interactive_requirements_steps.py
@@ -34,7 +34,7 @@ class DummyBridge(UXBridge):
         pass
 
 
-scenarios("../features/interactive_requirements.feature")
+scenarios("../features/general/interactive_requirements.feature")
 
 
 @given("the DevSynth CLI is installed")

--- a/tests/behavior/steps/test_langgraph_adapter_steps.py
+++ b/tests/behavior/steps/test_langgraph_adapter_steps.py
@@ -2,7 +2,7 @@
 
 from pytest_bdd import scenarios, given, when, then
 
-scenarios("../features/langgraph_adapter.feature")
+scenarios("../features/general/langgraph_adapter.feature")
 
 
 @given("the langgraph_adapter feature context")

--- a/tests/behavior/steps/test_mddr_common_steps.py
+++ b/tests/behavior/steps/test_mddr_common_steps.py
@@ -6,7 +6,7 @@ from devsynth.application.agents.base import BaseAgent
 from devsynth.domain.models.memory import MemoryItem
 
 # Import the feature file
-scenarios('../features/multi_disciplinary_dialectical_reasoning.feature')
+scenarios('../features/general/multi_disciplinary_dialectical_reasoning.feature')
 
 # Define a fixture for the context
 @pytest.fixture

--- a/tests/behavior/steps/test_memory_adapter_integration_steps.py
+++ b/tests/behavior/steps/test_memory_adapter_integration_steps.py
@@ -19,7 +19,8 @@ except ImportError:
 feature_file_path = os.path.join(
     os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
     "features",
-    "memory_adapter_integration.feature"
+    "general",
+    "memory_adapter_integration.feature",
 )
 scenarios(feature_file_path)
 

--- a/tests/behavior/steps/test_memory_backend_integration_steps.py
+++ b/tests/behavior/steps/test_memory_backend_integration_steps.py
@@ -18,7 +18,7 @@ if not chromadb_enabled:
 from pytest_bdd import given, when, then, parsers, scenarios
 
 # Import the feature file
-scenarios('../features/memory_backend_integration.feature')
+scenarios('../features/general/memory_backend_integration.feature')
 
 # Import the modules needed for the steps
 from devsynth.domain.models.wsde import WSDETeam

--- a/tests/behavior/steps/test_memory_context_steps.py
+++ b/tests/behavior/steps/test_memory_context_steps.py
@@ -10,7 +10,7 @@ import pytest
 from pytest_bdd import given, when, then, parsers, scenarios
 
 # Import the feature file
-scenarios('../features/memory_context_system.feature')
+scenarios('../features/general/memory_context_system.feature')
 
 # Import the modules needed for the steps
 from devsynth.domain.models.memory import MemoryItem, MemoryType

--- a/tests/behavior/steps/test_memory_manager_steps.py
+++ b/tests/behavior/steps/test_memory_manager_steps.py
@@ -12,7 +12,7 @@ from pytest_bdd import given, when, then, parsers, scenarios
 from typing import Dict, List, Any, Optional
 
 # Import the feature file
-scenarios('../features/memory_manager.feature')
+scenarios('../features/general/memory_manager.feature')
 
 # Import the modules needed for the steps
 from devsynth.domain.models.memory import MemoryItem, MemoryType, MemoryVector

--- a/tests/behavior/steps/test_methodology_adapters_steps.py
+++ b/tests/behavior/steps/test_methodology_adapters_steps.py
@@ -7,7 +7,7 @@ from devsynth.methodology.sprint import SprintAdapter
 from devsynth.methodology.adhoc import AdHocAdapter
 
 # Import the feature file
-scenarios('../features/methodology_adapters.feature')
+scenarios('../features/general/methodology_adapters.feature')
 
 # Define a fixture for the context
 @pytest.fixture

--- a/tests/behavior/steps/test_metrics_steps.py
+++ b/tests/behavior/steps/test_metrics_steps.py
@@ -21,7 +21,7 @@ from io import StringIO
 from devsynth.adapters.cli.typer_adapter import run_cli, show_help, parse_args
 
 # Register the scenarios
-scenarios("../features/test_metrics.feature")
+scenarios("../features/general/test_metrics.feature")
 
 
 # Define fixtures and step definitions

--- a/tests/behavior/steps/test_micro_edrr_cycle_steps.py
+++ b/tests/behavior/steps/test_micro_edrr_cycle_steps.py
@@ -5,7 +5,7 @@ from pytest_bdd import scenarios
 import pytest
 
 # Import the scenarios from the feature file
-scenarios('../features/micro_edrr_cycle.feature')
+scenarios('../features/general/micro_edrr_cycle.feature')
 
 # Import the necessary components
 import os

--- a/tests/behavior/steps/test_multi_disciplinary_dialectical_reasoning_steps.py
+++ b/tests/behavior/steps/test_multi_disciplinary_dialectical_reasoning_steps.py
@@ -6,7 +6,7 @@ from devsynth.application.agents.base import BaseAgent
 from devsynth.domain.models.memory import MemoryItem
 
 # Import the feature file
-scenarios('../features/multi_disciplinary_dialectical_reasoning.feature')
+scenarios('../features/general/multi_disciplinary_dialectical_reasoning.feature')
 
 # Define a fixture for the context
 @pytest.fixture

--- a/tests/behavior/steps/test_multi_layered_memory_system_steps.py
+++ b/tests/behavior/steps/test_multi_layered_memory_system_steps.py
@@ -12,7 +12,7 @@ import pytest
 from pytest_bdd import given, when, then, parsers, scenarios
 
 # Import the feature file
-scenarios('../features/multi_layered_memory_system.feature')
+scenarios('../features/general/multi_layered_memory_system.feature')
 
 # Import the modules needed for the steps
 from devsynth.domain.models.memory import MemoryItem, MemoryType

--- a/tests/behavior/steps/test_non_hierarchical_collaboration_steps.py
+++ b/tests/behavior/steps/test_non_hierarchical_collaboration_steps.py
@@ -19,7 +19,7 @@ from devsynth.application.agents.unified_agent import UnifiedAgent
 from devsynth.domain.models.agent import AgentConfig, AgentType
 
 # Import the feature file
-scenarios("../features/non_hierarchical_collaboration.feature")
+scenarios("../features/general/non_hierarchical_collaboration.feature")
 
 
 # Define a fixture for the context

--- a/tests/behavior/steps/test_performance_testing_steps.py
+++ b/tests/behavior/steps/test_performance_testing_steps.py
@@ -6,7 +6,7 @@ import os
 import tempfile
 import shutil
 from pathlib import Path
-scenarios('../features/performance_testing.feature')
+scenarios('../features/general/performance_testing.feature')
 
 
 @pytest.fixture

--- a/tests/behavior/steps/test_project_documentation_ingestion_steps.py
+++ b/tests/behavior/steps/test_project_documentation_ingestion_steps.py
@@ -12,7 +12,7 @@ from devsynth.application.documentation.documentation_ingestion_manager import D
 from devsynth.application.memory.memory_manager import MemoryManager
 from devsynth.domain.models.memory import MemoryType
 
-scenarios("../features/project_documentation_ingestion.feature")
+scenarios("../features/general/project_documentation_ingestion.feature")
 
 
 @pytest.fixture

--- a/tests/behavior/steps/test_project_ingestion_steps.py
+++ b/tests/behavior/steps/test_project_ingestion_steps.py
@@ -2,7 +2,7 @@
 
 from pytest_bdd import scenarios, given, when, then
 
-scenarios("../features/project_ingestion.feature")
+scenarios("../features/general/project_ingestion.feature")
 
 
 @given("the project_ingestion feature context")

--- a/tests/behavior/steps/test_project_initialization_steps.py
+++ b/tests/behavior/steps/test_project_initialization_steps.py
@@ -3,7 +3,7 @@
 import pytest
 from pytest_bdd import scenarios, given, when, then
 
-scenarios("../features/project_initialization.feature")
+scenarios("../features/general/project_initialization.feature")
 
 
 @pytest.fixture

--- a/tests/behavior/steps/test_project_state_analyzer_steps.py
+++ b/tests/behavior/steps/test_project_state_analyzer_steps.py
@@ -17,7 +17,7 @@ from devsynth.methodology.base import Phase
 
 
 # Import the feature file
-scenarios = pytest.importorskip("pytest_bdd").scenarios("features/project_state_analyzer.feature")
+scenarios = pytest.importorskip("pytest_bdd").scenarios("../features/general/project_state_analyzer.feature")
 
 
 @pytest.fixture

--- a/tests/behavior/steps/test_promise_system_steps.py
+++ b/tests/behavior/steps/test_promise_system_steps.py
@@ -10,7 +10,7 @@ from devsynth.application.promises.broker import PromiseBroker, UnauthorizedAcce
 from devsynth.application.promises.agent import PromiseAgent
 
 # Import the feature file
-scenarios('../features/promise_system.feature')
+scenarios('../features/general/promise_system.feature')
 
 # Define a fixture for the context
 @pytest.fixture

--- a/tests/behavior/steps/test_prompt_management_steps.py
+++ b/tests/behavior/steps/test_prompt_management_steps.py
@@ -9,7 +9,7 @@ import random
 from pytest_bdd import given, when, then, parsers, scenarios
 
 # Import the feature file
-scenarios('../features/prompt_management.feature')
+scenarios('../features/general/prompt_management.feature')
 
 # Import the modules needed for the steps
 from devsynth.application.prompts.prompt_manager import PromptManager

--- a/tests/behavior/steps/test_recursive_edrr_coordinator_steps.py
+++ b/tests/behavior/steps/test_recursive_edrr_coordinator_steps.py
@@ -5,7 +5,7 @@ from pytest_bdd import scenarios
 import pytest
 
 # Import the scenarios from the feature file
-scenarios('../features/recursive_edrr_coordinator.feature')
+scenarios('../features/general/recursive_edrr_coordinator.feature')
 
 # Import the necessary components
 

--- a/tests/behavior/steps/test_refactor_command_steps.py
+++ b/tests/behavior/steps/test_refactor_command_steps.py
@@ -4,7 +4,7 @@ from pytest_bdd import given, when, then, parsers, scenarios
 from unittest.mock import patch, MagicMock
 
 # Import the scenarios from the feature file
-scenarios('../features/refactor_command.feature')
+scenarios('../features/general/refactor_command.feature')
 
 # Fixtures for test isolation
 @pytest.fixture

--- a/tests/behavior/steps/test_requirements_gathering_steps.py
+++ b/tests/behavior/steps/test_requirements_gathering_steps.py
@@ -35,7 +35,7 @@ class DummyBridge(UXBridge):
         pass
 
 
-scenarios("../features/requirements_gathering.feature")
+scenarios("../features/general/requirements_gathering.feature")
 
 
 @given("the DevSynth CLI is installed")

--- a/tests/behavior/steps/test_requirements_management_steps.py
+++ b/tests/behavior/steps/test_requirements_management_steps.py
@@ -2,7 +2,7 @@
 
 from pytest_bdd import scenarios, given, when, then
 
-scenarios("../features/requirements_management.feature")
+scenarios("../features/general/requirements_management.feature")
 
 
 @given("the requirements_management feature context")

--- a/tests/behavior/steps/test_retry_mechanism_steps.py
+++ b/tests/behavior/steps/test_retry_mechanism_steps.py
@@ -3,7 +3,7 @@
 import pytest
 from pytest_bdd import scenarios, given, when, then
 
-scenarios("../features/retry_mechanism.feature")
+scenarios("../features/general/retry_mechanism.feature")
 
 
 @pytest.fixture

--- a/tests/behavior/steps/test_run_pipeline_command_steps.py
+++ b/tests/behavior/steps/test_run_pipeline_command_steps.py
@@ -4,7 +4,7 @@ from pytest_bdd import given, when, then, parsers, scenarios
 from unittest.mock import patch, MagicMock
 
 # Import the scenarios from the feature file
-scenarios('../features/run_pipeline_command.feature')
+scenarios('../features/general/run_pipeline_command.feature')
 
 # Fixtures for test isolation
 @pytest.fixture

--- a/tests/behavior/steps/test_self_analyzer_steps.py
+++ b/tests/behavior/steps/test_self_analyzer_steps.py
@@ -17,7 +17,7 @@ from devsynth.methodology.base import Phase
 
 
 # Import the feature file
-scenarios = pytest.importorskip("pytest_bdd").scenarios("features/self_analyzer.feature")
+scenarios = pytest.importorskip("pytest_bdd").scenarios("../features/general/self_analyzer.feature")
 
 
 @pytest.fixture

--- a/tests/behavior/steps/test_serve_command_steps.py
+++ b/tests/behavior/steps/test_serve_command_steps.py
@@ -5,7 +5,7 @@ from pytest_bdd import given, when, then, parsers, scenarios
 from unittest.mock import patch, MagicMock
 
 # Import the scenarios from the feature file
-scenarios('../features/serve_command.feature')
+scenarios('../features/general/serve_command.feature')
 
 # Fixtures for test isolation
 @pytest.fixture

--- a/tests/behavior/steps/test_setup_wizard_steps.py
+++ b/tests/behavior/steps/test_setup_wizard_steps.py
@@ -32,7 +32,7 @@ class DummyBridge(UXBridge):
         pass
 
 
-scenarios("../features/setup_wizard.feature")
+scenarios("../features/general/setup_wizard.feature")
 
 
 @given("the DevSynth CLI is installed")

--- a/tests/behavior/steps/test_simple_coordinator_steps.py
+++ b/tests/behavior/steps/test_simple_coordinator_steps.py
@@ -8,7 +8,7 @@ from pytest_bdd import scenarios
 import pytest
 
 # Import the scenarios from the feature file
-scenarios('../features/edrr_coordinator.feature')
+scenarios('../features/general/edrr_coordinator.feature')
 
 @pytest.fixture
 def context():

--- a/tests/behavior/steps/test_simple_steps.py
+++ b/tests/behavior/steps/test_simple_steps.py
@@ -10,7 +10,7 @@ from pytest_bdd import scenarios
 import pytest
 
 # Import the scenarios from the feature file
-scenarios('../features/edrr_cycle.feature')
+scenarios('../features/general/edrr_cycle.feature')
 
 @pytest.fixture
 def context() -> Dict[str, object]:

--- a/tests/behavior/steps/test_training_materials_steps.py
+++ b/tests/behavior/steps/test_training_materials_steps.py
@@ -8,7 +8,7 @@ from pytest_bdd import given, when, then, parsers, scenarios
 from typing import Dict, Any, List
 
 # Import the feature file
-scenarios("../features/training_materials.feature")
+scenarios("../features/general/training_materials.feature")
 
 
 # Define a fixture for the context

--- a/tests/behavior/steps/test_user_guide_enhancement_steps.py
+++ b/tests/behavior/steps/test_user_guide_enhancement_steps.py
@@ -6,7 +6,7 @@ import pytest
 from pytest_bdd import given, when, then, parsers, scenarios
 
 # Import the feature file
-scenarios('../features/user_guide_enhancement.feature')
+scenarios('../features/general/user_guide_enhancement.feature')
 
 # Define a fixture for the context
 @pytest.fixture

--- a/tests/behavior/steps/test_validate_manifest_command_steps.py
+++ b/tests/behavior/steps/test_validate_manifest_command_steps.py
@@ -4,7 +4,7 @@ from pytest_bdd import scenarios, then
 
 from .cli_commands_steps import run_command  # noqa: F401
 
-scenarios("../features/validate_manifest_command.feature")
+scenarios("../features/general/validate_manifest_command.feature")
 
 
 @then("the output should indicate the project configuration is valid")

--- a/tests/behavior/steps/test_validate_manifest_steps.py
+++ b/tests/behavior/steps/test_validate_manifest_steps.py
@@ -2,7 +2,7 @@
 
 from pytest_bdd import scenarios, given, when, then
 
-scenarios("../features/validate_manifest.feature")
+scenarios("../features/general/validate_manifest.feature")
 
 
 @given("the validate_manifest feature context")

--- a/tests/behavior/steps/test_validate_metadata_command_steps.py
+++ b/tests/behavior/steps/test_validate_metadata_command_steps.py
@@ -5,7 +5,7 @@ from pytest_bdd import scenarios, given, then
 
 from .cli_commands_steps import run_command  # noqa: F401
 
-scenarios("../features/validate_metadata_command.feature")
+scenarios("../features/general/validate_metadata_command.feature")
 
 
 @given("a documentation file with valid metadata")

--- a/tests/behavior/steps/test_validate_metadata_steps.py
+++ b/tests/behavior/steps/test_validate_metadata_steps.py
@@ -2,7 +2,7 @@
 
 from pytest_bdd import scenarios, given, when, then
 
-scenarios("../features/validate_metadata.feature")
+scenarios("../features/general/validate_metadata.feature")
 
 
 @given("the validate_metadata feature context")

--- a/tests/behavior/steps/test_version_aware_documentation_steps.py
+++ b/tests/behavior/steps/test_version_aware_documentation_steps.py
@@ -15,7 +15,7 @@ from devsynth.domain.models.memory import MemoryItem, MemoryType
 from devsynth.application.memory.memory_manager import MemoryManager
 
 # Import the feature file
-scenarios('../features/version_aware_documentation.feature')
+scenarios('../features/general/version_aware_documentation.feature')
 
 # Define a fixture for the context
 @pytest.fixture

--- a/tests/behavior/steps/test_webapp_generation_steps.py
+++ b/tests/behavior/steps/test_webapp_generation_steps.py
@@ -3,7 +3,7 @@
 import pytest
 from pytest_bdd import scenarios, given, when, then
 
-scenarios("../features/webapp_generation.feature")
+scenarios("../features/general/webapp_generation.feature")
 
 
 @pytest.fixture

--- a/tests/behavior/steps/test_webui_commands_steps.py
+++ b/tests/behavior/steps/test_webui_commands_steps.py
@@ -6,7 +6,7 @@ from pytest_bdd import given, when, then, scenarios
 
 from .webui_steps import webui_context, DummyForm
 
-scenarios("../features/webui_commands.feature")
+scenarios("../features/general/webui_commands.feature")
 
 
 @given("the WebUI is initialized")

--- a/tests/behavior/steps/test_webui_doctor_steps.py
+++ b/tests/behavior/steps/test_webui_doctor_steps.py
@@ -2,7 +2,7 @@ from pytest_bdd import scenarios, then
 
 from .webui_steps import *  # noqa: F401,F403
 
-scenarios("../features/webui_doctor.feature")
+scenarios("../features/general/webui_doctor.feature")
 
 
 @then("the doctor command should be executed")

--- a/tests/behavior/steps/test_webui_integration_steps.py
+++ b/tests/behavior/steps/test_webui_integration_steps.py
@@ -7,7 +7,7 @@ from pytest_bdd import given, when, then, scenarios, parsers
 import streamlit as st
 
 # Register the feature scenarios to ensure step discovery
-scenarios("../features/webui_integration.feature")
+scenarios("../features/general/webui_integration.feature")
 
 
 # Mock the WebUI and related components

--- a/tests/behavior/steps/test_webui_navigation_prompts_steps.py
+++ b/tests/behavior/steps/test_webui_navigation_prompts_steps.py
@@ -2,7 +2,7 @@ from pytest_bdd import given, when, then, scenarios, parsers
 
 from .webui_steps import webui_context
 
-scenarios("../features/webui_navigation_prompts.feature")
+scenarios("../features/general/webui_navigation_prompts.feature")
 
 
 @given("the WebUI is initialized")

--- a/tests/behavior/steps/test_webui_onboarding_steps.py
+++ b/tests/behavior/steps/test_webui_onboarding_steps.py
@@ -105,7 +105,7 @@ def webui_context(monkeypatch):
     return ctx
 
 
-scenarios("../features/webui_onboarding_flow.feature")
+scenarios("../features/general/webui_onboarding_flow.feature")
 
 
 @given("the WebUI is initialized")

--- a/tests/behavior/steps/test_webui_spec_editor_steps.py
+++ b/tests/behavior/steps/test_webui_spec_editor_steps.py
@@ -2,7 +2,7 @@ from pytest_bdd import scenarios, then, when
 
 from .webui_steps import webui_context
 
-scenarios("../features/webui_spec_editor.feature")
+scenarios("../features/general/webui_spec_editor.feature")
 
 
 @when("I edit a specification file")

--- a/tests/behavior/steps/test_webui_steps.py
+++ b/tests/behavior/steps/test_webui_steps.py
@@ -5,7 +5,7 @@ from unittest.mock import MagicMock
 import pytest
 from pytest_bdd import given, when, then, scenarios, parsers
 
-scenarios("../features/webui.feature")
+scenarios("../features/general/webui.feature")
 
 
 class DummyForm:

--- a/tests/behavior/steps/test_workflow_execution_steps.py
+++ b/tests/behavior/steps/test_workflow_execution_steps.py
@@ -3,7 +3,7 @@
 import pytest
 from pytest_bdd import scenarios, given, when, then
 
-scenarios("../features/workflow_execution.feature")
+scenarios("../features/general/workflow_execution.feature")
 
 
 @pytest.fixture

--- a/tests/behavior/steps/test_wsde_agent_model_steps.py
+++ b/tests/behavior/steps/test_wsde_agent_model_steps.py
@@ -9,7 +9,7 @@ from pytest_bdd import given, when, then, parsers, scenarios
 from unittest.mock import MagicMock
 
 # Import the feature file
-scenarios('../features/wsde_agent_model.feature')
+scenarios('../features/general/wsde_agent_model.feature')
 
 # Import the modules needed for the steps
 from devsynth.domain.models.wsde import WSDETeam

--- a/tests/behavior/steps/test_wsde_edrr_integration_steps.py
+++ b/tests/behavior/steps/test_wsde_edrr_integration_steps.py
@@ -9,7 +9,7 @@ import pytest
 from unittest.mock import MagicMock, patch
 
 # Import the scenarios from the feature file
-scenarios('../features/wsde_edrr_integration.feature')
+scenarios('../features/general/wsde_edrr_integration.feature')
 
 # Import the necessary components
 from devsynth.application.edrr.edrr_coordinator_enhanced import EnhancedEDRRCoordinator

--- a/tests/behavior/steps/test_wsde_memory_integration_fixed2_steps.py
+++ b/tests/behavior/steps/test_wsde_memory_integration_fixed2_steps.py
@@ -9,7 +9,7 @@ import pytest
 from pytest_bdd import given, when, then, parsers, scenarios
 
 # Import the feature file
-scenarios("../features/wsde_memory_integration.feature")
+scenarios("../features/general/wsde_memory_integration.feature")
 
 # Import the modules needed for the steps
 from devsynth.adapters.agents.agent_adapter import WSDETeamCoordinator

--- a/tests/behavior/steps/test_wsde_memory_integration_fixed_steps.py
+++ b/tests/behavior/steps/test_wsde_memory_integration_fixed_steps.py
@@ -8,7 +8,7 @@ import pytest
 from pytest_bdd import given, when, then, parsers, scenarios
 
 # Import the feature file
-scenarios('../features/wsde_memory_integration.feature')
+scenarios('../features/general/wsde_memory_integration.feature')
 
 # Import the modules needed for the steps
 from devsynth.domain.models.wsde import WSDETeam

--- a/tests/behavior/steps/test_wsde_memory_integration_steps.py
+++ b/tests/behavior/steps/test_wsde_memory_integration_steps.py
@@ -8,7 +8,7 @@ import pytest
 from pytest_bdd import given, when, then, parsers, scenarios
 
 # Import the feature file
-scenarios('../features/wsde_memory_integration.feature')
+scenarios('../features/general/wsde_memory_integration.feature')
 
 # Import the modules needed for the steps
 from devsynth.domain.models.wsde import WSDETeam

--- a/tests/behavior/steps/test_wsde_message_passing_peer_review_steps.py
+++ b/tests/behavior/steps/test_wsde_message_passing_peer_review_steps.py
@@ -7,7 +7,7 @@ pytest.skip(
 from pytest_bdd import given, when, then, parsers, scenarios
 from unittest.mock import MagicMock
 
-scenarios("../features/wsde_message_passing_peer_review.feature")
+scenarios("../features/general/wsde_message_passing_peer_review.feature")
 
 from devsynth.adapters.agents.agent_adapter import WSDETeamCoordinator
 from devsynth.application.agents.unified_agent import UnifiedAgent

--- a/tests/behavior/steps/test_wsde_voting_mechanisms_steps.py
+++ b/tests/behavior/steps/test_wsde_voting_mechanisms_steps.py
@@ -15,7 +15,7 @@ from pytest_bdd import given, when, then, parsers, scenarios
 from unittest.mock import MagicMock
 
 # Import the feature file
-scenarios("../features/wsde_voting_mechanisms.feature")
+scenarios("../features/general/wsde_voting_mechanisms.feature")
 
 # Import the modules needed for the steps
 from devsynth.domain.models.wsde import WSDETeam


### PR DESCRIPTION
## Summary
- update all step definitions to reference feature files under `tests/behavior/features/general`
- adjust `test_memory_adapter_integration_steps` to build feature path correctly

## Testing
- `poetry run pytest --collect-only tests/behavior/steps/test_simple_addition_steps.py`
- `poetry run pytest --collect-only tests/behavior/steps` *(fails: ImportError but no FileNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_687fa2fc7d2883338d542e8e24883c13