### PR TITLE
feat: add run tests tool

### DIFF
--- a/src/devsynth/agents/tools.py
+++ b/src/devsynth/agents/tools.py
@@ -2,9 +2,10 @@
 
 from __future__ import annotations
 
-from typing import Any, Callable, Dict, Optional
+from typing import Any, Callable, Dict, Optional, Sequence
 
 from devsynth.logging_setup import DevSynthLogger
+from devsynth.testing.run_tests import run_tests
 
 logger = DevSynthLogger(__name__)
 
@@ -61,3 +62,84 @@ tool_registry = _tool_registry
 def get_tool_registry() -> ToolRegistry:
     """Return the global tool registry."""
     return _tool_registry
+
+
+def run_tests_tool(
+    target: str = "unit-tests",
+    speed_categories: Optional[Sequence[str]] = None,
+    verbose: bool = False,
+    report: bool = False,
+    parallel: bool = True,
+    segment: bool = False,
+    segment_size: int = 50,
+) -> Dict[str, Any]:
+    """Execute pytest tests and return the result.
+
+    Args:
+        target: Test target to execute (e.g., ``unit-tests``).
+        speed_categories: Optional sequence of speed markers to filter tests.
+        verbose: Show verbose output when running tests.
+        report: Generate an HTML report for the test run.
+        parallel: Run tests in parallel using ``pytest-xdist``.
+        segment: Run tests in smaller batches.
+        segment_size: Number of tests per batch when ``segment`` is ``True``.
+
+    Returns:
+        A dictionary containing ``success`` (bool) and ``output`` (str).
+    """
+
+    logger.debug(
+        "Running tests with target=%s, speed_categories=%s", target, speed_categories
+    )
+    success, output = run_tests(
+        target=target,
+        speed_categories=speed_categories,
+        verbose=verbose,
+        report=report,
+        parallel=parallel,
+        segment=segment,
+        segment_size=segment_size,
+    )
+    return {"success": success, "output": output}
+
+
+_tool_registry.register(
+    "run_tests",
+    run_tests_tool,
+    description="Run the project's pytest suites and return their output.",
+    parameters={
+        "type": "object",
+        "properties": {
+            "target": {
+                "type": "string",
+                "description": "Test target to run (unit-tests, integration-tests, behavior-tests, all-tests)",
+            },
+            "speed_categories": {
+                "type": "array",
+                "items": {"type": "string"},
+                "description": "Optional speed markers to filter tests",
+            },
+            "verbose": {
+                "type": "boolean",
+                "description": "Show verbose output",
+            },
+            "report": {
+                "type": "boolean",
+                "description": "Generate an HTML report",
+            },
+            "parallel": {
+                "type": "boolean",
+                "description": "Run tests in parallel",
+            },
+            "segment": {
+                "type": "boolean",
+                "description": "Run tests in batches",
+            },
+            "segment_size": {
+                "type": "integer",
+                "description": "Batch size when segmenting tests",
+            },
+        },
+        "required": [],
+    },
+)

--- a/tests/unit/agents/test_run_tests_tool.py
+++ b/tests/unit/agents/test_run_tests_tool.py
@@ -1,0 +1,19 @@
+"""Tests for the run_tests_tool."""
+
+from unittest.mock import patch
+
+from devsynth.agents.tools import get_tool_registry, run_tests_tool
+
+
+def test_run_tests_tool_returns_structure() -> None:
+    """run_tests_tool should return a success flag and output string."""
+    with patch("devsynth.agents.tools.run_tests", return_value=(True, "ok")) as mock_run:
+        result = run_tests_tool(target="unit-tests")
+        assert result == {"success": True, "output": "ok"}
+        mock_run.assert_called_once()
+
+
+def test_run_tests_tool_registered() -> None:
+    """The tool should be registered in the global registry."""
+    registry = get_tool_registry()
+    assert registry.get("run_tests") is run_tests_tool


### PR DESCRIPTION
## Summary
- add `run_tests_tool` helper wrapping pytest runner
- register `run_tests` tool with metadata in agent tool registry
- cover new tool with unit tests verifying structure and registry

## Testing
- `pytest tests/unit/agents/test_tools.py tests/unit/agents/test_run_tests_tool.py -q -p no:tests.fixtures.ports`


------
https://chatgpt.com/codex/tasks/task_e_688fd174d4348333827c3addf2c6cf58