### PR TITLE
Add async cross-store query support and tests

### DIFF
--- a/src/devsynth/application/memory/memory_manager.py
+++ b/src/devsynth/application/memory/memory_manager.py
@@ -646,11 +646,12 @@ class MemoryManager:
         store: Union[str, None] = None,
         strategy: str = "direct",
         context: Optional[Dict[str, Any]] = None,
+        stores: Optional[List[str]] | None = None,
     ) -> Any:
         """Route a query through the :class:`QueryRouter`."""
 
         return self.query_router.route(
-            query, store=store, strategy=strategy, context=context
+            query, store=store, strategy=strategy, context=context, stores=stores
         )
 
     def synchronize(

--- a/src/devsynth/application/memory/query_router.py
+++ b/src/devsynth/application/memory/query_router.py
@@ -59,9 +59,17 @@ class QueryRouter:
         logger.warning("Adapter %s does not support direct queries", store)
         return []
 
-    def cross_store_query(self, query: str) -> Dict[str, List[Any]]:
-        """Query all configured stores and return grouped results."""
-        grouped = self.memory_manager.sync_manager.cross_store_query(query)
+    def cross_store_query(
+        self, query: str, stores: Optional[List[str]] | None = None
+    ) -> Dict[str, List[Any]]:
+        """Query configured stores and return grouped results.
+
+        Args:
+            query: The search query.
+            stores: Optional list of store names to restrict the query. If not
+                provided, all configured stores are queried.
+        """
+        grouped = self.memory_manager.sync_manager.cross_store_query(query, stores)
         for store, items in grouped.items():
             for item in items:
                 if hasattr(item, "metadata"):
@@ -138,12 +146,13 @@ class QueryRouter:
         store: Optional[str] = None,
         strategy: str = "direct",
         context: Optional[Dict[str, Any]] = None,
+        stores: Optional[List[str]] | None = None,
     ) -> Any:
         """Route a query according to the specified strategy."""
         if strategy == "direct" and store:
             return self.direct_query(query, store)
         if strategy == "cross":
-            return self.cross_store_query(query)
+            return self.cross_store_query(query, stores)
         if strategy == "cascading":
             return self.cascading_query(query)
         if strategy == "federated":


### PR DESCRIPTION
## Summary
- add asynchronous cross-store querying and caching in sync manager
- allow query router and memory manager to target specific stores for cross-store queries
- add unit and integration tests for async sync manager and cross-store routing

## Testing
- `pytest tests/unit/adapters/test_sync_manager.py -q`
- `pytest tests/integration/general/test_query_router_integration.py -q`


------
https://chatgpt.com/codex/tasks/task_e_688f7b419cec8333be4385d97395d32a