### PR TITLE
refactor: wrap alignment script around CLI

### DIFF
--- a/scripts/alignment_check.py
+++ b/scripts/alignment_check.py
@@ -1,170 +1,48 @@
 #!/usr/bin/env python3
-"""
-Pre-commit hook script to check for alignment issues between SDLC artifacts.
+"""Run the DevSynth alignment check as a pre-commit hook.
 
-This script checks for basic alignment issues like missing references to requirements
-in specifications, missing references to specifications in tests, and missing references
-to tests in code.
-
-Usage:
-    1. Install as a pre-commit hook:
-       cp scripts/alignment_check.py .git/hooks/pre-commit
-       chmod +x .git/hooks/pre-commit
-    
-    2. Run manually:
-       python scripts/alignment_check.py [--files file1 file2 ...]
+This script is a thin wrapper around the project's CLI alignment command. It
+executes the same alignment logic to ensure consistent behaviour with the
+`devsynth align` command and exits with compatible status codes.
 """
+
+from __future__ import annotations
 
 import argparse
-import os
-import re
 import sys
-from typing import Dict, List, Set, Tuple
 
-# Regular expressions for finding references
-REQ_REF_PATTERN = re.compile(r'FR-\d+|NFR-\d+')
-SPEC_REF_PATTERN = re.compile(r'SPEC-\d+')
-TEST_REF_PATTERN = re.compile(r'TEST-\d+')
+from devsynth.application.cli.commands import align_cmd
 
-# File patterns for different artifact types
-REQUIREMENT_FILES = ['docs/requirements/', 'docs/system_requirements_specification.md']
-SPECIFICATION_FILES = ['docs/specifications/']
-TEST_FILES = ['tests/']
-CODE_FILES = ['src/']
 
-def parse_args():
-    """Parse command line arguments."""
-    parser = argparse.ArgumentParser(description='Check alignment between SDLC artifacts')
-    parser.add_argument('--files', nargs='+', help='Specific files to check')
+def parse_args() -> argparse.Namespace:
+    """Parse command line arguments for the alignment wrapper."""
+    parser = argparse.ArgumentParser(
+        description="Check alignment between SDLC artifacts using DevSynth's CLI"
+    )
+    parser.add_argument(
+        "--path",
+        default=".",
+        help="Path to the project directory to check (default: current directory)",
+    )
+    parser.add_argument(
+        "--verbose",
+        action="store_true",
+        help="Enable verbose output from the alignment command",
+    )
     return parser.parse_args()
 
-def get_changed_files() -> List[str]:
-    """Get list of files changed in the current commit."""
-    try:
-        # Get staged files
-        import subprocess
-        result = subprocess.run(
-            ['git', 'diff', '--cached', '--name-only'],
-            capture_output=True, text=True, check=True
-        )
-        return result.stdout.splitlines()
-    except Exception as e:
-        print(f"Error getting changed files: {e}")
-        return []
 
-def is_file_of_type(file_path: str, type_patterns: List[str]) -> bool:
-    """Check if a file matches any of the given patterns."""
-    return any(pattern in file_path for pattern in type_patterns)
-
-def extract_references(file_path: str, pattern: re.Pattern) -> Set[str]:
-    """Extract references matching the given pattern from a file."""
-    try:
-        with open(file_path, 'r', encoding='utf-8') as f:
-            content = f.read()
-        return set(pattern.findall(content))
-    except Exception as e:
-        print(f"Error reading {file_path}: {e}")
-        return set()
-
-def check_requirement_references(files: List[str]) -> List[str]:
-    """Check if specifications reference requirements."""
-    issues = []
-    
-    # Get all requirement IDs
-    all_requirements = set()
-    for file in files:
-        if is_file_of_type(file, REQUIREMENT_FILES):
-            all_requirements.update(extract_references(file, REQ_REF_PATTERN))
-    
-    # Check specifications for requirement references
-    for file in files:
-        if is_file_of_type(file, SPECIFICATION_FILES):
-            spec_requirements = extract_references(file, REQ_REF_PATTERN)
-            if not spec_requirements:
-                issues.append(f"Specification {file} does not reference any requirements")
-    
-    return issues
-
-def check_specification_references(files: List[str]) -> List[str]:
-    """Check if tests reference specifications."""
-    issues = []
-    
-    # Get all specification IDs
-    all_specifications = set()
-    for file in files:
-        if is_file_of_type(file, SPECIFICATION_FILES):
-            all_specifications.update(extract_references(file, SPEC_REF_PATTERN))
-    
-    # Check tests for specification references
-    for file in files:
-        if is_file_of_type(file, TEST_FILES):
-            test_specifications = extract_references(file, SPEC_REF_PATTERN)
-            if not test_specifications:
-                issues.append(f"Test {file} does not reference any specifications")
-    
-    return issues
-
-def check_test_references(files: List[str]) -> List[str]:
-    """Check if code references tests."""
-    issues = []
-    
-    # Get all test IDs
-    all_tests = set()
-    for file in files:
-        if is_file_of_type(file, TEST_FILES):
-            all_tests.update(extract_references(file, TEST_REF_PATTERN))
-    
-    # Check code for test references
-    for file in files:
-        if is_file_of_type(file, CODE_FILES) and file.endswith('.py'):
-            code_tests = extract_references(file, TEST_REF_PATTERN)
-            if not code_tests:
-                issues.append(f"Code {file} does not reference any tests")
-    
-    return issues
-
-def check_alignment(files: List[str]) -> List[str]:
-    """Check alignment between SDLC artifacts."""
-    issues = []
-    
-    # Only check files that exist
-    existing_files = [f for f in files if os.path.isfile(f)]
-    
-    # Run checks
-    issues.extend(check_requirement_references(existing_files))
-    issues.extend(check_specification_references(existing_files))
-    issues.extend(check_test_references(existing_files))
-    
-    return issues
-
-def main():
-    """Main function."""
+def main() -> int:
+    """Execute the alignment check and return the CLI's exit status."""
     args = parse_args()
-    
-    # Get files to check
-    if args.files:
-        files = args.files
-    else:
-        files = get_changed_files()
-    
-    if not files:
-        print("No files to check")
-        return 0
-    
-    # Check alignment
-    issues = check_alignment(files)
-    
-    # Print issues
-    if issues:
-        print("Alignment issues found:")
-        for issue in issues:
-            print(f"  - {issue}")
-        
-        print("\nYou can bypass this check with git commit --no-verify")
+    try:
+        issues = align_cmd.check_alignment(path=args.path, verbose=args.verbose)
+        align_cmd.display_issues(issues)
+        return 0 if not issues else 1
+    except Exception as exc:  # pragma: no cover - mirror CLI behaviour
+        print(f"Error checking alignment: {exc}", file=sys.stderr)
         return 1
-    
-    print("No alignment issues found")
-    return 0
 
-if __name__ == "__main__":
+
+if __name__ == "__main__":  # pragma: no cover - script entry point
     sys.exit(main())


### PR DESCRIPTION
## Summary
- replace bespoke alignment checks with thin wrapper around `align_cmd`
- preserve CLI exit codes for pre-commit compatibility

## Testing
- `poetry run pre-commit run --files scripts/alignment_check.py`
- `bash scripts/codex_setup.sh` *(fails: IndentationError)*
- `poetry run pytest tests/unit/interface/test_webui.py -q` *(fails: AttributeError)*

------
https://chatgpt.com/codex/tasks/task_e_688fbacb71c88333b4d7a28abc5a63d0