### PR TITLE
Fix wizard tests and kuzu init

### DIFF
--- a/src/devsynth/adapters/memory/kuzu_adapter.py
+++ b/src/devsynth/adapters/memory/kuzu_adapter.py
@@ -34,7 +34,11 @@ class KuzuAdapter(VectorStore):
     ) -> None:
         self.persist_directory = os.path.expanduser(persist_directory)
         self.collection_name = collection_name
+        # Ensure the directory exists even when ``ensure_path_exists`` is
+        # patched to no-op during tests.  ``os.makedirs`` is safe to call on an
+        # existing path and avoids failures when persisting vectors.
         ensure_path_exists(self.persist_directory)
+        os.makedirs(self.persist_directory, exist_ok=True)
         self._data_file = os.path.join(
             self.persist_directory, f"{collection_name}.json"
         )

--- a/tests/behavior/steps/test_interactive_init_wizard_steps.py
+++ b/tests/behavior/steps/test_interactive_init_wizard_steps.py
@@ -68,7 +68,9 @@ def run_wizard(tmp_project_dir, monkeypatch):
         True,  # proceed
     ]
     bridge = DummyBridge(answers, confirms)
-    init_cmd(bridge=bridge)
+    # Pass an empty features dict so the wizard prompts for each feature
+    # allowing our ``DummyBridge`` confirmations to be used.
+    init_cmd(bridge=bridge, features={})
 
 
 @then("a project configuration file should include the selected options")


### PR DESCRIPTION
## Summary
- ensure KuzuAdapter creates its directory
- prompt for feature selections in interactive init wizard tests
- verify wizard scenarios and kuzu adapter unit tests

## Testing
- `poetry run pytest tests/behavior/steps/test_interactive_init_wizard_steps.py tests/unit/general/test_kuzu_adapter.py tests/unit/general/test_memory_system_with_kuzu.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68842740792483339ee2cea307385b1e