### PR TITLE
Update RTM and test req IDs

### DIFF
--- a/docs/adapters/providers/retry_mechanism.md
+++ b/docs/adapters/providers/retry_mechanism.md
@@ -77,6 +77,6 @@ The retry mechanism logs each retry attempt with increasing severity levels. Aft
 - Implement circuit breaker pattern for persistent failures
 - Add metrics collection for retry attempts and success rates
 ## Implementation Status
-This feature is **partially implemented**. The core retry decorator works but
-conditional retry logic, circuit breaker integration, and metrics collection are
+This feature is **partially implemented**. Conditional retry logic is now
+available, but circuit breaker integration and detailed metrics collection are
 still planned.

--- a/docs/requirements_traceability.md
+++ b/docs/requirements_traceability.md
@@ -94,8 +94,10 @@ This matrix links requirements to design, code modules, and tests, ensuring bidi
 | FR-85 | Offline fallback provider for LLM operations | [DevSynth Technical Specification](specifications/devsynth_specification_mvp_updated.md#offline-fallback-modes) | src/devsynth/application/llm/offline_provider.py | tests/unit/application/llm/test_offline_provider.py | Implemented |
 | FR-86 | Guided setup wizard accessible via WebUI | [DevSynth Technical Specification](specifications/devsynth_specification_mvp_updated.md#interactive-init-workflow) | src/devsynth/interface/webui_setup.py, src/devsynth/application/cli/setup_wizard.py | tests/unit/interface/test_webui_setup.py, tests/unit/application/cli/test_setup_wizard.py | Implemented |
 | FR-87 | Core values conflict detection | [DevSynth Technical Specification](specifications/devsynth_specification.md) | src/devsynth/core/values.py | tests/unit/core/test_core_values.py | Implemented |
+| FR-88 | Methodology adapter system for customizing development workflows | [Methodology Integration Framework](technical_reference/methodology_integration_framework.md) | src/devsynth/methodology/adhoc.py, src/devsynth/methodology/sprint.py | tests/unit/methodology/test_adhoc_adapter.py, tests/unit/methodology/test_sprint_adapter.py | Implemented |
+| FR-89 | Conditional retry logic for provider API calls | [Retry Mechanism with Exponential Backoff](adapters/providers/retry_mechanism.md) | src/devsynth/fallback.py, src/devsynth/adapters/provider_system.py, src/devsynth/application/llm/openai_provider.py, src/devsynth/application/llm/lmstudio_provider.py | tests/unit/fallback/test_retry_conditions.py, tests/unit/adapters/test_provider_system.py | Implemented |
 
-_Last updated: July 19, 2025
+_Last updated: July 23, 2025
 ## Implementation Status
 
 All documented requirements are implemented or planned as noted above.

--- a/tests/unit/adapters/test_provider_system.py
+++ b/tests/unit/adapters/test_provider_system.py
@@ -354,7 +354,7 @@ def test_openai_provider_complete_error_raises_error(mock_post):
 def test_openai_provider_complete_retry_has_expected(mock_post):
     """Test retry mechanism in the complete method of OpenAIProvider.
 
-    ReqID: N/A"""
+    ReqID: FR-89"""
     with patch(
         "devsynth.adapters.provider_system.retry_with_exponential_backoff"
     ) as mock_retry:

--- a/tests/unit/fallback/test_retry_conditions.py
+++ b/tests/unit/fallback/test_retry_conditions.py
@@ -7,7 +7,7 @@ from devsynth.fallback import retry_with_exponential_backoff
 def test_should_retry_prevents_retry():
     """Retry decorator should not retry when ``should_retry`` returns False.
 
-    ReqID: N/A"""
+    ReqID: FR-89"""
     mock_func = Mock(side_effect=ValueError("boom"))
     mock_func.__name__ = "mock_func"
 
@@ -22,7 +22,9 @@ def test_should_retry_prevents_retry():
 
 
 def test_should_retry_allows_retry_until_success():
-    """Retry decorator retries when ``should_retry`` returns True."""
+    """Retry decorator retries when ``should_retry`` returns True.
+
+    ReqID: FR-89"""
     mock_func = Mock(side_effect=[ValueError("err"), ValueError("err"), "ok"])
     mock_func.__name__ = "mock_func"
 

--- a/tests/unit/methodology/test_adhoc_adapter.py
+++ b/tests/unit/methodology/test_adhoc_adapter.py
@@ -5,13 +5,17 @@ from devsynth.methodology.base import Phase
 
 
 def test_should_start_cycle_true():
-    """AdHocAdapter begins a cycle when requested."""
+    """AdHocAdapter begins a cycle when requested.
+
+    ReqID: FR-88"""
     adapter = AdHocAdapter({"settings": {"startNewCycle": True}})
     assert adapter.should_start_cycle()
 
 
 def test_should_progress_to_next_phase():
-    """Progresses when user marks phase complete and requests progression."""
+    """Progresses when user marks phase complete and requests progression.
+
+    ReqID: FR-88"""
     adapter = AdHocAdapter({"settings": {}})
     context = {"progress_to_next": True}
     results = {"phase_complete": True}

--- a/tests/unit/methodology/test_sprint_adapter.py
+++ b/tests/unit/methodology/test_sprint_adapter.py
@@ -5,7 +5,9 @@ from devsynth.methodology.base import Phase
 
 
 def test_calculate_phase_end_time():
-    """SprintAdapter calculates phase end time correctly."""
+    """SprintAdapter calculates phase end time correctly.
+
+    ReqID: FR-88"""
     adapter = SprintAdapter({"settings": {"sprintDuration": 1}})
     start = datetime.datetime(2023, 1, 1)
     end = adapter._calculate_phase_end_time(Phase.EXPAND, start)
@@ -14,7 +16,9 @@ def test_calculate_phase_end_time():
 
 
 def test_is_phase_time_exceeded_false(monkeypatch):
-    """_is_phase_time_exceeded respects allocation."""
+    """_is_phase_time_exceeded respects allocation.
+
+    ReqID: FR-88"""
     adapter = SprintAdapter({"settings": {"sprintDuration": 1}})
     start = datetime.datetime.now()
     monkeypatch.setattr(datetime, "datetime", datetime.datetime)
@@ -22,7 +26,9 @@ def test_is_phase_time_exceeded_false(monkeypatch):
 
 
 def test_should_progress_when_time_exceeded(monkeypatch):
-    """should_progress_to_next_phase triggers when time is exceeded."""
+    """should_progress_to_next_phase triggers when time is exceeded.
+
+    ReqID: FR-88"""
     adapter = SprintAdapter({"settings": {"sprintDuration": 1}})
     start = datetime.datetime.now() - datetime.timedelta(days=8)
     adapter.sprint_start_time = start


### PR DESCRIPTION
## Summary
- record methodology adapters and retry logic in requirements matrix
- document conditional retry feature status
- note new ReqIDs in unit tests

## Testing
- `bash scripts/codex_setup.sh --minimal`
- `poetry run pytest` *(fails: FileNotFoundError during test collection)*

------
https://chatgpt.com/codex/tasks/task_e_68805257d0588333b78adb99ee142339