### PR TITLE
Verify environment during Codex setup

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,12 +35,17 @@ Fix the script and rerun it offline to finish provisioning:
    `--minimal` variant) and verifies key packages such as `pytest-bdd` are
    available.
 2. Run `bash scripts/codex_setup.sh` (without network access) until it completes
-   without errors. After it finishes, verify the installation by running
-   `poetry run pip list | grep pytest-bdd`.
+   without errors. After it finishes, verify the environment and dependencies:
+
+   ```bash
+   poetry env info --path
+   poetry run pip check
+   poetry run pip list | grep pytest-bdd
+   ```
 3. Remove the failure marker with `rm CODEX_ENVIRONMENT_SETUP_FAILED`.
-4. Execute `poetry run pytest` to verify the environment.
+4. Execute `poetry run pytest --maxfail=1` to verify the environment quickly.
 5. If the tests fail, rerun the setup script and repeat until
-   `poetry run pytest` succeeds.
+   `poetry run pytest --maxfail=1` succeeds.
 
 Changes to the setup script only take effect the next time Codex provisions an
 environment. OpenAI disables network access during execution, so `scripts/codex_setup.sh`

--- a/scripts/codex_setup.sh
+++ b/scripts/codex_setup.sh
@@ -6,6 +6,9 @@ set -exo pipefail
 # Use Python 3.12 if available, otherwise fall back to Python 3.11
 poetry env use "$(command -v python3.12 || command -v python3.11)"
 
+# Verify that the virtual environment was created
+poetry env info --path >/dev/null
+
 # Install only the extras required for the test suite. Large GPU packages
 # provided by the `offline` extra are intentionally excluded to keep setup
 # fast. Add the `offline` extra manually if GPU features are needed.
@@ -13,6 +16,9 @@ poetry install \
   --with dev,docs \
   --all-extras \
   --no-interaction
+
+# Validate dependency installation
+poetry run pip check
 
 # Prefetch the cl100k_base encoding for tiktoken
 poetry run python - <<'EOF'
@@ -46,6 +52,9 @@ poetry run python -c "import pytest_bdd"
 
 # Ensure pytest-bdd is installed in the environment
 poetry run pip list | grep pytest-bdd >/dev/null
+
+# Run a smoke test to catch failures early
+poetry run pytest --maxfail=1
 
 # Cleanup any failure marker if the setup completes successfully
 [ -f CODEX_ENVIRONMENT_SETUP_FAILED ] && rm CODEX_ENVIRONMENT_SETUP_FAILED


### PR DESCRIPTION
## Summary
- Ensure codex setup script verifies virtual environment creation and installed dependencies
- Run a smoke `pytest --maxfail=1` during setup for early failure detection
- Document offline rerun steps and quick test command in AGENTS.md

## Testing
- `bash scripts/codex_setup.sh` *(fails: NameError: name 'pytest' is not defined in tests/behavior/steps/test_doctor_steps.py)*
- `poetry run pytest tests/behavior/steps/test_doctor_steps.py -q` *(fails: NameError: name 'pytest' is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_688f890f44648333abd85e8d977c223d