### PR TITLE
Improve primus rotation logic

### DIFF
--- a/src/devsynth/application/edrr/coordinator.py
+++ b/src/devsynth/application/edrr/coordinator.py
@@ -2621,8 +2621,8 @@ class EDRRCoordinator:
             ):
                 return "analysis_of_code"
 
-            # Add keys
-            key_parts.append(",".join(sorted(result.keys())))
+            # Add keys (convert to string to avoid comparison errors)
+            key_parts.append(",".join(sorted(str(k) for k in result.keys())))
 
             # Add some key values if present
             for important_key in ["type", "description", "category", "approach"]:

--- a/src/devsynth/domain/models/wsde_facade.py
+++ b/src/devsynth/domain/models/wsde_facade.py
@@ -19,6 +19,7 @@ from devsynth.exceptions import DevSynthError
 
 # Import from specialized modules
 from devsynth.domain.models.wsde_base import WSDE, WSDETeam
+from devsynth.domain.models.wsde import WSDETeam as LegacyWSDETeam
 from devsynth.domain.models.wsde_roles import (
     assign_roles,
     assign_roles_for_phase,
@@ -26,10 +27,6 @@ from devsynth.domain.models.wsde_roles import (
     _validate_role_mapping,
     _auto_assign_roles,
     get_role_map,
-    _calculate_expertise_score,
-    _calculate_phase_expertise_score,
-    select_primus_by_expertise,
-    rotate_roles,
     _assign_roles_for_edrr_phase,
 )
 from devsynth.domain.models.wsde_voting import (
@@ -149,10 +146,8 @@ WSDETeam.dynamic_role_reassignment = dynamic_role_reassignment
 WSDETeam._validate_role_mapping = _validate_role_mapping
 WSDETeam._auto_assign_roles = _auto_assign_roles
 WSDETeam.get_role_map = get_role_map
-WSDETeam._calculate_expertise_score = _calculate_expertise_score
-WSDETeam._calculate_phase_expertise_score = _calculate_phase_expertise_score
-WSDETeam.select_primus_by_expertise = select_primus_by_expertise
-WSDETeam.rotate_roles = rotate_roles
+WSDETeam._calculate_expertise_score = LegacyWSDETeam._calculate_expertise_score
+WSDETeam._calculate_phase_expertise_score = LegacyWSDETeam._calculate_phase_expertise_score
 WSDETeam._assign_roles_for_edrr_phase = _assign_roles_for_edrr_phase
 
 # Enhanced Context-Driven Leadership methods
@@ -328,58 +323,11 @@ def new_init(
 
 WSDETeam.__init__ = new_init
 
-# Override rotate_primus method to update primus_index
-original_rotate_primus = WSDETeam.rotate_primus
-
-
-def new_rotate_primus(self):
-    """
-    Rotate the primus role to the next agent in the team.
-
-    Returns:
-        The new primus agent or None if no agents are available
-    """
-    if not self.agents:
-        self.logger.warning("Cannot rotate primus: no agents in team")
-        return None
-
-    # Get the current primus agent
-    old_primus = None
-    if self.primus_index < len(self.agents):
-        old_primus = self.agents[self.primus_index]
-
-    # Update primus_index
-    self.primus_index = (self.primus_index + 1) % len(self.agents)
-
-    # Update roles dictionary
-    self.roles["primus"] = self.agents[self.primus_index]
-
-    # Update agent's current_role
-    for i, agent in enumerate(self.agents):
-        if i == self.primus_index:
-            agent.current_role = "Primus"
-
-    self.logger.info(f"Rotated primus role to {self.roles['primus'].name}")
-    return self.roles["primus"]
-
-
-WSDETeam.rotate_primus = new_rotate_primus
-
-
-# Override get_primus method to return agent at primus_index
-def new_get_primus(self):
-    """
-    Get the current primus agent.
-
-    Returns:
-        The current primus agent or None if not assigned
-    """
-    if not self.agents or self.primus_index >= len(self.agents):
-        return None
-    return self.agents[self.primus_index]
-
-
-WSDETeam.get_primus = new_get_primus
+# Use legacy implementations for Primus rotation and retrieval
+WSDETeam.rotate_primus = LegacyWSDETeam.rotate_primus
+WSDETeam.get_primus = LegacyWSDETeam.get_primus
+WSDETeam.rotate_roles = LegacyWSDETeam.rotate_roles
+WSDETeam.select_primus_by_expertise = LegacyWSDETeam.select_primus_by_expertise
 
 # ------------------------------------------------------------------
 # Peer review methods

--- a/tests/unit/domain/test_wsde_facade_roles.py
+++ b/tests/unit/domain/test_wsde_facade_roles.py
@@ -1,0 +1,34 @@
+import types
+from devsynth.domain.models.wsde_facade import WSDETeam
+
+class SimpleAgent:
+    def __init__(self, name, expertise):
+        self.name = name
+        self.expertise = expertise
+        self.config = types.SimpleNamespace(parameters={'expertise': expertise})
+        self.current_role = None
+
+
+def test_select_primus_updates_index_and_role():
+    team = WSDETeam(name='facade')
+    doc = SimpleAgent('doc', ['documentation'])
+    coder = SimpleAgent('coder', ['python'])
+    team.add_agents([doc, coder])
+    team.select_primus_by_expertise({'type': 'coding', 'language': 'python'})
+    assert team.get_primus() is coder
+    assert team.primus_index == 1
+    assert getattr(coder, 'has_been_primus', False)
+
+
+def test_dynamic_role_reassignment_rotates_primus():
+    team = WSDETeam(name='facade')
+    doc = SimpleAgent('doc', ['documentation'])
+    coder = SimpleAgent('coder', ['python'])
+    tester = SimpleAgent('tester', ['testing'])
+    team.add_agents([doc, coder, tester])
+    team.dynamic_role_reassignment({'type': 'documentation'})
+    first = team.get_primus()
+    team.dynamic_role_reassignment({'type': 'coding', 'language': 'python'})
+    second = team.get_primus()
+    assert first is doc
+    assert second is coder


### PR DESCRIPTION
## Summary
- patch wsde_facade to use primus algorithms from wsde
- fix similarity key generation for EDRR coordinator
- add unit tests for primus selection and dynamic role reassignment

## Testing
- `poetry run pytest tests/unit/domain/test_wsde_facade_roles.py -q`
- `poetry run pytest tests/integration/general/test_edrr_micro_cycle_auto_transition.py::test_micro_cycle_auto_transitions_succeeds -q` *(fails: assert <Phase.EXPAND ...> == <Phase.RETROSPECT...>)*

------
https://chatgpt.com/codex/tasks/task_e_6887ca2590e08333b8ed8efc24421aa8