### PR TITLE
Ensure chromadb extra installed and add import test

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -7932,7 +7932,7 @@ cffi = ["cffi (>=1.11)"]
 
 [extras]
 api = ["fastapi", "prometheus-client"]
-chromadb = ["chromadb"]
+chromadb = ["chromadb", "tiktoken"]
 dev = ["pydantic-settings", "pyyaml", "toml"]
 docs = ["hypothesis"]
 gpu = ["nvidia-cublas-cu12", "nvidia-cuda-cupti-cu12", "nvidia-cuda-nvrtc-cu12", "nvidia-cuda-runtime-cu12", "nvidia-cudnn-cu12", "nvidia-cufft-cu12", "nvidia-cufile-cu12", "nvidia-curand-cu12", "nvidia-cusolver-cu12", "nvidia-cusparse-cu12", "nvidia-cusparselt-cu12", "nvidia-nccl-cu12", "nvidia-nvjitlink-cu12", "nvidia-nvtx-cu12", "torch"]
@@ -7948,4 +7948,4 @@ webui = ["streamlit"]
 [metadata]
 lock-version = "2.1"
 python-versions = "<3.13,>=3.12"
-content-hash = "47881f56fd28efa4a9b1b237e08c9c8bb2a14ba2e898b16a656da41c6dc0a03d"
+content-hash = "021eee086164b12a07adbc450fe00bae000245895785ae0281acf966706b790b"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -133,7 +133,7 @@ minimal = [
 ]
 
 retrieval = ["kuzu", "faiss-cpu"]
-chromadb = ["chromadb"]
+chromadb = ["chromadb", "tiktoken"]
 lmstudio = ["lmstudio"]
 memory = ["tinydb", "duckdb", "lmdb", "kuzu", "faiss-cpu", "chromadb", "numpy"]
 llm = ["tiktoken", "httpx"]

--- a/scripts/codex_setup.sh
+++ b/scripts/codex_setup.sh
@@ -30,7 +30,7 @@ poetry run python - <<'EOF'
 import importlib
 import sys
 
-required = ["pytest", "pytest_bdd", "pydantic", "yaml", "typer", "tiktoken"]
+required = ["pytest", "pytest_bdd", "pydantic", "yaml", "typer", "tiktoken", "chromadb"]
 missing = []
 for pkg in required:
     try:

--- a/src/devsynth/application/memory/chromadb_store.py
+++ b/src/devsynth/application/memory/chromadb_store.py
@@ -46,6 +46,9 @@ from ...domain.models.memory import MemoryItem, MemoryType
 logger = DevSynthLogger(__name__)
 
 
+__all__ = ["ChromaDBStore"]
+
+
 class ChromaDBStore(MemoryStore):
     """
     ChromaDB implementation of the MemoryStore interface.

--- a/tests/test_chromadb_store_import.py
+++ b/tests/test_chromadb_store_import.py
@@ -1,0 +1,7 @@
+from tests.lightweight_imports import apply_lightweight_imports
+
+
+def test_chromadb_store_import() -> None:
+    """ChromaDBStore should import when chromadb extras are installed."""
+    apply_lightweight_imports()
+    from devsynth.application.memory.chromadb_store import ChromaDBStore  # noqa: F401


### PR DESCRIPTION
## Summary
- include tiktoken in chromadb extra
- verify chromadb presence in codex setup
- expose `ChromaDBStore` and test its import

## Testing
- `bash scripts/codex_setup.sh`
- `poetry run pip list | grep chromadb`
- `poetry run pytest tests/test_chromadb_store_import.py`


------
https://chatgpt.com/codex/tasks/task_e_688f82f5cf608333bbc1fe200a373dfa