### PR TITLE
Fix interactive requirements wizard defaults and tests

### DIFF
--- a/src/devsynth/application/cli/requirements_commands.py
+++ b/src/devsynth/application/cli/requirements_commands.py
@@ -5,6 +5,7 @@ CLI commands for requirements management.
 import logging
 import uuid
 import json
+import os
 from typing import List, Optional
 
 import typer
@@ -762,6 +763,17 @@ def wizard_cmd(
     Users can move backward by typing ``back`` when prompted.
     The collected data is written to ``output_file`` in JSON format.
     """
+
+    if isinstance(title, typer.models.OptionInfo):
+        title = None
+    if isinstance(description, typer.models.OptionInfo):
+        description = None
+    if isinstance(req_type, typer.models.OptionInfo):
+        req_type = None
+    if isinstance(priority, typer.models.OptionInfo):
+        priority = None
+    if isinstance(constraints, typer.models.OptionInfo):
+        constraints = None
 
     title = title or os.environ.get("DEVSYNTH_REQ_TITLE")
     description = description or os.environ.get("DEVSYNTH_REQ_DESCRIPTION")

--- a/src/devsynth/interface/webui.py
+++ b/src/devsynth/interface/webui.py
@@ -29,6 +29,7 @@ UX guidance for clarity and responsiveness.
 from __future__ import annotations
 
 import json
+import os
 import time
 import traceback
 from pathlib import Path
@@ -861,11 +862,15 @@ class WebUI(UXBridge):
             st.session_state["wizard_step"] = st.session_state.wizard_step
 
         defaults = {
-            "title": "",
-            "description": "",
-            "type": RequirementType.FUNCTIONAL.value,
-            "priority": RequirementPriority.MEDIUM.value,
-            "constraints": "",
+            "title": os.environ.get("DEVSYNTH_REQ_TITLE", ""),
+            "description": os.environ.get("DEVSYNTH_REQ_DESCRIPTION", ""),
+            "type": os.environ.get(
+                "DEVSYNTH_REQ_TYPE", RequirementType.FUNCTIONAL.value
+            ),
+            "priority": os.environ.get(
+                "DEVSYNTH_REQ_PRIORITY", RequirementPriority.MEDIUM.value
+            ),
+            "constraints": os.environ.get("DEVSYNTH_REQ_CONSTRAINTS", ""),
         }
         raw_data = getattr(st.session_state, "wizard_data", None)
         if raw_data is None and isinstance(st.session_state, dict):

--- a/tests/behavior/steps/test_interactive_requirements_steps.py
+++ b/tests/behavior/steps/test_interactive_requirements_steps.py
@@ -7,7 +7,7 @@ import pytest
 from pytest_bdd import scenarios, given, when, then
 
 
-scenarios("../features/general/interactive_requirements.feature")
+scenarios("../features/interactive_requirements.feature")
 
 
 @given("the DevSynth CLI is installed")


### PR DESCRIPTION
## Summary
- handle direct function calls for wizard command
- allow environment variables in WebUI requirements wizard
- point interactive requirements steps at the correct feature file

## Testing
- `pytest tests/behavior/steps/test_interactive_requirements_steps.py tests/integration/general/test_kuzu_memory_fallback.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68856040c3f48333a1a81512fb2b4899