### PR TITLE
feat: add DearPyGui optional extra

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,14 +117,14 @@ For more on Docker deployment, see the [Deployment Guide](docs/deployment/deploy
 Certain features use additional backends that are not installed by default. Install them if you need these capabilities:
 
 ```bash
-poetry install --extras retrieval --extras memory --extras llm --extras api --extras webui
+poetry install --extras retrieval --extras memory --extras llm --extras api --extras webui --extras dpgui
 # Install GPU support if you plan to run local models
 # poetry install --extras gpu
 # or install from PyPI
-pip install 'devsynth[retrieval,memory,llm,api,webui]'
+pip install 'devsynth[retrieval,memory,llm,api,webui,dpgui]'
 ```
 
-These extras enable optional vector stores such as **ChromaDB**, **Kuzu**, **FAISS**, and **LMDB**, additional LLM providers, the FastAPI server with Prometheus metrics, and the Streamlit WebUI. ChromaDB runs in embedded mode by default.
+These extras enable optional vector stores such as **ChromaDB**, **Kuzu**, **FAISS**, and **LMDB**, additional LLM providers, the FastAPI server with Prometheus metrics, the Streamlit WebUI, and the Dear PyGui interface. ChromaDB runs in embedded mode by default.
 
 ### Offline Mode
 
@@ -201,12 +201,12 @@ poetry install --with dev --extras minimal
 # poetry install --extras gpu
 ```
 
-Running the **full** test suite additionally requires the optional extras `minimal`, `retrieval`, `memory`, `llm`, `api`, `webui`, `lmstudio`, and `chromadb`:
+Running the **full** test suite additionally requires the optional extras `minimal`, `retrieval`, `memory`, `llm`, `api`, `webui`, `lmstudio`, `chromadb`, and `dpgui`:
 
 ```bash
 poetry install --extras minimal --extras retrieval --extras memory \
   --extras llm --extras api --extras webui --extras lmstudio \
-  --extras chromadb
+  --extras chromadb --extras dpgui
 ```
 Alternatively, install them all at once:
 

--- a/README.md
+++ b/README.md
@@ -117,11 +117,11 @@ For more on Docker deployment, see the [Deployment Guide](docs/deployment/deploy
 Certain features use additional backends that are not installed by default. Install them if you need these capabilities:
 
 ```bash
-poetry install --extras retrieval --extras memory --extras llm --extras api --extras webui --extras dpgui
+poetry install --extras retrieval --extras memory --extras llm --extras api --extras webui --extras gui
 # Install GPU support if you plan to run local models
 # poetry install --extras gpu
 # or install from PyPI
-pip install 'devsynth[retrieval,memory,llm,api,webui,dpgui]'
+pip install 'devsynth[retrieval,memory,llm,api,webui,gui]'
 ```
 
 These extras enable optional vector stores such as **ChromaDB**, **Kuzu**, **FAISS**, and **LMDB**, additional LLM providers, the FastAPI server with Prometheus metrics, the Streamlit WebUI, and the Dear PyGui interface. ChromaDB runs in embedded mode by default.
@@ -201,12 +201,12 @@ poetry install --with dev --extras minimal
 # poetry install --extras gpu
 ```
 
-Running the **full** test suite additionally requires the optional extras `minimal`, `retrieval`, `memory`, `llm`, `api`, `webui`, `lmstudio`, `chromadb`, and `dpgui`:
+Running the **full** test suite additionally requires the optional extras `minimal`, `retrieval`, `memory`, `llm`, `api`, `webui`, `lmstudio`, `chromadb`, and `gui`:
 
 ```bash
-poetry install --extras minimal --extras retrieval --extras memory \
-  --extras llm --extras api --extras webui --extras lmstudio \
-  --extras chromadb --extras dpgui
+  poetry install --extras minimal --extras retrieval --extras memory \
+    --extras llm --extras api --extras webui --extras lmstudio \
+    --extras chromadb --extras gui
 ```
 Alternatively, install them all at once:
 

--- a/docs/developer_guides/dependencies.md
+++ b/docs/developer_guides/dependencies.md
@@ -36,8 +36,8 @@ Some features rely on additional packages. These dependencies are grouped using 
 - **`offline`** – Enables deterministic offline mode. Combine with `gpu` to load local models.
 - **`gpu`** – Installs `torch` and NVIDIA libraries for hardware acceleration.
 - **`api`** – Enables the FastAPI server and Prometheus metrics.
-- **`webui`** – Installs the Streamlit-based WebUI.
-- **`dpgui`** – Installs the Dear PyGui-based desktop UI.
+  - **`webui`** – Installs the Streamlit-based WebUI.
+  - **`gui`** – Installs the Dear PyGui-based desktop UI.
 - **`lmstudio`** – Adds the LM Studio provider integration.
 - **`dev`** and **`docs`** – Development and documentation tooling.
 
@@ -68,7 +68,7 @@ From PyPI you can simply run:
 pip install devsynth
 ```
 
-Extras can be enabled later with `poetry install --extras llm --extras api --extras dpgui` or `pip install 'devsynth[llm,api,dpgui]'`.
+Extras can be enabled later with `poetry install --extras llm --extras api --extras gui` or `pip install 'devsynth[llm,api,gui]'`.
 
 ## Checking for Updates
 

--- a/docs/developer_guides/dependencies.md
+++ b/docs/developer_guides/dependencies.md
@@ -37,6 +37,7 @@ Some features rely on additional packages. These dependencies are grouped using 
 - **`gpu`** – Installs `torch` and NVIDIA libraries for hardware acceleration.
 - **`api`** – Enables the FastAPI server and Prometheus metrics.
 - **`webui`** – Installs the Streamlit-based WebUI.
+- **`dpgui`** – Installs the Dear PyGui-based desktop UI.
 - **`lmstudio`** – Adds the LM Studio provider integration.
 - **`dev`** and **`docs`** – Development and documentation tooling.
 
@@ -67,7 +68,7 @@ From PyPI you can simply run:
 pip install devsynth
 ```
 
-Extras can be enabled later with `poetry install --extras llm --extras api` or `pip install 'devsynth[llm,api]'`.
+Extras can be enabled later with `poetry install --extras llm --extras api --extras dpgui` or `pip install 'devsynth[llm,api,dpgui]'`.
 
 ## Checking for Updates
 

--- a/docs/getting_started/installation.md
+++ b/docs/getting_started/installation.md
@@ -47,7 +47,7 @@ For a lightweight setup with only the core runtime:
 poetry install --without dev --without docs
 ```
 
-Extras may be added later using `poetry install --extras llm --extras api --extras offline --extras dpgui`.
+Extras may be added later using `poetry install --extras llm --extras api --extras offline --extras gui`.
 Install the optional `gpu` extra for hardware-accelerated models:
 `poetry install --extras gpu`.
 

--- a/docs/getting_started/installation.md
+++ b/docs/getting_started/installation.md
@@ -47,7 +47,7 @@ For a lightweight setup with only the core runtime:
 poetry install --without dev --without docs
 ```
 
-Extras may be added later using `poetry install --extras llm --extras api --extras offline`.
+Extras may be added later using `poetry install --extras llm --extras api --extras offline --extras dpgui`.
 Install the optional `gpu` extra for hardware-accelerated models:
 `poetry install --extras gpu`.
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -1059,7 +1059,7 @@ description = "DearPyGui: A simple Python GUI Toolkit"
 optional = true
 python-versions = ">=3.8"
 groups = ["main"]
-markers = "extra == \"dpgui\""
+markers = "extra == \"gui\""
 files = [
     {file = "dearpygui-2.1.0-cp310-cp310-macosx_10_6_x86_64.whl", hash = "sha256:374d4c605affdf8a49eef4cf434f76e17df374590e51745b62c67025d1d41ec3"},
     {file = "dearpygui-2.1.0-cp310-cp310-macosx_13_0_arm64.whl", hash = "sha256:074985fa9d1622edda89c7f113d7a25ae5543f2e3f684bba3601e688c873936f"},
@@ -7968,8 +7968,8 @@ api = ["fastapi", "prometheus-client"]
 chromadb = ["chromadb", "tiktoken"]
 dev = ["pydantic-settings", "pyyaml", "toml"]
 docs = ["hypothesis"]
-dpgui = ["dearpygui"]
 gpu = ["nvidia-cublas-cu12", "nvidia-cuda-cupti-cu12", "nvidia-cuda-nvrtc-cu12", "nvidia-cuda-runtime-cu12", "nvidia-cudnn-cu12", "nvidia-cufft-cu12", "nvidia-cufile-cu12", "nvidia-curand-cu12", "nvidia-cusolver-cu12", "nvidia-cusparse-cu12", "nvidia-cusparselt-cu12", "nvidia-nccl-cu12", "nvidia-nvjitlink-cu12", "nvidia-nvtx-cu12", "torch"]
+gui = ["dearpygui"]
 llm = ["httpx", "tiktoken"]
 lmstudio = ["lmstudio"]
 memory = ["chromadb", "duckdb", "faiss-cpu", "kuzu", "lmdb", "numpy", "tinydb"]
@@ -7982,4 +7982,4 @@ webui = ["streamlit"]
 [metadata]
 lock-version = "2.1"
 python-versions = "<3.13,>=3.12"
-content-hash = "522beedc9eb6b064aea978db570dba68126e62c4bb580004c827a27922608c36"
+content-hash = "8fdb9bb7f62977c8163525a52f3475812976e991cdfccd9c8afd5443a358fe0a"

--- a/poetry.lock
+++ b/poetry.lock
@@ -1053,6 +1053,39 @@ marshmallow = ">=3.18.0,<4.0.0"
 typing-inspect = ">=0.4.0,<1"
 
 [[package]]
+name = "dearpygui"
+version = "2.1.0"
+description = "DearPyGui: A simple Python GUI Toolkit"
+optional = true
+python-versions = ">=3.8"
+groups = ["main"]
+markers = "extra == \"dpgui\""
+files = [
+    {file = "dearpygui-2.1.0-cp310-cp310-macosx_10_6_x86_64.whl", hash = "sha256:374d4c605affdf8a49eef4cf434f76e17df374590e51745b62c67025d1d41ec3"},
+    {file = "dearpygui-2.1.0-cp310-cp310-macosx_13_0_arm64.whl", hash = "sha256:074985fa9d1622edda89c7f113d7a25ae5543f2e3f684bba3601e688c873936f"},
+    {file = "dearpygui-2.1.0-cp310-cp310-manylinux1_x86_64.whl", hash = "sha256:49808389f1d1acfb4f5cbd9f1b1ec188fbcd2d828414094864f7035e27158db2"},
+    {file = "dearpygui-2.1.0-cp310-cp310-win_amd64.whl", hash = "sha256:792c1cd34dd0d03bf15838cc1e66ad01282c672ef0d2b9981368b6dcd37e67d3"},
+    {file = "dearpygui-2.1.0-cp311-cp311-macosx_10_6_x86_64.whl", hash = "sha256:03e5dc0b3dd2f7965e50bbe41f3316a814408064b582586de994d93afedb125c"},
+    {file = "dearpygui-2.1.0-cp311-cp311-macosx_13_0_arm64.whl", hash = "sha256:b5b37710c3fa135c48e2347f39ecd1f415146e86db5d404707a0bf72d16bd304"},
+    {file = "dearpygui-2.1.0-cp311-cp311-manylinux1_x86_64.whl", hash = "sha256:b0cfd7ac7eaa090fc22d6aa60fc4b527fc631cee10c348e4d8df92bb39af03d2"},
+    {file = "dearpygui-2.1.0-cp311-cp311-win_amd64.whl", hash = "sha256:a9af54f96d3ef30c5db9d12cdf3266f005507396fb0da2e12e6b22b662161070"},
+    {file = "dearpygui-2.1.0-cp312-cp312-macosx_10_6_x86_64.whl", hash = "sha256:1270ceb9cdb8ecc047c42477ccaa075b7864b314a5d09191f9280a24c8aa90a0"},
+    {file = "dearpygui-2.1.0-cp312-cp312-macosx_13_0_arm64.whl", hash = "sha256:ce9969eb62057b9d4c88a8baaed13b5fbe4058caa9faf5b19fec89da75aece3d"},
+    {file = "dearpygui-2.1.0-cp312-cp312-manylinux1_x86_64.whl", hash = "sha256:a3ca8cf788db63ef7e2e8d6f277631b607d548b37606f080ca1b42b1f0a9b183"},
+    {file = "dearpygui-2.1.0-cp312-cp312-win_amd64.whl", hash = "sha256:43f0e4db9402f44fc3683a1f5c703564819de18cc15a042de7f1ed1c8cb5d148"},
+    {file = "dearpygui-2.1.0-cp313-cp313-macosx_10_6_x86_64.whl", hash = "sha256:5c32402f75f87ca23faedc626975f546098bcbc71e1dc8b22ddc6054f4c800f1"},
+    {file = "dearpygui-2.1.0-cp313-cp313-macosx_13_0_arm64.whl", hash = "sha256:f776c4c81195b2e7248305db21c7d429881d306a9557a8a4e4f002eb477cd247"},
+    {file = "dearpygui-2.1.0-cp313-cp313-manylinux1_x86_64.whl", hash = "sha256:3900ce7f68e8967dc937adbd9088a7c294fd676fa878d9905e4f25b0d76232ae"},
+    {file = "dearpygui-2.1.0-cp313-cp313-win_amd64.whl", hash = "sha256:205def95d6862e80ee908d080f5a8065f30421d87ddfa88a3607a5c8e253a9bb"},
+    {file = "dearpygui-2.1.0-cp38-cp38-macosx_10_6_x86_64.whl", hash = "sha256:d526f71367950c3e0b91ca06a87fafa9317663d3d55a245c67e34147b34f531e"},
+    {file = "dearpygui-2.1.0-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:9daa11a4ff8ee4278c7ec614680d5d2a18712eed1b54655137c1b6e1fcfd6852"},
+    {file = "dearpygui-2.1.0-cp38-cp38-win_amd64.whl", hash = "sha256:eacd0093a985cc1c8d860b82ee518b387c13be3e21c2222ac90b3331656de905"},
+    {file = "dearpygui-2.1.0-cp39-cp39-macosx_10_6_x86_64.whl", hash = "sha256:0d228a4934c642fb01f1602b71b11f54e8b739ee3902a98fd71618ddca088213"},
+    {file = "dearpygui-2.1.0-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:4e4c2df52ffee0810652bdb165972dad2ca8d89c65ea37d69d6157576adba2d7"},
+    {file = "dearpygui-2.1.0-cp39-cp39-win_amd64.whl", hash = "sha256:c337fb8b27f6fbdae89fdb5f36a377e09f955642c025005b1be9b96eef73df3b"},
+]
+
+[[package]]
 name = "decorator"
 version = "5.2.1"
 description = "Decorators for Humans"
@@ -7935,6 +7968,7 @@ api = ["fastapi", "prometheus-client"]
 chromadb = ["chromadb", "tiktoken"]
 dev = ["pydantic-settings", "pyyaml", "toml"]
 docs = ["hypothesis"]
+dpgui = ["dearpygui"]
 gpu = ["nvidia-cublas-cu12", "nvidia-cuda-cupti-cu12", "nvidia-cuda-nvrtc-cu12", "nvidia-cuda-runtime-cu12", "nvidia-cudnn-cu12", "nvidia-cufft-cu12", "nvidia-cufile-cu12", "nvidia-curand-cu12", "nvidia-cusolver-cu12", "nvidia-cusparse-cu12", "nvidia-cusparselt-cu12", "nvidia-nccl-cu12", "nvidia-nvjitlink-cu12", "nvidia-nvtx-cu12", "torch"]
 llm = ["httpx", "tiktoken"]
 lmstudio = ["lmstudio"]
@@ -7948,4 +7982,4 @@ webui = ["streamlit"]
 [metadata]
 lock-version = "2.1"
 python-versions = "<3.13,>=3.12"
-content-hash = "021eee086164b12a07adbc450fe00bae000245895785ae0281acf966706b790b"
+content-hash = "522beedc9eb6b064aea978db570dba68126e62c4bb580004c827a27922608c36"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -104,7 +104,7 @@ mkdocs-section-index = "^0.3.10"
 # minimal: baseline runtime requirements without heavy optional dependencies
 # retrieval: enables vector retrieval support via kuzu and faiss
 # chromadb: use chromadb as the vector store
-# dpgui: install Dear PyGui for a lightweight GUI
+# gui: install Dear PyGui for a desktop GUI
 docs = [
     "mkdocs",
     "mkdocs-material",
@@ -160,7 +160,7 @@ gpu = [
 offline = ["transformers"]
 api = ["fastapi", "prometheus-client"]
 webui = ["streamlit"]
-dpgui = ["dearpygui"]
+gui = ["dearpygui"]
 tests = ["fastapi", "httpx", "tinydb", "duckdb", "lmdb", "astor"]
 dev = [
     "responses",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,8 @@ kuzu = {version = "0.10.0", optional = true}
 numpy = "==2.3.2"
 torch = {version = "2.7.1", optional = true}
 transformers = {version = "4.53.0", optional = true}
+# GUI dependencies
+dearpygui = {version = "^2.1", optional = true}
 nvidia-cublas-cu12 = {version = "12.6.4.1", optional = true, markers = "platform_system == 'Linux' and platform_machine == 'x86_64'"}
 nvidia-cuda-cupti-cu12 = {version = "12.6.80", optional = true, markers = "platform_system == 'Linux' and platform_machine == 'x86_64'"}
 nvidia-cuda-nvrtc-cu12 = {version = "12.6.77", optional = true, markers = "platform_system == 'Linux' and platform_machine == 'x86_64'"}
@@ -102,6 +104,7 @@ mkdocs-section-index = "^0.3.10"
 # minimal: baseline runtime requirements without heavy optional dependencies
 # retrieval: enables vector retrieval support via kuzu and faiss
 # chromadb: use chromadb as the vector store
+# dpgui: install Dear PyGui for a lightweight GUI
 docs = [
     "mkdocs",
     "mkdocs-material",
@@ -157,6 +160,7 @@ gpu = [
 offline = ["transformers"]
 api = ["fastapi", "prometheus-client"]
 webui = ["streamlit"]
+dpgui = ["dearpygui"]
 tests = ["fastapi", "httpx", "tinydb", "duckdb", "lmdb", "astor"]
 dev = [
     "responses",


### PR DESCRIPTION
## Summary
- add DearPyGui optional dependency and dpgui extra
- document dpgui extra in README and developer guides

## Testing
- `poetry run pre-commit run --files pyproject.toml README.md docs/developer_guides/dependencies.md docs/getting_started/installation.md`
- `poetry run pytest --maxfail=1 -q` *(fails: IndentationError in tests/unit/application/cli/test_init_cmd.py)*

------
https://chatgpt.com/codex/tasks/task_e_688fa7be9bb083338598c7aa97312e00