### PR TITLE
Fix docs referencing obsolete ChromaDB import

### DIFF
--- a/docs/architecture/memory_system.md
+++ b/docs/architecture/memory_system.md
@@ -602,7 +602,7 @@ class RDFLibStore(MemoryPort):
 ### Setting Up ChromaDB Memory Store
 
 ```python
-from devsynth.adapters.memory.chromadb_store import ChromaDBStore
+from devsynth.application.memory.chromadb_store import ChromaDBStore
 from devsynth.adapters.providers.openai_provider import OpenAIProvider
 
 # Configure with OpenAI embeddings

--- a/docs/architecture/provider_system.md
+++ b/docs/architecture/provider_system.md
@@ -1160,7 +1160,7 @@ The provider system integrates with the memory system for RAG applications:
 
 ```python
 from devsynth.adapters.providers.factory import ProviderFactory
-from devsynth.adapters.memory.chromadb_store import ChromaDBStore
+from devsynth.application.memory.chromadb_store import ChromaDBStore
 
 # Initialize memory and provider
 


### PR DESCRIPTION
## Summary
- correct ChromaDBStore import examples in architecture docs

## Testing
- `poetry run pytest tests/unit/application/memory/test_chromadb_store.py -q`
- `ENABLE_CHROMADB=1 poetry run pytest tests/unit/application/memory/test_chromadb_store.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68867792dab08333bd863853cc38c401