### PR TITLE
Add repo analyzer and CLI entry

### DIFF
--- a/src/devsynth/application/code_analysis/__init__.py
+++ b/src/devsynth/application/code_analysis/__init__.py
@@ -1,9 +1,9 @@
-"""
-Application layer for code analysis.
+"""Application layer for code analysis.
 
 This package provides functionality for analyzing code and project structure.
 """
 
 from .project_state_analyzer import ProjectStateAnalyzer
+from .repo_analyzer import RepoAnalyzer
 
-__all__ = ['ProjectStateAnalyzer']
+__all__ = ["ProjectStateAnalyzer", "RepoAnalyzer"]

--- a/src/devsynth/application/code_analysis/repo_analyzer.py
+++ b/src/devsynth/application/code_analysis/repo_analyzer.py
@@ -1,0 +1,117 @@
+"""Repository analyzer for mapping dependencies and structure.
+
+This module provides a lightweight utility for examining a Python project
+directory.  It walks the file tree, builds a simple representation of the
+directory structure, and parses Python files to determine their import
+dependencies.  The intent is to give a quick overview of how modules relate to
+one another without requiring a full build or runtime environment.
+"""
+
+from __future__ import annotations
+
+import ast
+import os
+from pathlib import Path
+from typing import Dict, List, Set, Any
+
+from devsynth.logging_setup import DevSynthLogger
+
+
+logger = DevSynthLogger(__name__)
+
+
+class RepoAnalyzer:
+    """Analyze repository structure and dependencies.
+
+    The analyzer focuses on Python source files.  It recursively searches the
+    provided root directory for ``.py`` files, extracts their import statements
+    and records a basic directory structure.  The resulting data can be used to
+    understand how modules are organised and which top level dependencies each
+    file relies on.
+    """
+
+    def __init__(self, root_path: str) -> None:
+        """Initialise the analyzer.
+
+        Args:
+            root_path: Path to the repository root that should be analysed.
+        """
+
+        self.root_path = Path(root_path)
+
+    # ------------------------------------------------------------------
+    def analyze(self) -> Dict[str, Any]:
+        """Run the analysis and return structure and dependency maps."""
+
+        logger.debug("Starting repository analysis at %s", self.root_path)
+        result = {
+            "dependencies": self._map_dependencies(),
+            "structure": self._build_structure(),
+        }
+        logger.debug("Finished repository analysis")
+        return result
+
+    # ------------------------------------------------------------------
+    def _map_dependencies(self) -> Dict[str, List[str]]:
+        """Map Python file dependencies based on import statements."""
+
+        dependencies: Dict[str, Set[str]] = {}
+        for file_path in self._find_python_files():
+            imports = self._parse_imports(file_path)
+            rel_path = os.path.relpath(file_path, self.root_path)
+            dependencies[rel_path] = sorted(imports)
+            logger.debug("%s depends on %s", rel_path, dependencies[rel_path])
+        return dependencies
+
+    # ------------------------------------------------------------------
+    def _build_structure(self) -> Dict[str, List[str]]:
+        """Build a simple representation of the directory structure."""
+
+        structure: Dict[str, List[str]] = {}
+        for dirpath, dirnames, filenames in os.walk(self.root_path):
+            rel = os.path.relpath(dirpath, self.root_path)
+            structure[rel] = sorted(dirnames + filenames)
+            logger.debug("Indexed directory %s: %s", rel, structure[rel])
+        return structure
+
+    # ------------------------------------------------------------------
+    def _find_python_files(self) -> List[Path]:
+        """Return a list of all Python files under the root path."""
+
+        files: List[Path] = []
+        for dirpath, _, filenames in os.walk(self.root_path):
+            for name in filenames:
+                if name.endswith(".py"):
+                    files.append(Path(dirpath) / name)
+        return files
+
+    # ------------------------------------------------------------------
+    def _parse_imports(self, file_path: Path) -> Set[str]:
+        """Parse import statements from a Python file.
+
+        Only the top level module name is recorded for each import.
+        """
+
+        imports: Set[str] = set()
+        try:
+            with open(file_path, "r", encoding="utf-8") as f:
+                tree = ast.parse(f.read(), filename=str(file_path))
+
+            for node in ast.walk(tree):
+                if isinstance(node, ast.Import):
+                    for alias in node.names:
+                        imports.add(alias.name.split(".")[0])
+                elif isinstance(node, ast.ImportFrom):
+                    if node.module:
+                        imports.add(node.module.split(".")[0])
+                    else:
+                        for alias in node.names:
+                            imports.add(alias.name.split(".")[0])
+        except (OSError, SyntaxError) as exc:  # pragma: no cover - logging
+            logger.debug("Failed to parse %s: %s", file_path, exc)
+
+        return imports
+
+
+__all__ = ["RepoAnalyzer"]
+

--- a/src/devsynth/cli.py
+++ b/src/devsynth/cli.py
@@ -1,10 +1,45 @@
 #!/usr/bin/env python3
-"""DevSynth CLI entry point."""
+"""DevSynth CLI entry point.
 
-from devsynth.adapters.cli.typer_adapter import run_cli
+This module primarily delegates to the Typer based CLI defined in
+``devsynth.adapters.cli.typer_adapter``.  A lightweight ``--analyze-repo``
+option is provided for invoking the :class:`RepoAnalyzer` directly from the
+command line without loading the full CLI stack.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from typing import Any
+
+from devsynth.application.code_analysis.repo_analyzer import RepoAnalyzer
 from devsynth.logging_setup import DevSynthLogger
 
 logger = DevSynthLogger(__name__)
 
-if __name__ == "__main__":
-    run_cli()
+
+def main(argv: list[str] | None = None) -> None:
+    """CLI entry point.
+
+    If ``--analyze-repo`` is supplied, the repository at the provided path is
+    analysed and the resulting data is printed as JSON.  Otherwise the standard
+    Typer CLI is executed.
+    """
+
+    parser = argparse.ArgumentParser(add_help=False)
+    parser.add_argument("--analyze-repo", metavar="PATH", help="Analyze a repository and output JSON data")
+    args, remaining = parser.parse_known_args(argv)
+
+    if args.analyze_repo:
+        analyzer = RepoAnalyzer(args.analyze_repo)
+        result: dict[str, Any] = analyzer.analyze()
+        print(json.dumps(result, indent=2))
+    else:
+        from devsynth.adapters.cli.typer_adapter import run_cli
+
+        run_cli()
+
+
+if __name__ == "__main__":  # pragma: no cover - tested via integration test
+    main()

--- a/tests/unit/application/code_analysis/test_repo_analyzer.py
+++ b/tests/unit/application/code_analysis/test_repo_analyzer.py
@@ -1,0 +1,67 @@
+"""Tests for the :mod:`repo_analyzer` module."""
+
+import contextlib
+import io
+import json
+import runpy
+import sys
+import tempfile
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from devsynth.application.code_analysis.repo_analyzer import RepoAnalyzer
+
+
+class TestRepoAnalyzer:
+    """Unit tests for :class:`RepoAnalyzer`."""
+
+    @pytest.mark.medium
+    def test_analyze_maps_dependencies_and_structure(self) -> None:
+        """Ensure dependencies and structure are correctly mapped."""
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            (root / "a.py").write_text("import b\n")
+            (root / "b.py").write_text("x = 1\n")
+            (root / "sub").mkdir()
+            (root / "sub" / "c.py").write_text("from a import something\n")
+
+            analyzer = RepoAnalyzer(tmpdir)
+            result = analyzer.analyze()
+
+            assert result["dependencies"]["a.py"] == ["b"]
+            assert result["dependencies"]["sub/c.py"] == ["a"]
+            structure = result["structure"]
+            assert set(structure["."]) == {"a.py", "b.py", "sub"}
+            assert "c.py" in structure["sub"]
+
+    @pytest.mark.medium
+    def test_cli_entry_invokes_repo_analyzer(self, monkeypatch) -> None:
+        """Verify ``--analyze-repo`` uses the RepoAnalyzer and prints JSON."""
+
+        fake_result = {"dependencies": {}, "structure": {}}
+        analyze_mock = MagicMock(return_value=fake_result)
+        monkeypatch.setattr(
+            "devsynth.application.code_analysis.repo_analyzer.RepoAnalyzer.analyze",
+            analyze_mock,
+        )
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            argv = ["devsynth", "--analyze-repo", tmpdir]
+            buf = io.StringIO()
+            with contextlib.redirect_stdout(buf):
+                old_argv = sys.argv
+                sys.argv = argv
+                try:
+                    runpy.run_module("devsynth.cli", run_name="__main__")
+                except SystemExit:
+                    pass
+                finally:
+                    sys.argv = old_argv
+
+        assert "devsynth.adapters.cli.typer_adapter" not in sys.modules
+        analyze_mock.assert_called_once()
+        assert json.loads(buf.getvalue()) == fake_result
+


### PR DESCRIPTION
## Summary
- add RepoAnalyzer to map Python repository structure and imports
- expose --analyze-repo CLI flag to run analysis without loading full Typer stack
- test RepoAnalyzer logic and CLI integration

## Testing
- `pytest tests/unit/application/code_analysis/test_repo_analyzer.py -p no:tests.fixtures.ports -p no:tests.fixtures.kuzu -q`

------
https://chatgpt.com/codex/tasks/task_e_688f884e5ab08333a90418dffb05d2a5