### PR TITLE
Add transaction and volatility controls

### DIFF
--- a/src/devsynth/adapters/kuzu_memory_store.py
+++ b/src/devsynth/adapters/kuzu_memory_store.py
@@ -34,8 +34,10 @@ class KuzuMemoryStore(MemoryStore):
         collection_name: str = "devsynth_artifacts",
     ) -> None:
         self._temp_dir: Optional[str] = None
-        self.persist_directory = persist_directory or os.path.join(
-            os.getcwd(), ".devsynth", "kuzu_store"
+        self.persist_directory = (
+            persist_directory
+            or settings_module.kuzu_db_path
+            or os.path.join(os.getcwd(), ".devsynth", "kuzu_store")
         )
         # ``ensure_path_exists`` may redirect the path when running under the
         # test isolation fixtures.  Capture the returned value so both the
@@ -43,7 +45,7 @@ class KuzuMemoryStore(MemoryStore):
         self.persist_directory = settings_module.ensure_path_exists(
             self.persist_directory
         )
-        self._store = KuzuStore(self.persist_directory)
+        self._store = KuzuStore(self.persist_directory, use_embedded=None)
         self.vector = KuzuAdapter(self.persist_directory, collection_name)
         self.use_provider_system = use_provider_system
         self.provider_type = provider_type

--- a/tests/fixtures/kuzu.py
+++ b/tests/fixtures/kuzu.py
@@ -15,3 +15,12 @@ def ephemeral_kuzu_store():
     finally:
         store.cleanup()
 
+
+@pytest.fixture
+def temporary_kuzu_config(tmp_path, monkeypatch):
+    """Set temporary Kuzu configuration via environment variables."""
+    db_path = tmp_path / "kuzu_db"
+    monkeypatch.setenv("DEVSYNTH_KUZU_DB_PATH", str(db_path))
+    monkeypatch.setenv("DEVSYNTH_KUZU_EMBEDDED", "true")
+    yield str(db_path)
+


### PR DESCRIPTION
## Summary
- add kuzu store default config usage
- implement transaction context and volatility controls
- honor kuzu config in adapters and tests
- provide fixture for temporary kuzu setup
- test transaction rollback path for graph memory adapter

## Testing
- `poetry run pytest -k graph_memory_edrr_integration -q`

------
https://chatgpt.com/codex/tasks/task_e_6887e4d92b0c83339bc678ff8b454602