### PR TITLE
Add automated security audit checks

### DIFF
--- a/docs/policies/security.md
+++ b/docs/policies/security.md
@@ -54,6 +54,18 @@ export DEVSYNTH_TLS_CA_FILE=/path/to/ca.pem
 export DEVSYNTH_ACCESS_TOKEN=my-secret-token
 ```
 
+## Automated Audit Procedures and Enforcement
+
+DevSynth automates routine security checks to prevent regressions:
+
+- `scripts/security_audit.py` performs dependency vulnerability scans, Bandit
+  static analysis, and verifies required security environment variables such as
+  `DEVSYNTH_ACCESS_TOKEN`.
+- The script exits with a non‑zero status if any check fails, which blocks CI
+  pipelines and deployment.
+- Developers should run `python scripts/security_audit.py` locally before
+  committing changes to catch issues early.
+
 ## Incident Response Procedures
 
 The [Incident Response Runbook](../deployment/runbooks/incident_response.md)

--- a/scripts/security_audit.py
+++ b/scripts/security_audit.py
@@ -3,9 +3,11 @@
 from __future__ import annotations
 
 import argparse
+import os
 import subprocess
 import sys
-from pathlib import Path
+
+REQUIRED_ENV_VARS = ["DEVSYNTH_ACCESS_TOKEN"]
 
 
 def run_safety() -> None:
@@ -18,9 +20,18 @@ def run_bandit() -> None:
     subprocess.check_call(["bandit", "-r", "src", "-ll"])
 
 
+def check_required_env() -> None:
+    """Ensure required security environment variables are set."""
+    missing = [name for name in REQUIRED_ENV_VARS if not os.getenv(name)]
+    if missing:
+        raise RuntimeError(
+            f"Missing required environment variables: {', '.join(missing)}"
+        )
+
+
 def main() -> None:
     parser = argparse.ArgumentParser(
-        description="Execute security audits and monitoring checks."
+        description="Execute security audits and monitoring checks.",
     )
     parser.add_argument(
         "--skip-static",
@@ -29,6 +40,7 @@ def main() -> None:
     )
     args = parser.parse_args()
 
+    check_required_env()
     run_safety()
     if not args.skip_static:
         run_bandit()

--- a/tests/unit/security/test_security_audit.py
+++ b/tests/unit/security/test_security_audit.py
@@ -1,0 +1,22 @@
+"""Tests for security audit environment variable checks."""
+
+import sys
+
+import pytest
+
+sys.path.append("scripts")
+
+from security_audit import check_required_env  # type: ignore
+
+
+def test_check_required_env_missing(monkeypatch):
+    """check_required_env should raise when required variables are absent."""
+    monkeypatch.delenv("DEVSYNTH_ACCESS_TOKEN", raising=False)
+    with pytest.raises(RuntimeError):
+        check_required_env()
+
+
+def test_check_required_env_present(monkeypatch):
+    """check_required_env should pass when variables are set."""
+    monkeypatch.setenv("DEVSYNTH_ACCESS_TOKEN", "token")
+    check_required_env()


### PR DESCRIPTION
## Summary
- document automated security audit procedures and enforcement steps
- ensure security audit script verifies required env vars before scanning
- test security audit env var enforcement

## Testing
- `poetry run pre-commit run --files docs/policies/security.md scripts/security_audit.py tests/unit/security/test_security_audit.py`
- `poetry run pre-commit run --files scripts/security_audit.py`
- `poetry run pytest tests/unit/security/test_security_audit.py`


------
https://chatgpt.com/codex/tasks/task_e_688f82d157688333a5bdb10400f30e88