### PR TITLE
Fix wizard state reset and add navigation tests

### DIFF
--- a/src/devsynth/interface/webui_state.py
+++ b/src/devsynth/interface/webui_state.py
@@ -165,10 +165,19 @@ class PageState(Generic[T]):
                 logger.warning(f"Session state not available, cannot clear {self.page_name} state")
                 return
                 
-            keys_to_remove = [k for k in st.session_state.keys() 
-                             if k.startswith(f"{self.page_name}_")]
+            keys_to_remove = [
+                k for k in st.session_state.keys()
+                if k.startswith(f"{self.page_name}_")
+            ]
             for key in keys_to_remove:
-                del st.session_state[key]
+                try:
+                    del st.session_state[key]
+                except KeyError:
+                    pass
+                try:
+                    delattr(st.session_state, key)
+                except AttributeError:
+                    pass
                 
             logger.debug(f"Cleared {len(keys_to_remove)} keys for {self.page_name}")
         except Exception as e:

--- a/tests/behavior/features/general/requirements_wizard_navigation.feature
+++ b/tests/behavior/features/general/requirements_wizard_navigation.feature
@@ -10,3 +10,10 @@ Feature: Requirements Wizard Navigation
     Then the wizard should show step 2
     When I click the wizard back button
     Then the wizard should show step 1
+
+  Scenario: Cancel resets wizard state
+    Given the WebUI is initialized
+    When I open the requirements wizard
+    And I click the wizard next button
+    And I click the wizard cancel button
+    Then the wizard state should reset to step 1


### PR DESCRIPTION
## Summary
- ensure page state clearing removes attributes and items
- add requirements wizard navigation and cancel tests

## Testing
- `poetry run pytest tests/behavior/steps/test_requirements_wizard_navigation_steps.py -q`


------
https://chatgpt.com/codex/tasks/task_e_688f7b1dc8d48333b678f1ba26b9ea40