### PR TITLE
Implement WebUI page hooks

### DIFF
--- a/src/devsynth/application/cli/commands/inspect_code_cmd.py
+++ b/src/devsynth/application/cli/commands/inspect_code_cmd.py
@@ -17,10 +17,14 @@ from devsynth.application.code_analysis.project_state_analyzer import (
 from devsynth.logging_setup import DevSynthLogger
 
 logger = DevSynthLogger(__name__)
-bridge: UXBridge = CLIUXBridge()
+cli_bridge: UXBridge = CLIUXBridge()
 
 
-def inspect_code_cmd(path: Optional[str] = None) -> None:
+def inspect_code_cmd(
+    path: Optional[str] = None,
+    *,
+    bridge: Optional[UXBridge] = None,
+) -> None:
     """Inspect a codebase to understand its architecture and quality.
 
     Example:
@@ -28,7 +32,9 @@ def inspect_code_cmd(path: Optional[str] = None) -> None:
 
     Args:
         path: Path to the codebase to inspect (default: current directory)
+        bridge: Optional UXBridge for user feedback
     """
+    bridge = bridge or cli_bridge
     console = Console()
 
     try:

--- a/src/devsynth/interface/webui.py
+++ b/src/devsynth/interface/webui.py
@@ -964,6 +964,7 @@ class WebUI(UXBridge):
                                     cmd,
                                     "Failed to inspect code",
                                     path=path,
+                                    bridge=self,
                                 )
 
     def synthesis_page(self) -> None:

--- a/tests/behavior/features/general/webui_commands.feature
+++ b/tests/behavior/features/general/webui_commands.feature
@@ -20,6 +20,11 @@ Feature: WebUI Command Execution
     And I submit the inspect form
     Then the inspect command should be executed
 
+  Scenario: Inspect code from the analysis page
+    When I navigate to "Analysis"
+    And I submit the analysis form
+    Then the inspect_code command should be executed
+
   Scenario: Generate tests from the synthesis page
     When I navigate to "Synthesis"
     And I submit the test form

--- a/tests/behavior/features/general/webui_navigation_prompts.feature
+++ b/tests/behavior/features/general/webui_navigation_prompts.feature
@@ -13,3 +13,18 @@ Feature: WebUI Navigation and Prompts
     When I navigate to "Onboarding"
     And I submit the onboarding form
     Then the init command should be executed
+
+  Scenario: Navigate to Analysis page
+    Given the WebUI is initialized
+    When I navigate to "Analysis"
+    Then the "Code Analysis" header is shown
+
+  Scenario: Navigate to Synthesis page
+    Given the WebUI is initialized
+    When I navigate to "Synthesis"
+    Then the "Synthesis Execution" header is shown
+
+  Scenario: Navigate to Config page
+    Given the WebUI is initialized
+    When I navigate to "Config"
+    Then the "Configuration Editing" header is shown

--- a/tests/behavior/features/webui_commands.feature
+++ b/tests/behavior/features/webui_commands.feature
@@ -20,6 +20,11 @@ Feature: WebUI Command Execution
     And I submit the inspect form
     Then the inspect command should be executed
 
+  Scenario: Inspect code from the analysis page
+    When I navigate to "Analysis"
+    And I submit the analysis form
+    Then the inspect_code command should be executed
+
   Scenario: Generate tests from the synthesis page
     When I navigate to "Synthesis"
     And I submit the test form

--- a/tests/behavior/features/webui_navigation_prompts.feature
+++ b/tests/behavior/features/webui_navigation_prompts.feature
@@ -13,3 +13,18 @@ Feature: WebUI Navigation and Prompts
     When I navigate to "Onboarding"
     And I submit the onboarding form
     Then the init command should be executed
+
+  Scenario: Navigate to Analysis page
+    Given the WebUI is initialized
+    When I navigate to "Analysis"
+    Then the "Code Analysis" header is shown
+
+  Scenario: Navigate to Synthesis page
+    Given the WebUI is initialized
+    When I navigate to "Synthesis"
+    Then the "Synthesis Execution" header is shown
+
+  Scenario: Navigate to Config page
+    Given the WebUI is initialized
+    When I navigate to "Config"
+    Then the "Configuration Editing" header is shown

--- a/tests/behavior/steps/test_webui_commands_steps.py
+++ b/tests/behavior/steps/test_webui_commands_steps.py
@@ -74,6 +74,13 @@ def submit_alignment(webui_context):
     webui_context["ui"].run()
 
 
+@when("I submit the analysis form")
+def submit_analysis(webui_context):
+    webui_context["st"].sidebar.radio.return_value = "Analysis"
+    webui_context["st"].form_submit_button.return_value = True
+    webui_context["ui"].run()
+
+
 @then("the spec command should be executed")
 def check_spec(webui_context):
     assert webui_context["cli"].spec_cmd.called
@@ -107,3 +114,8 @@ def check_edrr_cycle(webui_context):
 @then("the align command should be executed")
 def check_align(webui_context):
     assert webui_context["cli"].align_cmd.called
+
+
+@then("the inspect_code command should be executed")
+def check_inspect_code(webui_context):
+    assert webui_context["cli"].inspect_code_cmd.called

--- a/tests/behavior/steps/test_webui_steps.py
+++ b/tests/behavior/steps/test_webui_steps.py
@@ -96,6 +96,7 @@ def webui_context(monkeypatch):
     monkeypatch.setitem(
         sys.modules, "devsynth.application.cli.commands.inspect_code_cmd", analyze_stub
     )
+    cli_stub.inspect_code_cmd = analyze_stub.inspect_code_cmd
 
     doctor_stub = ModuleType("devsynth.application.cli.commands.doctor_cmd")
     doctor_stub.doctor_cmd = MagicMock()


### PR DESCRIPTION
## Summary
- wire analysis page to CLI via UXBridge
- add inspect_code_cmd bridge parameter
- cover navigation to all core pages in BDD
- test analysis form execution with inspect_code

## Testing
- `poetry run pytest -q` *(fails: wsde memory integration tests)*

------
https://chatgpt.com/codex/tasks/task_e_688127139cf48333825405f0850364ae