### PR TITLE
Implement BasicPromise and tests

### DIFF
--- a/src/devsynth/application/promises/__init__.py
+++ b/src/devsynth/application/promises/__init__.py
@@ -5,8 +5,18 @@ This module provides the Promise system, a capability declaration and
 fulfillment mechanism for agents within DevSynth.
 """
 
-from devsynth.application.promises.interface import IPromiseManager, IPromiseAuthority, PromiseType
-from devsynth.application.promises.implementation import Promise, PromiseState, PromiseError, PromiseStateError
+from devsynth.application.promises.interface import (
+    IPromiseManager,
+    IPromiseAuthority,
+    PromiseType,
+    BasicPromise,
+)
+from devsynth.application.promises.interface import PromiseState
+from devsynth.application.promises.implementation import (
+    Promise,
+    PromiseError,
+    PromiseStateError,
+)
 from devsynth.application.promises.broker import PromiseBroker, CapabilityMetadata, CapabilityNotFoundError, UnauthorizedAccessError, CapabilityAlreadyRegisteredError
 from devsynth.application.promises.agent import PromiseAgent, PromiseAgentMixin, CapabilityHandler, AgentCapabilityError
 
@@ -17,6 +27,7 @@ __all__ = [
     'PromiseState',
     'PromiseError',
     'PromiseStateError',
+    'BasicPromise',
     'PromiseBroker',
     'CapabilityMetadata',
     'CapabilityNotFoundError',

--- a/tests/unit/application/promises/test_basic_promise.py
+++ b/tests/unit/application/promises/test_basic_promise.py
@@ -1,0 +1,36 @@
+import pytest
+from devsynth.application.promises import BasicPromise, PromiseState
+from devsynth.exceptions import PromiseStateError
+
+
+def test_basic_promise_resolve_and_value():
+    promise = BasicPromise[int]()
+    promise.resolve(42)
+    assert promise.is_fulfilled
+    assert promise.value == 42
+    assert promise.state is PromiseState.FULFILLED
+    assert not promise.is_pending
+
+
+def test_basic_promise_then_chains():
+    first = BasicPromise[int]()
+    chained = first.then(lambda x: x * 2)
+    first.resolve(5)
+    assert chained.is_fulfilled
+    assert chained.value == 10
+
+
+def test_basic_promise_catch_handles_rejection():
+    first = BasicPromise[int]()
+    chained = first.catch(lambda e: str(e))
+    first.reject(RuntimeError("fail"))
+    assert chained.is_fulfilled
+    assert chained.value == "fail"
+
+
+def test_access_value_wrong_state_raises():
+    promise = BasicPromise[int]()
+    with pytest.raises(PromiseStateError):
+        _ = promise.value
+    with pytest.raises(PromiseStateError):
+        _ = promise.reason


### PR DESCRIPTION
## Summary
- add `BasicPromise` implementation for promise interface
- expose `BasicPromise` and use interface `PromiseState`
- test the basic promise behavior

## Testing
- `poetry run pytest tests/unit/application/promises/test_basic_promise.py -q`

------
https://chatgpt.com/codex/tasks/task_e_688913653f508333bdd8c68c9f7b2386