### PR TITLE
docs: emphasize poetry pytest

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,7 +176,9 @@ The repository includes runnable examples that walk through common workflows:
 
 ## Running Tests
 
-Run `poetry run pytest` to execute the test suite.
+Run `poetry run pytest` to execute the test suite. Invoking plain `pytest`
+outside of Poetry may fail because required plugins are installed only in the
+Poetry virtual environment.
 
 Before running the test suite manually, you **must** install DevSynth with its development extras:
 
@@ -198,7 +200,7 @@ poetry install --all-extras --all-groups
 
 Ingestion and WSDE integration tests are skipped unless you set
 `DEVSYNTH_RUN_INGEST_TESTS=1` or `DEVSYNTH_RUN_WSDE_TESTS=1` before running
-`pytest`.
+`poetry run pytest`.
 
 Use pip only for installing from PyPI, not for local development.
 

--- a/docs/developer_guides/development_setup.md
+++ b/docs/developer_guides/development_setup.md
@@ -126,6 +126,8 @@ Ensure your setup is working correctly by running the tests:
 ```bash
 poetry run pytest
 ```
+Running plain `pytest` outside of Poetry may fail because required plugins are installed only in the Poetry-managed virtual environment.
+
 
 ### Configuration Version Locking
 
@@ -218,14 +220,17 @@ For more details, see the [Contributing Guide](contributing.md).
 ## Running Tests
 
 DevSynth uses pytest for unit testing and pytest-bdd for behavior-driven tests.
-To run the entire test suite, ensure all optional features are installed:
+Always invoke the test runner with `poetry run pytest` so that plugins from the
+Poetry environment are available. To run the entire test suite, ensure all
+optional features are installed:
 
 ```bash
 poetry install --all-extras --all-groups
 ```
 
-Some ingestion and WSDE tests are skipped unless you set `DEVSYNTH_RUN_INGEST_TESTS=1`
-or `DEVSYNTH_RUN_WSDE_TESTS=1` when invoking `pytest`.
+Some ingestion and WSDE tests are skipped unless you set
+`DEVSYNTH_RUN_INGEST_TESTS=1` or `DEVSYNTH_RUN_WSDE_TESTS=1` when invoking
+`poetry run pytest`.
 
 ### Running Unit Tests
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -84,6 +84,9 @@ To execute the entire suite run:
 poetry run pytest
 ```
 
+Running `pytest` directly may fail because required plugins (for example
+`pytest-bdd`) are installed only in the Poetry virtual environment.
+
 ## Conditional Test Execution
 
 The test framework includes a mechanism for conditionally skipping tests based on resource availability. This is useful for tests that depend on external resources like LM Studio or other services that might not always be available.
@@ -176,6 +179,7 @@ export OPENAI_API_KEY=sk-your-key
 
 poetry run pytest
 ```
+Running plain `pytest` may fail because required plugins are installed only in the Poetry-managed environment.
 
 ### Environment Variables for Tests
 
@@ -244,6 +248,7 @@ To run all tests:
 ```bash
 poetry run pytest
 ```
+Invoking plain `pytest` outside of the Poetry environment may fail because some required plugins are installed only in that virtual environment.
 
 ### Environment Setup
 


### PR DESCRIPTION
## Summary
- warn that plain `pytest` may fail due to missing plugins
- document using `poetry run pytest` in README
- document using `poetry run pytest` in development setup guide
- document using `poetry run pytest` in tests README

## Testing
- `poetry run pytest tests/unit/docs/test_feature_matrix.py -q`

------
https://chatgpt.com/codex/tasks/task_e_688032f67dcc83338796105285226ca3