### PR TITLE
Fix KuzuMemoryStore path handling

### DIFF
--- a/src/devsynth/adapters/kuzu_memory_store.py
+++ b/src/devsynth/adapters/kuzu_memory_store.py
@@ -37,7 +37,12 @@ class KuzuMemoryStore(MemoryStore):
         self.persist_directory = persist_directory or os.path.join(
             os.getcwd(), ".devsynth", "kuzu_store"
         )
-        settings_module.ensure_path_exists(self.persist_directory)
+        # ``ensure_path_exists`` may redirect the path when running under the
+        # test isolation fixtures.  Capture the returned value so both the
+        # ``KuzuStore`` and ``KuzuAdapter`` use the same final directory.
+        self.persist_directory = settings_module.ensure_path_exists(
+            self.persist_directory
+        )
         self._store = KuzuStore(self.persist_directory)
         self.vector = KuzuAdapter(self.persist_directory, collection_name)
         self.use_provider_system = use_provider_system


### PR DESCRIPTION
## Summary
- ensure `KuzuMemoryStore` uses the path returned by `ensure_path_exists`
- keep vector and memory store paths consistent

## Testing
- `poetry run pytest tests/unit/general/test_memory_system_with_kuzu.py -q`


------
https://chatgpt.com/codex/tasks/task_e_6887a778fdf08333b435ca80d7e848a7