### PR TITLE
Update package check

### DIFF
--- a/scripts/codex_setup.sh
+++ b/scripts/codex_setup.sh
@@ -30,7 +30,7 @@ poetry run python - <<'EOF'
 import importlib
 import sys
 
-required = ["pytest", "pytest_bdd", "pydantic", "yaml", "typer"]
+required = ["pytest", "pytest_bdd", "pydantic", "yaml", "typer", "tiktoken"]
 missing = []
 for pkg in required:
     try:


### PR DESCRIPTION
## Summary
- verify `tiktoken` is installed during Codex environment setup

## Testing
- `bash scripts/codex_setup.sh`
- `poetry run pip list | grep pytest-bdd`
- `poetry run pytest tests/unit/behavior/test_analyze_commands_steps_unit.py --setup-show -vv -s`

------
https://chatgpt.com/codex/tasks/task_e_68884c9905e08333972d5f31430f3270