### PR TITLE
Add missing BDD scenarios for real LLM EDRR

### DIFF
--- a/tests/behavior/steps/test_edrr_real_llm_integration_steps.py
+++ b/tests/behavior/steps/test_edrr_real_llm_integration_steps.py
@@ -2,7 +2,9 @@ import os
 import pytest
 import tempfile
 from pathlib import Path
-from pytest_bdd import given, when, then, parsers
+from pytest_bdd import given, when, then, parsers, scenarios
+
+scenarios("../features/general/edrr_real_llm_integration.feature")
 
 from devsynth.application.edrr.coordinator import EDRRCoordinator
 from devsynth.application.memory.memory_manager import MemoryManager


### PR DESCRIPTION
## Summary
- map edrr_real_llm_integration feature to its step module

## Testing
- `poetry run pytest tests/behavior/steps/test_edrr_real_llm_integration_steps.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68824df4b0e08333af2831fe6c42f9e3