### PR TITLE
Fix chromadb test paths and add kuzu startup regression

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -16,6 +16,7 @@ logging:
 # Memory system configuration
 memory:
   default_store: kuzu
+  memory_file_path: ./.devsynth/memory
   stores:
     chromadb:
       enabled: true
@@ -26,6 +27,7 @@ memory:
       port: 8000
     kuzu:
       persist_directory: ./.devsynth/kuzu
+      embedded: true
     faiss:
       enabled: false
       index_file: ./.devsynth/faiss/index.bin

--- a/tests/behavior/test_chromadb_integration.py
+++ b/tests/behavior/test_chromadb_integration.py
@@ -17,4 +17,4 @@ def test_chromadb_scenarios_succeeds():
     """Test that chromadb scenarios succeeds.
 
 ReqID: N/A"""
-    scenarios('features/chromadb_integration.feature')
+    scenarios('chromadb_integration.feature')

--- a/tests/behavior/test_enhanced_chromadb_integration.py
+++ b/tests/behavior/test_enhanced_chromadb_integration.py
@@ -18,4 +18,4 @@ def test_enhanced_chromadb_scenarios_succeeds():
     """Test that enhanced chromadb scenarios succeeds.
 
 ReqID: N/A"""
-    scenarios('features/enhanced_chromadb_integration.feature')
+    scenarios('enhanced_chromadb_integration.feature')

--- a/tests/unit/general/test_kuzu_project_startup.py
+++ b/tests/unit/general/test_kuzu_project_startup.py
@@ -1,0 +1,41 @@
+import os
+import shutil
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from devsynth.config import load_project_config
+from devsynth.adapters.memory.memory_adapter import MemorySystemAdapter
+from devsynth.adapters.kuzu_memory_store import KuzuMemoryStore
+
+
+@pytest.fixture
+def project_dir(tmp_path):
+    # Create minimal project with project.yaml specifying kuzu
+    project = tmp_path / "proj"
+    config_dir = project / ".devsynth"
+    config_dir.mkdir(parents=True)
+    (config_dir / "project.yaml").write_text("memory_store_type: kuzu\n")
+    return project
+
+
+def test_project_startup_with_kuzu(project_dir, monkeypatch):
+    monkeypatch.setenv("DEVSYNTH_PROJECT_DIR", str(project_dir))
+    # Prevent actual embedding calls
+    with patch("devsynth.adapters.kuzu_memory_store.embed", return_value=[[0.0]]):
+        cfg = load_project_config(project_dir)
+        adapter = MemorySystemAdapter(
+            {
+                "memory_store_type": cfg.config.memory_store_type,
+                "memory_file_path": str(project_dir / ".devsynth" / "kuzu"),
+                "vector_store_enabled": True,
+            }
+        )
+        try:
+            assert isinstance(adapter.memory_store, KuzuMemoryStore)
+        finally:
+            # Cleanup any created resources
+            if isinstance(adapter.memory_store, KuzuMemoryStore):
+                adapter.memory_store.cleanup()
+    monkeypatch.delenv("DEVSYNTH_PROJECT_DIR", raising=False)


### PR DESCRIPTION
## Summary
- update feature paths for chromadb BDD tests
- expand default config with memory path and embedded kuzu flag
- add regression test ensuring projects start with kuzu enabled

## Testing
- `poetry run pytest tests/unit/general/test_kuzu_project_startup.py -q`
- `poetry run pytest tests/behavior/test_chromadb_integration.py tests/behavior/test_enhanced_chromadb_integration.py tests/unit/general/test_kuzu_project_startup.py -q`

------
https://chatgpt.com/codex/tasks/task_e_688940cad0ec83338ebab11b69474459