### PR TITLE
Add Dear PyGUI scenario for UXBridge

### DIFF
--- a/tests/behavior/features/general/uxbridge.feature
+++ b/tests/behavior/features/general/uxbridge.feature
@@ -17,3 +17,8 @@ Feature: UXBridge Interface
     Given the Agent API is used
     When a workflow requires confirmation
     Then the choice is confirmed through the bridge
+
+  Scenario: Dear PyGUI prompts the user
+    Given Dear PyGUI is running
+    When a workflow asks a question in Dear PyGUI
+    Then the user is prompted through Dear PyGUI


### PR DESCRIPTION
## Summary
- add behavior test scenario showing user prompts via Dear PyGUI
- implement mocked Dear PyGUI bridge and steps for prompting

## Testing
- `poetry run pytest tests/behavior/test_uxbridge.py --maxfail=1 -q`
- `poetry run pytest --maxfail=1` *(fails: IndentationError in tests/unit/application/cli/test_init_cmd.py)*

------
https://chatgpt.com/codex/tasks/task_e_688fc5ff94a08333a991f17c4c6b8a43