### PR TITLE
Fix kuzu memory fallback initialisation

### DIFF
--- a/src/devsynth/adapters/kuzu_memory_store.py
+++ b/src/devsynth/adapters/kuzu_memory_store.py
@@ -47,6 +47,9 @@ class KuzuMemoryStore(MemoryStore):
         else:
             self.embedder = lambda x: [0.0] * 5
 
+        if self._store._use_fallback:
+            logger.info("Kuzu unavailable; using in-memory fallback store")
+
     def _get_embedding(self, text: str):
         if self.use_provider_system:
             try:


### PR DESCRIPTION
## Summary
- fix runtime detection of kuzu database
- ensure directories are created even when file logging is disabled
- log fallback usage when kuzu is unavailable

## Testing
- `poetry run pytest tests/integration/general/test_kuzu_memory_integration.py tests/integration/general/test_kuzu_memory_fallback.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6882ed14bf5c833380473898616f1f97