### PR TITLE
Update docs with limitation callouts

### DIFF
--- a/docs/architecture/edrr_framework.md
+++ b/docs/architecture/edrr_framework.md
@@ -371,6 +371,21 @@ management to produce a comprehensive final report after each cycle. Feature
 flags can still disable collaborative reasoning features, but the core EDRR
 orchestration operates end-to-end.
 
+## Current Limitations
+
+While end-to-end cycles execute successfully, several pieces remain only
+partially implemented:
+
+- Phase monitoring and debugging tools are minimal.
+- Micro-cycle helpers lack advanced recovery hooks.
+- WSDE collaboration is enabled by default but still requires additional
+  validation with real projects.
+- Dialectical reasoning hooks are experimental and disabled via
+  `features.dialectical_reasoning`.
+
+See the [Feature Status Matrix](../implementation/feature_status_matrix.md) for
+the most up-to-date progress on these items.
+
 ## Related Documents
 
 - [EDRR Specification](../specifications/edrr_cycle_specification.md)

--- a/docs/architecture/wsde_edrr_integration.md
+++ b/docs/architecture/wsde_edrr_integration.md
@@ -675,3 +675,13 @@ The integration between the WSDE model and the EDRR framework provides a powerfu
 ## Implementation Status
 
 This feature is **in progress** and not yet implemented.
+
+## Current Limitations
+
+- WSDE collaboration is enabled via feature flags but lacks extensive
+  end-to-end validation.
+- Dialectical reasoning hooks are experimental and disabled by default.
+- Integration tests for combined EDRR and WSDE workflows are incomplete.
+
+Refer to the [Feature Status Matrix](../implementation/feature_status_matrix.md)
+for detailed progress tracking.

--- a/docs/requirements_traceability.md
+++ b/docs/requirements_traceability.md
@@ -44,10 +44,10 @@ This matrix links requirements to design, code modules, and tests, ensuring bidi
 | FR-36 | Context pruning strategies | [Memory System Architecture](architecture/memory_system.md) | src/devsynth/adapters/memory/context_manager.py | tests/behavior/test_enhanced_chromadb_integration.py | Implemented |
 | FR-37 | Context information persistence | [Memory System Architecture](architecture/memory_system.md) | src/devsynth/adapters/memory/json_file_store.py | tests/behavior/test_chromadb_integration.py | Implemented |
 | FR-38 | Token count tracking for context | [DevSynth Technical Specification](specifications/devsynth_specification.md) | src/devsynth/application/utils/token_tracker.py | tests/unit/general/test_token_tracker.py | Implemented |
-| FR-40 | EDRR (Expand, Differentiate, Refine, Retrospect) framework | [EDRR Specification](specifications/edrr_cycle_specification.md) | src/devsynth/application/EDRR/coordinator.py | tests/behavior/features/edrr_coordinator.feature | Implemented |
-| FR-41 | WSDE (WSDE) model | [WSDE Interaction Specification](specifications/wsde_interaction_specification.md) | src/devsynth/application/collaboration/WSDE.py | tests/behavior/features/wsde_agent_model.feature | Implemented |
-| FR-42 | Role management in multi-agent collaboration | [WSDE Interaction Specification](specifications/wsde_interaction_specification.md) | src/devsynth/application/collaboration/WSDE.py | tests/behavior/features/wsde_agent_model.feature | Implemented |
-| FR-43 | Dialectical reasoning in agent collaboration | [WSDE Interaction Specification](specifications/wsde_interaction_specification.md) | src/devsynth/application/collaboration/WSDE.py | tests/behavior/features/wsde_agent_model.feature | Implemented |
+| FR-40 | EDRR (Expand, Differentiate, Refine, Retrospect) framework | [EDRR Specification](specifications/edrr_cycle_specification.md) | src/devsynth/application/EDRR/coordinator.py | tests/behavior/features/edrr_coordinator.feature | Partially Implemented |
+| FR-41 | WSDE (WSDE) model | [WSDE Interaction Specification](specifications/wsde_interaction_specification.md) | src/devsynth/application/collaboration/WSDE.py | tests/behavior/features/wsde_agent_model.feature | Partially Implemented |
+| FR-42 | Role management in multi-agent collaboration | [WSDE Interaction Specification](specifications/wsde_interaction_specification.md) | src/devsynth/application/collaboration/WSDE.py | tests/behavior/features/wsde_agent_model.feature | Partially Implemented |
+| FR-43 | Dialectical reasoning in agent collaboration | [WSDE Interaction Specification](specifications/wsde_interaction_specification.md) | src/devsynth/application/collaboration/WSDE.py | tests/behavior/features/wsde_agent_model.feature | Partially Implemented |
 | FR-44 | TinyDB memory adapter | [Hybrid Memory Architecture](specifications/hybrid_memory_architecture.md) | src/devsynth/application/memory/adapters/tinydb_adapter.py | tests/unit/application/memory/test_tinydb_store.py | Implemented |
 | FR-45 | RDFLib knowledge graph store | [Hybrid Memory Architecture](specifications/hybrid_memory_architecture.md) | src/devsynth/application/memory/adapters/rdflib_store.py | tests/behavior/features/advanced_graph_memory_features.feature | Implemented |
 | FR-46 | Graph memory adapter | [Hybrid Memory Architecture](specifications/hybrid_memory_architecture.md) | src/devsynth/application/memory/adapters/graph_adapter.py | tests/unit/application/memory/test_graph_memory_adapter.py | Implemented |
@@ -97,7 +97,9 @@ This matrix links requirements to design, code modules, and tests, ensuring bidi
 | FR-88 | Methodology adapter system for customizing development workflows | [Methodology Integration Framework](technical_reference/methodology_integration_framework.md) | src/devsynth/methodology/adhoc.py, src/devsynth/methodology/sprint.py | tests/unit/methodology/test_adhoc_adapter.py, tests/unit/methodology/test_sprint_adapter.py | Implemented |
 | FR-89 | Conditional retry logic for provider API calls | [Retry Mechanism with Exponential Backoff](adapters/providers/retry_mechanism.md) | src/devsynth/fallback.py, src/devsynth/adapters/provider_system.py, src/devsynth/application/llm/openai_provider.py, src/devsynth/application/llm/lmstudio_provider.py | tests/unit/fallback/test_retry_conditions.py, tests/unit/adapters/test_provider_system.py | Implemented |
 
-_Last updated: July 23, 2025
+_Last updated: July 23, 2025_
 ## Implementation Status
 
-All documented requirements are implemented or planned as noted above.
+Several requirements remain **partially implemented**. Consult the status column
+above and the [Feature Status Matrix](implementation/feature_status_matrix.md)
+for work still in progress.

--- a/docs/roadmap/release_plan.md
+++ b/docs/roadmap/release_plan.md
@@ -84,3 +84,7 @@ To publish `0.1.0-beta.1`, the project must:
   [Feature Status Matrix](../implementation/feature_status_matrix.md) such as
   Methodology Integration and the Retry Mechanism.
 - Continue documentation cleanup and polish the Web UI preview.
+
+Current builds run with `features.wsde_collaboration` enabled but
+`features.dialectical_reasoning` disabled. Collaborative and dialectical
+reasoning features are still experimental and may fail in complex projects.


### PR DESCRIPTION
## Summary
- highlight partial EDRR support
- add limitations for WSDE/EDRR integration
- mark EDRR and WSDE requirements as partial
- note experimental collaboration features in release plan

## Testing
- `poetry run pip list | grep pytest-bdd`
- `poetry run pytest` *(fails: 408 failed, 853 passed, 94 skipped, 1 error)*

------
https://chatgpt.com/codex/tasks/task_e_688579d51cf883338963f8a5851f2c53