### PR TITLE
Implement query router search patterns

### DIFF
--- a/src/devsynth/application/memory/__init__.py
+++ b/src/devsynth/application/memory/__init__.py
@@ -11,6 +11,7 @@ from devsynth.logging_setup import DevSynthLogger
 from .context_manager import InMemoryStore, SimpleContextManager
 from .json_file_store import JSONFileStore
 from .memory_manager import MemoryManager
+from .search_patterns import SearchPatterns
 from .persistent_context_manager import PersistentContextManager
 from .multi_layered_memory import MultiLayeredMemorySystem
 
@@ -42,6 +43,7 @@ __all__ = [
     "JSONFileStore",
     "PersistentContextManager",
     "MemoryManager",
+    "SearchPatterns",
     "MultiLayeredMemorySystem",
 ]
 

--- a/src/devsynth/application/memory/search_patterns.py
+++ b/src/devsynth/application/memory/search_patterns.py
@@ -1,0 +1,28 @@
+"""High level search helpers for the hybrid memory system."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List
+
+from .memory_manager import MemoryManager
+from .query_router import QueryRouter
+
+
+class SearchPatterns:
+    """Provide convenience methods for common search patterns."""
+
+    def __init__(self, manager: MemoryManager) -> None:
+        self.manager = manager
+        self.router = QueryRouter(manager)
+
+    def direct_search(self, query: str, store: str) -> List[Any]:
+        """Search a single store directly."""
+        return self.router.direct_query(query, store)
+
+    def cross_store_search(self, query: str) -> Dict[str, List[Any]]:
+        """Search all configured stores and return grouped results."""
+        return self.router.cross_store_query(query)
+
+    def federated_search(self, query: str) -> List[Any]:
+        """Search all stores and return a ranked, aggregated list."""
+        return self.router.federated_query(query)

--- a/tests/integration/general/test_query_router_integration.py
+++ b/tests/integration/general/test_query_router_integration.py
@@ -1,0 +1,56 @@
+import pytest
+
+from devsynth.application.memory.memory_manager import MemoryManager
+from devsynth.application.memory.context_manager import InMemoryStore
+from devsynth.application.memory.adapters.vector_memory_adapter import (
+    VectorMemoryAdapter,
+)
+from devsynth.domain.models.memory import MemoryItem, MemoryType, MemoryVector
+
+
+class TestQueryRouterIntegration:
+    @pytest.fixture
+    def manager(self):
+        adapters = {
+            "vector": VectorMemoryAdapter(),
+            "tinydb": InMemoryStore(),
+            "document": InMemoryStore(),
+        }
+        return MemoryManager(adapters=adapters)
+
+    def _populate(self, manager: MemoryManager):
+        vec = MemoryVector(
+            id="v1",
+            content="apple vector",
+            embedding=manager._embed_text("apple vector"),
+            metadata={"memory_type": MemoryType.CODE.value},
+        )
+        manager.adapters["vector"].store_vector(vec)
+        manager.adapters["tinydb"].store(
+            MemoryItem(id="t1", content="apple tinydb", memory_type=MemoryType.CODE)
+        )
+        manager.adapters["document"].store(
+            MemoryItem(id="d1", content="apple document", memory_type=MemoryType.CODE)
+        )
+
+    def test_direct_query(self, manager):
+        self._populate(manager)
+        results = manager.route_query("apple", store="vector", strategy="direct")
+        assert len(results) == 1
+        assert results[0].content == "apple vector"
+        assert results[0].metadata.get("source_store") == "vector"
+
+    def test_cross_store_query(self, manager):
+        self._populate(manager)
+        results = manager.route_query("apple", strategy="cross")
+        assert set(results.keys()) >= {"vector", "tinydb", "document"}
+        for store, items in results.items():
+            for item in items:
+                assert item.metadata.get("source_store") == store
+
+    def test_federated_query(self, manager):
+        self._populate(manager)
+        results = manager.route_query("apple", strategy="federated")
+        assert len(results) == 3
+        stores = {item.metadata.get("source_store") for item in results}
+        assert stores == {"vector", "tinydb", "document"}


### PR DESCRIPTION
## Summary
- extend memory query router with metadata tagging, deduplication, and ranking
- add `SearchPatterns` helper for common search strategies
- expose search helpers from `devsynth.application.memory`
- add integration tests for direct, cross-store, and federated queries

## Testing
- `poetry run pytest tests/integration/general/test_query_router_integration.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68843a5e4d248333a98ccd2c5e62aea5