### PR TITLE
Fix tiktoken optional import in ChromaDB store

### DIFF
--- a/src/devsynth/application/memory/chromadb_store.py
+++ b/src/devsynth/application/memory/chromadb_store.py
@@ -22,7 +22,12 @@ except ImportError as e:  # pragma: no cover - optional dependency
         "ChromaDBStore requires the 'chromadb' package. Install it with 'pip install chromadb' or use the dev extras."
     ) from e
 
-import tiktoken
+try:
+    import tiktoken
+except ImportError as e:  # pragma: no cover - optional dependency
+    raise ImportError(
+        "ChromaDBStore requires the 'tiktoken' package. Install it with 'pip install tiktoken' or use the dev extras."
+    ) from e
 
 from devsynth.exceptions import (
     DevSynthError,

--- a/tests/unit/application/memory/test_chromadb_store.py
+++ b/tests/unit/application/memory/test_chromadb_store.py
@@ -5,6 +5,7 @@ from datetime import datetime
 from unittest.mock import MagicMock, patch
 import pytest
 pytest.importorskip('chromadb')
+pytest.importorskip('tiktoken')
 if os.environ.get('ENABLE_CHROMADB', 'false').lower() in {'0', 'false', 'no'}:
     pytest.skip('ChromaDB feature not enabled', allow_module_level=True)
 from devsynth.application.memory.chromadb_store import ChromaDBStore


### PR DESCRIPTION
## Summary
- handle missing `tiktoken` dependency in `ChromaDBStore`
- skip ChromaDB store tests if `tiktoken` is not installed

## Testing
- `bash scripts/codex_setup.sh`
- `poetry run pytest tests/unit/application/memory/test_chromadb_store.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6886f14fd1c0833398527cd17edd44e9