### PR TITLE
Enable real LLM usage and timestamp tracking

### DIFF
--- a/src/devsynth/application/agents/multi_language_code.py
+++ b/src/devsynth/application/agents/multi_language_code.py
@@ -59,7 +59,7 @@ class MultiLanguageCodeAgent(BaseAgent):
                     code = self.generate_text(prompt)
                 except Exception as e:  # pragma: no cover - defensive
                     logger.error(f"Error generating text: {str(e)}")
-                    code = self.SUPPORTED_LANGUAGES[lang]
+                    code = f"# Error generating {lang} code: {str(e)}"
 
                 wsde = None
                 try:
@@ -106,12 +106,11 @@ class MultiLanguageCodeAgent(BaseAgent):
         {inputs.get('tests', '')}
         """
 
-        # In a real implementation this would query the LLM. Use placeholder text for now.
         try:
             code = self.generate_text(prompt)
         except Exception as e:  # pragma: no cover - defensive
             logger.error(f"Error generating text: {str(e)}")
-            code = self.SUPPORTED_LANGUAGES[language]
+            code = f"# Error generating {language} code: {str(e)}"
 
         # Create WSDE for the generated code
         code_wsde = None

--- a/src/devsynth/interface/webui_bridge.py
+++ b/src/devsynth/interface/webui_bridge.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from typing import List, Optional, Sequence, Dict, Any
+import time
 
 from .ux_bridge import UXBridge, ProgressIndicator, sanitize_output
 from .shared_bridge import SharedBridgeMixin
@@ -69,7 +70,7 @@ class WebUIProgressIndicator(ProgressIndicator):
                 self._status = "Starting..."
 
         self._current += advance
-        self._update_times.append((0, self._current))  # Use 0 as a placeholder for time
+        self._update_times.append((time.time(), self._current))
 
     def complete(self) -> None:
         """Mark the progress indicator as complete."""

--- a/tests/unit/application/agents/test_multi_language_code.py
+++ b/tests/unit/application/agents/test_multi_language_code.py
@@ -78,3 +78,19 @@ class TestMultiLanguageCodeAgent:
             result = agent.process({"language": "python"})
             mock_logger.error.assert_called_once()
             assert result["wsde"] is None
+
+    def test_process_calls_llm_generate(self, agent, mock_llm_port):
+        agent.process({"language": "python"})
+        mock_llm_port.generate.assert_called_once()
+
+    def test_process_without_llm_returns_placeholder(self):
+        agent = MultiLanguageCodeAgent()
+        config = AgentConfig(
+            name="MultiLangAgent",
+            agent_type=AgentType.CODE,
+            description="Test multi language agent",
+            capabilities=[],
+        )
+        agent.initialize(config)
+        result = agent.process({"language": "python"})
+        assert "Placeholder text for prompt" in result["code"]

--- a/tests/unit/interface/test_webui_progress_time.py
+++ b/tests/unit/interface/test_webui_progress_time.py
@@ -1,0 +1,11 @@
+import time
+from devsynth.interface.webui_bridge import WebUIProgressIndicator
+
+
+def test_update_records_time(monkeypatch):
+    times = iter([100.0, 101.0])
+    monkeypatch.setattr(time, "time", lambda: next(times))
+    indicator = WebUIProgressIndicator("Task", 10)
+    indicator.update()
+    indicator.update(advance=2)
+    assert indicator._update_times == [(100.0, 1), (101.0, 3)]


### PR DESCRIPTION
## Summary
- call LLM provider in `MultiLanguageCodeAgent` instead of returning placeholders
- record real timestamps in `WebUIProgressIndicator`
- test that code generation uses the provider and placeholder behaviour
- test WebUI progress timestamp updates

## Testing
- `poetry run pytest tests/unit/application/agents/test_multi_language_code.py tests/unit/interface/test_webui_progress_time.py -q`
- `poetry run pytest -q` *(fails: 159 failed, 117 passed, 41 skipped, 1 error)*

------
https://chatgpt.com/codex/tasks/task_e_688710ac48b08333b37bee88d574d213