### PR TITLE
Add consensus summary utilities and peer review scenarios

### DIFF
--- a/src/devsynth/domain/models/wsde_facade.py
+++ b/src/devsynth/domain/models/wsde_facade.py
@@ -41,6 +41,9 @@ from devsynth.domain.models.wsde_voting import (
     consensus_vote,
     build_consensus,
 )
+from devsynth.application.collaboration.wsde_team_consensus import (
+    ConsensusBuildingMixin,
+)
 from devsynth.domain.models.wsde_dialectical import (
     apply_dialectical_reasoning,
     _generate_antithesis,
@@ -168,6 +171,8 @@ WSDETeam._apply_weighted_voting = _apply_weighted_voting
 WSDETeam._record_voting_history = _record_voting_history
 WSDETeam.consensus_vote = consensus_vote
 WSDETeam.build_consensus = build_consensus
+WSDETeam.summarize_voting_result = ConsensusBuildingMixin.summarize_voting_result
+WSDETeam.summarize_consensus_result = ConsensusBuildingMixin.summarize_consensus_result
 
 # Dialectical reasoning
 WSDETeam.apply_dialectical_reasoning = apply_dialectical_reasoning

--- a/tests/behavior/features/wsde_peer_review.feature
+++ b/tests/behavior/features/wsde_peer_review.feature
@@ -1,0 +1,18 @@
+Feature: WSDE Peer Review Workflow
+  As a developer using DevSynth
+  I want work products reviewed by a team and summarized
+  So that I can understand consensus outcomes quickly
+
+  Scenario: Consensus summary after peer review
+    Given the DevSynth system is initialized
+    And a team of agents is configured
+    And the WSDE model is enabled
+    And a simple work product and two reviewers
+    When the peer review workflow is executed
+    Then a consensus result should be produced
+    And the system should provide a summary of the consensus
+
+  Scenario: Summarize voting results
+    Given a voting result with a clear winner
+    When the team summarizes the voting result
+    Then the summary should mention the winning option

--- a/tests/behavior/steps/wsde_peer_review_steps.py
+++ b/tests/behavior/steps/wsde_peer_review_steps.py
@@ -1,0 +1,108 @@
+from unittest.mock import MagicMock
+
+import pytest
+from pytest_bdd import given, when, then, scenarios
+
+from devsynth.application.collaboration.peer_review import run_peer_review
+from devsynth.adapters.agents.agent_adapter import WSDETeamCoordinator
+from devsynth.application.agents.unified_agent import UnifiedAgent
+from devsynth.domain.models.agent import AgentConfig, AgentType
+from devsynth.domain.models.wsde import WSDETeam
+
+scenarios("../features/wsde_peer_review.feature")
+
+
+@pytest.fixture
+def context():
+    class Context:
+        pass
+
+    return Context()
+
+
+@given("the DevSynth system is initialized")
+def system_initialized(context):
+    context.coordinator = WSDETeamCoordinator()
+
+
+@given("a team of agents is configured")
+def configure_team(context):
+    context.team = context.coordinator.create_team("peer-team")
+
+
+@given("the WSDE model is enabled")
+def wsde_enabled(context):
+    assert isinstance(context.team, WSDETeam)
+
+
+@given("a simple work product and two reviewers")
+def simple_work_and_reviewers(context):
+    author = UnifiedAgent()
+    author.initialize(
+        AgentConfig(name="author", agent_type=AgentType.ORCHESTRATOR)
+    )
+    r1 = UnifiedAgent()
+    r1.initialize(AgentConfig(name="rev1", agent_type=AgentType.ORCHESTRATOR))
+    r2 = UnifiedAgent()
+    r2.initialize(AgentConfig(name="rev2", agent_type=AgentType.ORCHESTRATOR))
+    for agent in (author, r1, r2):
+        context.coordinator.add_agent(agent)
+    r1.process = MagicMock(return_value={"feedback": "ok", "opinion": "approve"})
+    r2.process = MagicMock(return_value={"feedback": "ok", "opinion": "approve"})
+    context.team.build_consensus = MagicMock(
+        return_value={
+            "method": "majority_opinion",
+            "majority_opinion": "approve",
+            "agent_opinions": {
+                "rev1": {"opinion": "approve", "rationale": ""},
+                "rev2": {"opinion": "approve", "rationale": ""},
+            },
+        }
+    )
+    context.work = {"code": "print('hi')"}
+    context.author = author
+    context.reviewers = [r1, r2]
+
+
+@when("the peer review workflow is executed")
+def execute_workflow(context):
+    context.result = run_peer_review(
+        context.work,
+        context.author,
+        context.reviewers,
+        team=context.team,
+    )
+
+
+@then("a consensus result should be produced")
+def consensus_result(context):
+    assert "consensus" in context.result
+    assert context.result["consensus"]["method"] == "majority_opinion"
+
+
+@then("the system should provide a summary of the consensus")
+def summary_of_consensus(context):
+    summary = context.team.summarize_consensus_result(context.result["consensus"])
+    assert "approve" in summary
+
+
+@given("a voting result with a clear winner")
+def voting_result_setup(context):
+    context.team = WSDETeam("vote-team")
+    context.voting_result = {
+        "status": "completed",
+        "result": {"winner": "optA"},
+        "vote_counts": {"optA": 3, "optB": 1},
+    }
+
+
+@when("the team summarizes the voting result")
+def team_summarizes_vote(context):
+    context.vote_summary = context.team.summarize_voting_result(
+        context.voting_result
+    )
+
+
+@then("the summary should mention the winning option")
+def summary_mentions_winner(context):
+    assert "optA" in context.vote_summary


### PR DESCRIPTION
## Summary
- implement summarization helpers for voting and consensus results
- expose helpers via WSDE facade
- add BDD scenarios for peer review consensus
- implement step definitions for new scenarios

## Testing
- `pytest tests/behavior/steps/wsde_peer_review_steps.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6881baf44574833394f334dc016789d0