### PR TITLE
Ensure hermetic tests

### DIFF
--- a/.github/workflows.disabled/verify_test_organization.yml
+++ b/.github/workflows.disabled/verify_test_organization.yml
@@ -1,0 +1,30 @@
+name: Verify Test Organization
+
+on:
+  push:
+    branches: [ main, master ]
+    paths:
+      - 'tests/**'
+      - '.github/workflows.disabled/verify_test_organization.yml'
+  pull_request:
+    branches: [ main, master ]
+    paths:
+      - 'tests/**'
+      - '.github/workflows.disabled/verify_test_organization.yml'
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.12'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e .[dev]
+      - name: Run test organization checks
+        run: |
+          python tests/verify_test_organization.py

--- a/tests/unit/adapters/test_kuzu_memory_store.py
+++ b/tests/unit/adapters/test_kuzu_memory_store.py
@@ -1,6 +1,4 @@
 """Tests for :class:`KuzuMemoryStore`."""
-import tempfile
-import shutil
 import importlib.util
 from pathlib import Path
 import sys
@@ -24,18 +22,14 @@ spec_adapter.loader.exec_module(kuzu_memory_store)
 KuzuMemoryStore = kuzu_memory_store.KuzuMemoryStore
 
 
-def test_store_and_search_succeeds():
+def test_store_and_search_succeeds(tmp_path):
     """Test that store and search succeeds.
 
 ReqID: N/A"""
-    temp_dir = tempfile.mkdtemp()
-    store = KuzuMemoryStore(persist_directory=temp_dir, use_provider_system
-        =True)
+    store = KuzuMemoryStore(persist_directory=str(tmp_path), use_provider_system=True)
     with patch.object(store, '_get_embedding', return_value=[0.1, 0.2, 0.3]):
-        item = MemoryItem(id='t1', content='hello world', memory_type=
-            MemoryType.WORKING)
+        item = MemoryItem(id='t1', content='hello world', memory_type=MemoryType.WORKING)
         store.store(item)
         results = store.search({'query': 'hello', 'top_k': 1})
-    shutil.rmtree(temp_dir)
     assert len(results) == 1
     assert results[0].id == 't1'

--- a/tests/unit/general/test_kuzu_adapter.py
+++ b/tests/unit/general/test_kuzu_adapter.py
@@ -1,53 +1,45 @@
 """Tests for the ``KuzuAdapter`` vector store."""
 
-import tempfile
-import shutil
 from devsynth.domain.models.memory import MemoryVector
 from devsynth.adapters.memory.kuzu_adapter import KuzuAdapter
 
 
-def test_store_and_retrieve_vector_succeeds():
+def test_store_and_retrieve_vector_succeeds(tmp_path):
     """Test that store and retrieve vector succeeds.
 
     ReqID: N/A"""
-    temp_dir = tempfile.mkdtemp()
-    adapter = KuzuAdapter(temp_dir)
+    adapter = KuzuAdapter(str(tmp_path))
     vec = MemoryVector(id="v1", content="text", embedding=[0.1, 0.2, 0.3])
     adapter.store_vector(vec)
     retrieved = adapter.retrieve_vector("v1")
-    shutil.rmtree(temp_dir)
     assert retrieved is not None
     assert retrieved.id == "v1"
 
 
-def test_similarity_search_succeeds():
+def test_similarity_search_succeeds(tmp_path):
     """Test that similarity search succeeds.
 
     ReqID: N/A"""
-    temp_dir = tempfile.mkdtemp()
-    adapter = KuzuAdapter(temp_dir)
+    adapter = KuzuAdapter(str(tmp_path))
     vectors = [
         MemoryVector(id=f"v{i}", content="x", embedding=[i, i, i]) for i in range(3)
     ]
     for v in vectors:
         adapter.store_vector(v)
     res = adapter.similarity_search([0.0, 0.0, 0.0], top_k=2)
-    shutil.rmtree(temp_dir)
     assert len(res) == 2
     assert res[0].id == "v0"
 
 
-def test_persistence_between_instances_succeeds():
+def test_persistence_between_instances_succeeds(tmp_path):
     """Vectors should persist to disk across adapter instances."""
-    temp_dir = tempfile.mkdtemp()
-    adapter1 = KuzuAdapter(temp_dir)
+    adapter1 = KuzuAdapter(str(tmp_path))
     adapter1.store_vector(
         MemoryVector(id="v1", content="text", embedding=[0.1, 0.2, 0.3])
     )
     # Recreate adapter to trigger loading from disk
-    adapter2 = KuzuAdapter(temp_dir)
+    adapter2 = KuzuAdapter(str(tmp_path))
     retrieved = adapter2.retrieve_vector("v1")
-    shutil.rmtree(temp_dir)
     assert retrieved is not None
 
 

--- a/tests/unit/general/test_kuzu_store.py
+++ b/tests/unit/general/test_kuzu_store.py
@@ -1,6 +1,4 @@
 """Basic tests for :class:`KuzuStore`."""
-import tempfile
-import shutil
 import importlib.util
 from pathlib import Path
 from devsynth.domain.models.memory import MemoryItem, MemoryType
@@ -11,12 +9,11 @@ spec.loader.exec_module(kuzu_store)
 KuzuStore = kuzu_store.KuzuStore
 
 
-def test_store_retrieve_and_versions_succeeds():
+def test_store_retrieve_and_versions_succeeds(tmp_path):
     """Test that store retrieve and versions succeeds.
 
 ReqID: N/A"""
-    temp_dir = tempfile.mkdtemp()
-    store = KuzuStore(temp_dir)
+    store = KuzuStore(str(tmp_path))
     item = MemoryItem(id='a', content='hello', memory_type=MemoryType.WORKING)
     store.store(item)
     item2 = MemoryItem(id='a', content='hello2', memory_type=MemoryType.WORKING
@@ -24,22 +21,19 @@ ReqID: N/A"""
     store.store(item2)
     retrieved = store.retrieve('a')
     versions = store.get_versions('a')
-    shutil.rmtree(temp_dir)
     assert retrieved.content == 'hello2'
     assert len(versions) == 1
 
 
-def test_search_by_metadata_succeeds():
+def test_search_by_metadata_succeeds(tmp_path):
     """Test that search by metadata succeeds.
 
 ReqID: N/A"""
-    temp_dir = tempfile.mkdtemp()
-    store = KuzuStore(temp_dir)
+    store = KuzuStore(str(tmp_path))
     store.store(MemoryItem(id='1', content='alpha', memory_type=MemoryType.
         WORKING, metadata={'tag': 'x'}))
     store.store(MemoryItem(id='2', content='beta', memory_type=MemoryType.
         WORKING, metadata={'tag': 'y'}))
     results = store.search({'metadata.tag': 'y'})
-    shutil.rmtree(temp_dir)
     assert len(results) == 1
     assert results[0].id == '2'

--- a/tests/unit/general/test_kuzu_store_fallback.py
+++ b/tests/unit/general/test_kuzu_store_fallback.py
@@ -1,31 +1,25 @@
 import importlib
 import sys
 from pathlib import Path
-import tempfile
-import shutil
 from devsynth.domain.models.memory import MemoryItem, MemoryType
 
 
-def test_kuzu_store_falls_back_when_dependency_missing(monkeypatch):
+def test_kuzu_store_falls_back_when_dependency_missing(monkeypatch, tmp_path):
     # Remove kuzu module to simulate missing dependency
     monkeypatch.setitem(sys.modules, "kuzu", None)
     # Reload module after patching
     spec = importlib.util.spec_from_file_location(
-        "kuzu_store", Path(__file__).resolve().parents[3] / "src/devsynth/application/memory/kuzu_store.py"
+        "kuzu_store",
+        Path(__file__).resolve().parents[3] / "src/devsynth/application/memory/kuzu_store.py",
     )
     kuzu_store = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(kuzu_store)
     KuzuStore = kuzu_store.KuzuStore
 
-    temp_dir = tempfile.mkdtemp()
-    try:
-        store = KuzuStore(temp_dir)
-        assert store._use_fallback is True
-        item = MemoryItem(id="a", content="hello", memory_type=MemoryType.WORKING)
-        store.store(item)
-        retrieved = store.retrieve("a")
-        assert retrieved is not None
-        assert retrieved.content == "hello"
-    finally:
-        shutil.rmtree(temp_dir)
-
+    store = KuzuStore(str(tmp_path))
+    assert store._use_fallback is True
+    item = MemoryItem(id="a", content="hello", memory_type=MemoryType.WORKING)
+    store.store(item)
+    retrieved = store.retrieve("a")
+    assert retrieved is not None
+    assert retrieved.content == "hello"


### PR DESCRIPTION
## Summary
- disable verify_test_organization workflow by moving it to workflows.disabled
- refactor Kuzu tests to use pytest's tmp_path

## Testing
- `bash scripts/codex_setup.sh`
- `python tests/verify_test_organization.py | tail -n 5`
- `poetry run pytest tests/unit/general/test_kuzu_store.py::test_store_retrieve_and_versions_succeeds -q` *(fails: ImportError)*

------
https://chatgpt.com/codex/tasks/task_e_6885081bba88833392a0be579ce1f353