### PR TITLE
Update codex setup and docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,8 +29,8 @@ Fix the script and rerun it offline to finish provisioning:
    `--minimal` variant) and verifies key packages such as `pytest-bdd` are
    available.
 2. Run `bash scripts/codex_setup.sh` (without network access) until it completes
-   without errors, then confirm with `poetry run pip list` that packages like
-   `pytest-bdd` appear.
+   without errors. After it finishes, verify the installation by running
+   `poetry run pip list | grep pytest-bdd`.
 3. Remove the failure marker with `rm CODEX_ENVIRONMENT_SETUP_FAILED`.
 4. Execute `poetry run pytest` to verify the environment.
 

--- a/scripts/codex_setup.sh
+++ b/scripts/codex_setup.sh
@@ -8,13 +8,7 @@ poetry env use "$(command -v python3.12 || command -v python3.11)"
 # fast. Add the `offline` extra manually if GPU features are needed.
 poetry install \
   --with dev,docs \
-  --extras minimal \
-  --extras retrieval \
-  --extras memory \
-  --extras llm \
-  --extras api \
-  --extras webui \
-  --extras lmstudio \
+  --all-extras \
   --no-interaction
 
 # Verify key packages are present


### PR DESCRIPTION
## Summary
- simplify installation in `scripts/codex_setup.sh` using `--all-extras`
- clarify environment setup verification in `AGENTS.md`

## Testing
- `bash scripts/codex_setup.sh`
- `poetry run pip list | grep pytest-bdd`
- `poetry run pytest tests/unit --maxfail=1 -q`

------
https://chatgpt.com/codex/tasks/task_e_68842099babc8333bfae234b3f335563