### PR TITLE
Refactor bridges and tests

### DIFF
--- a/src/devsynth/interface/shared_bridge.py
+++ b/src/devsynth/interface/shared_bridge.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+"""Shared utilities for UXBridge implementations."""
+
+from typing import Optional
+
+from .output_formatter import OutputFormatter
+from .ux_bridge import sanitize_output
+
+
+class SharedBridgeMixin:
+    """Mixin providing common display logic for bridges."""
+
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)  # type: ignore[misc]
+        self.formatter = OutputFormatter(getattr(self, "console", None))
+
+    def _format_for_output(
+        self,
+        message: str,
+        *,
+        highlight: bool = False,
+        message_type: Optional[str] = None,
+    ) -> str:
+        """Format and sanitize a message for output."""
+        formatted = self.formatter.format_message(
+            message, message_type=message_type, highlight=highlight
+        )
+        return sanitize_output(str(formatted))

--- a/tests/unit/interface/test_uxbridge_aliases.py
+++ b/tests/unit/interface/test_uxbridge_aliases.py
@@ -1,0 +1,30 @@
+from devsynth.interface.ux_bridge import UXBridge
+
+
+class DummyBridge(UXBridge):
+    def __init__(self) -> None:
+        self.calls = []
+
+    def ask_question(self, message, *, choices=None, default=None, show_default=True):
+        self.calls.append(("ask_question", message, choices, default, show_default))
+        return "ans"
+
+    def confirm_choice(self, message, *, default=False):
+        self.calls.append(("confirm_choice", message, default))
+        return default
+
+    def display_result(self, message, *, highlight=False):
+        self.calls.append(("display_result", message, highlight))
+
+
+def test_prompt_alias_delegates():
+    bridge = DummyBridge()
+    result = bridge.prompt("q", choices=["x"], default="x", show_default=False)
+    assert result == "ans"
+    assert bridge.calls[0] == ("ask_question", "q", ["x"], "x", False)
+
+
+def test_print_alias_delegates():
+    bridge = DummyBridge()
+    bridge.print("msg", highlight=True)
+    assert bridge.calls[0] == ("display_result", "msg", True)


### PR DESCRIPTION
## Summary
- add `SharedBridgeMixin` for common UXBridge logic
- refactor CLI and WebUI bridges to reuse `SharedBridgeMixin`
- simplify CLI BDD steps to invoke the Typer app
- add unit tests for UXBridge method aliases

## Testing
- `poetry run pytest tests/unit/interface/test_uxbridge_aliases.py tests/behavior/steps/test_cli_commands_steps.py -q`
- `poetry run pytest tests -q` *(fails: ModuleNotFoundError: No module named 'tests.behavior.steps.test_pytest_plugins')*

------
https://chatgpt.com/codex/tasks/task_e_68810a8ff1c88333b2e0e6004322accc