### PR TITLE
Fix docs referencing codex_setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,9 +185,9 @@ The repository includes runnable examples that walk through common workflows:
 
 Always execute tests with `poetry run pytest`. Invoking plain `pytest`
 may fail because required plugins are installed only in the Poetry
-virtual environment. If you have not provisioned the environment yet,
-run `bash scripts/codex_setup.sh` to install all dependencies before
-running the tests.
+virtual environment. Environment provisioning is handled automatically
+in Codex environments. For manual setups, run `poetry install` to
+install all dependencies before running the tests.
 
 Before running the test suite manually, you **must** install DevSynth with its development extras:
 
@@ -237,8 +237,8 @@ After installation, execute the tests with:
 ```bash
 poetry run pytest
 ```
-If `pytest` reports missing packages, re-run `bash scripts/codex_setup.sh`
-or `poetry install` to ensure all dependencies are installed.
+If `pytest` reports missing packages, run `poetry install` to ensure all
+dependencies are installed.
 
 You can also use the helper script `scripts/run_all_tests.py` to run the entire
 suite or specific groups of tests and optionally generate an HTML report:

--- a/docs/developer_guides/testing.md
+++ b/docs/developer_guides/testing.md
@@ -264,7 +264,7 @@ The ChromaDB tests use fixtures for isolation and provider integration:
 
 ## Running Tests
 
-Before executing tests, install DevSynth with its development extras so that all test dependencies are available. Run `bash scripts/codex_setup.sh` first if the environment has not been provisioned.
+Before executing tests, install DevSynth with its development extras so that all test dependencies are available. Environment provisioning is handled automatically in Codex environments. For manual setups run `poetry install`.
 
 ```bash
 poetry install --with dev,docs
@@ -277,7 +277,7 @@ poetry run pytest -q
 # pip commands are for installing from PyPI only
 
 ```
-Always run tests with `poetry run pytest`. If `pytest` reports missing packages, re-run `bash scripts/codex_setup.sh` or `poetry install` to restore them.
+Always run tests with `poetry run pytest`. If `pytest` reports missing packages, run `poetry install` to restore them.
 
 ## Running All Tests
 


### PR DESCRIPTION
## Summary
- remove `codex_setup.sh` references
- clarify that Codex environments are provisioned automatically and to use `poetry install` for manual setup

## Testing
- `poetry run pytest -q` *(fails: ModuleNotFoundError: devsynth.application.memory.chromadb_store)*

------
https://chatgpt.com/codex/tasks/task_e_688449f82be08333a99aff61f609f667