### PR TITLE
Fix token tracker network access in tests

### DIFF
--- a/src/devsynth/application/utils/token_tracker.py
+++ b/src/devsynth/application/utils/token_tracker.py
@@ -44,6 +44,12 @@ class TokenTracker:
             except KeyError:
                 # Fall back to cl100k_base encoding if model not found
                 self._encoding = tiktoken.get_encoding("cl100k_base")
+            except Exception as e:  # pragma: no cover - network issues
+                logger.warning(
+                    f"Failed to load tiktoken encoding for model '{model}': {e}. "
+                    "Falling back to approximate token counting"
+                )
+                self._encoding = None
 
     def count_tokens(self, text: str) -> int:
         """Count the number of tokens in a text.


### PR DESCRIPTION
## Summary
- avoid tiktoken network fetch by catching errors in `TokenTracker`
- ensure OpenAI provider integration tests use mocked settings

## Testing
- `poetry run pytest tests/integration/general/test_openai_provider.py -q`
- `poetry run pytest tests/integration/general/test_lmstudio_provider.py -q`


------
https://chatgpt.com/codex/tasks/task_e_6885595ec3188333be13ec85de4915a9