### PR TITLE
Enhance retry metrics

### DIFF
--- a/src/devsynth/metrics.py
+++ b/src/devsynth/metrics.py
@@ -6,6 +6,7 @@ from typing import Dict
 # Counters for operations
 _memory_metrics: Counter = Counter()
 _provider_metrics: Counter = Counter()
+_retry_metrics: Counter = Counter()
 
 
 def inc_memory(op: str) -> None:
@@ -18,6 +19,11 @@ def inc_provider(op: str) -> None:
     _provider_metrics[op] += 1
 
 
+def inc_retry(op: str) -> None:
+    """Increment retry operation counter."""
+    _retry_metrics[op] += 1
+
+
 def get_memory_metrics() -> Dict[str, int]:
     """Return memory operation counters."""
     return dict(_memory_metrics)
@@ -28,7 +34,13 @@ def get_provider_metrics() -> Dict[str, int]:
     return dict(_provider_metrics)
 
 
+def get_retry_metrics() -> Dict[str, int]:
+    """Return retry operation counters."""
+    return dict(_retry_metrics)
+
+
 def reset_metrics() -> None:
     """Reset all metrics counters."""
     _memory_metrics.clear()
     _provider_metrics.clear()
+    _retry_metrics.clear()

--- a/tests/unit/fallback/test_retry_metrics.py
+++ b/tests/unit/fallback/test_retry_metrics.py
@@ -1,0 +1,34 @@
+import pytest
+from unittest.mock import Mock
+
+from devsynth.fallback import retry_with_exponential_backoff
+from devsynth.metrics import get_retry_metrics, reset_metrics
+
+
+def test_retry_metrics_success():
+    reset_metrics()
+    mock_func = Mock(side_effect=[ValueError("err"), "ok"])
+    mock_func.__name__ = "mock_func"
+    decorated = retry_with_exponential_backoff(
+        max_retries=2, initial_delay=0, track_metrics=True
+    )(mock_func)
+    result = decorated()
+    assert result == "ok"
+    metrics = get_retry_metrics()
+    assert metrics.get("attempt") == 1
+    assert metrics.get("success") == 1
+
+
+def test_retry_metrics_failure():
+    reset_metrics()
+    mock_func = Mock(side_effect=ValueError("err"))
+    mock_func.__name__ = "mock_func"
+    decorated = retry_with_exponential_backoff(
+        max_retries=1, initial_delay=0, track_metrics=True
+    )(mock_func)
+    with pytest.raises(ValueError):
+        decorated()
+    metrics = get_retry_metrics()
+    # one retry attempt, failure recorded
+    assert metrics.get("attempt") == 1
+    assert metrics.get("failure") == 1


### PR DESCRIPTION
## Summary
- support retry metrics in the fallback utilities
- expose new metric counters
- test retry metrics logic

## Testing
- `poetry run pytest tests/unit/fallback -q`

------
https://chatgpt.com/codex/tasks/task_e_68805d4dd7a483339232adf28b7fa9d8