### PR TITLE
Add pytest import to doctor steps test

### DIFF
--- a/tests/behavior/steps/test_doctor_steps.py
+++ b/tests/behavior/steps/test_doctor_steps.py
@@ -1,5 +1,6 @@
 """Steps for the doctor.feature without mocks."""
 
+import pytest
 from pytest_bdd import given, when
 
 from .cli_commands_steps import run_command


### PR DESCRIPTION
## Summary
- add missing `pytest` import in `test_doctor_steps` to enable `@pytest.mark.medium`

## Testing
- `poetry run pre-commit run --files tests/behavior/steps/test_doctor_steps.py`
- `poetry run pytest tests/behavior/steps/test_doctor_steps.py`


------
https://chatgpt.com/codex/tasks/task_e_688f89052c108333851a73b4343739ae