### PR TITLE
Add missing behavior step definitions

### DIFF
--- a/tests/behavior/steps/test_code_command_steps.py
+++ b/tests/behavior/steps/test_code_command_steps.py
@@ -1,0 +1,54 @@
+from io import StringIO
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+from pytest_bdd import scenarios, when, then
+from pytest_bdd import given
+
+from devsynth.application.cli import cli_commands
+
+@given("the DevSynth CLI is installed")
+def devsynth_cli_installed():
+    return True
+
+@given("I have a valid DevSynth project")
+def valid_devsynth_project(tmp_project_dir):
+    return tmp_project_dir
+
+scenarios("../features/general/code_command.feature")
+
+
+@when('I run the command "devsynth code"')
+def run_code_command(monkeypatch, command_context, tmp_project_dir):
+    """Execute the code command with a mocked environment."""
+    monkeypatch.setattr(cli_commands, "_check_services", lambda bridge: True)
+    monkeypatch.setattr(cli_commands, "generate_code", lambda: {"success": True, "output_dir": "src"})
+    monkeypatch.setattr(cli_commands, "test_cmd", MagicMock())
+
+    tests_dir = Path(tmp_project_dir) / "tests"
+    tests_dir.mkdir(exist_ok=True)
+    (tests_dir / "test_sample.py").write_text("def test_sample():\n    assert True\n")
+
+    captured = StringIO()
+    bridge = MagicMock()
+    bridge.display_result.side_effect = lambda msg: captured.write(msg + "\n")
+
+    cli_commands.code_cmd(bridge=bridge)
+
+    command_context["output"] = captured.getvalue()
+
+
+@then("the code command should be executed")
+def code_executed(command_context):
+    assert "Code generated" in command_context["output"]
+
+
+@then("the workflow should execute successfully")
+def workflow_success(command_context):
+    assert "Code generated" in command_context["output"]
+
+
+@then("the system should display a success message")
+def success_message(command_context):
+    assert "generated" in command_context["output"].lower()

--- a/tests/behavior/steps/test_spec_command_steps.py
+++ b/tests/behavior/steps/test_spec_command_steps.py
@@ -1,0 +1,60 @@
+from io import StringIO
+from unittest.mock import MagicMock
+
+import pytest
+from pytest_bdd import scenarios, when, then, parsers
+
+from pytest_bdd import given
+from devsynth.application.cli import cli_commands
+
+scenarios("../features/general/spec_command.feature")
+
+
+@given("the DevSynth CLI is installed")
+def devsynth_cli_installed():
+    return True
+
+@given("I have a valid DevSynth project")
+def valid_devsynth_project(tmp_project_dir):
+    return tmp_project_dir
+
+@when(parsers.parse('I run the command "{command}"'))
+def run_spec_command(command, monkeypatch, command_context, tmp_project_dir):
+    """Execute the spec command with a mocked environment."""
+    req_file = command.split()[-1]
+    monkeypatch.setattr(cli_commands, "_check_services", lambda bridge: True)
+    monkeypatch.setattr(cli_commands, "_validate_file_path", lambda p: None)
+    monkeypatch.setattr(
+        cli_commands,
+        "generate_specs",
+        lambda **_k: {"success": True, "output_file": "specs.md"},
+    )
+
+    captured = StringIO()
+    bridge = MagicMock()
+    bridge.display_result.side_effect = lambda msg: captured.write(msg + "\n")
+
+    cli_commands.spec_cmd(requirements_file=req_file, bridge=bridge)
+
+    command_context["output"] = captured.getvalue()
+    command_context["requirements_file"] = req_file
+
+
+@then(parsers.parse('the spec command should process "{req_file}"'))
+def check_spec_processed(command_context, req_file):
+    assert command_context["requirements_file"] == req_file
+
+
+@then("generate specifications based on the requirements")
+def check_generation(command_context):
+    assert "Specifications generated" in command_context["output"]
+
+
+@then("the workflow should execute successfully")
+def workflow_success(command_context):
+    assert "Specifications generated" in command_context["output"]
+
+
+@then("the system should display a success message")
+def success_message(command_context):
+    assert "generated" in command_context["output"].lower()


### PR DESCRIPTION
## Summary
- implement step functions for `spec_command` and `code_command` features
- use mocked CLI command behavior to avoid network or workflow calls

## Testing
- `pytest tests/behavior/steps/test_spec_command_steps.py -q`
- `pytest tests/behavior/steps/test_code_command_steps.py -q`


------
https://chatgpt.com/codex/tasks/task_e_687fa67730888333b65d6bb01e8f655e