### PR TITLE
Add non-interactive mode to SetupWizard

### DIFF
--- a/src/devsynth/application/cli/setup_wizard.py
+++ b/src/devsynth/application/cli/setup_wizard.py
@@ -6,6 +6,14 @@ import os
 from pathlib import Path
 from typing import Dict, Optional
 
+
+def _env_flag(name: str) -> Optional[bool]:
+    """Return boolean value for ``name`` if set, otherwise ``None``."""
+    val = os.environ.get(name)
+    if val is None:
+        return None
+    return val.lower() in {"1", "true", "yes"}
+
 from devsynth.config import load_project_config, ProjectUnifiedConfig
 from devsynth.config.unified_loader import UnifiedConfigLoader
 from devsynth.interface.cli import CLIUXBridge
@@ -21,8 +29,15 @@ class SetupWizard:
     # ------------------------------------------------------------------
     # Private helpers
     # ------------------------------------------------------------------
-    def _prompt_features(self, cfg: ProjectUnifiedConfig) -> Dict[str, bool]:
-        features = cfg.config.features or {}
+    def _prompt_features(
+        self,
+        cfg: ProjectUnifiedConfig,
+        features: Optional[Dict[str, bool]],
+        auto_confirm: bool,
+    ) -> Dict[str, bool]:
+        existing = cfg.config.features or {}
+        result: Dict[str, bool] = {}
+        features = features or {}
         for feat in [
             "wsde_collaboration",
             "dialectical_reasoning",
@@ -31,17 +46,36 @@ class SetupWizard:
             "documentation_generation",
             "experimental_features",
         ]:
-            features[feat] = self.bridge.confirm_choice(
-                f"Enable {feat.replace('_', ' ')}?",
-                default=features.get(feat, False),
-            )
-        return features
+            if feat in features:
+                result[feat] = bool(features[feat])
+            elif auto_confirm:
+                result[feat] = bool(existing.get(feat, False))
+            else:
+                result[feat] = self.bridge.confirm_choice(
+                    f"Enable {feat.replace('_', ' ')}?",
+                    default=existing.get(feat, False),
+                )
+        return result
 
     # ------------------------------------------------------------------
     # Public API
     # ------------------------------------------------------------------
-    def run(self) -> ProjectUnifiedConfig:
+    def run(
+        self,
+        *,
+        root: Optional[str] = None,
+        structure: Optional[str] = None,
+        language: Optional[str] = None,
+        constraints: Optional[str] = None,
+        goals: Optional[str] = None,
+        memory_backend: Optional[str] = None,
+        offline_mode: Optional[bool] = None,
+        features: Optional[Dict[str, bool]] = None,
+        auto_confirm: Optional[bool] = None,
+    ) -> ProjectUnifiedConfig:
         """Execute the wizard steps and persist configuration."""
+
+        auto_confirm = _env_flag("DEVSYNTH_AUTO_CONFIRM") if auto_confirm is None else auto_confirm
 
         try:
             cfg = load_project_config()
@@ -57,42 +91,70 @@ class SetupWizard:
             self.bridge.display_result("Project already initialized")
             return cfg
 
-        root = self.bridge.ask_question("Project root", default=os.getcwd())
-        structure = self.bridge.ask_question(
-            "Project structure",
-            choices=["single_package", "monorepo"],
-            default="single_package",
-        )
-        language = self.bridge.ask_question("Primary language", default="python")
-        constraints = (
-            self.bridge.ask_question(
-                "Path to constraint file (optional)",
-                default="",
-                show_default=False,
+        root = root or os.environ.get("DEVSYNTH_INIT_ROOT")
+        if root is None:
+            root = self.bridge.ask_question("Project root", default=os.getcwd())
+
+        structure = structure or os.environ.get("DEVSYNTH_INIT_STRUCTURE")
+        if structure is None:
+            structure = self.bridge.ask_question(
+                "Project structure",
+                choices=["single_package", "monorepo"],
+                default="single_package",
             )
-            or None
-        )
-        goals = (
-            self.bridge.ask_question(
-                "Project goals (optional)",
-                default="",
-                show_default=False,
+
+        language = language or os.environ.get("DEVSYNTH_INIT_LANGUAGE")
+        if language is None:
+            language = self.bridge.ask_question("Primary language", default="python")
+
+        if constraints is None:
+            constraints = os.environ.get("DEVSYNTH_INIT_CONSTRAINTS")
+            if constraints is None:
+                constraints = (
+                    self.bridge.ask_question(
+                        "Path to constraint file (optional)",
+                        default="",
+                        show_default=False,
+                    )
+                    or None
+                )
+
+        if goals is None:
+            goals = os.environ.get("DEVSYNTH_INIT_GOALS")
+            if goals is None:
+                goals = (
+                    self.bridge.ask_question(
+                        "Project goals (optional)",
+                        default="",
+                        show_default=False,
+                    )
+                    or None
+                )
+
+        memory_backend = memory_backend or os.environ.get("DEVSYNTH_INIT_MEMORY_BACKEND")
+        if memory_backend is None:
+            memory_backend = self.bridge.ask_question(
+                "Select memory backend",
+                choices=["memory", "file", "kuzu", "chromadb"],
+                default=cfg.config.memory_store_type,
             )
-            or None
-        )
 
-        memory_backend = self.bridge.ask_question(
-            "Select memory backend",
-            choices=["memory", "file", "kuzu", "chromadb"],
-            default=cfg.config.memory_store_type,
-        )
-        offline_mode = self.bridge.confirm_choice(
-            "Enable offline mode?", default=cfg.config.offline_mode
-        )
+        if offline_mode is None:
+            env_offline = _env_flag("DEVSYNTH_INIT_OFFLINE_MODE")
+            if env_offline is not None:
+                offline_mode = env_offline
+            else:
+                offline_mode = self.bridge.confirm_choice(
+                    "Enable offline mode?", default=cfg.config.offline_mode
+                )
 
-        features = self._prompt_features(cfg)
+        features = self._prompt_features(cfg, features, auto_confirm)
 
-        if not self.bridge.confirm_choice("Proceed with initialization?", default=True):
+        proceed = auto_confirm
+        if not proceed:
+            proceed = self.bridge.confirm_choice("Proceed with initialization?", default=True)
+
+        if not proceed:
             self.bridge.display_result("[yellow]Initialization aborted.[/yellow]")
             return cfg
 

--- a/tests/behavior/steps/test_setup_wizard_steps.py
+++ b/tests/behavior/steps/test_setup_wizard_steps.py
@@ -46,27 +46,18 @@ def run_setup_wizard(tmp_project_dir, monkeypatch):
     monkeypatch.setitem(os.sys.modules, "uvicorn", MagicMock())
     from devsynth.application.cli.setup_wizard import SetupWizard
 
-    answers = [
-        str(tmp_project_dir),
-        "single_package",
-        "python",
-        "",
-        "demo goals",
-        "kuzu",
-    ]
-    confirms = [
-        True,  # offline mode
-        True,  # wsde_collaboration
-        False,  # dialectical_reasoning
-        False,  # code_generation
-        False,  # test_generation
-        False,  # documentation_generation
-        False,  # experimental_features
-        True,  # proceed
-    ]
-    bridge = DummyBridge(answers, confirms)
-    wizard = SetupWizard(bridge)
-    wizard.run()
+    wizard = SetupWizard(DummyBridge([], []))
+    wizard.run(
+        root=str(tmp_project_dir),
+        structure="single_package",
+        language="python",
+        constraints="",
+        goals="demo goals",
+        memory_backend="kuzu",
+        offline_mode=True,
+        features={"wsde_collaboration": True},
+        auto_confirm=True,
+    )
 
 
 @when("I cancel the setup wizard")
@@ -75,27 +66,25 @@ def cancel_setup_wizard(tmp_project_dir, monkeypatch):
     monkeypatch.setitem(os.sys.modules, "uvicorn", MagicMock())
     from devsynth.application.cli.setup_wizard import SetupWizard
 
-    answers = [
-        str(tmp_project_dir),
-        "single_package",
-        "python",
-        "",
-        "",
-        "memory",
-    ]
-    confirms = [
-        False,  # offline mode
-        False,  # wsde_collaboration
-        False,  # dialectical_reasoning
-        False,  # code_generation
-        False,  # test_generation
-        False,  # documentation_generation
-        False,  # experimental_features
-        False,  # proceed
-    ]
-    bridge = DummyBridge(answers, confirms)
-    wizard = SetupWizard(bridge)
-    wizard.run()
+    wizard = SetupWizard(DummyBridge([], [False]))
+    wizard.run(
+        root=str(tmp_project_dir),
+        structure="single_package",
+        language="python",
+        constraints="",
+        goals="",
+        memory_backend="memory",
+        offline_mode=False,
+        features={
+            "wsde_collaboration": False,
+            "dialectical_reasoning": False,
+            "code_generation": False,
+            "test_generation": False,
+            "documentation_generation": False,
+            "experimental_features": False,
+        },
+        auto_confirm=False,
+    )
 
 
 @then("a project configuration file should include the selected options")


### PR DESCRIPTION
## Summary
- allow SetupWizard to run with defaults or env vars
- adjust behaviour tests to use the new `auto_confirm` flow

## Testing
- `poetry run pytest tests/unit/application/cli/test_setup_wizard.py tests/behavior/steps/test_setup_wizard_steps.py -q`

------
https://chatgpt.com/codex/tasks/task_e_688415e174c48333ba93f3e6dfa4b638