### PR TITLE
Fix WebUI onboarding and test setup

### DIFF
--- a/src/devsynth/interface/webui.py
+++ b/src/devsynth/interface/webui.py
@@ -724,12 +724,13 @@ class WebUI(UXBridge):
                         cmd = _cli("init_cmd")
                         if cmd:
                             cmd(
-                                path=path,
-                                project_root=project_root,
+                                root=project_root or path,
                                 language=language,
                                 goals=goals or None,
+                                memory_backend="kuzu",
                                 bridge=self,
                             )
+                        st.session_state.nav = "Requirements"
             if st.button("Guided Setup", key="guided_setup"):
                 with st.spinner("Starting guided setup..."):
                     SetupWizard(self).run()

--- a/tests/behavior/conftest.py
+++ b/tests/behavior/conftest.py
@@ -8,8 +8,66 @@ import pytest
 import tempfile
 import shutil
 from unittest.mock import MagicMock, patch
+from types import ModuleType
 
 from devsynth.config.settings import ensure_path_exists
+
+# Stub optional heavy dependencies so test collection succeeds without them
+_stub_modules = [
+    "langgraph",
+    "langgraph.checkpoint",
+    "langgraph.checkpoint.base",
+    "langgraph.graph",
+    "langchain",
+    "langchain_openai",
+    "langchain_community",
+    "tiktoken",
+    "tinydb",
+    "tinydb.storages",
+    "tinydb.middlewares",
+    "duckdb",
+    "lmdb",
+    "faiss",
+    "httpx",
+    "lmstudio",
+    "openai",
+    "openai.types",
+    "openai.types.chat",
+    "torch",
+    "transformers",
+    "astor",
+]
+
+for _name in _stub_modules:
+    if _name not in sys.modules:
+        _mod = ModuleType(_name)
+        if _name == "langgraph.checkpoint.base":
+            _mod.BaseCheckpointSaver = object
+            _mod.empty_checkpoint = object()
+        if _name == "langgraph.graph":
+            _mod.END = None
+            _mod.StateGraph = object
+        if _name == "tinydb":
+            _mod.TinyDB = object
+            _mod.Query = object
+        if _name == "tinydb.storages":
+            _mod.JSONStorage = object
+            _mod.MemoryStorage = object
+        if _name == "tinydb.middlewares":
+            _mod.CachingMiddleware = object
+        if _name == "openai":
+            _mod.OpenAI = object
+            _mod.AsyncOpenAI = object
+        if _name == "openai.types.chat":
+            _mod.ChatCompletion = object
+            _mod.ChatCompletionChunk = object
+        if _name == "transformers":
+            _mod.AutoModelForCausalLM = object
+            _mod.AutoTokenizer = object
+        if _name == "httpx":
+            _mod.RequestError = Exception
+            _mod.HTTPStatusError = Exception
+        sys.modules[_name] = _mod
 
 # Add the src directory to the Python path if needed
 sys.path.insert(

--- a/tests/behavior/steps/test_webui_steps.py
+++ b/tests/behavior/steps/test_webui_steps.py
@@ -75,6 +75,62 @@ def webui_context(monkeypatch):
     st.markdown = MagicMock()
     monkeypatch.setitem(sys.modules, "streamlit", st)
 
+    # Stub optional dependencies used during WebUI import
+    modules = [
+        "langgraph",
+        "langgraph.checkpoint",
+        "langgraph.checkpoint.base",
+        "langgraph.graph",
+        "langchain",
+        "langchain_openai",
+        "langchain_community",
+        "tiktoken",
+        "tinydb",
+        "tinydb.storages",
+        "tinydb.middlewares",
+        "duckdb",
+        "lmdb",
+        "faiss",
+        "httpx",
+        "lmstudio",
+        "openai",
+        "openai.types",
+        "openai.types.chat",
+        "torch",
+        "transformers",
+        "astor",
+    ]
+
+    for name in modules:
+        module = ModuleType(name)
+        if name == "langgraph.checkpoint.base":
+            module.BaseCheckpointSaver = object
+            module.empty_checkpoint = object()
+        if name == "langgraph.graph":
+            module.END = None
+            module.StateGraph = object
+        if name == "tinydb":
+            module.TinyDB = object
+            module.Query = object
+        if name == "tinydb.storages":
+            module.JSONStorage = object
+            module.MemoryStorage = object
+        if name == "tinydb.middlewares":
+            module.CachingMiddleware = object
+        if name == "openai":
+            module.OpenAI = object
+            module.AsyncOpenAI = object
+        if name == "openai.types.chat":
+            module.ChatCompletion = object
+            module.ChatCompletionChunk = object
+        if name == "transformers":
+            module.AutoModelForCausalLM = object
+            module.AutoTokenizer = object
+        if name == "httpx":
+            module.RequestError = Exception
+            module.HTTPStatusError = Exception
+        monkeypatch.setitem(sys.modules, name, module)
+
     cli_stub = ModuleType("devsynth.application.cli")
     for name in [
         "init_cmd",


### PR DESCRIPTION
## Summary
- fix onboarding page to call `init_cmd` with the right parameters and persist page state
- stub optional dependencies in behaviour test fixtures so collection works without heavy installs
- expand webui steps fixture with the same stubs for isolated testing

## Testing
- `pytest tests/behavior/test_webui.py -k onboarding -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_68892fdd48508333a6b38cdf4bfbb678