### PR TITLE
feat: add security audit CLI command

### DIFF
--- a/docs/policies/security.md
+++ b/docs/policies/security.md
@@ -58,13 +58,13 @@ export DEVSYNTH_ACCESS_TOKEN=my-secret-token
 
 DevSynth automates routine security checks to prevent regressions:
 
-- `scripts/security_audit.py` performs dependency vulnerability scans, Bandit
-  static analysis, and verifies required security environment variables such as
-  `DEVSYNTH_ACCESS_TOKEN`.
-- The script exits with a non‑zero status if any check fails, which blocks CI
+- The `security-audit` CLI command performs dependency vulnerability scans,
+  Bandit static analysis, and verifies required security environment variables
+  such as `DEVSYNTH_ACCESS_TOKEN`.
+- The command exits with a non‑zero status if any check fails, which blocks CI
   pipelines and deployment.
-- Developers should run `python scripts/security_audit.py` locally before
-  committing changes to catch issues early.
+- Developers should run `devsynth security-audit` locally before committing
+  changes to catch issues early.
 
 ## Incident Response Procedures
 
@@ -78,7 +78,7 @@ python scripts/security_incident_response.py --collect-logs --audit --output inc
 ```
 
 This script archives the `logs/` directory and executes the existing
-`security_audit.py` checks to aid in forensics.
+`security-audit` command to aid in forensics.
 
 ## Vulnerability Management
 
@@ -111,7 +111,8 @@ communication, bearer token authentication for API and agent actions,
 and routine dependency and static analysis checks in CI.
 ## Implementation Status
 Security configuration flags and basic encryption utilities are implemented.
-Automated audits and basic monitoring are provided via `scripts/security_audit.py`.
+Automated audits and basic monitoring are provided via the
+`security-audit` command (also available as `scripts/security_audit.py`).
 Memory stores support encryption at rest and emit audit logs for store, retrieve,
 and delete operations.
 Runtime checks in [`src/devsynth/config/settings.py`](../../src/devsynth/config/settings.py)

--- a/docs/user_guides/cli_command_reference.md
+++ b/docs/user_guides/cli_command_reference.md
@@ -770,6 +770,32 @@ devsynth generate-docs --code-dir app --output-dir api_docs
 devsynth generate-docs --format html
 ```
 
+## security-audit
+
+Run dependency and static analysis security checks.
+
+**Usage:**
+
+```bash
+devsynth security-audit [OPTIONS]
+```
+
+**Options:**
+| Option | Description |
+|--------|-------------|
+| `--skip-static` | Skip running Bandit static analysis |
+
+**Examples:**
+
+```bash
+
+# Run full security audit
+devsynth security-audit
+
+# Run audit without static analysis
+devsynth security-audit --skip-static
+```
+
 ## Environment Variables
 
 DevSynth respects the following environment variables:

--- a/scripts/security_audit.py
+++ b/scripts/security_audit.py
@@ -40,10 +40,9 @@ def main() -> None:
     )
     args = parser.parse_args()
 
-    check_required_env()
-    run_safety()
-    if not args.skip_static:
-        run_bandit()
+    from devsynth.application.cli.commands.security_audit_cmd import security_audit_cmd
+
+    security_audit_cmd(skip_static=args.skip_static)
 
 
 if __name__ == "__main__":

--- a/src/devsynth/adapters/cli/typer_adapter.py
+++ b/src/devsynth/adapters/cli/typer_adapter.py
@@ -48,6 +48,7 @@ from devsynth.application.cli.commands.validate_metadata_cmd import (
 )
 from devsynth.application.cli.commands.test_metrics_cmd import test_metrics_cmd
 from devsynth.application.cli.commands.generate_docs_cmd import generate_docs_cmd
+from devsynth.application.cli.commands.security_audit_cmd import security_audit_cmd
 from devsynth.application.cli.requirements_commands import requirements_app
 
 logger = DevSynthLogger(__name__)
@@ -448,6 +449,10 @@ def build_app() -> typer.Typer:
         name="generate-docs",
         help="Generate API docs. Example: devsynth generate-docs",
     )(generate_docs_cmd)
+    app.command(
+        name="security-audit",
+        help="Run security checks. Example: devsynth security-audit --skip-static",
+    )(security_audit_cmd)
     app.command(
         name="ingest",
         help="Ingest a project. Example: devsynth ingest manifest.yaml",

--- a/src/devsynth/application/cli/commands/security_audit_cmd.py
+++ b/src/devsynth/application/cli/commands/security_audit_cmd.py
@@ -1,0 +1,62 @@
+"""CLI command to run DevSynth security audits.
+
+Wraps dependency vulnerability scanning and optional static code
+analysis. This command mirrors the behaviour of ``scripts/security_audit.py``
+so that the audit can be executed via the ``devsynth`` CLI.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from typing import Optional
+
+from devsynth.interface.cli import CLIUXBridge
+from devsynth.interface.ux_bridge import UXBridge
+from devsynth.logging_setup import DevSynthLogger
+
+logger = DevSynthLogger(__name__)
+bridge: UXBridge = CLIUXBridge()
+
+REQUIRED_ENV_VARS = ["DEVSYNTH_ACCESS_TOKEN"]
+
+
+def run_safety() -> None:
+    """Run dependency vulnerability scan using safety."""
+    subprocess.check_call(["python", "scripts/dependency_safety_check.py"])
+
+
+def run_bandit() -> None:
+    """Run Bandit static analysis over the src directory."""
+    subprocess.check_call(["bandit", "-r", "src", "-ll"])
+
+
+def check_required_env() -> None:
+    """Ensure required security environment variables are set."""
+    missing = [name for name in REQUIRED_ENV_VARS if not os.getenv(name)]
+    if missing:
+        raise RuntimeError(
+            f"Missing required environment variables: {', '.join(missing)}"
+        )
+
+
+def security_audit_cmd(
+    skip_static: bool = False, *, bridge: Optional[UXBridge] = None
+) -> None:
+    """Execute security audits and monitoring checks.
+
+    Example:
+        ``devsynth security-audit --skip-static``
+
+    Args:
+        skip_static: Skip running Bandit static analysis when ``True``.
+        bridge: Optional UX bridge for user feedback.
+    """
+    bridge = bridge or globals()["bridge"]
+
+    bridge.display_result("[blue]Running security audit checks...[/blue]")
+    check_required_env()
+    run_safety()
+    if not skip_static:
+        run_bandit()
+    bridge.display_result("[green]Security audit completed successfully.[/green]")

--- a/tests/behavior/steps/test_user_guide_enhancement_steps.py
+++ b/tests/behavior/steps/test_user_guide_enhancement_steps.py
@@ -49,7 +49,7 @@ def all_cli_commands_documented(context):
         "init", "spec", "test", "code", "run-pipeline", "config", "gather", "inspect", 
         "refactor", "webapp", "serve", "dbschema", "webui", "doctor", "edrr-cycle", 
         "align", "alignment-metrics", "inspect-config", "validate-manifest", 
-        "validate-metadata", "test-metrics", "generate-docs"
+        "validate-metadata", "test-metrics", "generate-docs", "security-audit"
     ]
 
     for command in expected_commands:


### PR DESCRIPTION
## Summary
- add `security_audit_cmd` for running dependency and static security checks
- expose `devsynth security-audit` via Typer CLI
- document the new security audit command and reference it in policies

## Testing
- `pytest tests/unit/security/test_security_audit.py tests/unit/scripts/test_security_ops.py -q` *(fails: No module named 'tiktoken')*


------
https://chatgpt.com/codex/tasks/task_e_688fc9de85a48333ae73af4ad96f8c4a