### PR TITLE
Add scenario hooks for EDRR feature files

### DIFF
--- a/tests/behavior/steps/edrr_coordinator_steps.py
+++ b/tests/behavior/steps/edrr_coordinator_steps.py
@@ -1,1 +1,8 @@
+"""Step definitions for the ``edrr_coordinator.feature`` file."""
+
+from pytest_bdd import scenarios
+
 from .test_edrr_coordinator_steps import *  # noqa: F401,F403
+
+
+scenarios("../features/edrr_coordinator.feature")

--- a/tests/behavior/steps/edrr_cycle_steps.py
+++ b/tests/behavior/steps/edrr_cycle_steps.py
@@ -1,1 +1,8 @@
-from .test_edrr_cycle_steps import *
+"""Step definitions for the ``edrr_cycle.feature`` file."""
+
+from pytest_bdd import scenarios
+
+from .test_edrr_cycle_steps import *  # noqa: F401,F403
+
+
+scenarios("../features/edrr_cycle.feature")

--- a/tests/behavior/steps/edrr_enhanced_memory_integration_steps.py
+++ b/tests/behavior/steps/edrr_enhanced_memory_integration_steps.py
@@ -1,0 +1,7 @@
+"""Step definitions for the ``edrr_enhanced_memory_integration.feature`` file."""
+
+from pytest_bdd import scenarios
+
+from .test_edrr_enhanced_memory_integration_steps import *  # noqa: F401,F403
+
+scenarios("../features/edrr_enhanced_memory_integration.feature")

--- a/tests/behavior/steps/edrr_enhanced_phase_transitions_steps.py
+++ b/tests/behavior/steps/edrr_enhanced_phase_transitions_steps.py
@@ -1,0 +1,7 @@
+"""Step definitions for the ``edrr_enhanced_phase_transitions.feature`` file."""
+
+from pytest_bdd import scenarios
+
+from .test_edrr_enhanced_phase_transitions_steps import *  # noqa: F401,F403
+
+scenarios("../features/edrr_enhanced_phase_transitions.feature")

--- a/tests/behavior/steps/edrr_enhanced_recursion_steps.py
+++ b/tests/behavior/steps/edrr_enhanced_recursion_steps.py
@@ -1,0 +1,7 @@
+"""Step definitions for the ``edrr_enhanced_recursion.feature`` file."""
+
+from pytest_bdd import scenarios
+
+from .test_edrr_enhanced_recursion_steps import *  # noqa: F401,F403
+
+scenarios("../features/edrr_enhanced_recursion.feature")

--- a/tests/behavior/steps/edrr_real_llm_integration_steps.py
+++ b/tests/behavior/steps/edrr_real_llm_integration_steps.py
@@ -1,1 +1,8 @@
-from .test_edrr_real_llm_integration_steps import *
+"""Step definitions for the ``edrr_real_llm_integration.feature`` file."""
+
+from pytest_bdd import scenarios
+
+from .test_edrr_real_llm_integration_steps import *  # noqa: F401,F403
+
+
+scenarios("../features/edrr_real_llm_integration.feature")

--- a/tests/behavior/steps/micro_edrr_cycle_steps.py
+++ b/tests/behavior/steps/micro_edrr_cycle_steps.py
@@ -1,0 +1,7 @@
+"""Step definitions for the ``micro_edrr_cycle.feature`` file."""
+
+from pytest_bdd import scenarios
+
+from .test_micro_edrr_cycle_steps import *  # noqa: F401,F403
+
+scenarios("../features/micro_edrr_cycle.feature")

--- a/tests/behavior/steps/recursive_edrr_coordinator_steps.py
+++ b/tests/behavior/steps/recursive_edrr_coordinator_steps.py
@@ -1,0 +1,7 @@
+"""Step definitions for the ``recursive_edrr_coordinator.feature`` file."""
+
+from pytest_bdd import scenarios
+
+from .test_recursive_edrr_coordinator_steps import *  # noqa: F401,F403
+
+scenarios("../features/recursive_edrr_coordinator.feature")

--- a/tests/behavior/steps/wsde_edrr_integration_steps.py
+++ b/tests/behavior/steps/wsde_edrr_integration_steps.py
@@ -1,0 +1,7 @@
+"""Step definitions for the ``wsde_edrr_integration.feature`` file."""
+
+from pytest_bdd import scenarios
+
+from .test_wsde_edrr_integration_steps import *  # noqa: F401,F403
+
+scenarios("../features/wsde_edrr_integration.feature")


### PR DESCRIPTION
## Summary
- ensure edrr coordinator scenarios load by registering the .feature files
- add missing wrappers for other edrr-related feature files

## Testing
- `poetry run pytest -q tests/behavior/steps/edrr_coordinator_steps.py` *(fails: StepDefinitionNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_6883d5e3d49c8333a829b3ed44c3ae60