### PR TITLE
feat: enhance retry telemetry

### DIFF
--- a/src/devsynth/application/llm/lmstudio_provider.py
+++ b/src/devsynth/application/llm/lmstudio_provider.py
@@ -20,6 +20,7 @@ from ...config import get_llm_settings
 # Create a logger for this module
 from devsynth.logging_setup import DevSynthLogger
 from devsynth.fallback import CircuitBreaker, retry_with_exponential_backoff
+from devsynth.metrics import inc_provider
 
 logger = DevSynthLogger(__name__)
 from devsynth.exceptions import DevSynthError
@@ -132,11 +133,23 @@ class LMStudioProvider(BaseLLMProvider):
             return False
         return True
 
+    def _on_retry(self, exc: Exception, attempt: int, delay: float) -> None:
+        """Emit telemetry when a retry occurs."""
+        logger.warning(
+            "Retrying LMStudioProvider due to %s (attempt %d, delay %.2fs)",
+            exc,
+            attempt,
+            delay,
+        )
+        inc_provider("retry")
+
     def _execute_with_resilience(self, func, *args, **kwargs):
         """Execute a function with retry and circuit breaker protection."""
 
         @retry_with_exponential_backoff(
-            max_retries=self.max_retries, should_retry=self._should_retry
+            max_retries=self.max_retries,
+            should_retry=self._should_retry,
+            on_retry=self._on_retry,
         )
         def _wrapped():
             return self.circuit_breaker.call(func, *args, **kwargs)


### PR DESCRIPTION
## Summary
- support string-based retry conditions and expose retry metrics via fallback module
- emit retry telemetry from provider adapters
- cover string condition retries

## Testing
- `pytest tests/unit/fallback/test_retry_conditions.py::test_should_retry_prevents_retry tests/unit/fallback/test_retry_conditions.py::test_should_retry_allows_retry_until_success tests/unit/fallback/test_retry_conditions.py::test_retry_on_result_triggers_retry tests/unit/fallback/test_retry_conditions.py::test_retry_conditions_abort_when_condition_fails tests/unit/fallback/test_retry_conditions.py::test_retry_conditions_allow_retry tests/unit/fallback/test_retry_conditions.py::test_string_condition_allows_retry tests/unit/fallback/test_retry_conditions.py::test_string_condition_aborts_when_missing tests/unit/fallback/test_retry_conditions.py::test_exponential_backoff tests/unit/fallback/test_retry_metrics.py tests/unit/fallback/test_retry_counts.py` (fails: Error importing plugin "tests.fixtures.adapter_mocks")

------
https://chatgpt.com/codex/tasks/task_e_688f7b48f9a88333a4cc16a72fd7851f