### PR TITLE
Add missing BDD step hooks

### DIFF
--- a/tests/behavior/steps/__init__.py
+++ b/tests/behavior/steps/__init__.py
@@ -2,6 +2,22 @@
 
 from __future__ import annotations
 
+# Pytest inspects packages for a ``pytest_plugins`` variable when importing test
+# modules.  Without this variable defined, ``pytest`` attempts to import a
+# ``pytest_plugins`` *module* from this package which triggers our ``__getattr__``
+# loader and results in ``ModuleNotFoundError`` during test collection.  Export
+# an empty list so pytest does not try to load a missing module.
+pytest_plugins: list[str] = []
+
+# Provide no-op ``setUpModule`` and ``tearDownModule`` hooks so pytest does not
+# attempt to lazy-import these as modules via ``__getattr__`` on this package.
+def setUpModule() -> None:  # noqa: N802 - pytest expects this exact name
+    """Package-level setup hook for pytest."""
+
+
+def tearDownModule() -> None:  # noqa: N802 - pytest expects this exact name
+    """Package-level teardown hook for pytest."""
+
 import importlib
 import sys
 from types import ModuleType

--- a/tests/behavior/steps/test_validate_manifest_command_steps.py
+++ b/tests/behavior/steps/test_validate_manifest_command_steps.py
@@ -2,7 +2,21 @@
 
 from pytest_bdd import scenarios, then
 
-from .cli_commands_steps import run_command  # noqa: F401
+# Reuse generic CLI step implementations so we don't duplicate behavior.
+from .cli_commands_steps import *  # noqa: F401,F403 - re-export CLI steps
+from pathlib import Path
+
+from pytest_bdd import given
+
+from .test_analyze_commands_steps import check_error_message  # noqa: F401
+
+
+@given("no manifest file exists at the provided path")
+def missing_manifest(tmp_path: Path, command_context):
+    """Provide a path to a nonexistent manifest file for error handling."""
+    path = tmp_path / "missing.json"
+    command_context["manifest_path"] = path
+    return path
 
 scenarios("../features/general/validate_manifest_command.feature")
 

--- a/tests/behavior/steps/test_validate_metadata_command_steps.py
+++ b/tests/behavior/steps/test_validate_metadata_command_steps.py
@@ -3,7 +3,9 @@
 from pathlib import Path
 from pytest_bdd import scenarios, given, then
 
-from .cli_commands_steps import run_command  # noqa: F401
+# Reuse generic CLI step implementations to share common steps.
+from .cli_commands_steps import *  # noqa: F401,F403
+from .test_analyze_commands_steps import check_error_message  # noqa: F401
 
 scenarios("../features/general/validate_metadata_command.feature")
 


### PR DESCRIPTION
## Summary
- expose `pytest_plugins` and setup hooks in `tests.behavior.steps`
- load generic CLI steps for manifest/metadata command tests
- add step for missing manifest path

## Testing
- `poetry run pytest -k validate_manifest_command -vv`
- `poetry run pytest -k validate_metadata_command -vv`


------
https://chatgpt.com/codex/tasks/task_e_6881b115eea48333a9c9b67b31ca45a2