### PR TITLE
refactor: centralize prompt manager module

### DIFF
--- a/src/devsynth/application/edrr/coordinator.py
+++ b/src/devsynth/application/edrr/coordinator.py
@@ -24,7 +24,7 @@ from devsynth.application.documentation.documentation_manager import (
 )
 from devsynth.application.edrr.manifest_parser import ManifestParseError, ManifestParser
 from devsynth.application.memory.memory_manager import MemoryManager
-from devsynth.application.prompts.prompt_manager import PromptManager
+from devsynth.application.requirements.prompt_manager import PromptManager
 from devsynth.core import CoreValues, check_report_for_value_conflicts
 from devsynth.domain.models.wsde import WSDETeam
 from devsynth.domain.models.memory import MemoryType

--- a/src/devsynth/application/edrr/coordinator_core.py
+++ b/src/devsynth/application/edrr/coordinator_core.py
@@ -24,7 +24,7 @@ from devsynth.application.documentation.documentation_manager import (
 )
 from devsynth.application.edrr.manifest_parser import ManifestParseError, ManifestParser
 from devsynth.application.memory.memory_manager import MemoryManager
-from devsynth.application.prompts.prompt_manager import PromptManager
+from devsynth.application.requirements.prompt_manager import PromptManager
 from devsynth.core import CoreValues, check_report_for_value_conflicts
 from devsynth.domain.models.wsde import WSDETeam
 from devsynth.domain.models.memory import MemoryType

--- a/src/devsynth/application/edrr/edrr_coordinator_enhanced.py
+++ b/src/devsynth/application/edrr/edrr_coordinator_enhanced.py
@@ -21,7 +21,7 @@ from devsynth.application.edrr.edrr_phase_transitions import (
     collect_phase_metrics,
 )
 from devsynth.application.memory.memory_manager import MemoryManager
-from devsynth.application.prompts.prompt_manager import PromptManager
+from devsynth.application.requirements.prompt_manager import PromptManager
 from devsynth.domain.models.wsde import WSDETeam
 from devsynth.domain.models.memory import MemoryType
 from devsynth.logging_setup import DevSynthLogger

--- a/src/devsynth/application/edrr/templates.py
+++ b/src/devsynth/application/edrr/templates.py
@@ -7,7 +7,7 @@ It provides functions to register these templates with the PromptManager.
 
 from typing import Dict, Any, Optional
 
-from devsynth.application.prompts.prompt_manager import PromptManager
+from devsynth.application.requirements.prompt_manager import PromptManager
 from devsynth.methodology.base import Phase
 from devsynth.logging_setup import DevSynthLogger
 

--- a/src/devsynth/application/requirements/prompt_manager.py
+++ b/src/devsynth/application/requirements/prompt_manager.py
@@ -1,0 +1,10 @@
+"""Compatibility module for prompt management.
+
+This module provides backward compatibility by exposing the
+``PromptManager`` class from the prompts package under the
+``devsynth.application.requirements`` namespace.
+"""
+
+from devsynth.application.prompts.prompt_manager import PromptManager
+
+__all__ = ["PromptManager"]

--- a/tests/behavior/steps/edrr_coordinator_steps.py
+++ b/tests/behavior/steps/edrr_coordinator_steps.py
@@ -22,7 +22,7 @@ from devsynth.domain.models.memory import MemoryType
 from devsynth.domain.models.wsde import WSDETeam
 from devsynth.application.code_analysis.analyzer import CodeAnalyzer
 from devsynth.application.code_analysis.ast_transformer import AstTransformer
-from devsynth.application.prompts.prompt_manager import PromptManager
+from devsynth.application.requirements.prompt_manager import PromptManager
 from devsynth.application.documentation.documentation_manager import (
     DocumentationManager,
 )

--- a/tests/behavior/steps/edrr_enhanced_memory_integration_steps.py
+++ b/tests/behavior/steps/edrr_enhanced_memory_integration_steps.py
@@ -31,7 +31,7 @@ from devsynth.domain.models.memory import MemoryType
 from devsynth.domain.models.wsde import WSDETeam
 from devsynth.application.code_analysis.analyzer import CodeAnalyzer
 from devsynth.application.code_analysis.ast_transformer import AstTransformer
-from devsynth.application.prompts.prompt_manager import PromptManager
+from devsynth.application.requirements.prompt_manager import PromptManager
 from devsynth.application.documentation.documentation_manager import (
     DocumentationManager,
 )
@@ -971,7 +971,7 @@ from devsynth.domain.models.wsde import WSDETeam
 from devsynth.domain.models.memory import MemoryType
 from devsynth.application.code_analysis.analyzer import CodeAnalyzer
 from devsynth.application.code_analysis.ast_transformer import AstTransformer
-from devsynth.application.prompts.prompt_manager import PromptManager
+from devsynth.application.requirements.prompt_manager import PromptManager
 from devsynth.application.documentation.documentation_manager import (
     DocumentationManager,
 )

--- a/tests/behavior/steps/edrr_enhanced_phase_transitions_steps.py
+++ b/tests/behavior/steps/edrr_enhanced_phase_transitions_steps.py
@@ -28,7 +28,7 @@ from devsynth.domain.models.memory import MemoryType
 from devsynth.domain.models.wsde import WSDETeam
 from devsynth.application.code_analysis.analyzer import CodeAnalyzer
 from devsynth.application.code_analysis.ast_transformer import AstTransformer
-from devsynth.application.prompts.prompt_manager import PromptManager
+from devsynth.application.requirements.prompt_manager import PromptManager
 from devsynth.application.documentation.documentation_manager import (
     DocumentationManager,
 )
@@ -955,7 +955,7 @@ from devsynth.application.memory.memory_manager import MemoryManager
 from devsynth.domain.models.wsde import WSDETeam
 from devsynth.application.code_analysis.analyzer import CodeAnalyzer
 from devsynth.application.code_analysis.ast_transformer import AstTransformer
-from devsynth.application.prompts.prompt_manager import PromptManager
+from devsynth.application.requirements.prompt_manager import PromptManager
 from devsynth.application.documentation.documentation_manager import (
     DocumentationManager,
 )

--- a/tests/behavior/steps/edrr_enhanced_recursion_steps.py
+++ b/tests/behavior/steps/edrr_enhanced_recursion_steps.py
@@ -29,7 +29,7 @@ from devsynth.domain.models.memory import MemoryType
 from devsynth.domain.models.wsde import WSDETeam
 from devsynth.application.code_analysis.analyzer import CodeAnalyzer
 from devsynth.application.code_analysis.ast_transformer import AstTransformer
-from devsynth.application.prompts.prompt_manager import PromptManager
+from devsynth.application.requirements.prompt_manager import PromptManager
 from devsynth.application.documentation.documentation_manager import (
     DocumentationManager,
 )
@@ -959,7 +959,7 @@ from devsynth.application.memory.memory_manager import MemoryManager
 from devsynth.domain.models.wsde import WSDETeam
 from devsynth.application.code_analysis.analyzer import CodeAnalyzer
 from devsynth.application.code_analysis.ast_transformer import AstTransformer
-from devsynth.application.prompts.prompt_manager import PromptManager
+from devsynth.application.requirements.prompt_manager import PromptManager
 from devsynth.application.documentation.documentation_manager import (
     DocumentationManager,
 )

--- a/tests/behavior/steps/edrr_real_llm_integration_steps.py
+++ b/tests/behavior/steps/edrr_real_llm_integration_steps.py
@@ -18,7 +18,7 @@ from devsynth.application.memory.adapters.graph_memory_adapter import GraphMemor
 from devsynth.domain.models.wsde import WSDETeam
 from devsynth.application.code_analysis.analyzer import CodeAnalyzer
 from devsynth.application.code_analysis.ast_transformer import AstTransformer
-from devsynth.application.prompts.prompt_manager import PromptManager
+from devsynth.application.requirements.prompt_manager import PromptManager
 from devsynth.application.documentation.documentation_manager import DocumentationManager
 from devsynth.adapters.provider_system import get_provider, ProviderType
 from devsynth.methodology.base import Phase

--- a/tests/behavior/steps/micro_edrr_cycle_steps.py
+++ b/tests/behavior/steps/micro_edrr_cycle_steps.py
@@ -23,7 +23,7 @@ from devsynth.application.memory.memory_manager import MemoryManager
 from devsynth.domain.models.wsde import WSDETeam
 from devsynth.application.code_analysis.analyzer import CodeAnalyzer
 from devsynth.application.code_analysis.ast_transformer import AstTransformer
-from devsynth.application.prompts.prompt_manager import PromptManager
+from devsynth.application.requirements.prompt_manager import PromptManager
 from devsynth.application.documentation.documentation_manager import DocumentationManager
 from devsynth.application.edrr.coordinator import EDRRCoordinator
 

--- a/tests/behavior/steps/recursive_edrr_coordinator_steps.py
+++ b/tests/behavior/steps/recursive_edrr_coordinator_steps.py
@@ -23,7 +23,7 @@ from devsynth.application.memory.memory_manager import MemoryManager
 from devsynth.domain.models.wsde import WSDETeam
 from devsynth.application.code_analysis.analyzer import CodeAnalyzer
 from devsynth.application.code_analysis.ast_transformer import AstTransformer
-from devsynth.application.prompts.prompt_manager import PromptManager
+from devsynth.application.requirements.prompt_manager import PromptManager
 from devsynth.application.documentation.documentation_manager import DocumentationManager
 from devsynth.application.edrr.coordinator import EDRRCoordinator, EDRRCoordinatorError
 from devsynth.application.edrr.manifest_parser import ManifestParser

--- a/tests/behavior/steps/test_edrr_coordinator_steps.py
+++ b/tests/behavior/steps/test_edrr_coordinator_steps.py
@@ -17,7 +17,7 @@ from devsynth.domain.models.memory import MemoryType
 from devsynth.domain.models.wsde import WSDETeam
 from devsynth.application.code_analysis.analyzer import CodeAnalyzer
 from devsynth.application.code_analysis.ast_transformer import AstTransformer
-from devsynth.application.prompts.prompt_manager import PromptManager
+from devsynth.application.requirements.prompt_manager import PromptManager
 from devsynth.application.documentation.documentation_manager import (
     DocumentationManager,
 )

--- a/tests/behavior/steps/test_edrr_enhanced_memory_integration_steps.py
+++ b/tests/behavior/steps/test_edrr_enhanced_memory_integration_steps.py
@@ -26,7 +26,7 @@ from devsynth.domain.models.memory import MemoryType
 from devsynth.domain.models.wsde import WSDETeam
 from devsynth.application.code_analysis.analyzer import CodeAnalyzer
 from devsynth.application.code_analysis.ast_transformer import AstTransformer
-from devsynth.application.prompts.prompt_manager import PromptManager
+from devsynth.application.requirements.prompt_manager import PromptManager
 from devsynth.application.documentation.documentation_manager import (
     DocumentationManager,
 )
@@ -996,7 +996,7 @@ from devsynth.domain.models.wsde import WSDETeam
 from devsynth.domain.models.memory import MemoryType
 from devsynth.application.code_analysis.analyzer import CodeAnalyzer
 from devsynth.application.code_analysis.ast_transformer import AstTransformer
-from devsynth.application.prompts.prompt_manager import PromptManager
+from devsynth.application.requirements.prompt_manager import PromptManager
 from devsynth.application.documentation.documentation_manager import (
     DocumentationManager,
 )

--- a/tests/behavior/steps/test_edrr_enhanced_phase_transitions_steps.py
+++ b/tests/behavior/steps/test_edrr_enhanced_phase_transitions_steps.py
@@ -27,7 +27,7 @@ from devsynth.domain.models.memory import MemoryType
 from devsynth.domain.models.wsde import WSDETeam
 from devsynth.application.code_analysis.analyzer import CodeAnalyzer
 from devsynth.application.code_analysis.ast_transformer import AstTransformer
-from devsynth.application.prompts.prompt_manager import PromptManager
+from devsynth.application.requirements.prompt_manager import PromptManager
 from devsynth.application.documentation.documentation_manager import (
     DocumentationManager,
 )
@@ -984,7 +984,7 @@ from devsynth.application.memory.memory_manager import MemoryManager
 from devsynth.domain.models.wsde import WSDETeam
 from devsynth.application.code_analysis.analyzer import CodeAnalyzer
 from devsynth.application.code_analysis.ast_transformer import AstTransformer
-from devsynth.application.prompts.prompt_manager import PromptManager
+from devsynth.application.requirements.prompt_manager import PromptManager
 from devsynth.application.documentation.documentation_manager import (
     DocumentationManager,
 )

--- a/tests/behavior/steps/test_edrr_enhanced_recursion_steps.py
+++ b/tests/behavior/steps/test_edrr_enhanced_recursion_steps.py
@@ -28,7 +28,7 @@ from devsynth.domain.models.memory import MemoryType
 from devsynth.domain.models.wsde import WSDETeam
 from devsynth.application.code_analysis.analyzer import CodeAnalyzer
 from devsynth.application.code_analysis.ast_transformer import AstTransformer
-from devsynth.application.prompts.prompt_manager import PromptManager
+from devsynth.application.requirements.prompt_manager import PromptManager
 from devsynth.application.documentation.documentation_manager import (
     DocumentationManager,
 )
@@ -988,7 +988,7 @@ from devsynth.application.memory.memory_manager import MemoryManager
 from devsynth.domain.models.wsde import WSDETeam
 from devsynth.application.code_analysis.analyzer import CodeAnalyzer
 from devsynth.application.code_analysis.ast_transformer import AstTransformer
-from devsynth.application.prompts.prompt_manager import PromptManager
+from devsynth.application.requirements.prompt_manager import PromptManager
 from devsynth.application.documentation.documentation_manager import (
     DocumentationManager,
 )

--- a/tests/behavior/steps/test_edrr_real_llm_integration_steps.py
+++ b/tests/behavior/steps/test_edrr_real_llm_integration_steps.py
@@ -13,7 +13,7 @@ from devsynth.application.memory.adapters.graph_memory_adapter import GraphMemor
 from devsynth.domain.models.wsde import WSDETeam
 from devsynth.application.code_analysis.analyzer import CodeAnalyzer
 from devsynth.application.code_analysis.ast_transformer import AstTransformer
-from devsynth.application.prompts.prompt_manager import PromptManager
+from devsynth.application.requirements.prompt_manager import PromptManager
 from devsynth.application.documentation.documentation_manager import DocumentationManager
 from devsynth.adapters.provider_system import get_provider, ProviderType
 from devsynth.methodology.base import Phase

--- a/tests/behavior/steps/test_micro_edrr_cycle_steps.py
+++ b/tests/behavior/steps/test_micro_edrr_cycle_steps.py
@@ -18,7 +18,7 @@ from devsynth.application.memory.memory_manager import MemoryManager
 from devsynth.domain.models.wsde import WSDETeam
 from devsynth.application.code_analysis.analyzer import CodeAnalyzer
 from devsynth.application.code_analysis.ast_transformer import AstTransformer
-from devsynth.application.prompts.prompt_manager import PromptManager
+from devsynth.application.requirements.prompt_manager import PromptManager
 from devsynth.application.documentation.documentation_manager import DocumentationManager
 from devsynth.application.edrr.coordinator import EDRRCoordinator
 

--- a/tests/behavior/steps/test_prompt_management_steps.py
+++ b/tests/behavior/steps/test_prompt_management_steps.py
@@ -16,7 +16,7 @@ logger = logging.getLogger(__name__)
 scenarios("../features/general/prompt_management.feature")
 
 # Import the modules needed for the steps
-from devsynth.application.prompts.prompt_manager import PromptManager
+from devsynth.application.requirements.prompt_manager import PromptManager
 from devsynth.application.prompts.prompt_template import (
     PromptTemplate,
     PromptTemplateVersion,

--- a/tests/behavior/steps/test_recursive_edrr_coordinator_steps.py
+++ b/tests/behavior/steps/test_recursive_edrr_coordinator_steps.py
@@ -18,7 +18,7 @@ from devsynth.application.memory.memory_manager import MemoryManager
 from devsynth.domain.models.wsde import WSDETeam
 from devsynth.application.code_analysis.analyzer import CodeAnalyzer
 from devsynth.application.code_analysis.ast_transformer import AstTransformer
-from devsynth.application.prompts.prompt_manager import PromptManager
+from devsynth.application.requirements.prompt_manager import PromptManager
 from devsynth.application.documentation.documentation_manager import DocumentationManager
 from devsynth.application.edrr.coordinator import EDRRCoordinator, EDRRCoordinatorError
 from devsynth.application.edrr.manifest_parser import ManifestParser

--- a/tests/behavior/steps/test_simple_coordinator_steps.py
+++ b/tests/behavior/steps/test_simple_coordinator_steps.py
@@ -27,7 +27,7 @@ from devsynth.domain.models.memory import MemoryType
 from devsynth.domain.models.wsde import WSDETeam
 from devsynth.application.code_analysis.analyzer import CodeAnalyzer
 from devsynth.application.code_analysis.ast_transformer import AstTransformer
-from devsynth.application.prompts.prompt_manager import PromptManager
+from devsynth.application.requirements.prompt_manager import PromptManager
 from devsynth.application.documentation.documentation_manager import (
     DocumentationManager,
 )

--- a/tests/behavior/steps/test_wsde_edrr_integration_steps.py
+++ b/tests/behavior/steps/test_wsde_edrr_integration_steps.py
@@ -17,7 +17,7 @@ from devsynth.domain.models.wsde import WSDETeam
 from devsynth.application.memory.memory_manager import MemoryManager
 from devsynth.application.code_analysis.analyzer import CodeAnalyzer
 from devsynth.application.code_analysis.ast_transformer import AstTransformer
-from devsynth.application.prompts.prompt_manager import PromptManager
+from devsynth.application.requirements.prompt_manager import PromptManager
 from devsynth.application.documentation.documentation_manager import DocumentationManager
 from devsynth.methodology.base import Phase
 from devsynth.domain.models.agent import AgentConfig, AgentType

--- a/tests/behavior/steps/wsde_edrr_integration_steps.py
+++ b/tests/behavior/steps/wsde_edrr_integration_steps.py
@@ -22,7 +22,7 @@ from devsynth.domain.models.wsde import WSDETeam
 from devsynth.application.memory.memory_manager import MemoryManager
 from devsynth.application.code_analysis.analyzer import CodeAnalyzer
 from devsynth.application.code_analysis.ast_transformer import AstTransformer
-from devsynth.application.prompts.prompt_manager import PromptManager
+from devsynth.application.requirements.prompt_manager import PromptManager
 from devsynth.application.documentation.documentation_manager import DocumentationManager
 from devsynth.methodology.base import Phase
 from devsynth.domain.models.agent import AgentConfig, AgentType


### PR DESCRIPTION
## Summary
- expose PromptManager under requirements namespace for consistent imports
- update EDRR components and BDD step definitions to use the new prompt manager path

## Testing
- `pytest tests/behavior/steps/test_prompt_management_steps.py::test_register_a_prompt_template -q` *(fails: cannot import name 'Storage' from 'tinydb.storages')*

------
https://chatgpt.com/codex/tasks/task_e_688fa0c2b5bc8333a866830b0274e6e9