### PR TITLE
Fix logging and Kuzu initialization

### DIFF
--- a/docs/roadmap/development_status.md
+++ b/docs/roadmap/development_status.md
@@ -409,7 +409,7 @@ Most failures occur in the Web UI requirements wizard and the Kuzu-backed memory
 
 ### Test Failure Summary
 
-The latest run executed **1369** tests: **921** passed, **348** failed, and **100** were skipped. Test collection triggered **3** errors. WebUI wizard failures appear resolved, but memory integration tests still need work. Refer to the [Feature Status Matrix](../implementation/feature_status_matrix.md) for remaining partial features.
+The latest run executed **1,031** tests: **584** passed, **355** failed, and **89** were skipped. Test collection triggered **3** errors. WSDE collaboration and memory integration tests continue to fail and will be tracked in upcoming sprint reports.
 
 
 ## Maintenance Strategy

--- a/issues/112.md
+++ b/issues/112.md
@@ -1,0 +1,8 @@
+# Issue 112: WSDE collaboration test failures
+
+Recent test runs show multiple failures in the WSDE/EDRR integration suites:
+- `tests/integration/general/test_wsde_edrr_component_interactions.py`
+- `tests/integration/general/test_wsde_edrr_integration_advanced.py`
+- `tests/integration/general/test_wsde_edrr_integration_end_to_end.py`
+
+These failures indicate unfinished collaboration workflows and memory synchronisation. Investigate component interactions and finalise the workflow logic so these tests pass.

--- a/issues/113.md
+++ b/issues/113.md
@@ -1,0 +1,7 @@
+# Issue 113: Kuzu memory integration errors
+
+The Kuzu backed memory store fails during test setup:
+```
+AttributeError: module 'devsynth.config.settings' has no attribute 'kuzu_embedded'
+```
+Tests affected include `tests/integration/general/test_kuzu_memory_integration.py` and unit adapter tests. Fix the configuration lookup and ensure ephemeral stores initialise correctly.

--- a/issues/114.md
+++ b/issues/114.md
@@ -1,0 +1,3 @@
+# Issue 114: Requirements wizard failures
+
+Behaviour and integration tests for the requirements wizard (`tests/integration/general/test_requirements_gathering.py` and related behaviour step files) fail due to logging errors and incorrect persistence of the priority value. Update `DevSynthLogger` to handle `exc_info` correctly and verify the gather and wizard flows write expected configuration.

--- a/src/devsynth/application/memory/kuzu_store.py
+++ b/src/devsynth/application/memory/kuzu_store.py
@@ -84,8 +84,15 @@ class KuzuStore(MemoryStore):
         except Exception:  # pragma: no cover - optional
             self.tokenizer = None
 
+        # ``settings_module`` refers to ``devsynth.config.settings`` which
+        # exposes a `_settings` instance.  The module itself does not define a
+        # ``kuzu_embedded`` attribute which previously caused attribute errors
+        # when initializing the store.  Read the value from the exported
+        # constant via ``devsynth.config`` instead of the module attribute.
         self.use_embedded = (
-            settings_module.kuzu_embedded if use_embedded is None else use_embedded
+            getattr(settings_module, "KUZU_EMBEDDED", settings_module._settings.kuzu_embedded)
+            if use_embedded is None
+            else use_embedded
         )
 
         kuzu_mod = None

--- a/src/devsynth/logging_setup.py
+++ b/src/devsynth/logging_setup.py
@@ -367,27 +367,33 @@ class DevSynthLogger:
 
     def debug(self, msg: str, *args, **kwargs) -> None:
         """Log a debug message."""
-        self.logger.debug(msg, *args, extra=kwargs if kwargs else None)
+        exc = kwargs.pop("exc_info", None)
+        self.logger.debug(msg, *args, exc_info=exc, extra=kwargs if kwargs else None)
 
     def info(self, msg: str, *args, **kwargs) -> None:
         """Log an info message."""
-        self.logger.info(msg, *args, extra=kwargs if kwargs else None)
+        exc = kwargs.pop("exc_info", None)
+        self.logger.info(msg, *args, exc_info=exc, extra=kwargs if kwargs else None)
 
     def warning(self, msg: str, *args, **kwargs) -> None:
         """Log a warning message."""
-        self.logger.warning(msg, *args, extra=kwargs if kwargs else None)
+        exc = kwargs.pop("exc_info", None)
+        self.logger.warning(msg, *args, exc_info=exc, extra=kwargs if kwargs else None)
 
     def error(self, msg: str, *args, **kwargs) -> None:
         """Log an error message."""
-        self.logger.error(msg, *args, extra=kwargs if kwargs else None)
+        exc = kwargs.pop("exc_info", None)
+        self.logger.error(msg, *args, exc_info=exc, extra=kwargs if kwargs else None)
 
     def critical(self, msg: str, *args, **kwargs) -> None:
         """Log a critical message."""
-        self.logger.critical(msg, *args, extra=kwargs if kwargs else None)
+        exc = kwargs.pop("exc_info", None)
+        self.logger.critical(msg, *args, exc_info=exc, extra=kwargs if kwargs else None)
 
     def exception(self, msg: str, *args, **kwargs) -> None:
         """Log an exception message with traceback."""
-        self.logger.exception(msg, *args, extra=kwargs if kwargs else None)
+        exc = kwargs.pop("exc_info", None)
+        self.logger.exception(msg, *args, exc_info=exc, extra=kwargs if kwargs else None)
 
 
 # Don't configure logging on import - this is now explicit

--- a/tests/behavior/steps/__init__.py
+++ b/tests/behavior/steps/__init__.py
@@ -30,16 +30,15 @@ import sys
 from pathlib import Path
 from types import ModuleType
 
-# Eagerly import all step modules so pytest-bdd registers their definitions
+# Eagerly importing every step module caused issues during test collection when
+# some modules executed ``pytest_bdd.scenarios`` at import time.  This resulted
+# in ``IndexError: list index out of range`` because pytest's configuration
+# stack was not yet initialized.  To avoid these side effects we no longer
+# automatically import all step modules.  Test files explicitly import the
+# modules they depend on which keeps collection reliable without forcing all
+# modules to be executed here.
+
 _STEP_DIR = Path(__file__).parent
-for module_path in _STEP_DIR.glob("*.py"):
-    if module_path.stem in {"__init__"} or module_path.stem.startswith("__"):
-        continue
-    name = module_path.stem
-    try:
-        importlib.import_module(f".{name}", __name__)
-    except ModuleNotFoundError:
-        importlib.import_module(f".test_{name}", __name__)
 
 
 def __getattr__(name: str) -> ModuleType:


### PR DESCRIPTION
## Summary
- fix attribute lookup in `KuzuStore` initialization
- handle `exc_info` in `DevSynthLogger` methods
- avoid eager step imports in behavior tests
- update development status metrics
- record failing test groups as issues

## Testing
- `poetry run pytest tests/unit/adapters/memory/test_memory_adapter.py::TestMemorySystemAdapter::test_init_with_kuzu_storage_succeeds -q`
- `poetry run pytest tests/integration/general/test_requirements_gathering.py::test_gather_updates_config_succeeds -q`
- `poetry run pytest tests/behavior/test_requirements_wizard.py -q`
- `poetry run pytest tests/integration/general/test_wsde_edrr_component_interactions.py::TestWSDEEDRRComponentInteractions::test_wsde_team_role_assignment_in_edrr_phases_has_expected -q` (fails as expected)

------
https://chatgpt.com/codex/tasks/task_e_6888f92f21b48333b9f7a59bb010fba0