### PR TITLE
Implement circuit open abort logic

### DIFF
--- a/tests/unit/general/test_provider_logging.py
+++ b/tests/unit/general/test_provider_logging.py
@@ -4,7 +4,12 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from devsynth.application.llm.offline_provider import OfflineProvider
-from devsynth.application.llm.lmstudio_provider import LMStudioProvider
+from devsynth.application.llm.lmstudio_provider import (
+    LMStudioProvider,
+    LMStudioConnectionError,
+)
+from devsynth.exceptions import DevSynthError
+from devsynth.metrics import get_retry_metrics, reset_metrics
 
 
 def test_provider_logging_cleanup(capsys):
@@ -29,3 +34,45 @@ def test_provider_logging_cleanup(capsys):
     sync_api._reset_default_client()
     logging.shutdown()
     assert "I/O operation on closed file" not in capsys.readouterr().err
+
+
+def test_lmstudio_retry_metrics_and_circuit_breaker():
+    """Failures increment retry metrics and open the circuit breaker."""
+    reset_metrics()
+    with (
+        patch("devsynth.application.llm.lmstudio_provider.lmstudio.llm") as mock_llm,
+        patch(
+            "devsynth.application.llm.lmstudio_provider.TokenTracker"
+        ) as mock_tracker,
+    ):
+        mock_model = MagicMock()
+        mock_model.complete.side_effect = Exception("boom")
+        mock_llm.return_value = mock_model
+        mock_tracker.return_value.count_tokens.return_value = 1
+        mock_tracker.return_value.ensure_token_limit.return_value = None
+
+        provider = LMStudioProvider(
+            {
+                "auto_select_model": False,
+                "max_retries": 2,
+                "failure_threshold": 2,
+                "recovery_timeout": 60,
+            }
+        )
+
+        with pytest.raises(LMStudioConnectionError):
+            provider.generate("hi")
+
+        metrics = get_retry_metrics()
+        assert metrics.get("attempt") == 2
+        assert metrics.get("failure") == 1
+        assert provider.circuit_breaker.state == provider.circuit_breaker.OPEN
+        call_count = mock_model.complete.call_count
+
+        with pytest.raises(LMStudioConnectionError):
+            provider.generate("hi")
+
+        assert mock_model.complete.call_count == call_count
+        metrics = get_retry_metrics()
+        assert metrics.get("failure") == 2
+        assert metrics.get("attempt") == 4


### PR DESCRIPTION
## Summary
- support early abort when circuit breaker is open in `retry_with_exponential_backoff`
- expand provider logging tests for retry metrics and circuit breaker states

## Testing
- `poetry run pytest tests/unit/general/test_provider_logging.py::test_lmstudio_retry_metrics_and_circuit_breaker -q`
- `poetry run pytest tests/unit/fallback/test_retry_metrics.py tests/unit/fallback/test_retry_conditions.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68870478440883338e0a2168925ff8ee