### PR TITLE
Fix ingestion pipeline tests and provider retry

### DIFF
--- a/src/devsynth/adapters/provider_system.py
+++ b/src/devsynth/adapters/provider_system.py
@@ -796,6 +796,15 @@ class LMStudioProvider(BaseProvider):
         if retry_config is not None:
             self.retry_config = retry_config
 
+    def _should_retry(self, exc: Exception) -> bool:
+        """Return ``True`` if the exception should trigger a retry."""
+        status = getattr(exc.response, "status_code", None)
+        if status is None:
+            status = getattr(exc, "status_code", None)
+        if status is not None and 400 <= int(status) < 500 and int(status) != 429:
+            return False
+        return True
+
     def _get_retry_config(self):
         """Get the retry configuration for LM Studio API calls."""
         return {
@@ -847,7 +856,7 @@ class LMStudioProvider(BaseProvider):
                 raise ProviderError("top_p must be between 0 and 1")
 
         def _api_call():
-            url = f"{self.endpoint}/v1/completions"
+            url = f"{self.endpoint}/v1/chat/completions"
 
             if parameters and "messages" in parameters:
                 messages = list(parameters["messages"])
@@ -929,7 +938,7 @@ class LMStudioProvider(BaseProvider):
                 raise ProviderError("top_p must be between 0 and 1")
 
         async def _api_call():
-            url = f"{self.endpoint}/v1/completions"
+            url = f"{self.endpoint}/v1/chat/completions"
 
             if parameters and "messages" in parameters:
                 messages = list(parameters["messages"])

--- a/src/devsynth/application/prompts/prompt_manager.py
+++ b/src/devsynth/application/prompts/prompt_manager.py
@@ -308,6 +308,16 @@ class PromptManager:
 
     def _load_templates(self) -> None:
         """Load templates from the storage path."""
+        no_file_logging = os.environ.get("DEVSYNTH_NO_FILE_LOGGING", "0").lower() in (
+            "1",
+            "true",
+            "yes",
+        )
+
+        if no_file_logging:
+            logger.debug("DEVSYNTH_NO_FILE_LOGGING set; skipping template load")
+            return
+
         template_files = Path(self.storage_path).glob("*.json")
         for file_path in template_files:
             try:
@@ -323,6 +333,20 @@ class PromptManager:
 
     def _save_template(self, template: PromptTemplate) -> None:
         """Save a template to the storage path."""
+        # Skip file writes when file logging is disabled for tests
+        no_file_logging = os.environ.get("DEVSYNTH_NO_FILE_LOGGING", "0").lower() in (
+            "1",
+            "true",
+            "yes",
+        )
+
+        if no_file_logging:
+            logger.debug(
+                "DEVSYNTH_NO_FILE_LOGGING set; not persisting template %s to disk",
+                template.name,
+            )
+            return
+
         file_path = os.path.join(self.storage_path, f"{template.name}.json")
         try:
             with open(file_path, "w") as f:


### PR DESCRIPTION
## Summary
- handle ingestion cycle startup errors gracefully
- skip prompt template filesystem operations when file logging disabled
- adjust LM Studio provider endpoints and add retry helper
- update tests for ingestion pipeline and provider system

## Testing
- `poetry run pytest tests/integration/general/test_ingestion_pipeline.py::TestIngestion::test_run_ingestion_succeeds tests/integration/general/test_ingestion_pipeline.py::TestIngestion::test_run_ingestion_with_error_raises_error tests/integration/general/test_ingestion_pipeline.py::TestIngestion::test_save_refined_data_succeeds tests/integration/general/test_ingestion_pipeline.py::TestIngestion::test_generate_markdown_summary_succeeds tests/integration/general/test_provider_system.py::TestProviderIntegration::test_lm_studio_complete_succeeds`

------
https://chatgpt.com/codex/tasks/task_e_688710bf7d9c83338fc232315fc31538