### PR TITLE
Fix enable feature behavior test

### DIFF
--- a/tests/behavior/steps/test_cli_commands_steps.py
+++ b/tests/behavior/steps/test_cli_commands_steps.py
@@ -268,6 +268,7 @@ def check_success_message(command_context):
         "executed",
         "updated",
         "complete",
+        "enabled",
     ]
 
     # Check if any of the success indicators are in the output

--- a/tests/behavior/steps/test_config_enable_feature_steps.py
+++ b/tests/behavior/steps/test_config_enable_feature_steps.py
@@ -4,18 +4,35 @@ import os
 from pathlib import Path
 
 from pytest_bdd import given, scenarios, when, then
+import pytest
 
 from devsynth.config.loader import ConfigModel, save_config, load_config
-from .cli_commands_steps import run_command
+from .cli_commands_steps import *
 
 scenarios("../features/general/config_enable_feature.feature")
 
 
+@pytest.fixture
+def context():
+    class Context:
+        def __init__(self):
+            self.root = None
+            self.cfg_path = None
+            self.orig_cwd = None
+            self.monkeypatch = None
+
+    return Context()
+
+
 @given('a project configuration without the "code_generation" feature enabled')
-def config_without_feature(tmp_path, monkeypatch):
+def config_without_feature(tmp_path, monkeypatch, context):
     cfg = ConfigModel(project_root=str(tmp_path))
     cfg.features["code_generation"] = False
-    save_config(cfg, path=str(tmp_path))
+    context.cfg_path = save_config(cfg, path=str(tmp_path))
+    context.root = tmp_path
+    context.orig_cwd = Path(os.environ.get("ORIGINAL_CWD", Path.cwd()))
+    context.monkeypatch = monkeypatch
+    assert context.cfg_path.exists()
     monkeypatch.chdir(tmp_path)
 
 
@@ -30,6 +47,14 @@ def enable_feature(monkeypatch, mock_workflow_manager, command_context):
 
 
 @then('the configuration should mark "code_generation" as enabled')
-def feature_enabled():
+def feature_enabled(context):
     cfg = load_config()
+    assert cfg.project_root == str(context.root)
     assert cfg.features.get("code_generation") is True
+    assert context.cfg_path.exists()
+    monkeypatch = context.monkeypatch
+    if monkeypatch:
+        monkeypatch.chdir(context.orig_cwd)
+        monkeypatch._cwd = context.orig_cwd  # ensure undo path exists
+    else:
+        os.chdir(context.orig_cwd)


### PR DESCRIPTION
## Summary
- add automatic Typer parameter patching to behavior tests
- include 'enabled' in success message search
- store project config path and original directory in enable feature test
- ensure cleanup doesn't fail by restoring working directory

## Testing
- `poetry run pytest tests/behavior/steps/test_config_enable_feature_steps.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6887e9a663348333a9222f1f668c8b6d