### PR TITLE
Add issues for partial features

### DIFF
--- a/docs/implementation/feature_status_matrix.md
+++ b/docs/implementation/feature_status_matrix.md
@@ -51,21 +51,21 @@ Each feature is scored on two dimensions:
 | **Core Framework** |
 | EDRR Framework | Partial | src/devsynth/application/EDRR | 5 | 4 | Agent Orchestration | | Phase transition logic, recursion handling, and CLI integration are stable. Micro-cycle helpers and recovery hooks added. Remaining tasks are tracked in [issue 104](../../issues/104.md).
 | WSDE Agent Collaboration | Partial | src/devsynth/application/collaboration | 4 | 5 | Memory System | | Consensus voting validated with dynamic role reassignment. Summary utilities for voting results implemented. Coordination with the EDRR cycle is still under review (see [issue 104](../../issues/104.md)).  |
-| Dialectical Reasoning | Partial | src/devsynth/application/requirements/dialectical_reasoner.py | 4 | 3 | WSDE Model | | Hooks integrated in WSDETeam, framework largely implemented |
+| Dialectical Reasoning | Partial | src/devsynth/application/requirements/dialectical_reasoner.py | 4 | 3 | WSDE Model | | Hooks integrated in WSDETeam, framework largely implemented. Tracked in [issue 105](../../issues/105.md) |
 | Message Passing Protocol | Complete | src/devsynth/application/collaboration/message_protocol.py | 4 | 2 | WSDE Model | | Enables structured agent communication |
 | Peer Review Mechanism | Complete | src/devsynth/application/collaboration/peer_review.py | 4 | 3 | WSDE Model | | Workflow implemented with revision cycles and integration tests |
-| Memory System | Partial | src/devsynth/application/memory | 5 | 4 | None | | ChromaDB adapter with full client support available, and a new sync manager coordinates LMDB, FAISS, and Kuzu stores |
+| Memory System | Partial | src/devsynth/application/memory | 5 | 4 | None | | ChromaDB adapter with full client support available, and a new sync manager coordinates LMDB, FAISS, and Kuzu stores. Tracked in [issue 106](../../issues/106.md) |
 | Provider System | Complete | src/devsynth/application/llm | 5 | 3 | None | | LM Studio, OpenAI, Anthropic, and Local providers fully implemented and tested |
 | LM Studio Integration | Complete | src/devsynth/application/llm/lmstudio_provider.py | 4 | 3 | Provider System | | Local provider stable; remote support experimental |
 | Code Analysis | Complete | src/devsynth/application/code_analysis | 4 | 4 | None | | AST visitor and project state analyzer implemented |
 | Knowledge Graph Utilities | Complete | src/devsynth/application/memory/knowledge_graph_utils.py | 3 | 3 | Memory System | | Basic querying available |
 | Methodology Integration Framework | Complete | src/devsynth/methodology | 4 | 4 | None | | Sprint, Kanban, Milestone and AdHoc adapters implemented |
-| Sprint-EDRR Integration | Partial | src/devsynth/methodology/sprint.py | 3 | 3 | Methodology Integration Framework | | Basic mapping of sprint ceremonies to EDRR phases |
+| Sprint-EDRR Integration | Partial | src/devsynth/methodology/sprint.py | 3 | 3 | Methodology Integration Framework | | Basic mapping of sprint ceremonies to EDRR phases. Tracked in [issue 107](../../issues/107.md) |
 | **User-Facing Features** |
-| CLI Interface | Partial | src/devsynth/cli.py, src/devsynth/application/cli | 5 | 2 | None | | All commands implemented and tested |
+| CLI Interface | Partial | src/devsynth/cli.py, src/devsynth/application/cli | 5 | 2 | None | | All commands implemented and tested. Additional polish in [issue 102](../../issues/102.md) |
 | Project Initialization | Complete | src/devsynth/application/orchestration/workflow.py, src/devsynth/application/agents/unified_agent.py | 5 | 2 | None | | Complete with configuration options |
 | Code Generation | Complete | src/devsynth/application/agents/code.py | 5 | 5 | AST Analysis | | Basic generation working, advanced features pending |
-| Test Generation | Partial | src/devsynth/application/agents/test.py | 4 | 4 | Code Generation | | Unit test generation working, integration tests pending |
+| Test Generation | Partial | src/devsynth/application/agents/test.py | 4 | 4 | Code Generation | | Unit test generation working, integration tests pending. Tracked in [issue 108](../../issues/108.md) |
 | Documentation Generation | Complete | src/devsynth/application/agents/documentation.py | 3 | 3 | Code Analysis | | Basic documentation generation implemented |
 | Documentation Ingestion | Complete | src/devsynth/application/documentation/ingestion.py | 3 | 3 | Memory System | | Project configuration controls offline ingestion |
 | Requirements Gathering | Complete | src/devsynth/application/cli/requirements_commands.py, src/devsynth/interface/webui.py | 5 | 2 | CLI Interface | | Wizard persists goals, constraints and priority |
@@ -73,12 +73,12 @@ Each feature is scored on two dimensions:
 | Docker Containerization | Complete | Dockerfile, docker-compose.yml | 4 | 3 | None | | Dockerfile and Compose provided |
 | Configuration Management | Complete | src/devsynth/config, config/ | 4 | 3 | None | | Environment-specific templates available |
 | Unified Configuration Loader | Complete | src/devsynth/config/loader.py | 3 | 2 | Configuration Management | | Supports YAML and TOML with autocompletion |
-| Deployment Automation | Partial | docker-compose.yml, scripts/deployment | 3 | 3 | Docker | | Basic Docker Compose workflows |
+| Deployment Automation | Partial | docker-compose.yml, scripts/deployment | 3 | 3 | Docker | | Basic Docker Compose workflows. Tracked in [issue 109](../../issues/109.md) |
 | Security Framework | Complete | src/devsynth/security | 4 | 4 | None | | Environment validation, security policies, and Fernet-based encryption implemented |
 | Dependency Management | Complete | pyproject.toml | 3 | 2 | None | | Basic management implemented, optimization pending |
 | Metrics Commands | Complete | src/devsynth/application/cli/commands/alignment_metrics_cmd.py, test_metrics_cmd.py | 3 | 2 | None | | `alignment_metrics` and `test_metrics` commands available |
-| Retry Mechanism | Partial | src/devsynth/fallback.py | 3 | 2 | Providers | | Exponential backoff implemented; conditional retries and metrics planned |
-| SDLC Security Policy | Partial | docs/policies/security.md | 3 | 2 | Security Framework | | Configuration flags exist, automated audits planned |
+| Retry Mechanism | Partial | src/devsynth/fallback.py | 3 | 2 | Providers | | Exponential backoff implemented; conditional retries and metrics planned. Tracked in [issue 110](../../issues/110.md) |
+| SDLC Security Policy | Partial | docs/policies/security.md | 3 | 2 | Security Framework | | Configuration flags exist, automated audits planned. Tracked in [issue 111](../../issues/111.md) |
 | Documentation Policies | Complete | docs/policies/documentation_policies.md | 2 | 1 | None | | Policies implemented across documentation |
 | **Planned/Unimplemented Features** |
 | Core Values Subsystem | Complete | src/devsynth/core/values.py | 2 | 3 | None | | Helper methods added for value management and report validation |

--- a/issues/102.md
+++ b/issues/102.md
@@ -5,3 +5,5 @@ This issue tracks tasks for refining the interactive CLI and planned WebUI.
 - Streamline the `devsynth init` wizard.
 - Provide richer progress indicators and clearer error messages.
 - Expose optional dashboard metrics.
+- Polish help output and flag descriptions
+- Add shell completion support for common terminals

--- a/issues/105.md
+++ b/issues/105.md
@@ -1,0 +1,7 @@
+# Issue 105: Finalize dialectical reasoning
+
+This issue tracks tasks needed to finish the dialectical reasoning framework.
+
+- Integrate dialectical reasoning loop into EDRR workflow
+- Add consensus failure handling and logging
+- Expand unit tests for reasoning modules

--- a/issues/106.md
+++ b/issues/106.md
@@ -1,0 +1,7 @@
+# Issue 106: Complete memory system integration
+
+The memory subsystem supports multiple backends but remains unstable.
+
+- Finalize sync manager for LMDB, FAISS, and Kuzu stores
+- Harden ChromaDB adapter and transactional semantics
+- Expand integration tests covering persistence and retrieval

--- a/issues/107.md
+++ b/issues/107.md
@@ -1,0 +1,7 @@
+# Issue 107: Complete Sprint-EDRR integration
+
+Sprint adapters map ceremonies to EDRR phases but workflow coverage is incomplete.
+
+- Align sprint planning with requirement analysis phase
+- Automate review of sprint retrospectives in EDRR evaluation
+- Document integration steps and add tests

--- a/issues/108.md
+++ b/issues/108.md
@@ -1,0 +1,7 @@
+# Issue 108: Expand test generation capabilities
+
+Automated unit test generation works but integration coverage is lacking.
+
+- Implement integration test scaffolding for generated modules
+- Improve prompt templates for edge cases
+- Document recommended review workflow for generated tests

--- a/issues/109.md
+++ b/issues/109.md
@@ -1,0 +1,7 @@
+# Issue 109: Improve deployment automation
+
+Current Docker Compose workflows require manual steps.
+
+- Add scripts for environment bootstrapping and health checks
+- Integrate Docker image publishing into CI pipeline
+- Provide rollback instructions and test coverage

--- a/issues/110.md
+++ b/issues/110.md
@@ -1,0 +1,7 @@
+# Issue 110: Enhance retry mechanism
+
+The fallback module implements exponential backoff but lacks metrics and conditional logic.
+
+- Add configurable retry conditions and circuit-breaker support
+- Record retry statistics for monitoring
+- Write regression tests for failure scenarios

--- a/issues/111.md
+++ b/issues/111.md
@@ -1,0 +1,7 @@
+# Issue 111: Implement SDLC security audits
+
+Security policy flags exist but automation is missing.
+
+- Integrate static analysis tools into CI
+- Enforce policy checks before deployment
+- Document procedure for periodic security reviews


### PR DESCRIPTION
## Summary
- add issue links in feature status matrix for every partial feature
- update issue 102 with more CLI tasks
- create issues 105-111 to track partial features

## Testing
- `poetry run pytest tests` *(fails: 395 failed, 493 passed, 83 skipped, 1 error)*

------
https://chatgpt.com/codex/tasks/task_e_68854d6982b88333a2b851c25d563c2a