### PR TITLE
Add CRUD adapter tests and fix ChromaDB cache

### DIFF
--- a/src/devsynth/application/memory/chromadb_store.py
+++ b/src/devsynth/application/memory/chromadb_store.py
@@ -720,6 +720,7 @@ class ChromaDBStore(MemoryStore):
                 existed = item_id in self._store
                 self._store.pop(item_id, None)
                 self._versions.pop(item_id, None)
+                self._cache.pop(item_id, None)
                 self._save_fallback()
                 return existed
 
@@ -727,7 +728,7 @@ class ChromaDBStore(MemoryStore):
             self.collection.delete(ids=[item_id])
 
             # Remove the item from the cache if it exists
-            if not self._use_fallback and item_id in self._cache:
+            if item_id in self._cache:
                 del self._cache[item_id]
 
             logger.info(f"Deleted item with ID {item_id} from ChromaDB")

--- a/tests/unit/application/memory/test_basic_crud_adapters.py
+++ b/tests/unit/application/memory/test_basic_crud_adapters.py
@@ -1,0 +1,56 @@
+import os
+import pytest
+from datetime import datetime
+
+from devsynth.domain.models.memory import MemoryItem, MemoryType
+from devsynth.application.memory.tinydb_store import TinyDBStore
+from devsynth.application.memory.lmdb_store import LMDBStore
+from devsynth.application.memory.kuzu_store import KuzuStore
+from devsynth.application.memory.chromadb_store import ChromaDBStore
+
+
+def _make_store(store_cls, tmp_path, monkeypatch):
+    if store_cls is TinyDBStore:
+        return TinyDBStore(str(tmp_path))
+    if store_cls is LMDBStore:
+        return LMDBStore(str(tmp_path))
+    if store_cls is KuzuStore:
+        return KuzuStore(str(tmp_path))
+    if store_cls is ChromaDBStore:
+        monkeypatch.setenv("DEVSYNTH_NO_FILE_LOGGING", "1")
+        monkeypatch.setenv("ENABLE_CHROMADB", "1")
+        return ChromaDBStore(str(tmp_path))
+    raise ValueError(store_cls)
+
+
+@pytest.mark.parametrize(
+    "store_cls",
+    [TinyDBStore, LMDBStore, KuzuStore, ChromaDBStore],
+)
+def test_basic_crud_lifecycle(store_cls, tmp_path, monkeypatch):
+    store = _make_store(store_cls, tmp_path, monkeypatch)
+    try:
+        # KuzuStore and ChromaDBStore do not generate IDs automatically
+        item_id = "test-item" if store_cls in {KuzuStore, ChromaDBStore} else ""
+        item = MemoryItem(
+            id=item_id,
+            content="hello",
+            memory_type=MemoryType.WORKING,
+            metadata={},
+            created_at=datetime.now(),
+        )
+        item_id = store.store(item)
+        assert item_id
+        retrieved = store.retrieve(item_id)
+        assert retrieved and retrieved.content == "hello"
+
+        item.content = "updated"
+        store.store(item)
+        updated = store.retrieve(item_id)
+        assert updated and updated.content == "updated"
+
+        assert store.delete(item_id) is True
+        assert store.retrieve(item_id) is None
+    finally:
+        if hasattr(store, "close"):
+            store.close()


### PR DESCRIPTION
## Summary
- extend memory adapter coverage with CRUD lifecycle test
- clean up cached records when deleting in `ChromaDBStore`

## Testing
- `poetry run pytest tests/unit/application/memory/test_basic_crud_adapters.py -q`
- `poetry run pytest tests/unit/application/memory`

------
https://chatgpt.com/codex/tasks/task_e_68895fa5d760833380c75c827e43392f