### PR TITLE
Improve CLI lookup in WebUI

### DIFF
--- a/src/devsynth/interface/webui.py
+++ b/src/devsynth/interface/webui.py
@@ -61,8 +61,20 @@ except Exception:  # pragma: no cover
 
 
 def _cli(name: str):
-    """Return a CLI command by name if available."""
+    """Return a CLI command by name if available.
 
+    The helper first checks for a module level variable with the given
+    name. This allows unit tests to patch commands like ``init_cmd`` or
+    ``spec_cmd`` directly on ``devsynth.interface.webui`` without also
+    modifying the underlying ``devsynth.application.cli`` module.  If no
+    such attribute exists it falls back to resolving the command from the
+    CLI module itself.
+    """
+
+    if name in globals():
+        cmd = globals()[name]
+        if cmd is not None:
+            return cmd
     return getattr(_cli_mod, name, None) if _cli_mod else None
 
 


### PR DESCRIPTION
## Summary
- adjust `_cli` helper to first check module level variables before falling back to the CLI module

## Testing
- `poetry run pytest tests/integration/general/test_cli_webui_agentapi_pipeline.py -q` *(fails: init_cmd mock not called)*

------
https://chatgpt.com/codex/tasks/task_e_6888f2c1b5f883338b0fea550fc32710