### PR TITLE
Clean up verbose step output

### DIFF
--- a/tests/behavior/steps/test_ast_code_analysis_steps.py
+++ b/tests/behavior/steps/test_ast_code_analysis_steps.py
@@ -4,17 +4,23 @@ Step Definitions for AST-Based Code Analysis and Transformation BDD Tests
 This module implements the step definitions for the AST-based code analysis and transformation
 feature file, testing the integration between AST-based code analysis and the EDRR workflow.
 """
+
 import pytest
 import uuid
+import logging
 from pytest_bdd import given, when, then, parsers, scenarios
 
+logger = logging.getLogger(__name__)
+
 # Import the feature file
-scenarios('../features/general/ast_code_analysis.feature')
+scenarios("../features/general/ast_code_analysis.feature")
 
 # Import the modules needed for the steps
 from devsynth.application.code_analysis.analyzer import CodeAnalyzer
 from devsynth.application.code_analysis.ast_transformer import AstTransformer
-from devsynth.application.code_analysis.ast_workflow_integration import AstWorkflowIntegration
+from devsynth.application.code_analysis.ast_workflow_integration import (
+    AstWorkflowIntegration,
+)
 from devsynth.application.memory.memory_manager import MemoryManager
 from devsynth.domain.models.memory import MemoryType, MemoryItem
 from devsynth.methodology.base import Phase as EDRRPhase
@@ -23,6 +29,7 @@ from devsynth.methodology.base import Phase as EDRRPhase
 @pytest.fixture
 def context():
     """Fixture to provide a context object for sharing state between steps."""
+
     class MockMemoryStore:
         def __init__(self):
             self.items = {}
@@ -43,9 +50,9 @@ def context():
         def __init__(self):
             self.code_analyzer = CodeAnalyzer()
             self.ast_transformer = AstTransformer()
-            self.memory_manager = MemoryManager({
-                'default': MockMemoryStore()  # Mock memory store for testing
-            })
+            self.memory_manager = MemoryManager(
+                {"default": MockMemoryStore()}  # Mock memory store for testing
+            )
             self.ast_workflow_integration = AstWorkflowIntegration(self.memory_manager)
             self.code = ""
             self.ast = None
@@ -61,6 +68,7 @@ def context():
 
 
 # Background steps
+
 
 @given("the DevSynth system is initialized")
 def devsynth_system_initialized(context):
@@ -78,6 +86,7 @@ def ast_code_analysis_module_configured(context):
 
 
 # Scenario: Parse Python code into AST
+
 
 @when("I provide Python code to the analyzer")
 def provide_code_to_analyzer(context):
@@ -103,6 +112,7 @@ def parse_code_into_ast(context):
     """Parse the code into an AST representation."""
     # Use the ast module to parse the code
     import ast
+
     context.ast = ast.parse(context.code)
 
     # Verify that the AST is not None
@@ -116,11 +126,15 @@ def ast_represents_code_structure(context):
     import ast
 
     # Check for function definition
-    function_nodes = [node for node in ast.walk(context.ast) if isinstance(node, ast.FunctionDef)]
+    function_nodes = [
+        node for node in ast.walk(context.ast) if isinstance(node, ast.FunctionDef)
+    ]
     assert any(node.name == "hello" for node in function_nodes)
 
     # Check for class definition
-    class_nodes = [node for node in ast.walk(context.ast) if isinstance(node, ast.ClassDef)]
+    class_nodes = [
+        node for node in ast.walk(context.ast) if isinstance(node, ast.ClassDef)
+    ]
     assert any(node.name == "Person" for node in class_nodes)
 
 
@@ -142,6 +156,7 @@ def access_code_elements_through_ast(context):
 
 
 # Scenario: Extract code structure information
+
 
 @given("I have Python code with classes, functions, and variables")
 def have_code_with_classes_functions_variables(context):
@@ -197,7 +212,9 @@ def representation_includes_classes_with_methods(context):
     # Verify that the analysis result includes the Calculator class with its methods
     classes = context.analysis_result.get_classes()
 
-    calculator_class = next((cls for cls in classes if cls["name"] == "Calculator"), None)
+    calculator_class = next(
+        (cls for cls in classes if cls["name"] == "Calculator"), None
+    )
     assert calculator_class is not None
     assert "add" in calculator_class["methods"]
     assert "get_history" in calculator_class["methods"]
@@ -209,7 +226,9 @@ def representation_includes_functions_with_parameters(context):
     # Verify that the analysis result includes the calculate_sum function with its parameters
     functions = context.analysis_result.get_functions()
 
-    calculate_sum_func = next((func for func in functions if func["name"] == "calculate_sum"), None)
+    calculate_sum_func = next(
+        (func for func in functions if func["name"] == "calculate_sum"), None
+    )
     assert calculate_sum_func is not None
     assert "a" in calculate_sum_func["params"]
     assert "b" in calculate_sum_func["params"]
@@ -222,7 +241,9 @@ def representation_includes_variables_with_types(context):
     variables = context.analysis_result.get_variables()
 
     max_value_var = next((var for var in variables if var["name"] == "MAX_VALUE"), None)
-    default_name_var = next((var for var in variables if var["name"] == "default_name"), None)
+    default_name_var = next(
+        (var for var in variables if var["name"] == "default_name"), None
+    )
 
     assert max_value_var is not None
     assert default_name_var is not None
@@ -231,6 +252,7 @@ def representation_includes_variables_with_types(context):
 
 
 # Scenario: Perform AST-based code transformations
+
 
 @given("I have Python code that needs refactoring")
 def have_code_that_needs_refactoring(context):
@@ -259,16 +281,14 @@ def request_ast_based_transformation(context):
     try:
         # Add docstring to the calculate_sum function
         transformed_code = context.ast_transformer.add_docstring(
-            context.code,
-            "calculate_sum",
-            "Calculate the sum of two numbers."
+            context.code, "calculate_sum", "Calculate the sum of two numbers."
         )
 
         # Add docstring to the Calculator class
         transformed_code = context.ast_transformer.add_docstring(
             transformed_code,
             "Calculator",
-            "A simple calculator class that keeps history of operations."
+            "A simple calculator class that keeps history of operations.",
         )
 
         # Store the transformed code
@@ -312,6 +332,7 @@ def transformed_code_maintains_functionality(context):
 
 
 # Scenario: Extract function definitions
+
 
 @given("I have Python code with multiple function definitions")
 def have_code_with_multiple_function_definitions(context):
@@ -390,8 +411,8 @@ def extracted_information_stored_in_memory(context):
         memory_type=MemoryType.CODE_ANALYSIS,
         metadata={
             "code_hash": hash(context.code),
-            "analysis_type": "function_extraction"
-        }
+            "analysis_type": "function_extraction",
+        },
     )
     # Store the memory item
     item_id = context.memory_manager.store_item(memory_item)
@@ -402,6 +423,7 @@ def extracted_information_stored_in_memory(context):
 
 
 # Scenario: Rename identifiers
+
 
 @given("I have Python code with identifiers that need renaming")
 def have_code_with_identifiers_to_rename(context):
@@ -430,16 +452,12 @@ def request_to_rename_identifier(context):
     try:
         # Rename the calc_sum function to calculate_sum
         transformed_code = context.ast_transformer.rename_identifier(
-            context.code,
-            "calc_sum",
-            "calculate_sum"
+            context.code, "calc_sum", "calculate_sum"
         )
 
         # Rename the Calc class to Calculator
         transformed_code = context.ast_transformer.rename_identifier(
-            transformed_code,
-            "Calc",
-            "Calculator"
+            transformed_code, "Calc", "Calculator"
         )
 
         # Store the transformed code
@@ -454,8 +472,8 @@ def system_identifies_all_occurrences(context):
     # Verify that the transformation result is not None
     assert context.transformation_result is not None
 
-    # Print the transformation result for debugging
-    print(f"Transformation result:\n{context.transformation_result}")
+    # Log the transformation result for debugging
+    logger.debug("Transformation result:\n%s", context.transformation_result)
 
     # Verify that the transformation result contains the new identifiers
     assert "calculate_sum" in context.transformation_result
@@ -495,6 +513,7 @@ def resulting_code_is_valid_python(context):
 
 # Scenario: Integrate with EDRR workflow
 
+
 @given("the EDRR workflow is configured")
 def edrr_workflow_configured(context):
     """Configure the EDRR workflow."""
@@ -529,29 +548,38 @@ class Calculator:
 """
 
 
-@then("the system should use AST analysis in the Expand phase to explore implementation options")
+@then(
+    "the system should use AST analysis in the Expand phase to explore implementation options"
+)
 def system_uses_ast_analysis_in_expand_phase(context):
     """Verify that the system uses AST analysis in the Expand phase to explore implementation options."""
     # Use the AST workflow integration to explore implementation options
-    context.implementation_options = context.ast_workflow_integration.expand_implementation_options(
-        context.code,
-        context.task_id
+    context.implementation_options = (
+        context.ast_workflow_integration.expand_implementation_options(
+            context.code, context.task_id
+        )
     )
 
     # Verify that implementation options were generated
     assert len(context.implementation_options) > 0
 
     # Verify that the options include the current implementation
-    assert any(option["name"] == "current_implementation" for option in context.implementation_options)
+    assert any(
+        option["name"] == "current_implementation"
+        for option in context.implementation_options
+    )
 
 
-@then("the system should use AST analysis in the Differentiate phase to evaluate code quality")
+@then(
+    "the system should use AST analysis in the Differentiate phase to evaluate code quality"
+)
 def system_uses_ast_analysis_in_differentiate_phase(context):
     """Verify that the system uses AST analysis in the Differentiate phase to evaluate code quality."""
     # Use the AST workflow integration to evaluate implementation quality
-    context.selected_option = context.ast_workflow_integration.differentiate_implementation_quality(
-        context.implementation_options,
-        context.task_id
+    context.selected_option = (
+        context.ast_workflow_integration.differentiate_implementation_quality(
+            context.implementation_options, context.task_id
+        )
     )
 
     # Verify that an option was selected
@@ -564,13 +592,14 @@ def system_uses_ast_analysis_in_differentiate_phase(context):
     assert "maintainability" in context.selected_option["metrics"]
 
 
-@then("the system should use AST transformations in the Refine phase to improve the code")
+@then(
+    "the system should use AST transformations in the Refine phase to improve the code"
+)
 def system_uses_ast_transformations_in_refine_phase(context):
     """Verify that the system uses AST transformations in the Refine phase to improve the code."""
     # Use the AST workflow integration to refine the implementation
     context.refined_code = context.ast_workflow_integration.refine_implementation(
-        context.code,
-        context.task_id
+        context.code, context.task_id
     )
 
     # Verify that the code was refined
@@ -582,13 +611,16 @@ def system_uses_ast_transformations_in_refine_phase(context):
     assert True
 
 
-@then("the system should use AST analysis in the Retrospect phase to verify code quality")
+@then(
+    "the system should use AST analysis in the Retrospect phase to verify code quality"
+)
 def system_uses_ast_analysis_in_retrospect_phase(context):
     """Verify that the system uses AST analysis in the Retrospect phase to verify code quality."""
     # Use the AST workflow integration to perform a retrospective
-    context.retrospective_result = context.ast_workflow_integration.retrospect_code_quality(
-        context.refined_code,
-        context.task_id
+    context.retrospective_result = (
+        context.ast_workflow_integration.retrospect_code_quality(
+            context.refined_code, context.task_id
+        )
     )
 
     # Verify that a retrospective was performed
@@ -604,7 +636,9 @@ def system_uses_ast_analysis_in_retrospect_phase(context):
     assert "recommendations" in context.retrospective_result
 
 
-@then("the memory system should store AST analysis results with appropriate EDRR phase tags")
+@then(
+    "the memory system should store AST analysis results with appropriate EDRR phase tags"
+)
 def memory_system_stores_results_with_edrr_tags(context):
     """Verify that the memory system stores AST analysis results with appropriate EDRR phase tags."""
     # In a real implementation, we would query the memory system for items with EDRR phase tags
@@ -624,6 +658,7 @@ def memory_system_stores_results_with_edrr_tags(context):
 
 
 # Scenario: Remove unused imports
+
 
 @given("I have Python code with unused imports")
 def have_code_with_unused_imports(context):
@@ -707,7 +742,9 @@ def resulting_code_is_valid_python_without_unused_imports(context):
     original_result = execute_code(context.code, "generate_random_number")
 
     # Test the transformed code
-    transformed_result = execute_code(context.transformation_result, "generate_random_number")
+    transformed_result = execute_code(
+        context.transformation_result, "generate_random_number"
+    )
 
     # Verify that both functions return a number between 1 and 100
     assert 1 <= original_result <= 100
@@ -715,6 +752,7 @@ def resulting_code_is_valid_python_without_unused_imports(context):
 
 
 # Scenario: Remove redundant assignments
+
 
 @given("I have Python code with redundant assignments")
 def have_code_with_redundant_assignments(context):
@@ -750,7 +788,9 @@ def request_to_remove_redundant_assignments(context):
     # Use the AST transformer to remove redundant assignments
     try:
         # Remove redundant assignments
-        transformed_code = context.ast_transformer.remove_redundant_assignments(context.code)
+        transformed_code = context.ast_transformer.remove_redundant_assignments(
+            context.code
+        )
 
         # Store the transformed code
         context.transformation_result = transformed_code
@@ -808,23 +848,30 @@ def resulting_code_is_valid_python_with_same_functionality(context):
     # Test the transformed code
     try:
         # First try with the transformed name (snake_case)
-        transformed_result = execute_code(context.transformation_result, "process_data", [])
+        transformed_result = execute_code(
+            context.transformation_result, "process_data", []
+        )
     except KeyError:
         # If that fails, try with the original name
-        transformed_result = execute_code(context.transformation_result, "processData", [])
+        transformed_result = execute_code(
+            context.transformation_result, "processData", []
+        )
 
     # Verify that both functions return the same result
     assert original_result == transformed_result
 
     # Test the calculate_total function
     original_total = execute_code(context.code, "calculate_total", [1, 2, 3])
-    transformed_total = execute_code(context.transformation_result, "calculate_total", [1, 2, 3])
+    transformed_total = execute_code(
+        context.transformation_result, "calculate_total", [1, 2, 3]
+    )
 
     # Verify that both functions return the same result
     assert original_total == transformed_total == 6
 
 
 # Scenario: Remove unused variables
+
 
 @given("I have Python code with unused variables")
 def have_code_with_unused_variables(context):
@@ -919,20 +966,25 @@ def resulting_code_is_valid_python_without_unused_variables(context):
     original_result = execute_code(context.code, "process_data", [1, 2, 3])
 
     # Test the transformed code
-    transformed_result = execute_code(context.transformation_result, "process_data", [1, 2, 3])
+    transformed_result = execute_code(
+        context.transformation_result, "process_data", [1, 2, 3]
+    )
 
     # Verify that both functions return the same result
     assert original_result == transformed_result == 6
 
     # Test the calculate_average function
     original_avg = execute_code(context.code, "calculate_average", [1, 2, 3])
-    transformed_avg = execute_code(context.transformation_result, "calculate_average", [1, 2, 3])
+    transformed_avg = execute_code(
+        context.transformation_result, "calculate_average", [1, 2, 3]
+    )
 
     # Verify that both functions return the same result
     assert original_avg == transformed_avg == 2.0
 
 
 # Scenario: Optimize string literals
+
 
 @given("I have Python code with string literals that can be optimized")
 def have_code_with_string_literals_to_optimize(context):
@@ -966,7 +1018,9 @@ def request_to_optimize_string_literals(context):
     # Use the AST transformer to optimize string literals
     try:
         # Optimize string literals
-        transformed_code = context.ast_transformer.optimize_string_literals(context.code)
+        transformed_code = context.ast_transformer.optimize_string_literals(
+            context.code
+        )
 
         # Store the transformed code
         context.transformation_result = transformed_code
@@ -990,20 +1044,34 @@ def optimize_string_literals_in_code(context):
     # Verify that the inefficient string operations are replaced with more efficient ones
 
     # Check for f-strings or format method instead of concatenation
-    assert "\"Hello, \" + name + \"! Welcome to our application.\"" not in context.transformation_result
-    assert ("f\"Hello, {name}! Welcome to our application.\"" in context.transformation_result or 
-            "\"Hello, {}! Welcome to our application.\".format(name)" in context.transformation_result)
+    assert (
+        '"Hello, " + name + "! Welcome to our application."'
+        not in context.transformation_result
+    )
+    assert (
+        'f"Hello, {name}! Welcome to our application."' in context.transformation_result
+        or '"Hello, {}! Welcome to our application.".format(name)'
+        in context.transformation_result
+    )
 
     # Check for f-strings or format method in address formatting
-    assert "street + \", \" + city + \", \" + state + \" \" + zip_code" not in context.transformation_result
-    assert ("f\"{street}, {city}, {state} {zip_code}\"" in context.transformation_result or 
-            "\"{}, {}, {} {}\".format(street, city, state, zip_code)" in context.transformation_result)
+    assert (
+        'street + ", " + city + ", " + state + " " + zip_code'
+        not in context.transformation_result
+    )
+    assert (
+        'f"{street}, {city}, {state} {zip_code}"' in context.transformation_result
+        or '"{}, {}, {} {}".format(street, city, state, zip_code)'
+        in context.transformation_result
+    )
 
     # Check for more efficient string building in report generation
     assert "report = report + " not in context.transformation_result
-    assert ("report += " in context.transformation_result or 
-            "\"\\n\".join" in context.transformation_result or 
-            "append" in context.transformation_result)
+    assert (
+        "report += " in context.transformation_result
+        or '"\\n".join' in context.transformation_result
+        or "append" in context.transformation_result
+    )
 
 
 @then("the resulting code should be valid Python with optimized string literals")
@@ -1030,20 +1098,36 @@ def resulting_code_is_valid_python_with_optimized_string_literals(context):
 
     # Test the get_greeting function
     original_greeting = execute_code(context.code, "get_greeting", "John")
-    transformed_greeting = execute_code(context.transformation_result, "get_greeting", "John")
+    transformed_greeting = execute_code(
+        context.transformation_result, "get_greeting", "John"
+    )
 
     # Verify that both functions return the same result
-    assert original_greeting == transformed_greeting == "Hello, John! Welcome to our application."
+    assert (
+        original_greeting
+        == transformed_greeting
+        == "Hello, John! Welcome to our application."
+    )
 
     # Test the format_address function
-    original_address = execute_code(context.code, "format_address", "123 Main St", "Anytown", "CA", "12345")
-    transformed_address = execute_code(context.transformation_result, "format_address", "123 Main St", "Anytown", "CA", "12345")
+    original_address = execute_code(
+        context.code, "format_address", "123 Main St", "Anytown", "CA", "12345"
+    )
+    transformed_address = execute_code(
+        context.transformation_result,
+        "format_address",
+        "123 Main St",
+        "Anytown",
+        "CA",
+        "12345",
+    )
 
     # Verify that both functions return the same result
     assert original_address == transformed_address == "123 Main St, Anytown, CA 12345"
 
 
 # Scenario: Improve code style
+
 
 @given("I have Python code with style issues")
 def have_code_with_style_issues(context):
@@ -1152,16 +1236,21 @@ def resulting_code_follows_style_guidelines(context):
 
     # The function name might have changed in the transformed code
     try:
-        transformed_result = execute_code(context.transformation_result, "badly_formatted_function", 5, 10)
+        transformed_result = execute_code(
+            context.transformation_result, "badly_formatted_function", 5, 10
+        )
     except KeyError:
         # If the function name wasn't changed, try the original name
-        transformed_result = execute_code(context.transformation_result, "badlyFormattedFunction", 5, 10)
+        transformed_result = execute_code(
+            context.transformation_result, "badlyFormattedFunction", 5, 10
+        )
 
     # Verify that both functions return the same result
     assert original_result == transformed_result == 15
 
 
 # Scenario: Apply multiple transformations
+
 
 @given("I have Python code that needs multiple transformations")
 def have_code_that_needs_multiple_transformations(context):
@@ -1199,21 +1288,21 @@ def request_to_apply_multiple_transformations(context, table=None):
     """Request to apply multiple AST transformations."""
     # If table is not provided, create a mock table with default values
     if table is None:
+
         class MockRow:
             def __init__(self, transformation_type):
-                self.data = {
-                    'transformation_type': transformation_type
-                }
+                self.data = {"transformation_type": transformation_type}
+
             def __getitem__(self, key):
                 return self.data[key]
 
         class MockTable:
             def __init__(self):
                 self.rows = [
-                    MockRow('remove_unused_imports'),
-                    MockRow('remove_unused_variables'),
-                    MockRow('optimize_string_literals'),
-                    MockRow('improve_code_style')
+                    MockRow("remove_unused_imports"),
+                    MockRow("remove_unused_variables"),
+                    MockRow("optimize_string_literals"),
+                    MockRow("improve_code_style"),
                 ]
 
         table = MockTable()
@@ -1224,28 +1313,38 @@ def request_to_apply_multiple_transformations(context, table=None):
 
     # Apply each transformation in sequence
     for row in table.rows:
-        transformation_type = row['transformation_type']
+        transformation_type = row["transformation_type"]
 
         try:
             # Apply the transformation
-            if transformation_type == 'remove_unused_imports':
-                transformed_code = context.ast_transformer.remove_unused_imports(transformed_code)
-            elif transformation_type == 'remove_unused_variables':
-                transformed_code = context.ast_transformer.remove_unused_variables(transformed_code)
-            elif transformation_type == 'optimize_string_literals':
-                transformed_code = context.ast_transformer.optimize_string_literals(transformed_code)
-            elif transformation_type == 'improve_code_style':
-                transformed_code = context.ast_transformer.improve_code_style(transformed_code)
+            if transformation_type == "remove_unused_imports":
+                transformed_code = context.ast_transformer.remove_unused_imports(
+                    transformed_code
+                )
+            elif transformation_type == "remove_unused_variables":
+                transformed_code = context.ast_transformer.remove_unused_variables(
+                    transformed_code
+                )
+            elif transformation_type == "optimize_string_literals":
+                transformed_code = context.ast_transformer.optimize_string_literals(
+                    transformed_code
+                )
+            elif transformation_type == "improve_code_style":
+                transformed_code = context.ast_transformer.improve_code_style(
+                    transformed_code
+                )
             else:
                 pytest.fail(f"Unknown transformation type: {transformation_type}")
         except Exception as e:
-            pytest.fail(f"AST transformation failed for {transformation_type}: {str(e)}")
+            pytest.fail(
+                f"AST transformation failed for {transformation_type}: {str(e)}"
+            )
 
     # Store the transformed code
     context.transformation_result = transformed_code
 
     # Store the transformation types for later verification
-    context.transformation_types = [row['transformation_type'] for row in table.rows]
+    context.transformation_types = [row["transformation_type"] for row in table.rows]
 
 
 @then("the system should apply all transformations in the correct order")

--- a/tests/behavior/steps/test_edrr_cycle_steps.py
+++ b/tests/behavior/steps/test_edrr_cycle_steps.py
@@ -3,11 +3,14 @@
 from __future__ import annotations
 
 import json
+import logging
 from pathlib import Path
 from typing import Dict
 
 import pytest
 from pytest_bdd import given, scenarios, then, when
+
+logger = logging.getLogger(__name__)
 
 scenarios("../features/general/edrr_cycle.feature")
 
@@ -19,15 +22,15 @@ def context() -> Dict[str, object]:
 
 @given("a valid manifest file")
 def valid_manifest(tmp_path: Path, context: Dict[str, object]) -> Path:
-    print("\n=== Setting up valid manifest ===")
+    logger.debug("Setting up valid manifest")
     manifest = tmp_path / "manifest.json"
     manifest_content = '{"project": "demo"}'
-    print(f"Writing manifest content: {manifest_content}")
+    logger.debug("Writing manifest content: %s", manifest_content)
     manifest.write_text(manifest_content)
     context["manifest"] = manifest
-    print(f"Manifest path: {manifest}")
-    print(f"Manifest exists: {manifest.exists()}")
-    print(f"Manifest content: {manifest.read_text()}")
+    logger.debug("Manifest path: %s", manifest)
+    logger.debug("Manifest exists: %s", manifest.exists())
+    logger.debug("Manifest content: %s", manifest.read_text())
     return manifest
 
 
@@ -48,36 +51,36 @@ def invalid_manifest(tmp_path: Path, context: Dict[str, object]) -> Path:
 @when('I run the command "devsynth edrr-cycle" with that file')
 def run_edrr_cycle(context: Dict[str, object]) -> None:
     manifest: Path = context["manifest"]
-    print(f"Manifest path: {manifest}")
-    print(f"Manifest exists: {manifest.exists()}")
+    logger.debug("Manifest path: %s", manifest)
+    logger.debug("Manifest exists: %s", manifest.exists())
 
     if not manifest.exists():
         context["output"] = f"[red]Manifest file not found:[/red] {manifest}"
         context["started"] = False
-        print(f"Manifest not found, started = {context.get('started')}")
+        logger.debug("Manifest not found, started = %s", context.get("started"))
         return
 
     try:
         manifest_content = manifest.read_text()
-        print(f"Manifest content: {manifest_content}")
+        logger.debug("Manifest content: %s", manifest_content)
         json_content = json.loads(manifest_content)
-        print(f"Parsed JSON: {json_content}")
+        logger.debug("Parsed JSON: %s", json_content)
     except Exception as e:
         context["output"] = f"[red]Invalid manifest:[/red] {manifest}"
         context["started"] = False
-        print(f"Invalid manifest: {e}, started = {context.get('started')}")
+        logger.debug("Invalid manifest: %s, started = %s", e, context.get("started"))
         return
 
     context["output"] = "[bold]Starting EDRR cycle[/bold]"
     context["started"] = True
-    print(f"EDRR cycle started, started = {context.get('started')}")
+    logger.debug("EDRR cycle started, started = %s", context.get("started"))
 
 
 @then("the coordinator should process the manifest")
 def coordinator_processed_manifest(context: Dict[str, object]) -> None:
-    print("\n=== Checking if coordinator processed manifest ===")
-    print(f"Context: {context}")
-    print(f"Started: {context.get('started')}")
+    logger.debug("Checking if coordinator processed manifest")
+    logger.debug("Context: %s", context)
+    logger.debug("Started: %s", context.get("started"))
     assert context.get("started") is True
 
 

--- a/tests/behavior/steps/test_edrr_enhanced_memory_integration_steps.py
+++ b/tests/behavior/steps/test_edrr_enhanced_memory_integration_steps.py
@@ -3,12 +3,15 @@
 from pytest_bdd import given, when, then, parsers
 from pytest_bdd import scenarios
 import pytest
+import logging
 
 # Import the scenarios from the feature file
 scenarios("../features/general/edrr_enhanced_memory_integration.feature")
 
 # Import the necessary components
 from unittest.mock import MagicMock, patch
+
+logger = logging.getLogger(__name__)
 
 from devsynth.application.edrr.coordinator import EDRRCoordinator
 from devsynth.application.memory.memory_manager import MemoryManager
@@ -78,9 +81,9 @@ def context():
 
         def __getattr__(self, name):
             """Handle attribute access for debugging."""
-            print(f"Accessing attribute: {name}")
+            logger.debug("Accessing attribute: %s", name)
             if name not in self.__dict__:
-                print(f"Attribute {name} not found")
+                logger.debug("Attribute %s not found", name)
                 return None
             return self.__dict__[name]
 
@@ -155,8 +158,14 @@ def step_coordinator_retrieves_information(context):
             Phase.DIFFERENTIATE.value,
             {"task_id": context.coordinator.cycle_id},
         )
-        print(f"Type of context.retrieved_items: {type(context.retrieved_items)}")
-        print(f"Value of context.retrieved_items: {context.retrieved_items}")
+        logger.debug(
+            "Type of context.retrieved_items: %s",
+            type(context.retrieved_items),
+        )
+        logger.debug(
+            "Value of context.retrieved_items: %s",
+            context.retrieved_items,
+        )
 
 
 @then("the retrieval should be context-aware based on the current phase")

--- a/tests/behavior/steps/test_prompt_management_steps.py
+++ b/tests/behavior/steps/test_prompt_management_steps.py
@@ -4,16 +4,23 @@ Step Definitions for Prompt Management with DPSy-AI BDD Tests
 This file implements the step definitions for the prompt management feature file,
 testing the DPSy-AI prompt management system.
 """
+
 import pytest
 import random
+import logging
 from pytest_bdd import given, when, then, parsers, scenarios
 
+logger = logging.getLogger(__name__)
+
 # Import the feature file
-scenarios('../features/general/prompt_management.feature')
+scenarios("../features/general/prompt_management.feature")
 
 # Import the modules needed for the steps
 from devsynth.application.prompts.prompt_manager import PromptManager
-from devsynth.application.prompts.prompt_template import PromptTemplate, PromptTemplateVersion
+from devsynth.application.prompts.prompt_template import (
+    PromptTemplate,
+    PromptTemplateVersion,
+)
 from devsynth.application.prompts.prompt_efficacy import PromptEfficacyTracker
 from devsynth.application.prompts.prompt_reflection import PromptReflection
 from devsynth.application.prompts.auto_tuning import PromptAutoTuner, PromptVariant
@@ -26,6 +33,7 @@ from devsynth.adapters.llm.mock_llm_adapter import MockLLMAdapter
 @pytest.fixture
 def context():
     """Fixture to provide a context object for sharing state between steps."""
+
     class Context:
         def __init__(self):
             # Create a mock LLM adapter for testing
@@ -42,7 +50,7 @@ def context():
             # Initialize the prompt manager with only the supported parameters
             self.prompt_manager = PromptManager(
                 efficacy_tracker=self.efficacy_tracker,
-                reflection_system=self.reflection_system
+                reflection_system=self.reflection_system,
             )
 
             # Storage for test data
@@ -63,6 +71,7 @@ def context():
 
 # Background steps
 
+
 @given("the DPSy-AI prompt management system is initialized")
 def prompt_management_system_initialized(context):
     """Initialize the DPSy-AI prompt management system."""
@@ -73,18 +82,21 @@ def prompt_management_system_initialized(context):
 
 # Scenario: Register a prompt template
 
-@when(parsers.parse('I register a prompt template with the following details:'))
+
+@when(parsers.parse("I register a prompt template with the following details:"))
 def register_prompt_template(context, table=None):
     """Register a prompt template with the provided details."""
     # If table is not provided, create a mock table with default values
     if table is None:
+
         class MockRow:
             def __init__(self):
                 self.data = {
-                    'name': 'code_review',
-                    'description': 'Template for code reviews',
-                    'template_text': 'Review the following code:\n\n{code}\n\n{instructions}'
+                    "name": "code_review",
+                    "description": "Template for code reviews",
+                    "template_text": "Review the following code:\n\n{code}\n\n{instructions}",
                 }
+
             def __getitem__(self, key):
                 return self.data[key]
 
@@ -96,15 +108,13 @@ def register_prompt_template(context, table=None):
 
     # Get the template details from the table
     template_data = table.rows[0]
-    name = template_data['name']
-    description = template_data['description']
-    template_text = template_data['template_text']
+    name = template_data["name"]
+    description = template_data["description"]
+    template_text = template_data["template_text"]
 
     # Register the template
     template = context.prompt_manager.register_template(
-        name=name,
-        description=description,
-        template_text=template_text
+        name=name, description=description, template_text=template_text
     )
 
     # Store the template for later use
@@ -140,7 +150,8 @@ def retrieve_template_by_name(context):
 
 # Scenario: Use a prompt template with an agent
 
-@given("a prompt template named \"code_review\" exists")
+
+@given('a prompt template named "code_review" exists')
 def prompt_template_exists(context):
     """Ensure a prompt template named "code_review" exists."""
     template = context.prompt_manager.get_template("code_review")
@@ -149,7 +160,7 @@ def prompt_template_exists(context):
         template = context.prompt_manager.register_template(
             name="code_review",
             description="Template for code reviews",
-            template_text="Review the following code:\n\n{code}\n\n{instructions}"
+            template_text="Review the following code:\n\n{code}\n\n{instructions}",
         )
 
     assert template is not None
@@ -165,23 +176,29 @@ def code_agent_initialized(context):
         agent_type=AgentType.CODE,
         description="Agent for code-related tasks",
         capabilities=[],
-        parameters={}
+        parameters={},
     )
     agent.initialize(agent_config)
     context.agents["code_agent"] = agent
 
 
-@when(parsers.parse('the agent uses the "{template_name}" template with the following variables:'))
+@when(
+    parsers.parse(
+        'the agent uses the "{template_name}" template with the following variables:'
+    )
+)
 def agent_uses_template(context, template_name, table=None):
     """Use a template with the provided variables."""
     # If table is not provided, create a mock table with default values
     if table is None:
+
         class MockRow:
             def __init__(self):
                 self.data = {
-                    'code': 'code',
-                    'def add(a, b): return a + b': 'def add(a, b): return a + b'
+                    "code": "code",
+                    "def add(a, b): return a + b": "def add(a, b): return a + b",
                 }
+
             def __getitem__(self, key):
                 return self.data[key]
 
@@ -192,15 +209,14 @@ def agent_uses_template(context, template_name, table=None):
         table = MockTable()
 
     # Get the variables from the table
-    variables = {row['code']: row['def add(a, b): return a + b'] for row in table.rows}
+    variables = {row["code"]: row["def add(a, b): return a + b"] for row in table.rows}
 
     # Add the instructions variable
     variables["instructions"] = "Check for bugs and suggest improvements"
 
     # Render the prompt
     result = context.prompt_manager.render_and_reflect(
-        name=template_name,
-        variables=variables
+        name=template_name, variables=variables
     )
 
     # Store the rendered prompt and reflection ID
@@ -227,16 +243,19 @@ def prompt_usage_logged(context):
 
 # Scenario: Prompt template versioning
 
-@when(parsers.parse('I update the template with a new version:'))
+
+@when(parsers.parse("I update the template with a new version:"))
 def update_template_with_new_version(context, table=None):
     """Update the template with a new version."""
     # If table is not provided, create a mock table with default values
     if table is None:
+
         class MockRow:
             def __init__(self):
                 self.data = {
-                    'template_text': 'Review this code carefully:\n\n{code}\n\n{instructions}\n\nFocus on: security, performance, readability'
+                    "template_text": "Review this code carefully:\n\n{code}\n\n{instructions}\n\nFocus on: security, performance, readability"
                 }
+
             def __getitem__(self, key):
                 return self.data[key]
 
@@ -247,12 +266,11 @@ def update_template_with_new_version(context, table=None):
         table = MockTable()
 
     # Get the template text from the table
-    template_text = table.rows[0]['template_text']
+    template_text = table.rows[0]["template_text"]
 
     # Update the template
     version = context.prompt_manager.update_template(
-        name="code_review",
-        template_text=template_text
+        name="code_review", template_text=template_text
     )
 
     assert version is not None
@@ -274,8 +292,8 @@ def latest_version_used_by_default(context):
         name="code_review",
         variables={
             "code": "def subtract(a, b): return a - b",
-            "instructions": "Check for bugs"
-        }
+            "instructions": "Check for bugs",
+        },
     )
 
     assert rendered is not None
@@ -297,9 +315,9 @@ def specify_version_to_use(context):
         name="code_review",
         variables={
             "code": "def multiply(a, b): return a * b",
-            "instructions": "Check for bugs"
+            "instructions": "Check for bugs",
         },
-        version_id=first_version_id
+        version_id=first_version_id,
     )
 
     assert rendered is not None
@@ -309,7 +327,8 @@ def specify_version_to_use(context):
 
 # Scenario: Prompt efficacy tracking
 
-@given("a prompt template named \"code_review\" has been used multiple times")
+
+@given('a prompt template named "code_review" has been used multiple times')
 def template_used_multiple_times(context):
     """Ensure the template has been used multiple times."""
     template = context.prompt_manager.get_template("code_review")
@@ -318,7 +337,7 @@ def template_used_multiple_times(context):
         template = context.prompt_manager.register_template(
             name="code_review",
             description="Template for code reviews",
-            template_text="Review the following code:\n\n{code}\n\n{instructions}"
+            template_text="Review the following code:\n\n{code}\n\n{instructions}",
         )
     assert template is not None
 
@@ -326,30 +345,26 @@ def template_used_multiple_times(context):
     for i in range(5):
         variables = {
             "code": f"def function_{i}(a, b): return a + b",
-            "instructions": "Check for bugs"
+            "instructions": "Check for bugs",
         }
 
         # Render the prompt
         rendered = context.prompt_manager.render_prompt(
-            name="code_review",
-            variables=variables
+            name="code_review", variables=variables
         )
 
         # Track the usage
         tracking_id = context.efficacy_tracker.track_usage(
             template_name="code_review",
-            version_id=template.get_latest_version().version_id
+            version_id=template.get_latest_version().version_id,
         )
 
         # Record an outcome (alternating success/failure)
         context.efficacy_tracker.record_outcome(
             tracking_id=tracking_id,
             success=i % 2 == 0,
-            metrics={
-                "response_time": 0.5 + i * 0.1,
-                "token_count": 100 + i * 10
-            },
-            feedback=f"Feedback for usage {i}"
+            metrics={"response_time": 0.5 + i * 0.1, "token_count": 100 + i * 10},
+            feedback=f"Feedback for usage {i}",
         )
 
 
@@ -386,11 +401,14 @@ def receive_performance_statistics(context):
 @then("recommendations for potential improvements")
 def receive_improvement_recommendations(context):
     """Verify that improvement recommendations are received."""
-    recommendations = context.efficacy_tracker.get_optimization_recommendations("code_review")
+    recommendations = context.efficacy_tracker.get_optimization_recommendations(
+        "code_review"
+    )
     assert recommendations is not None
 
 
 # Scenario: Structured reflection after prompt response
+
 
 @when("an agent uses the template and receives a response")
 def agent_uses_template_and_receives_response(context):
@@ -400,8 +418,8 @@ def agent_uses_template_and_receives_response(context):
         name="code_review",
         variables={
             "code": "def divide(a, b): return a / b",
-            "instructions": "Check for bugs and edge cases"
-        }
+            "instructions": "Check for bugs and edge cases",
+        },
     )
 
     assert result["prompt"] is not None
@@ -433,8 +451,7 @@ def agent_uses_template_and_receives_response(context):
 
     # Process the response
     reflection_result = context.prompt_manager.process_response(
-        reflection_id=result["reflection_id"],
-        response=response
+        reflection_id=result["reflection_id"], response=response
     )
 
     assert reflection_result is not None
@@ -453,13 +470,16 @@ def reflection_step_triggered(context):
 def reflection_results_stored(context):
     """Verify that reflection results are stored for future optimization."""
     # Get the reflection from the reflection system
-    reflection = context.reflection_system.get_reflection(context.reflection_ids["current"])
+    reflection = context.reflection_system.get_reflection(
+        context.reflection_ids["current"]
+    )
     assert reflection is not None
     assert "reflection_result" in reflection
     assert reflection["reflection_result"] is not None
 
 
 # Scenario: Dynamic prompt adjustment based on feedback
+
 
 @given("the prompt auto-tuner is enabled")
 def prompt_auto_tuner_enabled(context):
@@ -470,7 +490,7 @@ def prompt_auto_tuner_enabled(context):
     # Register the template with the auto-tuner
     context.auto_tuner.register_template(
         template_id="code_review",
-        template="Review the following code:\n\n{code}\n\n{instructions}"
+        template="Review the following code:\n\n{code}\n\n{instructions}",
     )
 
     # Verify that the template is registered
@@ -499,12 +519,14 @@ def template_used_with_varying_feedback(context):
             template_id="code_review",
             variant_id=variant.variant_id,
             success=success,
-            feedback_score=feedback_score
+            feedback_score=feedback_score,
         )
 
     # Manually create and add a new variant with lower performance
     # This ensures we have multiple variants for testing
-    new_variant_template = "Review this code with less detail:\n\n{code}\n\n{instructions}"
+    new_variant_template = (
+        "Review this code with less detail:\n\n{code}\n\n{instructions}"
+    )
     new_variant = PromptVariant(new_variant_template)
 
     # Add some usage data to the new variant with lower performance
@@ -530,7 +552,9 @@ def template_used_with_varying_feedback(context):
     context.auto_tuner.prompt_variants["code_review"].append(better_variant)
 
     # Store the variants for later verification
-    context.variants["after_feedback"] = context.auto_tuner.prompt_variants["code_review"]
+    context.variants["after_feedback"] = context.auto_tuner.prompt_variants[
+        "code_review"
+    ]
     context.variants["better_variant"] = better_variant
 
 
@@ -543,8 +567,9 @@ def system_adjusts_prompt_template(context):
 
     # The best variant should be different from the initial one
     best_variant = max(variants, key=lambda v: v.performance_score)
-    assert best_variant.variant_id != context.variants["initial"].variant_id, \
-        "Expected the best variant to be different from the initial one"
+    assert (
+        best_variant.variant_id != context.variants["initial"].variant_id
+    ), "Expected the best variant to be different from the initial one"
 
 
 @then("the adjusted template should incorporate successful patterns")
@@ -555,12 +580,14 @@ def adjusted_template_incorporates_successful_patterns(context):
     best_variant = max(variants, key=lambda v: v.performance_score)
 
     # Check that it has a good performance score
-    assert best_variant.performance_score > 0.5, \
-        f"Expected performance score > 0.5, but got {best_variant.performance_score}"
+    assert (
+        best_variant.performance_score > 0.5
+    ), f"Expected performance score > 0.5, but got {best_variant.performance_score}"
 
     # Check that it has been used successfully
-    assert best_variant.success_count > 0, \
-        f"Expected success_count > 0, but got {best_variant.success_count}"
+    assert (
+        best_variant.success_count > 0
+    ), f"Expected success_count > 0, but got {best_variant.success_count}"
 
 
 @then("the adjusted template should avoid unsuccessful patterns")
@@ -572,32 +599,33 @@ def adjusted_template_avoids_unsuccessful_patterns(context):
 
     # Check that it has a lower performance score than the best variant
     best_variant = max(variants, key=lambda v: v.performance_score)
-    assert worst_variant.performance_score < best_variant.performance_score, \
-        f"Expected worst variant ({worst_variant.performance_score}) to have lower score than best variant ({best_variant.performance_score})"
+    assert (
+        worst_variant.performance_score < best_variant.performance_score
+    ), f"Expected worst variant ({worst_variant.performance_score}) to have lower score than best variant ({best_variant.performance_score})"
 
 
 # Scenario: Track prompt variant performance
+
 
 @given("multiple variants of a prompt template exist:")
 def multiple_variants_exist(context, table=None):
     """Create multiple variants of a prompt template."""
     # If table is not provided, create a mock table with default values
     if table is None:
+
         class MockRow:
             def __init__(self, variant_name, description):
-                self.data = {
-                    'variant_name': variant_name,
-                    'description': description
-                }
+                self.data = {"variant_name": variant_name, "description": description}
+
             def __getitem__(self, key):
                 return self.data[key]
 
         class MockTable:
             def __init__(self):
                 self.rows = [
-                    MockRow('variant_1', 'Original version'),
-                    MockRow('variant_2', 'More detailed instructions'),
-                    MockRow('variant_3', 'Simplified instructions')
+                    MockRow("variant_1", "Original version"),
+                    MockRow("variant_2", "More detailed instructions"),
+                    MockRow("variant_3", "Simplified instructions"),
                 ]
 
         table = MockTable()
@@ -606,13 +634,13 @@ def multiple_variants_exist(context, table=None):
     if "code_review" not in context.auto_tuner.prompt_variants:
         context.auto_tuner.register_template(
             template_id="code_review",
-            template="Review the following code:\n\n{code}\n\n{instructions}"
+            template="Review the following code:\n\n{code}\n\n{instructions}",
         )
 
     # Create variants based on the table
     for row in table.rows:
-        variant_name = row['variant_name']
-        description = row['description']
+        variant_name = row["variant_name"]
+        description = row["description"]
 
         # Create a variant with a different template based on the description
         if description == "Original version":
@@ -661,7 +689,9 @@ def variants_used_in_similar_contexts(context):
             variant.record_usage(success, feedback_score)
 
     # Store the variants with performance data
-    context.variants["with_performance"] = context.auto_tuner.prompt_variants["code_review"]
+    context.variants["with_performance"] = context.auto_tuner.prompt_variants[
+        "code_review"
+    ]
 
 
 @then("the system should track performance metrics for each variant")
@@ -669,28 +699,40 @@ def system_tracks_performance_metrics(context):
     """Verify that the system tracks performance metrics for each variant."""
     # Check that each variant has performance metrics
     for variant in context.variants["with_performance"]:
-        assert variant.usage_count > 0, f"Expected usage_count > 0, but got {variant.usage_count}"
-        assert variant.success_rate >= 0, f"Expected success_rate >= 0, but got {variant.success_rate}"
-        assert variant.average_feedback_score >= 0, f"Expected average_feedback_score >= 0, but got {variant.average_feedback_score}"
-        assert variant.performance_score >= 0, f"Expected performance_score >= 0, but got {variant.performance_score}"
+        assert (
+            variant.usage_count > 0
+        ), f"Expected usage_count > 0, but got {variant.usage_count}"
+        assert (
+            variant.success_rate >= 0
+        ), f"Expected success_rate >= 0, but got {variant.success_rate}"
+        assert (
+            variant.average_feedback_score >= 0
+        ), f"Expected average_feedback_score >= 0, but got {variant.average_feedback_score}"
+        assert (
+            variant.performance_score >= 0
+        ), f"Expected performance_score >= 0, but got {variant.performance_score}"
 
 
 @then("the system should identify the best-performing variant")
 def system_identifies_best_variant(context):
     """Verify that the system identifies the best-performing variant."""
     # Find the best-performing variant
-    best_variant = max(context.variants["with_performance"], key=lambda v: v.performance_score)
+    best_variant = max(
+        context.variants["with_performance"], key=lambda v: v.performance_score
+    )
 
     # Store it for the next step
     context.variants["best"] = best_variant
 
     # Verify it has good performance
-    assert best_variant.performance_score > 0.5, \
-        f"Expected best variant to have performance_score > 0.5, but got {best_variant.performance_score}"
+    assert (
+        best_variant.performance_score > 0.5
+    ), f"Expected best variant to have performance_score > 0.5, but got {best_variant.performance_score}"
 
     # The best variant should be the detailed one
-    assert "Focus on: security, performance, readability" in best_variant.template, \
-        "Expected the detailed variant to be the best performer"
+    assert (
+        "Focus on: security, performance, readability" in best_variant.template
+    ), "Expected the detailed variant to be the best performer"
 
 
 @then("the best-performing variant should be recommended for future use")
@@ -707,20 +749,22 @@ def best_variant_recommended(context):
     selected_variant = context.auto_tuner.select_variant("code_review")
 
     # Verify it's the best one
-    assert selected_variant.variant_id == context.variants["best"].variant_id, \
-        f"Expected variant {context.variants['best'].variant_id} to be selected, but got {selected_variant.variant_id}"
+    assert (
+        selected_variant.variant_id == context.variants["best"].variant_id
+    ), f"Expected variant {context.variants['best'].variant_id} to be selected, but got {selected_variant.variant_id}"
 
 
 # Scenario: Generate new prompt variants through mutation
 
-@given("a prompt template named \"code_review\" exists with performance data")
+
+@given('a prompt template named "code_review" exists with performance data')
 def template_exists_with_performance_data(context):
     """Ensure a prompt template exists with performance data."""
     # Register the template with the auto-tuner if it doesn't exist
     if "code_review" not in context.auto_tuner.prompt_variants:
         context.auto_tuner.register_template(
             template_id="code_review",
-            template="Review the following code:\n\n{code}\n\n{instructions}"
+            template="Review the following code:\n\n{code}\n\n{instructions}",
         )
 
     # Get the initial variant
@@ -743,7 +787,9 @@ def template_exists_with_performance_data(context):
 def request_generate_new_variants(context):
     """Request the auto-tuner to generate new variants."""
     # Store the initial number of variants
-    context.initial_variant_count = len(context.auto_tuner.prompt_variants["code_review"])
+    context.initial_variant_count = len(
+        context.auto_tuner.prompt_variants["code_review"]
+    )
 
     # Generate new variants through mutation
     for _ in range(3):  # Generate 3 new variants
@@ -757,7 +803,8 @@ def request_generate_new_variants(context):
 
     # Store the new variants
     context.variants["mutated"] = [
-        v for v in context.auto_tuner.prompt_variants["code_review"]
+        v
+        for v in context.auto_tuner.prompt_variants["code_review"]
         if v.variant_id != context.variants["initial"].variant_id
     ]
 
@@ -767,13 +814,15 @@ def system_creates_mutated_versions(context):
     """Verify that the system creates mutated versions of the template."""
     # Check that we have more variants now
     current_variant_count = len(context.auto_tuner.prompt_variants["code_review"])
-    assert current_variant_count > context.initial_variant_count, \
-        f"Expected more than {context.initial_variant_count} variants, but got {current_variant_count}"
+    assert (
+        current_variant_count > context.initial_variant_count
+    ), f"Expected more than {context.initial_variant_count} variants, but got {current_variant_count}"
 
     # Check that the new variants are different from the initial one
     for variant in context.variants["mutated"]:
-        assert variant.template != context.variants["initial"].template, \
-            f"Expected mutated variant to have different template, but got the same template"
+        assert (
+            variant.template != context.variants["initial"].template
+        ), f"Expected mutated variant to have different template, but got the same template"
 
 
 @then("each mutation should modify different aspects of the prompt")
@@ -783,8 +832,9 @@ def mutations_modify_different_aspects(context):
     templates = [v.template for v in context.variants["mutated"]]
     for i in range(len(templates)):
         for j in range(i + 1, len(templates)):
-            assert templates[i] != templates[j], \
-                f"Expected mutated variants to have different templates, but found duplicates"
+            assert (
+                templates[i] != templates[j]
+            ), f"Expected mutated variants to have different templates, but found duplicates"
 
     # Check that the mutations include different types of changes
     # This is a simplified check - in a real test, we might look for specific mutation patterns
@@ -802,8 +852,9 @@ def mutations_modify_different_aspects(context):
             mutation_types.add("structure")
 
     # We should have at least 2 different types of mutations
-    assert len(mutation_types) >= 2, \
-        f"Expected at least 2 different types of mutations, but got {len(mutation_types)}: {mutation_types}"
+    assert (
+        len(mutation_types) >= 2
+    ), f"Expected at least 2 different types of mutations, but got {len(mutation_types)}: {mutation_types}"
 
 
 @then("the mutations should be based on historical performance data")
@@ -818,11 +869,13 @@ def mutations_based_on_performance_data(context):
 
     # The mutated variants should start with no usage data
     for variant in context.variants["mutated"]:
-        assert variant.usage_count == 0, \
-            f"Expected new variant to have no usage data, but got usage_count={variant.usage_count}"
+        assert (
+            variant.usage_count == 0
+        ), f"Expected new variant to have no usage data, but got usage_count={variant.usage_count}"
 
 
 # Scenario: Generate new prompt variants through recombination
+
 
 @given("multiple prompt templates exist with performance data")
 def multiple_templates_with_performance_data(context):
@@ -830,15 +883,14 @@ def multiple_templates_with_performance_data(context):
     # Create two different templates
     templates = {
         "code_review": "Review the following code:\n\n{code}\n\n{instructions}",
-        "bug_fix": "Fix bugs in this code:\n\n{code}\n\nBugs to fix: {bugs}"
+        "bug_fix": "Fix bugs in this code:\n\n{code}\n\nBugs to fix: {bugs}",
     }
 
     # Register the templates with the auto-tuner
     for template_id, template_text in templates.items():
         if template_id not in context.auto_tuner.prompt_variants:
             context.auto_tuner.register_template(
-                template_id=template_id,
-                template=template_text
+                template_id=template_id, template=template_text
             )
 
     # Add performance data to the templates
@@ -910,14 +962,16 @@ def system_creates_recombined_templates(context):
     # Check that we have more variants now
     for template_id, initial_count in context.initial_variant_counts.items():
         current_count = len(context.auto_tuner.prompt_variants[template_id])
-        assert current_count > initial_count, \
-            f"Expected more than {initial_count} variants for template {template_id}, but got {current_count}"
+        assert (
+            current_count > initial_count
+        ), f"Expected more than {initial_count} variants for template {template_id}, but got {current_count}"
 
     # Check that the recombined variants are different from the original ones
     original_templates = list(context.templates_with_data.values())
     for variant in context.variants["recombined"]:
-        assert variant.template not in original_templates, \
-            f"Expected recombined variant to have different template, but got an original template"
+        assert (
+            variant.template not in original_templates
+        ), f"Expected recombined variant to have different template, but got an original template"
 
 
 @then("the recombined templates should preserve the core functionality")
@@ -926,12 +980,14 @@ def recombined_templates_preserve_functionality(context):
     # Check that the recombined variants contain key elements from both parents
     for variant in context.variants["recombined"]:
         # Check for elements from the code_review template
-        assert "{code}" in variant.template, \
-            f"Expected recombined variant to include '{{code}}', but it was missing"
+        assert (
+            "{code}" in variant.template
+        ), f"Expected recombined variant to include '{{code}}', but it was missing"
 
         # Check for elements from either the code_review or bug_fix template
-        assert "{instructions}" in variant.template or "{bugs}" in variant.template, \
-            f"Expected recombined variant to include either '{{instructions}}' or '{{bugs}}', but both were missing"
+        assert (
+            "{instructions}" in variant.template or "{bugs}" in variant.template
+        ), f"Expected recombined variant to include either '{{instructions}}' or '{{bugs}}', but both were missing"
 
 
 @then("the recombined templates should be added to the available templates")
@@ -947,10 +1003,13 @@ def recombined_templates_added_to_available(context):
             if recombined.variant_id in variant_ids:
                 break
         else:
-            assert False, f"Recombined variant {recombined.variant_id} not found in any template's variants"
+            assert (
+                False
+            ), f"Recombined variant {recombined.variant_id} not found in any template's variants"
 
 
 # Scenario: Automatic A/B testing of prompt variants
+
 
 @given("multiple variants of a prompt template exist")
 def multiple_variants_exist_for_ab_testing(context):
@@ -959,14 +1018,14 @@ def multiple_variants_exist_for_ab_testing(context):
     if "code_review" not in context.auto_tuner.prompt_variants:
         context.auto_tuner.register_template(
             template_id="code_review",
-            template="Review the following code:\n\n{code}\n\n{instructions}"
+            template="Review the following code:\n\n{code}\n\n{instructions}",
         )
 
     # Create additional variants with different characteristics
     variants = [
         "Review the following code carefully:\n\n{code}\n\n{instructions}\n\nFocus on: security, performance, readability",
         "Review this code:\n\n{code}\n\n{instructions}\n\nCheck for bugs and edge cases",
-        "Code Review Request:\n\n{code}\n\n{instructions}\n\nPlease provide detailed feedback"
+        "Code Review Request:\n\n{code}\n\n{instructions}\n\nPlease provide detailed feedback",
     ]
 
     # Add the variants to the auto-tuner
@@ -976,8 +1035,9 @@ def multiple_variants_exist_for_ab_testing(context):
         context.variants[f"ab_variant_{i+1}"] = variant
 
     # Verify that we have multiple variants
-    assert len(context.auto_tuner.prompt_variants["code_review"]) >= 4, \
-        f"Expected at least 4 variants, but got {len(context.auto_tuner.prompt_variants['code_review'])}"
+    assert (
+        len(context.auto_tuner.prompt_variants["code_review"]) >= 4
+    ), f"Expected at least 4 variants, but got {len(context.auto_tuner.prompt_variants['code_review'])}"
 
 
 @when("I enable A/B testing for the template")
@@ -1005,8 +1065,9 @@ def system_distributes_usage(context):
 
     # Check that all variants were used
     for variant in context.auto_tuner.prompt_variants["code_review"]:
-        assert variant.usage_count > context.initial_usage_counts.get(variant.variant_id, 0), \
-            f"Expected variant {variant.variant_id} to be used, but usage count didn't increase"
+        assert variant.usage_count > context.initial_usage_counts.get(
+            variant.variant_id, 0
+        ), f"Expected variant {variant.variant_id} to be used, but usage count didn't increase"
 
 
 @then("the system should collect performance metrics for each variant")
@@ -1033,14 +1094,20 @@ def system_collects_performance_metrics(context):
             template_id="code_review",
             variant_id=variant.variant_id,
             success=success,
-            feedback_score=feedback_score
+            feedback_score=feedback_score,
         )
 
     # Verify that performance metrics were collected
     for variant in context.auto_tuner.prompt_variants["code_review"]:
-        assert variant.success_rate >= 0, f"Expected success_rate >= 0, but got {variant.success_rate}"
-        assert variant.average_feedback_score >= 0, f"Expected average_feedback_score >= 0, but got {variant.average_feedback_score}"
-        assert variant.performance_score >= 0, f"Expected performance_score >= 0, but got {variant.performance_score}"
+        assert (
+            variant.success_rate >= 0
+        ), f"Expected success_rate >= 0, but got {variant.success_rate}"
+        assert (
+            variant.average_feedback_score >= 0
+        ), f"Expected average_feedback_score >= 0, but got {variant.average_feedback_score}"
+        assert (
+            variant.performance_score >= 0
+        ), f"Expected performance_score >= 0, but got {variant.performance_score}"
 
 
 @then("after sufficient data is collected, the system should select the best variant")
@@ -1068,14 +1135,15 @@ def system_selects_best_variant(context):
     selected_variant = context.auto_tuner.select_variant("code_review")
 
     # Force the selection to use the best variant for test stability
-    if hasattr(context.auto_tuner, '_best_variant_ids'):
+    if hasattr(context.auto_tuner, "_best_variant_ids"):
         context.auto_tuner._best_variant_ids["code_review"] = best_variant.variant_id
 
     # Select again to ensure we get the best variant
     selected_variant = context.auto_tuner.select_variant("code_review")
 
-    assert selected_variant.variant_id == best_variant.variant_id, \
-        f"Expected best variant {best_variant.variant_id} to be selected, but got {selected_variant.variant_id}"
+    assert (
+        selected_variant.variant_id == best_variant.variant_id
+    ), f"Expected best variant {best_variant.variant_id} to be selected, but got {selected_variant.variant_id}"
 
 
 @then("the best variant should become the new default")
@@ -1093,11 +1161,13 @@ def best_variant_becomes_default(context):
     # All selections should be the best variant
     best_variant_id = context.variants["ab_best"].variant_id
     for variant in selected_variants:
-        assert variant.variant_id == best_variant_id, \
-            f"Expected all selections to be the best variant {best_variant_id}, but got {variant.variant_id}"
+        assert (
+            variant.variant_id == best_variant_id
+        ), f"Expected all selections to be the best variant {best_variant_id}, but got {variant.variant_id}"
 
 
 # Scenario: Continuous prompt optimization cycle
+
 
 @given("the prompt auto-tuner is enabled for a template")
 def auto_tuner_enabled_for_template(context):
@@ -1106,7 +1176,7 @@ def auto_tuner_enabled_for_template(context):
     if "code_review" not in context.auto_tuner.prompt_variants:
         context.auto_tuner.register_template(
             template_id="code_review",
-            template="Review the following code:\n\n{code}\n\n{instructions}"
+            template="Review the following code:\n\n{code}\n\n{instructions}",
         )
 
     # Set the selection strategy to balance exploration and exploitation
@@ -1114,7 +1184,9 @@ def auto_tuner_enabled_for_template(context):
     context.auto_tuner.exploration_rate = 0.3  # 30% exploration
 
     # Store the initial state
-    context.initial_variant_count = len(context.auto_tuner.prompt_variants["code_review"])
+    context.initial_variant_count = len(
+        context.auto_tuner.prompt_variants["code_review"]
+    )
     context.initial_variants = list(context.auto_tuner.prompt_variants["code_review"])
 
 
@@ -1154,7 +1226,7 @@ def template_used_in_production(context):
                 template_id="code_review",
                 variant_id=variant.variant_id,
                 success=success,
-                feedback_score=feedback_score
+                feedback_score=feedback_score,
             )
 
         # After each cycle, force generation of new variants
@@ -1168,7 +1240,7 @@ def template_used_in_production(context):
         "initial_count": context.initial_variant_count,
         "final_count": len(context.final_variants),
         "initial_variants": context.initial_variants,
-        "final_variants": context.final_variants
+        "final_variants": context.final_variants,
     }
 
 
@@ -1176,19 +1248,25 @@ def template_used_in_production(context):
 def system_generates_and_tests_variants(context):
     """Verify that the system continuously generates and tests new variants."""
     # Check that we have more variants now
-    assert len(context.final_variants) > context.initial_variant_count, \
-        f"Expected more than {context.initial_variant_count} variants, but got {len(context.final_variants)}"
+    assert (
+        len(context.final_variants) > context.initial_variant_count
+    ), f"Expected more than {context.initial_variant_count} variants, but got {len(context.final_variants)}"
 
     # Check that new variants were generated
     initial_variant_ids = {v.variant_id for v in context.initial_variants}
-    new_variants = [v for v in context.final_variants if v.variant_id not in initial_variant_ids]
+    new_variants = [
+        v for v in context.final_variants if v.variant_id not in initial_variant_ids
+    ]
 
-    assert len(new_variants) > 0, "Expected new variants to be generated, but none were found"
+    assert (
+        len(new_variants) > 0
+    ), "Expected new variants to be generated, but none were found"
 
     # Check that the new variants have been tested
     for variant in new_variants:
-        assert variant.usage_count > 0, \
-            f"Expected new variant {variant.variant_id} to be tested, but usage_count={variant.usage_count}"
+        assert (
+            variant.usage_count > 0
+        ), f"Expected new variant {variant.variant_id} to be tested, but usage_count={variant.usage_count}"
 
 
 @then("the system should progressively improve template performance")
@@ -1196,7 +1274,9 @@ def system_improves_performance(context):
     """Verify that the system progressively improves template performance."""
     # Calculate the average performance of initial variants
     if context.initial_variants:
-        initial_performance = sum(v.performance_score for v in context.initial_variants) / len(context.initial_variants)
+        initial_performance = sum(
+            v.performance_score for v in context.initial_variants
+        ) / len(context.initial_variants)
     else:
         initial_performance = 0
 
@@ -1207,18 +1287,28 @@ def system_improves_performance(context):
     # This is a test-only modification to ensure the test passes
 
     # First, ensure the best variant includes the expected patterns
-    if "Focus on: security" not in best_variant.template and "detailed feedback" not in best_variant.template.lower():
+    if (
+        "Focus on: security" not in best_variant.template
+        and "detailed feedback" not in best_variant.template.lower()
+    ):
         # Create a new variant with the required patterns
-        enhanced_template = best_variant.template + "\n\nFocus on: security, performance, readability\n\nPlease provide detailed feedback."
+        enhanced_template = (
+            best_variant.template
+            + "\n\nFocus on: security, performance, readability\n\nPlease provide detailed feedback."
+        )
         enhanced_variant = type(best_variant)(enhanced_template)
 
         # Copy the usage data from the best variant
         enhanced_variant.usage_count = best_variant.usage_count
         enhanced_variant.success_count = best_variant.success_count
-        if hasattr(best_variant, 'failure_count'):
+        if hasattr(best_variant, "failure_count"):
             enhanced_variant.failure_count = best_variant.failure_count
-        if hasattr(best_variant, 'feedback_scores'):
-            enhanced_variant.feedback_scores = best_variant.feedback_scores.copy() if best_variant.feedback_scores else []
+        if hasattr(best_variant, "feedback_scores"):
+            enhanced_variant.feedback_scores = (
+                best_variant.feedback_scores.copy()
+                if best_variant.feedback_scores
+                else []
+            )
 
         # Add the enhanced variant to the final variants
         context.final_variants.append(enhanced_variant)
@@ -1234,7 +1324,7 @@ def system_improves_performance(context):
             best_variant.record_usage(success=True, feedback_score=0.95)
 
         # Reset any failure counts to ensure high success rate
-        if hasattr(best_variant, 'failure_count'):
+        if hasattr(best_variant, "failure_count"):
             best_variant.failure_count = 0
 
     # Recalculate the best variant after boosting
@@ -1243,13 +1333,15 @@ def system_improves_performance(context):
     # The best variant should have better performance than the initial average
     # Add a small epsilon to handle floating point comparison
     epsilon = 0.0001
-    assert best_variant.performance_score > initial_performance - epsilon, \
-        f"Expected best variant ({best_variant.performance_score}) to outperform initial average ({initial_performance})"
+    assert (
+        best_variant.performance_score > initial_performance - epsilon
+    ), f"Expected best variant ({best_variant.performance_score}) to outperform initial average ({initial_performance})"
 
     # The best variant should have good absolute performance
     # For test stability, we'll lower the threshold slightly
-    assert best_variant.performance_score > 0.45, \
-        f"Expected best variant to have performance_score > 0.45, but got {best_variant.performance_score}"
+    assert (
+        best_variant.performance_score > 0.45
+    ), f"Expected best variant to have performance_score > 0.45, but got {best_variant.performance_score}"
 
     # Store the best variant for the next step
     context.variants["optimization_best"] = best_variant
@@ -1264,23 +1356,31 @@ def system_maintains_optimization_history(context):
     # Check that we have variants with different usage counts
     # This indicates they were created and tested at different times
     usage_counts = [v.usage_count for v in context.final_variants]
-    assert len(set(usage_counts)) > 1, \
-        f"Expected variants with different usage counts, but all have {usage_counts[0]}"
+    assert (
+        len(set(usage_counts)) > 1
+    ), f"Expected variants with different usage counts, but all have {usage_counts[0]}"
 
     # Check that we have at least some unique variant IDs
     # In the real implementation, this would be tracked explicitly
     # For testing, we'll use the variant IDs as a proxy for creation order
     variant_ids = [v.variant_id for v in context.final_variants]
     unique_ids = set(variant_ids)
-    assert len(unique_ids) > 1, \
-        "Expected multiple unique variant IDs, but found only one"
+    assert (
+        len(unique_ids) > 1
+    ), "Expected multiple unique variant IDs, but found only one"
 
     # It's acceptable to have some duplicates in the test environment
     # due to how variants are created and managed during testing
     if len(unique_ids) < len(variant_ids):
-        print(f"Note: Found {len(variant_ids)} variants with {len(unique_ids)} unique IDs")
+        logger.debug(
+            "Note: Found %s variants with %s unique IDs",
+            len(variant_ids),
+            len(unique_ids),
+        )
 
     # Verify that the best variant incorporates successful patterns
     best_variant = context.variants["optimization_best"]
-    assert any(pattern in best_variant.template for pattern in ["Focus on: security", "detailed feedback"]), \
-        f"Expected best variant to incorporate successful patterns, but got: {best_variant.template}"
+    assert any(
+        pattern in best_variant.template
+        for pattern in ["Focus on: security", "detailed feedback"]
+    ), f"Expected best variant to incorporate successful patterns, but got: {best_variant.template}"


### PR DESCRIPTION
## Summary
- replace debug `print` calls in step modules with `logging`
- drop noisy output from EDRR cycle steps

## Testing
- `poetry run pytest tests/behavior/steps/test_edrr_cycle_steps.py -q`
- `poetry run pytest tests/behavior/steps/test_edrr_enhanced_memory_integration_steps.py -q` *(fails: StepDefinitionNotFoundError)*
- `poetry run pytest tests/behavior/steps/test_memory_backend_integration_steps.py -q`
- `poetry run pytest tests/behavior/steps/test_prompt_management_steps.py -q`


------
https://chatgpt.com/codex/tasks/task_e_6883e05a75f0833393239d35133adb00