### PR TITLE
Harmonize docs and capture maintenance strategy

### DIFF
--- a/docs/architecture/uxbridge.md
+++ b/docs/architecture/uxbridge.md
@@ -33,6 +33,7 @@ invoke workflow functions through this common layer, allowing the same code in
 - Provide a single point where alternative UIs (e.g., a WebUI) can plug in
 
 
+<!-- Diagram: Interfaces connected through UXBridge -->
 ```mermaid
 graph LR
     CLI[CLI Modules] --> Bridge[UXBridge]
@@ -70,6 +71,7 @@ analysis, synthesis, and configuration. By adhering to the `UXBridge`
 interface, the WebUI can provide richer interactivity while leveraging the same
 logic already used by the CLI.
 
+<!-- Diagram: Streamlit pages using UXBridge -->
 ```mermaid
 graph LR
     ST[Streamlit Pages] --> Bridge[UXBridge]

--- a/docs/architecture/wsde_edrr_integration.md
+++ b/docs/architecture/wsde_edrr_integration.md
@@ -598,6 +598,8 @@ def _retrieve_relevant_knowledge(self, task: str, solution: Dict[str, Any]) -> L
 
 The following diagram illustrates the data flow between components in the WSDE-EDRR integration:
 
+<!-- Diagram: WSDE and EDRR data flow -->
+
 ```mermaid
 sequenceDiagram
     participant CLI as DevSynth CLI

--- a/docs/implementation/feature_status_matrix.md
+++ b/docs/implementation/feature_status_matrix.md
@@ -1,7 +1,7 @@
 ---
 author: DevSynth Team
 date: '2025-06-01'
-last_reviewed: "2025-07-11"
+last_reviewed: "2025-07-20"
 status: active
 tags:
 
@@ -18,7 +18,7 @@ version: 0.1.0
 
 This document provides a comprehensive status matrix for all features in the DevSynth project. It is a key deliverable of the Feature Implementation Audit conducted as part of Phase 1: Foundation Stabilization.
 
-**Implementation Status:** The overall project is **partially implemented**. Each feature row below lists the current completion level and outstanding work.
+**Implementation Status:** The overall project is **partially implemented**. The documentation harmonization phase is complete and work is progressing toward the `0.1.0-beta.1` milestone. Each feature row below lists the current completion level and outstanding work.
 
 ## Status Categories
 

--- a/docs/policies/maintenance.md
+++ b/docs/policies/maintenance.md
@@ -1,7 +1,7 @@
 ---
 author: DevSynth Team
 date: '2025-07-07'
-last_reviewed: "2025-07-10"
+last_reviewed: "2025-07-20"
 status: published
 tags:
 - policy
@@ -22,6 +22,20 @@ This policy defines best practices for ongoing support, updates, and knowledge c
 - Schedule regular refactoring and technical debt management.
 - Document dependency update procedures and test requirements.
 - Provide handoff/retirement procedures for agents/components.
+
+## Maintenance Strategy
+
+The DevSynth maintenance strategy ensures documentation, code, and tests remain
+in sync as development progresses:
+
+1. **Documentation Review Process**: Establish a regular review cycle for all
+   documentation to keep diagrams and metadata consistent.
+2. **CI/CD Integration**: Include automated documentation validation in the
+   continuous integration pipeline.
+3. **Traceability Enforcement**: Require updates to the requirements
+   traceability matrix whenever changes are introduced.
+4. **BDD-First Development**: Update feature files before implementing new
+   functionality to maintain behavioural alignment.
 
 ## Artifacts
 

--- a/docs/roadmap/ROADMAP.md
+++ b/docs/roadmap/ROADMAP.md
@@ -1,5 +1,10 @@
 ---
 title: DevSynth Roadmap
+date: '2025-07-07'
+last_reviewed: '2025-07-20'
+tags:
+  - roadmap
+  - milestones
 version: 0.1.0
 status: published
 author: DevSynth Team

--- a/docs/roadmap/development_status.md
+++ b/docs/roadmap/development_status.md
@@ -1,7 +1,7 @@
 ---
 author: DevSynth Team
 date: '2025-06-01'
-last_reviewed: "2025-07-15"
+last_reviewed: "2025-07-20"
 status: active
 tags:
 
@@ -443,4 +443,5 @@ For updated scheduling, see the consolidated [ROADMAP](ROADMAP.md).
 ## Implementation Status
 
 Development is **in progress** with outstanding tasks tracked in
-[issue 102](../../issues/102.md) and related issues.
+[issue 102](../../issues/102.md) and related issues. Repository harmonization is
+complete and efforts are shifting toward the `0.1.0-beta.1` milestone.

--- a/docs/roadmap/index.md
+++ b/docs/roadmap/index.md
@@ -1,7 +1,7 @@
 ---
 author: DevSynth Team
 date: '2025-07-07'
-last_reviewed: "2025-07-10"
+last_reviewed: "2025-07-20"
 status: published
 tags:
 - roadmap
@@ -30,6 +30,7 @@ current implementation progress, see the [Feature Status Matrix](../implementati
 - **[ROADMAP](ROADMAP.md)**: Consolidated list of release milestones.
 - **[Post-MVP Roadmap](post_mvp_roadmap.md)**: Details the features and enhancements planned after the Minimum Viable Product stage.
 - **[Release Automation Workflow](release_automation.md)**: Describes the CI pipeline for tagging and publishing releases.
+- **[Maintenance Policy](../policies/maintenance.md)**: Defines the maintenance strategy and review process.
 
 ## Documentation and Testing Plans
 

--- a/docs/roadmap/release_plan.md
+++ b/docs/roadmap/release_plan.md
@@ -7,7 +7,7 @@ tags:
   - "release"
 status: "published"
 author: "DevSynth Team"
-last_reviewed: "2025-07-10"
+last_reviewed: "2025-07-20"
 ---
 
 # DevSynth Release Plan
@@ -72,7 +72,8 @@ For a detailed breakdown of feature implementation progress, see the
 ## Implementation Status
 
 Execution of this release plan is **in progress** with milestones tracked in
-[issue 104](../../issues/104.md).
+[issue 104](../../issues/104.md). The repository harmonization effort has concluded,
+and preparations for the `0.1.0-beta.1` release are underway.
 
 ### Current Test Summary
 

--- a/docs/specifications/agent_api_stub.md
+++ b/docs/specifications/agent_api_stub.md
@@ -1,6 +1,7 @@
 ---
 author: DevSynth Team
 date: '2025-06-19'
+last_reviewed: '2025-07-20'
 status: draft
 tags:
 
@@ -143,6 +144,7 @@ Example response:
 
 ## Sequence Diagram
 
+<!-- Diagram: API initialization sequence -->
 ```mermaid
 sequenceDiagram
     participant Client

--- a/docs/specifications/config_loader_spec.md
+++ b/docs/specifications/config_loader_spec.md
@@ -1,6 +1,7 @@
 ---
 author: DevSynth Team
 date: '2025-06-16'
+last_reviewed: '2025-07-20'
 status: draft
 tags:
 

--- a/docs/specifications/devsynth_specification_mvp_updated.md
+++ b/docs/specifications/devsynth_specification_mvp_updated.md
@@ -424,6 +424,7 @@ DevSynth exposes a common `UXBridge` abstraction so that multiple user
 interfaces can share the same workflows. The CLI, WebUI and Agent API all
 communicate with the orchestration layer through this bridge.
 
+<!-- Diagram: Unified interface through UXBridge -->
 ```mermaid
 flowchart TD
     CLI("CLI") --> Bridge

--- a/docs/specifications/interactive_requirements_gathering.md
+++ b/docs/specifications/interactive_requirements_gathering.md
@@ -1,6 +1,7 @@
 ---
 author: DevSynth Team
 date: '2025-07-01'
+last_reviewed: '2025-07-20'
 status: draft
 tags:
 
@@ -56,6 +57,7 @@ Responses are written to `requirements_plan.yaml` (or `.json`) in the project ro
 
 ## User Flow
 
+<!-- Diagram: Wizard flowchart -->
 ```mermaid
 flowchart TD
     Start --> Goals
@@ -65,6 +67,7 @@ flowchart TD
     Confirm --> Save
 ```
 
+<!-- Diagram: Wizard interaction sequence -->
 ```mermaid
 sequenceDiagram
     participant User

--- a/docs/specifications/interactive_requirements_wizard.md
+++ b/docs/specifications/interactive_requirements_wizard.md
@@ -1,6 +1,7 @@
 ---
 title: "Interactive Requirements Wizard"
 date: "2025-06-16"
+last_reviewed: "2025-07-20"
 version: "0.1.0"
 tags:
   - "specification"

--- a/docs/specifications/requirements_gathering.md
+++ b/docs/specifications/requirements_gathering.md
@@ -1,6 +1,7 @@
 ---
 title: "Requirements Gathering Workflow"
 date: "2025-07-20"
+last_reviewed: "2025-07-20"
 version: "0.1.0"
 tags:
   - "specification"
@@ -19,6 +20,7 @@ interfaces.
 
 ## Sequence Diagram
 
+<!-- Diagram: Requirements collection sequence -->
 ```mermaid
 sequenceDiagram
     participant User

--- a/docs/specifications/unified_configuration_loader.md
+++ b/docs/specifications/unified_configuration_loader.md
@@ -1,6 +1,7 @@
 ---
 title: "Unified Configuration Loader"
 date: "2025-06-16"
+last_reviewed: "2025-07-20"
 version: "0.2.0"
 tags:
   - "specification"

--- a/docs/specifications/uxbridge_extension.md
+++ b/docs/specifications/uxbridge_extension.md
@@ -1,6 +1,7 @@
 ---
 title: "UXBridge Interface Extension"
 date: "2025-06-19"
+last_reviewed: "2025-07-20"
 version: "0.1.0"
 tags:
   - "specification"

--- a/docs/specifications/webui_detailed_spec.md
+++ b/docs/specifications/webui_detailed_spec.md
@@ -1,6 +1,7 @@
 ---
 title: "WebUI Detailed Specification"
 date: "2025-06-18"
+last_reviewed: "2025-07-20"
 version: "0.2.0"
 tags:
   - "specification"
@@ -35,6 +36,7 @@ This document details the features, constraints and interaction flow for the Str
 - Collapsible sections for optional details to keep the layout tidy.
 - Interaction through the `UXBridge` ensures parity with CLI commands.
 
+<!-- Diagram: WebUI page selection flow -->
 ```mermaid
 flowchart TD
     Sidebar -->|select page| Page
@@ -50,6 +52,7 @@ flowchart TD
 
 ## Interaction Flow
 
+<!-- Diagram: WebUI interaction sequence -->
 ```mermaid
 sequenceDiagram
     participant User

--- a/docs/specifications/webui_pseudocode.md
+++ b/docs/specifications/webui_pseudocode.md
@@ -1,6 +1,7 @@
 ---
 author: DevSynth Team
 date: '2025-06-18'
+last_reviewed: '2025-07-20'
 status: draft
 tags:
 

--- a/docs/specifications/webui_spec.md
+++ b/docs/specifications/webui_spec.md
@@ -1,6 +1,7 @@
 ---
 author: DevSynth Team
 date: '2025-06-16'
+last_reviewed: '2025-07-20'
 status: draft
 tags:
 - specification


### PR DESCRIPTION
## Summary
- sync metadata across roadmap and release docs
- reference maintenance policy in the roadmap index
- record maintenance strategy steps in the policy doc
- clarify implementation status and upcoming milestone
- add missing review dates and diagram comments

## Testing
- `poetry run pytest` *(fails: 390 failed, 483 passed, 81 skipped, 1 error)*

------
https://chatgpt.com/codex/tasks/task_e_6882c99f5a408333b7b93369aa274b0c