### PR TITLE
Update codex setup and guidelines

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,6 +33,8 @@ Fix the script and rerun it offline to finish provisioning:
    `poetry run pip list | grep pytest-bdd`.
 3. Remove the failure marker with `rm CODEX_ENVIRONMENT_SETUP_FAILED`.
 4. Execute `poetry run pytest` to verify the environment.
+5. If the tests fail, rerun the setup script and repeat until
+   `poetry run pytest` succeeds.
 
 Changes to the setup script only take effect the next time Codex provisions an
 environment. OpenAI disables network access during execution, so `scripts/codex_setup.sh`

--- a/scripts/codex_setup.sh
+++ b/scripts/codex_setup.sh
@@ -27,5 +27,8 @@ if missing:
     sys.exit("Missing packages: " + ", ".join(missing))
 EOF
 
+# Double-check that pytest-bdd can be imported
+poetry run python -c "import pytest_bdd"
+
 # Cleanup any failure marker if the setup completes successfully
 [ -f CODEX_ENVIRONMENT_SETUP_FAILED ] && rm CODEX_ENVIRONMENT_SETUP_FAILED


### PR DESCRIPTION
## Summary
- confirm codex setup uses Python 3.12
- validate pytest-bdd in setup script
- advise running the setup script until `poetry run pytest` succeeds

## Testing
- `bash scripts/codex_setup.sh > /tmp/setup.log`
- `poetry run pytest --maxfail=1 -q`

------
https://chatgpt.com/codex/tasks/task_e_688538b9f76083338f1a33ed08ad22de