### PR TITLE
Add tests for offline provider and metrics CLI

### DIFF
--- a/tests/unit/application/cli/test_metrics_commands.py
+++ b/tests/unit/application/cli/test_metrics_commands.py
@@ -1,0 +1,130 @@
+from __future__ import annotations
+
+import types
+from contextlib import contextmanager
+from pathlib import Path
+
+import importlib.util
+import importlib
+
+align_mod = importlib.import_module(
+    "devsynth.application.cli.commands.alignment_metrics_cmd"
+)
+test_mod = importlib.import_module(
+    "devsynth.application.cli.commands.test_metrics_cmd"
+)
+
+
+def _dummy_progress(*args, **kwargs):
+    @contextmanager
+    def _cm():
+        class Dummy:
+            def update(self, **_):
+                pass
+
+        yield Dummy()
+
+    return _cm()
+
+
+def test_alignment_metrics_cmd_success(monkeypatch, tmp_path):
+    metrics_path = tmp_path / "metrics.json"
+    report_path = tmp_path / "report.md"
+    monkeypatch.setattr(
+        align_mod,
+        "bridge",
+        types.SimpleNamespace(
+            print=lambda *a, **k: None, create_progress=_dummy_progress
+        ),
+    )
+    monkeypatch.setattr(align_mod, "get_all_files", lambda p: ["a.txt"])
+    monkeypatch.setattr(align_mod, "calculate_alignment_coverage", lambda f: {"cov": 1})
+    monkeypatch.setattr(
+        align_mod,
+        "calculate_alignment_issues",
+        lambda f: {
+            "total_issues": 0,
+            "high_severity": 0,
+            "medium_severity": 0,
+            "low_severity": 0,
+        },
+    )
+    monkeypatch.setattr(align_mod, "load_historical_metrics", lambda f: [])
+    saved = {}
+    monkeypatch.setattr(align_mod, "save_metrics", lambda m, f, h: saved.update(m))
+    monkeypatch.setattr(align_mod, "display_metrics", lambda m, h: None)
+    monkeypatch.setattr(
+        align_mod, "generate_metrics_report", lambda m, h, o: Path(o).write_text("ok")
+    )
+
+    assert align_mod.alignment_metrics_cmd(
+        path=str(tmp_path), metrics_file=str(metrics_path), output=str(report_path)
+    )
+    assert saved["cov"] == 1
+    assert report_path.read_text() == "ok"
+
+
+def test_alignment_metrics_cmd_failure(monkeypatch):
+    outputs = []
+    monkeypatch.setattr(
+        align_mod,
+        "bridge",
+        types.SimpleNamespace(
+            print=lambda m: outputs.append(m), create_progress=_dummy_progress
+        ),
+    )
+    monkeypatch.setattr(
+        align_mod,
+        "get_all_files",
+        lambda p: (_ for _ in ()).throw(RuntimeError("boom")),
+    )
+    assert align_mod.alignment_metrics_cmd(path=".") is False
+    assert any("Error collecting alignment metrics" in o for o in outputs)
+
+
+def _dummy_console():
+    return types.SimpleNamespace(status=lambda *a, **k: _dummy_progress())
+
+
+def test_test_metrics_cmd_writes_report(monkeypatch, tmp_path):
+    out_file = tmp_path / "rep.md"
+    prints = []
+    monkeypatch.setattr(
+        test_mod, "bridge", types.SimpleNamespace(print=lambda m: prints.append(m))
+    )
+    monkeypatch.setattr(test_mod, "Console", _dummy_console)
+    monkeypatch.setattr(test_mod, "get_commit_history", lambda d: [{}])
+    monkeypatch.setattr(
+        test_mod,
+        "calculate_metrics",
+        lambda c: {
+            "total_commits": 1,
+            "test_first_commits": 1,
+            "code_first_commits": 0,
+            "mixed_commits": 0,
+            "test_first_ratio": 1.0,
+            "code_first_ratio": 0.0,
+            "mixed_ratio": 0.0,
+            "test_files_count": 0,
+            "code_files_count": 0,
+            "test_to_code_ratio": 0.0,
+            "recent_test_first_commits": [],
+            "recent_code_first_commits": [],
+        },
+    )
+    monkeypatch.setattr(test_mod, "generate_metrics_report", lambda m: "report")
+
+    test_mod.test_metrics_cmd(days=1, output_file=str(out_file))
+    assert out_file.read_text() == "report"
+    assert any("Metrics report written to" in str(p) for p in prints)
+
+
+def test_test_metrics_cmd_no_commits(monkeypatch):
+    prints = []
+    monkeypatch.setattr(
+        test_mod, "bridge", types.SimpleNamespace(print=lambda m: prints.append(m))
+    )
+    monkeypatch.setattr(test_mod, "Console", _dummy_console)
+    monkeypatch.setattr(test_mod, "get_commit_history", lambda d: [])
+    test_mod.test_metrics_cmd(days=1)
+    assert any("No commits" in str(p) for p in prints)

--- a/tests/unit/application/llm/test_offline_provider_deps.py
+++ b/tests/unit/application/llm/test_offline_provider_deps.py
@@ -1,0 +1,73 @@
+import importlib
+import importlib.util
+import sys
+import types
+import builtins
+from contextlib import contextmanager
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[4]
+spec = importlib.util.spec_from_file_location(
+    "devsynth.application.llm.offline_provider",
+    ROOT / "src/devsynth/application/llm/offline_provider.py",
+)
+offline_provider = importlib.util.module_from_spec(spec)
+sys.modules[spec.name] = offline_provider
+spec.loader.exec_module(offline_provider)
+
+
+def _reload_provider():
+    importlib.reload(offline_provider)
+
+
+def test_load_transformer_deps_imports_when_available(monkeypatch):
+    _reload_provider()
+    dummy_torch = types.SimpleNamespace(
+        no_grad=lambda: contextmanager(lambda: (yield None))()
+    )
+    dummy_trans = types.SimpleNamespace(
+        AutoModelForCausalLM="Model", AutoTokenizer="Tok"
+    )
+    monkeypatch.setitem(sys.modules, "torch", dummy_torch)
+    monkeypatch.setitem(sys.modules, "transformers", dummy_trans)
+    offline_provider.torch = None
+    offline_provider.AutoModelForCausalLM = None
+    offline_provider.AutoTokenizer = None
+    offline_provider._load_transformer_deps()
+    assert offline_provider.torch is dummy_torch
+    assert offline_provider.AutoModelForCausalLM == "Model"
+    assert offline_provider.AutoTokenizer == "Tok"
+
+
+def test_load_transformer_deps_noop_when_already_loaded(monkeypatch):
+    _reload_provider()
+    sentinel = object()
+    offline_provider.torch = sentinel
+    offline_provider.AutoModelForCausalLM = sentinel
+    offline_provider.AutoTokenizer = sentinel
+    offline_provider._load_transformer_deps()
+    assert offline_provider.torch is sentinel
+    assert offline_provider.AutoModelForCausalLM is sentinel
+    assert offline_provider.AutoTokenizer is sentinel
+
+
+def test_load_transformer_deps_handles_import_error(monkeypatch):
+    _reload_provider()
+    offline_provider.torch = None
+    offline_provider.AutoModelForCausalLM = None
+    offline_provider.AutoTokenizer = None
+    orig_import = builtins.__import__
+
+    def fake_import(name, globals=None, locals=None, fromlist=(), level=0):
+        if name in {"torch", "transformers"}:
+            raise ImportError("missing")
+        return orig_import(name, globals, locals, fromlist, level)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+    offline_provider._load_transformer_deps()
+    assert offline_provider.torch is None
+    assert offline_provider.AutoModelForCausalLM is None
+    assert offline_provider.AutoTokenizer is None
+    monkeypatch.setattr(builtins, "__import__", orig_import)


### PR DESCRIPTION
## Summary
- add tests for `_load_transformer_deps` logic
- cover alignment_metrics and test_metrics CLI commands

## Testing
- `poetry run pytest tests/unit/application/llm/test_offline_provider_deps.py tests/unit/application/cli/test_metrics_commands.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68844a2b25588333816ca181443e5abc