### PR TITLE
chore: add devsynth alignment pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,11 @@
 repos:
+- repo: local
+  hooks:
+    - id: devsynth-align
+      name: devsynth align
+      entry: devsynth align --quiet
+      language: system
+      pass_filenames: false
 - repo: https://github.com/pre-commit/pre-commit-hooks
   rev: v4.4.0
   hooks:
@@ -20,4 +27,3 @@ repos:
     - id: flake8
       additional_dependencies: [flake8-docstrings]
       args: [--exit-zero]
-

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,0 +1,6 @@
+- id: devsynth-align
+  name: devsynth align
+  description: "Check SDLC artifact alignment with devsynth"
+  entry: devsynth align --quiet
+  language: system
+  pass_filenames: false

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,7 +50,13 @@ pre-commit install
 
 # Run all hooks on the current codebase
 pre-commit run --all-files
+
+# Run the alignment check manually
+pre-commit run devsynth-align --all-files
 ```
+
+The `devsynth-align` hook runs `devsynth align --quiet` and will block commits
+if alignment issues are detected.
 
 ## Testing
 


### PR DESCRIPTION
## Summary
- run `devsynth align --quiet` as a pre-commit hook
- document alignment hook usage in contributing guide

## Testing
- `poetry run pre-commit run --files .pre-commit-config.yaml .pre-commit-hooks.yaml CONTRIBUTING.md` *(fails: RuntimeError: Type not yet supported: typing.Dict[str, bool])* 
- `poetry run pytest --maxfail=1` *(fails: IndentationError: expected an indented block after 'if' statement on line 55)*

------
https://chatgpt.com/codex/tasks/task_e_688fceef235c83338957d64832e398b4