### PR TITLE
Add regression tests for Kuzu fallback

### DIFF
--- a/tests/integration/general/test_kuzu_memory_fallback.py
+++ b/tests/integration/general/test_kuzu_memory_fallback.py
@@ -1,0 +1,40 @@
+import importlib
+import sys
+import types
+import tempfile
+import shutil
+from devsynth.adapters.memory.memory_adapter import MemorySystemAdapter
+from devsynth.domain.models.memory import MemoryItem, MemoryType
+from unittest.mock import patch
+
+
+def test_memory_system_falls_back_when_kuzu_unavailable(monkeypatch):
+    # Simulate kuzu not installed
+    monkeypatch.setitem(sys.modules, "kuzu", None)
+    import importlib
+    import devsynth.application.memory.kuzu_store as kuzu_store
+    importlib.reload(kuzu_store)
+    import devsynth.adapters.kuzu_memory_store as km_store
+    importlib.reload(km_store)
+    monkeypatch.setattr(km_store, "embedding_functions", None)
+
+    temp_dir = tempfile.mkdtemp()
+    try:
+        with patch("devsynth.adapters.kuzu_memory_store.embed", return_value=[0.1, 0.2, 0.3]):
+            adapter = MemorySystemAdapter(
+                config={
+                    "memory_store_type": "kuzu",
+                    "memory_file_path": temp_dir,
+                    "vector_store_enabled": True,
+                }
+            )
+        # Memory store should have fallen back
+        assert adapter.memory_store._store._use_fallback is True
+        item = MemoryItem(id="t1", content="hi", memory_type=MemoryType.WORKING)
+        adapter.memory_store.store(item)
+        result = adapter.memory_store.retrieve("t1")
+        assert result is not None
+        assert result.content == "hi"
+    finally:
+        shutil.rmtree(temp_dir)
+

--- a/tests/unit/general/test_kuzu_store_fallback.py
+++ b/tests/unit/general/test_kuzu_store_fallback.py
@@ -1,0 +1,31 @@
+import importlib
+import sys
+from pathlib import Path
+import tempfile
+import shutil
+from devsynth.domain.models.memory import MemoryItem, MemoryType
+
+
+def test_kuzu_store_falls_back_when_dependency_missing(monkeypatch):
+    # Remove kuzu module to simulate missing dependency
+    monkeypatch.setitem(sys.modules, "kuzu", None)
+    # Reload module after patching
+    spec = importlib.util.spec_from_file_location(
+        "kuzu_store", Path(__file__).resolve().parents[3] / "src/devsynth/application/memory/kuzu_store.py"
+    )
+    kuzu_store = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(kuzu_store)
+    KuzuStore = kuzu_store.KuzuStore
+
+    temp_dir = tempfile.mkdtemp()
+    try:
+        store = KuzuStore(temp_dir)
+        assert store._use_fallback is True
+        item = MemoryItem(id="a", content="hello", memory_type=MemoryType.WORKING)
+        store.store(item)
+        retrieved = store.retrieve("a")
+        assert retrieved is not None
+        assert retrieved.content == "hello"
+    finally:
+        shutil.rmtree(temp_dir)
+


### PR DESCRIPTION
## Summary
- ensure the Kuzu memory backend gracefully falls back to in-memory mode when KuzuDB is unavailable
- test MemorySystemAdapter and KuzuStore fallback behavior

## Testing
- `poetry run pytest tests/unit/general/test_kuzu_store_fallback.py tests/integration/general/test_kuzu_memory_fallback.py tests/unit/interface/test_webui_requirements_wizard.py tests/unit/interface/test_webui_requirements.py -q`

------
https://chatgpt.com/codex/tasks/task_e_687fb3694ea083338924bb2315091cdb