### PR TITLE
Update test extras docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,16 +200,26 @@ poetry install --with dev --extras minimal
 # poetry install --extras gpu
 ```
 
-Running the **full** test suite additionally requires the optional extras `minimal`, `retrieval`, `memory`, `llm`, `api`, `webui`, and `lmstudio`:
+Running the **full** test suite additionally requires the optional extras `minimal`, `retrieval`, `memory`, `llm`, `api`, `webui`, `lmstudio`, and `chromadb`:
 
 ```bash
 poetry install --extras minimal --extras retrieval --extras memory \
-  --extras llm --extras api --extras webui --extras lmstudio
+  --extras llm --extras api --extras webui --extras lmstudio \
+  --extras chromadb
 ```
 Alternatively, install them all at once:
 
 ```bash
 poetry install --all-extras --all-groups
+```
+
+The Codex environment runs a similar command automatically:
+
+```bash
+poetry install \
+  --with dev,docs \
+  --all-extras \
+  --no-interaction
 ```
 
 The test suite runs entirely in isolated temporary directories.  Ingestion and

--- a/docs/developer_guides/testing.md
+++ b/docs/developer_guides/testing.md
@@ -264,11 +264,17 @@ The ChromaDB tests use fixtures for isolation and provider integration:
 
 ## Running Tests
 
-Before executing tests, install DevSynth with its development extras so that all test dependencies are available. Environment provisioning is handled automatically in Codex environments. For manual setups run `poetry install`.
+Before executing tests, install DevSynth with its development extras so that all test dependencies are available. Running the **full** suite requires the `minimal`, `retrieval`, `memory`, `llm`, `api`, `webui`, `lmstudio`, and `chromadb` extras. Environment provisioning is handled automatically in Codex environments. For manual setups run `poetry install`.
 
 ```bash
 poetry install --with dev,docs
 poetry sync --all-extras --all-groups
+
+# The Codex environment runs a similar command automatically
+poetry install \
+  --with dev,docs \
+  --all-extras \
+  --no-interaction
 
 # Verify that pytest can start without import errors
 


### PR DESCRIPTION
## Summary
- document required extras for full test suite
- add installation snippet similar to codex_setup.sh

## Testing
- `poetry run pytest -q` *(fails: 373 failed, 868 passed, 100 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_68866c8c5e108333839abf796eabf4c9