### PR TITLE
test: add DearPyGUI bridge factory

### DIFF
--- a/tests/unit/interface/test_bridge_conformance.py
+++ b/tests/unit/interface/test_bridge_conformance.py
@@ -1,15 +1,17 @@
 import sys
 from types import ModuleType
 from unittest.mock import MagicMock
+
 import pytest
-from devsynth.interface.cli import CLIUXBridge
+
 from devsynth.interface.agentapi import APIBridge
-from devsynth.interface.ux_bridge import UXBridge, ProgressIndicator
+from devsynth.interface.cli import CLIUXBridge
+from devsynth.interface.ux_bridge import ProgressIndicator, UXBridge
 
 
 class DummyCtx:
     """Context manager for testing."""
-    
+
     def __enter__(self):
         return self
 
@@ -19,10 +21,10 @@ class DummyCtx:
 
 def _stub_streamlit(monkeypatch):
     """Create a stub for the streamlit module."""
-    st = ModuleType('streamlit')
+    st = ModuleType("streamlit")
     st.session_state = {}
-    st.text_input = MagicMock(return_value='')
-    st.selectbox = MagicMock(return_value='')
+    st.text_input = MagicMock(return_value="")
+    st.selectbox = MagicMock(return_value="")
     st.checkbox = MagicMock(return_value=True)
     st.write = MagicMock()
     st.markdown = MagicMock()
@@ -31,16 +33,18 @@ def _stub_streamlit(monkeypatch):
     st.form = lambda *_a, **_k: DummyCtx()
     st.form_submit_button = MagicMock(return_value=True)
     st.button = MagicMock(return_value=False)
-    
+
     # Fix the line continuation issue with proper indentation
-    st.columns = MagicMock(return_value=(
-        MagicMock(button=lambda *a, **k: False),
-        MagicMock(button=lambda *a, **k: False)
-    ))
-    
+    st.columns = MagicMock(
+        return_value=(
+            MagicMock(button=lambda *a, **k: False),
+            MagicMock(button=lambda *a, **k: False),
+        )
+    )
+
     st.divider = MagicMock()
     st.spinner = DummyCtx
-    monkeypatch.setitem(sys.modules, 'streamlit', st)
+    monkeypatch.setitem(sys.modules, "streamlit", st)
     return st
 
 
@@ -48,12 +52,14 @@ def _get_webui(monkeypatch):
     """Get the WebUI class and streamlit stub."""
     st = _stub_streamlit(monkeypatch)
     import importlib
+
     from devsynth.interface import webui
-    
+
     # Reload the module to ensure clean state
     importlib.reload(webui)
-    
+
     from devsynth.interface.webui import WebUI
+
     return WebUI, st
 
 
@@ -73,16 +79,39 @@ def _make_web(monkeypatch):
     return WebUI()
 
 
+def _make_dpg(monkeypatch):
+    """Create a DearPyGUI bridge instance using a stubbed dearpygui module."""
+    # Stub out the dearpygui package and the dearpygui.dearpygui module
+    dpg_pkg = ModuleType("dearpygui")
+    dpg_mod = ModuleType("dearpygui.dearpygui")
+
+    dpg_mod.is_viewport_created = MagicMock(return_value=True)
+    dpg_mod.window = lambda *a, **k: DummyCtx()
+    dpg_mod.add_progress_bar = MagicMock(return_value=MagicMock())
+    dpg_mod.set_item_label = MagicMock()
+    dpg_mod.set_value = MagicMock()
+    dpg_mod.render_dearpygui_frame = MagicMock()
+    dpg_mod.delete_item = MagicMock()
+
+    dpg_pkg.dearpygui = dpg_mod
+    monkeypatch.setitem(sys.modules, "dearpygui", dpg_pkg)
+    monkeypatch.setitem(sys.modules, "dearpygui.dearpygui", dpg_mod)
+
+    from devsynth.interface.dpg_bridge import DearPyGUIBridge
+
+    return DearPyGUIBridge()
+
+
 @pytest.mark.medium
-@pytest.mark.parametrize('factory', [_make_cli, _make_api, _make_web])
+@pytest.mark.parametrize("factory", [_make_cli, _make_api, _make_web, _make_dpg])
 def test_bridge_implements_methods_succeeds(factory, monkeypatch):
     """Test that bridge implements methods succeeds.
 
     ReqID: N/A"""
     bridge = factory(monkeypatch)
     assert isinstance(bridge, UXBridge)
-    
-    for name in ['ask_question', 'confirm_choice', 'display_result', 'create_progress']:
+
+    for name in ["ask_question", "confirm_choice", "display_result", "create_progress"]:
         assert callable(getattr(bridge, name))
-        
-    assert isinstance(bridge.create_progress('x'), ProgressIndicator)
+
+    assert isinstance(bridge.create_progress("x"), ProgressIndicator)


### PR DESCRIPTION
## Summary
- add `_make_dpg` factory using stubbed `dearpygui` to build `DearPyGUIBridge`
- include `_make_dpg` in `test_bridge_implements_methods_succeeds` parameter list

## Testing
- `poetry run pre-commit run --files tests/unit/interface/test_bridge_conformance.py`
- `poetry run pytest tests/unit/interface/test_bridge_conformance.py::test_bridge_implements_methods_succeeds -q`


------
https://chatgpt.com/codex/tasks/task_e_688fbae73758833392045c4adf90c101