### PR TITLE
Fix BDD coordinator step import

### DIFF
--- a/tests/behavior/steps/edrr_coordinator_steps.py
+++ b/tests/behavior/steps/edrr_coordinator_steps.py
@@ -1,0 +1,1 @@
+from .test_edrr_coordinator_steps import *  # noqa: F401,F403

--- a/tests/behavior/steps/test_simple_coordinator_steps.py
+++ b/tests/behavior/steps/test_simple_coordinator_steps.py
@@ -1,67 +1,10 @@
-"""Simple test to isolate the issue with the coordinator."""
+"""Step definitions for the ``edrr_coordinator.feature`` file.
 
-from __future__ import annotations
-from typing import Dict
+This module previously contained minimal stub implementations that
+resulted in "step definition not found" errors for many scenarios.  To
+reuse the comprehensive step implementations while keeping this module
+importable, it now simply re-exports everything from
+``test_edrr_coordinator_steps``.
+"""
 
-from pytest_bdd import given, when, then, parsers
-from pytest_bdd import scenarios
-import pytest
-
-# Import the scenarios from the feature file
-scenarios('../features/general/edrr_coordinator.feature')
-
-@pytest.fixture
-def context():
-    """Fixture to provide a context object for storing test state between steps."""
-    class Context:
-        def __init__(self):
-            self.memory_manager = None
-            self.wsde_team = None
-            self.code_analyzer = None
-            self.ast_transformer = None
-            self.prompt_manager = None
-            self.documentation_manager = None
-            self.edrr_coordinator = None
-            self.task = None
-            self.temp_dir = None
-            self.manifest_path = None
-            self.final_report = None
-            self.execution_traces = None
-
-    return Context()
-
-@given("the EDRR coordinator is initialized")
-def edrr_coordinator_initialized(context):
-    """Initialize the EDRR coordinator with actual implementations."""
-    # Just a stub for testing
-    pass
-
-@given("the memory system is available")
-def memory_system_available(context):
-    """Make the memory system available."""
-    # Just a stub for testing
-    pass
-
-@given("the WSDE team is available")
-def wsde_team_available(context):
-    """Make the WSDE team available."""
-    # Just a stub for testing
-    pass
-
-@given("the AST analyzer is available")
-def ast_analyzer_available(context):
-    """Make the AST analyzer available."""
-    # Just a stub for testing
-    pass
-
-@given("the prompt manager is available")
-def prompt_manager_available(context):
-    """Make the prompt manager available."""
-    # Just a stub for testing
-    pass
-
-@given("the documentation manager is available")
-def documentation_manager_available(context):
-    """Make the documentation manager available."""
-    # Just a stub for testing
-    pass
+from .test_edrr_coordinator_steps import *  # noqa: F401,F403


### PR DESCRIPTION
## Summary
- fix missing EDRR coordinator step definitions by re-exporting real steps
- add wrapper `edrr_coordinator_steps` for clarity

## Testing
- `poetry run pytest tests/behavior/test_edrr_cycle.py -vv`
- `poetry run pytest tests/behavior/test_requirements_wizard.py -vv`
- `poetry run pytest tests/behavior/test_requirements_wizard_navigation.py -vv`

------
https://chatgpt.com/codex/tasks/task_e_688391519eec8333ad8b0d568b9d8867