### PR TITLE
Enable non-interactive CLI tests

### DIFF
--- a/src/devsynth/application/cli/cli_commands.py
+++ b/src/devsynth/application/cli/cli_commands.py
@@ -44,6 +44,14 @@ def _resolve_bridge(b: Optional[UXBridge]) -> UXBridge:
     return b if b is not None else bridge
 
 
+def _env_flag(name: str) -> Optional[bool]:
+    """Return boolean value for ``name`` if set, otherwise ``None``."""
+    val = os.environ.get(name)
+    if val is None:
+        return None
+    return val.lower() in {"1", "true", "yes"}
+
+
 console = Console()
 config_app = typer.Typer(help="Manage configuration settings")
 
@@ -92,7 +100,9 @@ def _check_services(bridge: Optional[UXBridge] = None) -> bool:
     return True
 
 
-def _handle_error(bridge: UXBridge, error: Union[Exception, Dict[str, Any], str]) -> None:
+def _handle_error(
+    bridge: UXBridge, error: Union[Exception, Dict[str, Any], str]
+) -> None:
     """Handle errors consistently across all commands.
 
     Args:
@@ -132,7 +142,9 @@ def _handle_error(bridge: UXBridge, error: Union[Exception, Dict[str, Any], str]
         error_msg = str(error)
 
         # Create a panel with the error details
-        bridge.display_result(f"[bold red]Error:[/bold red] {error_msg}", highlight=False)
+        bridge.display_result(
+            f"[bold red]Error:[/bold red] {error_msg}", highlight=False
+        )
 
         # Find relevant solutions based on error message
         solutions = []
@@ -150,36 +162,47 @@ def _handle_error(bridge: UXBridge, error: Union[Exception, Dict[str, Any], str]
 
         # Display solutions if found
         if solutions:
-            bridge.display_result("[bold yellow]Suggested solutions:[/bold yellow]", highlight=False)
+            bridge.display_result(
+                "[bold yellow]Suggested solutions:[/bold yellow]", highlight=False
+            )
             for i, solution in enumerate(solutions, 1):
-                bridge.display_result(f"  [yellow]{i}.[/yellow] {solution}", highlight=False)
+                bridge.display_result(
+                    f"  [yellow]{i}.[/yellow] {solution}", highlight=False
+                )
 
         # Display documentation links if found
         if relevant_docs:
-            bridge.display_result("[bold cyan]Relevant documentation:[/bold cyan]", highlight=False)
+            bridge.display_result(
+                "[bold cyan]Relevant documentation:[/bold cyan]", highlight=False
+            )
             for doc in relevant_docs:
                 bridge.display_result(f"  • {doc}", highlight=False)
 
         # Always provide a general help tip
         bridge.display_result(
             "[dim]Run 'devsynth help' or 'devsynth <command> --help' for more information.[/dim]",
-            highlight=False
+            highlight=False,
         )
 
     elif isinstance(error, dict):
         # Handle result dict with error message
-        message = error.get('message', 'Unknown error')
-        code = error.get('code', '')
-        details = error.get('details', '')
+        message = error.get("message", "Unknown error")
+        code = error.get("code", "")
+        details = error.get("details", "")
 
         # Log the error
         logger.error(f"Command error: {message} (Code: {code})")
 
         # Display a structured error message
-        bridge.display_result(f"[bold red]Error {code if code else ''}:[/bold red] {message}", highlight=False)
+        bridge.display_result(
+            f"[bold red]Error {code if code else ''}:[/bold red] {message}",
+            highlight=False,
+        )
 
         if details:
-            bridge.display_result(f"[yellow]Details:[/yellow] {details}", highlight=False)
+            bridge.display_result(
+                f"[yellow]Details:[/yellow] {details}", highlight=False
+            )
 
         # Find relevant solutions based on error message
         solutions = []
@@ -187,30 +210,40 @@ def _handle_error(bridge: UXBridge, error: Union[Exception, Dict[str, Any], str]
 
         # Check for known error patterns
         for pattern, solution in error_solutions.items():
-            if pattern.lower() in message.lower() or (details and pattern.lower() in details.lower()):
+            if pattern.lower() in message.lower() or (
+                details and pattern.lower() in details.lower()
+            ):
                 solutions.append(solution)
 
         # Add documentation links based on error type
         for keyword, link in doc_links.items():
-            if keyword.lower() in message.lower() or (details and keyword.lower() in details.lower()):
+            if keyword.lower() in message.lower() or (
+                details and keyword.lower() in details.lower()
+            ):
                 relevant_docs.append(link)
 
         # Display solutions if found
         if solutions:
-            bridge.display_result("[bold yellow]Suggested solutions:[/bold yellow]", highlight=False)
+            bridge.display_result(
+                "[bold yellow]Suggested solutions:[/bold yellow]", highlight=False
+            )
             for i, solution in enumerate(solutions, 1):
-                bridge.display_result(f"  [yellow]{i}.[/yellow] {solution}", highlight=False)
+                bridge.display_result(
+                    f"  [yellow]{i}.[/yellow] {solution}", highlight=False
+                )
 
         # Display documentation links if found
         if relevant_docs:
-            bridge.display_result("[bold cyan]Relevant documentation:[/bold cyan]", highlight=False)
+            bridge.display_result(
+                "[bold cyan]Relevant documentation:[/bold cyan]", highlight=False
+            )
             for doc in relevant_docs:
                 bridge.display_result(f"  • {doc}", highlight=False)
 
         # Always provide a general help tip
         bridge.display_result(
             "[dim]Run 'devsynth help' or 'devsynth <command> --help' for more information.[/dim]",
-            highlight=False
+            highlight=False,
         )
     else:
         # Handle string error message
@@ -235,20 +268,26 @@ def _handle_error(bridge: UXBridge, error: Union[Exception, Dict[str, Any], str]
 
         # Display solutions if found
         if solutions:
-            bridge.display_result("[bold yellow]Suggested solutions:[/bold yellow]", highlight=False)
+            bridge.display_result(
+                "[bold yellow]Suggested solutions:[/bold yellow]", highlight=False
+            )
             for i, solution in enumerate(solutions, 1):
-                bridge.display_result(f"  [yellow]{i}.[/yellow] {solution}", highlight=False)
+                bridge.display_result(
+                    f"  [yellow]{i}.[/yellow] {solution}", highlight=False
+                )
 
         # Display documentation links if found
         if relevant_docs:
-            bridge.display_result("[bold cyan]Relevant documentation:[/bold cyan]", highlight=False)
+            bridge.display_result(
+                "[bold cyan]Relevant documentation:[/bold cyan]", highlight=False
+            )
             for doc in relevant_docs:
                 bridge.display_result(f"  • {doc}", highlight=False)
 
         # Always provide a general help tip
         bridge.display_result(
             "[dim]Run 'devsynth help' or 'devsynth <command> --help' for more information.[/dim]",
-            highlight=False
+            highlight=False,
         )
 
 
@@ -277,7 +316,18 @@ def config_key_autocomplete(ctx: typer.Context, incomplete: str):
     return loader_autocomplete(ctx, incomplete)
 
 
-def init_cmd(wizard: bool = False, *, bridge: Optional[UXBridge] = None) -> None:
+def init_cmd(
+    wizard: bool = False,
+    *,
+    root: Optional[str] = None,
+    language: Optional[str] = None,
+    goals: Optional[str] = None,
+    memory_backend: Optional[str] = None,
+    offline_mode: Optional[bool] = None,
+    features: Optional[Dict[str, bool]] = None,
+    auto_confirm: Optional[bool] = None,
+    bridge: Optional[UXBridge] = None,
+) -> None:
     """Initialize a new project.
 
     This command sets up a new DevSynth project with the specified configuration.
@@ -300,6 +350,9 @@ def init_cmd(wizard: bool = False, *, bridge: Optional[UXBridge] = None) -> None
     """
 
     bridge = _resolve_bridge(bridge)
+    auto_confirm = (
+        _env_flag("DEVSYNTH_AUTO_CONFIRM") if auto_confirm is None else auto_confirm
+    )
     try:
         if wizard:
             from .setup_wizard import SetupWizard
@@ -312,30 +365,57 @@ def init_cmd(wizard: bool = False, *, bridge: Optional[UXBridge] = None) -> None
             bridge.display_result("[yellow]Project already initialized[/yellow]")
             return
 
-        # Get project information
-        root = bridge.ask_question("Project root directory?", default=str(Path.cwd()))
+        root = root or os.environ.get("DEVSYNTH_INIT_ROOT")
+        if root is None:
+            root = bridge.ask_question(
+                "Project root directory?", default=str(Path.cwd())
+            )
 
         # Validate root directory
         root_path = Path(root)
         if not root_path.exists():
-            if bridge.confirm_choice(f"Directory '{root}' does not exist. Create it?", default=True):
+            if auto_confirm or bridge.confirm_choice(
+                f"Directory '{root}' does not exist. Create it?", default=True
+            ):
                 root_path.mkdir(parents=True, exist_ok=True)
             else:
                 bridge.display_result("[yellow]Initialization cancelled[/yellow]")
                 return
 
-        language = bridge.ask_question("Primary language?", default="python")
-        goals = bridge.ask_question("Project goals?", default="")
+        language = language or os.environ.get("DEVSYNTH_INIT_LANGUAGE")
+        if language is None:
+            language = bridge.ask_question("Primary language?", default="python")
 
-        memory_backend = bridge.ask_question(
-            "Select memory backend",
-            choices=["memory", "file", "kuzu", "chromadb"],
-            default="memory",
+        goals = goals or os.environ.get("DEVSYNTH_INIT_GOALS")
+        if goals is None:
+            goals = bridge.ask_question("Project goals?", default="")
+
+        memory_backend = memory_backend or os.environ.get(
+            "DEVSYNTH_INIT_MEMORY_BACKEND"
         )
-        offline_mode = bridge.confirm_choice("Enable offline mode?", default=False)
+        if memory_backend is None:
+            memory_backend = bridge.ask_question(
+                "Select memory backend",
+                choices=["memory", "file", "kuzu", "chromadb"],
+                default="memory",
+            )
+
+        if offline_mode is None:
+            env_offline = _env_flag("DEVSYNTH_INIT_OFFLINE_MODE")
+            if env_offline is not None:
+                offline_mode = env_offline
+            else:
+                offline_mode = bridge.confirm_choice(
+                    "Enable offline mode?", default=False
+                )
 
         # Configure features
-        features = config.features or {}
+        if features is None:
+            env_feats = os.environ.get("DEVSYNTH_INIT_FEATURES")
+            if env_feats:
+                features = {f.strip(): True for f in env_feats.split(";") if f.strip()}
+            else:
+                features = config.features or {}
         for feat in [
             "wsde_collaboration",
             "dialectical_reasoning",
@@ -344,13 +424,23 @@ def init_cmd(wizard: bool = False, *, bridge: Optional[UXBridge] = None) -> None
             "documentation_generation",
             "experimental_features",
         ]:
-            features[feat] = bridge.confirm_choice(
-                f"Enable {feat.replace('_', ' ')}?",
-                default=features.get(feat, False),
-            )
+            if feat in features:
+                features[feat] = bool(features[feat])
+            elif auto_confirm:
+                features[feat] = True
+            else:
+                features[feat] = bridge.confirm_choice(
+                    f"Enable {feat.replace('_', ' ')}?",
+                    default=features.get(feat, False),
+                )
 
         # Confirm and save
-        if not bridge.confirm_choice("Proceed with initialization?", default=True):
+        proceed = auto_confirm if auto_confirm is not None else None
+        if proceed is None:
+            proceed = bridge.confirm_choice(
+                "Proceed with initialization?", default=True
+            )
+        if not proceed:
             bridge.display_result("[yellow]Initialization cancelled[/yellow]")
             return
 
@@ -366,7 +456,9 @@ def init_cmd(wizard: bool = False, *, bridge: Optional[UXBridge] = None) -> None
                 ConfigModel(**config.as_dict()),
                 use_pyproject=(Path("pyproject.toml").exists()),
             )
-            bridge.display_result("[green]Initialization complete[/green]", highlight=True)
+            bridge.display_result(
+                "[green]Initialization complete[/green]", highlight=True
+            )
         except Exception as save_err:
             _handle_error(bridge, save_err)
     except Exception as err:  # pragma: no cover - defensive
@@ -374,7 +466,10 @@ def init_cmd(wizard: bool = False, *, bridge: Optional[UXBridge] = None) -> None
 
 
 def spec_cmd(
-    requirements_file: str = "requirements.md", *, bridge: Optional[UXBridge] = None
+    requirements_file: str = "requirements.md",
+    *,
+    auto_confirm: Optional[bool] = None,
+    bridge: Optional[UXBridge] = None,
 ) -> None:
     """Generate specifications from a requirements file.
 
@@ -397,6 +492,9 @@ def spec_cmd(
         ```
     """
     bridge = _resolve_bridge(bridge)
+    auto_confirm = (
+        _env_flag("DEVSYNTH_AUTO_CONFIRM") if auto_confirm is None else auto_confirm
+    )
     try:
         # Check required services
         if not _check_services(bridge):
@@ -406,9 +504,13 @@ def spec_cmd(
         error = _validate_file_path(requirements_file)
         if error:
             bridge.display_result(f"[yellow]{error}[/yellow]")
-            if bridge.confirm_choice(f"Create empty '{requirements_file}' file?", default=False):
+            if auto_confirm or bridge.confirm_choice(
+                f"Create empty '{requirements_file}' file?", default=False
+            ):
                 Path(requirements_file).touch()
-                bridge.display_result(f"[green]Created empty file: {requirements_file}[/green]")
+                bridge.display_result(
+                    f"[green]Created empty file: {requirements_file}[/green]"
+                )
             else:
                 return
 
@@ -422,16 +524,19 @@ def spec_cmd(
             bridge.display_result(
                 f"[green]Specifications generated from {requirements_file}.[/green]"
             )
-            bridge.display_result(
-                f"[blue]Output saved to: {output_file}[/blue]"
-            )
+            bridge.display_result(f"[blue]Output saved to: {output_file}[/blue]")
         else:
             _handle_error(bridge, result)
     except Exception as err:  # pragma: no cover - defensive
         _handle_error(bridge, err)
 
 
-def test_cmd(spec_file: str = "specs.md", *, bridge: Optional[UXBridge] = None) -> None:
+def test_cmd(
+    spec_file: str = "specs.md",
+    *,
+    auto_confirm: Optional[bool] = None,
+    bridge: Optional[UXBridge] = None,
+) -> None:
     """Generate tests based on specifications.
 
     This command analyzes a specifications file and generates test cases
@@ -453,6 +558,9 @@ def test_cmd(spec_file: str = "specs.md", *, bridge: Optional[UXBridge] = None) 
         ```
     """
     bridge = _resolve_bridge(bridge)
+    auto_confirm = (
+        _env_flag("DEVSYNTH_AUTO_CONFIRM") if auto_confirm is None else auto_confirm
+    )
     try:
         # Check required services
         if not _check_services(bridge):
@@ -462,9 +570,10 @@ def test_cmd(spec_file: str = "specs.md", *, bridge: Optional[UXBridge] = None) 
         error = _validate_file_path(spec_file)
         if error:
             bridge.display_result(f"[yellow]{error}[/yellow]")
-            if bridge.confirm_choice(f"Run 'devsynth spec' to generate {spec_file}?", default=True):
-                # Call spec_cmd to generate the specifications file
-                spec_cmd(bridge=bridge)
+            if auto_confirm or bridge.confirm_choice(
+                f"Run 'devsynth spec' to generate {spec_file}?", default=True
+            ):
+                spec_cmd(bridge=bridge, auto_confirm=auto_confirm)
             else:
                 return
 
@@ -476,14 +585,18 @@ def test_cmd(spec_file: str = "specs.md", *, bridge: Optional[UXBridge] = None) 
         if result.get("success"):
             output_dir = result.get("output_dir", "tests")
             bridge.display_result(f"[green]Tests generated from {spec_file}.[/green]")
-            bridge.display_result(f"[blue]Tests saved to directory: {output_dir}[/blue]")
+            bridge.display_result(
+                f"[blue]Tests saved to directory: {output_dir}[/blue]"
+            )
         else:
             _handle_error(bridge, result)
     except Exception as err:  # pragma: no cover - defensive
         _handle_error(bridge, err)
 
 
-def code_cmd(*, bridge: Optional[UXBridge] = None) -> None:
+def code_cmd(
+    *, auto_confirm: Optional[bool] = None, bridge: Optional[UXBridge] = None
+) -> None:
     """Generate implementation code from tests.
 
     This command analyzes the test files and generates implementation code
@@ -499,6 +612,9 @@ def code_cmd(*, bridge: Optional[UXBridge] = None) -> None:
         ```
     """
     bridge = _resolve_bridge(bridge)
+    auto_confirm = (
+        _env_flag("DEVSYNTH_AUTO_CONFIRM") if auto_confirm is None else auto_confirm
+    )
     try:
         # Check required services
         if not _check_services(bridge):
@@ -507,15 +623,20 @@ def code_cmd(*, bridge: Optional[UXBridge] = None) -> None:
         # Check if tests directory exists
         tests_dir = Path("tests")
         if not tests_dir.exists() or not any(tests_dir.iterdir()):
-            bridge.display_result("[yellow]No tests found in 'tests' directory.[/yellow]")
-            if bridge.confirm_choice("Run 'devsynth test' to generate tests?", default=True):
-                # Call test_cmd to generate the tests
-                test_cmd(bridge=bridge)
+            bridge.display_result(
+                "[yellow]No tests found in 'tests' directory.[/yellow]"
+            )
+            if auto_confirm or bridge.confirm_choice(
+                "Run 'devsynth test' to generate tests?", default=True
+            ):
+                test_cmd(bridge=bridge, auto_confirm=auto_confirm)
             else:
                 return
 
         # Generate code
-        bridge.display_result("[blue]Generating implementation code from tests...[/blue]")
+        bridge.display_result(
+            "[blue]Generating implementation code from tests...[/blue]"
+        )
         result = generate_code()
 
         # Handle result
@@ -533,6 +654,7 @@ def run_pipeline_cmd(
     target: Optional[str] = None,
     report: Optional[Dict[str, Any]] = None,
     *,
+    auto_confirm: Optional[bool] = None,
     bridge: Optional[UXBridge] = None,
 ) -> None:
     """Run the generated code or a specific target.
@@ -557,6 +679,9 @@ def run_pipeline_cmd(
         ```
     """
     bridge = _resolve_bridge(bridge)
+    auto_confirm = (
+        _env_flag("DEVSYNTH_AUTO_CONFIRM") if auto_confirm is None else auto_confirm
+    )
     try:
         # Check required services
         if not _check_services(bridge):
@@ -568,11 +693,18 @@ def run_pipeline_cmd(
             bridge.display_result(
                 f"[yellow]Warning: '{target}' is not a standard target. Valid targets are: {', '.join(valid_targets)}[/yellow]"
             )
-            if not bridge.confirm_choice(f"Continue with target '{target}'?", default=True):
+            if not (
+                auto_confirm
+                or bridge.confirm_choice(
+                    f"Continue with target '{target}'?", default=True
+                )
+            ):
                 return
 
         # Execute command
-        bridge.display_result(f"[blue]Running {'target: ' + target if target else 'default pipeline'}...[/blue]")
+        bridge.display_result(
+            f"[blue]Running {'target: ' + target if target else 'default pipeline'}...[/blue]"
+        )
         result = workflows.execute_command(
             "run-pipeline", {"target": target, "report": report}
         )
@@ -580,7 +712,9 @@ def run_pipeline_cmd(
         # Handle result
         if result.get("success"):
             if target:
-                bridge.display_result(f"[green]Successfully executed target: {target}[/green]")
+                bridge.display_result(
+                    f"[green]Successfully executed target: {target}[/green]"
+                )
             else:
                 bridge.display_result(f"[green]Pipeline execution complete.[/green]")
 
@@ -1685,7 +1819,9 @@ def dbschema_cmd(
         )
 
 
-def doctor_cmd(config_dir: str = "config", *, bridge: Optional[UXBridge] = None) -> None:
+def doctor_cmd(
+    config_dir: str = "config", *, bridge: Optional[UXBridge] = None
+) -> None:
     """Validate environment configuration files."""
 
     _doctor_impl(config_dir=config_dir, bridge=_resolve_bridge(bridge))

--- a/tests/integration/general/test_refactor_workflow.py
+++ b/tests/integration/general/test_refactor_workflow.py
@@ -5,6 +5,7 @@ These tests verify that the RefactorWorkflowManager can correctly analyze
 a project's state, determine the optimal workflow, and suggest appropriate
 next steps.
 """
+
 import os
 import pytest
 import tempfile
@@ -18,7 +19,7 @@ from devsynth.application.cli.cli_commands import init_cmd
 class TestRefactorWorkflowManager:
     """Tests for the RefactorWorkflowManager class.
 
-ReqID: N/A"""
+    ReqID: N/A"""
 
     @pytest.fixture
     def temp_project_dir(self):
@@ -32,13 +33,15 @@ ReqID: N/A"""
     def test_analyze_project_state_succeeds(self, temp_project_dir):
         """Test analyzing the project state.
 
-ReqID: N/A"""
-        with patch('devsynth.application.cli.cli_commands.bridge.ask_question',
-            side_effect=[temp_project_dir, 'python', '', 'memory']), patch(
-            'devsynth.application.cli.cli_commands.bridge.confirm_choice',
-            return_value=True):
-            init_cmd()
-        requirements_dir = os.path.join(temp_project_dir, 'docs')
+        ReqID: N/A"""
+        init_cmd(
+            root=temp_project_dir,
+            language="python",
+            goals="",
+            memory_backend="memory",
+            auto_confirm=True,
+        )
+        requirements_dir = os.path.join(temp_project_dir, "docs")
         os.makedirs(requirements_dir, exist_ok=True)
         requirements_content = """
         # Project Requirements
@@ -51,36 +54,38 @@ ReqID: N/A"""
         1. Requirement 3
         2. Requirement 4
         """
-        with open(os.path.join(requirements_dir, 'requirements.md'), 'w') as f:
+        with open(os.path.join(requirements_dir, "requirements.md"), "w") as f:
             f.write(requirements_content)
         manager = RefactorWorkflowManager()
         project_state = manager.analyze_project_state(temp_project_dir)
-        assert 'project_path' in project_state
-        assert 'file_count' in project_state
-        assert 'languages' in project_state
-        assert 'architecture' in project_state
-        assert 'requirements_count' in project_state
-        assert 'specifications_count' in project_state
-        assert 'test_count' in project_state
-        assert 'code_count' in project_state
-        assert 'health_score' in project_state
-        assert 'issues' in project_state
-        assert 'recommendations' in project_state
-        assert project_state['requirements_count'] > 0
-        assert project_state['specifications_count'] == 0
-        assert project_state['test_count'] == 0
-        assert project_state['code_count'] == 0
+        assert "project_path" in project_state
+        assert "file_count" in project_state
+        assert "languages" in project_state
+        assert "architecture" in project_state
+        assert "requirements_count" in project_state
+        assert "specifications_count" in project_state
+        assert "test_count" in project_state
+        assert "code_count" in project_state
+        assert "health_score" in project_state
+        assert "issues" in project_state
+        assert "recommendations" in project_state
+        assert project_state["requirements_count"] > 0
+        assert project_state["specifications_count"] == 0
+        assert project_state["test_count"] == 0
+        assert project_state["code_count"] == 0
 
     def test_determine_optimal_workflow_succeeds(self, temp_project_dir):
         """Test determining the optimal workflow based on the project state.
 
-ReqID: N/A"""
-        with patch('devsynth.application.cli.cli_commands.bridge.ask_question',
-            side_effect=[temp_project_dir, 'python', '', 'memory']), patch(
-            'devsynth.application.cli.cli_commands.bridge.confirm_choice',
-            return_value=True):
-            init_cmd()
-        requirements_dir = os.path.join(temp_project_dir, 'docs')
+        ReqID: N/A"""
+        init_cmd(
+            root=temp_project_dir,
+            language="python",
+            goals="",
+            memory_backend="memory",
+            auto_confirm=True,
+        )
+        requirements_dir = os.path.join(temp_project_dir, "docs")
         os.makedirs(requirements_dir, exist_ok=True)
         requirements_content = """
         # Project Requirements
@@ -93,12 +98,12 @@ ReqID: N/A"""
         1. Requirement 3
         2. Requirement 4
         """
-        with open(os.path.join(requirements_dir, 'requirements.md'), 'w') as f:
+        with open(os.path.join(requirements_dir, "requirements.md"), "w") as f:
             f.write(requirements_content)
         manager = RefactorWorkflowManager()
         project_state = manager.analyze_project_state(temp_project_dir)
         workflow = manager.determine_optimal_workflow(project_state)
-        assert workflow == 'specifications'
+        assert workflow == "specifications"
         specifications_content = """
         # Project Specifications
         
@@ -110,12 +115,12 @@ ReqID: N/A"""
         1. Specification 3
         2. Specification 4
         """
-        with open(os.path.join(temp_project_dir, 'specs.md'), 'w') as f:
+        with open(os.path.join(temp_project_dir, "specs.md"), "w") as f:
             f.write(specifications_content)
         project_state = manager.analyze_project_state(temp_project_dir)
         workflow = manager.determine_optimal_workflow(project_state)
-        assert workflow == 'tests'
-        tests_dir = os.path.join(temp_project_dir, 'tests')
+        assert workflow == "tests"
+        tests_dir = os.path.join(temp_project_dir, "tests")
         os.makedirs(tests_dir, exist_ok=True)
         test_content = """
         def test_feature_1():
@@ -126,12 +131,12 @@ ReqID: N/A"""
             # Test implementation
             pass
         """
-        with open(os.path.join(tests_dir, 'test_features.py'), 'w') as f:
+        with open(os.path.join(tests_dir, "test_features.py"), "w") as f:
             f.write(test_content)
         project_state = manager.analyze_project_state(temp_project_dir)
         workflow = manager.determine_optimal_workflow(project_state)
-        assert workflow == 'code'
-        src_dir = os.path.join(temp_project_dir, 'src')
+        assert workflow == "code"
+        src_dir = os.path.join(temp_project_dir, "src")
         os.makedirs(src_dir, exist_ok=True)
         code_content = """
         class Feature1:
@@ -158,28 +163,30 @@ ReqID: N/A"""
                 # Implementation
                 pass
         """
-        with open(os.path.join(src_dir, 'features.py'), 'w') as f:
+        with open(os.path.join(src_dir, "features.py"), "w") as f:
             f.write(code_content)
         project_state = manager.analyze_project_state(temp_project_dir)
         workflow = manager.determine_optimal_workflow(project_state)
-        assert workflow == 'complete'
+        assert workflow == "complete"
 
     def test_suggest_next_steps_succeeds(self, temp_project_dir):
         """Test suggesting next steps based on the project state.
 
-ReqID: N/A"""
-        with patch('devsynth.application.cli.cli_commands.bridge.ask_question',
-            side_effect=[temp_project_dir, 'python', '', 'memory']), patch(
-            'devsynth.application.cli.cli_commands.bridge.confirm_choice',
-            return_value=True):
-            init_cmd()
+        ReqID: N/A"""
+        init_cmd(
+            root=temp_project_dir,
+            language="python",
+            goals="",
+            memory_backend="memory",
+            auto_confirm=True,
+        )
         manager = RefactorWorkflowManager()
         suggestions = manager.suggest_next_steps(temp_project_dir)
         assert len(suggestions) > 0
-        assert suggestions[0]['command'] == 'analyze'
-        assert 'requirements' in suggestions[0]['description'].lower()
-        assert suggestions[0]['priority'] == 'high'
-        requirements_dir = os.path.join(temp_project_dir, 'docs')
+        assert suggestions[0]["command"] == "analyze"
+        assert "requirements" in suggestions[0]["description"].lower()
+        assert suggestions[0]["priority"] == "high"
+        requirements_dir = os.path.join(temp_project_dir, "docs")
         os.makedirs(requirements_dir, exist_ok=True)
         requirements_content = """
         # Project Requirements
@@ -192,24 +199,26 @@ ReqID: N/A"""
         1. Requirement 3
         2. Requirement 4
         """
-        with open(os.path.join(requirements_dir, 'requirements.md'), 'w') as f:
+        with open(os.path.join(requirements_dir, "requirements.md"), "w") as f:
             f.write(requirements_content)
         suggestions = manager.suggest_next_steps(temp_project_dir)
         assert len(suggestions) > 0
-        assert suggestions[0]['command'] == 'spec'
-        assert 'specifications' in suggestions[0]['description'].lower()
-        assert suggestions[0]['priority'] == 'high'
+        assert suggestions[0]["command"] == "spec"
+        assert "specifications" in suggestions[0]["description"].lower()
+        assert suggestions[0]["priority"] == "high"
 
     def test_initialize_workflow_succeeds(self, temp_project_dir):
         """Test initializing a workflow based on the project state.
 
-ReqID: N/A"""
-        with patch('devsynth.application.cli.cli_commands.bridge.ask_question',
-            side_effect=[temp_project_dir, 'python', '', 'memory']), patch(
-            'devsynth.application.cli.cli_commands.bridge.confirm_choice',
-            return_value=True):
-            init_cmd()
-        requirements_dir = os.path.join(temp_project_dir, 'docs')
+        ReqID: N/A"""
+        init_cmd(
+            root=temp_project_dir,
+            language="python",
+            goals="",
+            memory_backend="memory",
+            auto_confirm=True,
+        )
+        requirements_dir = os.path.join(temp_project_dir, "docs")
         os.makedirs(requirements_dir, exist_ok=True)
         requirements_content = """
         # Project Requirements
@@ -222,29 +231,31 @@ ReqID: N/A"""
         1. Requirement 3
         2. Requirement 4
         """
-        with open(os.path.join(requirements_dir, 'requirements.md'), 'w') as f:
+        with open(os.path.join(requirements_dir, "requirements.md"), "w") as f:
             f.write(requirements_content)
         manager = RefactorWorkflowManager()
         workflow, entry_point, suggestions = manager.initialize_workflow(
-            temp_project_dir)
-        assert workflow == 'specifications'
-        assert entry_point == 'spec'
+            temp_project_dir
+        )
+        assert workflow == "specifications"
+        assert entry_point == "spec"
         assert len(suggestions) > 0
-        assert suggestions[0]['command'] == 'spec'
-        assert 'specifications' in suggestions[0]['description'].lower()
-        assert suggestions[0]['priority'] == 'high'
+        assert suggestions[0]["command"] == "spec"
+        assert "specifications" in suggestions[0]["description"].lower()
+        assert suggestions[0]["priority"] == "high"
 
-    def test_execute_refactor_workflow_succeeds(self, temp_project_dir,
-        monkeypatch):
+    def test_execute_refactor_workflow_succeeds(self, temp_project_dir, monkeypatch):
         """Test executing a refactor workflow.
 
-ReqID: N/A"""
-        with patch('devsynth.application.cli.cli_commands.bridge.ask_question',
-            side_effect=[temp_project_dir, 'python', '', 'memory']), patch(
-            'devsynth.application.cli.cli_commands.bridge.confirm_choice',
-            return_value=True):
-            init_cmd()
-        requirements_dir = os.path.join(temp_project_dir, 'docs')
+        ReqID: N/A"""
+        init_cmd(
+            root=temp_project_dir,
+            language="python",
+            goals="",
+            memory_backend="memory",
+            auto_confirm=True,
+        )
+        requirements_dir = os.path.join(temp_project_dir, "docs")
         os.makedirs(requirements_dir, exist_ok=True)
         requirements_content = """
         # Project Requirements
@@ -257,24 +268,28 @@ ReqID: N/A"""
         1. Requirement 3
         2. Requirement 4
         """
-        with open(os.path.join(requirements_dir, 'requirements.md'), 'w') as f:
+        with open(os.path.join(requirements_dir, "requirements.md"), "w") as f:
             f.write(requirements_content)
         manager = RefactorWorkflowManager()
 
         def mock_execute_command(command, args):
-            return {'success': True, 'message':
-                f'Executed {command} command', 'result': {}}
-        monkeypatch.setattr(manager, 'execute_command', mock_execute_command)
+            return {
+                "success": True,
+                "message": f"Executed {command} command",
+                "result": {},
+            }
+
+        monkeypatch.setattr(manager, "execute_command", mock_execute_command)
         result = manager.execute_refactor_workflow(temp_project_dir)
-        assert 'success' in result
-        assert 'message' in result
-        assert 'workflow' in result
-        assert 'entry_point' in result
-        assert 'suggestions' in result
-        assert result['workflow'] == 'specifications'
-        assert result['entry_point'] == 'spec'
-        assert len(result['suggestions']) > 0
+        assert "success" in result
+        assert "message" in result
+        assert "workflow" in result
+        assert "entry_point" in result
+        assert "suggestions" in result
+        assert result["workflow"] == "specifications"
+        assert result["entry_point"] == "spec"
+        assert len(result["suggestions"]) > 0
 
 
-if __name__ == '__main__':
-    pytest.main(['-v', 'test_refactor_workflow.py'])
+if __name__ == "__main__":
+    pytest.main(["-v", "test_refactor_workflow.py"])

--- a/tests/integration/general/test_requirements_gathering.py
+++ b/tests/integration/general/test_requirements_gathering.py
@@ -7,15 +7,16 @@ from devsynth.application.cli.cli_commands import init_cmd, gather_cmd
 def test_gather_updates_config_succeeds(tmp_path):
     """Test that gather updates config succeeds.
 
-ReqID: N/A"""
+    ReqID: N/A"""
     os.chdir(tmp_path)
-    with patch('devsynth.application.cli.cli_commands.bridge.ask_question',
-        side_effect=[str(tmp_path), 'python', '', 'memory']), patch(
-        'devsynth.application.cli.cli_commands.bridge.confirm_choice',
-        return_value=True):
-        init_cmd()
-    answers = ['goal1', 'constraint1', 'high']
-
+    init_cmd(
+        root=str(tmp_path),
+        language="python",
+        goals="",
+        memory_backend="memory",
+        auto_confirm=True,
+    )
+    answers = ["goal1", "constraint1", "high"]
 
     class Bridge:
 
@@ -38,8 +39,9 @@ ReqID: N/A"""
 
         def display_result(self, *a, **k):
             pass
+
     bridge = Bridge()
-    gather_cmd(output_file='requirements_plan.yaml', bridge=bridge)
-    cfg_path = tmp_path / '.devsynth' / 'project.yaml'
+    gather_cmd(output_file="requirements_plan.yaml", bridge=bridge)
+    cfg_path = tmp_path / ".devsynth" / "project.yaml"
     data = yaml.safe_load(open(cfg_path))
-    assert data.get('priority') == 'high'
+    assert data.get("priority") == "high"

--- a/tests/unit/general/test_unit_cli_commands.py
+++ b/tests/unit/general/test_unit_cli_commands.py
@@ -4,285 +4,336 @@ import yaml
 from devsynth.config.unified_loader import UnifiedConfigLoader
 import pytest
 from devsynth.application.cli import cli_commands
-from devsynth.application.cli.cli_commands import code_cmd, config_cmd, init_cmd, run_pipeline_cmd, spec_cmd, test_cmd, inspect_cmd, refactor_cmd
+from devsynth.application.cli.cli_commands import (
+    code_cmd,
+    config_cmd,
+    init_cmd,
+    run_pipeline_cmd,
+    spec_cmd,
+    test_cmd,
+    inspect_cmd,
+    refactor_cmd,
+)
+
 ORIG_CHECK_SERVICES = cli_commands._check_services
 
 
 class TestCLICommands:
     """Tests for the CLI command functions.
 
-ReqID: N/A"""
+    ReqID: N/A"""
 
     @pytest.fixture(autouse=True)
     def service_check(self):
-        with patch('devsynth.application.cli.cli_commands._check_services',
-            return_value=True):
+        with patch(
+            "devsynth.application.cli.cli_commands._check_services", return_value=True
+        ):
             yield
 
     @pytest.fixture
     def mock_workflow_manager(self):
         """Create a mock workflow executor."""
-        with patch('devsynth.core.workflows.execute_command') as mock:
+        with patch("devsynth.core.workflows.execute_command") as mock:
             yield mock
 
     @pytest.fixture
     def mock_bridge(self):
         """Create a mock UX bridge."""
-        with patch('devsynth.application.cli.cli_commands.bridge') as mock:
+        with patch("devsynth.application.cli.cli_commands.bridge") as mock:
             yield mock
 
     def test_init_cmd_success_succeeds(self, mock_bridge):
         """Project initializes when no config exists.
 
-ReqID: N/A"""
+        ReqID: N/A"""
         cfg = MagicMock()
         cfg.exists.return_value = False
-        with patch('devsynth.config.unified_loader.UnifiedConfigLoader.load',
-            return_value=cfg), patch(
-            'devsynth.application.cli.cli_commands.bridge.ask_question',
-            side_effect=['/proj', 'python', 'goal']), patch(
-            'devsynth.application.cli.cli_commands.bridge.confirm_choice',
-            return_value=True):
-            init_cmd()
-        assert cfg.project_root == '/proj'
-        assert cfg.language == 'python'
-        assert cfg.goals == 'goal'
-        assert any('Initialization complete' in c.args[0] for c in
-            mock_bridge.display_result.call_args_list)
+        with patch(
+            "devsynth.config.unified_loader.UnifiedConfigLoader.load",
+            return_value=cfg,
+        ):
+            init_cmd(
+                root="/proj",
+                language="python",
+                goals="goal",
+                memory_backend="memory",
+                auto_confirm=True,
+            )
+        assert cfg.project_root == "/proj"
+        assert cfg.language == "python"
+        assert cfg.goals == "goal"
+        assert any(
+            "Initialization complete" in c.args[0]
+            for c in mock_bridge.display_result.call_args_list
+        )
 
     def test_init_cmd_already_initialized_succeeds(self, mock_bridge):
         """init_cmd exits when config exists.
 
-ReqID: N/A"""
+        ReqID: N/A"""
         cfg = MagicMock()
         cfg.exists.return_value = True
-        with patch('devsynth.config.unified_loader.UnifiedConfigLoader.load',
-            return_value=cfg):
+        with patch(
+            "devsynth.config.unified_loader.UnifiedConfigLoader.load", return_value=cfg
+        ):
             init_cmd()
-        mock_bridge.display_result.assert_any_call(
-            'Project already initialized')
+        mock_bridge.display_result.assert_any_call("Project already initialized")
 
     def test_init_cmd_exception_raises_error(self, mock_bridge):
         """Errors are reported via the bridge.
 
-ReqID: N/A"""
-        with patch('devsynth.config.unified_loader.UnifiedConfigLoader.load',
-            side_effect=Exception('boom')):
-            init_cmd()
-        assert any('boom' in c.args[0] for c in mock_bridge.display_result.
-            call_args_list)
-
-    def test_spec_cmd_success_succeeds(self, mock_workflow_manager, mock_bridge
+        ReqID: N/A"""
+        with patch(
+            "devsynth.config.unified_loader.UnifiedConfigLoader.load",
+            side_effect=Exception("boom"),
         ):
+            init_cmd()
+        assert any(
+            "boom" in c.args[0] for c in mock_bridge.display_result.call_args_list
+        )
+
+    def test_spec_cmd_success_succeeds(self, mock_workflow_manager, mock_bridge):
         """Test successful spec generation.
 
-ReqID: N/A"""
-        mock_workflow_manager.return_value = {'success': True, 'message':
-            'Specs generated successfully'}
-        spec_cmd('requirements.md')
-        mock_workflow_manager.assert_called_once_with('spec', {
-            'requirements_file': 'requirements.md'})
+        ReqID: N/A"""
+        mock_workflow_manager.return_value = {
+            "success": True,
+            "message": "Specs generated successfully",
+        }
+        spec_cmd("requirements.md")
+        mock_workflow_manager.assert_called_once_with(
+            "spec", {"requirements_file": "requirements.md"}
+        )
         success_message = (
-            '[green]Specifications generated from requirements.md.[/green]')
-        assert any(call.args[0] == success_message for call in mock_bridge.
-            display_result.call_args_list)
+            "[green]Specifications generated from requirements.md.[/green]"
+        )
+        assert any(
+            call.args[0] == success_message
+            for call in mock_bridge.display_result.call_args_list
+        )
 
-    def test_test_cmd_success_succeeds(self, mock_workflow_manager, mock_bridge
-        ):
+    def test_test_cmd_success_succeeds(self, mock_workflow_manager, mock_bridge):
         """Test successful test generation.
 
-ReqID: N/A"""
-        mock_workflow_manager.return_value = {'success': True, 'message':
-            'Tests generated successfully'}
-        test_cmd('specs.md')
-        mock_workflow_manager.assert_called_once_with('test', {'spec_file':
-            'specs.md'})
-        success_message = '[green]Tests generated from specs.md.[/green]'
-        assert any(call.args[0] == success_message for call in mock_bridge.
-            display_result.call_args_list)
+        ReqID: N/A"""
+        mock_workflow_manager.return_value = {
+            "success": True,
+            "message": "Tests generated successfully",
+        }
+        test_cmd("specs.md")
+        mock_workflow_manager.assert_called_once_with("test", {"spec_file": "specs.md"})
+        success_message = "[green]Tests generated from specs.md.[/green]"
+        assert any(
+            call.args[0] == success_message
+            for call in mock_bridge.display_result.call_args_list
+        )
 
-    def test_code_cmd_success_succeeds(self, mock_workflow_manager, mock_bridge
-        ):
+    def test_code_cmd_success_succeeds(self, mock_workflow_manager, mock_bridge):
         """Test successful code generation.
 
-ReqID: N/A"""
-        mock_workflow_manager.return_value = {'success': True, 'message':
-            'Code generated successfully'}
+        ReqID: N/A"""
+        mock_workflow_manager.return_value = {
+            "success": True,
+            "message": "Code generated successfully",
+        }
         code_cmd()
-        mock_workflow_manager.assert_called_once_with('code', {})
-        success_message = '[green]Code generated successfully.[/green]'
-        assert any(call.args[0] == success_message for call in mock_bridge.
-            display_result.call_args_list)
+        mock_workflow_manager.assert_called_once_with("code", {})
+        success_message = "[green]Code generated successfully.[/green]"
+        assert any(
+            call.args[0] == success_message
+            for call in mock_bridge.display_result.call_args_list
+        )
 
-    def test_run_pipeline_cmd_success_with_target_succeeds(self,
-        mock_workflow_manager, mock_bridge):
+    def test_run_pipeline_cmd_success_with_target_succeeds(
+        self, mock_workflow_manager, mock_bridge
+    ):
         """Test successful run with target.
 
-ReqID: N/A"""
-        mock_workflow_manager.return_value = {'success': True, 'message':
-            'Target executed successfully'}
-        run_pipeline_cmd('unit-tests')
-        mock_workflow_manager.assert_called_once_with('run-pipeline', {
-            'target': 'unit-tests', 'report': None})
+        ReqID: N/A"""
+        mock_workflow_manager.return_value = {
+            "success": True,
+            "message": "Target executed successfully",
+        }
+        run_pipeline_cmd("unit-tests")
+        mock_workflow_manager.assert_called_once_with(
+            "run-pipeline", {"target": "unit-tests", "report": None}
+        )
         mock_bridge.display_result.assert_called_once_with(
-            '[green]Executed target: unit-tests[/green]')
+            "[green]Executed target: unit-tests[/green]"
+        )
 
-    def test_run_pipeline_cmd_success_without_target_succeeds(self,
-        mock_workflow_manager, mock_bridge):
+    def test_run_pipeline_cmd_success_without_target_succeeds(
+        self, mock_workflow_manager, mock_bridge
+    ):
         """Test successful run without target.
 
-ReqID: N/A"""
-        mock_workflow_manager.return_value = {'success': True, 'message':
-            'Execution complete'}
+        ReqID: N/A"""
+        mock_workflow_manager.return_value = {
+            "success": True,
+            "message": "Execution complete",
+        }
         run_pipeline_cmd()
-        mock_workflow_manager.assert_called_once_with('run-pipeline', {
-            'target': None, 'report': None})
+        mock_workflow_manager.assert_called_once_with(
+            "run-pipeline", {"target": None, "report": None}
+        )
         mock_bridge.display_result.assert_called_once_with(
-            '[green]Execution complete.[/green]')
+            "[green]Execution complete.[/green]"
+        )
 
-    def test_config_cmd_set_value_succeeds(self, mock_workflow_manager,
-        mock_bridge):
+    def test_config_cmd_set_value_succeeds(self, mock_workflow_manager, mock_bridge):
         """Test setting a configuration value.
 
-ReqID: N/A"""
-        mock_workflow_manager.return_value = {'success': True, 'message':
-            'Configuration updated'}
-        config_cmd('model', 'gpt-4')
-        mock_workflow_manager.assert_called_once_with('config', {'key':
-            'model', 'value': 'gpt-4'})
+        ReqID: N/A"""
+        mock_workflow_manager.return_value = {
+            "success": True,
+            "message": "Configuration updated",
+        }
+        config_cmd("model", "gpt-4")
+        mock_workflow_manager.assert_called_once_with(
+            "config", {"key": "model", "value": "gpt-4"}
+        )
         mock_bridge.display_result.assert_called_once_with(
-            '[green]Configuration updated: model = gpt-4[/green]')
+            "[green]Configuration updated: model = gpt-4[/green]"
+        )
 
-    def test_config_cmd_get_value_succeeds(self, mock_workflow_manager,
-        mock_bridge):
+    def test_config_cmd_get_value_succeeds(self, mock_workflow_manager, mock_bridge):
         """Test getting a configuration value.
 
-ReqID: N/A"""
-        mock_workflow_manager.return_value = {'success': True, 'value': 'gpt-4'
-            }
-        config_cmd('model')
-        mock_workflow_manager.assert_called_once_with('config', {'key':
-            'model', 'value': None})
-        mock_bridge.display_result.assert_called_once_with(
-            '[blue]model:[/blue] gpt-4')
+        ReqID: N/A"""
+        mock_workflow_manager.return_value = {"success": True, "value": "gpt-4"}
+        config_cmd("model")
+        mock_workflow_manager.assert_called_once_with(
+            "config", {"key": "model", "value": None}
+        )
+        mock_bridge.display_result.assert_called_once_with("[blue]model:[/blue] gpt-4")
 
-    def test_config_cmd_list_all_succeeds(self, mock_workflow_manager,
-        mock_bridge):
+    def test_config_cmd_list_all_succeeds(self, mock_workflow_manager, mock_bridge):
         """Test listing all configuration values.
 
-ReqID: N/A"""
-        mock_workflow_manager.return_value = {'success': True, 'config': {
-            'model': 'gpt-4', 'temperature': 0.7, 'max_tokens': 2000}}
+        ReqID: N/A"""
+        mock_workflow_manager.return_value = {
+            "success": True,
+            "config": {"model": "gpt-4", "temperature": 0.7, "max_tokens": 2000},
+        }
         config_cmd()
-        mock_workflow_manager.assert_called_once_with('config', {'key':
-            None, 'value': None})
+        mock_workflow_manager.assert_called_once_with(
+            "config", {"key": None, "value": None}
+        )
         assert mock_bridge.display_result.call_count == 4
 
     def test_enable_feature_cmd_succeeds(self, tmp_path, mock_bridge):
         """enable_feature_cmd should toggle a flag in project.yaml.
 
-ReqID: N/A"""
-        dev_dir = tmp_path / '.devsynth'
+        ReqID: N/A"""
+        dev_dir = tmp_path / ".devsynth"
         dev_dir.mkdir()
-        config_file = dev_dir / 'project.yaml'
-        config_file.write_text('features:\n  code_generation: false\n')
+        config_file = dev_dir / "project.yaml"
+        config_file.write_text("features:\n  code_generation: false\n")
         cwd = os.getcwd()
         os.chdir(tmp_path)
         try:
-            cli_commands.enable_feature_cmd('code_generation')
+            cli_commands.enable_feature_cmd("code_generation")
         finally:
             os.chdir(cwd)
         cfg = UnifiedConfigLoader.load(tmp_path).config
-        assert cfg.features['code_generation'] is True
-        assert any("Feature 'code_generation' enabled." == call.args[0] for
-            call in mock_bridge.display_result.call_args_list)
+        assert cfg.features["code_generation"] is True
+        assert any(
+            "Feature 'code_generation' enabled." == call.args[0]
+            for call in mock_bridge.display_result.call_args_list
+        )
 
     def test_config_cmd_updates_yaml_succeeds(self, tmp_path, mock_bridge):
         """Test that config cmd updates yaml succeeds.
 
-ReqID: N/A"""
-        cfg_dir = tmp_path / '.devsynth'
+        ReqID: N/A"""
+        cfg_dir = tmp_path / ".devsynth"
         cfg_dir.mkdir()
-        cfg = cfg_dir / 'project.yaml'
-        cfg.write_text('language: python\n')
+        cfg = cfg_dir / "project.yaml"
+        cfg.write_text("language: python\n")
 
         def fake_exec(command, args):
             data = UnifiedConfigLoader.load(tmp_path).config.as_dict()
-            if command == 'config' and args.get('key') and args.get('value'):
-                data[args['key']] = args['value']
+            if command == "config" and args.get("key") and args.get("value"):
+                data[args["key"]] = args["value"]
                 cfg.write_text(yaml.safe_dump(data))
-                return {'success': True}
-            return {'success': True, 'config': data}
+                return {"success": True}
+            return {"success": True, "config": data}
+
         with patch(
-            'devsynth.application.cli.cli_commands.workflows.execute_command',
-            side_effect=fake_exec):
+            "devsynth.application.cli.cli_commands.workflows.execute_command",
+            side_effect=fake_exec,
+        ):
             cwd = os.getcwd()
             os.chdir(tmp_path)
             try:
-                cli_commands.config_cmd('language', 'javascript')
+                cli_commands.config_cmd("language", "javascript")
             finally:
                 os.chdir(cwd)
         cfg_loaded = UnifiedConfigLoader.load(tmp_path).config
-        assert cfg_loaded.language == 'javascript'
+        assert cfg_loaded.language == "javascript"
 
     def test_enable_feature_cmd_yaml_succeeds(self, tmp_path, mock_bridge):
         """Test that enable feature cmd yaml succeeds.
 
-ReqID: N/A"""
-        cfg_dir = tmp_path / '.devsynth'
+        ReqID: N/A"""
+        cfg_dir = tmp_path / ".devsynth"
         cfg_dir.mkdir()
-        cfg = cfg_dir / 'project.yaml'
-        cfg.write_text('features:\n  code_generation: false\n')
+        cfg = cfg_dir / "project.yaml"
+        cfg.write_text("features:\n  code_generation: false\n")
         cwd = os.getcwd()
         os.chdir(tmp_path)
         try:
-            cli_commands.enable_feature_cmd('code_generation')
+            cli_commands.enable_feature_cmd("code_generation")
         finally:
             os.chdir(cwd)
         cfg_loaded = UnifiedConfigLoader.load(tmp_path).config
-        assert cfg_loaded.features['code_generation'] is True
+        assert cfg_loaded.features["code_generation"] is True
 
-    def test_config_cmd_uses_loader_succeeds(self, mock_workflow_manager,
-        mock_bridge):
+    def test_config_cmd_uses_loader_succeeds(self, mock_workflow_manager, mock_bridge):
         """Test that config cmd uses loader succeeds.
 
-ReqID: N/A"""
+        ReqID: N/A"""
         cfg = MagicMock()
         cfg.config = MagicMock()
-        cfg.config.language = 'python'
-        mock_workflow_manager.return_value = {'success': True}
-        with patch('devsynth.config.unified_loader.UnifiedConfigLoader.load',
-            return_value=cfg) as mock_load:
-            cli_commands.config_cmd('language', 'javascript')
+        cfg.config.language = "python"
+        mock_workflow_manager.return_value = {"success": True}
+        with patch(
+            "devsynth.config.unified_loader.UnifiedConfigLoader.load", return_value=cfg
+        ) as mock_load:
+            cli_commands.config_cmd("language", "javascript")
         mock_load.assert_called_once()
 
     def test_enable_feature_cmd_loader_succeeds(self, mock_bridge):
         """Test that enable feature cmd loader succeeds.
 
-ReqID: N/A"""
+        ReqID: N/A"""
         cfg = MagicMock()
         cfg.features = {}
-        with patch('devsynth.config.unified_loader.UnifiedConfigLoader.load',
-            return_value=cfg) as mock_load:
-            cli_commands.enable_feature_cmd('code_generation')
+        with patch(
+            "devsynth.config.unified_loader.UnifiedConfigLoader.load", return_value=cfg
+        ) as mock_load:
+            cli_commands.enable_feature_cmd("code_generation")
         mock_load.assert_called_once()
 
-    def test_init_creates_config_and_commands_use_loader_succeeds(self,
-        tmp_path, mock_bridge):
+    def test_init_creates_config_and_commands_use_loader_succeeds(
+        self, tmp_path, mock_bridge
+    ):
         """Test that init creates config and commands use loader succeeds.
 
-ReqID: N/A"""
-        answers = [str(tmp_path), 'python', 'goal']
-        with patch.object(cli_commands.bridge, 'ask_question', side_effect=
-            answers), patch.object(cli_commands.bridge, 'confirm_choice',
-            return_value=True):
-            cwd = os.getcwd()
-            os.chdir(tmp_path)
-            try:
-                cli_commands.init_cmd()
-            finally:
-                os.chdir(cwd)
-        cfg_path = tmp_path / '.devsynth' / 'project.yaml'
+        ReqID: N/A"""
+        cwd = os.getcwd()
+        os.chdir(tmp_path)
+        try:
+            cli_commands.init_cmd(
+                root=str(tmp_path),
+                language="python",
+                goals="goal",
+                memory_backend="memory",
+                auto_confirm=True,
+            )
+        finally:
+            os.chdir(cwd)
+        cfg_path = tmp_path / ".devsynth" / "project.yaml"
         assert cfg_path.exists()
         real_load = cli_commands.load_config
 
@@ -290,10 +341,17 @@ ReqID: N/A"""
             cfg = real_load(path)
             spy_load.path = cfg.path
             return cfg
-        with patch('devsynth.config.unified_loader.UnifiedConfigLoader.load',
-            side_effect=spy_load) as mock_load, patch(
-            'devsynth.application.cli.cli_commands.workflows.execute_command',
-            return_value={'success': True}):
+
+        with (
+            patch(
+                "devsynth.config.unified_loader.UnifiedConfigLoader.load",
+                side_effect=spy_load,
+            ) as mock_load,
+            patch(
+                "devsynth.application.cli.cli_commands.workflows.execute_command",
+                return_value={"success": True},
+            ),
+        ):
             cwd = os.getcwd()
             os.chdir(tmp_path)
             try:
@@ -303,158 +361,187 @@ ReqID: N/A"""
         mock_load.assert_called()
         assert spy_load.path == cfg_path
 
-    def test_inspect_cmd_file_succeeds(self, mock_workflow_manager, mock_bridge
-        ):
+    def test_inspect_cmd_file_succeeds(self, mock_workflow_manager, mock_bridge):
         """Inspect command with input file.
 
-ReqID: N/A"""
-        mock_workflow_manager.return_value = {'success': True}
-        inspect_cmd('requirements.md')
-        mock_workflow_manager.assert_called_once_with('inspect', {'input':
-            'requirements.md', 'interactive': False})
+        ReqID: N/A"""
+        mock_workflow_manager.return_value = {"success": True}
+        inspect_cmd("requirements.md")
+        mock_workflow_manager.assert_called_once_with(
+            "inspect", {"input": "requirements.md", "interactive": False}
+        )
 
-    def test_inspect_cmd_interactive_succeeds(self, mock_workflow_manager,
-        mock_bridge):
+    def test_inspect_cmd_interactive_succeeds(self, mock_workflow_manager, mock_bridge):
         """Inspect command in interactive mode.
 
-ReqID: N/A"""
-        mock_workflow_manager.return_value = {'success': True}
+        ReqID: N/A"""
+        mock_workflow_manager.return_value = {"success": True}
         inspect_cmd(interactive=True)
-        mock_workflow_manager.assert_called_once_with('inspect', {
-            'interactive': True})
+        mock_workflow_manager.assert_called_once_with("inspect", {"interactive": True})
 
-    def test_spec_cmd_missing_openai_key_succeeds(self,
-        mock_workflow_manager, mock_bridge):
+    def test_spec_cmd_missing_openai_key_succeeds(
+        self, mock_workflow_manager, mock_bridge
+    ):
         """spec_cmd should warn when OpenAI API key is missing.
 
-ReqID: N/A"""
-
+        ReqID: N/A"""
 
         class DummySettings:
             vector_store_enabled = False
-            memory_store_type = 'chromadb'
-            provider_type = 'openai'
+            memory_store_type = "chromadb"
+            provider_type = "openai"
             openai_api_key = None
             lm_studio_endpoint = None
-        with patch('devsynth.application.cli.cli_commands.get_settings',
-            return_value=DummySettings), patch(
-            'devsynth.application.cli.cli_commands._check_services', new=
-            ORIG_CHECK_SERVICES):
-            spec_cmd('req.md')
-            mock_workflow_manager.assert_not_called()
-            assert any('OPENAI_API_KEY' in call.args[0] for call in
-                mock_bridge.display_result.call_args_list)
 
-    def test_spec_cmd_missing_chromadb_package_succeeds(self,
-        mock_workflow_manager, mock_bridge):
+        with (
+            patch(
+                "devsynth.application.cli.cli_commands.get_settings",
+                return_value=DummySettings,
+            ),
+            patch(
+                "devsynth.application.cli.cli_commands._check_services",
+                new=ORIG_CHECK_SERVICES,
+            ),
+        ):
+            spec_cmd("req.md")
+            mock_workflow_manager.assert_not_called()
+            assert any(
+                "OPENAI_API_KEY" in call.args[0]
+                for call in mock_bridge.display_result.call_args_list
+            )
+
+    def test_spec_cmd_missing_chromadb_package_succeeds(
+        self, mock_workflow_manager, mock_bridge
+    ):
         """spec_cmd should warn when ChromaDB package is unavailable.
 
-ReqID: N/A"""
-
+        ReqID: N/A"""
 
         class DummySettings:
             vector_store_enabled = True
-            memory_store_type = 'chromadb'
-            provider_type = 'openai'
-            openai_api_key = 'key'
+            memory_store_type = "chromadb"
+            provider_type = "openai"
+            openai_api_key = "key"
             lm_studio_endpoint = None
             enable_chromadb = True
-        with patch('devsynth.application.cli.cli_commands.get_settings',
-            return_value=DummySettings), patch(
-            'devsynth.application.cli.cli_commands.importlib.util.find_spec',
-            return_value=None), patch(
-            'devsynth.application.cli.cli_commands._check_services', new=
-            ORIG_CHECK_SERVICES):
-            spec_cmd('req.md')
-            mock_workflow_manager.assert_not_called()
-            assert any('chromadb' in call.args[0].lower() for call in
-                mock_bridge.display_result.call_args_list)
 
-    def test_spec_cmd_missing_kuzu_package_succeeds(self,
-        mock_workflow_manager, mock_bridge):
+        with (
+            patch(
+                "devsynth.application.cli.cli_commands.get_settings",
+                return_value=DummySettings,
+            ),
+            patch(
+                "devsynth.application.cli.cli_commands.importlib.util.find_spec",
+                return_value=None,
+            ),
+            patch(
+                "devsynth.application.cli.cli_commands._check_services",
+                new=ORIG_CHECK_SERVICES,
+            ),
+        ):
+            spec_cmd("req.md")
+            mock_workflow_manager.assert_not_called()
+            assert any(
+                "chromadb" in call.args[0].lower()
+                for call in mock_bridge.display_result.call_args_list
+            )
+
+    def test_spec_cmd_missing_kuzu_package_succeeds(
+        self, mock_workflow_manager, mock_bridge
+    ):
         """spec_cmd should warn when Kuzu package is unavailable.
 
-ReqID: N/A"""
-
+        ReqID: N/A"""
 
         class DummySettings:
             vector_store_enabled = True
-            memory_store_type = 'kuzu'
-            provider_type = 'openai'
-            openai_api_key = 'key'
+            memory_store_type = "kuzu"
+            provider_type = "openai"
+            openai_api_key = "key"
             lm_studio_endpoint = None
-        with patch('devsynth.application.cli.cli_commands.get_settings',
-            return_value=DummySettings), patch(
-            'devsynth.application.cli.cli_commands.importlib.util.find_spec',
-            return_value=None), patch(
-            'devsynth.application.cli.cli_commands._check_services', new=
-            ORIG_CHECK_SERVICES):
-            spec_cmd('req.md')
+
+        with (
+            patch(
+                "devsynth.application.cli.cli_commands.get_settings",
+                return_value=DummySettings,
+            ),
+            patch(
+                "devsynth.application.cli.cli_commands.importlib.util.find_spec",
+                return_value=None,
+            ),
+            patch(
+                "devsynth.application.cli.cli_commands._check_services",
+                new=ORIG_CHECK_SERVICES,
+            ),
+        ):
+            spec_cmd("req.md")
             mock_workflow_manager.assert_not_called()
-            assert any('kuzu' in call.args[0].lower() for call in
-                mock_bridge.display_result.call_args_list)
+            assert any(
+                "kuzu" in call.args[0].lower()
+                for call in mock_bridge.display_result.call_args_list
+            )
 
     def test_config_key_autocomplete_succeeds(self, tmp_path, monkeypatch):
         """Test that config key autocomplete succeeds.
 
-ReqID: N/A"""
-        cfg_dir = tmp_path / '.devsynth'
+        ReqID: N/A"""
+        cfg_dir = tmp_path / ".devsynth"
         cfg_dir.mkdir()
-        (cfg_dir / 'project.yaml').write_text(
-            'language: python\nmodel: gpt-4\n')
+        (cfg_dir / "project.yaml").write_text("language: python\nmodel: gpt-4\n")
         monkeypatch.chdir(tmp_path)
-        result = cli_commands.config_key_autocomplete(None, 'l')
-        assert 'language' in result
+        result = cli_commands.config_key_autocomplete(None, "l")
+        assert "language" in result
 
     def test_check_services_warns_succeeds(self, monkeypatch, capsys):
         """Test that check services warns succeeds.
 
-ReqID: N/A"""
-
+        ReqID: N/A"""
 
         class DummySettings:
             vector_store_enabled = False
-            memory_store_type = 'chromadb'
-            provider_type = 'openai'
+            memory_store_type = "chromadb"
+            provider_type = "openai"
             openai_api_key = None
             lm_studio_endpoint = None
-        monkeypatch.setattr(cli_commands, 'get_settings', lambda :
-            DummySettings)
-        monkeypatch.setattr(cli_commands, '_check_services',
-            ORIG_CHECK_SERVICES)
+
+        monkeypatch.setattr(cli_commands, "get_settings", lambda: DummySettings)
+        monkeypatch.setattr(cli_commands, "_check_services", ORIG_CHECK_SERVICES)
         res = cli_commands._check_services()
         output = capsys.readouterr().out
         assert res is False
-        assert 'OPENAI_API_KEY' in output
+        assert "OPENAI_API_KEY" in output
 
     def test_doctor_cmd_invokes_loader_succeeds(self):
         """Test that doctor cmd invokes loader succeeds.
 
-ReqID: N/A"""
-        with patch('devsynth.config.unified_loader.UnifiedConfigLoader.load'
-            ) as mock_load, patch(
-            'devsynth.application.cli.commands.doctor_cmd.bridge.print'
-            ) as mock_print:
-            cli_commands.doctor_cmd('config')
+        ReqID: N/A"""
+        with (
+            patch(
+                "devsynth.config.unified_loader.UnifiedConfigLoader.load"
+            ) as mock_load,
+            patch(
+                "devsynth.application.cli.commands.doctor_cmd.bridge.print"
+            ) as mock_print,
+        ):
+            cli_commands.doctor_cmd("config")
             mock_load.assert_called_once()
             assert mock_print.called
 
     def test_check_cmd_alias_succeeds(self):
         """Test that check cmd alias succeeds.
 
-ReqID: N/A"""
-        with patch('devsynth.application.cli.cli_commands.doctor_cmd'
-            ) as mock_doctor:
-            cli_commands.check_cmd('config')
-            mock_doctor.assert_called_once_with('config')
+        ReqID: N/A"""
+        with patch("devsynth.application.cli.cli_commands.doctor_cmd") as mock_doctor:
+            cli_commands.check_cmd("config")
+            mock_doctor.assert_called_once_with("config")
 
     def test_gather_cmd_creates_file_succeeds(self, tmp_path):
         """Test that gather cmd creates file succeeds.
 
-ReqID: N/A"""
+        ReqID: N/A"""
         from devsynth.application.cli.cli_commands import gather_cmd
-        answers = ['goal', 'constraint', 'medium']
 
+        answers = ["goal", "constraint", "medium"]
 
         class Bridge(cli_commands.UXBridge):
 
@@ -471,15 +558,16 @@ ReqID: N/A"""
 
             def display_result(self, *a, **k):
                 pass
+
         bridge = Bridge()
-        output = tmp_path / 'requirements_plan.yaml'
+        output = tmp_path / "requirements_plan.yaml"
         gather_cmd(output_file=str(output), bridge=bridge)
         assert output.exists()
 
     def test_init_cmd_wizard_runs_wizard(self):
         """Wizard mode should invoke SetupWizard.run."""
 
-        with patch('devsynth.application.cli.cli_commands.SetupWizard') as wiz:
+        with patch("devsynth.application.cli.cli_commands.SetupWizard") as wiz:
             init_cmd(wizard=True)
             wiz.assert_called_once()
             wiz.return_value.run.assert_called_once()
@@ -487,102 +575,138 @@ ReqID: N/A"""
     def test_spec_cmd_invalid_file(self, mock_workflow_manager, mock_bridge):
         """Invalid requirements file should not trigger generation."""
 
-        with patch('devsynth.application.cli.cli_commands._validate_file_path',
-                    return_value='bad'), patch.object(cli_commands.bridge,
-                    'confirm_choice', return_value=False):
-            spec_cmd('missing.md')
+        with (
+            patch(
+                "devsynth.application.cli.cli_commands._validate_file_path",
+                return_value="bad",
+            ),
+            patch.object(cli_commands.bridge, "confirm_choice", return_value=False),
+        ):
+            spec_cmd("missing.md")
         mock_workflow_manager.assert_not_called()
 
     def test_test_cmd_invalid_file(self, mock_workflow_manager, mock_bridge):
         """Invalid spec file should not trigger generation."""
 
-        with patch('devsynth.application.cli.cli_commands._validate_file_path',
-                    return_value='bad'), patch.object(cli_commands.bridge,
-                    'confirm_choice', return_value=False):
-            test_cmd('missing.md')
+        with (
+            patch(
+                "devsynth.application.cli.cli_commands._validate_file_path",
+                return_value="bad",
+            ),
+            patch.object(cli_commands.bridge, "confirm_choice", return_value=False),
+        ):
+            test_cmd("missing.md")
         mock_workflow_manager.assert_not_called()
 
     def test_code_cmd_no_tests(self, mock_workflow_manager, tmp_path, monkeypatch):
         """code_cmd exits when no tests are present."""
 
         monkeypatch.chdir(tmp_path)
-        with patch.object(cli_commands.bridge, 'confirm_choice', return_value=False):
+        with patch.object(cli_commands.bridge, "confirm_choice", return_value=False):
             code_cmd()
         mock_workflow_manager.assert_not_called()
 
     def test_run_pipeline_cmd_invalid_target(self, mock_workflow_manager, mock_bridge):
         """run_pipeline_cmd warns on invalid target and aborts when declined."""
 
-        with patch.object(cli_commands.bridge, 'confirm_choice', return_value=False):
-            run_pipeline_cmd('bogus')
+        with patch.object(cli_commands.bridge, "confirm_choice", return_value=False):
+            run_pipeline_cmd("bogus")
         mock_workflow_manager.assert_not_called()
 
     def test_config_cmd_invalid_key(self, mock_bridge):
         """config_cmd should report errors from workflow."""
 
-        with patch('devsynth.core.workflows.execute_command',
-                    return_value={'success': False, 'message': 'bad'}), \
-             patch('devsynth.application.cli.cli_commands._handle_error') as herr:
-            config_cmd('bad', 'value')
+        with (
+            patch(
+                "devsynth.core.workflows.execute_command",
+                return_value={"success": False, "message": "bad"},
+            ),
+            patch("devsynth.application.cli.cli_commands._handle_error") as herr,
+        ):
+            config_cmd("bad", "value")
             herr.assert_called_once()
 
     def test_gather_cmd_error_propagates(self):
         """Errors from gather_requirements propagate to caller."""
 
-        with patch('devsynth.application.cli.cli_commands.gather_requirements',
-                    side_effect=FileNotFoundError('boom')):
+        with patch(
+            "devsynth.application.cli.cli_commands.gather_requirements",
+            side_effect=FileNotFoundError("boom"),
+        ):
             with pytest.raises(FileNotFoundError):
-                gather_cmd(output_file='x')
+                gather_cmd(output_file="x")
 
     def test_refactor_cmd_error(self, mock_bridge):
         """refactor_cmd should display error when workflow fails."""
 
-        with patch('devsynth.application.cli.orchestration.refactor_workflow.refactor_workflow_manager.execute_refactor_workflow',
-                    return_value={'success': False, 'message': 'fail'}):
-            refactor_cmd(path='proj')
-        mock_bridge.display_result.assert_any_call('[red]Error:[/red] fail')
+        with patch(
+            "devsynth.application.cli.orchestration.refactor_workflow.refactor_workflow_manager.execute_refactor_workflow",
+            return_value={"success": False, "message": "fail"},
+        ):
+            refactor_cmd(path="proj")
+        mock_bridge.display_result.assert_any_call("[red]Error:[/red] fail")
 
     def test_inspect_cmd_failure(self, mock_bridge):
         """inspect_cmd should show error message when workflow fails."""
 
-        with patch('devsynth.core.workflows.inspect_requirements',
-                    return_value={'success': False, 'message': 'bad'}):
-            inspect_cmd('req.md')
-        mock_bridge.display_result.assert_any_call('[red]Error:[/red] bad', highlight=False)
+        with patch(
+            "devsynth.core.workflows.inspect_requirements",
+            return_value={"success": False, "message": "bad"},
+        ):
+            inspect_cmd("req.md")
+        mock_bridge.display_result.assert_any_call(
+            "[red]Error:[/red] bad", highlight=False
+        )
 
     def test_webapp_cmd_invalid_framework(self, tmp_path):
         """Unknown framework triggers warning and prompt."""
 
-        with patch.object(cli_commands.bridge, 'prompt', return_value='flask'), \
-             patch.object(cli_commands.bridge, 'confirm', return_value=True), \
-             patch.object(cli_commands.bridge, 'create_progress',
-                          return_value=MagicMock(__enter__=lambda s: s,
-                                               __exit__=lambda s, *a: None,
-                                               update=lambda *a, **k: None,
-                                               complete=lambda *a, **k: None)), \
-             patch('os.makedirs'), patch('os.path.exists', return_value=False):
-            webapp_cmd(framework='bad', name='app', path=str(tmp_path))
+        with (
+            patch.object(cli_commands.bridge, "prompt", return_value="flask"),
+            patch.object(cli_commands.bridge, "confirm", return_value=True),
+            patch.object(
+                cli_commands.bridge,
+                "create_progress",
+                return_value=MagicMock(
+                    __enter__=lambda s: s,
+                    __exit__=lambda s, *a: None,
+                    update=lambda *a, **k: None,
+                    complete=lambda *a, **k: None,
+                ),
+            ),
+            patch("os.makedirs"),
+            patch("os.path.exists", return_value=False),
+        ):
+            webapp_cmd(framework="bad", name="app", path=str(tmp_path))
 
     def test_serve_cmd_passes_options(self, monkeypatch):
         """serve_cmd forwards host and port to uvicorn."""
 
-        monkeypatch.setattr(cli_commands, 'configure_logging', lambda: None)
-        with patch('uvicorn.run') as run:
-            serve_cmd(host='1.2.3.4', port=1234)
+        monkeypatch.setattr(cli_commands, "configure_logging", lambda: None)
+        with patch("uvicorn.run") as run:
+            serve_cmd(host="1.2.3.4", port=1234)
             run.assert_called_once()
             args, kwargs = run.call_args
-            assert kwargs['host'] == '1.2.3.4'
-            assert kwargs['port'] == 1234
+            assert kwargs["host"] == "1.2.3.4"
+            assert kwargs["port"] == 1234
 
     def test_dbschema_cmd_invalid_type(self, tmp_path):
         """Unknown db type should prompt selection."""
 
-        with patch.object(cli_commands.bridge, 'prompt', return_value='sqlite'), \
-             patch.object(cli_commands.bridge, 'confirm', return_value=True), \
-             patch.object(cli_commands.bridge, 'create_progress',
-                          return_value=MagicMock(__enter__=lambda s: s,
-                                               __exit__=lambda s, *a: None,
-                                               update=lambda *a, **k: None,
-                                               complete=lambda *a, **k: None)), \
-             patch('os.makedirs'), patch('os.path.exists', return_value=False):
-            dbschema_cmd(db_type='foo', name='schema', path=str(tmp_path))
+        with (
+            patch.object(cli_commands.bridge, "prompt", return_value="sqlite"),
+            patch.object(cli_commands.bridge, "confirm", return_value=True),
+            patch.object(
+                cli_commands.bridge,
+                "create_progress",
+                return_value=MagicMock(
+                    __enter__=lambda s: s,
+                    __exit__=lambda s, *a: None,
+                    update=lambda *a, **k: None,
+                    complete=lambda *a, **k: None,
+                ),
+            ),
+            patch("os.makedirs"),
+            patch("os.path.exists", return_value=False),
+        ):
+            dbschema_cmd(db_type="foo", name="schema", path=str(tmp_path))


### PR DESCRIPTION
## Summary
- add `_env_flag` helper
- allow CLI commands to accept parameters or env vars and skip prompts
- update unit and integration tests to use new parameters

## Testing
- `poetry run pytest -q` *(fails: Step definition not found)*

------
https://chatgpt.com/codex/tasks/task_e_68829cc5d77883339b77ddd7cc284a28