### PR TITLE
Add unit tests for voting logic and memory adapter

### DIFF
--- a/tests/unit/application/collaboration/test_wsde_team_consensus_summary.py
+++ b/tests/unit/application/collaboration/test_wsde_team_consensus_summary.py
@@ -1,0 +1,32 @@
+from devsynth.application.collaboration.wsde_team_consensus import ConsensusBuildingMixin
+
+class DummyTeam(ConsensusBuildingMixin):
+    def __init__(self):
+        self.tracked_decisions = {}
+
+
+def test_summarize_voting_result_tie():
+    mixin = DummyTeam()
+    result = {
+        'status': 'completed',
+        'result': {'tied': True, 'tied_options': ['A', 'B']},
+        'tie_resolution': {'winner': 'A'},
+    }
+    summary = mixin.summarize_voting_result(result)
+    assert 'tie between a, b' in summary.lower()
+    assert 'favour of a' in summary.lower()
+
+
+def test_summarize_voting_result_winner():
+    mixin = DummyTeam()
+    result = {'status': 'completed', 'result': 'B', 'vote_counts': {'B': 3}}
+    summary = mixin.summarize_voting_result(result)
+    assert summary == "Option 'B' selected with 3 votes."
+
+
+def test_summarize_consensus_result_methods():
+    mixin = DummyTeam()
+    consensus = {'method': 'synthesis', 'synthesis': {'text': 'do x'}}
+    assert 'synthesis consensus' in mixin.summarize_consensus_result(consensus).lower()
+    consensus = {'majority_opinion': 'opt', 'method': 'vote'}
+    assert 'majority opinion chosen' in mixin.summarize_consensus_result(consensus).lower()

--- a/tests/unit/application/memory/test_vector_memory_adapter_extra.py
+++ b/tests/unit/application/memory/test_vector_memory_adapter_extra.py
@@ -1,0 +1,30 @@
+from devsynth.application.memory.adapters.vector_memory_adapter import VectorMemoryAdapter
+from devsynth.domain.models.memory import MemoryVector
+
+
+def test_similarity_empty_store():
+    adapter = VectorMemoryAdapter()
+    results = adapter.similarity_search([0.1, 0.2, 0.3])
+    assert results == []
+
+
+def test_similarity_zero_norm(monkeypatch):
+    adapter = VectorMemoryAdapter()
+    vec = MemoryVector(id="v1", content="c", embedding=[0.0, 0.0], metadata=None)
+    adapter.store_vector(vec)
+    results = adapter.similarity_search([0.0, 0.0])
+    assert results == [vec]
+
+
+def test_delete_missing():
+    adapter = VectorMemoryAdapter()
+    assert adapter.delete_vector("missing") is False
+
+
+def test_collection_stats():
+    adapter = VectorMemoryAdapter()
+    vec = MemoryVector(id="v1", content="c", embedding=[1.0, 0.0], metadata=None)
+    adapter.store_vector(vec)
+    stats = adapter.get_collection_stats()
+    assert stats["vector_count"] == 1
+    assert stats["embedding_dimensions"] == 2

--- a/tests/unit/domain/test_wsde_voting_logic.py
+++ b/tests/unit/domain/test_wsde_voting_logic.py
@@ -1,0 +1,179 @@
+import types
+import random
+import devsynth.application.edrr.edrr_phase_transitions as _ph
+
+import pytest
+
+from devsynth.domain.models import wsde_voting
+
+class DummyAgent:
+    def __init__(self, name, expertise=None):
+        self.name = name
+        self.expertise = expertise or []
+
+class DummyTeam:
+    def __init__(self, agents, primus=None):
+        self.agents = agents
+        self.voting_history = []
+        self.logger = types.SimpleNamespace(info=lambda *a, **k: None, warning=lambda *a, **k: None)
+        self._primus = primus
+
+    def get_primus(self):
+        return self._primus
+
+
+def bind(team):
+    team.vote_on_critical_decision = wsde_voting.vote_on_critical_decision.__get__(team)
+    team._apply_majority_voting = wsde_voting._apply_majority_voting.__get__(team)
+    team._apply_weighted_voting = wsde_voting._apply_weighted_voting.__get__(team)
+    team._handle_tied_vote = wsde_voting._handle_tied_vote.__get__(team)
+    team._record_voting_history = lambda *a, **k: None
+    return team
+
+
+def test_majority_voting_simple(monkeypatch):
+    agents = [DummyAgent("a1", ["a"]), DummyAgent("a2", ["b"]), DummyAgent("a3", ["a"])]
+    team = bind(DummyTeam(agents, primus=agents[0]))
+    monkeypatch.setattr(random, "choice", lambda x: x[0])
+    task = {"options": ["option_a", "option_b"], "voting_method": "majority"}
+    result = team.vote_on_critical_decision(task)
+    assert result["status"] == "completed"
+    assert result["result"] == "option_a"
+
+
+def test_handle_tied_vote_primus_breaks(monkeypatch):
+    agents = [DummyAgent("primus", ["x"]), DummyAgent("other", ["y"])]
+    team = bind(DummyTeam(agents, primus=agents[0]))
+    voting_result = {
+        "votes": {"primus": "A", "other": "B"},
+        "options": ["A", "B"],
+        "status": "pending",
+    }
+    vote_counts = {"A": 1, "B": 1}
+    res = team._handle_tied_vote({"options": ["A", "B"]}, voting_result, vote_counts, ["A", "B"])
+    assert res["result"] == "A"
+    assert res["status"] == "completed"
+
+
+def test_weighted_voting_tie_primus_resolution(monkeypatch):
+    a1 = DummyAgent("p", ["frontend"])
+    a2 = DummyAgent("s", ["frontend"])
+    team = bind(DummyTeam([a1, a2], primus=a1))
+    monkeypatch.setattr(random, "choice", lambda opts: opts[0])
+    task = {
+        "options": ["frontend", "backend"],
+        "voting_method": "weighted",
+        "domain": "frontend",
+    }
+    # Force votes to create a tie
+    voting_result = {
+        "options": ["frontend", "backend"],
+        "votes": {"p": "frontend", "s": "backend"},
+        "method": "weighted",
+        "status": "pending",
+    }
+    vote_counts = {"frontend": 1, "backend": 1}
+    res = team._handle_tied_vote(task, voting_result, vote_counts, ["frontend", "backend"])
+    assert res["result"] == "frontend"
+
+
+def test_vote_on_critical_decision_majority(monkeypatch):
+    agents = [DummyAgent("a1", ["opt1"]), DummyAgent("a2", ["opt1"]), DummyAgent("a3", ["opt2"])]
+    team = bind(DummyTeam(agents, primus=agents[0]))
+    monkeypatch.setattr(random, "choice", lambda opts: opts[0])
+    task = {"id": "t", "options": ["opt1", "opt2"], "voting_method": "majority"}
+    result = team.vote_on_critical_decision(task)
+    assert result["result"] == "opt1"
+    assert result["status"] == "completed"
+
+
+def test_vote_on_critical_decision_weighted(monkeypatch):
+    a1 = DummyAgent("a1", ["frontend"])
+    a2 = DummyAgent("a2", ["backend"])
+    team = bind(DummyTeam([a1, a2], primus=a1))
+    monkeypatch.setattr(random, "choice", lambda opts: opts[0])
+    task = {
+        "id": "t2",
+        "options": ["frontend", "backend"],
+        "voting_method": "weighted",
+        "domain": "frontend",
+    }
+    result = team.vote_on_critical_decision(task)
+    assert result["status"] == "completed"
+    assert result["result"] == "frontend"
+
+
+def test_apply_majority_voting_no_tie(monkeypatch):
+    agents = [DummyAgent('a1'), DummyAgent('a2')]
+    team = bind(DummyTeam(agents, primus=agents[0]))
+    voting_result = {
+        'options': ['X', 'Y'],
+        'votes': {'a1': 'X', 'a2': 'X'},
+        'vote_counts': {'X': 2, 'Y': 0},
+        'status': 'pending'
+    }
+    res = team._apply_majority_voting({}, voting_result)
+    assert res['result'] == 'X'
+    assert res['status'] == 'completed'
+
+
+def test_consensus_vote(monkeypatch):
+    agents = [DummyAgent('a1', ['front']), DummyAgent('a2', ['front'])]
+    team = bind(DummyTeam(agents, primus=agents[0]))
+    monkeypatch.setattr(random, 'choice', lambda opts: opts[0])
+    task = {'options': ['front', 'back']}
+    res = wsde_voting.consensus_vote(team, task)
+    assert res['decision'] in {'front', 'back'}
+
+def test_build_consensus_simple(monkeypatch):
+    agents = [DummyAgent('a1', ['front']), DummyAgent('a2', ['back'])]
+    team = bind(DummyTeam(agents, primus=agents[0]))
+    monkeypatch.setattr(random, 'choice', lambda opts: opts[0])
+    task = {
+        'options': ['front', 'back'],
+        'domain': 'front',
+        'max_rounds': 1,
+    }
+    res = wsde_voting.build_consensus(team, task)
+    assert 'status' in res
+
+def test_build_consensus_rounds(monkeypatch):
+    agents = [DummyAgent('a1', ['x']), DummyAgent('a2', ['y']), DummyAgent('a3', ['x'])]
+    team = bind(DummyTeam(agents, primus=agents[0]))
+    monkeypatch.setattr(random, 'choice', lambda opts: opts[0])
+    task = {
+        'options': ['x', 'y'],
+        'domain': 'x',
+        'consensus_threshold': 0.6,
+        'max_rounds': 2,
+    }
+    res = wsde_voting.build_consensus(team, task)
+    assert 'status' in res
+
+def test_apply_weighted_voting_primus_tie(monkeypatch):
+    p = DummyAgent('p', ['front'])
+    o = DummyAgent('o', ['front'])
+    team = bind(DummyTeam([p, o], primus=p))
+    monkeypatch.setattr(random, 'choice', lambda opts: opts[0])
+    voting_result = {
+        'options': ['front', 'back'],
+        'votes': {'p': 'front', 'o': 'back'},
+        'status': 'pending'
+    }
+    res = team._apply_weighted_voting({'options': ['front', 'back']}, voting_result, 'front')
+    assert res['result'] == 'front'
+
+
+def test_apply_weighted_voting_random(monkeypatch):
+    a1 = DummyAgent('a1')
+    a2 = DummyAgent('a2')
+    team = bind(DummyTeam([a1, a2], primus=None))
+    monkeypatch.setattr(random, 'choice', lambda opts: opts[-1])
+    voting_result = {
+        'options': ['A', 'B'],
+        'votes': {'a1': 'A', 'a2': 'B'},
+        'status': 'pending'
+    }
+    res = team._apply_weighted_voting({'options': ['A', 'B']}, voting_result, 'none')
+    assert res['status'] == 'completed'
+    assert res['result'] in {'A', 'B'}


### PR DESCRIPTION
## Summary
- add regression-style unit tests for WSDE voting logic
- test summarization helpers in WSDE consensus mixin
- add tests for vector memory adapter

## Testing
- `pytest tests/unit/domain/test_wsde_voting_logic.py tests/unit/application/memory/test_vector_memory_adapter_extra.py tests/unit/application/collaboration/test_wsde_team_consensus_summary.py tests/unit/application/edrr/test_edrr_phase_transitions.py --cov=devsynth.domain.models.wsde_voting --cov=devsynth.application.memory.adapters.vector_memory_adapter --cov=devsynth.application.edrr.edrr_phase_transitions --cov=devsynth.application.collaboration.wsde_team_consensus --cov-report=term-missing`

------
https://chatgpt.com/codex/tasks/task_e_6883e8abf79c83338733bcde009aabf6