### PR TITLE
Enable LLM generation in agents

### DIFF
--- a/src/devsynth/application/agents/code.py
+++ b/src/devsynth/application/agents/code.py
@@ -38,9 +38,8 @@ class CodeAgent(BaseAgent):
         Implement code that passes the tests and meets the specifications.
         """
 
-        # In a real implementation, this would call the LLM through a port
-        # For now, we'll just return a placeholder
-        code = f"Code (created by {self.name} as {self.current_role})"
+        # Generate the code using the LLM port
+        code = self.generate_text(prompt)
 
         # Create a WSDE with the code
         code_wsde = None

--- a/src/devsynth/application/agents/diagram.py
+++ b/src/devsynth/application/agents/diagram.py
@@ -45,9 +45,8 @@ class DiagramAgent(BaseAgent):
         Use mermaid or PlantUML syntax for the diagrams.
         """
 
-        # In a real implementation, this would call the LLM through a port
-        # For now, we'll just return a placeholder
-        diagrams = f"Diagrams (created by {self.name} as {self.current_role})"
+        # Generate the diagrams using the LLM port
+        diagrams = self.generate_text(prompt)
 
         # Create a WSDE with the diagrams
         diagram_wsde = None

--- a/src/devsynth/application/agents/documentation.py
+++ b/src/devsynth/application/agents/documentation.py
@@ -44,9 +44,8 @@ class DocumentationAgent(BaseAgent):
         6. Troubleshooting
         """
 
-        # In a real implementation, this would call the LLM through a port
-        # For now, we'll just return a placeholder
-        documentation = f"Documentation (created by {self.name} as {self.current_role})"
+        # Generate the documentation using the LLM port
+        documentation = self.generate_text(prompt)
 
         # Create a WSDE with the documentation
         doc_wsde = None

--- a/src/devsynth/application/agents/planner.py
+++ b/src/devsynth/application/agents/planner.py
@@ -41,9 +41,8 @@ class PlannerAgent(BaseAgent):
         6. Deployment plan
         """
 
-        # In a real implementation, this would call the LLM through a port
-        # For now, we'll just return a placeholder
-        plan = f"Development Plan (created by {self.name} as {self.current_role})"
+        # Generate the plan using the LLM port
+        plan = self.generate_text(prompt)
 
         # Create a WSDE with the plan
         plan_wsde = None

--- a/src/devsynth/application/agents/refactor.py
+++ b/src/devsynth/application/agents/refactor.py
@@ -45,10 +45,11 @@ class RefactorAgent(BaseAgent):
         Provide a detailed explanation of the changes made.
         """
 
-        # In a real implementation, this would call the LLM through a port
-        # For now, we'll just return a placeholder
-        refactored_code = f"Refactored Code (created by {self.name} as {self.current_role})"
-        refactor_explanation = f"Refactor Explanation (created by {self.name} as {self.current_role})"
+        # Generate the refactored code and explanation using the LLM port
+        refactored_code = self.generate_text(prompt)
+        refactor_explanation = self.generate_text(
+            f"{prompt}\nProvide an explanation of the refactoring decisions."
+        )
 
         # Create WSDEs with the refactored code and explanation
         code_wsde = None

--- a/src/devsynth/application/agents/specification.py
+++ b/src/devsynth/application/agents/specification.py
@@ -44,9 +44,8 @@ class SpecificationAgent(BaseAgent):
         6. Integration points
         """
         
-        # In a real implementation, this would call the LLM through a port
-        # For now, we'll just return a placeholder
-        specifications = f"Specifications (created by {self.name} as {self.current_role})"
+        # Generate the specifications using the LLM port
+        specifications = self.generate_text(prompt)
         
         # Create a WSDE with the specifications
         spec_wsde = self.create_wsde(

--- a/src/devsynth/application/agents/test.py
+++ b/src/devsynth/application/agents/test.py
@@ -43,9 +43,8 @@ class TestAgent(BaseAgent):
         5. Security tests
         """
 
-        # In a real implementation, this would call the LLM through a port
-        # For now, we'll just return a placeholder
-        tests = f"Tests (created by {self.name} as {self.current_role})"
+        # Generate the tests using the LLM port
+        tests = self.generate_text(prompt)
 
         # Create a WSDE with the tests
         test_wsde = None

--- a/src/devsynth/application/agents/validation.py
+++ b/src/devsynth/application/agents/validation.py
@@ -42,9 +42,11 @@ class ValidationAgent(BaseAgent):
         Provide a detailed validation report.
         """
         
-        # In a real implementation, this would call the LLM through a port
-        # For now, we'll just return a placeholder
-        validation_report = f"Validation Report (created by {self.name} as {self.current_role})"
+        # Generate the validation report using the LLM port
+        validation_report = self.generate_text(prompt)
+
+        # Determine if the code is valid based on the report
+        is_valid = "fail" not in validation_report.lower()
         
         # Create a WSDE with the validation report
         validation_wsde = self.create_wsde(
@@ -62,7 +64,7 @@ class ValidationAgent(BaseAgent):
             "wsde": validation_wsde,
             "agent": self.name,
             "role": self.current_role,
-            "is_valid": True  # Placeholder
+            "is_valid": is_valid,
         }
     
     def get_capabilities(self) -> List[str]:

--- a/tests/unit/application/agents/test_code_agent.py
+++ b/tests/unit/application/agents/test_code_agent.py
@@ -52,12 +52,14 @@ ReqID: N/A"""
             'Implement a function that adds two numbers', 'tests':
             'def test_add(): assert add(1, 2) == 3'}
         result = code_agent.process(inputs)
+        code_agent.llm_port.generate.assert_called_once()
         assert 'code' in result
         assert 'wsde' in result
         assert 'agent' in result
         assert 'role' in result
         assert result['agent'] == 'TestCodeAgent'
         wsde = result['wsde']
+        assert result['code'] == 'Generated code'
         assert wsde.content == result['code']
         assert wsde.content_type == 'code'
         assert wsde.metadata['agent'] == 'TestCodeAgent'
@@ -68,6 +70,7 @@ ReqID: N/A"""
 
 ReqID: N/A"""
         result = code_agent.process({})
+        code_agent.llm_port.generate.assert_called()
         assert 'code' in result
         assert 'wsde' in result
         assert 'agent' in result

--- a/tests/unit/application/agents/test_diagram_agent.py
+++ b/tests/unit/application/agents/test_diagram_agent.py
@@ -52,12 +52,14 @@ ReqID: N/A"""
             'Create diagrams for a user authentication system',
             'architecture': 'Microservices architecture'}
         result = diagram_agent.process(inputs)
+        diagram_agent.llm_port.generate.assert_called_once()
         assert 'diagrams' in result
         assert 'wsde' in result
         assert 'agent' in result
         assert 'role' in result
         assert result['agent'] == 'TestDiagramAgent'
         wsde = result['wsde']
+        assert result['diagrams'] == 'Generated diagrams'
         assert wsde.content == result['diagrams']
         assert wsde.content_type == 'diagram'
         assert wsde.metadata['agent'] == 'TestDiagramAgent'
@@ -68,6 +70,7 @@ ReqID: N/A"""
 
 ReqID: N/A"""
         result = diagram_agent.process({})
+        diagram_agent.llm_port.generate.assert_called()
         assert 'diagrams' in result
         assert 'wsde' in result
         assert 'agent' in result

--- a/tests/unit/application/agents/test_documentation_agent.py
+++ b/tests/unit/application/agents/test_documentation_agent.py
@@ -53,12 +53,14 @@ ReqID: N/A"""
             'Create documentation for a user authentication system', 'code':
             'def authenticate(username, password): return True'}
         result = documentation_agent.process(inputs)
+        documentation_agent.llm_port.generate.assert_called_once()
         assert 'documentation' in result
         assert 'wsde' in result
         assert 'agent' in result
         assert 'role' in result
         assert result['agent'] == 'TestDocumentationAgent'
         wsde = result['wsde']
+        assert result['documentation'] == 'Generated documentation'
         assert wsde.content == result['documentation']
         assert wsde.content_type == 'text'
         assert wsde.metadata['agent'] == 'TestDocumentationAgent'
@@ -69,6 +71,7 @@ ReqID: N/A"""
 
 ReqID: N/A"""
         result = documentation_agent.process({})
+        documentation_agent.llm_port.generate.assert_called()
         assert 'documentation' in result
         assert 'wsde' in result
         assert 'agent' in result

--- a/tests/unit/application/agents/test_planner_agent.py
+++ b/tests/unit/application/agents/test_planner_agent.py
@@ -51,12 +51,14 @@ ReqID: N/A"""
         inputs = {'context': 'This is a test project', 'requirements':
             'Create a user authentication system'}
         result = planner_agent.process(inputs)
+        planner_agent.llm_port.generate.assert_called_once()
         assert 'plan' in result
         assert 'wsde' in result
         assert 'agent' in result
         assert 'role' in result
         assert result['agent'] == 'TestPlannerAgent'
         wsde = result['wsde']
+        assert result['plan'] == 'Generated development plan'
         assert wsde.content == result['plan']
         assert wsde.content_type == 'text'
         assert wsde.metadata['agent'] == 'TestPlannerAgent'
@@ -67,6 +69,7 @@ ReqID: N/A"""
 
 ReqID: N/A"""
         result = planner_agent.process({})
+        planner_agent.llm_port.generate.assert_called()
         assert 'plan' in result
         assert 'wsde' in result
         assert 'agent' in result

--- a/tests/unit/application/agents/test_refactor_agent.py
+++ b/tests/unit/application/agents/test_refactor_agent.py
@@ -53,6 +53,8 @@ ReqID: N/A"""
             'def add(a, b): return a + b', 'validation_report':
             'The code is functional but could be improved'}
         result = refactor_agent.process(inputs)
+        assert refactor_agent.llm_port.generate.call_count == 2
+        assert result['refactored_code'] == 'Generated refactored code'
         assert 'refactored_code' in result
         assert 'explanation' in result
         assert 'code_wsde' in result
@@ -76,6 +78,8 @@ ReqID: N/A"""
 
 ReqID: N/A"""
         result = refactor_agent.process({})
+        assert refactor_agent.llm_port.generate.call_count >= 2
+        assert result['refactored_code'] == 'Generated refactored code'
         assert 'refactored_code' in result
         assert 'explanation' in result
         assert 'code_wsde' in result

--- a/tests/unit/application/agents/test_specification_agent.py
+++ b/tests/unit/application/agents/test_specification_agent.py
@@ -1,0 +1,49 @@
+import pytest
+from unittest.mock import MagicMock, patch
+from devsynth.application.agents.specification import SpecificationAgent
+from devsynth.domain.models.agent import AgentConfig, AgentType
+from devsynth.ports.llm_port import LLMPort
+
+
+class TestSpecificationAgent:
+    @pytest.fixture
+    def mock_llm_port(self):
+        port = MagicMock(spec=LLMPort)
+        port.generate.return_value = "Generated specifications"
+        port.generate_with_context.return_value = "Generated specifications with context"
+        return port
+
+    @pytest.fixture
+    def specification_agent(self, mock_llm_port):
+        agent = SpecificationAgent()
+        config = AgentConfig(
+            name="TestSpecificationAgent",
+            agent_type=AgentType.SPECIFICATION,
+            description="Test Specification Agent",
+            capabilities=[],
+        )
+        agent.initialize(config)
+        agent.set_llm_port(mock_llm_port)
+        return agent
+
+    def test_process_succeeds(self, specification_agent):
+        inputs = {"context": "ctx", "requirements": "reqs"}
+        result = specification_agent.process(inputs)
+        specification_agent.llm_port.generate.assert_called_once()
+        assert result["specifications"] == "Generated specifications"
+        wsde = result["wsde"]
+        assert wsde.content == result["specifications"]
+        assert wsde.content_type == "text"
+        assert wsde.metadata["agent"] == "TestSpecificationAgent"
+        assert wsde.metadata["type"] == "specifications"
+
+    def test_get_capabilities_with_custom_capabilities_succeeds(self):
+        agent = SpecificationAgent()
+        config = AgentConfig(
+            name="TestSpecificationAgent",
+            agent_type=AgentType.SPECIFICATION,
+            description="Test",
+            capabilities=["custom"],
+        )
+        agent.initialize(config)
+        assert agent.get_capabilities() == ["custom"]

--- a/tests/unit/application/agents/test_test_agent.py
+++ b/tests/unit/application/agents/test_test_agent.py
@@ -45,10 +45,12 @@ class TestTestAgent:
             "specifications": "Do something",
         }
         result = test_agent.process(inputs)
+        test_agent.llm_port.generate.assert_called_once()
         assert "tests" in result
         assert "wsde" in result
         assert result["agent"] == "TestTestAgent"
         wsde = result["wsde"]
+        assert result["tests"] == "Generated tests"
         assert wsde.content == result["tests"]
         assert wsde.content_type == "text"
         assert wsde.metadata["agent"] == "TestTestAgent"

--- a/tests/unit/application/agents/test_validation_agent.py
+++ b/tests/unit/application/agents/test_validation_agent.py
@@ -1,0 +1,44 @@
+import pytest
+from unittest.mock import MagicMock
+from devsynth.application.agents.validation import ValidationAgent
+from devsynth.domain.models.agent import AgentConfig, AgentType
+from devsynth.ports.llm_port import LLMPort
+
+
+class TestValidationAgent:
+    @pytest.fixture
+    def mock_llm_port(self):
+        port = MagicMock(spec=LLMPort)
+        port.generate.return_value = "All tests pass"
+        port.generate_with_context.return_value = "All tests pass"
+        return port
+
+    @pytest.fixture
+    def validation_agent(self, mock_llm_port):
+        agent = ValidationAgent()
+        config = AgentConfig(
+            name="TestValidationAgent",
+            agent_type=AgentType.VALIDATION,
+            description="Test Validation Agent",
+            capabilities=[],
+        )
+        agent.initialize(config)
+        agent.set_llm_port(mock_llm_port)
+        return agent
+
+    def test_process_succeeds(self, validation_agent):
+        inputs = {
+            "context": "ctx",
+            "specifications": "spec",
+            "tests": "tests",
+            "code": "code",
+        }
+        result = validation_agent.process(inputs)
+        validation_agent.llm_port.generate.assert_called_once()
+        assert result["validation_report"] == "All tests pass"
+        assert result["is_valid"] is True
+        wsde = result["wsde"]
+        assert wsde.content == result["validation_report"]
+        assert wsde.content_type == "text"
+        assert wsde.metadata["agent"] == "TestValidationAgent"
+        assert wsde.metadata["type"] == "validation_report"


### PR DESCRIPTION
## Summary
- call `generate_text` in application agents instead of placeholder strings
- compute validity heuristics in `ValidationAgent`
- update agent unit tests to expect LLM calls
- add tests for SpecificationAgent and ValidationAgent

## Testing
- `poetry run pytest -q` *(fails: StepDefinitionNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_6884345f73548333be57b88517eb5b51