### PR TITLE
Graceful Kuzu memory handling with fallback tests

### DIFF
--- a/src/devsynth/adapters/kuzu_memory_store.py
+++ b/src/devsynth/adapters/kuzu_memory_store.py
@@ -305,27 +305,16 @@ class KuzuMemoryStore(MemoryStore):
 
     def cleanup(self) -> None:
         """Remove any temporary directory created by :meth:`create_ephemeral`.
-        
+
         This method ensures that all temporary files and directories are properly
         cleaned up, including those created by KuzuStore and KuzuAdapter.
         """
-        # First, try to close any open connections
+        # First, allow the underlying store to release resources
         try:
-            if hasattr(self._store, "conn") and self._store.conn:
-                try:
-                    # Try to commit any pending transactions
-                    self._store.conn.execute("COMMIT")
-                except Exception:
-                    pass
-                
-                # Close the connection if possible
-                if hasattr(self._store.conn, "close"):
-                    try:
-                        self._store.conn.close()
-                    except Exception as e:
-                        logger.warning(f"Error closing Kuzu connection: {e}")
+            if hasattr(self, "_store") and hasattr(self._store, "close"):
+                self._store.close()
         except Exception as e:
-            logger.warning(f"Error during connection cleanup: {e}")
+            logger.warning(f"Error closing Kuzu store: {e}")
             
         # Clean up vector store files
         try:


### PR DESCRIPTION
## Summary
- add explicit close and destructor logic to KuzuStore to release DB resources
- simplify KuzuMemoryStore cleanup and ensure tests run without Kuzu
- extend integration tests to cover Kuzu fallback and cross-store synchronization

## Testing
- `poetry run pytest tests/integration/general/test_kuzu_memory_integration.py tests/integration/memory/test_cross_store_sync.py -q`


------
https://chatgpt.com/codex/tasks/task_e_688f7b355998833382014ecd627ee769