### PR TITLE
Implement conditional retry logic

### DIFF
--- a/tests/unit/adapters/test_provider_system.py
+++ b/tests/unit/adapters/test_provider_system.py
@@ -384,6 +384,7 @@ def test_openai_provider_complete_retry_has_expected(mock_post):
             for call in mock_retry.call_args_list
             if call[1].get("retryable_exceptions")
             == (requests.exceptions.RequestException,)
+            and call[1].get("should_retry") is provider._should_retry
         ]
         assert len(retry_calls_with_correct_params) >= 1
 

--- a/tests/unit/fallback/test_retry_conditions.py
+++ b/tests/unit/fallback/test_retry_conditions.py
@@ -1,0 +1,36 @@
+import pytest
+from unittest.mock import Mock, patch
+
+from devsynth.fallback import retry_with_exponential_backoff
+
+
+def test_should_retry_prevents_retry():
+    """Retry decorator should not retry when ``should_retry`` returns False.
+
+    ReqID: N/A"""
+    mock_func = Mock(side_effect=ValueError("boom"))
+    mock_func.__name__ = "mock_func"
+
+    decorated = retry_with_exponential_backoff(
+        max_retries=3, initial_delay=0.1, should_retry=lambda exc: False
+    )(mock_func)
+
+    with pytest.raises(ValueError):
+        decorated()
+
+    assert mock_func.call_count == 1
+
+
+def test_should_retry_allows_retry_until_success():
+    """Retry decorator retries when ``should_retry`` returns True."""
+    mock_func = Mock(side_effect=[ValueError("err"), ValueError("err"), "ok"])
+    mock_func.__name__ = "mock_func"
+
+    decorated = retry_with_exponential_backoff(
+        max_retries=5, initial_delay=0.0, should_retry=lambda exc: True
+    )(mock_func)
+
+    result = decorated()
+
+    assert result == "ok"
+    assert mock_func.call_count == 3


### PR DESCRIPTION
## Summary
- add `should_retry` option in `retry_with_exponential_backoff`
- integrate conditional retry into OpenAI and LMStudio providers
- update provider system to pass retry condition callbacks
- test conditional retry behaviour

## Testing
- `pytest -q tests/unit/fallback/test_retry_conditions.py`

------
https://chatgpt.com/codex/tasks/task_e_68804c5533f083338458c443a43bd6c3