### PR TITLE
Fix test isolation for memory backend imports

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -227,6 +227,8 @@ def global_test_isolation(monkeypatch, tmp_path):
     """
     # Save original environment
     original_env = dict(os.environ)
+    # Save loaded modules so tests can modify sys.modules safely
+    original_modules = dict(sys.modules)
 
     # Save original working directory
     original_cwd = os.getcwd()
@@ -302,6 +304,9 @@ def global_test_isolation(monkeypatch, tmp_path):
     # Restore original environment
     os.environ.clear()
     os.environ.update(original_env)
+    # Restore original modules
+    sys.modules.clear()
+    sys.modules.update(original_modules)
 
     # Undo any monkeypatches from the test before running cleanup logic
     monkeypatch.undo()

--- a/tests/unit/adapters/test_kuzu_memory_store.py
+++ b/tests/unit/adapters/test_kuzu_memory_store.py
@@ -1,35 +1,47 @@
 """Tests for :class:`KuzuMemoryStore`."""
+
 import importlib.util
 from pathlib import Path
 import sys
 from types import ModuleType
 from unittest.mock import patch
+
 from devsynth.domain.models.memory import MemoryItem, MemoryType
-root = Path(__file__).resolve().parents[3]
-spec_store = importlib.util.spec_from_file_location('kuzu_store', root /
-    'src/devsynth/application/memory/kuzu_store.py')
-kuzu_store_mod = importlib.util.module_from_spec(spec_store)
-spec_store.loader.exec_module(kuzu_store_mod)
-fake_pkg = ModuleType('devsynth.application.memory')
-fake_pkg.kuzu_store = kuzu_store_mod
-fake_pkg.__path__ = []
-sys.modules['devsynth.application.memory'] = fake_pkg
-sys.modules['devsynth.application.memory.kuzu_store'] = kuzu_store_mod
-spec_adapter = importlib.util.spec_from_file_location('kuzu_memory_store', 
-    root / 'src/devsynth/adapters/kuzu_memory_store.py')
-kuzu_memory_store = importlib.util.module_from_spec(spec_adapter)
-spec_adapter.loader.exec_module(kuzu_memory_store)
-KuzuMemoryStore = kuzu_memory_store.KuzuMemoryStore
+
+ROOT = Path(__file__).resolve().parents[3]
+KUZU_STORE_PATH = ROOT / "src/devsynth/application/memory/kuzu_store.py"
+KUZU_ADAPTER_PATH = ROOT / "src/devsynth/adapters/kuzu_memory_store.py"
 
 
-def test_store_and_search_succeeds(tmp_path):
+def test_store_and_search_succeeds(tmp_path, monkeypatch):
     """Test that store and search succeeds.
 
-ReqID: N/A"""
+    ReqID: N/A"""
+
+    fake_pkg = ModuleType("devsynth.application.memory")
+    fake_pkg.__path__ = [str(KUZU_STORE_PATH.parent)]
+    monkeypatch.setitem(sys.modules, "devsynth.application.memory", fake_pkg)
+    spec_store = importlib.util.spec_from_file_location(
+        "devsynth.application.memory.kuzu_store", KUZU_STORE_PATH
+    )
+    kuzu_store_mod = importlib.util.module_from_spec(spec_store)
+    spec_store.loader.exec_module(kuzu_store_mod)
+    monkeypatch.setitem(
+        sys.modules, "devsynth.application.memory.kuzu_store", kuzu_store_mod
+    )
+    spec_adapter = importlib.util.spec_from_file_location(
+        "devsynth.adapters.kuzu_memory_store", KUZU_ADAPTER_PATH
+    )
+    kuzu_memory_store = importlib.util.module_from_spec(spec_adapter)
+    spec_adapter.loader.exec_module(kuzu_memory_store)
+    KuzuMemoryStore = kuzu_memory_store.KuzuMemoryStore
+
     store = KuzuMemoryStore(persist_directory=str(tmp_path), use_provider_system=True)
-    with patch.object(store, '_get_embedding', return_value=[0.1, 0.2, 0.3]):
-        item = MemoryItem(id='t1', content='hello world', memory_type=MemoryType.WORKING)
+    with patch.object(store, "_get_embedding", return_value=[0.1, 0.2, 0.3]):
+        item = MemoryItem(
+            id="t1", content="hello world", memory_type=MemoryType.WORKING
+        )
         store.store(item)
-        results = store.search({'query': 'hello', 'top_k': 1})
+        results = store.search({"query": "hello", "top_k": 1})
     assert len(results) == 1
-    assert results[0].id == 't1'
+    assert results[0].id == "t1"

--- a/tests/unit/adapters/test_sync_manager.py
+++ b/tests/unit/adapters/test_sync_manager.py
@@ -3,7 +3,8 @@ import pathlib
 import sys
 import types
 import pytest
-SRC_ROOT = pathlib.Path(__file__).resolve().parents[3] / 'src'
+
+SRC_ROOT = pathlib.Path(__file__).resolve().parents[3] / "src"
 
 
 def _load_module(path: pathlib.Path, name: str):
@@ -13,17 +14,17 @@ def _load_module(path: pathlib.Path, name: str):
     return module
 
 
-package_path = SRC_ROOT / 'devsynth/application/memory'
-dummy_pkg = types.ModuleType('devsynth.application.memory')
-dummy_pkg.__path__ = [str(package_path)]
-sys.modules.setdefault('devsynth.application.memory', dummy_pkg)
-memory_manager_module = _load_module(package_path / 'memory_manager.py',
-    'devsynth.application.memory.memory_manager')
-vector_adapter_module = _load_module(package_path /
-    'adapters/vector_memory_adapter.py',
-    'devsynth.application.memory.adapters.vector_memory_adapter')
-context_module = _load_module(package_path / 'context_manager.py',
-    'devsynth.application.memory.context_manager')
+PACKAGE_PATH = SRC_ROOT / "devsynth/application/memory"
+memory_manager_module = _load_module(
+    PACKAGE_PATH / "memory_manager.py", "devsynth.application.memory.memory_manager"
+)
+vector_adapter_module = _load_module(
+    PACKAGE_PATH / "adapters/vector_memory_adapter.py",
+    "devsynth.application.memory.adapters.vector_memory_adapter",
+)
+context_module = _load_module(
+    PACKAGE_PATH / "context_manager.py", "devsynth.application.memory.context_manager"
+)
 MemoryManager = memory_manager_module.MemoryManager
 VectorMemoryAdapter = vector_adapter_module.VectorMemoryAdapter
 InMemoryStore = context_module.InMemoryStore
@@ -33,44 +34,52 @@ from devsynth.domain.models.memory import MemoryItem, MemoryType, MemoryVector
 class TestSyncManagerCrossStoreQuery:
     """Tests for the SyncManagerCrossStoreQuery component.
 
-ReqID: N/A"""
+    ReqID: N/A"""
 
     @pytest.fixture
-    def manager(self):
-        adapters = {'vector': VectorMemoryAdapter(), 'tinydb': InMemoryStore()}
+    def manager(self, monkeypatch):
+        fake_pkg = types.ModuleType("devsynth.application.memory")
+        fake_pkg.__path__ = [str(PACKAGE_PATH)]
+        monkeypatch.setitem(sys.modules, "devsynth.application.memory", fake_pkg)
+        adapters = {"vector": VectorMemoryAdapter(), "tinydb": InMemoryStore()}
         return MemoryManager(adapters=adapters)
 
     def _add_items(self, manager: MemoryManager):
-        vec = MemoryVector(id='', content='apple', embedding=manager.
-            _embed_text('apple'), metadata={'memory_type': MemoryType.CODE.
-            value})
-        manager.adapters['vector'].store_vector(vec)
-        item = MemoryItem(id='', content='apple', memory_type=MemoryType.
-            CODE, metadata={})
-        manager.adapters['tinydb'].store(item)
+        vec = MemoryVector(
+            id="",
+            content="apple",
+            embedding=manager._embed_text("apple"),
+            metadata={"memory_type": MemoryType.CODE.value},
+        )
+        manager.adapters["vector"].store_vector(vec)
+        item = MemoryItem(
+            id="", content="apple", memory_type=MemoryType.CODE, metadata={}
+        )
+        manager.adapters["tinydb"].store(item)
 
     def test_cross_store_query_returns_results_succeeds(self, manager):
         """Test that cross store query returns results succeeds.
 
-ReqID: N/A"""
+        ReqID: N/A"""
         self._add_items(manager)
-        results = manager.sync_manager.cross_store_query('apple')
-        assert 'vector' in results and 'tinydb' in results
-        assert len(results['vector']) == 1
-        assert len(results['tinydb']) == 1
+        results = manager.sync_manager.cross_store_query("apple")
+        assert "vector" in results and "tinydb" in results
+        assert len(results["vector"]) == 1
+        assert len(results["tinydb"]) == 1
 
     def test_query_results_cached_succeeds(self, manager):
         """Test that query results cached succeeds.
 
-ReqID: N/A"""
+        ReqID: N/A"""
         self._add_items(manager)
-        manager.sync_manager.cross_store_query('apple')
-        new_item = MemoryItem(id='', content='apple second', memory_type=
-            MemoryType.CODE, metadata={})
-        manager.adapters['tinydb'].store(new_item)
-        cached = manager.sync_manager.cross_store_query('apple')
-        assert len(cached['tinydb']) == 1
+        manager.sync_manager.cross_store_query("apple")
+        new_item = MemoryItem(
+            id="", content="apple second", memory_type=MemoryType.CODE, metadata={}
+        )
+        manager.adapters["tinydb"].store(new_item)
+        cached = manager.sync_manager.cross_store_query("apple")
+        assert len(cached["tinydb"]) == 1
         assert manager.sync_manager.get_cache_size() == 1
         manager.sync_manager.clear_cache()
-        refreshed = manager.sync_manager.cross_store_query('apple')
-        assert len(refreshed['tinydb']) == 2
+        refreshed = manager.sync_manager.cross_store_query("apple")
+        assert len(refreshed["tinydb"]) == 2

--- a/tests/unit/application/memory/test_memory_manager.py
+++ b/tests/unit/application/memory/test_memory_manager.py
@@ -1,9 +1,11 @@
 import importlib.util
 import pathlib
 import types
+import sys
 from unittest.mock import MagicMock, patch
 import pytest
-SRC_ROOT = pathlib.Path(__file__).resolve().parents[4] / 'src'
+
+SRC_ROOT = pathlib.Path(__file__).resolve().parents[4] / "src"
 
 
 def _load_module(path: pathlib.Path, name: str):
@@ -13,15 +15,19 @@ def _load_module(path: pathlib.Path, name: str):
     return module
 
 
-package_path = SRC_ROOT / 'devsynth/application/memory'
-dummy_pkg = types.ModuleType('devsynth.application.memory')
-dummy_pkg.__path__ = [str(package_path)]
-import sys
-sys.modules.setdefault('devsynth.application.memory', dummy_pkg)
-memory_manager_module = _load_module(package_path / 'memory_manager.py',
-    'devsynth.application.memory.memory_manager')
+PACKAGE_PATH = SRC_ROOT / "devsynth/application/memory"
+memory_manager_module = _load_module(
+    PACKAGE_PATH / "memory_manager.py", "devsynth.application.memory.memory_manager"
+)
 MemoryManager = memory_manager_module.MemoryManager
 from devsynth.domain.models.memory import MemoryType, MemoryItem
+
+
+@pytest.fixture(autouse=True)
+def _patch_memory_module(monkeypatch):
+    pkg = types.ModuleType("devsynth.application.memory")
+    pkg.__path__ = [str(PACKAGE_PATH)]
+    monkeypatch.setitem(sys.modules, "devsynth.application.memory", pkg)
 
 
 class DummyVectorStore:
@@ -31,7 +37,7 @@ class DummyVectorStore:
 
     def store(self, item):
         self.stored.append(item)
-        return 'vector-id'
+        return "vector-id"
 
 
 class DummyGraphStore:
@@ -42,68 +48,67 @@ class DummyGraphStore:
 
     def store(self, item):
         self.stored.append(item)
-        return 'graph-id'
+        return "graph-id"
 
     def retrieve_with_edrr_phase(self, item_type, edrr_phase, metadata=None):
-        key = f'{item_type}_{edrr_phase}'
+        key = f"{item_type}_{edrr_phase}"
         return self.edrr_items.get(key)
 
-    def store_with_edrr_phase(self, content, memory_type, edrr_phase,
-        metadata=None):
-        key = f'{memory_type}_{edrr_phase}'
+    def store_with_edrr_phase(self, content, memory_type, edrr_phase, metadata=None):
+        key = f"{memory_type}_{edrr_phase}"
         self.edrr_items[key] = content
-        return 'graph-edrr-id'
+        return "graph-edrr-id"
 
 
 class TestMemoryManagerStore:
     """Tests for the MemoryManagerStore component.
 
-ReqID: N/A"""
+    ReqID: N/A"""
 
     @pytest.fixture
     def adapters(self):
         tinydb = MagicMock()
         vector = DummyVectorStore()
-        return {'tinydb': tinydb, 'vector': vector}
+        return {"tinydb": tinydb, "vector": vector}
 
     @pytest.fixture
     def graph_adapters(self):
         graph = DummyGraphStore()
         tinydb = MagicMock()
-        return {'graph': graph, 'tinydb': tinydb}
+        return {"graph": graph, "tinydb": tinydb}
 
     def test_store_prefers_graph_for_edrr_succeeds(self, graph_adapters):
         """Test that store prefers graph for edrr succeeds.
 
-ReqID: N/A"""
+        ReqID: N/A"""
         manager = MemoryManager(adapters=graph_adapters)
-        manager.store_with_edrr_phase('x', MemoryType.CODE, 'EXPAND')
-        assert len(graph_adapters['graph'].stored) == 1
-        graph_adapters['tinydb'].store.assert_not_called()
+        manager.store_with_edrr_phase("x", MemoryType.CODE, "EXPAND")
+        assert len(graph_adapters["graph"].stored) == 1
+        graph_adapters["tinydb"].store.assert_not_called()
 
     def test_store_falls_back_to_tinydb_succeeds(self):
         """Test that store falls back to tinydb succeeds.
 
-ReqID: N/A"""
+        ReqID: N/A"""
         tinydb = MagicMock()
-        manager = MemoryManager(adapters={'tinydb': tinydb})
-        manager.store_with_edrr_phase('x', MemoryType.CODE, 'EXPAND')
+        manager = MemoryManager(adapters={"tinydb": tinydb})
+        manager.store_with_edrr_phase("x", MemoryType.CODE, "EXPAND")
         tinydb.store.assert_called_once()
 
     def test_store_falls_back_to_first_succeeds(self):
         """Test that store falls back to first succeeds.
 
-ReqID: N/A"""
+        ReqID: N/A"""
         vector = DummyVectorStore()
-        manager = MemoryManager(adapters={'vector': vector})
-        manager.store_with_edrr_phase('x', MemoryType.CODE, 'EXPAND')
+        manager = MemoryManager(adapters={"vector": vector})
+        manager.store_with_edrr_phase("x", MemoryType.CODE, "EXPAND")
         assert vector.stored
 
 
 class TestMemoryManagerRetrieve:
     """Tests for the MemoryManagerRetrieve component.
 
-ReqID: N/A"""
+    ReqID: N/A"""
 
     @pytest.fixture
     def graph_adapter(self):
@@ -111,55 +116,54 @@ ReqID: N/A"""
 
     @pytest.fixture
     def manager_with_graph(self, graph_adapter):
-        return MemoryManager(adapters={'graph': graph_adapter})
+        return MemoryManager(adapters={"graph": graph_adapter})
 
-    def test_retrieve_with_edrr_phase_succeeds(self, manager_with_graph,
-        graph_adapter):
+    def test_retrieve_with_edrr_phase_succeeds(self, manager_with_graph, graph_adapter):
         """Test that retrieve with edrr phase succeeds.
 
-ReqID: N/A"""
-        test_content = {'key': 'value'}
-        graph_adapter.edrr_items['CODE_EXPAND'] = test_content
-        result = manager_with_graph.retrieve_with_edrr_phase('CODE', 'EXPAND')
+        ReqID: N/A"""
+        test_content = {"key": "value"}
+        graph_adapter.edrr_items["CODE_EXPAND"] = test_content
+        result = manager_with_graph.retrieve_with_edrr_phase("CODE", "EXPAND")
         assert result == test_content
 
-    def test_retrieve_with_edrr_phase_not_found_succeeds(self,
-        manager_with_graph):
+    def test_retrieve_with_edrr_phase_not_found_succeeds(self, manager_with_graph):
         """Test that retrieve with edrr phase not found succeeds.
 
-ReqID: N/A"""
-        result = manager_with_graph.retrieve_with_edrr_phase('CODE',
-            'NONEXISTENT')
+        ReqID: N/A"""
+        result = manager_with_graph.retrieve_with_edrr_phase("CODE", "NONEXISTENT")
         assert result == {}
 
-    def test_retrieve_with_edrr_phase_with_metadata_succeeds(self,
-        manager_with_graph, graph_adapter):
+    def test_retrieve_with_edrr_phase_with_metadata_succeeds(
+        self, manager_with_graph, graph_adapter
+    ):
         """Test that retrieve with edrr phase with metadata succeeds.
 
-ReqID: N/A"""
-        test_content = {'key': 'value'}
-        graph_adapter.edrr_items['CODE_EXPAND'] = test_content
-        result = manager_with_graph.retrieve_with_edrr_phase('CODE',
-            'EXPAND', {'cycle_id': '123'})
+        ReqID: N/A"""
+        test_content = {"key": "value"}
+        graph_adapter.edrr_items["CODE_EXPAND"] = test_content
+        result = manager_with_graph.retrieve_with_edrr_phase(
+            "CODE", "EXPAND", {"cycle_id": "123"}
+        )
         assert result == test_content
 
 
 class TestEmbedText:
     """Tests for the EmbedText component.
 
-ReqID: N/A"""
+    ReqID: N/A"""
 
     def test_fallback_and_provider_succeeds(self):
         """Test that fallback and provider succeeds.
 
-ReqID: N/A"""
+        ReqID: N/A"""
         manager = MemoryManager()
-        default = manager._embed_text('abc', dimension=5)
+        default = manager._embed_text("abc", dimension=5)
         provider = MagicMock()
-        provider.embed.side_effect = Exception('boom')
+        provider.embed.side_effect = Exception("boom")
         manager_fail = MemoryManager(embedding_provider=provider)
-        assert manager_fail._embed_text('abc', dimension=5) == default
+        assert manager_fail._embed_text("abc", dimension=5) == default
         provider.embed.side_effect = None
         provider.embed.return_value = [1.0, 2.0]
         manager_ok = MemoryManager(embedding_provider=provider)
-        assert manager_ok._embed_text('hi') == [1.0, 2.0]
+        assert manager_ok._embed_text("hi") == [1.0, 2.0]

--- a/tests/unit/application/memory/test_memory_manager_search.py
+++ b/tests/unit/application/memory/test_memory_manager_search.py
@@ -3,7 +3,8 @@ import pathlib
 import types
 import sys
 import pytest
-SRC_ROOT = pathlib.Path(__file__).resolve().parents[4] / 'src'
+
+SRC_ROOT = pathlib.Path(__file__).resolve().parents[4] / "src"
 
 
 def _load_module(path: pathlib.Path, name: str):
@@ -13,62 +14,77 @@ def _load_module(path: pathlib.Path, name: str):
     return module
 
 
-package_path = SRC_ROOT / 'devsynth/application/memory'
-dummy_pkg = types.ModuleType('devsynth.application.memory')
-dummy_pkg.__path__ = [str(package_path)]
-sys.modules.setdefault('devsynth.application.memory', dummy_pkg)
-memory_manager_module = _load_module(package_path / 'memory_manager.py',
-    'devsynth.application.memory.memory_manager')
-vector_adapter_module = _load_module(package_path /
-    'adapters/vector_memory_adapter.py',
-    'devsynth.application.memory.adapters.vector_memory_adapter')
+PACKAGE_PATH = SRC_ROOT / "devsynth/application/memory"
+memory_manager_module = _load_module(
+    PACKAGE_PATH / "memory_manager.py", "devsynth.application.memory.memory_manager"
+)
+vector_adapter_module = _load_module(
+    PACKAGE_PATH / "adapters/vector_memory_adapter.py",
+    "devsynth.application.memory.adapters.vector_memory_adapter",
+)
 MemoryManager = memory_manager_module.MemoryManager
 VectorMemoryAdapter = vector_adapter_module.VectorMemoryAdapter
 from devsynth.domain.models.memory import MemoryVector, MemoryType
 
 
+@pytest.fixture(autouse=True)
+def _patch_memory_module(monkeypatch):
+    pkg = types.ModuleType("devsynth.application.memory")
+    pkg.__path__ = [str(PACKAGE_PATH)]
+    monkeypatch.setitem(sys.modules, "devsynth.application.memory", pkg)
+
+
 class TestMemoryManagerSearch:
     """Tests for the MemoryManagerSearch component.
 
-ReqID: N/A"""
+    ReqID: N/A"""
 
     @pytest.fixture
     def manager(self):
         adapter = VectorMemoryAdapter()
-        return MemoryManager(adapters={'vector': adapter})
+        return MemoryManager(adapters={"vector": adapter})
 
-    def _add_vector(self, manager: MemoryManager, text: str, memory_type: (
-        MemoryType | str), **metadata):
+    def _add_vector(
+        self,
+        manager: MemoryManager,
+        text: str,
+        memory_type: MemoryType | str,
+        **metadata,
+    ):
         embedding = manager._embed_text(text)
-        meta = {'memory_type': memory_type.value if hasattr(memory_type,
-            'value') else memory_type}
+        meta = {
+            "memory_type": (
+                memory_type.value if hasattr(memory_type, "value") else memory_type
+            )
+        }
         meta.update(metadata)
-        vector = MemoryVector(id='', content=text, embedding=embedding,
-            metadata=meta)
-        manager.adapters['vector'].store_vector(vector)
+        vector = MemoryVector(id="", content=text, embedding=embedding, metadata=meta)
+        manager.adapters["vector"].store_vector(vector)
         return vector
 
     def test_search_returns_similar_results_succeeds(self, manager):
         """Test that search returns similar results succeeds.
 
-ReqID: N/A"""
-        self._add_vector(manager, 'apple item', MemoryType.CODE)
-        self._add_vector(manager, 'banana item', MemoryType.CODE)
-        self._add_vector(manager, 'car', 'DOC')
-        results = manager.search_memory('apple', limit=2)
+        ReqID: N/A"""
+        self._add_vector(manager, "apple item", MemoryType.CODE)
+        self._add_vector(manager, "banana item", MemoryType.CODE)
+        self._add_vector(manager, "car", "DOC")
+        results = manager.search_memory("apple", limit=2)
         assert results
-        assert results[0].content == 'apple item'
+        assert results[0].content == "apple item"
 
     def test_search_filters_by_metadata_succeeds(self, manager):
         """Test that search filters by metadata succeeds.
 
-ReqID: N/A"""
-        self._add_vector(manager, 'apple item', MemoryType.CODE, category=
-            'fruit')
-        self._add_vector(manager, 'banana item', MemoryType.CODE, category=
-            'fruit')
-        self._add_vector(manager, 'car', 'DOC', category='vehicle')
-        results = manager.search_memory('apple', memory_type=MemoryType.
-            CODE, metadata_filter={'category': 'fruit'}, limit=5)
+        ReqID: N/A"""
+        self._add_vector(manager, "apple item", MemoryType.CODE, category="fruit")
+        self._add_vector(manager, "banana item", MemoryType.CODE, category="fruit")
+        self._add_vector(manager, "car", "DOC", category="vehicle")
+        results = manager.search_memory(
+            "apple",
+            memory_type=MemoryType.CODE,
+            metadata_filter={"category": "fruit"},
+            limit=5,
+        )
         assert len(results) == 2
-        assert all(v.metadata.get('category') == 'fruit' for v in results)
+        assert all(v.metadata.get("category") == "fruit" for v in results)


### PR DESCRIPTION
## Summary
- ensure global test isolation restores `sys.modules`
- patch memory package imports inside tests instead of at module import time

## Testing
- `poetry run pytest -k "kuzu_memory_store or sync_manager or memory_manager_search or memory_manager and sync_across_backends" -q`

------
https://chatgpt.com/codex/tasks/task_e_68851edf2c3c83338d73d7d91ab33d31