### PR TITLE
feat: add monitoring and env profiles

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,6 +21,10 @@ services:
       - DEVSYNTH_LLM_PROVIDER=openai
     networks:
       - devsynth-network
+    profiles:
+      - development
+      - staging
+      - production
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8000/health"]
       interval: 30s
@@ -28,6 +32,11 @@ services:
       retries: 3
       start_period: 5s
     restart: unless-stopped
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "10m"
+        max-file: "3"
 
 
   # Development tools
@@ -44,11 +53,17 @@ services:
       - devsynth-network
     profiles:
       - tools
+      - development
     healthcheck:
       test: ["CMD", "true"]
       interval: 1m
       timeout: 10s
       retries: 3
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "10m"
+        max-file: "3"
 
   # Test runner
   test-runner:
@@ -65,11 +80,17 @@ services:
       - devsynth-network
     profiles:
       - test
+      - testing
     healthcheck:
       test: ["CMD", "true"]
       interval: 1m
       timeout: 10s
       retries: 3
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "10m"
+        max-file: "3"
 
   # Optional ChromaDB service for persistent vector storage
   chromadb:
@@ -84,6 +105,19 @@ services:
       - devsynth-network
     profiles:
       - memory
+      - development
+      - staging
+      - production
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8000/api/v1/collections"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "10m"
+        max-file: "3"
 
   prometheus:
     image: prom/prometheus
@@ -100,6 +134,36 @@ services:
       retries: 3
     profiles:
       - monitoring
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "10m"
+        max-file: "3"
+
+  grafana:
+    image: grafana/grafana
+    ports:
+      - "3000:3000"
+    environment:
+      - GF_SECURITY_ADMIN_PASSWORD=admin
+    volumes:
+      - grafana-data:/var/lib/grafana
+    depends_on:
+      - prometheus
+    networks:
+      - devsynth-network
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:3000/api/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+    profiles:
+      - monitoring
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "10m"
+        max-file: "3"
 
 
 networks:
@@ -108,3 +172,5 @@ networks:
 volumes:
   chromadb-data:
     name: devsynth-chromadb-data
+  grafana-data:
+    name: devsynth-grafana-data

--- a/scripts/deployment/check_health.sh
+++ b/scripts/deployment/check_health.sh
@@ -1,6 +1,19 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Simple health check for DevSynth API
+# Simple health check for DevSynth containers
+# Usage: check_health.sh [environment]
+#   environment: development (default), staging, production, testing
 
-curl -f http://localhost:8000/health && echo "API healthy" || { echo "API unhealthy"; exit 1; }
+ENVIRONMENT=${1:-development}
+
+echo "Checking container health for profile: ${ENVIRONMENT}"
+
+UNHEALTHY=$(docker compose --profile "${ENVIRONMENT}" ps --format '{{.Name}} {{.State}} {{.Health}}' | awk '$3 != "healthy"')
+if [[ -n "${UNHEALTHY}" ]]; then
+  echo "Unhealthy services detected:"
+  echo "${UNHEALTHY}"
+  exit 1
+fi
+
+curl -f http://localhost:8000/health >/dev/null && echo "API healthy" || { echo "API unhealthy"; exit 1; }

--- a/scripts/deployment/prometheus_exporter.py
+++ b/scripts/deployment/prometheus_exporter.py
@@ -1,14 +1,20 @@
 """Simple Prometheus exporter for DevSynth."""
 
-from prometheus_client import Counter, start_http_server
+import logging
+import os
 import time
+
+from prometheus_client import Counter, start_http_server
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
 
 REQUESTS = Counter("devsynth_exporter_requests_total", "Exporter request count")
 
 if __name__ == "__main__":
-    start_http_server(9200)
+    port = int(os.getenv("EXPORTER_PORT", "9200"))
+    start_http_server(port)
+    logging.info("Prometheus exporter running on port %s", port)
     while True:
         REQUESTS.inc()
+        logging.info("heartbeat")
         time.sleep(5)
-
-

--- a/scripts/deployment/start_stack.sh
+++ b/scripts/deployment/start_stack.sh
@@ -2,5 +2,12 @@
 set -euo pipefail
 
 # Start DevSynth stack with monitoring
+# Usage: start_stack.sh [environment]
+#   environment: development (default), staging, production, testing
 
-docker compose -f docker-compose.yml -f deployment/docker-compose.monitoring.yml up -d
+ENVIRONMENT=${1:-development}
+
+docker compose --profile "${ENVIRONMENT}" --profile monitoring up -d
+
+# Verify container health
+"$(dirname "$0")/check_health.sh" "${ENVIRONMENT}"

--- a/scripts/deployment/stop_stack.sh
+++ b/scripts/deployment/stop_stack.sh
@@ -2,5 +2,9 @@
 set -euo pipefail
 
 # Stop DevSynth stack
+# Usage: stop_stack.sh [environment]
+#   environment: development (default), staging, production, testing
 
-docker compose down
+ENVIRONMENT=${1:-development}
+
+docker compose --profile "${ENVIRONMENT}" --profile monitoring down


### PR DESCRIPTION
## Summary
- add environment profiles, health checks, and structured logging to docker-compose
- add profile-aware deployment scripts with health validation and exporter logging
- document deployment with profiles, scripts, and monitoring steps

## Testing
- `poetry run pre-commit run --files docker-compose.yml scripts/deployment/start_stack.sh scripts/deployment/stop_stack.sh scripts/deployment/check_health.sh scripts/deployment/prometheus_exporter.py docs/deployment/deployment_guide.md`
- `poetry run pytest tests/unit/scripts/test_security_ops.py`


------
https://chatgpt.com/codex/tasks/task_e_688f82c3a65883339e21ea504cb4f402