### PR TITLE
Fix codex setup script

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,12 +24,20 @@ The script is executed **before** network access is disabled. If it fails, a
 file named `CODEX_ENVIRONMENT_SETUP_FAILED` will appear in the repository root.
 Fix the script and rerun it offline to finish provisioning:
 
-1. Review and update `scripts/codex_setup.sh` so it succeeds in your
-   environment. You may need to install packages manually or modify the script.
+1. Review and update `scripts/codex_setup.sh` so it installs all project
+   dependencies with `poetry install --with dev,docs --all-extras` (or the
+   `--minimal` variant) and verifies key packages such as `pytest-bdd` are
+   available.
 2. Run `bash scripts/codex_setup.sh` (without network access) until it completes
-   without errors.
+   without errors, then confirm with `poetry run pip list` that packages like
+   `pytest-bdd` appear.
 3. Remove the failure marker with `rm CODEX_ENVIRONMENT_SETUP_FAILED`.
 4. Execute `poetry run pytest` to verify the environment.
+
+Changes to the setup script only take effect the next time Codex provisions an
+environment. OpenAI disables network access during execution, so `scripts/codex_setup.sh`
+runs first with network access to install dependencies before the sandbox is
+handed to the agent.
 
 Development and test commands may fail until the setup script completes
 successfully, the marker file is removed, and the tests pass.

--- a/scripts/codex_setup.sh
+++ b/scripts/codex_setup.sh
@@ -23,7 +23,7 @@ poetry run python - <<'EOF'
 import sys
 import pkg_resources
 
-required = ["typer", "pytest"]
+required = ["typer", "pytest", "pytest-bdd"]
 missing = [pkg for pkg in required if pkg not in {d.key for d in pkg_resources.working_set}]
 if missing:
     sys.exit(f"Missing packages: {', '.join(missing)}")


### PR DESCRIPTION
## Summary
- verify pytest-bdd in codex_setup.sh
- add clarification to AGENTS.md about updating codex_setup.sh

## Testing
- `poetry run pip list | grep pytest-bdd`
- `poetry run pytest -k "not slow" -q`

------
https://chatgpt.com/codex/tasks/task_e_6881010b36408333be1c66006ec4f589