### PR TITLE
refactor: centralize test running

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,9 +252,9 @@ You can also use the helper script `scripts/run_all_tests.py` to run the entire
 suite or specific groups of tests and optionally generate an HTML report:
 
 ```bash
-./scripts/run_all_tests.py         # run all tests
-./scripts/run_all_tests.py --unit  # run only unit tests
-./scripts/run_all_tests.py --report  # generate HTML report under test_reports/
+./scripts/run_all_tests.py                     # run all tests
+./scripts/run_all_tests.py --target unit-tests  # run only unit tests
+./scripts/run_all_tests.py --report             # generate HTML report under test_reports/
 ```
 
 See [docs/developer_guides/testing.md](docs/developer_guides/testing.md) for detailed testing guidance.

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -13,13 +13,13 @@ This script executes all unit, integration, and behavior tests and generates a c
 ./scripts/run_all_tests.py
 
 # Run only unit tests
-./scripts/run_all_tests.py --unit
+./scripts/run_all_tests.py --target unit-tests
 
 # Run only integration tests
-./scripts/run_all_tests.py --integration
+./scripts/run_all_tests.py --target integration-tests
 
 # Run only behavior tests
-./scripts/run_all_tests.py --behavior
+./scripts/run_all_tests.py --target behavior-tests
 
 # Generate HTML report
 ./scripts/run_all_tests.py --report

--- a/scripts/manual_cli_testing.py
+++ b/scripts/manual_cli_testing.py
@@ -19,6 +19,8 @@ import sys
 from datetime import datetime
 from pathlib import Path
 
+from devsynth.testing.run_tests import run_tests
+
 
 class CLIWorkflowTester:
     """Class to guide manual testing of CLI workflows."""
@@ -26,55 +28,52 @@ class CLIWorkflowTester:
     def __init__(self, output_file="cli_test_results.md"):
         """
         Initialize the tester.
-        
+
         Args:
             output_file (str): Path to the output file for test results
         """
         self.output_file = output_file
         self.results = []
         self.current_date = datetime.now().strftime("%Y-%m-%d")
-        
+
         # Create a temporary directory for testing
         self.test_dir = Path("./temp_cli_test")
         if not self.test_dir.exists():
             self.test_dir.mkdir(parents=True)
-            
+
     def cleanup(self):
         """Clean up temporary files and directories."""
         import shutil
+
         if self.test_dir.exists():
             try:
                 shutil.rmtree(self.test_dir)
                 print(f"Cleaned up temporary directory: {self.test_dir}")
             except Exception as e:
                 print(f"Error cleaning up temporary directory: {e}")
-    
+
     def run_command(self, command):
         """
         Run a command and return the result.
-        
+
         Args:
             command (str): Command to run
-            
+
         Returns:
             tuple: (returncode, stdout, stderr)
         """
         try:
             process = subprocess.run(
-                command,
-                shell=True,
-                check=False,
-                capture_output=True,
-                text=True
+                command, shell=True, check=False, capture_output=True, text=True
             )
             return process.returncode, process.stdout, process.stderr
         except Exception as e:
             return 1, "", str(e)
-    
+
     def print_step(self, step_number, description):
         """
         Print a step in the testing process.
-        
+
         Args:
             step_number (int): Step number
             description (str): Step description
@@ -82,15 +81,15 @@ class CLIWorkflowTester:
         print(f"\n{'='*80}")
         print(f"Step {step_number}: {description}")
         print(f"{'='*80}")
-    
+
     def get_user_input(self, prompt, options=None):
         """
         Get input from the user.
-        
+
         Args:
             prompt (str): Prompt to display
             options (list): List of valid options
-            
+
         Returns:
             str: User input
         """
@@ -103,43 +102,45 @@ class CLIWorkflowTester:
                 print(f"Invalid input. Please enter one of: {option_str}")
             else:
                 return input(f"{prompt}: ").strip()
-    
+
     def record_result(self, test_name, command, result, notes=""):
         """
         Record a test result.
-        
+
         Args:
             test_name (str): Name of the test
             command (str): Command that was run
             result (str): Result of the test (pass/fail)
             notes (str): Additional notes
         """
-        self.results.append({
-            "test_name": test_name,
-            "command": command,
-            "result": result,
-            "notes": notes
-        })
-    
+        self.results.append(
+            {
+                "test_name": test_name,
+                "command": command,
+                "result": result,
+                "notes": notes,
+            }
+        )
+
     def save_results(self):
         """Save the test results to a file."""
         with open(self.output_file, "w") as f:
             f.write(f"# DevSynth CLI Workflow Test Results\n\n")
             f.write(f"Date: {self.current_date}\n\n")
-            
+
             f.write("## Summary\n\n")
-            
+
             # Count passes and fails
             passes = sum(1 for r in self.results if r["result"] == "pass")
             fails = sum(1 for r in self.results if r["result"] == "fail")
             total = len(self.results)
-            
+
             f.write(f"- Total tests: {total}\n")
             f.write(f"- Passed: {passes}\n")
             f.write(f"- Failed: {fails}\n\n")
-            
+
             f.write("## Detailed Results\n\n")
-            
+
             for i, result in enumerate(self.results, 1):
                 f.write(f"### {i}. {result['test_name']}\n\n")
                 f.write(f"**Command:** `{result['command']}`\n\n")
@@ -147,101 +148,103 @@ class CLIWorkflowTester:
                 if result["notes"]:
                     f.write(f"**Notes:** {result['notes']}\n\n")
                 f.write("---\n\n")
-        
+
         print(f"\nTest results saved to {self.output_file}")
-    
+
     def test_help_command(self):
         """Test the help command."""
         self.print_step(1, "Testing the help command")
-        
+
         command = "devsynth help"
         print(f"Running command: {command}")
-        
+
         returncode, stdout, stderr = self.run_command(command)
-        
+
         print("\nOutput:")
         print(stdout)
-        
+
         if stderr:
             print("\nErrors:")
             print(stderr)
-        
+
         result = self.get_user_input(
             "Did the help command display the expected output?",
-            options=["pass", "fail"]
+            options=["pass", "fail"],
         )
-        
+
         notes = self.get_user_input("Enter any notes about this test (optional)")
-        
+
         self.record_result("Help Command", command, result, notes)
-    
+
     def test_init_command(self):
         """Test the init command."""
         self.print_step(2, "Testing the init command")
-        
+
         # Change to the test directory
         os.chdir(self.test_dir)
-        
+
         command = "devsynth init --path ./test_project"
         print(f"Running command: {command}")
-        
+
         returncode, stdout, stderr = self.run_command(command)
-        
+
         print("\nOutput:")
         print(stdout)
-        
+
         if stderr:
             print("\nErrors:")
             print(stderr)
-        
+
         # Check if the project was created
-        project_created = Path("./test_project").exists() and Path("./test_project/.devsynth").exists()
-        
+        project_created = (
+            Path("./test_project").exists()
+            and Path("./test_project/.devsynth").exists()
+        )
+
         if project_created:
             print("\nProject directory was created successfully.")
         else:
             print("\nProject directory was NOT created.")
-        
+
         result = self.get_user_input(
-            "Did the init command work as expected?",
-            options=["pass", "fail"]
+            "Did the init command work as expected?", options=["pass", "fail"]
         )
-        
+
         notes = self.get_user_input("Enter any notes about this test (optional)")
-        
+
         # Change back to the original directory
         os.chdir("..")
-        
+
         self.record_result("Init Command", command, result, notes)
-    
+
     def test_spec_command(self):
         """Test the spec command."""
         self.print_step(3, "Testing the spec command")
-        
+
         # Change to the test directory
         os.chdir(self.test_dir / "test_project")
-        
+
         # Create a simple requirements file
         with open("requirements.md", "w") as f:
             f.write("# Test Requirements\n\n")
             f.write("1. The system shall provide a calculator function\n")
             f.write("2. The calculator shall support addition and subtraction\n")
-        
+
         command = "devsynth spec --requirements-file requirements.md"
         print(f"Running command: {command}")
-        
+
         returncode, stdout, stderr = self.run_command(command)
-        
+
         print("\nOutput:")
         print(stdout)
-        
+
         if stderr:
             print("\nErrors:")
             print(stderr)
-        
+
         # Check if the spec file was created
         spec_created = Path("./.devsynth/specs.md").exists()
-        
+
         if spec_created:
             print("\nSpec file was created successfully.")
             # Show the content of the spec file
@@ -250,41 +253,40 @@ class CLIWorkflowTester:
                 print(f.read())
         else:
             print("\nSpec file was NOT created.")
-        
+
         result = self.get_user_input(
-            "Did the spec command work as expected?",
-            options=["pass", "fail"]
+            "Did the spec command work as expected?", options=["pass", "fail"]
         )
-        
+
         notes = self.get_user_input("Enter any notes about this test (optional)")
-        
+
         # Change back to the original directory
         os.chdir("../..")
-        
+
         self.record_result("Spec Command", command, result, notes)
-    
+
     def test_test_command(self):
         """Test the test command."""
         self.print_step(4, "Testing the test command")
-        
+
         # Change to the test directory
         os.chdir(self.test_dir / "test_project")
-        
+
         command = "devsynth test"
         print(f"Running command: {command}")
-        
+
         returncode, stdout, stderr = self.run_command(command)
-        
+
         print("\nOutput:")
         print(stdout)
-        
+
         if stderr:
             print("\nErrors:")
             print(stderr)
-        
+
         # Check if test files were created
         tests_created = Path("./tests").exists()
-        
+
         if tests_created:
             print("\nTest files were created successfully.")
             # List the test files
@@ -294,41 +296,40 @@ class CLIWorkflowTester:
                 print(f"- {test_file}")
         else:
             print("\nTest files were NOT created.")
-        
+
         result = self.get_user_input(
-            "Did the test command work as expected?",
-            options=["pass", "fail"]
+            "Did the test command work as expected?", options=["pass", "fail"]
         )
-        
+
         notes = self.get_user_input("Enter any notes about this test (optional)")
-        
+
         # Change back to the original directory
         os.chdir("../..")
-        
+
         self.record_result("Test Command", command, result, notes)
-    
+
     def test_code_command(self):
         """Test the code command."""
         self.print_step(5, "Testing the code command")
-        
+
         # Change to the test directory
         os.chdir(self.test_dir / "test_project")
-        
+
         command = "devsynth code"
         print(f"Running command: {command}")
-        
+
         returncode, stdout, stderr = self.run_command(command)
-        
+
         print("\nOutput:")
         print(stdout)
-        
+
         if stderr:
             print("\nErrors:")
             print(stderr)
-        
+
         # Check if code files were created
         code_created = Path("./src").exists()
-        
+
         if code_created:
             print("\nCode files were created successfully.")
             # List the code files
@@ -338,75 +339,68 @@ class CLIWorkflowTester:
                 print(f"- {code_file}")
         else:
             print("\nCode files were NOT created.")
-        
+
         result = self.get_user_input(
-            "Did the code command work as expected?",
-            options=["pass", "fail"]
+            "Did the code command work as expected?", options=["pass", "fail"]
         )
-        
+
         notes = self.get_user_input("Enter any notes about this test (optional)")
-        
+
         # Change back to the original directory
         os.chdir("../..")
-        
+
         self.record_result("Code Command", command, result, notes)
-    
+
     def test_run_command(self):
-        """Test the run command."""
+        """Test running the generated test suite."""
         self.print_step(6, "Testing the run command")
-        
+
         # Change to the test directory
         os.chdir(self.test_dir / "test_project")
-        
-        command = "devsynth run --target unit-tests"
-        print(f"Running command: {command}")
-        
-        returncode, stdout, stderr = self.run_command(command)
-        
+
+        print("Running unit tests...")
+        success, output = run_tests("unit-tests")
+
         print("\nOutput:")
-        print(stdout)
-        
-        if stderr:
-            print("\nErrors:")
-            print(stderr)
-        
+        print(output)
+
         result = self.get_user_input(
-            "Did the run command work as expected?",
-            options=["pass", "fail"]
+            "Did the run command work as expected?", options=["pass", "fail"]
         )
-        
+
         notes = self.get_user_input("Enter any notes about this test (optional)")
-        
+
         # Change back to the original directory
         os.chdir("../..")
-        
-        self.record_result("Run Command", command, result, notes)
-    
+
+        self.record_result("Run Command", "run_tests('unit-tests')", result, notes)
+
     def test_config_command(self):
         """Test the config command."""
         self.print_step(7, "Testing the config command")
-        
+
         # Change to the test directory
         os.chdir(self.test_dir / "test_project")
-        
+
         command = "devsynth config --key model --value gpt-4"
         print(f"Running command: {command}")
-        
+
         returncode, stdout, stderr = self.run_command(command)
-        
+
         print("\nOutput:")
         print(stdout)
-        
+
         if stderr:
             print("\nErrors:")
             print(stderr)
-        
+
         # Check if the config was updated
         config_updated = False
         config_file = Path("./.devsynth/config.json")
-        
+
         if config_file.exists():
             import json
+
             try:
                 with open(config_file, "r") as f:
                     config = json.load(f)
@@ -416,27 +410,26 @@ class CLIWorkflowTester:
                         print(f"Current config: {config}")
             except Exception as e:
                 print(f"\nError reading config file: {e}")
-        
+
         if not config_updated:
             print("\nConfig was NOT updated.")
-        
+
         result = self.get_user_input(
-            "Did the config command work as expected?",
-            options=["pass", "fail"]
+            "Did the config command work as expected?", options=["pass", "fail"]
         )
-        
+
         notes = self.get_user_input("Enter any notes about this test (optional)")
-        
+
         # Change back to the original directory
         os.chdir("../..")
-        
+
         self.record_result("Config Command", command, result, notes)
-    
+
     def run_all_tests(self):
         """Run all CLI workflow tests."""
         print("Starting DevSynth CLI Workflow Tests")
         print(f"Results will be saved to {self.output_file}")
-        
+
         try:
             self.test_help_command()
             self.test_init_command()
@@ -445,9 +438,9 @@ class CLIWorkflowTester:
             self.test_code_command()
             self.test_run_command()
             self.test_config_command()
-            
+
             # Additional tests can be added here
-            
+
             self.save_results()
         finally:
             self.cleanup()
@@ -459,14 +452,14 @@ def main():
     parser.add_argument(
         "--output",
         default="cli_test_results.md",
-        help="Output file for test results (default: cli_test_results.md)"
+        help="Output file for test results (default: cli_test_results.md)",
     )
-    
+
     args = parser.parse_args()
-    
+
     tester = CLIWorkflowTester(args.output)
     tester.run_all_tests()
-    
+
     return 0
 
 

--- a/scripts/run_all_tests.py
+++ b/scripts/run_all_tests.py
@@ -1,348 +1,96 @@
 #!/usr/bin/env python3
-"""
-Script to execute all unit, integration, and behavior tests for DevSynth.
+"""Script to execute DevSynth tests.
 
-This script runs all tests and generates a comprehensive report of the results.
-It's part of the Phase 4 comprehensive testing effort.
+This script wraps the shared :func:`devsynth.testing.run_tests` helper and
+provides a command line interface similar to the DevSynth CLI.
 
 Usage:
-    python scripts/run_all_tests.py [--unit] [--integration] [--behavior] [--all]
+    python scripts/run_all_tests.py [--target TARGET]
                                    [--fast] [--medium] [--slow]
-
-Options:
-    --unit        Run only unit tests
-    --integration Run only integration tests
-    --behavior    Run only behavior tests
-    --all         Run all tests (default)
-    --fast        Run only fast tests (execution time < 1s)
-    --medium      Run only medium tests (execution time between 1s and 5s)
-    --slow        Run only slow tests (execution time > 5s)
-    --report      Generate HTML report
-    --verbose     Show verbose output
-    --no-parallel Disable parallel test execution
-    --segment     Run tests in smaller batches to improve performance
-    --segment-size SIZE  Number of tests per batch when using --segment (default: 50)
+                                   [--report] [--verbose]
+                                   [--no-parallel] [--segment]
+                                   [--segment-size SIZE]
 """
 
 import argparse
-import subprocess
 import sys
-import os
 import time
-import json
-from datetime import datetime
-from pathlib import Path
 
-# Cache directory for test collection
-COLLECTION_CACHE_DIR = ".test_collection_cache"
+from devsynth.testing.run_tests import run_tests
 
 
 def parse_args():
     """Parse command line arguments."""
     parser = argparse.ArgumentParser(description="Run DevSynth tests")
-    
-    # Test type group
-    type_group = parser.add_argument_group("Test Type")
-    type_group.add_argument("--unit", action="store_true", help="Run only unit tests")
-    type_group.add_argument(
-        "--integration", action="store_true", help="Run only integration tests"
+
+    parser.add_argument(
+        "--target",
+        choices=["unit-tests", "integration-tests", "behavior-tests", "all-tests"],
+        help="Test target to run",
     )
-    type_group.add_argument(
-        "--behavior", action="store_true", help="Run only behavior tests"
-    )
-    type_group.add_argument("--all", action="store_true", help="Run all tests (default)")
-    
-    # Speed category group
+    # Backwards compatibility flags
+    parser.add_argument("--unit", action="store_true", help=argparse.SUPPRESS)
+    parser.add_argument("--integration", action="store_true", help=argparse.SUPPRESS)
+    parser.add_argument("--behavior", action="store_true", help=argparse.SUPPRESS)
+    parser.add_argument("--all", action="store_true", help=argparse.SUPPRESS)
+
     speed_group = parser.add_argument_group("Speed Category")
     speed_group.add_argument(
         "--fast", action="store_true", help="Run only fast tests (execution time < 1s)"
     )
     speed_group.add_argument(
-        "--medium", action="store_true", 
-        help="Run only medium tests (execution time between 1s and 5s)"
+        "--medium",
+        action="store_true",
+        help="Run only medium tests (execution time between 1s and 5s)",
     )
     speed_group.add_argument(
         "--slow", action="store_true", help="Run only slow tests (execution time > 5s)"
     )
-    
-    # Output options
+
     parser.add_argument("--report", action="store_true", help="Generate HTML report")
     parser.add_argument("--verbose", action="store_true", help="Show verbose output")
-    
-    # Performance options
+
     parser.add_argument(
         "--no-parallel", action="store_true", help="Disable parallel test execution"
     )
     parser.add_argument(
-        "--segment", action="store_true", 
-        help="Run tests in smaller batches to improve performance"
+        "--segment",
+        action="store_true",
+        help="Run tests in smaller batches to improve performance",
     )
     parser.add_argument(
-        "--segment-size", type=int, default=50,
-        help="Number of tests per batch when using --segment (default: 50)"
+        "--segment-size",
+        type=int,
+        default=50,
+        help="Number of tests per batch when using segmentation",
     )
 
     args = parser.parse_args()
 
-    # If no test type is specified, run all tests
-    if not (args.unit or args.integration or args.behavior or args.all):
-        args.all = True
-        
-    # If no speed category is specified, run all speed categories
+    if not args.target:
+        targets = []
+        if args.unit:
+            targets.append("unit-tests")
+        if args.integration:
+            targets.append("integration-tests")
+        if args.behavior:
+            targets.append("behavior-tests")
+        if args.all or not targets:
+            targets = ["all-tests"]
+        args.targets = targets
+    else:
+        args.targets = [args.target]
+
     if not (args.fast or args.medium or args.slow):
         args.fast = args.medium = args.slow = True
 
     return args
 
 
-def collect_tests_with_cache(test_type, speed_category=None):
-    """
-    Collect tests of the specified type and speed category, using cache when available.
-
-    Args:
-        test_type (str): Type of tests to run ('unit', 'integration', 'behavior', or 'all')
-        speed_category (str): Speed category to run ('fast', 'medium', 'slow')
-
-    Returns:
-        list: List of test paths
-    """
-    # Determine test path
-    if test_type == "unit":
-        test_path = "tests/unit/"
-    elif test_type == "integration":
-        test_path = "tests/integration/"
-    elif test_type == "behavior":
-        test_path = "tests/behavior/"
-    elif test_type == "all":
-        test_path = "tests/"
-    
-    # Create cache key
-    cache_key = f"{test_type}_{speed_category or 'all'}"
-    cache_file = os.path.join(COLLECTION_CACHE_DIR, f"{cache_key}_tests.json")
-    
-    # Check if we have a cached collection
-    if os.path.exists(cache_file):
-        try:
-            with open(cache_file, "r") as f:
-                cached_data = json.load(f)
-            
-            # Use cache if it's less than 1 hour old
-            cache_time = datetime.fromisoformat(cached_data["timestamp"])
-            if (datetime.now() - cache_time).total_seconds() < 3600:  # 1 hour
-                print(f"Using cached test collection for {test_type} tests ({speed_category or 'all'})")
-                return cached_data["tests"]
-        except (json.JSONDecodeError, KeyError):
-            # Invalid cache, ignore and collect tests
-            pass
-    
-    # Ensure cache directory exists
-    os.makedirs(COLLECTION_CACHE_DIR, exist_ok=True)
-    
-    # Collect tests using pytest
-    collect_cmd = [
-        sys.executable, "-m", "pytest",
-        test_path,
-        "--collect-only",
-        "-q"
-    ]
-    
-    # Special handling for behavior tests - don't filter by speed marker if they're not categorized yet
-    if test_type == "behavior" and speed_category:
-        # Check if there are any behavior tests with speed markers
-        check_cmd = collect_cmd.copy() + ["-m", speed_category]
-        check_result = subprocess.run(check_cmd, check=False, capture_output=True, text=True)
-        
-        # If no tests are found with the speed marker, collect all behavior tests
-        if "no tests ran" in check_result.stdout or not check_result.stdout.strip():
-            print(f"No behavior tests found with {speed_category} marker. Collecting all behavior tests...")
-            # Don't add speed marker to collect command
-        else:
-            # Add speed marker to collect command
-            collect_cmd.extend(["-m", speed_category])
-    elif speed_category:
-        # For unit and integration tests, use speed markers as normal
-        collect_cmd.extend(["-m", speed_category])
-    
-    try:
-        collect_result = subprocess.run(collect_cmd, check=False, capture_output=True, text=True)
-        test_list = []
-        
-        # Parse the output to get the list of tests
-        for line in collect_result.stdout.split('\n'):
-            if line.startswith('tests/'):
-                test_list.append(line.strip())
-        
-        # Cache the results
-        cache_data = {
-            "timestamp": datetime.now().isoformat(),
-            "tests": test_list
-        }
-        with open(cache_file, "w") as f:
-            json.dump(cache_data, f, indent=2)
-        
-        return test_list
-    except Exception as e:
-        print(f"Error collecting tests: {e}")
-        return []
-
-
-def run_tests(test_type, speed_categories=None, verbose=False, report=False, 
-             parallel=True, segment=False, segment_size=50):
-    """
-    Run tests of the specified type and speed categories.
-
-    Args:
-        test_type (str): Type of tests to run ('unit', 'integration', 'behavior', or 'all')
-        speed_categories (list): List of speed categories to run ('fast', 'medium', 'slow')
-        verbose (bool): Whether to show verbose output
-        report (bool): Whether to generate an HTML report
-        parallel (bool): Whether to run tests in parallel using pytest-xdist
-        segment (bool): Whether to run tests in smaller batches
-        segment_size (int): Number of tests per batch when using segmentation
-
-    Returns:
-        tuple: (success, output) where success is a boolean indicating if all tests passed
-               and output is the command output
-    """
-    print(f"\n{'='*80}")
-    print(f"Running {test_type} tests with speed categories: {speed_categories or 'all'}...")
-    print(f"{'='*80}")
-
-    # Base command
-    base_cmd = [sys.executable, "-m", "pytest"]
-
-    # Determine test path
-    if test_type == "unit":
-        test_path = "tests/unit/"
-    elif test_type == "integration":
-        test_path = "tests/integration/"
-    elif test_type == "behavior":
-        test_path = "tests/behavior/"
-    elif test_type == "all":
-        test_path = "tests/"
-    
-    # Add test path to base command
-    base_cmd.append(test_path)
-
-    # Add verbose flag if requested
-    if verbose:
-        base_cmd.append("-v")
-        
-    # Add parallel execution if requested
-    if parallel:
-        base_cmd.append("-n")
-        base_cmd.append("auto")  # Use auto to determine the optimal number of processes
-
-    # Add report options if requested
-    report_options = []
-    if report:
-        timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
-        report_dir = Path(f"test_reports/{timestamp}/{test_type}")
-        report_dir.parent.mkdir(parents=True, exist_ok=True)
-
-        # Add HTML report options
-        report_options = [
-            f"--html=test_reports/{timestamp}/{test_type}/report.html",
-            "--self-contained-html",
-        ]
-
-    # If no speed categories specified, run all tests
-    if not speed_categories:
-        cmd = base_cmd + report_options
-        
-        # Run the tests
-        try:
-            result = subprocess.run(cmd, check=False, capture_output=True, text=True)
-            print(result.stdout)
-            if result.stderr:
-                print("ERRORS:")
-                print(result.stderr)
-
-            success = result.returncode == 0
-            return success, result.stdout + result.stderr
-        except Exception as e:
-            print(f"Error running tests: {e}")
-            return False, str(e)
-    
-    # Run tests for each speed category
-    all_success = True
-    all_output = ""
-    
-    for speed in speed_categories:
-        print(f"\nRunning {speed} tests...")
-        
-        # Special handling for behavior tests - don't filter by speed marker if they're not categorized yet
-        if test_type == "behavior":
-            # Check if there are any behavior tests with speed markers
-            has_speed_markers = False
-            check_cmd = base_cmd + ["-m", speed, "--collect-only", "-q"]
-            check_result = subprocess.run(check_cmd, check=False, capture_output=True, text=True)
-            
-            # If no tests are found with the speed marker, run all behavior tests
-            if "no tests ran" in check_result.stdout or not check_result.stdout.strip():
-                print(f"No behavior tests found with {speed} marker. Running all behavior tests...")
-                speed_cmd = base_cmd + report_options
-            else:
-                has_speed_markers = True
-                speed_cmd = base_cmd + ["-m", speed] + report_options
-        else:
-            # For unit and integration tests, use speed markers as normal
-            speed_cmd = base_cmd + ["-m", speed] + report_options
-        
-        if segment:
-            # Collect tests with caching
-            test_list = collect_tests_with_cache(test_type, speed)
-            
-            if not test_list:
-                print(f"No {speed} tests found for {test_type}")
-                continue
-            
-            print(f"Found {len(test_list)} {speed} tests, running in batches of {segment_size}...")
-            
-            # Run tests in batches
-            batch_success = True
-            for i in range(0, len(test_list), segment_size):
-                batch = test_list[i:i+segment_size]
-                print(f"\nRunning batch {i//segment_size + 1}/{(len(test_list) + segment_size - 1)//segment_size}...")
-                
-                # Create command for this batch
-                batch_cmd = base_cmd + ["-m", speed] + batch + report_options
-                
-                # Run the batch
-                batch_result = subprocess.run(batch_cmd, check=False, capture_output=True, text=True)
-                print(batch_result.stdout)
-                if batch_result.stderr:
-                    print("ERRORS:")
-                    print(batch_result.stderr)
-                
-                batch_success = batch_success and batch_result.returncode == 0
-                all_output += batch_result.stdout + batch_result.stderr
-            
-            all_success = all_success and batch_success
-        else:
-            # Run all tests for this speed category at once
-            try:
-                result = subprocess.run(speed_cmd, check=False, capture_output=True, text=True)
-                print(result.stdout)
-                if result.stderr:
-                    print("ERRORS:")
-                    print(result.stderr)
-                
-                all_success = all_success and result.returncode == 0
-                all_output += result.stdout + result.stderr
-            except Exception as e:
-                print(f"Error running {speed} tests: {e}")
-                all_success = False
-                all_output += str(e)
-    
-    return all_success, all_output
-
-
-def main():
+def main() -> int:
     """Main function to run tests based on command line arguments."""
     args = parse_args()
 
-    # Ensure pytest-html is installed if report is requested
     if args.report:
         try:
             import pytest_html  # noqa: F401
@@ -353,7 +101,6 @@ def main():
             print("  poetry install --with dev,docs --all-extras")
             return 1
 
-    # Ensure pytest-xdist is installed if parallel execution is requested
     if not args.no_parallel:
         try:
             import xdist  # noqa: F401
@@ -364,13 +111,7 @@ def main():
             print("  poetry install --with dev,docs --all-extras")
             return 1
 
-    all_success = True
-    results = {}
-
-    # Determine if parallel execution should be used
     parallel = not args.no_parallel
-    
-    # Determine which speed categories to run
     speed_categories = []
     if args.fast:
         speed_categories.append("fast")
@@ -378,24 +119,11 @@ def main():
         speed_categories.append("medium")
     if args.slow:
         speed_categories.append("slow")
-    
-    # Print test execution plan
+
     print("\n" + "=" * 80)
     print("TEST EXECUTION PLAN")
     print("=" * 80)
-    
-    test_types = []
-    if args.all:
-        test_types.append("all")
-    else:
-        if args.unit:
-            test_types.append("unit")
-        if args.integration:
-            test_types.append("integration")
-        if args.behavior:
-            test_types.append("behavior")
-    
-    print(f"Test Types: {', '.join(test_types)}")
+    print(f"Targets: {', '.join(args.targets)}")
     print(f"Speed Categories: {', '.join(speed_categories)}")
     print(f"Parallel Execution: {'Disabled' if args.no_parallel else 'Enabled'}")
     print(f"Test Segmentation: {'Enabled' if args.segment else 'Disabled'}")
@@ -403,82 +131,53 @@ def main():
         print(f"Segment Size: {args.segment_size}")
     print(f"Report Generation: {'Enabled' if args.report else 'Disabled'}")
     print(f"Verbose Output: {'Enabled' if args.verbose else 'Disabled'}")
-    
+
     start_time = time.time()
-    
-    # Run the specified tests
-    if args.all or args.unit:
-        unit_success, unit_output = run_tests(
-            "unit", 
-            speed_categories, 
-            args.verbose, 
-            args.report, 
-            parallel,
-            args.segment,
-            args.segment_size
-        )
-        all_success = all_success and unit_success
-        results["unit"] = unit_success
+    overall_success = True
+    results = {}
 
-    if args.all or args.integration:
-        integration_success, integration_output = run_tests(
-            "integration", 
-            speed_categories, 
-            args.verbose, 
-            args.report, 
+    for target in args.targets:
+        success, _ = run_tests(
+            target,
+            speed_categories,
+            args.verbose,
+            args.report,
             parallel,
             args.segment,
-            args.segment_size
+            args.segment_size,
         )
-        all_success = all_success and integration_success
-        results["integration"] = integration_success
-
-    if args.all or args.behavior:
-        behavior_success, behavior_output = run_tests(
-            "behavior", 
-            speed_categories, 
-            args.verbose, 
-            args.report, 
-            parallel,
-            args.segment,
-            args.segment_size
-        )
-        all_success = all_success and behavior_success
-        results["behavior"] = behavior_success
+        overall_success = overall_success and success
+        results[target] = success
 
     end_time = time.time()
     execution_time = end_time - start_time
-    
-    # Print summary
+
     print("\n" + "=" * 80)
     print("TEST SUMMARY")
     print("=" * 80)
-    for test_type, success in results.items():
+    for target, success in results.items():
         status = "PASSED" if success else "FAILED"
-        print(f"{test_type.upper()} TESTS: {status}")
+        print(f"{target.upper()}: {status}")
 
-    print("\nOVERALL STATUS:", "PASSED" if all_success else "FAILED")
-    print(f"EXECUTION TIME: {execution_time:.2f} seconds ({execution_time/60:.2f} minutes)")
+    print(f"\nOVERALL STATUS: {'PASSED' if overall_success else 'FAILED'}")
+    print(
+        f"EXECUTION TIME: {execution_time:.2f} seconds ({execution_time/60:.2f} minutes)"
+    )
 
-    if args.report:
-        print(
-            f"\nTest reports generated in test_reports/{datetime.now().strftime('%Y%m%d_%H%M%S')}/"
-        )
-
-    # Print tips for faster test execution
-    if execution_time > 60:  # If tests took more than a minute
+    if execution_time > 60:
         print("\nTips for faster test execution:")
         if not args.fast and not args.medium:
             print("- Run only fast tests during development: --fast")
         if not args.segment:
             print("- Enable test segmentation: --segment")
-        if args.all:
-            print("- Run only specific test types: --unit, --integration, or --behavior")
+        if args.targets == ["all-tests"]:
+            print(
+                "- Run only specific test types with --target (unit-tests, integration-tests, behavior-tests)"
+            )
         if not parallel:
             print("- Enable parallel execution (if disabled): remove --no-parallel")
 
-    # Return appropriate exit code
-    return 0 if all_success else 1
+    return 0 if overall_success else 1
 
 
 if __name__ == "__main__":

--- a/src/devsynth/testing/__init__.py
+++ b/src/devsynth/testing/__init__.py
@@ -1,0 +1,1 @@
+"""Testing utilities for DevSynth."""

--- a/src/devsynth/testing/run_tests.py
+++ b/src/devsynth/testing/run_tests.py
@@ -1,0 +1,225 @@
+"""Shared pytest runner for DevSynth scripts and utilities.
+
+This module provides a :func:`run_tests` function that executes pytest with
+options compatible with DevSynth's CLI test commands. It is intended to be
+reused by helper scripts such as ``scripts/run_all_tests.py`` and
+``scripts/manual_cli_testing.py``.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from datetime import datetime
+from pathlib import Path
+from typing import List, Optional, Sequence, Tuple
+
+# Cache directory for test collection
+COLLECTION_CACHE_DIR = ".test_collection_cache"
+
+# Mapping of CLI targets to test paths
+TARGET_PATHS = {
+    "unit-tests": "tests/unit/",
+    "integration-tests": "tests/integration/",
+    "behavior-tests": "tests/behavior/",
+    "all-tests": "tests/",
+}
+
+
+def collect_tests_with_cache(
+    target: str, speed_category: Optional[str] = None
+) -> List[str]:
+    """Collect tests for the given target and speed category.
+
+    Results are cached for a short period to speed up repeated collections.
+
+    Args:
+        target: Test target (e.g. ``unit-tests`` or ``integration-tests``).
+        speed_category: Optional speed marker to filter tests.
+
+    Returns:
+        A list of test paths matching the criteria.
+    """
+    test_path = TARGET_PATHS.get(target, TARGET_PATHS["all-tests"])
+
+    cache_key = f"{target}_{speed_category or 'all'}"
+    cache_file = os.path.join(COLLECTION_CACHE_DIR, f"{cache_key}_tests.json")
+
+    if os.path.exists(cache_file):
+        try:
+            with open(cache_file, "r") as f:
+                cached_data = json.load(f)
+            cache_time = datetime.fromisoformat(cached_data["timestamp"])
+            if (datetime.now() - cache_time).total_seconds() < 3600:
+                print(
+                    f"Using cached test collection for {target} ({speed_category or 'all'})"
+                )
+                return cached_data["tests"]
+        except (json.JSONDecodeError, KeyError):
+            pass
+
+    os.makedirs(COLLECTION_CACHE_DIR, exist_ok=True)
+
+    collect_cmd = [
+        sys.executable,
+        "-m",
+        "pytest",
+        test_path,
+        "--collect-only",
+        "-q",
+    ]
+
+    if target == "behavior-tests" and speed_category:
+        check_cmd = collect_cmd + ["-m", speed_category]
+        check_result = subprocess.run(
+            check_cmd, check=False, capture_output=True, text=True
+        )
+        if "no tests ran" not in check_result.stdout and check_result.stdout.strip():
+            collect_cmd.extend(["-m", speed_category])
+    elif speed_category:
+        collect_cmd.extend(["-m", speed_category])
+
+    try:
+        collect_result = subprocess.run(
+            collect_cmd, check=False, capture_output=True, text=True
+        )
+        test_list = [
+            line.strip()
+            for line in collect_result.stdout.split("\n")
+            if line.startswith("tests/")
+        ]
+
+        cache_data = {"timestamp": datetime.now().isoformat(), "tests": test_list}
+        with open(cache_file, "w") as f:
+            json.dump(cache_data, f, indent=2)
+
+        return test_list
+    except Exception as exc:  # pragma: no cover - defensive
+        print(f"Error collecting tests: {exc}")
+        return []
+
+
+def run_tests(
+    target: str,
+    speed_categories: Optional[Sequence[str]] = None,
+    verbose: bool = False,
+    report: bool = False,
+    parallel: bool = True,
+    segment: bool = False,
+    segment_size: int = 50,
+) -> Tuple[bool, str]:
+    """Execute pytest for the specified target.
+
+    Args:
+        target: Test target (``unit-tests``, ``integration-tests``,
+            ``behavior-tests`` or ``all-tests``).
+        speed_categories: Optional sequence of speed markers to run
+            (``fast``, ``medium``, ``slow``). If ``None`` all tests are run.
+        verbose: Whether to show verbose output.
+        report: Whether to generate an HTML report.
+        parallel: Run tests in parallel using ``pytest-xdist``.
+        segment: Run tests in smaller batches for large suites.
+        segment_size: Number of tests per batch when ``segment`` is ``True``.
+
+    Returns:
+        A tuple of ``(success, output)`` where ``success`` indicates whether all
+        tests passed and ``output`` contains combined stdout/stderr.
+    """
+    print(f"\n{'=' * 80}")
+    print(f"Running {target} with speed categories: {speed_categories or 'all'}...")
+    print(f"{'=' * 80}")
+
+    base_cmd = [sys.executable, "-m", "pytest"]
+    test_path = TARGET_PATHS.get(target, TARGET_PATHS["all-tests"])
+    base_cmd.append(test_path)
+
+    if verbose:
+        base_cmd.append("-v")
+    if parallel:
+        base_cmd += ["-n", "auto"]
+
+    report_options: List[str] = []
+    if report:
+        timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+        report_dir = Path(f"test_reports/{timestamp}/{target}")
+        report_dir.mkdir(parents=True, exist_ok=True)
+        report_options = [
+            f"--html={report_dir}/report.html",
+            "--self-contained-html",
+        ]
+        print(f"Report will be saved to {report_dir}/report.html")
+
+    if not speed_categories:
+        cmd = base_cmd + report_options
+        try:
+            result = subprocess.run(cmd, check=False, capture_output=True, text=True)
+            output = result.stdout + result.stderr
+            print(result.stdout)
+            if result.stderr:
+                print("ERRORS:")
+                print(result.stderr)
+            return result.returncode == 0, output
+        except Exception as exc:  # pragma: no cover - defensive
+            print(f"Error running tests: {exc}")
+            return False, str(exc)
+
+    all_success = True
+    all_output = ""
+
+    for speed in speed_categories:
+        print(f"\nRunning {speed} tests...")
+        if target == "behavior-tests":
+            check_cmd = base_cmd + ["-m", speed, "--collect-only", "-q"]
+            check_result = subprocess.run(
+                check_cmd, check=False, capture_output=True, text=True
+            )
+            if "no tests ran" in check_result.stdout or not check_result.stdout.strip():
+                print(
+                    f"No behavior tests found with {speed} marker. Running all behavior tests..."
+                )
+                speed_cmd = base_cmd + report_options
+            else:
+                speed_cmd = base_cmd + ["-m", speed] + report_options
+        else:
+            speed_cmd = base_cmd + ["-m", speed] + report_options
+
+        if segment:
+            test_list = collect_tests_with_cache(target, speed)
+            if not test_list:
+                print(f"No {speed} tests found for {target}")
+                continue
+
+            print(
+                f"Found {len(test_list)} {speed} tests, running in batches of {segment_size}..."
+            )
+            batch_success = True
+            for i in range(0, len(test_list), segment_size):
+                batch = test_list[i : i + segment_size]
+                print(
+                    f"\nRunning batch {i // segment_size + 1}/{(len(test_list) + segment_size - 1) // segment_size}..."
+                )
+                batch_cmd = base_cmd + ["-m", speed] + batch + report_options
+                batch_result = subprocess.run(
+                    batch_cmd, check=False, capture_output=True, text=True
+                )
+                print(batch_result.stdout)
+                if batch_result.stderr:
+                    print("ERRORS:")
+                    print(batch_result.stderr)
+                batch_success = batch_success and batch_result.returncode == 0
+                all_output += batch_result.stdout + batch_result.stderr
+            all_success = all_success and batch_success
+        else:
+            result = subprocess.run(
+                speed_cmd, check=False, capture_output=True, text=True
+            )
+            print(result.stdout)
+            if result.stderr:
+                print("ERRORS:")
+                print(result.stderr)
+            all_success = all_success and result.returncode == 0
+            all_output += result.stdout + result.stderr
+
+    return all_success, all_output

--- a/tests/README.md
+++ b/tests/README.md
@@ -302,9 +302,9 @@ required plugins to be installed via Poetry. Invoke it from the Poetry
 environment to run the full suite or selected groups:
 
 ```bash
-poetry run python scripts/run_all_tests.py           # run all tests
-poetry run python scripts/run_all_tests.py --unit    # run only unit tests
-poetry run python scripts/run_all_tests.py --report  # generate HTML report under test_reports/
+poetry run python scripts/run_all_tests.py                     # run all tests
+poetry run python scripts/run_all_tests.py --target unit-tests  # run only unit tests
+poetry run python scripts/run_all_tests.py --report             # generate HTML report under test_reports/
 ```
 
 ## Referencing Requirements in Tests


### PR DESCRIPTION
## Summary
- add shared `run_tests` utility under `devsynth.testing` to execute pytest with caching, speed markers and reports
- update `run_all_tests.py` to delegate to the new runner and expose a `--target` flag matching DevSynth test targets
- call the shared runner from `manual_cli_testing.py` and refresh docs for new CLI usage

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests'; No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_688fc332c81c8333aee49b344cc68980