### PR TITLE
Handle optional FAISS/ChromaDB imports in tests

### DIFF
--- a/tests/behavior/steps/test_chromadb_steps.py
+++ b/tests/behavior/steps/test_chromadb_steps.py
@@ -1,6 +1,7 @@
 """
 Step definitions for ChromaDB Integration feature with provider system integration.
 """
+
 import os
 import sys
 import pytest
@@ -11,6 +12,8 @@ from unittest.mock import patch, MagicMock
 
 # Import the necessary modules
 from devsynth.domain.models.memory import MemoryItem, MemoryType
+
+pytest.importorskip("chromadb")
 from devsynth.adapters.chromadb_memory_store import ChromaDBMemoryStore
 from devsynth.ports.memory_port import MemoryPort
 from devsynth.adapters.provider_system import get_provider, embed
@@ -35,8 +38,7 @@ def memory_store(temp_chromadb_path, llm_provider):
     the memory store can use either OpenAI or LM Studio for embeddings.
     """
     store = ChromaDBMemoryStore(
-        persist_directory=temp_chromadb_path,
-        use_provider_system=True
+        persist_directory=temp_chromadb_path, use_provider_system=True
     )
     return store
 
@@ -55,10 +57,12 @@ def memory_port(memory_store):
 def configure_memory_store_type(store_type):
     """Configure the memory store type."""
     # This step is now an assertion that we're using ChromaDB
-    assert store_type == "chromadb", "Only chromadb store type is supported in these tests"
+    assert (
+        store_type == "chromadb"
+    ), "Only chromadb store type is supported in these tests"
 
 
-@then('a ChromaDB memory store should be initialized')
+@then("a ChromaDB memory store should be initialized")
 def check_chromadb_initialized(memory_store):
     """Verify that a ChromaDB memory store is initialized."""
     assert isinstance(memory_store, ChromaDBMemoryStore)
@@ -69,22 +73,24 @@ def check_chromadb_initialized(memory_store):
 @given(parsers.parse('the memory store type is configured as "{store_type}"'))
 def given_memory_store_type(store_type, memory_store):
     """Configure the memory store type."""
-    assert store_type == "chromadb", "Only chromadb store type is supported in these tests"
+    assert (
+        store_type == "chromadb"
+    ), "Only chromadb store type is supported in these tests"
     assert isinstance(memory_store, ChromaDBMemoryStore)
 
 
-@when('I store an item in the memory store')
+@when("I store an item in the memory store")
 def store_item_in_memory(memory_port):
     """Store an item in the memory store."""
     # Store a test item in memory
     memory_port.store_memory(
         content="This is a test item for semantic search",
         memory_type=MemoryType.WORKING,
-        metadata={"test_id": "test-item-1"}
+        metadata={"test_id": "test-item-1"},
     )
 
 
-@then('I should be able to retrieve the item by its ID')
+@then("I should be able to retrieve the item by its ID")
 def retrieve_item_by_id(memory_port):
     """Verify that an item can be retrieved by its ID."""
     # First search for the item to get its ID
@@ -102,26 +108,44 @@ def retrieve_item_by_id(memory_port):
     assert "test item" in retrieved_item.content.lower()
 
 
-@given('I have stored multiple items with different content')
+@given("I have stored multiple items with different content")
 def store_multiple_items(memory_port):
     """Store multiple items with different content."""
     items = [
-        ("Document about Python programming language", MemoryType.WORKING, {"test_id": "python"}),
-        ("Article about JavaScript frameworks", MemoryType.WORKING, {"test_id": "javascript"}),
-        ("Tutorial on machine learning algorithms", MemoryType.WORKING, {"test_id": "ml"}),
-        ("Guide to natural language processing", MemoryType.WORKING, {"test_id": "nlp"}),
-        ("Introduction to database systems", MemoryType.WORKING, {"test_id": "database"})
+        (
+            "Document about Python programming language",
+            MemoryType.WORKING,
+            {"test_id": "python"},
+        ),
+        (
+            "Article about JavaScript frameworks",
+            MemoryType.WORKING,
+            {"test_id": "javascript"},
+        ),
+        (
+            "Tutorial on machine learning algorithms",
+            MemoryType.WORKING,
+            {"test_id": "ml"},
+        ),
+        (
+            "Guide to natural language processing",
+            MemoryType.WORKING,
+            {"test_id": "nlp"},
+        ),
+        (
+            "Introduction to database systems",
+            MemoryType.WORKING,
+            {"test_id": "database"},
+        ),
     ]
 
     for content, memory_type, metadata in items:
         memory_port.store_memory(
-            content=content,
-            memory_type=memory_type,
-            metadata=metadata
+            content=content, memory_type=memory_type, metadata=metadata
         )
 
 
-@when(parsers.parse('I perform a semantic search for similar content'))
+@when(parsers.parse("I perform a semantic search for similar content"))
 def perform_semantic_search(memory_port):
     """Perform a semantic search for similar content."""
     memory_port.context_manager.add_to_context.return_value = None
@@ -133,11 +157,13 @@ def perform_semantic_search(memory_port):
     memory_port.context_manager.add_to_context.return_value = results
 
 
-@then('I should receive items ranked by semantic similarity')
+@then("I should receive items ranked by semantic similarity")
 def check_semantic_search_results(memory_port):
     """Verify that items are ranked by semantic similarity."""
     # Retrieve the search results from the context
-    memory_port.context_manager.get_from_context.return_value = memory_port.search_memory({"query": "programming languages", "top_k": 3})
+    memory_port.context_manager.get_from_context.return_value = (
+        memory_port.search_memory({"query": "programming languages", "top_k": 3})
+    )
     results = memory_port.context_manager.get_from_context.return_value
 
     # Verify that we have results
@@ -153,13 +179,12 @@ def check_semantic_search_results(memory_port):
     assert python_found, "Expected Python document in top results"
 
 
-@when('I restart the application')
+@when("I restart the application")
 def restart_application(memory_store, temp_chromadb_path):
     """Simulate restarting the application by recreating the memory store."""
     # We're simulating a restart by creating a new instance with the same persistence directory
     new_store = ChromaDBMemoryStore(
-        persist_directory=temp_chromadb_path,
-        use_provider_system=True
+        persist_directory=temp_chromadb_path, use_provider_system=True
     )
 
     # Store the new instance for later assertions
@@ -167,7 +192,7 @@ def restart_application(memory_store, temp_chromadb_path):
     memory_store.collection = new_store.collection
 
 
-@then('the previously stored items should still be available')
+@then("the previously stored items should still be available")
 def check_item_persistence(memory_port):
     """Verify that items are still available after restart."""
     # Check that items can still be found

--- a/tests/unit/adapters/memory/test_memory_adapter.py
+++ b/tests/unit/adapters/memory/test_memory_adapter.py
@@ -9,15 +9,6 @@ from devsynth.adapters.memory.memory_adapter import MemorySystemAdapter
 from devsynth.application.memory.json_file_store import JSONFileStore
 from devsynth.application.memory.tinydb_store import TinyDBStore
 from devsynth.application.memory.duckdb_store import DuckDBStore
-
-try:
-    from devsynth.application.memory.lmdb_store import LMDBStore
-except ImportError:
-    LMDBStore = None
-try:
-    from devsynth.application.memory.faiss_store import FAISSStore
-except ImportError:
-    FAISSStore = None
 from devsynth.adapters.kuzu_memory_store import KuzuMemoryStore
 from devsynth.adapters.memory.kuzu_adapter import KuzuAdapter
 from devsynth.application.memory.rdflib_store import RDFLibStore
@@ -119,6 +110,9 @@ class TestMemorySystemAdapter:
             "context_expiration_days": 1,
             "vector_store_enabled": False,
         }
+        pytest.importorskip("lmdb")
+        from devsynth.application.memory.lmdb_store import LMDBStore
+
         adapter = MemorySystemAdapter(config=config)
         assert adapter.storage_type == "lmdb"
         assert adapter.memory_path == temp_dir
@@ -151,6 +145,9 @@ class TestMemorySystemAdapter:
         """Test initialization with FAISS storage.
 
         ReqID: N/A"""
+        pytest.importorskip("faiss")
+        from devsynth.application.memory.faiss_store import FAISSStore
+
         config = {
             "memory_store_type": "faiss",
             "memory_file_path": temp_dir,
@@ -171,8 +168,9 @@ class TestMemorySystemAdapter:
         """Test vector store operations with FAISS.
 
         ReqID: N/A"""
-        if FAISSStore is None:
-            pytest.skip("FAISS is not available")
+        pytest.importorskip("faiss")
+        from devsynth.application.memory.faiss_store import FAISSStore
+
         pytest.skip("Skipping FAISS test due to known issues with FAISS library")
         try:
             config = {
@@ -209,8 +207,9 @@ class TestMemorySystemAdapter:
         """Test integration between memory store and vector store.
 
         ReqID: N/A"""
-        if FAISSStore is None:
-            pytest.skip("FAISS is not available")
+        pytest.importorskip("faiss")
+        from devsynth.application.memory.faiss_store import FAISSStore
+
         pytest.skip(
             "Skipping FAISS integration test due to known issues with FAISS library"
         )

--- a/tests/unit/adapters/test_chromadb_vector_adapter.py
+++ b/tests/unit/adapters/test_chromadb_vector_adapter.py
@@ -10,12 +10,9 @@ from devsynth.application.memory.adapters.chromadb_vector_adapter import (
 )
 from devsynth.domain.models.memory import MemoryVector
 
-try:
-    import chromadb
-    from chromadb.api.models.Collection import Collection
-except Exception:  # pragma: no cover - optional dependency
-    chromadb = None
-    Collection = object
+pytest.importorskip("chromadb")
+import chromadb
+from chromadb.api.models.Collection import Collection
 
 pytestmark = pytest.mark.requires_resource("chromadb")
 


### PR DESCRIPTION
## Summary
- lazily import FAISS in additional storage backend steps
- add `pytest.importorskip("chromadb")` in ChromaDB step files
- defer optional imports in ChromaDB adapter tests
- gate LMDB and FAISS unit tests with `importorskip`

## Testing
- `poetry run pytest -q` *(fails: 399 failed, 865 passed, 95 skipped, 1 error)*

------
https://chatgpt.com/codex/tasks/task_e_688591f50ebc8333ab1b4efc1274d2f6