### PR TITLE
Fix KuzuStore init and add wizard navigation helper

### DIFF
--- a/src/devsynth/adapters/kuzu_memory_store.py
+++ b/src/devsynth/adapters/kuzu_memory_store.py
@@ -13,7 +13,7 @@ from devsynth.logging_setup import DevSynthLogger
 from devsynth.adapters.provider_system import embed, ProviderError
 from devsynth.adapters.memory.kuzu_adapter import KuzuAdapter
 from devsynth.application.memory.kuzu_store import KuzuStore
-from devsynth.config.settings import ensure_path_exists
+from devsynth.config import settings as settings_module
 
 try:  # pragma: no cover - optional dependency
     from chromadb.utils import embedding_functions
@@ -37,7 +37,7 @@ class KuzuMemoryStore(MemoryStore):
         self.persist_directory = persist_directory or os.path.join(
             os.getcwd(), ".devsynth", "kuzu_store"
         )
-        ensure_path_exists(self.persist_directory)
+        settings_module.ensure_path_exists(self.persist_directory)
         self._store = KuzuStore(self.persist_directory)
         self.vector = KuzuAdapter(self.persist_directory, collection_name)
         self.use_provider_system = use_provider_system

--- a/src/devsynth/adapters/memory/kuzu_adapter.py
+++ b/src/devsynth/adapters/memory/kuzu_adapter.py
@@ -21,7 +21,9 @@ except Exception:  # pragma: no cover - optional dependency
 from devsynth.domain.interfaces.memory import VectorStore
 from devsynth.domain.models.memory import MemoryVector
 from devsynth.logging_setup import DevSynthLogger
-from devsynth.config.settings import ensure_path_exists
+
+# Import settings module so ``ensure_path_exists`` can be monkeypatched
+from devsynth.config import settings as settings_module
 
 logger = DevSynthLogger(__name__)
 
@@ -37,7 +39,7 @@ class KuzuAdapter(VectorStore):
         # Ensure the directory exists even when ``ensure_path_exists`` is
         # patched to no-op during tests.  ``os.makedirs`` is safe to call on an
         # existing path and avoids failures when persisting vectors.
-        ensure_path_exists(self.persist_directory)
+        settings_module.ensure_path_exists(self.persist_directory)
         os.makedirs(self.persist_directory, exist_ok=True)
         self._data_file = os.path.join(
             self.persist_directory, f"{collection_name}.json"

--- a/src/devsynth/application/memory/kuzu_store.py
+++ b/src/devsynth/application/memory/kuzu_store.py
@@ -42,7 +42,9 @@ from devsynth.fallback import retry_with_exponential_backoff
 from devsynth.domain.interfaces.memory import MemoryStore
 from devsynth.domain.models.memory import MemoryItem, MemoryType
 from devsynth.exceptions import MemoryStoreError
-from devsynth.config.settings import ensure_path_exists
+
+# Import the settings module so tests can monkeypatch ``ensure_path_exists``
+from devsynth.config import settings as settings_module
 
 logger = DevSynthLogger(__name__)
 
@@ -60,7 +62,7 @@ class KuzuStore(MemoryStore):
         # test isolation fixtures.  Use the returned path so the database is
         # created in the correct location rather than the original argument
         # which may be outside the temporary test directory.
-        self.file_path = ensure_path_exists(file_path)
+        self.file_path = settings_module.ensure_path_exists(file_path)
         # Explicitly create the directory even when ``ensure_path_exists`` is
         # patched not to, ensuring the database can always be opened.
         os.makedirs(self.file_path, exist_ok=True)
@@ -87,7 +89,7 @@ class KuzuStore(MemoryStore):
         self._use_fallback = kuzu_mod is None
         if not self._use_fallback:
             try:
-                ensure_path_exists(file_path)
+                settings_module.ensure_path_exists(file_path)
                 self.db = kuzu_mod.Database(self.db_path)
                 self.conn = kuzu_mod.Connection(self.db)
                 self.conn.execute(

--- a/src/devsynth/interface/webui.py
+++ b/src/devsynth/interface/webui.py
@@ -36,6 +36,8 @@ from pathlib import Path
 from typing import Any, Callable, Optional, Sequence, TypeVar
 from unittest.mock import MagicMock
 
+from devsynth.interface.webui_bridge import WebUIBridge
+
 import streamlit as st
 
 # ``webui`` is imported in several unit tests with a partially mocked
@@ -937,9 +939,13 @@ class WebUI(UXBridge):
 
         col1, col2 = st.columns(2)
         if col1.button("Back", disabled=step == 0):
-            st.session_state.wizard_step = max(0, step - 1)
+            st.session_state.wizard_step = WebUIBridge.adjust_wizard_step(
+                step, direction="back", total=len(steps)
+            )
         elif col2.button("Next", disabled=step >= len(steps) - 1):
-            st.session_state.wizard_step = min(len(steps) - 1, step + 1)
+            st.session_state.wizard_step = WebUIBridge.adjust_wizard_step(
+                step, direction="next", total=len(steps)
+            )
 
         st.session_state.wizard_data = data
         if hasattr(st.session_state, "__setitem__"):

--- a/src/devsynth/interface/webui_bridge.py
+++ b/src/devsynth/interface/webui_bridge.py
@@ -298,6 +298,35 @@ class WebUIBridge(SharedBridgeMixin, UXBridge):
         self.messages: List[str] = []
         super().__init__()
 
+    # ------------------------------------------------------------------
+    # Wizard utilities
+    # ------------------------------------------------------------------
+    @staticmethod
+    def adjust_wizard_step(current: int, *, direction: str, total: int) -> int:
+        """Return the next wizard step given a direction.
+
+        Parameters
+        ----------
+        current:
+            Current step index.
+        direction:
+            Either ``"next"`` or ``"back"``.
+        total:
+            Total number of steps.
+
+        Returns
+        -------
+        int
+            Clamped step index.
+        """
+        if direction == "next":
+            candidate = current + 1
+        elif direction == "back":
+            candidate = current - 1
+        else:
+            candidate = current
+        return max(0, min(total - 1, candidate))
+
     def ask_question(
         self,
         message: str,

--- a/tests/unit/general/test_kuzu_store_fallback.py
+++ b/tests/unit/general/test_kuzu_store_fallback.py
@@ -10,7 +10,8 @@ def test_kuzu_store_falls_back_when_dependency_missing(monkeypatch, tmp_path):
     # Reload module after patching
     spec = importlib.util.spec_from_file_location(
         "kuzu_store",
-        Path(__file__).resolve().parents[3] / "src/devsynth/application/memory/kuzu_store.py",
+        Path(__file__).resolve().parents[3]
+        / "src/devsynth/application/memory/kuzu_store.py",
     )
     kuzu_store = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(kuzu_store)
@@ -18,6 +19,8 @@ def test_kuzu_store_falls_back_when_dependency_missing(monkeypatch, tmp_path):
 
     store = KuzuStore(str(tmp_path))
     assert store._use_fallback is True
+    assert store.file_path == str(tmp_path)
+    assert tmp_path.exists()
     item = MemoryItem(id="a", content="hello", memory_type=MemoryType.WORKING)
     store.store(item)
     retrieved = store.retrieve("a")

--- a/tests/unit/interface/test_webui.py
+++ b/tests/unit/interface/test_webui.py
@@ -552,3 +552,13 @@ def test_run_method_renders_pages_succeeds(monkeypatch, stub_streamlit):
     stub_streamlit.sidebar.radio = MagicMock(return_value="Requirements")
     webui_instance.run()
     webui_instance.requirements_page.assert_called_once()
+
+
+def test_wizard_navigation_helper_clamps_steps():
+    """``WebUIBridge.adjust_wizard_step`` clamps step boundaries."""
+
+    from devsynth.interface.webui_bridge import WebUIBridge
+
+    assert WebUIBridge.adjust_wizard_step(0, direction="back", total=5) == 0
+    assert WebUIBridge.adjust_wizard_step(4, direction="next", total=5) == 4
+    assert WebUIBridge.adjust_wizard_step(2, direction="next", total=5) == 3


### PR DESCRIPTION
## Summary
- fix path handling in `KuzuStore` so test monkeypatch works
- update Kuzu adapters to import `ensure_path_exists` dynamically
- add `adjust_wizard_step` helper in `WebUIBridge`
- use the helper for wizard navigation
- test kuzu fallback path and wizard helper

## Testing
- `poetry run pytest -q tests/unit/general/test_kuzu_store_fallback.py tests/unit/interface/test_webui.py::test_wizard_navigation_helper_clamps_steps`

------
https://chatgpt.com/codex/tasks/task_e_6886f38e55cc8333b9f5be9a6d536772