### PR TITLE
docs: refresh requirements traceability and add CI check

### DIFF
--- a/.github/workflows.disabled/validate_documentation.yml
+++ b/.github/workflows.disabled/validate_documentation.yml
@@ -8,6 +8,7 @@ on:
       - '.github/workflows/validate_documentation.yml'
       - 'scripts/validate_metadata.py'
       - 'scripts/verify_code_examples.py'
+      - 'scripts/verify_requirements_traceability.py'
   pull_request:
     branches: [ main, master ]
     paths:
@@ -15,6 +16,7 @@ on:
       - '.github/workflows/validate_documentation.yml'
       - 'scripts/validate_metadata.py'
       - 'scripts/verify_code_examples.py'
+      - 'scripts/verify_requirements_traceability.py'
   workflow_dispatch:
 
 jobs:
@@ -44,6 +46,8 @@ jobs:
       - name: Verify code examples in documentation
         run: |
           python scripts/verify_code_examples.py docs README.md DEVELOPMENT_PLAN.md DEVONBOARDING.md --verbose
+      - name: Verify requirements traceability
+        run: python scripts/verify_requirements_traceability.py docs/requirements_traceability.md
       - name: Check for broken links
         run: |
           echo "Checking for broken links in documentation..."

--- a/docs/requirements_traceability.md
+++ b/docs/requirements_traceability.md
@@ -10,7 +10,7 @@ tags:
 
 status: "published"
 author: "DevSynth Team"
-last_reviewed: "2025-07-31"---
+last_reviewed: "2025-08-03"---
 
 <div class="breadcrumbs">
 <a href="../index.md">Documentation</a> &gt; Requirements Traceability Matrix (RTM)
@@ -75,7 +75,7 @@ This matrix links requirements to design, code modules, and tests, ensuring bidi
 | FR-57 | Message passing protocol between agents | [WSDE Interaction Specification](specifications/wsde_interaction_specification.md) | src/devsynth/application/collaboration/message_protocol.py | tests/behavior/features/wsde_message_passing_peer_review.feature | Implemented |
 | FR-58 | Peer review mechanism for agent outputs | [WSDE Interaction Specification](specifications/wsde_interaction_specification.md) | src/devsynth/application/collaboration/peer_review.py | tests/behavior/features/wsde_message_passing_peer_review.feature | Implemented |
 | FR-59 | Advanced query patterns across memory stores | [Hybrid Memory Architecture](specifications/hybrid_memory_architecture.md) | src/devsynth/application/memory/query_router.py | tests/behavior/features/hybrid_memory_query_patterns.feature, tests/integration/test_memory_agent_integration.py, tests/integration/test_wsde_memory_edrr_integration.py | Partially Implemented |
-| FR-60 | Synchronization between memory stores | [Hybrid Memory Architecture](specifications/hybrid_memory_architecture.md) | src/devsynth/application/memory/sync_manager.py | tests/behavior/features/hybrid_memory_query_patterns.feature, tests/unit/adapters/test_sync_manager.py, tests/integration/test_graph_memory_edrr_integration.py | Partially Implemented |
+| FR-60 | Synchronization between memory stores | [Hybrid Memory Architecture](specifications/hybrid_memory_architecture.md) | src/devsynth/application/memory/sync_manager.py, src/devsynth/application/collaboration/collaboration_memory_utils.py | tests/behavior/features/hybrid_memory_query_patterns.feature, tests/unit/adapters/test_sync_manager.py, tests/integration/test_graph_memory_edrr_integration.py, tests/integration/memory/test_cross_store_sync.py | Implemented |
 | FR-61 | Authentication utilities with Argon2 hashing | [Secure Coding Guidelines](developer_guides/secure_coding.md) | src/devsynth/security/authentication.py | tests/unit/security/test_authentication.py | Implemented |
 | FR-62 | Role-based authorization checks | [Security and Privacy Framework](analysis/critical_recommendations.md#5-security-and-privacy-framework-high) | src/devsynth/security/authorization.py | tests/unit/security/test_authorization.py | Implemented |
 | FR-63 | Input sanitization utilities | [Secure Coding Guidelines](developer_guides/secure_coding.md) | src/devsynth/security/sanitization.py | tests/unit/security/test_sanitization.py | Implemented |
@@ -106,8 +106,9 @@ This matrix links requirements to design, code modules, and tests, ensuring bidi
 | FR-90 | Metrics commands for alignment and test reporting | [Metrics System Specification](specifications/metrics_system.md) | src/devsynth/application/cli/commands/alignment_metrics_cmd.py, src/devsynth/application/cli/commands/test_metrics_cmd.py | tests/unit/application/cli/test_metrics_commands.py, tests/behavior/features/alignment_metrics_command.feature, tests/behavior/features/test_metrics.feature | Implemented |
 | FR-91 | Knowledge graph utility functions for advanced memory queries | [Hybrid Memory Architecture](specifications/hybrid_memory_architecture.md) | src/devsynth/application/memory/knowledge_graph_utils.py | tests/unit/application/memory/test_knowledge_graph_utils.py | Implemented |
 | FR-92 | Multi-language code generation agent | [DevSynth Technical Specification](specifications/devsynth_specification.md) | src/devsynth/application/agents/multi_language_code.py | tests/unit/application/agents/test_multi_language_code.py | Implemented |
+| FR-93 | Embedded Kuzu graph memory store support | [Memory System Architecture](architecture/memory_system.md) | src/devsynth/application/memory/kuzu_store.py, src/devsynth/adapters/kuzu_memory_store.py | tests/unit/application/memory/test_kuzu_store.py, tests/integration/general/test_kuzu_memory_integration.py, tests/integration/general/test_kuzu_memory_fallback.py | Implemented |
 
-_Last updated: July 31, 2025_
+_Last updated: August 29, 2025_
 ## Implementation Status
 
 Several requirements remain **partially implemented**. Consult the status column

--- a/scripts/verify_requirements_traceability.py
+++ b/scripts/verify_requirements_traceability.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python3
+"""Validate requirements traceability matrix.
+
+Ensures each requirement row includes references to code modules and tests.
+"""
+
+from __future__ import annotations
+
+import argparse
+import pathlib
+import sys
+
+
+def verify_traceability(matrix: pathlib.Path) -> int:
+    """Return 0 if all requirements have code and test references."""
+    errors = []
+    for lineno, line in enumerate(matrix.read_text().splitlines(), start=1):
+        if (
+            not line.startswith("| FR")
+            and not line.startswith("| NFR")
+            and not line.startswith("| IR")
+        ):
+            continue
+        parts = [p.strip() for p in line.split("|")[1:-1]]
+        if len(parts) < 6:
+            continue
+        req_id, _, _, code_cell, test_cell, _ = parts
+        if not code_cell or code_cell.lower() == "n/a":
+            errors.append(f"{req_id} missing code reference (line {lineno})")
+        if not test_cell or test_cell.lower() == "n/a":
+            errors.append(f"{req_id} missing test reference (line {lineno})")
+    if errors:
+        for err in errors:
+            print(err, file=sys.stderr)
+        return 1
+    return 0
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Verify requirements traceability matrix"
+    )
+    parser.add_argument(
+        "matrix", type=pathlib.Path, help="Path to requirements_traceability.md"
+    )
+    args = parser.parse_args()
+    sys.exit(verify_traceability(args.matrix))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add Kuzu memory store requirement and mark memory sync as implemented in requirements traceability matrix
- add script to verify requirement entries include code and tests
- run traceability check in documentation workflow
- update requirements traceability last-reviewed date to 2025-08-03

## Testing
- `poetry run pre-commit run --files docs/requirements_traceability.md`
- `python scripts/verify_requirements_traceability.py docs/requirements_traceability.md`


------
https://chatgpt.com/codex/tasks/task_e_688fa7a3f49c8333a69a30979ee682f7