### PR TITLE
Fix wizard reset and KuzuStore path handling

### DIFF
--- a/src/devsynth/application/memory/kuzu_store.py
+++ b/src/devsynth/application/memory/kuzu_store.py
@@ -64,10 +64,12 @@ class KuzuStore(MemoryStore):
         # test isolation fixtures.  Use the returned path so the database is
         # created in the correct location rather than the original argument
         # which may be outside the temporary test directory.
-        self.file_path = settings_module.ensure_path_exists(
-            file_path
-            or settings_module.kuzu_db_path
-            or os.path.join(os.getcwd(), ".devsynth", "kuzu_store")
+        self.file_path = os.path.abspath(
+            settings_module.ensure_path_exists(
+                file_path
+                or settings_module.kuzu_db_path
+                or os.path.join(os.getcwd(), ".devsynth", "kuzu_store")
+            )
         )
         # Explicitly create the directory even when ``ensure_path_exists`` is
         # patched not to, ensuring the database can always be opened.

--- a/src/devsynth/interface/webui.py
+++ b/src/devsynth/interface/webui.py
@@ -925,6 +925,8 @@ class WebUI(UXBridge):
                 self.display_result(
                     "[green]Requirements saved to requirements_wizard.json[/green]"
                 )
+                st.session_state.wizard_step = 0
+                st.session_state.wizard_data = {}
                 if hasattr(st.session_state, "__setitem__"):
                     st.session_state["wizard_step"] = st.session_state.wizard_step
                     st.session_state["wizard_data"] = st.session_state.wizard_data

--- a/tests/unit/general/test_kuzu_store.py
+++ b/tests/unit/general/test_kuzu_store.py
@@ -1,12 +1,11 @@
 """Basic tests for :class:`KuzuStore`."""
-import importlib.util
-from pathlib import Path
+import importlib
+import os
 from devsynth.domain.models.memory import MemoryItem, MemoryType
-spec = importlib.util.spec_from_file_location('kuzu_store', Path(__file__).
-    resolve().parents[3] / 'src/devsynth/application/memory/kuzu_store.py')
-kuzu_store = importlib.util.module_from_spec(spec)
-spec.loader.exec_module(kuzu_store)
-KuzuStore = kuzu_store.KuzuStore
+
+KuzuStore = importlib.import_module(
+    "devsynth.application.memory.kuzu_store"
+).KuzuStore
 
 
 def test_store_retrieve_and_versions_succeeds(tmp_path):
@@ -37,3 +36,9 @@ ReqID: N/A"""
     results = store.search({'metadata.tag': 'y'})
     assert len(results) == 1
     assert results[0].id == '2'
+
+
+def test_store_path_is_absolute(tmp_path):
+    """Initialization should normalize the store path."""
+    store = KuzuStore(str(tmp_path))
+    assert os.path.isabs(store.file_path)

--- a/tests/unit/general/test_kuzu_store_fallback.py
+++ b/tests/unit/general/test_kuzu_store_fallback.py
@@ -8,13 +8,10 @@ def test_kuzu_store_falls_back_when_dependency_missing(monkeypatch, tmp_path):
     # Remove kuzu module to simulate missing dependency
     monkeypatch.setitem(sys.modules, "kuzu", None)
     # Reload module after patching
-    spec = importlib.util.spec_from_file_location(
-        "kuzu_store",
-        Path(__file__).resolve().parents[3]
-        / "src/devsynth/application/memory/kuzu_store.py",
+    kuzu_store = importlib.import_module(
+        "devsynth.application.memory.kuzu_store"
     )
-    kuzu_store = importlib.util.module_from_spec(spec)
-    spec.loader.exec_module(kuzu_store)
+    importlib.reload(kuzu_store)
     KuzuStore = kuzu_store.KuzuStore
 
     store = KuzuStore(str(tmp_path))

--- a/tests/unit/interface/test_webui_requirements_wizard.py
+++ b/tests/unit/interface/test_webui_requirements_wizard.py
@@ -143,6 +143,14 @@ def test_requirements_wizard_save_requirements_succeeds(stub_streamlit, monkeypa
     assert result == expected_data
     webui_instance = WebUI()
     webui_instance.display_result = MagicMock()
+    stub_streamlit.session_state.wizard_step = 4
+    stub_streamlit.session_state.wizard_data = {
+        "title": "Test Requirement",
+        "description": "Test Description",
+        "type": "functional",
+        "priority": "medium",
+        "constraints": "constraint1, constraint2",
+    }
     with patch("builtins.open", m):
         result = webui_instance._requirements_wizard()
     webui_instance.display_result.assert_called_once()
@@ -215,3 +223,27 @@ def test_requirements_wizard_error_handling_raises_error(stub_streamlit, monkeyp
         webui_instance._requirements_wizard()
     webui_instance.display_result.assert_called_once()
     assert "ERROR" in webui_instance.display_result.call_args[0][0]
+
+
+def test_requirements_wizard_resets_after_save(stub_streamlit, monkeypatch):
+    """Wizard should reset state after saving."""
+    import importlib
+    import devsynth.interface.webui as webui
+
+    importlib.reload(webui)
+    from devsynth.interface.webui import WebUI
+
+    stub_streamlit.session_state.wizard_step = 4
+    stub_streamlit.session_state.wizard_data = {
+        "title": "Req",
+        "description": "Desc",
+        "type": "functional",
+        "priority": "medium",
+        "constraints": "",
+    }
+    stub_streamlit.button.return_value = True
+    m = mock_open()
+    with patch("builtins.open", m):
+        WebUI()._requirements_wizard()
+    assert stub_streamlit.session_state.wizard_step == 0
+    assert stub_streamlit.session_state.wizard_data == {}


### PR DESCRIPTION
## Summary
- refine requirements wizard to reset after saving
- normalize Kuzu store path using `os.path.abspath`
- update unit tests for path normalization and wizard reset
- simplify Kuzu store tests to import from package

## Testing
- `poetry run pytest tests/unit/interface/test_webui_requirements_wizard.py tests/unit/general/test_kuzu_store.py tests/unit/general/test_kuzu_store_fallback.py tests/behavior/steps/test_interactive_requirements_steps.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6889829297108333abca6ed287ebca55