### PR TITLE
Update specifications and SRS

### DIFF
--- a/docs/specifications/devsynth_specification.md
+++ b/docs/specifications/devsynth_specification.md
@@ -1,0 +1,24 @@
+---
+title: DevSynth Technical Specification
+status: published
+author: DevSynth Team
+version: 1.0
+---
+
+# DevSynth Technical Specification
+
+This document summarizes the latest high‑level specification for the DevSynth project. It complements the detailed [DevSynth Specification MVP Updated](devsynth_specification_mvp_updated.md) document and is kept in sync with the implemented API.
+
+## 1. API Overview
+
+DevSynth exposes two FastAPI applications:
+
+- **Internal API** (`src/devsynth/api.py`) providing `/health` and `/metrics` endpoints for basic monitoring.
+- **Agent API** (`src/devsynth/interface/agentapi.py`) providing workflow endpoints such as `/init`, `/gather`, `/synthesize`, `/status`, `/spec`, `/test`, `/code`, `/doctor`, `/edrr-cycle` and an additional `/metrics` endpoint.
+
+All endpoints require optional bearer token authentication when enabled via configuration.
+
+## 2. Implementation Status
+
+The API modules listed above are implemented and covered by unit and integration tests. Refer to the [Requirements Traceability Matrix](../requirements_traceability.md) for details on requirement coverage.
+

--- a/docs/system_requirements_specification.md
+++ b/docs/system_requirements_specification.md
@@ -215,7 +215,13 @@ Primary users are individual software developers who:
 - [FR-71] The system shall provide a `doctor` command (alias `check`) for environment diagnostics
 - [FR-72] The system shall provide a Streamlit-based WebUI for running workflows
 - [FR-73] The system shall offer an interactive requirement-gathering workflow
-- [FR-74] The system shall expose an HTTP API for agent operations
+- [FR-74] The system shall expose an HTTP API for agent operations with the following endpoints:
+  - `POST /init`
+  - `POST /gather`
+  - `POST /synthesize`
+  - `GET /status`
+  - `GET /health`
+  - `GET /metrics`
 
 
 ### 3.10 WebUI Integration


### PR DESCRIPTION
## Summary
- add missing `docs/specifications/devsynth_specification.md`
- document HTTP API endpoints in `docs/system_requirements_specification.md`

## Testing
- `poetry run pytest tests/unit/application/cli/test_metrics_commands.py::test_alignment_metrics_cmd_success -q` *(fails: alignment_metrics_cmd_success)*

------
https://chatgpt.com/codex/tasks/task_e_6889a26908908333ab1f6712fe4e3795