### PR TITLE
Remove codex_setup note from setup docs

### DIFF
--- a/docs/developer_guides/development_setup.md
+++ b/docs/developer_guides/development_setup.md
@@ -81,9 +81,8 @@ poetry install --with dev --extras minimal
 poetry shell
 ```
 
-> **Note**: In Codex environments the `scripts/codex_setup.sh` script runs
-> automatically during provisioning. You should not invoke this script manually
-> outside of the Codex setup process.
+These commands install all required packages and activate the Poetry-managed
+virtual environment. Once complete, proceed to configure environment variables.
 
 ## 3. Set Up Environment Variables
 


### PR DESCRIPTION
## Summary
- remove lines that referenced `scripts/codex_setup.sh`
- explain dependency installation only via `poetry install`

## Testing
- `poetry run pytest tests/unit/domain/test_memory_type.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68852b59c5d083338f46ea8722e367a4