### PR TITLE
Update test setup docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,8 @@ devsynth code
 
 # Install development dependencies
 poetry install --with dev
+# Install every optional feature and group (required for the full test suite)
+poetry install --all-extras --all-groups
 
 # Run the tests or execute the app
 poetry run pytest
@@ -178,8 +180,6 @@ Before running the test suite manually, you **must** install DevSynth with its d
 
 ```bash
 poetry install --with dev
-# or install everything
-poetry sync --all-extras --all-groups
 ```
 
 Running the **full** test suite additionally requires the optional extras `minimal`, `retrieval`, `memory`, `llm`, `api`, `webui`, and `lmstudio`:
@@ -188,6 +188,15 @@ Running the **full** test suite additionally requires the optional extras `minim
 poetry install --extras minimal --extras retrieval --extras memory \
   --extras llm --extras api --extras webui --extras lmstudio
 ```
+Alternatively, install them all at once:
+
+```bash
+poetry install --all-extras --all-groups
+```
+
+Ingestion and WSDE integration tests are skipped unless you set
+`DEVSYNTH_RUN_INGEST_TESTS=1` or `DEVSYNTH_RUN_WSDE_TESTS=1` before running
+`pytest`.
 
 Use pip only for installing from PyPI, not for local development.
 

--- a/docs/developer_guides/development_setup.md
+++ b/docs/developer_guides/development_setup.md
@@ -74,6 +74,9 @@ cd devsynth
 
 poetry install
 
+# Install every optional feature and group if you plan to run the full test suite
+poetry install --all-extras --all-groups
+
 # Activate the virtual environment
 
 poetry shell
@@ -213,6 +216,14 @@ For more details, see the [Contributing Guide](contributing.md).
 ## Running Tests
 
 DevSynth uses pytest for unit testing and pytest-bdd for behavior-driven tests.
+To run the entire test suite, ensure all optional features are installed:
+
+```bash
+poetry install --all-extras --all-groups
+```
+
+Some ingestion and WSDE tests are skipped unless you set `DEVSYNTH_RUN_INGEST_TESTS=1`
+or `DEVSYNTH_RUN_WSDE_TESTS=1` when invoking `pytest`.
 
 ### Running Unit Tests
 


### PR DESCRIPTION
## Summary
- clarify that running all tests requires `poetry install --all-extras --all-groups`
- note environment variables `DEVSYNTH_RUN_INGEST_TESTS` and `DEVSYNTH_RUN_WSDE_TESTS` for optional tests

## Testing
- `poetry run pytest tests/unit/general/test_api_health.py::test_health_endpoint_succeeds -q`


------
https://chatgpt.com/codex/tasks/task_e_687faec58b1483338c03446ae84654ba