### PR TITLE
Refactor CLI wizards for env options

### DIFF
--- a/tests/behavior/steps/test_interactive_init_wizard_steps.py
+++ b/tests/behavior/steps/test_interactive_init_wizard_steps.py
@@ -6,35 +6,10 @@ import toml
 import yaml
 from devsynth.config.unified_loader import UnifiedConfigLoader
 from pathlib import Path
-from typing import Sequence, Optional
 from unittest.mock import MagicMock
 
 import pytest
 from pytest_bdd import scenarios, given, when, then
-
-from devsynth.interface.ux_bridge import UXBridge
-
-
-class DummyBridge(UXBridge):
-    def __init__(self, answers: Sequence[str], confirms: Sequence[bool]):
-        self.answers = list(answers)
-        self.confirms = list(confirms)
-
-    def ask_question(
-        self,
-        message: str,
-        *,
-        choices: Optional[Sequence[str]] = None,
-        default: Optional[str] = None,
-        show_default: bool = True,
-    ) -> str:
-        return self.answers.pop(0)
-
-    def confirm_choice(self, message: str, *, default: bool = False) -> bool:
-        return self.confirms.pop(0)
-
-    def display_result(self, message: str, *, highlight: bool = False) -> None:
-        pass
 
 
 scenarios("../features/general/interactive_init_wizard.feature")
@@ -51,26 +26,13 @@ def run_wizard(tmp_project_dir, monkeypatch):
     monkeypatch.setitem(os.sys.modules, "uvicorn", MagicMock())
     from devsynth.application.cli.cli_commands import init_cmd
 
-    answers = [
-        str(tmp_project_dir),
-        "python",
-        "demo goals",
-        "kuzu",
-    ]
-    confirms = [
-        True,  # offline mode
-        True,  # wsde_collaboration
-        False,  # dialectical_reasoning
-        False,  # code_generation
-        False,  # test_generation
-        False,  # documentation_generation
-        False,  # experimental_features
-        True,  # proceed
-    ]
-    bridge = DummyBridge(answers, confirms)
-    # Pass an empty features dict so the wizard prompts for each feature
-    # allowing our ``DummyBridge`` confirmations to be used.
-    init_cmd(bridge=bridge, features={})
+    monkeypatch.setenv("DEVSYNTH_INIT_ROOT", str(tmp_project_dir))
+    monkeypatch.setenv("DEVSYNTH_INIT_LANGUAGE", "python")
+    monkeypatch.setenv("DEVSYNTH_INIT_GOALS", "demo goals")
+    monkeypatch.setenv("DEVSYNTH_INIT_MEMORY_BACKEND", "kuzu")
+    monkeypatch.setenv("DEVSYNTH_INIT_OFFLINE_MODE", "1")
+    monkeypatch.setenv("DEVSYNTH_INIT_FEATURES", "wsde_collaboration")
+    init_cmd(auto_confirm=True)
 
 
 @then("a project configuration file should include the selected options")


### PR DESCRIPTION
## Summary
- support environment variables in `wizard_cmd`
- update interactive BDD steps to use environment variables

## Testing
- `poetry run pytest -q` *(fails: KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_68853fea90f08333beb9d0cf2dc06025