### PR TITLE
Add sync support across memory backends

### DIFF
--- a/src/devsynth/adapters/kuzu_memory_store.py
+++ b/src/devsynth/adapters/kuzu_memory_store.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import os
 import tempfile
 import shutil
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Optional, List
 
 from devsynth.domain.interfaces.memory import MemoryStore
 from devsynth.domain.models.memory import MemoryItem, MemoryVector
@@ -141,3 +141,24 @@ class KuzuMemoryStore(MemoryStore):
         """Return all stored items."""
 
         return self._store.get_all_items()
+
+    # ------------------------------------------------------------------
+    def store_vector(self, vector: MemoryVector) -> str:
+        """Store a vector using the underlying ``KuzuAdapter``."""
+
+        return self.vector.store_vector(vector)
+
+    def retrieve_vector(self, vector_id: str) -> Optional[MemoryVector]:
+        """Retrieve a stored vector by ID."""
+
+        return self.vector.retrieve_vector(vector_id)
+
+    def delete_vector(self, vector_id: str) -> bool:
+        """Delete a vector by ID."""
+
+        return self.vector.delete_vector(vector_id)
+
+    def get_all_vectors(self) -> List[MemoryVector]:
+        """Return all stored vectors."""
+
+        return self.vector.get_all_vectors()

--- a/tests/integration/memory/test_cross_store_sync.py
+++ b/tests/integration/memory/test_cross_store_sync.py
@@ -1,0 +1,68 @@
+import os
+from unittest.mock import patch
+
+import pytest
+
+from devsynth.application.memory.lmdb_store import LMDBStore
+from devsynth.application.memory.faiss_store import FAISSStore
+from devsynth.adapters.kuzu_memory_store import KuzuMemoryStore
+from devsynth.application.memory.chromadb_store import ChromaDBStore
+from devsynth.adapters.memory.chroma_db_adapter import ChromaDBAdapter
+from devsynth.application.memory.memory_manager import MemoryManager
+from devsynth.application.memory.sync_manager import SyncManager
+from devsynth.domain.models.memory import MemoryItem, MemoryVector, MemoryType
+
+
+pytestmark = [
+    pytest.mark.requires_resource("lmdb"),
+    pytest.mark.requires_resource("faiss"),
+    pytest.mark.requires_resource("kuzu"),
+    pytest.mark.requires_resource("chromadb"),
+]
+
+
+def _manager(lmdb, faiss, kuzu, chroma, chroma_vec):
+    adapters = {
+        "lmdb": lmdb,
+        "faiss": faiss,
+        "kuzu": kuzu,
+        "chroma": chroma,
+        "chroma_vec": chroma_vec,
+    }
+    manager = MemoryManager(adapters=adapters)
+    manager.sync_manager = SyncManager(manager)
+    return manager
+
+
+def test_full_backend_synchronization(tmp_path, monkeypatch):
+    monkeypatch.setenv("DEVSYNTH_NO_FILE_LOGGING", "1")
+    monkeypatch.setenv("ENABLE_CHROMADB", "1")
+    import chromadb.utils.embedding_functions as ef
+
+    monkeypatch.setattr(ef, "DefaultEmbeddingFunction", lambda: (lambda x: [0.0] * 5))
+
+    lmdb_store = LMDBStore(str(tmp_path / "lmdb"))
+    faiss_store = FAISSStore(str(tmp_path / "faiss"))
+    kuzu_store = KuzuMemoryStore.create_ephemeral()
+    chroma_store = ChromaDBStore(str(tmp_path / "chroma"))
+    chroma_vec = ChromaDBAdapter(str(tmp_path / "chroma_vec"))
+
+    manager = _manager(lmdb_store, faiss_store, kuzu_store, chroma_store, chroma_vec)
+
+    item = MemoryItem(id="x", content="hello", memory_type=MemoryType.CODE)
+    vector = MemoryVector(id="x", content="hello", embedding=[0.1] * 5, metadata={})
+
+    lmdb_store.store(item)
+    faiss_store.store_vector(vector)
+
+    manager.synchronize("lmdb", "kuzu")
+    manager.synchronize("faiss", "kuzu")
+    manager.synchronize("kuzu", "chroma")
+    manager.synchronize("kuzu", "chroma_vec")
+
+    assert kuzu_store.retrieve("x") is not None
+    assert kuzu_store.vector.retrieve_vector("x") is not None
+    assert chroma_store.retrieve("x") is not None
+    assert chroma_vec.retrieve_vector("x") is not None
+
+    kuzu_store.cleanup()


### PR DESCRIPTION
## Summary
- support retrieval of all vectors in ChromaDB adapter
- expose vector operations from Kuzu memory store
- integration test covering LMDB, FAISS, Kuzu and ChromaDB sync

## Testing
- `poetry run pytest tests/integration/memory/test_cross_store_sync.py tests/unit/application/memory/test_sync_across_backends.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68898d684b8c8333a8142e67ca898f60