### PR TITLE
Fix test package init files

### DIFF
--- a/tests/behavior/features/general/__init__.py
+++ b/tests/behavior/features/general/__init__.py
@@ -1,0 +1,1 @@
+"""General feature files for behavior-driven tests."""

--- a/tests/fixtures/__init__.py
+++ b/tests/fixtures/__init__.py
@@ -1,1 +1,3 @@
+"""Shared test fixtures for DevSynth."""
+
 pytest_plugins = ["tests.fixtures.ports"]

--- a/tests/integration/__init__.py
+++ b/tests/integration/__init__.py
@@ -1,0 +1,1 @@
+"""Integration tests for DevSynth component interactions."""

--- a/tests/integration/config/__init__.py
+++ b/tests/integration/config/__init__.py
@@ -1,0 +1,1 @@
+"""Integration tests for configuration management."""

--- a/tests/integration/general/__init__.py
+++ b/tests/integration/general/__init__.py
@@ -1,0 +1,1 @@
+"""General integration tests covering end-to-end workflows."""

--- a/tests/unit/__init__.py
+++ b/tests/unit/__init__.py
@@ -1,0 +1,1 @@
+"""Unit tests for individual DevSynth components."""

--- a/tests/unit/adapters/__init__.py
+++ b/tests/unit/adapters/__init__.py
@@ -1,0 +1,1 @@
+"""Unit tests for adapter modules."""

--- a/tests/unit/application/config/__init__.py
+++ b/tests/unit/application/config/__init__.py
@@ -1,0 +1,1 @@
+"""Unit tests for application configuration components."""

--- a/tests/unit/core/__init__.py
+++ b/tests/unit/core/__init__.py
@@ -1,0 +1,1 @@
+"""Unit tests for core utilities and base classes."""

--- a/tests/unit/domain/__init__.py
+++ b/tests/unit/domain/__init__.py
@@ -1,0 +1,1 @@
+"""Unit tests for domain layer components."""

--- a/tests/unit/domain/models/__init__.py
+++ b/tests/unit/domain/models/__init__.py
@@ -1,0 +1,1 @@
+"""Unit tests for domain model classes."""

--- a/tests/unit/general/__init__.py
+++ b/tests/unit/general/__init__.py
@@ -1,0 +1,1 @@
+"""General unit tests for utilities and workflows."""


### PR DESCRIPTION
## Summary
- add docstrings to test package `__init__.py` files
- maintain test organization according to verifier script

## Testing
- `python tests/verify_test_organization.py`
- `pre-commit run --files tests/behavior/features/general/__init__.py tests/fixtures/__init__.py tests/integration/__init__.py tests/integration/config/__init__.py tests/integration/general/__init__.py tests/unit/__init__.py tests/unit/adapters/__init__.py tests/unit/application/config/__init__.py tests/unit/core/__init__.py tests/unit/domain/__init__.py tests/unit/domain/models/__init__.py tests/unit/general/__init__.py`

------
https://chatgpt.com/codex/tasks/task_e_68801b6b57e88333a4b69556539a9fe6