### PR TITLE
Update Codex setup verification

### DIFF
--- a/scripts/codex_setup.sh
+++ b/scripts/codex_setup.sh
@@ -1,5 +1,8 @@
 set -exo pipefail
 
+# NOTE: This script provisions the Codex testing environment only. It is not
+# intended for regular development setup.
+
 # Use Python 3.12 if available, otherwise fall back to Python 3.11
 poetry env use "$(command -v python3.12 || command -v python3.11)"
 
@@ -29,6 +32,9 @@ EOF
 
 # Double-check that pytest-bdd can be imported
 poetry run python -c "import pytest_bdd"
+
+# Ensure pytest-bdd is installed in the environment
+poetry run pip show pytest-bdd >/dev/null
 
 # Cleanup any failure marker if the setup completes successfully
 [ -f CODEX_ENVIRONMENT_SETUP_FAILED ] && rm CODEX_ENVIRONMENT_SETUP_FAILED


### PR DESCRIPTION
## Summary
- update `scripts/codex_setup.sh` with Codex-only note
- verify that `pytest-bdd` is installed

## Testing
- `poetry run pytest` *(fails: too long)*

------
https://chatgpt.com/codex/tasks/task_e_688547840d188333b7e251cad31c6d15