### PR TITLE
Add message sync and update WSDE BDD tests

### DIFF
--- a/src/devsynth/application/collaboration/message_protocol.py
+++ b/src/devsynth/application/collaboration/message_protocol.py
@@ -196,7 +196,17 @@ class MessageProtocol:
                 metadata=message.metadata,
             )
             try:
-                self.memory_manager.store_item(item)
+                if "tinydb" in self.memory_manager.adapters:
+                    primary = "tinydb"
+                elif "graph" in self.memory_manager.adapters:
+                    primary = "graph"
+                elif self.memory_manager.adapters:
+                    primary = next(iter(self.memory_manager.adapters))
+                else:
+                    primary = None
+
+                if primary:
+                    self.memory_manager.sync_manager.update_item(primary, item)
             except Exception:
                 pass
         return message


### PR DESCRIPTION
## Summary
- propagate collaboration messages across all memory stores using `SyncManager`
- load additional WSDE feature scenarios
- harden dialectical reasoning steps and add voting summary steps

## Testing
- `poetry run pytest -q tests/unit/application/collaboration/test_wsde_team_consensus_summary.py`
- `poetry run pytest -q tests/behavior/steps/test_wsde_agent_model_steps.py`


------
https://chatgpt.com/codex/tasks/task_e_688988bbf658833389b1bdf4a76162ef