### PR TITLE
Import all behavior step modules

### DIFF
--- a/tests/behavior/steps/README.md
+++ b/tests/behavior/steps/README.md
@@ -2,6 +2,11 @@
 
 This directory contains step definitions for BDD tests that verify the consistency of behavior across different interfaces (CLI, WebUI, Agent API) in the DevSynth project.
 
+All Python modules in this directory are imported automatically when the
+``tests.behavior.steps`` package is loaded.  This ensures that pytest-bdd can
+discover every step definition without having to import the modules manually in
+each test file.
+
 ## Key Files
 
 - `cross_interface_consistency_extended_steps.py`: Comprehensive step definitions for testing cross-interface consistency

--- a/tests/behavior/steps/__init__.py
+++ b/tests/behavior/steps/__init__.py
@@ -1,4 +1,11 @@
-"""Behavior test step definitions package."""
+"""Behavior test step definitions package.
+
+All step modules are imported when this package is loaded so that pytest-bdd
+can register every step definition.  The previous lazy-import approach caused
+``StepDefinitionNotFound`` errors when step modules were not referenced
+explicitly in test files.  Importing everything eagerly keeps collection
+reliable without a noticeable performance impact.
+"""
 
 from __future__ import annotations
 
@@ -20,7 +27,19 @@ def tearDownModule() -> None:  # noqa: N802 - pytest expects this exact name
 
 import importlib
 import sys
+from pathlib import Path
 from types import ModuleType
+
+# Eagerly import all step modules so pytest-bdd registers their definitions
+_STEP_DIR = Path(__file__).parent
+for module_path in _STEP_DIR.glob("*.py"):
+    if module_path.stem in {"__init__"} or module_path.stem.startswith("__"):
+        continue
+    name = module_path.stem
+    try:
+        importlib.import_module(f".{name}", __name__)
+    except ModuleNotFoundError:
+        importlib.import_module(f".test_{name}", __name__)
 
 
 def __getattr__(name: str) -> ModuleType:


### PR DESCRIPTION
## Summary
- import all step modules in `tests.behavior.steps` at package import
- clarify that automatic importing occurs in `steps` README

## Testing
- `poetry run pytest tests/behavior/test_simple_standalone.py -q`
- `poetry run pytest tests/behavior/test_cli_commands.py -k display_help -q`

------
https://chatgpt.com/codex/tasks/task_e_688812b6f6e883339c5e187618b6835b