### PR TITLE
Implement requirement repositories

### DIFF
--- a/src/devsynth/domain/interfaces/requirement.py
+++ b/src/devsynth/domain/interfaces/requirement.py
@@ -2,8 +2,7 @@
 Domain interfaces for requirements management.
 """
 
-from abc import ABC, abstractmethod
-from typing import Dict, List, Optional, Union
+from typing import Dict, List, Optional
 from uuid import UUID
 
 from devsynth.domain.models.requirement import (
@@ -16,411 +15,8 @@ from devsynth.domain.models.requirement import (
 )
 
 
-class RequirementRepositoryInterface(ABC):
-    """Interface for requirement repository."""
-
-    @abstractmethod
-    def get_requirement(self, requirement_id: UUID) -> Optional[Requirement]:
-        """
-        Get a requirement by ID.
-
-        Args:
-            requirement_id: The ID of the requirement.
-
-        Returns:
-            The requirement if found, None otherwise.
-        """
-        raise NotImplementedError("Method not implemented")
-
-    @abstractmethod
-    def get_all_requirements(self) -> List[Requirement]:
-        """
-        Get all requirements.
-
-        Returns:
-            A list of all requirements.
-        """
-        raise NotImplementedError("Method not implemented")
-
-    @abstractmethod
-    def save_requirement(self, requirement: Requirement) -> Requirement:
-        """
-        Save a requirement.
-
-        Args:
-            requirement: The requirement to save.
-
-        Returns:
-            The saved requirement.
-        """
-        raise NotImplementedError("Method not implemented")
-
-    @abstractmethod
-    def delete_requirement(self, requirement_id: UUID) -> bool:
-        """
-        Delete a requirement.
-
-        Args:
-            requirement_id: The ID of the requirement to delete.
-
-        Returns:
-            True if the requirement was deleted, False otherwise.
-        """
-        raise NotImplementedError("Method not implemented")
-
-    @abstractmethod
-    def get_requirements_by_status(self, status: str) -> List[Requirement]:
-        """
-        Get requirements by status.
-
-        Args:
-            status: The status to filter by.
-
-        Returns:
-            A list of requirements with the specified status.
-        """
-        raise NotImplementedError("Method not implemented")
-
-    @abstractmethod
-    def get_requirements_by_type(self, type_: str) -> List[Requirement]:
-        """
-        Get requirements by type.
-
-        Args:
-            type_: The type to filter by.
-
-        Returns:
-            A list of requirements with the specified type.
-        """
-        raise NotImplementedError("Method not implemented")
-
-
-class ChangeRepositoryInterface(ABC):
-    """Interface for requirement change repository."""
-
-    @abstractmethod
-    def get_change(self, change_id: UUID) -> Optional[RequirementChange]:
-        """
-        Get a change by ID.
-
-        Args:
-            change_id: The ID of the change.
-
-        Returns:
-            The change if found, None otherwise.
-        """
-        raise NotImplementedError("Method not implemented")
-
-    @abstractmethod
-    def get_changes_for_requirement(
-        self, requirement_id: UUID
-    ) -> List[RequirementChange]:
-        """
-        Get changes for a requirement.
-
-        Args:
-            requirement_id: The ID of the requirement.
-
-        Returns:
-            A list of changes for the requirement.
-        """
-        raise NotImplementedError("Method not implemented")
-
-    @abstractmethod
-    def save_change(self, change: RequirementChange) -> RequirementChange:
-        """
-        Save a change.
-
-        Args:
-            change: The change to save.
-
-        Returns:
-            The saved change.
-        """
-        raise NotImplementedError("Method not implemented")
-
-    @abstractmethod
-    def delete_change(self, change_id: UUID) -> bool:
-        """
-        Delete a change.
-
-        Args:
-            change_id: The ID of the change to delete.
-
-        Returns:
-            True if the change was deleted, False otherwise.
-        """
-        raise NotImplementedError("Method not implemented")
-
-
-class ImpactAssessmentRepositoryInterface(ABC):
-    """Interface for impact assessment repository."""
-
-    @abstractmethod
-    def get_impact_assessment(self, assessment_id: UUID) -> Optional[ImpactAssessment]:
-        """
-        Get an impact assessment by ID.
-
-        Args:
-            assessment_id: The ID of the impact assessment.
-
-        Returns:
-            The impact assessment if found, None otherwise.
-        """
-        raise NotImplementedError("Method not implemented")
-
-    @abstractmethod
-    def get_impact_assessment_for_change(
-        self, change_id: UUID
-    ) -> Optional[ImpactAssessment]:
-        """
-        Get an impact assessment for a change.
-
-        Args:
-            change_id: The ID of the change.
-
-        Returns:
-            The impact assessment if found, None otherwise.
-        """
-        raise NotImplementedError("Method not implemented")
-
-    @abstractmethod
-    def save_impact_assessment(self, assessment: ImpactAssessment) -> ImpactAssessment:
-        """
-        Save an impact assessment.
-
-        Args:
-            assessment: The impact assessment to save.
-
-        Returns:
-            The saved impact assessment.
-        """
-        raise NotImplementedError("Method not implemented")
-
-
-class DialecticalReasoningRepositoryInterface(ABC):
-    """Interface for dialectical reasoning repository."""
-
-    @abstractmethod
-    def get_reasoning(self, reasoning_id: UUID) -> Optional[DialecticalReasoning]:
-        """
-        Get a dialectical reasoning by ID.
-
-        Args:
-            reasoning_id: The ID of the dialectical reasoning.
-
-        Returns:
-            The dialectical reasoning if found, None otherwise.
-        """
-        raise NotImplementedError("Method not implemented")
-
-    @abstractmethod
-    def get_reasoning_for_change(
-        self, change_id: UUID
-    ) -> Optional[DialecticalReasoning]:
-        """
-        Get a dialectical reasoning for a change.
-
-        Args:
-            change_id: The ID of the change.
-
-        Returns:
-            The dialectical reasoning if found, None otherwise.
-        """
-        raise NotImplementedError("Method not implemented")
-
-    @abstractmethod
-    def save_reasoning(self, reasoning: DialecticalReasoning) -> DialecticalReasoning:
-        """
-        Save a dialectical reasoning.
-
-        Args:
-            reasoning: The dialectical reasoning to save.
-
-        Returns:
-            The saved dialectical reasoning.
-        """
-        raise NotImplementedError("Method not implemented")
-
-
-class ChatRepositoryInterface(ABC):
-    """Interface for chat repository."""
-
-    @abstractmethod
-    def get_session(self, session_id: UUID) -> Optional[ChatSession]:
-        """
-        Get a chat session by ID.
-
-        Args:
-            session_id: The ID of the chat session.
-
-        Returns:
-            The chat session if found, None otherwise.
-        """
-        raise NotImplementedError("Method not implemented")
-
-    @abstractmethod
-    def get_sessions_for_user(self, user_id: str) -> List[ChatSession]:
-        """
-        Get chat sessions for a user.
-
-        Args:
-            user_id: The ID of the user.
-
-        Returns:
-            A list of chat sessions for the user.
-        """
-        raise NotImplementedError("Method not implemented")
-
-    @abstractmethod
-    def save_session(self, session: ChatSession) -> ChatSession:
-        """
-        Save a chat session.
-
-        Args:
-            session: The chat session to save.
-
-        Returns:
-            The saved chat session.
-        """
-        raise NotImplementedError("Method not implemented")
-
-    @abstractmethod
-    def save_message(self, message: ChatMessage) -> ChatMessage:
-        """
-        Save a chat message.
-
-        Args:
-            message: The chat message to save.
-
-        Returns:
-            The saved chat message.
-        """
-        raise NotImplementedError("Method not implemented")
-
-    @abstractmethod
-    def get_messages_for_session(self, session_id: UUID) -> List[ChatMessage]:
-        """
-        Get messages for a chat session.
-
-        Args:
-            session_id: The ID of the chat session.
-
-        Returns:
-            A list of messages for the chat session.
-        """
-        raise NotImplementedError("Method not implemented")
-
-
-class DialecticalReasonerInterface(ABC):
-    """Interface for dialectical reasoner."""
-
-    @abstractmethod
-    def evaluate_change(self, change: RequirementChange) -> DialecticalReasoning:
-        """
-        Evaluate a requirement change using dialectical reasoning.
-
-        Args:
-            change: The requirement change to evaluate.
-
-        Returns:
-            The dialectical reasoning result.
-        """
-        raise NotImplementedError("Method not implemented")
-
-    @abstractmethod
-    def process_message(
-        self, session_id: UUID, message: str, user_id: str
-    ) -> ChatMessage:
-        """
-        Process a message in a dialectical reasoning chat session.
-
-        Args:
-            session_id: The ID of the chat session.
-            message: The message content.
-            user_id: The ID of the user sending the message.
-
-        Returns:
-            The response message.
-        """
-        raise NotImplementedError("Method not implemented")
-
-    @abstractmethod
-    def create_session(
-        self, user_id: str, change_id: Optional[UUID] = None
-    ) -> ChatSession:
-        """
-        Create a new dialectical reasoning chat session.
-
-        Args:
-            user_id: The ID of the user.
-            change_id: The ID of the change to discuss, if any.
-
-        Returns:
-            The created chat session.
-        """
-        raise NotImplementedError("Method not implemented")
-
-    @abstractmethod
-    def assess_impact(self, change: RequirementChange) -> ImpactAssessment:
-        """
-        Assess the impact of a requirement change.
-
-        Args:
-            change: The requirement change to assess.
-
-        Returns:
-            The impact assessment.
-        """
-        raise NotImplementedError("Method not implemented")
-
-
-class NotificationInterface(ABC):
-    """Interface for notifications."""
-
-    @abstractmethod
-    def notify_change_proposed(self, change: RequirementChange) -> None:
-        """
-        Notify that a change has been proposed.
-
-        Args:
-            change: The proposed change.
-        """
-        raise NotImplementedError("Method not implemented")
-
-    @abstractmethod
-    def notify_change_approved(self, change: RequirementChange) -> None:
-        """
-        Notify that a change has been approved.
-
-        Args:
-            change: The approved change.
-        """
-        raise NotImplementedError("Method not implemented")
-
-    @abstractmethod
-    def notify_change_rejected(self, change: RequirementChange) -> None:
-        """
-        Notify that a change has been rejected.
-
-        Args:
-            change: The rejected change.
-        """
-        raise NotImplementedError("Method not implemented")
-
-    @abstractmethod
-    def notify_impact_assessment_completed(self, assessment: ImpactAssessment) -> None:
-        """
-        Notify that an impact assessment has been completed.
-
-        Args:
-            assessment: The completed impact assessment.
-        """
-        raise NotImplementedError("Method not implemented")
-
-
-class InMemoryRequirementRepository(RequirementRepositoryInterface):
-    """In-memory implementation of :class:`RequirementRepositoryInterface`."""
+class RequirementRepositoryInterface:
+    """Simple in-memory requirement repository."""
 
     def __init__(self) -> None:
         self.requirements: Dict[UUID, Requirement] = {}
@@ -448,8 +44,8 @@ class InMemoryRequirementRepository(RequirementRepositoryInterface):
         return [r for r in self.requirements.values() if r.type.value == type_]
 
 
-class InMemoryChangeRepository(ChangeRepositoryInterface):
-    """In-memory implementation of :class:`ChangeRepositoryInterface`."""
+class ChangeRepositoryInterface:
+    """Simple in-memory repository for requirement changes."""
 
     def __init__(self) -> None:
         self.changes: Dict[UUID, RequirementChange] = {}
@@ -473,8 +69,8 @@ class InMemoryChangeRepository(ChangeRepositoryInterface):
         return False
 
 
-class InMemoryImpactAssessmentRepository(ImpactAssessmentRepositoryInterface):
-    """In-memory implementation of :class:`ImpactAssessmentRepositoryInterface`."""
+class ImpactAssessmentRepositoryInterface:
+    """Simple in-memory impact assessment repository."""
 
     def __init__(self) -> None:
         self.assessments: Dict[UUID, ImpactAssessment] = {}
@@ -498,8 +94,8 @@ class InMemoryImpactAssessmentRepository(ImpactAssessmentRepositoryInterface):
         return assessment
 
 
-class InMemoryDialecticalReasoningRepository(DialecticalReasoningRepositoryInterface):
-    """In-memory implementation of :class:`DialecticalReasoningRepositoryInterface`."""
+class DialecticalReasoningRepositoryInterface:
+    """Simple in-memory dialectical reasoning repository."""
 
     def __init__(self) -> None:
         self.reasonings: Dict[UUID, DialecticalReasoning] = {}
@@ -523,8 +119,8 @@ class InMemoryDialecticalReasoningRepository(DialecticalReasoningRepositoryInter
         return reasoning
 
 
-class InMemoryChatRepository(ChatRepositoryInterface):
-    """In-memory implementation of :class:`ChatRepositoryInterface`."""
+class ChatRepositoryInterface:
+    """Simple in-memory chat repository."""
 
     def __init__(self) -> None:
         self.sessions: Dict[UUID, ChatSession] = {}
@@ -551,6 +147,83 @@ class InMemoryChatRepository(ChatRepositoryInterface):
 
     def get_messages_for_session(self, session_id: UUID) -> List[ChatMessage]:
         return [m for m in self.messages.values() if m.session_id == session_id]
+
+
+class DialecticalReasonerInterface:
+    """Base dialectical reasoner implementation."""
+
+    def evaluate_change(self, change: RequirementChange) -> DialecticalReasoning:
+        reasoning = DialecticalReasoning(change_id=change.id)
+        reasoning.thesis = f"Proposed change {change.id}"
+        reasoning.antithesis = "Opposing view"
+        reasoning.synthesis = "Synthesis"
+        reasoning.conclusion = "Unreviewed"
+        reasoning.recommendation = "Review"
+        return reasoning
+
+    def process_message(
+        self, session_id: UUID, message: str, user_id: str
+    ) -> ChatMessage:
+        return ChatMessage(session_id=session_id, sender="system", content=message)
+
+    def create_session(
+        self, user_id: str, change_id: Optional[UUID] = None
+    ) -> ChatSession:
+        return ChatSession(user_id=user_id, change_id=change_id)
+
+    def assess_impact(self, change: RequirementChange) -> ImpactAssessment:
+        return ImpactAssessment(change_id=change.id, analysis="")
+
+
+class NotificationInterface:
+    """Base notification service."""
+
+    def notify_change_proposed(self, change: RequirementChange) -> None:
+        print(f"Change proposed: {change.id}")
+
+    def notify_change_approved(self, change: RequirementChange) -> None:
+        print(f"Change approved: {change.id}")
+
+    def notify_change_rejected(self, change: RequirementChange) -> None:
+        print(f"Change rejected: {change.id}")
+
+    def notify_impact_assessment_completed(self, assessment: ImpactAssessment) -> None:
+        print(f"Impact assessment completed: {assessment.id}")
+
+
+class InMemoryRequirementRepository(RequirementRepositoryInterface):
+    """In-memory implementation of :class:`RequirementRepositoryInterface`."""
+
+    def __init__(self) -> None:
+        super().__init__()
+
+
+class InMemoryChangeRepository(ChangeRepositoryInterface):
+    """In-memory implementation of :class:`ChangeRepositoryInterface`."""
+
+    def __init__(self) -> None:
+        super().__init__()
+
+
+class InMemoryImpactAssessmentRepository(ImpactAssessmentRepositoryInterface):
+    """In-memory implementation of :class:`ImpactAssessmentRepositoryInterface`."""
+
+    def __init__(self) -> None:
+        super().__init__()
+
+
+class InMemoryDialecticalReasoningRepository(DialecticalReasoningRepositoryInterface):
+    """In-memory implementation of :class:`DialecticalReasoningRepositoryInterface`."""
+
+    def __init__(self) -> None:
+        super().__init__()
+
+
+class InMemoryChatRepository(ChatRepositoryInterface):
+    """In-memory implementation of :class:`ChatRepositoryInterface`."""
+
+    def __init__(self) -> None:
+        super().__init__()
 
 
 class SimpleDialecticalReasoner(DialecticalReasonerInterface):

--- a/tests/unit/domain/test_requirement_interfaces.py
+++ b/tests/unit/domain/test_requirement_interfaces.py
@@ -10,7 +10,13 @@ from devsynth.domain.interfaces.requirement import (
     SimpleDialecticalReasoner,
     PrintNotificationService,
 )
-from devsynth.domain.models.requirement import Requirement, RequirementChange
+from devsynth.domain.models.requirement import (
+    Requirement,
+    RequirementChange,
+    RequirementStatus,
+    RequirementType,
+    ImpactAssessment,
+)
 
 
 class TestRequirementInterfaces(unittest.TestCase):
@@ -33,6 +39,25 @@ class TestRequirementInterfaces(unittest.TestCase):
         self.assertEqual(
             len(repo.get_changes_for_requirement(change.requirement_id)), 1
         )
+        self.assertTrue(repo.delete_change(change.id))
+        self.assertIsNone(repo.get_change(change.id))
+
+    def test_inmemory_impact_assessment_repository(self) -> None:
+        repo = InMemoryImpactAssessmentRepository()
+        change_id = uuid4()
+        assessment = ImpactAssessment(change_id=change_id, analysis="impact")
+        repo.save_impact_assessment(assessment)
+        self.assertEqual(repo.get_impact_assessment(assessment.id), assessment)
+        self.assertEqual(repo.get_impact_assessment_for_change(change_id), assessment)
+
+    def test_inmemory_requirement_repository_filters(self) -> None:
+        repo = InMemoryRequirementRepository()
+        req1 = Requirement(title="r1", status=RequirementStatus.PROPOSED, type=RequirementType.FUNCTIONAL)
+        req2 = Requirement(title="r2", status=RequirementStatus.APPROVED, type=RequirementType.BUSINESS)
+        repo.save_requirement(req1)
+        repo.save_requirement(req2)
+        self.assertEqual(repo.get_requirements_by_status("proposed"), [req1])
+        self.assertEqual(repo.get_requirements_by_type("business"), [req2])
 
     def test_dialectical_reasoner_creates_session_and_message(self) -> None:
         chat_repo = InMemoryChatRepository()


### PR DESCRIPTION
## Summary
- flesh out requirement interface implementations
- simplify in-memory subclasses to call new base logic
- provide basic notification behavior that prints messages

## Testing
- `poetry run pytest -q tests/unit/domain/test_requirement_interfaces.py`
- `poetry run pytest -q` *(fails: 230 failed, 1670 passed, 109 skipped, 466 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68812d030b288333b6add559b3251dc3