### PR TITLE
Add retry count metrics and conditional retry tests

### DIFF
--- a/src/devsynth/fallback.py
+++ b/src/devsynth/fallback.py
@@ -15,7 +15,7 @@ from typing import Any, Callable, Dict, List, Optional, Tuple, TypeVar, Union, c
 
 from .exceptions import DevSynthError
 from .logging_setup import DevSynthLogger
-from .metrics import inc_retry
+from .metrics import inc_retry, inc_retry_count
 
 # Type variables for generic functions
 T = TypeVar("T")
@@ -178,6 +178,7 @@ def retry_with_exponential_backoff(
                     )
                     if track_metrics:
                         inc_retry("attempt")
+                        inc_retry_count(func.__name__)
 
                     # Call on_retry callback if provided
                     if on_retry:

--- a/src/devsynth/metrics.py
+++ b/src/devsynth/metrics.py
@@ -7,6 +7,8 @@ from typing import Dict
 _memory_metrics: Counter = Counter()
 _provider_metrics: Counter = Counter()
 _retry_metrics: Counter = Counter()
+# Per-function retry count metrics
+_retry_count_metrics: Counter = Counter()
 
 
 def inc_memory(op: str) -> None:
@@ -24,6 +26,11 @@ def inc_retry(op: str) -> None:
     _retry_metrics[op] += 1
 
 
+def inc_retry_count(func_name: str) -> None:
+    """Increment retry count for a specific function."""
+    _retry_count_metrics[func_name] += 1
+
+
 def get_memory_metrics() -> Dict[str, int]:
     """Return memory operation counters."""
     return dict(_memory_metrics)
@@ -39,8 +46,14 @@ def get_retry_metrics() -> Dict[str, int]:
     return dict(_retry_metrics)
 
 
+def get_retry_count_metrics() -> Dict[str, int]:
+    """Return retry counts per function."""
+    return dict(_retry_count_metrics)
+
+
 def reset_metrics() -> None:
     """Reset all metrics counters."""
     _memory_metrics.clear()
     _provider_metrics.clear()
     _retry_metrics.clear()
+    _retry_count_metrics.clear()

--- a/tests/unit/fallback/test_retry_counts.py
+++ b/tests/unit/fallback/test_retry_counts.py
@@ -1,0 +1,51 @@
+import pytest
+from unittest.mock import Mock
+
+from devsynth.fallback import retry_with_exponential_backoff
+from devsynth.metrics import (
+    get_retry_metrics,
+    get_retry_count_metrics,
+    reset_metrics,
+)
+
+
+class NetworkError(Exception):
+    pass
+
+
+def test_retry_count_metrics():
+    reset_metrics()
+    mock_func = Mock(side_effect=[Exception("err"), Exception("err"), "ok"])
+    mock_func.__name__ = "mock_func"
+    decorated = retry_with_exponential_backoff(
+        max_retries=3, initial_delay=0, track_metrics=True
+    )(mock_func)
+
+    result = decorated()
+
+    assert result == "ok"
+    metrics = get_retry_count_metrics()
+    assert metrics.get("mock_func") == 2
+    retry_metrics = get_retry_metrics()
+    assert retry_metrics.get("attempt") == 2
+    assert retry_metrics.get("success") == 1
+
+
+def test_retry_only_network_errors():
+    reset_metrics()
+    mock_func = Mock(side_effect=[NetworkError("net"), ValueError("boom")])
+    mock_func.__name__ = "mock_func"
+    decorated = retry_with_exponential_backoff(
+        max_retries=3,
+        initial_delay=0,
+        retryable_exceptions=(NetworkError,),
+        track_metrics=True,
+    )(mock_func)
+
+    with pytest.raises(ValueError):
+        decorated()
+
+    metrics = get_retry_count_metrics()
+    assert metrics.get("mock_func") == 1
+    retry_metrics = get_retry_metrics()
+    assert retry_metrics.get("attempt") == 1


### PR DESCRIPTION
## Summary
- track retry counts per function in `metrics`
- expose `inc_retry_count` and `get_retry_count_metrics`
- record retry counts in `retry_with_exponential_backoff`
- test retry counting and conditional retry logic

## Testing
- `poetry run pytest tests/unit/fallback/test_retry_counts.py -q`
- `poetry run pytest tests/unit/fallback -q`

------
https://chatgpt.com/codex/tasks/task_e_688710b27ad48333b9ae4d03f2c21828