### PR TITLE
Fix step imports and add unit tests

### DIFF
--- a/tests/behavior/conftest.py
+++ b/tests/behavior/conftest.py
@@ -192,9 +192,10 @@ def mock_workflow_manager():
 
     # Patch the workflow_manager in the commands module
     with patch(
-        "devsynth.application.orchestration.workflow.workflow_manager", mock_manager
+        "devsynth.application.orchestration.workflow.workflow_manager",
+        mock_manager,
     ):
-        with patch("devsynth.core.workflows.workflow_manager", mock_manager):
+        with patch("devsynth.core.workflow_manager", mock_manager):
             yield mock_manager
 
 

--- a/tests/behavior/steps/alignment_metrics_steps.py
+++ b/tests/behavior/steps/alignment_metrics_steps.py
@@ -1,1 +1,15 @@
-from .test_alignment_metrics_steps import *
+"""Re-export alignment metrics step implementations with CLI helpers."""
+
+# Import the actual step functions for the alignment metrics feature
+from .test_alignment_metrics_steps import *  # noqa: F401,F403 - re-exported
+
+# Reuse common CLI step implementations so feature backgrounds resolve
+from .test_cli_commands_steps import (  # noqa: F401
+    devsynth_cli_installed,
+    valid_devsynth_project,
+    run_command,
+    check_workflow_success,
+)
+
+# Provide the generic error message assertion used by several features
+from .test_analyze_commands_steps import check_error_message  # noqa: F401

--- a/tests/behavior/steps/test_alignment_metrics_steps.py
+++ b/tests/behavior/steps/test_alignment_metrics_steps.py
@@ -2,7 +2,13 @@
 
 from pytest_bdd import scenarios, given, then
 
-from .cli_commands_steps import run_command  # noqa: F401
+from .cli_commands_steps import (  # noqa: F401
+    run_command,
+    devsynth_cli_installed,
+    valid_devsynth_project,
+    check_workflow_success,
+)
+from .test_analyze_commands_steps import check_error_message  # noqa: F401
 
 scenarios("../features/general/alignment_metrics_command.feature")
 
@@ -13,10 +19,12 @@ def metrics_fail(monkeypatch):
     def _raise(*_args, **_kwargs):
         raise Exception("metrics failure")
 
-    monkeypatch.setattr(
-        "devsynth.application.cli.commands.alignment_metrics_cmd.calculate_alignment_coverage",
-        _raise,
+    import importlib
+
+    mod = importlib.import_module(
+        "devsynth.application.cli.commands.alignment_metrics_cmd"
     )
+    monkeypatch.setattr(mod, "calculate_alignment_coverage", _raise)
 
 
 @then("the system should display alignment metrics")

--- a/tests/behavior/steps/test_analyze_commands_steps.py
+++ b/tests/behavior/steps/test_analyze_commands_steps.py
@@ -49,9 +49,10 @@ def mock_workflow_manager():
 
     # Patch the workflow_manager in the commands module
     with patch(
-        "devsynth.application.orchestration.workflow.workflow_manager", mock_manager
+        "devsynth.application.orchestration.workflow.workflow_manager",
+        mock_manager,
     ):
-        with patch("devsynth.core.workflows.workflow_manager", mock_manager):
+        with patch("devsynth.core.workflow_manager", mock_manager):
             yield mock_manager
 
 

--- a/tests/behavior/steps/test_metrics_steps.py
+++ b/tests/behavior/steps/test_metrics_steps.py
@@ -61,9 +61,10 @@ def mock_workflow_manager():
 
     # Patch the workflow_manager in the commands module
     with patch(
-        "devsynth.application.orchestration.workflow.workflow_manager", mock_manager
+        "devsynth.application.orchestration.workflow.workflow_manager",
+        mock_manager,
     ):
-        with patch("devsynth.core.workflows.workflow_manager", mock_manager):
+        with patch("devsynth.core.workflow_manager", mock_manager):
             yield mock_manager
 
 

--- a/tests/unit/behavior/test_alignment_metrics_steps_unit.py
+++ b/tests/unit/behavior/test_alignment_metrics_steps_unit.py
@@ -1,0 +1,20 @@
+import pytest
+import importlib
+
+import importlib
+
+# Importing the module before calling ``metrics_fail`` ensures the monkeypatch
+# targets the submodule rather than the function that is re-exported from the
+# package ``devsynth.application.cli.commands``.
+cmd = importlib.import_module(
+    "devsynth.application.cli.commands.alignment_metrics_cmd"
+)
+import sys
+sys.modules["devsynth.application.cli.commands.alignment_metrics_cmd"] = cmd
+from tests.behavior.steps.test_alignment_metrics_steps import metrics_fail
+
+
+def test_metrics_fail_patches_calculate(monkeypatch):
+    metrics_fail(monkeypatch)
+    with pytest.raises(Exception, match="metrics failure"):
+        cmd.calculate_alignment_coverage([])

--- a/tests/unit/behavior/test_analyze_commands_steps_unit.py
+++ b/tests/unit/behavior/test_analyze_commands_steps_unit.py
@@ -1,0 +1,28 @@
+from unittest.mock import MagicMock, patch
+import pytest
+
+import tests.behavior.steps.test_analyze_commands_steps as steps
+
+
+def test_run_command_inspect_code(monkeypatch):
+    mock_manager = MagicMock()
+    monkeypatch.setattr(steps, "inspect_code_cmd", lambda path: print("Architecture"))
+    command_context = {}
+    with patch("devsynth.application.orchestration.workflow.workflow_manager", mock_manager), \
+         patch("devsynth.core.workflow_manager", mock_manager):
+        steps.run_command("devsynth inspect-code --path /tmp", monkeypatch, mock_manager, command_context)
+    mock_manager.execute_command.assert_called_with("inspect-code", {"path": "/tmp"})
+    assert "Architecture" in command_context.get("output", "")
+
+
+def test_run_command_inspect_config_update(monkeypatch):
+    mock_manager = MagicMock()
+    monkeypatch.setattr(steps, "inspect_config_cmd", lambda path, upd, prn: print("Configuration updated successfully"))
+    command_context = {}
+    with patch("devsynth.application.orchestration.workflow.workflow_manager", mock_manager), \
+         patch("devsynth.core.workflow_manager", mock_manager):
+        steps.run_command("devsynth inspect-config --path proj --update", monkeypatch, mock_manager, command_context)
+    mock_manager.execute_command.assert_called_with(
+        "inspect-config", {"path": "proj", "update": True, "prune": False}
+    )
+    assert "Configuration updated successfully" in command_context.get("output", "")


### PR DESCRIPTION
## Summary
- clean up alignment metrics step definitions
- align workflow manager fixture patches with new export
- add helper imports to alignment metrics steps
- provide unit tests for analyze and alignment step modules

## Testing
- `poetry run pytest tests/unit/behavior/test_alignment_metrics_steps_unit.py tests/unit/behavior/test_analyze_commands_steps_unit.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6884fea23974833389978b948461f563