### PR TITLE
Add CLI option tests and enhance doctor check

### DIFF
--- a/src/devsynth/application/cli/commands/doctor_cmd.py
+++ b/src/devsynth/application/cli/commands/doctor_cmd.py
@@ -31,7 +31,9 @@ def doctor_cmd(config_dir: str = "config", *, bridge: Optional[UXBridge] = None)
     """
     ux_bridge = bridge if bridge is not None else globals()["bridge"]
     try:
+        from devsynth.application.cli.cli_commands import _check_services
         config = load_config()
+        _check_services(ux_bridge)
         if _find_project_config(Path.cwd()) is None:
             ux_bridge.print(
                 "[yellow]No project configuration found. Run 'devsynth init' to create it.[/yellow]"

--- a/tests/unit/application/cli/test_init_cmd.py
+++ b/tests/unit/application/cli/test_init_cmd.py
@@ -3,6 +3,7 @@ from devsynth.config.unified_loader import UnifiedConfigLoader
 from devsynth.application.cli.cli_commands import init_cmd
 from devsynth.interface.cli import CLIUXBridge
 import pytest
+from unittest.mock import patch
 
 
 def _run_init(tmp_path, monkeypatch, *, use_pyproject=False):
@@ -56,6 +57,15 @@ ReqID: N/A"""
     _run_init(tmp_path, monkeypatch)
     printed = _run_init(tmp_path, monkeypatch)
     assert any('Project already initialized' in msg for msg in printed)
+
+
+def test_init_cmd_wizard_option_invokes_setup(monkeypatch):
+    """--wizard flag should run the SetupWizard."""
+
+    with patch('devsynth.application.cli.setup_wizard.SetupWizard') as wiz:
+        init_cmd(wizard=True)
+        wiz.assert_called_once()
+        wiz.return_value.run.assert_called_once()
 
 
 def test_cli_help_lists_renamed_commands_succeeds(capsys, monkeypatch):


### PR DESCRIPTION
## Summary
- extend CLI tests for invalid input and options
- run setup wizard when --wizard passed to `init`
- warn on missing API keys and check services within `doctor_cmd`

## Testing
- `poetry run pytest tests/unit/application/cli/test_init_cmd.py::test_init_cmd_wizard_option_invokes_setup -q`
- `poetry run pytest tests/unit/general/test_unit_cli_commands.py::TestCLICommands::test_run_pipeline_cmd_invalid_target -q`
- `poetry run pytest tests/unit/application/cli/test_doctor_cmd.py::test_doctor_cmd_invokes_service_check -q`
- `poetry run pytest -q` *(fails: ModuleNotFoundError: No module named 'tests.behavior.steps.pytest_plugins')*

------
https://chatgpt.com/codex/tasks/task_e_6881129956888333af3ac938e88cc0a3