### PR TITLE
Expose workflow_manager singleton

### DIFF
--- a/src/devsynth/core/__init__.py
+++ b/src/devsynth/core/__init__.py
@@ -17,6 +17,7 @@ from .workflows import (
     inspect_requirements,
     run_pipeline,
     update_config,
+    workflow_manager,
 )
 
 __all__ = [
@@ -33,6 +34,7 @@ __all__ = [
     "update_config",
     "inspect_requirements",
     "execute_command",
+    "workflow_manager",
     "CoreValues",
     "check_report_for_value_conflicts",
     "find_value_conflicts",

--- a/src/devsynth/core/workflows.py
+++ b/src/devsynth/core/workflows.py
@@ -16,6 +16,10 @@ def _get_workflow_manager():
     return workflow_manager
 
 
+# Expose the singleton so it can be imported directly from this module
+workflow_manager = _get_workflow_manager()
+
+
 def execute_command(command: str, args: Dict[str, Any]) -> Dict[str, Any]:
     """Execute a workflow command through the application workflow manager."""
     return _get_workflow_manager().execute_command(command, args)
@@ -46,7 +50,9 @@ def generate_code() -> Dict[str, Any]:
     return execute_command("code", {})
 
 
-def run_pipeline(target: str | None = None, report: Dict[str, Any] | None = None) -> Dict[str, Any]:
+def run_pipeline(
+    target: str | None = None, report: Dict[str, Any] | None = None
+) -> Dict[str, Any]:
     """Execute the generated code or a specific target.
 
     Parameters

--- a/tests/unit/general/test_core_workflows.py
+++ b/tests/unit/general/test_core_workflows.py
@@ -7,42 +7,68 @@ from devsynth.core import workflows
 def test_filter_args_removes_none_values_succeeds():
     """Test that filter args removes none values succeeds.
 
-ReqID: N/A"""
-    assert workflows.filter_args({'a': 1, 'b': None, 'c': 0}) == {'a': 1,
-        'c': 0}
+    ReqID: N/A"""
+    assert workflows.filter_args({"a": 1, "b": None, "c": 0}) == {"a": 1, "c": 0}
 
 
-@pytest.mark.parametrize('func,command,kwargs,expected', [(workflows.
-    init_project, 'init', {'path': 'p'}, {'path': 'p'}), (workflows.
-    generate_specs, 'spec', {'requirements_file': 'req.md'}, {
-    'requirements_file': 'req.md'}), (workflows.generate_tests, 'test', {
-    'spec_file': 'spec.md'}, {'spec_file': 'spec.md'}), (workflows.
-    generate_code, 'code', {}, {}), (workflows.run_pipeline, 'run-pipeline',
-    {'target': 'build', 'report': None}, {'target': 'build'}), (workflows.
-    update_config, 'config', {'key': 'model', 'value': 'gpt-4'}, {'key':
-    'model', 'value': 'gpt-4'}), (workflows.update_config, 'config', {'key':
-    'model', 'value': None, 'list_models': True}, {'key': 'model',
-    'list_models': True}), (workflows.
-    inspect_requirements, 'inspect', {'input': 'requirements.txt',
-    'interactive': False}, {'input': 'requirements.txt', 'interactive': 
-    False})])
-def test_wrappers_call_execute_command_succeeds(func, command, kwargs, expected
-    ):
+@pytest.mark.parametrize(
+    "func,command,kwargs,expected",
+    [
+        (workflows.init_project, "init", {"path": "p"}, {"path": "p"}),
+        (
+            workflows.generate_specs,
+            "spec",
+            {"requirements_file": "req.md"},
+            {"requirements_file": "req.md"},
+        ),
+        (
+            workflows.generate_tests,
+            "test",
+            {"spec_file": "spec.md"},
+            {"spec_file": "spec.md"},
+        ),
+        (workflows.generate_code, "code", {}, {}),
+        (
+            workflows.run_pipeline,
+            "run-pipeline",
+            {"target": "build", "report": None},
+            {"target": "build"},
+        ),
+        (
+            workflows.update_config,
+            "config",
+            {"key": "model", "value": "gpt-4"},
+            {"key": "model", "value": "gpt-4"},
+        ),
+        (
+            workflows.update_config,
+            "config",
+            {"key": "model", "value": None, "list_models": True},
+            {"key": "model", "list_models": True},
+        ),
+        (
+            workflows.inspect_requirements,
+            "inspect",
+            {"input": "requirements.txt", "interactive": False},
+            {"input": "requirements.txt", "interactive": False},
+        ),
+    ],
+)
+def test_wrappers_call_execute_command_succeeds(func, command, kwargs, expected):
     """Test that wrappers call execute command succeeds.
 
-ReqID: N/A"""
-    with patch('devsynth.core.workflows.execute_command') as mock:
-        mock.return_value = {'success': True}
+    ReqID: N/A"""
+    with patch("devsynth.core.workflows.execute_command") as mock:
+        mock.return_value = {"success": True}
         result = func(**kwargs)
         mock.assert_called_once_with(command, expected)
-        assert result == {'success': True}
+        assert result == {"success": True}
 
 
 def test_gather_requirements_creates_file_succeeds(tmp_path):
     """Test that gather requirements creates file succeeds.
 
-ReqID: N/A"""
-
+    ReqID: N/A"""
 
     class Bridge:
 
@@ -50,7 +76,7 @@ ReqID: N/A"""
             self.i = 0
 
         def prompt(self, *args, **kwargs):
-            responses = ['goal1', 'constraint1', 'high']
+            responses = ["goal1", "constraint1", "high"]
             res = responses[self.i]
             self.i += 1
             return res
@@ -60,8 +86,19 @@ ReqID: N/A"""
 
         def display_result(self, *a, **k):
             pass
-    output = tmp_path / 'req.json'
+
+    output = tmp_path / "req.json"
     workflows.gather_requirements(Bridge(), output_file=str(output))
     assert output.exists()
     data = json.load(open(output))
-    assert data['priority'] == 'high'
+    assert data["priority"] == "high"
+
+
+def test_workflow_manager_singleton_succeeds():
+    """``workflow_manager`` should reference the application singleton."""
+    from devsynth.application.orchestration.workflow import (
+        workflow_manager as app_manager,
+    )
+    from devsynth.core.workflows import workflow_manager as core_manager
+
+    assert core_manager is app_manager


### PR DESCRIPTION
## Summary
- expose `workflow_manager` from `devsynth.core.workflows`
- re-export `workflow_manager` through `devsynth.core`
- test that the core workflow manager is the application singleton

## Testing
- `poetry run pytest tests/unit/general/test_core_workflows.py::test_workflow_manager_singleton_succeeds -q`
- `poetry run pytest tests/unit/general/test_core_workflows.py -q`


------
https://chatgpt.com/codex/tasks/task_e_688449e74bfc8333ad508d35240a81e5