### PR TITLE
Improve Kuzu test setup

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -50,3 +50,8 @@ except Exception:
 # Disable optional backends by default so tests don't try to import heavy
 # dependencies unless explicitly enabled.
 os.environ.setdefault("ENABLE_CHROMADB", "0")
+
+pytest_plugins = [
+    "tests.fixtures.ports",
+    "tests.fixtures.kuzu",
+]

--- a/tests/fixtures/__init__.py
+++ b/tests/fixtures/__init__.py
@@ -1,3 +1,6 @@
 """Shared test fixtures for DevSynth."""
 
-pytest_plugins = ["tests.fixtures.ports"]
+pytest_plugins = [
+    "tests.fixtures.ports",
+    "tests.fixtures.kuzu",
+]

--- a/tests/fixtures/kuzu.py
+++ b/tests/fixtures/kuzu.py
@@ -1,0 +1,17 @@
+import sys
+import types
+import pytest
+
+
+@pytest.fixture
+def ephemeral_kuzu_store():
+    """Yield an ephemeral :class:`KuzuMemoryStore` for tests."""
+    sys.modules.setdefault("kuzu", types.ModuleType("kuzu"))
+    from devsynth.adapters.kuzu_memory_store import KuzuMemoryStore
+
+    store = KuzuMemoryStore.create_ephemeral()
+    try:
+        yield store
+    finally:
+        store.cleanup()
+


### PR DESCRIPTION
## Summary
- make KuzuMemoryStore create ephemeral stores for tests
- add ephemeral_kuzu_store fixture and register test plugins
- use new fixture in Kuzu integration tests

## Testing
- `poetry run pytest tests/integration/general/test_kuzu_memory_integration.py -q`
- `poetry run pytest tests/integration/edrr -q`
- `poetry run pytest tests/unit/adapters/test_kuzu_memory_store.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6882432506248333b8e1546f23ee6384