### PR TITLE
Docs harmonization for phase 2

### DIFF
--- a/docs/architecture/provider_system.md
+++ b/docs/architecture/provider_system.md
@@ -17,7 +17,7 @@ version: 1.1.0
 
 ## Overview
 
-The DevSynth provider system enables seamless integration with multiple LLM providers (OpenAI, LM Studio) through a unified interface. It supports automatic fallback, configuration via environment variables, and selection based on task requirements.
+The DevSynth provider system enables seamless integration with multiple LLM providers (OpenAI, Anthropic, LM Studio, Local and Offline models) through a unified interface. It supports automatic fallback, configuration via environment variables, and selection based on task requirements.
 
 ## Key Features
 
@@ -41,18 +41,22 @@ graph TD
     C -->|Creates| D[Fallback Provider]
     D -->|Tries| E[OpenAI Provider]
     D -->|Tries| F[LM Studio Provider]
-    D -->|Tries| G[Local Provider]
-    D -->|Tries| H[Custom Provider]
-    E --> I["OpenAI API (GPT-4, Claude)"]
-    F --> J[LM Studio API]
-    G --> K["Local Models (LLama, Mistral)"]
-    H --> L[Custom API Integration]
+    D -->|Tries| G[Anthropic Provider]
+    D -->|Tries| H[Local Provider]
+    D -->|Tries| I[Offline Provider]
+    D -->|Tries| J[Custom Provider]
+    E --> K["OpenAI API"]
+    F --> L[LM Studio API]
+    G --> M["Anthropic API"]
+    H --> N["Local Models"]
+    I --> O["Deterministic Offline"]
+    J --> P[Custom API Integration]
 
-    M[Token Counter] -->|Used by| E & F & G & H
-    N[Prompt Templates] -->|Used by| E & F & G & H
-    O[Response Parser] -->|Used by| E & F & G & H
-    P[Cache Manager] -->|Used by| E & F & G & H
-    Q[Telemetry Collector] -->|Monitors| E & F & G & H
+    M1[Token Counter] -->|Used by| E & F & G & H & I & J
+    N1[Prompt Templates] -->|Used by| E & F & G & H & I & J
+    O1[Response Parser] -->|Used by| E & F & G & H & I & J
+    P1[Cache Manager] -->|Used by| E & F & G & H & I & J
+    Q1[Telemetry Collector] -->|Monitors| E & F & G & H & I & J
 
     C -->|Configures| R[Environment Config]
     C -->|Uses| S[Provider Registry]
@@ -63,6 +67,9 @@ graph TD
 - **BaseProvider**: Abstract base class defining the provider interface with common functionality
 - **OpenAIProvider**: Implementation for OpenAI API with comprehensive retry mechanisms
 - **LMStudioProvider**: Implementation for LM Studio local API with full feature parity
+- **AnthropicProvider**: Implementation for Anthropic's API
+- **LocalProvider**: Interface for running local LLM models
+- **OfflineProvider**: Deterministic provider used when network access is disabled
 - **FallbackProvider**: Meta-provider that tries multiple providers in sequence with circuit breaker pattern
 - **ProviderFactory**: Factory for creating appropriate provider instances based on configuration
 - **CircuitBreaker**: Utility class for preventing cascading failures when a provider is experiencing issues

--- a/docs/implementation/phase1_month1_summary.md
+++ b/docs/implementation/phase1_month1_summary.md
@@ -105,8 +105,8 @@ The following deliverables were produced during Month 1:
 
 3. **Documentation**:
    - Deployment Guide (`/docs/deployment/deployment_guide.md`)
-   - Updated Development Plan (`/docs/roadmap/development_plan.md`)
-   - Updated Development Status (`/docs/roadmap/development_status.md`)
+  - Updated Development Plan (`/docs/roadmap/development_plan.md`)
+  - See [development_status.md](../roadmap/development_status.md) for the latest implementation progress
 
 
 ## Metrics and Success Criteria

--- a/docs/specifications/agent_api_stub.md
+++ b/docs/specifications/agent_api_stub.md
@@ -176,4 +176,4 @@ function handle_request(path, body):
 ```
 ## Implementation Status
 
-This feature is **in progress** and not yet implemented.
+This feature is **implemented**. The API routes are defined in `src/devsynth/interface/agentapi.py` and expose the CLI workflows over HTTP.

--- a/docs/specifications/delimiting_recursion_algorithms.md
+++ b/docs/specifications/delimiting_recursion_algorithms.md
@@ -51,4 +51,4 @@ These heuristics are implemented in `EDRRCoordinator.should_terminate_recursion`
 and referenced in the [Recursive EDRR Pseudocode](recursive_edrr_pseudocode.md).
 ## Implementation Status
 
-This feature is **in progress** and not yet implemented.
+This feature is **implemented**. The heuristics are available in `src/devsynth/application/edrr/coordinator.py`.

--- a/docs/specifications/edrr_cycle_specification.md
+++ b/docs/specifications/edrr_cycle_specification.md
@@ -454,4 +454,4 @@ Planned improvements to the EDRR implementation:
 The EDRR provides a structured framework for iterative development in DevSynth, enabling systematic exploration, evaluation, improvement, and learning. By integrating with the WSDE model and hybrid memory system, it supports collaborative, knowledge-driven software development.
 ## Implementation Status
 
-This feature is **in progress** and not yet implemented.
+This feature is **implemented**. Core functionality resides in `src/devsynth/application/edrr/coordinator.py` and `edrr_coordinator_enhanced.py`.

--- a/docs/specifications/edrr_framework_integration_summary.md
+++ b/docs/specifications/edrr_framework_integration_summary.md
@@ -71,10 +71,8 @@ The key enhancement is the implementation of the EDRR framework as a recursive, 
    - Tasks for implementing micro-EDRR cycles for each macro phase
    - Tasks for implementing delimiting principles for recursion
 
-2. **Updated Development Status** to reflect:
-   - Current status of recursive EDRR framework understanding
-   - Specification updates and implementation planning
-   - In-progress tasks for recursive EDRR implementation
+2. **Development Status Reference**:
+   - See [development_status.md](../roadmap/development_status.md) for current progress on recursive EDRR implementation
 
 
 ### Integration Plan Creation
@@ -140,4 +138,4 @@ The integration of the expanded EDRR Framework understanding, inspired by advanc
 The multi-disciplined best-practices approach with dialectical reasoning ensured that the implementation is thorough, balanced, and effective. The integration maintains a focus on practical implementation while embracing the innovative concepts of the Recursive EDRR Framework.
 ## Implementation Status
 
-This feature is **in progress** and not yet implemented.
+This feature is **implemented**. Recursive EDRR coordination is handled in `src/devsynth/application/edrr/edrr_coordinator_enhanced.py`.

--- a/docs/specifications/index.md
+++ b/docs/specifications/index.md
@@ -62,4 +62,4 @@ If you're new to DevSynth's specifications, we recommend starting with the [DevS
 - [Developer Guides](../developer_guides/index.md) - Information for developers contributing to DevSynth
 ## Implementation Status
 
-This feature is **in progress** and not yet implemented.
+Most specifications correspond to implemented modules under `src/devsynth`. Refer to each document for specific paths and implementation details.

--- a/docs/specifications/requirements_gathering.md
+++ b/docs/specifications/requirements_gathering.md
@@ -61,4 +61,4 @@ The CLI exposes this via `devsynth requirements gather` while the WebUI
 presents a button that runs the same function through its bridge.
 ## Implementation Status
 
-This feature is **in progress** and not yet implemented.
+This feature is **implemented**. Interactive gathering is provided by `src/devsynth/application/requirements/interactions.py` and is accessible via the CLI and WebUI.

--- a/docs/specifications/uxbridge_extension.md
+++ b/docs/specifications/uxbridge_extension.md
@@ -65,4 +65,4 @@ both textual and graphical UIs and allow tests to mock the interface easily.
 
 ## Implementation Status
 
-This feature is **in progress** and not yet implemented.
+This feature is **implemented**. See `src/devsynth/interface/ux_bridge.py` for the reference implementation.

--- a/docs/specifications/webui_detailed_spec.md
+++ b/docs/specifications/webui_detailed_spec.md
@@ -75,4 +75,4 @@ sequenceDiagram
 - Multi‑project dashboard view.
 ## Implementation Status
 
-This feature is **in progress** and not yet implemented.
+This feature is **implemented**. The Streamlit UI resides in `src/devsynth/interface/webui.py`.

--- a/docs/specifications/webui_pseudocode.md
+++ b/docs/specifications/webui_pseudocode.md
@@ -72,4 +72,4 @@ User -> Streamlit Widget -> UXBridge -> Workflow -> UXBridge -> Streamlit
 This design keeps the presentation layer thin while core logic remains reusable across CLI and WebUI interfaces.
 ## Implementation Status
 
-This feature is **in progress** and not yet implemented.
+This feature is **implemented**. See the Streamlit implementation in `src/devsynth/interface/webui.py`.

--- a/docs/specifications/wsde_interaction_specification.md
+++ b/docs/specifications/wsde_interaction_specification.md
@@ -535,4 +535,4 @@ Planned improvements to the WSDE multi-agent interaction system:
 The WSDE multi-agent interaction specification provides a comprehensive framework for organizing and coordinating AI agents in collaborative software development. By defining clear roles, interaction patterns, and coordination mechanisms, it enables effective teamwork among specialized agents, leading to higher quality outputs and more robust solutions.
 ## Implementation Status
 
-This feature is **in progress** and not yet implemented.
+This feature is **implemented**. See `src/devsynth/adapters/agents/agent_adapter.py` for WSDE team coordination logic.


### PR DESCRIPTION
## Summary
- update provider architecture to show Anthropic and offline providers
- reference development status in summaries
- update implementation status in several specs to match code

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pytest_bdd')*

------
https://chatgpt.com/codex/tasks/task_e_68864e77ee748333865ce5a595ad71e0