### PR TITLE
Enhance retry metrics and conditional logic

### DIFF
--- a/tests/unit/fallback/test_retry_conditions.py
+++ b/tests/unit/fallback/test_retry_conditions.py
@@ -8,14 +8,14 @@ def test_should_retry_prevents_retry():
     """Retry decorator should not retry when ``should_retry`` returns False.
 
     ReqID: FR-89"""
-    mock_func = Mock(side_effect=ValueError("boom"))
+    mock_func = Mock(side_effect=Exception("boom"))
     mock_func.__name__ = "mock_func"
 
     decorated = retry_with_exponential_backoff(
         max_retries=3, initial_delay=0.1, should_retry=lambda exc: False
     )(mock_func)
 
-    with pytest.raises(ValueError):
+    with pytest.raises(Exception):
         decorated()
 
     assert mock_func.call_count == 1
@@ -25,7 +25,7 @@ def test_should_retry_allows_retry_until_success():
     """Retry decorator retries when ``should_retry`` returns True.
 
     ReqID: FR-89"""
-    mock_func = Mock(side_effect=[ValueError("err"), ValueError("err"), "ok"])
+    mock_func = Mock(side_effect=[Exception("err"), Exception("err"), "ok"])
     mock_func.__name__ = "mock_func"
 
     decorated = retry_with_exponential_backoff(
@@ -51,4 +51,30 @@ def test_retry_on_result_triggers_retry():
     result = decorated()
 
     assert result == "good"
+    assert mock_func.call_count == 2
+
+
+def test_retry_conditions_abort_when_condition_fails():
+    mock_func = Mock(side_effect=Exception("boom"))
+    mock_func.__name__ = "mock_func"
+    decorated = retry_with_exponential_backoff(
+        max_retries=2,
+        initial_delay=0,
+        retry_conditions=[lambda e: "retry" in str(e)],
+    )(mock_func)
+    with pytest.raises(Exception):
+        decorated()
+    assert mock_func.call_count == 1
+
+
+def test_retry_conditions_allow_retry():
+    mock_func = Mock(side_effect=[Exception("please retry"), "ok"])
+    mock_func.__name__ = "mock_func"
+    decorated = retry_with_exponential_backoff(
+        max_retries=2,
+        initial_delay=0,
+        retry_conditions=[lambda e: "retry" in str(e)],
+    )(mock_func)
+    result = decorated()
+    assert result == "ok"
     assert mock_func.call_count == 2


### PR DESCRIPTION
## Summary
- extend `retry_with_exponential_backoff` to accept `retry_conditions`
- count successes even with no retries
- add tests for conditional policies and first try success metrics

## Testing
- `pytest -p no:tests.fixtures.ports -p no:tests.fixtures.kuzu tests/unit/fallback/test_retry_conditions.py tests/unit/fallback/test_retry_metrics.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68858779ca108333b2721f1b6d065063