### PR TITLE
Enhance retry metrics

### DIFF
--- a/src/devsynth/metrics.py
+++ b/src/devsynth/metrics.py
@@ -9,6 +9,8 @@ _provider_metrics: Counter = Counter()
 _retry_metrics: Counter = Counter()
 # Per-function retry count metrics
 _retry_count_metrics: Counter = Counter()
+# Per-exception retry metrics
+_retry_error_metrics: Counter = Counter()
 
 
 def inc_memory(op: str) -> None:
@@ -31,6 +33,11 @@ def inc_retry_count(func_name: str) -> None:
     _retry_count_metrics[func_name] += 1
 
 
+def inc_retry_error(error_name: str) -> None:
+    """Increment retry counter for a specific error type."""
+    _retry_error_metrics[error_name] += 1
+
+
 def get_memory_metrics() -> Dict[str, int]:
     """Return memory operation counters."""
     return dict(_memory_metrics)
@@ -51,9 +58,15 @@ def get_retry_count_metrics() -> Dict[str, int]:
     return dict(_retry_count_metrics)
 
 
+def get_retry_error_metrics() -> Dict[str, int]:
+    """Return retry counts for each exception type."""
+    return dict(_retry_error_metrics)
+
+
 def reset_metrics() -> None:
     """Reset all metrics counters."""
     _memory_metrics.clear()
     _provider_metrics.clear()
     _retry_metrics.clear()
     _retry_count_metrics.clear()
+    _retry_error_metrics.clear()

--- a/tests/unit/fallback/test_retry_metrics.py
+++ b/tests/unit/fallback/test_retry_metrics.py
@@ -2,7 +2,7 @@ import pytest
 from unittest.mock import Mock
 
 from devsynth.fallback import retry_with_exponential_backoff
-from devsynth.metrics import get_retry_metrics, reset_metrics
+from devsynth.metrics import get_retry_metrics, reset_metrics, get_retry_error_metrics
 
 
 def test_retry_metrics_success():
@@ -78,3 +78,34 @@ def test_retry_metrics_success_without_retries():
     assert result == "ok"
     assert metrics.get("success") == 1
     assert metrics.get("attempt") is None
+
+
+def test_retry_error_metrics():
+    reset_metrics()
+    mock_func = Mock(side_effect=[ValueError("bad"), "ok"])
+    mock_func.__name__ = "mock_func"
+    decorated = retry_with_exponential_backoff(
+        max_retries=2, initial_delay=0, track_metrics=True
+    )(mock_func)
+    result = decorated()
+    metrics = get_retry_error_metrics()
+    assert result == "ok"
+    assert metrics.get("ValueError") == 1
+
+
+def test_retry_error_map_prevents_retry():
+    reset_metrics()
+    mock_func = Mock(side_effect=ValueError("boom"))
+    mock_func.__name__ = "mock_func"
+    decorated = retry_with_exponential_backoff(
+        max_retries=2,
+        initial_delay=0,
+        track_metrics=True,
+        error_retry_map={ValueError: False},
+    )(mock_func)
+    with pytest.raises(ValueError):
+        decorated()
+    metrics = get_retry_metrics()
+    err_metrics = get_retry_error_metrics()
+    assert metrics.get("abort") == 1
+    assert err_metrics.get("ValueError") == 1


### PR DESCRIPTION
## Summary
- expand metrics module with per-exception counters
- support per-error retry decision in `retry_with_exponential_backoff`
- surface metrics helpers via fallback module
- test new metrics and behaviour

## Testing
- `poetry run pytest tests/unit/fallback/test_retry_metrics.py -q`
- `poetry run pytest tests/unit/fallback -q`
- `poetry run pytest -q` *(fails: Fixture errors and missing directories)*

------
https://chatgpt.com/codex/tasks/task_e_6887af05631483339059fc4a18cf9f36