### PR TITLE
Enhance backend sync and fallback

### DIFF
--- a/src/devsynth/adapters/kuzu_memory_store.py
+++ b/src/devsynth/adapters/kuzu_memory_store.py
@@ -118,3 +118,8 @@ class KuzuMemoryStore(MemoryStore):
                 shutil.rmtree(temp_dir)
             except Exception as exc:  # pragma: no cover - defensive
                 logger.warning("Failed to clean up temporary Kuzu directory: %s", exc)
+
+    def get_all_items(self) -> List[MemoryItem]:
+        """Return all stored items."""
+
+        return self._store.get_all_items()

--- a/src/devsynth/adapters/memory/kuzu_adapter.py
+++ b/src/devsynth/adapters/memory/kuzu_adapter.py
@@ -131,6 +131,11 @@ class KuzuAdapter(VectorStore):
             self._persist()
         return existed
 
+    def get_all_vectors(self) -> List[MemoryVector]:
+        """Return all stored vectors."""
+
+        return list(self._store.values())
+
     def get_collection_stats(self) -> Dict[str, Any]:
         dim = 0
         if self._store:

--- a/src/devsynth/application/memory/faiss_store.py
+++ b/src/devsynth/application/memory/faiss_store.py
@@ -9,6 +9,7 @@ import json
 import uuid
 import tiktoken
 import numpy as np
+
 try:
     import faiss
 except ImportError as e:  # pragma: no cover - optional dependency
@@ -23,14 +24,15 @@ from ...domain.interfaces.memory import VectorStore
 from ...domain.models.memory import MemoryVector
 from devsynth.logging_setup import DevSynthLogger
 from devsynth.exceptions import (
-    DevSynthError, 
-    MemoryError, 
-    MemoryStoreError, 
-    MemoryItemNotFoundError
+    DevSynthError,
+    MemoryError,
+    MemoryStoreError,
+    MemoryItemNotFoundError,
 )
 
 # Create a logger for this module
 logger = DevSynthLogger(__name__)
+
 
 class FAISSStore(VectorStore):
     """
@@ -60,7 +62,9 @@ class FAISSStore(VectorStore):
         try:
             self.tokenizer = tiktoken.get_encoding("cl100k_base")  # OpenAI's encoding
         except Exception as e:
-            logger.warning(f"Failed to initialize tokenizer: {e}. Token counting will be approximate.")
+            logger.warning(
+                f"Failed to initialize tokenizer: {e}. Token counting will be approximate."
+            )
             self.tokenizer = None
 
         # Initialize FAISS index and metadata
@@ -71,13 +75,13 @@ class FAISSStore(VectorStore):
         try:
             # Initialize metadata dictionary
             if os.path.exists(self.metadata_file):
-                with open(self.metadata_file, 'r') as f:
+                with open(self.metadata_file, "r") as f:
                     self.metadata = json.load(f)
                 # Get dimension from existing metadata
                 if self.metadata and len(self.metadata) > 0:
                     first_id = next(iter(self.metadata))
-                    if 'embedding' in self.metadata[first_id]:
-                        self.dimension = len(self.metadata[first_id]['embedding'])
+                    if "embedding" in self.metadata[first_id]:
+                        self.dimension = len(self.metadata[first_id]["embedding"])
             else:
                 self.metadata = {}
 
@@ -107,7 +111,7 @@ class FAISSStore(VectorStore):
     def _save_metadata(self):
         """Save the metadata to disk."""
         try:
-            with open(self.metadata_file, 'w') as f:
+            with open(self.metadata_file, "w") as f:
                 json.dump(self.metadata, f)
             logger.info(f"Saved metadata to {self.metadata_file}")
         except Exception as e:
@@ -163,7 +167,7 @@ class FAISSStore(VectorStore):
         # Convert ISO format strings back to datetime objects
         result = {}
         for key, value in metadata.items():
-            if key == 'created_at' and isinstance(value, str):
+            if key == "created_at" and isinstance(value, str):
                 try:
                     result[key] = datetime.fromisoformat(value)
                 except ValueError:
@@ -205,10 +209,10 @@ class FAISSStore(VectorStore):
             # Check if the vector already exists
             if vector.id in self.metadata:
                 # Get the index of the existing vector
-                idx = self.metadata[vector.id].get('index')
+                idx = self.metadata[vector.id].get("index")
                 if idx is not None:
                     # Remove the existing vector (not directly supported by FAISS, so we'll handle in metadata)
-                    self.metadata[vector.id]['is_deleted'] = True
+                    self.metadata[vector.id]["is_deleted"] = True
 
             # Add the vector to the index
             self.index.add(embedding)
@@ -218,12 +222,16 @@ class FAISSStore(VectorStore):
 
             # Store metadata
             self.metadata[vector.id] = {
-                'content': vector.content,
-                'embedding': vector.embedding,
-                'metadata': self._serialize_metadata(vector.metadata or {}),
-                'created_at': vector.created_at.isoformat() if vector.created_at else datetime.now().isoformat(),
-                'index': idx,
-                'is_deleted': False
+                "content": vector.content,
+                "embedding": vector.embedding,
+                "metadata": self._serialize_metadata(vector.metadata or {}),
+                "created_at": (
+                    vector.created_at.isoformat()
+                    if vector.created_at
+                    else datetime.now().isoformat()
+                ),
+                "index": idx,
+                "is_deleted": False,
             }
 
             # Save the index and metadata
@@ -260,17 +268,23 @@ class FAISSStore(VectorStore):
             vector_metadata = self.metadata[vector_id]
 
             # Check if the vector is marked as deleted
-            if vector_metadata.get('is_deleted', False):
+            if vector_metadata.get("is_deleted", False):
                 logger.warning(f"Vector with ID {vector_id} is marked as deleted")
                 return None
 
             # Create a MemoryVector
             vector = MemoryVector(
                 id=vector_id,
-                content=vector_metadata.get('content'),
-                embedding=vector_metadata.get('embedding'),
-                metadata=self._deserialize_metadata(vector_metadata.get('metadata', {})),
-                created_at=datetime.fromisoformat(vector_metadata.get('created_at')) if vector_metadata.get('created_at') else None
+                content=vector_metadata.get("content"),
+                embedding=vector_metadata.get("embedding"),
+                metadata=self._deserialize_metadata(
+                    vector_metadata.get("metadata", {})
+                ),
+                created_at=(
+                    datetime.fromisoformat(vector_metadata.get("created_at"))
+                    if vector_metadata.get("created_at")
+                    else None
+                ),
             )
 
             # Update token count
@@ -284,7 +298,9 @@ class FAISSStore(VectorStore):
             logger.error(f"Error retrieving vector from FAISS: {e}")
             raise MemoryStoreError(f"Error retrieving vector: {e}")
 
-    def similarity_search(self, query_embedding: List[float], top_k: int = 5) -> List[MemoryVector]:
+    def similarity_search(
+        self, query_embedding: List[float], top_k: int = 5
+    ) -> List[MemoryVector]:
         """
         Search for vectors similar to the query embedding.
 
@@ -312,8 +328,12 @@ class FAISSStore(VectorStore):
 
             # Check if dimensions match
             if query.shape[1] != self.dimension:
-                logger.error(f"Query dimension {query.shape[1]} does not match index dimension {self.dimension}")
-                raise MemoryStoreError(f"Query dimension {query.shape[1]} does not match index dimension {self.dimension}")
+                logger.error(
+                    f"Query dimension {query.shape[1]} does not match index dimension {self.dimension}"
+                )
+                raise MemoryStoreError(
+                    f"Query dimension {query.shape[1]} does not match index dimension {self.dimension}"
+                )
 
             # Adjust top_k if it's larger than the number of vectors
             effective_top_k = min(top_k, self.index.ntotal)
@@ -368,7 +388,7 @@ class FAISSStore(VectorStore):
                 # Find the vector ID for this index
                 vector_id = None
                 for vid, meta in self.metadata.items():
-                    if meta.get('index') == idx and not meta.get('is_deleted', False):
+                    if meta.get("index") == idx and not meta.get("is_deleted", False):
                         vector_id = vid
                         break
 
@@ -410,13 +430,13 @@ class FAISSStore(VectorStore):
                 return False
 
             # Check if the vector is already marked as deleted
-            if self.metadata[vector_id].get('is_deleted', False):
+            if self.metadata[vector_id].get("is_deleted", False):
                 logger.warning(f"Vector with ID {vector_id} is already deleted")
                 return False
 
             # Mark the vector as deleted in metadata
             # Note: FAISS doesn't support direct deletion, so we mark it in metadata
-            self.metadata[vector_id]['is_deleted'] = True
+            self.metadata[vector_id]["is_deleted"] = True
 
             # Save the metadata
             self._save_metadata()
@@ -440,13 +460,17 @@ class FAISSStore(VectorStore):
         """
         try:
             # Count non-deleted vectors
-            active_vectors = sum(1 for meta in self.metadata.values() if not meta.get('is_deleted', False))
+            active_vectors = sum(
+                1
+                for meta in self.metadata.values()
+                if not meta.get("is_deleted", False)
+            )
 
             stats = {
                 "num_vectors": active_vectors,
                 "embedding_dimension": self.dimension,
                 "index_file": self.index_file,
-                "total_vectors_in_index": self.index.ntotal
+                "total_vectors_in_index": self.index.ntotal,
             }
 
             logger.info(f"Retrieved collection statistics: {stats}")
@@ -455,3 +479,13 @@ class FAISSStore(VectorStore):
         except Exception as e:
             logger.error(f"Error getting collection statistics from FAISS: {e}")
             raise MemoryStoreError(f"Error getting collection statistics: {e}")
+
+    def get_all_vectors(self) -> List[MemoryVector]:
+        """Return all stored vectors."""
+
+        vectors: List[MemoryVector] = []
+        for vid in list(self.metadata.keys()):
+            vec = self.retrieve_vector(vid)
+            if vec:
+                vectors.append(vec)
+        return vectors

--- a/src/devsynth/application/memory/kuzu_store.py
+++ b/src/devsynth/application/memory/kuzu_store.py
@@ -276,3 +276,19 @@ class KuzuStore(MemoryStore):
 
     def get_embedding_storage_efficiency(self) -> float:
         return 0.85
+
+    def get_all_items(self) -> List[MemoryItem]:
+        """Return all stored :class:`MemoryItem` objects."""
+
+        if self._use_fallback:
+            return list(self._store.values())
+
+        items: List[MemoryItem] = []
+        try:  # pragma: no cover - requires kuzu
+            for item_id in self._all_ids():
+                itm = self._retrieve_from_db(item_id)
+                if itm:
+                    items.append(itm)
+        except Exception as exc:  # pragma: no cover - defensive
+            logger.warning("Failed to fetch all items from Kuzu: %s", exc)
+        return items

--- a/tests/integration/general/test_ingestion_pipeline.py
+++ b/tests/integration/general/test_ingestion_pipeline.py
@@ -4,15 +4,31 @@ Integration tests for the ingestion pipeline.
 This module tests the functionality of the ingestion module, which implements
 the "Expand, Differentiate, Refine, Retrospect" methodology for project ingestion.
 """
+
 import os
 import pytest
 import tempfile
 import yaml
 import json
+import sys
 from pathlib import Path
 from unittest.mock import patch, MagicMock
-from devsynth.application.ingestion import Ingestion, ArtifactType, ArtifactStatus, IngestionPhase, ProjectStructureType, IngestionMetrics
+from devsynth.application.ingestion import (
+    Ingestion,
+    ArtifactType,
+    ArtifactStatus,
+    IngestionPhase,
+    ProjectStructureType,
+    IngestionMetrics,
+)
 from devsynth.exceptions import IngestionError, ManifestError
+from devsynth.application.memory.lmdb_store import LMDBStore
+from devsynth.application.memory.faiss_store import FAISSStore
+from devsynth.adapters.kuzu_memory_store import KuzuMemoryStore
+from devsynth.application.memory.memory_manager import MemoryManager
+from devsynth.application.memory.sync_manager import SyncManager
+from devsynth.domain.models.memory import MemoryItem, MemoryVector, MemoryType
+from devsynth.adapters.memory.memory_adapter import MemorySystemAdapter
 
 
 @pytest.fixture
@@ -25,16 +41,20 @@ def temp_project_dir():
 @pytest.fixture
 def basic_manifest_data():
     """Create basic manifest data for testing."""
-    return {'metadata': {'projectName': 'TestProject', 'version': '0.1.0'},
-        'structure': {'type': 'single_package', 'directories': {'source': [
-        'src'], 'tests': ['tests'], 'docs': ['docs']}}}
+    return {
+        "metadata": {"projectName": "TestProject", "version": "0.1.0"},
+        "structure": {
+            "type": "single_package",
+            "directories": {"source": ["src"], "tests": ["tests"], "docs": ["docs"]},
+        },
+    }
 
 
 @pytest.fixture
 def create_manifest_file(temp_project_dir, basic_manifest_data):
     """Create a manifest.yaml file in the temporary project directory."""
-    manifest_path = temp_project_dir / 'manifest.yaml'
-    with open(manifest_path, 'w') as f:
+    manifest_path = temp_project_dir / "manifest.yaml"
+    with open(manifest_path, "w") as f:
         yaml.dump(basic_manifest_data, f)
     return manifest_path
 
@@ -42,28 +62,28 @@ def create_manifest_file(temp_project_dir, basic_manifest_data):
 @pytest.fixture
 def create_project_structure(temp_project_dir):
     """Create a basic project structure in the temporary directory."""
-    src_dir = temp_project_dir / 'src'
-    tests_dir = temp_project_dir / 'tests'
-    docs_dir = temp_project_dir / 'docs'
+    src_dir = temp_project_dir / "src"
+    tests_dir = temp_project_dir / "tests"
+    docs_dir = temp_project_dir / "docs"
     src_dir.mkdir()
     tests_dir.mkdir()
     docs_dir.mkdir()
-    (src_dir / 'main.py').touch()
-    (src_dir / 'utils.py').touch()
-    (tests_dir / 'test_main.py').touch()
-    (docs_dir / 'README.md').touch()
+    (src_dir / "main.py").touch()
+    (src_dir / "utils.py").touch()
+    (tests_dir / "test_main.py").touch()
+    (docs_dir / "README.md").touch()
     return temp_project_dir
 
 
 class TestIngestionMetrics:
     """Tests for the IngestionMetrics class.
 
-ReqID: N/A"""
+    ReqID: N/A"""
 
     def test_metrics_initialization_succeeds(self):
         """Test initialization of IngestionMetrics.
 
-ReqID: N/A"""
+        ReqID: N/A"""
         metrics = IngestionMetrics()
         assert metrics.artifacts_discovered == 0
         assert metrics.errors_encountered == 0
@@ -78,7 +98,7 @@ ReqID: N/A"""
     def test_phase_timing_has_expected(self):
         """Test phase timing in IngestionMetrics.
 
-ReqID: N/A"""
+        ReqID: N/A"""
         metrics = IngestionMetrics()
         metrics.start_phase(IngestionPhase.EXPAND)
         assert metrics.current_phase == IngestionPhase.EXPAND
@@ -96,7 +116,7 @@ ReqID: N/A"""
     def test_complete_metrics_succeeds(self):
         """Test completing metrics collection.
 
-ReqID: N/A"""
+        ReqID: N/A"""
         metrics = IngestionMetrics()
         metrics.start_phase(IngestionPhase.EXPAND)
         metrics.complete()
@@ -108,7 +128,7 @@ ReqID: N/A"""
     def test_get_summary_succeeds(self):
         """Test getting a summary of metrics.
 
-ReqID: N/A"""
+        ReqID: N/A"""
         metrics = IngestionMetrics()
         metrics.artifacts_discovered = 10
         metrics.errors_encountered = 2
@@ -120,28 +140,27 @@ ReqID: N/A"""
         metrics.start_phase(IngestionPhase.EXPAND)
         metrics.end_phase()
         summary = metrics.get_summary()
-        assert summary['artifacts']['total'] == 10
-        assert summary['artifacts']['by_type']['CODE'] == 5
-        assert summary['artifacts']['by_type']['TEST'] == 3
-        assert summary['artifacts']['by_status']['NEW'] == 8
-        assert summary['artifacts']['by_status']['CHANGED'] == 2
-        assert summary['errors'] == 2
-        assert summary['warnings'] == 3
-        assert 'duration_seconds' in summary
-        assert 'phases' in summary
-        assert 'EXPAND' in summary['phases']
+        assert summary["artifacts"]["total"] == 10
+        assert summary["artifacts"]["by_type"]["CODE"] == 5
+        assert summary["artifacts"]["by_type"]["TEST"] == 3
+        assert summary["artifacts"]["by_status"]["NEW"] == 8
+        assert summary["artifacts"]["by_status"]["CHANGED"] == 2
+        assert summary["errors"] == 2
+        assert summary["warnings"] == 3
+        assert "duration_seconds" in summary
+        assert "phases" in summary
+        assert "EXPAND" in summary["phases"]
 
 
 class TestIngestion:
     """Tests for the Ingestion class.
 
-ReqID: N/A"""
+    ReqID: N/A"""
 
-    def test_initialization_succeeds(self, temp_project_dir,
-        create_manifest_file):
+    def test_initialization_succeeds(self, temp_project_dir, create_manifest_file):
         """Test initialization of the Ingestion class.
 
-ReqID: N/A"""
+        ReqID: N/A"""
         ingestion = Ingestion(temp_project_dir, create_manifest_file)
         assert str(ingestion.project_root) == str(temp_project_dir.resolve())
         assert ingestion.manifest_path == create_manifest_file
@@ -155,15 +174,16 @@ ReqID: N/A"""
     def test_initialization_with_nonexistent_project_root_succeeds(self):
         """Test initialization with a non-existent project root.
 
-ReqID: N/A"""
+        ReqID: N/A"""
         with pytest.raises(IngestionError):
-            Ingestion('/nonexistent/path')
+            Ingestion("/nonexistent/path")
 
-    def test_load_manifest_succeeds(self, temp_project_dir,
-        create_manifest_file, basic_manifest_data):
+    def test_load_manifest_succeeds(
+        self, temp_project_dir, create_manifest_file, basic_manifest_data
+    ):
         """Test loading the manifest file.
 
-ReqID: N/A"""
+        ReqID: N/A"""
         ingestion = Ingestion(temp_project_dir, create_manifest_file)
         manifest_data = ingestion.load_manifest()
         assert manifest_data == basic_manifest_data
@@ -173,144 +193,189 @@ ReqID: N/A"""
     def test_load_manifest_file_not_found_succeeds(self, temp_project_dir):
         """Test loading a non-existent manifest file.
 
-ReqID: N/A"""
-        ingestion = Ingestion(temp_project_dir, temp_project_dir /
-            'nonexistent.yaml')
+        ReqID: N/A"""
+        ingestion = Ingestion(temp_project_dir, temp_project_dir / "nonexistent.yaml")
         with pytest.raises(ManifestError):
             ingestion.load_manifest()
 
     def test_load_manifest_invalid_yaml_is_valid(self, temp_project_dir):
         """Test loading an invalid YAML manifest file.
 
-ReqID: N/A"""
-        manifest_path = temp_project_dir / 'manifest.yaml'
-        with open(manifest_path, 'w') as f:
-            f.write('invalid: yaml: content:\n  - missing colon\n')
+        ReqID: N/A"""
+        manifest_path = temp_project_dir / "manifest.yaml"
+        with open(manifest_path, "w") as f:
+            f.write("invalid: yaml: content:\n  - missing colon\n")
         ingestion = Ingestion(temp_project_dir, manifest_path)
         with pytest.raises(ManifestError):
             ingestion.load_manifest()
 
-    def test_load_manifest_missing_required_fields_succeeds(self,
-        temp_project_dir):
+    def test_load_manifest_missing_required_fields_succeeds(self, temp_project_dir):
         """Test loading a manifest file with missing required fields.
 
-ReqID: N/A"""
-        manifest_path = temp_project_dir / 'manifest.yaml'
-        with open(manifest_path, 'w') as f:
-            yaml.dump({'projectName': 'TestProject'}, f)
+        ReqID: N/A"""
+        manifest_path = temp_project_dir / "manifest.yaml"
+        with open(manifest_path, "w") as f:
+            yaml.dump({"projectName": "TestProject"}, f)
         ingestion = Ingestion(temp_project_dir, manifest_path)
         with pytest.raises(ManifestError):
             ingestion.load_manifest()
 
-    @patch('devsynth.domain.models.project.ProjectModel')
-    def test_run_ingestion_succeeds(self, mock_project_model,
-        temp_project_dir, create_manifest_file, create_project_structure):
+    @patch("devsynth.domain.models.project.ProjectModel")
+    def test_run_ingestion_succeeds(
+        self,
+        mock_project_model,
+        temp_project_dir,
+        create_manifest_file,
+        create_project_structure,
+    ):
         """Test running the full ingestion process.
 
-ReqID: N/A"""
+        ReqID: N/A"""
         mock_instance = MagicMock()
         mock_project_model.return_value = mock_instance
-        mock_instance.to_dict.return_value = {'artifacts': {
-            '/test/path/file.py': {'name': 'file.py', 'type': 'CODE',
-            'is_directory': False, 'metadata': {}}}, 'relationships': [{
-            'source': '/test/path', 'target': '/test/path/file.py',
-            'metadata': {'relationship': 'contains'}}]}
+        mock_instance.to_dict.return_value = {
+            "artifacts": {
+                "/test/path/file.py": {
+                    "name": "file.py",
+                    "type": "CODE",
+                    "is_directory": False,
+                    "metadata": {},
+                }
+            },
+            "relationships": [
+                {
+                    "source": "/test/path",
+                    "target": "/test/path/file.py",
+                    "metadata": {"relationship": "contains"},
+                }
+            ],
+        }
         ingestion = Ingestion(temp_project_dir, create_manifest_file)
         result = ingestion.run_ingestion(verbose=True)
-        assert result['success'] is True
-        assert 'metrics' in result
-        assert 'artifacts' in result
-        assert result['artifacts']['total'] == 1
-        assert 'project_structure' in result
+        assert result["success"] is True
+        assert "metrics" in result
+        assert "artifacts" in result
+        assert result["artifacts"]["total"] == 1
+        assert "project_structure" in result
         mock_project_model.assert_called_once()
         mock_instance.build_model.assert_called_once()
 
-    @patch('devsynth.domain.models.project.ProjectModel')
-    def test_run_ingestion_with_error_raises_error(self, mock_project_model,
-        temp_project_dir, create_manifest_file):
+    @patch("devsynth.domain.models.project.ProjectModel")
+    def test_run_ingestion_with_error_raises_error(
+        self, mock_project_model, temp_project_dir, create_manifest_file
+    ):
         """Test running ingestion with an error.
 
-ReqID: N/A"""
-        mock_project_model.side_effect = Exception('Test error')
+        ReqID: N/A"""
+        mock_project_model.side_effect = Exception("Test error")
         ingestion = Ingestion(temp_project_dir, create_manifest_file)
         result = ingestion.run_ingestion()
-        assert result['success'] is False
-        assert 'error' in result
-        assert 'Test error' in result['error']
-        assert 'metrics' in result
-        assert result['metrics']['errors'] == 2
+        assert result["success"] is False
+        assert "error" in result
+        assert "Test error" in result["error"]
+        assert "metrics" in result
+        assert result["metrics"]["errors"] == 2
 
-    @patch('devsynth.domain.models.project.ProjectModel')
-    def test_expand_phase_has_expected(self, mock_project_model,
-        temp_project_dir, create_manifest_file):
+    @patch("devsynth.domain.models.project.ProjectModel")
+    def test_expand_phase_has_expected(
+        self, mock_project_model, temp_project_dir, create_manifest_file
+    ):
         """Test the Expand phase of the ingestion process.
 
-ReqID: N/A"""
+        ReqID: N/A"""
         mock_instance = MagicMock()
         mock_project_model.return_value = mock_instance
-        mock_instance.to_dict.return_value = {'artifacts': {
-            '/test/path/file.py': {'name': 'file.py', 'type': 'CODE',
-            'is_directory': False, 'metadata': {}}}, 'relationships': [{
-            'source': '/test/path', 'target': '/test/path/file.py',
-            'metadata': {'relationship': 'contains'}}]}
+        mock_instance.to_dict.return_value = {
+            "artifacts": {
+                "/test/path/file.py": {
+                    "name": "file.py",
+                    "type": "CODE",
+                    "is_directory": False,
+                    "metadata": {},
+                }
+            },
+            "relationships": [
+                {
+                    "source": "/test/path",
+                    "target": "/test/path/file.py",
+                    "metadata": {"relationship": "contains"},
+                }
+            ],
+        }
         ingestion = Ingestion(temp_project_dir, create_manifest_file)
         ingestion.load_manifest()
         ingestion._run_expand_phase(False, True)
         assert len(ingestion.artifacts) == 1
-        assert '/test/path/file.py' in ingestion.artifacts
+        assert "/test/path/file.py" in ingestion.artifacts
         assert ingestion.metrics.artifacts_discovered == 1
         assert ingestion.metrics.artifacts_by_status[ArtifactStatus.NEW] == 1
         mock_project_model.assert_called_once()
         mock_instance.build_model.assert_called_once()
 
-    def test_differentiate_phase_has_expected(self, temp_project_dir,
-        create_manifest_file):
+    def test_differentiate_phase_has_expected(
+        self, temp_project_dir, create_manifest_file
+    ):
         """Test the Differentiate phase of the ingestion process.
 
-ReqID: N/A"""
+        ReqID: N/A"""
         ingestion = Ingestion(temp_project_dir, create_manifest_file)
         ingestion.load_manifest()
-        ingestion.artifacts = {str(temp_project_dir / 'src' / 'file.py'): {
-            'name': 'file.py', 'type': 'CODE', 'is_directory': False,
-            'metadata': {}}}
+        ingestion.artifacts = {
+            str(temp_project_dir / "src" / "file.py"): {
+                "name": "file.py",
+                "type": "CODE",
+                "is_directory": False,
+                "metadata": {},
+            }
+        }
         ingestion._run_differentiate_phase(False, True)
         ingestion.metrics.end_phase()
-        assert ingestion.metrics.phase_durations[IngestionPhase.DIFFERENTIATE
-            ] > 0
+        assert ingestion.metrics.phase_durations[IngestionPhase.DIFFERENTIATE] > 0
 
-    def test_refine_phase_has_expected(self, temp_project_dir,
-        create_manifest_file):
+    def test_refine_phase_has_expected(self, temp_project_dir, create_manifest_file):
         """Test the Refine phase of the ingestion process.
 
-ReqID: N/A"""
+        ReqID: N/A"""
         ingestion = Ingestion(temp_project_dir, create_manifest_file)
         ingestion.load_manifest()
-        ingestion.artifacts = {str(temp_project_dir / 'src' / 'file.py'): {
-            'name': 'file.py', 'type': 'CODE', 'is_directory': False,
-            'metadata': {}}}
+        ingestion.artifacts = {
+            str(temp_project_dir / "src" / "file.py"): {
+                "name": "file.py",
+                "type": "CODE",
+                "is_directory": False,
+                "metadata": {},
+            }
+        }
         ingestion._run_refine_phase(True, True)
         ingestion.metrics.end_phase()
         assert ingestion.metrics.phase_durations[IngestionPhase.REFINE] > 0
 
-    def test_retrospect_phase_has_expected(self, temp_project_dir,
-        create_manifest_file):
+    def test_retrospect_phase_has_expected(
+        self, temp_project_dir, create_manifest_file
+    ):
         """Test the Retrospect phase of the ingestion process.
 
-ReqID: N/A"""
+        ReqID: N/A"""
         ingestion = Ingestion(temp_project_dir, create_manifest_file)
         ingestion.load_manifest()
-        ingestion.artifacts = {str(temp_project_dir / 'src' / 'file.py'): {
-            'name': 'file.py', 'type': 'CODE', 'is_directory': False,
-            'metadata': {}}}
+        ingestion.artifacts = {
+            str(temp_project_dir / "src" / "file.py"): {
+                "name": "file.py",
+                "type": "CODE",
+                "is_directory": False,
+                "metadata": {},
+            }
+        }
         ingestion._run_retrospect_phase(True, True)
         ingestion.metrics.end_phase()
         assert ingestion.metrics.phase_durations[IngestionPhase.RETROSPECT] > 0
 
-    def test_evaluate_ingestion_process_succeeds(self, temp_project_dir,
-        create_manifest_file):
+    def test_evaluate_ingestion_process_succeeds(
+        self, temp_project_dir, create_manifest_file
+    ):
         """Test evaluating the ingestion process.
 
-ReqID: N/A"""
+        ReqID: N/A"""
         ingestion = Ingestion(temp_project_dir, create_manifest_file)
         ingestion.metrics.artifacts_discovered = 10
         ingestion.metrics.errors_encountered = 0
@@ -320,97 +385,196 @@ ReqID: N/A"""
         ingestion.metrics.phase_durations[IngestionPhase.REFINE] = 0.3
         ingestion.metrics.phase_durations[IngestionPhase.RETROSPECT] = 0.2
         evaluation = ingestion._evaluate_ingestion_process(True)
-        assert evaluation['success'] is True
-        assert evaluation['artifacts_discovered'] == 10
-        assert evaluation['errors'] == 0
-        assert evaluation['warnings'] == 2
-        assert 'phase_durations' in evaluation
-        assert 'phase_percentages' in evaluation
-        assert 'overall_assessment' in evaluation
+        assert evaluation["success"] is True
+        assert evaluation["artifacts_discovered"] == 10
+        assert evaluation["errors"] == 0
+        assert evaluation["warnings"] == 2
+        assert "phase_durations" in evaluation
+        assert "phase_percentages" in evaluation
+        assert "overall_assessment" in evaluation
 
-    def test_identify_improvement_areas_succeeds(self, temp_project_dir,
-        create_manifest_file):
+    def test_identify_improvement_areas_succeeds(
+        self, temp_project_dir, create_manifest_file
+    ):
         """Test identifying improvement areas.
 
-ReqID: N/A"""
+        ReqID: N/A"""
         ingestion = Ingestion(temp_project_dir, create_manifest_file)
         ingestion.load_manifest()
         ingestion.metrics.artifacts_by_type[ArtifactType.CODE] = 10
         ingestion.metrics.artifacts_by_type[ArtifactType.TEST] = 0
         improvements = ingestion._identify_improvement_areas(True)
         assert len(improvements) > 0
-        assert any(imp['area'] == 'Testing' for imp in improvements)
+        assert any(imp["area"] == "Testing" for imp in improvements)
 
-    def test_generate_recommendations_succeeds(self, temp_project_dir,
-        create_manifest_file):
+    def test_generate_recommendations_succeeds(
+        self, temp_project_dir, create_manifest_file
+    ):
         """Test generating recommendations.
 
-ReqID: N/A"""
+        ReqID: N/A"""
         ingestion = Ingestion(temp_project_dir, create_manifest_file)
         ingestion.project_structure = ProjectStructureType.STANDARD
         recommendations = ingestion._generate_recommendations(True)
         assert len(recommendations) > 0
-        assert any(rec['category'] == 'Project Configuration' for rec in
-            recommendations)
+        assert any(
+            rec["category"] == "Project Configuration" for rec in recommendations
+        )
 
-    @patch('builtins.open', new_callable=MagicMock)
-    @patch('json.dump')
-    def test_save_refined_data_succeeds(self, mock_json_dump, mock_open,
-        temp_project_dir, create_manifest_file):
+    @patch("builtins.open", new_callable=MagicMock)
+    @patch("json.dump")
+    def test_save_refined_data_succeeds(
+        self, mock_json_dump, mock_open, temp_project_dir, create_manifest_file
+    ):
         """Test saving refined data.
 
-ReqID: N/A"""
+        ReqID: N/A"""
         ingestion = Ingestion(temp_project_dir, create_manifest_file)
-        refined_data = {'project_root': str(temp_project_dir),
-            'manifest_path': str(create_manifest_file), 'artifacts': {
-            'test': 'data'}, 'metrics': {'test': 'metrics'}}
-        with patch('os.makedirs'):
+        refined_data = {
+            "project_root": str(temp_project_dir),
+            "manifest_path": str(create_manifest_file),
+            "artifacts": {"test": "data"},
+            "metrics": {"test": "metrics"},
+        }
+        with patch("os.makedirs"):
             ingestion._save_refined_data(refined_data, True)
         assert mock_open.call_count == 2
         assert mock_json_dump.call_count == 2
 
-    @patch('builtins.open', new_callable=MagicMock)
-    def test_generate_markdown_summary_succeeds(self, mock_open,
-        temp_project_dir, create_manifest_file):
+    @patch("builtins.open", new_callable=MagicMock)
+    def test_generate_markdown_summary_succeeds(
+        self, mock_open, temp_project_dir, create_manifest_file
+    ):
         """Test generating a markdown summary.
 
-ReqID: N/A"""
+        ReqID: N/A"""
         ingestion = Ingestion(temp_project_dir, create_manifest_file)
-        retrospective = {'project_root': str(temp_project_dir),
-            'evaluation': {'overall_assessment': 'Good'}, 'metrics': {
-            'duration_seconds': 2.5, 'artifacts': {'total': 10}, 'errors': 
-            0, 'warnings': 2}, 'improvements': [{'area': 'Testing', 'issue':
-            'No tests', 'recommendation': 'Add tests'}], 'recommendations':
-            [{'category': 'Code', 'priority': 'High', 'recommendation':
-            'Refactor'}]}
-        ingestion._generate_markdown_summary(retrospective, Path(
-            'test_output.md'))
+        retrospective = {
+            "project_root": str(temp_project_dir),
+            "evaluation": {"overall_assessment": "Good"},
+            "metrics": {
+                "duration_seconds": 2.5,
+                "artifacts": {"total": 10},
+                "errors": 0,
+                "warnings": 2,
+            },
+            "improvements": [
+                {"area": "Testing", "issue": "No tests", "recommendation": "Add tests"}
+            ],
+            "recommendations": [
+                {"category": "Code", "priority": "High", "recommendation": "Refactor"}
+            ],
+        }
+        ingestion._generate_markdown_summary(retrospective, Path("test_output.md"))
         mock_open.assert_called_once()
         file_handle = mock_open.return_value.__enter__.return_value
         assert file_handle.write.call_count > 10
 
-    @patch('devsynth.domain.models.project.ProjectModel')
-    def test_full_pipeline_functions_has_expected(self, mock_project_model,
-        temp_project_dir, create_manifest_file, create_project_structure):
+    @patch("devsynth.domain.models.project.ProjectModel")
+    def test_full_pipeline_functions_has_expected(
+        self,
+        mock_project_model,
+        temp_project_dir,
+        create_manifest_file,
+        create_project_structure,
+    ):
         """Test the wrapper methods for each ingestion phase.
 
-ReqID: N/A"""
+        ReqID: N/A"""
         mock_instance = MagicMock()
         mock_project_model.return_value = mock_instance
-        mock_instance.to_dict.return_value = {'artifacts': {str(
-            temp_project_dir / 'src' / 'main.py'): {'name': 'main.py',
-            'type': 'CODE', 'is_directory': False, 'metadata': {}}},
-            'relationships': []}
+        mock_instance.to_dict.return_value = {
+            "artifacts": {
+                str(temp_project_dir / "src" / "main.py"): {
+                    "name": "main.py",
+                    "type": "CODE",
+                    "is_directory": False,
+                    "metadata": {},
+                }
+            },
+            "relationships": [],
+        }
         ingestion = Ingestion(temp_project_dir, create_manifest_file)
         ingestion.load_manifest()
-        ingestion.edrr_coordinator.memory_manager.store_with_edrr_phase = (
-            MagicMock())
+        ingestion.edrr_coordinator.memory_manager.store_with_edrr_phase = MagicMock()
         expand_res = ingestion.analyze_project_structure(True)
-        assert expand_res['artifacts']
+        assert expand_res["artifacts"]
         diff_res = ingestion.validate_artifacts(True)
-        assert 'status' in diff_res
+        assert "status" in diff_res
         refine_res = ingestion.remove_outdated_items(True, True)
-        assert 'status' in refine_res
+        assert "status" in refine_res
         retro_res = ingestion.summarize_outcomes(True, True)
-        assert retro_res['evaluation']['success'] is True
-        assert ingestion.edrr_coordinator.memory_manager.store_with_edrr_phase.call_count == 4
+        assert retro_res["evaluation"]["success"] is True
+        assert (
+            ingestion.edrr_coordinator.memory_manager.store_with_edrr_phase.call_count
+            == 4
+        )
+
+
+@pytest.mark.requires_resource("lmdb")
+@pytest.mark.requires_resource("faiss")
+@pytest.mark.requires_resource("kuzu")
+@pytest.mark.requires_resource("chromadb")
+def test_sync_manager_persistence_across_backends(tmp_path, monkeypatch):
+    monkeypatch.setenv("DEVSYNTH_NO_FILE_LOGGING", "1")
+    monkeypatch.setenv("ENABLE_CHROMADB", "1")
+    import chromadb.utils.embedding_functions as ef
+
+    monkeypatch.setattr(ef, "DefaultEmbeddingFunction", lambda: (lambda x: [0.0] * 5))
+
+    lmdb_store = LMDBStore(str(tmp_path / "lmdb"))
+    faiss_store = FAISSStore(str(tmp_path / "faiss"))
+    kuzu_store = KuzuMemoryStore.create_ephemeral()
+
+    manager = MemoryManager(
+        adapters={"lmdb": lmdb_store, "faiss": faiss_store, "kuzu": kuzu_store}
+    )
+    manager.sync_manager = SyncManager(manager)
+
+    item = MemoryItem(id="sync1", content="hello", memory_type=MemoryType.CODE)
+    lmdb_store.store(item)
+    vector = MemoryVector(id="sync1", content="hello", embedding=[0.1] * 5, metadata={})
+    faiss_store.store_vector(vector)
+
+    manager.synchronize("lmdb", "kuzu")
+    manager.synchronize("faiss", "kuzu")
+
+    reloaded = KuzuMemoryStore(
+        persist_directory=kuzu_store.persist_directory,
+        use_provider_system=False,
+        provider_type=None,
+        collection_name="devsynth_artifacts",
+    )
+
+    assert reloaded.retrieve("sync1") is not None
+    assert reloaded.vector.retrieve_vector("sync1") is not None
+
+    kuzu_store.cleanup()
+
+
+def test_kuzu_fallback_to_chromadb(tmp_path, monkeypatch):
+    monkeypatch.setenv("ENABLE_CHROMADB", "1")
+    monkeypatch.setitem(sys.modules, "kuzu", None)
+    import importlib
+    import devsynth.application.memory.kuzu_store as kuzu_store_module
+
+    importlib.reload(kuzu_store_module)
+    import devsynth.adapters.kuzu_memory_store as km_store
+
+    importlib.reload(km_store)
+
+    with patch("devsynth.adapters.kuzu_memory_store.embed", return_value=[0.0] * 5):
+        adapter = MemorySystemAdapter(
+            config={
+                "memory_store_type": "kuzu",
+                "memory_file_path": str(tmp_path),
+                "vector_store_enabled": True,
+                "enable_chromadb": True,
+            }
+        )
+
+    from devsynth.application.memory.chromadb_store import ChromaDBStore
+    from devsynth.adapters.memory.chroma_db_adapter import ChromaDBAdapter
+
+    assert isinstance(adapter.memory_store, ChromaDBStore)
+    assert isinstance(adapter.vector_store, ChromaDBAdapter)


### PR DESCRIPTION
## Summary
- finalize LMDB/FAISS/Kuzu sync manager
- add `get_all_items` and `get_all_vectors` helpers
- fallback to ChromaDB when Kuzu unavailable
- verify persistence across backends

## Testing
- `poetry run pytest -k test_sync_manager_persistence_across_backends -q`
- `poetry run pytest tests/integration/general/test_ingestion_pipeline.py::test_sync_manager_persistence_across_backends tests/integration/general/test_ingestion_pipeline.py::test_kuzu_fallback_to_chromadb -q`

------
https://chatgpt.com/codex/tasks/task_e_688583d7b66883339473ef178552e9da