### PR TITLE
Implement role reassignment and consensus workflow

### DIFF
--- a/src/devsynth/application/collaboration/WSDE.py
+++ b/src/devsynth/application/collaboration/WSDE.py
@@ -1,0 +1,22 @@
+"""WSDE application wrapper providing collaboration helpers."""
+
+from typing import Any, Dict
+
+from devsynth.domain.models.wsde_facade import WSDETeam
+from devsynth.methodology.base import Phase
+
+
+class WSDE(WSDETeam):
+    """Application-facing WSDE team with utility methods."""
+
+    def reassign_roles(self, task: Dict[str, Any]) -> Dict[str, Any]:
+        """Reassign roles dynamically using task context."""
+        return self.dynamic_role_reassignment(task)
+
+    def run_consensus(self, task: Dict[str, Any]) -> Dict[str, Any]:
+        """Perform a consensus vote and fallback to consensus building."""
+        result = self.consensus_vote(task)
+        decision = result.get("decision") or result.get("result")
+        if not decision or result.get("status") != "completed":
+            result["consensus"] = self.build_consensus(task)
+        return result

--- a/src/devsynth/domain/models/wsde.py
+++ b/src/devsynth/domain/models/wsde.py
@@ -834,7 +834,17 @@ class WSDETeam(BaseWSDETeam):
             return {}
 
         self.select_primus_by_expertise(task)
-        self.assign_roles()
+
+        phase_value = task.get("phase", "expand")
+        if isinstance(phase_value, Phase):
+            phase = phase_value
+        else:
+            try:
+                phase = Phase(phase_value)
+            except Exception:
+                phase = Phase.EXPAND
+
+        self.assign_roles_for_phase(phase, task)
         return self.role_assignments
 
     def _validate_role_mapping(self, mapping: Dict[str, Any]) -> None:

--- a/src/devsynth/domain/models/wsde_roles.py
+++ b/src/devsynth/domain/models/wsde_roles.py
@@ -343,6 +343,19 @@ def dynamic_role_reassignment(self: WSDETeam, task: Dict[str, Any]):
         self.primus_index = self.agents.index(best_agent)
         setattr(best_agent, "has_been_primus", True)
 
+    # Determine the EDRR phase for role assignment
+    phase_value = task.get("phase", "expand")
+    if isinstance(phase_value, Phase):
+        phase = phase_value
+    else:
+        try:
+            phase = Phase(phase_value)
+        except Exception:
+            phase = Phase.EXPAND
+
+    # Assign roles for the detected phase
+    self.assign_roles_for_phase(phase, task)
+
     return self.roles
 
 

--- a/tests/integration/edrr/test_wsde_edrr_integration.py
+++ b/tests/integration/edrr/test_wsde_edrr_integration.py
@@ -2,6 +2,7 @@
 Test the integration between WSDE and EDRR, particularly the phase-specific
 role assignment functionality.
 """
+
 import pytest
 from unittest.mock import MagicMock, patch
 from devsynth.domain.models.wsde import WSDETeam
@@ -11,34 +12,34 @@ from devsynth.methodology.base import Phase
 class TestWSDEEDRRIntegration:
     """Test the integration between WSDE and EDRR components.
 
-ReqID: N/A"""
+    ReqID: N/A"""
 
     @pytest.fixture
     def mock_agents(self):
         """Create mock agents with different expertise."""
         agents = []
         agent1 = MagicMock()
-        agent1.expertise = ['brainstorming', 'creativity', 'exploration']
+        agent1.expertise = ["brainstorming", "creativity", "exploration"]
         agent1.current_role = None
         agent1.has_been_primus = False
         agents.append(agent1)
         agent2 = MagicMock()
-        agent2.expertise = ['analysis', 'evaluation', 'critical thinking']
+        agent2.expertise = ["analysis", "evaluation", "critical thinking"]
         agent2.current_role = None
         agent2.has_been_primus = False
         agents.append(agent2)
         agent3 = MagicMock()
-        agent3.expertise = ['implementation', 'coding', 'testing']
+        agent3.expertise = ["implementation", "coding", "testing"]
         agent3.current_role = None
         agent3.has_been_primus = False
         agents.append(agent3)
         agent4 = MagicMock()
-        agent4.expertise = ['documentation', 'reflection', 'learning']
+        agent4.expertise = ["documentation", "reflection", "learning"]
         agent4.current_role = None
         agent4.has_been_primus = False
         agents.append(agent4)
         agent5 = MagicMock()
-        agent5.expertise = ['management', 'coordination', 'planning']
+        agent5.expertise = ["management", "coordination", "planning"]
         agent5.current_role = None
         agent5.has_been_primus = False
         agents.append(agent5)
@@ -50,67 +51,89 @@ ReqID: N/A"""
         team = WSDETeam(name="TestEDRRIntegrationTeam", agents=mock_agents)
         return team
 
-    def test_phase_specific_role_assignment_has_expected(self, wsde_team,
-        mock_agents):
+    def test_phase_specific_role_assignment_has_expected(self, wsde_team, mock_agents):
         """Test that roles are assigned appropriately for each EDRR phase.
 
-ReqID: N/A"""
-        task = {'type': 'code_generation', 'language': 'python'}
+        ReqID: N/A"""
+        task = {"type": "code_generation", "language": "python"}
         wsde_team.assign_roles_for_phase(Phase.EXPAND, task)
-        print('\nEXPAND phase roles:')
+        print("\nEXPAND phase roles:")
         for agent in mock_agents:
             print(
-                f'Agent with expertise {agent.expertise}: role = {agent.current_role}'
-                )
-        creative_agents = [agent for agent in mock_agents if any(exp in [
-            'creativity', 'brainstorming', 'exploration'] for exp in
-            getattr(agent, 'expertise', []))]
-        assert any(agent.current_role in ['Primus', 'Designer'] for agent in
-            creative_agents
-            ), 'No agent with creative expertise was assigned Primus or Designer role in EXPAND phase'
+                f"Agent with expertise {agent.expertise}: role = {agent.current_role}"
+            )
+        creative_agents = [
+            agent
+            for agent in mock_agents
+            if any(
+                exp in ["creativity", "brainstorming", "exploration"]
+                for exp in getattr(agent, "expertise", [])
+            )
+        ]
+        assert any(
+            agent.current_role in ["Primus", "Designer"] for agent in creative_agents
+        ), "No agent with creative expertise was assigned Primus or Designer role in EXPAND phase"
         wsde_team.assign_roles_for_phase(Phase.DIFFERENTIATE, task)
-        print('\nDIFFERENTIATE phase roles:')
+        print("\nDIFFERENTIATE phase roles:")
         for agent in mock_agents:
             print(
-                f'Agent with expertise {agent.expertise}: role = {agent.current_role}'
-                )
-        analytical_agents = [agent for agent in mock_agents if any(exp in [
-            'analysis', 'evaluation', 'critical thinking'] for exp in
-            getattr(agent, 'expertise', []))]
-        assert any(agent.current_role in ['Primus', 'Evaluator',
-            'Supervisor'] for agent in analytical_agents
-            ), 'No agent with analytical expertise was assigned an appropriate role in DIFFERENTIATE phase'
+                f"Agent with expertise {agent.expertise}: role = {agent.current_role}"
+            )
+        analytical_agents = [
+            agent
+            for agent in mock_agents
+            if any(
+                exp in ["analysis", "evaluation", "critical thinking"]
+                for exp in getattr(agent, "expertise", [])
+            )
+        ]
+        assert any(
+            agent.current_role in ["Primus", "Evaluator", "Supervisor"]
+            for agent in analytical_agents
+        ), "No agent with analytical expertise was assigned an appropriate role in DIFFERENTIATE phase"
         wsde_team.assign_roles_for_phase(Phase.REFINE, task)
-        print('\nREFINE phase roles:')
+        print("\nREFINE phase roles:")
         for agent in mock_agents:
             print(
-                f'Agent with expertise {agent.expertise}: role = {agent.current_role}'
-                )
-        implementation_agents = [agent for agent in mock_agents if any(exp in
-            ['implementation', 'coding', 'testing'] for exp in getattr(
-            agent, 'expertise', []))]
-        assert any(agent.current_role is not None and agent.current_role !=
-            '' for agent in implementation_agents
-            ), 'No agent with implementation expertise was assigned any role in REFINE phase'
+                f"Agent with expertise {agent.expertise}: role = {agent.current_role}"
+            )
+        implementation_agents = [
+            agent
+            for agent in mock_agents
+            if any(
+                exp in ["implementation", "coding", "testing"]
+                for exp in getattr(agent, "expertise", [])
+            )
+        ]
+        assert any(
+            agent.current_role is not None and agent.current_role != ""
+            for agent in implementation_agents
+        ), "No agent with implementation expertise was assigned any role in REFINE phase"
         wsde_team.assign_roles_for_phase(Phase.RETROSPECT, task)
-        print('\nRETROSPECT phase roles:')
+        print("\nRETROSPECT phase roles:")
         for agent in mock_agents:
             print(
-                f'Agent with expertise {agent.expertise}: role = {agent.current_role}'
-                )
-        reflective_agents = [agent for agent in mock_agents if any(exp in [
-            'reflection', 'documentation', 'learning'] for exp in getattr(
-            agent, 'expertise', []))]
-        assert any(agent.current_role in ['Primus', 'Evaluator'] for agent in
-            reflective_agents
-            ), 'No agent with reflective expertise was assigned Primus or Evaluator role in RETROSPECT phase'
+                f"Agent with expertise {agent.expertise}: role = {agent.current_role}"
+            )
+        reflective_agents = [
+            agent
+            for agent in mock_agents
+            if any(
+                exp in ["reflection", "documentation", "learning"]
+                for exp in getattr(agent, "expertise", [])
+            )
+        ]
+        assert any(
+            agent.current_role in ["Primus", "Evaluator"] for agent in reflective_agents
+        ), "No agent with reflective expertise was assigned Primus or Evaluator role in RETROSPECT phase"
 
-    def test_role_rotation_on_phase_transition_has_expected(self, wsde_team,
-        mock_agents):
+    def test_role_rotation_on_phase_transition_has_expected(
+        self, wsde_team, mock_agents
+    ):
         """Test that roles are rotated when transitioning between phases.
 
-ReqID: N/A"""
-        task = {'type': 'code_generation', 'language': 'python'}
+        ReqID: N/A"""
+        task = {"type": "code_generation", "language": "python"}
         wsde_team.assign_roles_for_phase(Phase.EXPAND, task)
         initial_roles = {agent: agent.current_role for agent in mock_agents}
         wsde_team.assign_roles_for_phase(Phase.DIFFERENTIATE, task)
@@ -119,27 +142,79 @@ ReqID: N/A"""
             if agent.current_role != initial_roles[agent]:
                 roles_changed = True
                 break
-        assert roles_changed, 'Roles should change during phase transition'
+        assert roles_changed, "Roles should change during phase transition"
 
-    def test_phase_specific_expertise_scoring_succeeds(self, wsde_team,
-        mock_agents):
+    def test_phase_specific_expertise_scoring_succeeds(self, wsde_team, mock_agents):
         """Test that phase-specific expertise scoring works correctly.
 
-ReqID: N/A"""
-        task = {'type': 'code_generation', 'language': 'python'}
-        expand_keywords = ['brainstorming', 'exploration', 'creativity',
-            'ideation', 'divergent thinking', 'research', 'analysis',
-            'requirements']
-        score1 = wsde_team._calculate_phase_expertise_score(mock_agents[0],
-            task, expand_keywords)
-        score3 = wsde_team._calculate_phase_expertise_score(mock_agents[2],
-            task, expand_keywords)
-        assert score1 > score3, 'Agent with creativity expertise should score higher in EXPAND phase'
-        refine_keywords = ['implementation', 'coding', 'development',
-            'optimization', 'detail-oriented', 'testing', 'debugging',
-            'quality']
-        score3_refine = wsde_team._calculate_phase_expertise_score(mock_agents
-            [2], task, refine_keywords)
-        score1_refine = wsde_team._calculate_phase_expertise_score(mock_agents
-            [0], task, refine_keywords)
-        assert score3_refine > score1_refine, 'Agent with implementation expertise should score higher in REFINE phase'
+        ReqID: N/A"""
+        task = {"type": "code_generation", "language": "python"}
+        expand_keywords = [
+            "brainstorming",
+            "exploration",
+            "creativity",
+            "ideation",
+            "divergent thinking",
+            "research",
+            "analysis",
+            "requirements",
+        ]
+        score1 = wsde_team._calculate_phase_expertise_score(
+            mock_agents[0], task, expand_keywords
+        )
+        score3 = wsde_team._calculate_phase_expertise_score(
+            mock_agents[2], task, expand_keywords
+        )
+        assert (
+            score1 > score3
+        ), "Agent with creativity expertise should score higher in EXPAND phase"
+        refine_keywords = [
+            "implementation",
+            "coding",
+            "development",
+            "optimization",
+            "detail-oriented",
+            "testing",
+            "debugging",
+            "quality",
+        ]
+        score3_refine = wsde_team._calculate_phase_expertise_score(
+            mock_agents[2], task, refine_keywords
+        )
+        score1_refine = wsde_team._calculate_phase_expertise_score(
+            mock_agents[0], task, refine_keywords
+        )
+        assert (
+            score3_refine > score1_refine
+        ), "Agent with implementation expertise should score higher in REFINE phase"
+
+    def test_dynamic_role_reassignment_and_consensus(self, mock_agents):
+        """Dynamic role reassignment integrates with consensus voting."""
+        from devsynth.application.collaboration.WSDE import WSDE
+
+        team = WSDE(name="ConsensusTeam", agents=mock_agents)
+        task = {
+            "phase": "differentiate",
+            "description": "choose approach",
+            "options": ["a", "b"],
+        }
+        team.reassign_roles(task)
+        assert team.roles["primus"] is not None
+        vote = team.run_consensus(task)
+        assert vote.get("status") == "completed"
+        assert vote.get("decision") or vote.get("result")
+
+    def test_dialectical_hooks_invoked(self, mock_agents):
+        """Registered dialectical hooks should be called during reasoning."""
+        from devsynth.application.collaboration.WSDE import WSDE
+
+        team = WSDE(name="HookTeam", agents=mock_agents)
+        hook = MagicMock()
+        team.register_dialectical_hook(hook)
+        task = {
+            "id": "t1",
+            "solutions": [{"content": "sol"}],
+        }
+        critic = MagicMock()
+        team.apply_enhanced_dialectical_reasoning_multi(task, critic)
+        hook.assert_called()


### PR DESCRIPTION
## Summary
- implement missing dynamic role reassignment logic
- expose WSDE collaboration helpers at application layer
- extend WSDE/EDRR integration tests for consensus and dialectical hooks

## Testing
- `poetry run pytest tests/integration/edrr/test_wsde_edrr_integration.py::TestWSDEEDRRIntegration::test_dynamic_role_reassignment_and_consensus -q`
- `poetry run pytest tests/integration/edrr/test_wsde_edrr_integration.py::TestWSDEEDRRIntegration::test_dialectical_hooks_invoked -q`
- `poetry run pytest tests/integration/edrr/test_wsde_edrr_integration.py -q`

------
https://chatgpt.com/codex/tasks/task_e_688699737e9c8333b6c363b0bf2dd4ed