### PR TITLE
Update test documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,9 +178,11 @@ The repository includes runnable examples that walk through common workflows:
 
 ## Running Tests
 
-Run `poetry run pytest` to execute the test suite. Invoking plain `pytest`
-outside of Poetry may fail because required plugins are installed only in the
-Poetry virtual environment.
+Always execute tests with `poetry run pytest`. Invoking plain `pytest`
+may fail because required plugins are installed only in the Poetry
+virtual environment. If you have not provisioned the environment yet,
+run `bash scripts/codex_setup.sh` to install all dependencies before
+running the tests.
 
 Before running the test suite manually, you **must** install DevSynth with its development extras:
 
@@ -226,6 +228,8 @@ After installation, execute the tests with:
 ```bash
 poetry run pytest
 ```
+If `pytest` reports missing packages, re-run `bash scripts/codex_setup.sh`
+or `poetry install` to ensure all dependencies are installed.
 
 You can also use the helper script `scripts/run_all_tests.py` to run the entire
 suite or specific groups of tests and optionally generate an HTML report:

--- a/docs/developer_guides/testing.md
+++ b/docs/developer_guides/testing.md
@@ -264,8 +264,7 @@ The ChromaDB tests use fixtures for isolation and provider integration:
 
 ## Running Tests
 
-Before executing tests, install DevSynth with its development extras so that all
-test dependencies are available:
+Before executing tests, install DevSynth with its development extras so that all test dependencies are available. Run `bash scripts/codex_setup.sh` first if the environment has not been provisioned.
 
 ```bash
 poetry install --with dev,docs
@@ -278,6 +277,7 @@ poetry run pytest -q
 # pip commands are for installing from PyPI only
 
 ```
+Always run tests with `poetry run pytest`. If `pytest` reports missing packages, re-run `bash scripts/codex_setup.sh` or `poetry install` to restore them.
 
 ## Running All Tests
 


### PR DESCRIPTION
## Summary
- document running `scripts/codex_setup.sh` before executing tests
- reinforce using `poetry run pytest`
- add troubleshooting advice for missing packages

## Testing
- `poetry run pytest tests/unit/core/test_core_values.py -q`

------
https://chatgpt.com/codex/tasks/task_e_688396e8b7fc8333917249e9d8970262