### PR TITLE
Add tiktoken prefetch to codex setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,6 +230,9 @@ bash scripts/codex_setup.sh
 If the setup fails, a `CODEX_ENVIRONMENT_SETUP_FAILED` file will be created.
 Delete the file after resolving the issue and rerun the script until it
 completes successfully.
+The script also prefetches the `cl100k_base` encoding via `tiktoken` so
+language models work offline. A warning is printed and the script exits with
+an error if this prefetch step fails.
 
 The test suite runs entirely in isolated temporary directories.  Ingestion and
 WSDE tests no longer require special environment variables and are executed by

--- a/scripts/codex_setup.sh
+++ b/scripts/codex_setup.sh
@@ -14,6 +14,17 @@ poetry install \
   --all-extras \
   --no-interaction
 
+# Prefetch the cl100k_base encoding for tiktoken
+poetry run python - <<'EOF'
+import sys
+try:
+    import tiktoken
+    tiktoken.get_encoding("cl100k_base")
+except Exception as exc:
+    print(f"[warning] failed to prefetch tiktoken encoding: {exc}", file=sys.stderr)
+    sys.exit(1)
+EOF
+
 # Verify key packages are present
 poetry run python - <<'EOF'
 import importlib


### PR DESCRIPTION
## Summary
- prefetch `cl100k_base` encoding in `codex_setup.sh`
- note prefetch behaviour in README

## Testing
- `poetry run pytest -q` *(fails: ImportError in tests/unit/behavior/test_analyze_commands_steps_unit.py)*

------
https://chatgpt.com/codex/tasks/task_e_6888207fc71c8333a1b218f13f4a5218