### PR TITLE
Refactor gather wizard state management

### DIFF
--- a/tests/unit/interface/test_webui_gather_wizard.py
+++ b/tests/unit/interface/test_webui_gather_wizard.py
@@ -1,6 +1,7 @@
 import sys
 from types import ModuleType
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
+
 import pytest
 
 
@@ -8,227 +9,131 @@ import pytest
 def stub_streamlit(monkeypatch):
     """Create a stub streamlit module for testing."""
     st = ModuleType("streamlit")
+    st.session_state = {}
     st.text_input = MagicMock(return_value="Test Input")
     st.text_area = MagicMock(return_value="Test Area")
-    st.selectbox = MagicMock(return_value="Option 1")
-    st.multiselect = MagicMock(return_value=["Option 1", "Option 2"])
-    st.checkbox = MagicMock(return_value=True)
-    st.radio = MagicMock(return_value="Option 1")
-    st.slider = MagicMock(return_value=50)
-    st.select_slider = MagicMock(return_value="Option 1")
-    st.number_input = MagicMock(return_value=42)
-    st.date_input = MagicMock()
-    st.time_input = MagicMock()
-    st.file_uploader = MagicMock()
-    st.camera_input = MagicMock()
-    st.color_picker = MagicMock(return_value="#FF0000")
+    st.selectbox = MagicMock(return_value="documentation")
     st.button = MagicMock(return_value=False)
-    
-    # Mock container and columns
-    st.container = MagicMock()
-    st.container.return_value = MagicMock()
-    st.columns = MagicMock()
-    st.columns.return_value = [MagicMock(), MagicMock(), MagicMock()]
-    
-    # Mock expander
-    st.expander = MagicMock()
-    st.expander.return_value = MagicMock()
-    st.expander.return_value.__enter__ = MagicMock()
-    st.expander.return_value.__exit__ = MagicMock()
-    
-    # Mock spinner
-    st.spinner = MagicMock()
-    st.spinner.return_value = MagicMock()
-    st.spinner.return_value.__enter__ = MagicMock()
-    st.spinner.return_value.__exit__ = MagicMock()
-    
-    # Mock progress
+    st.columns = MagicMock(return_value=[MagicMock(), MagicMock(), MagicMock()])
+    st.header = MagicMock()
+    st.write = MagicMock()
+    st.subheader = MagicMock()
     st.progress = MagicMock()
-    st.progress.return_value = MagicMock()
-    st.progress.return_value.__enter__ = MagicMock()
-    st.progress.return_value.__exit__ = MagicMock()
-    
-    # Mock form
-    st.form = MagicMock()
-    st.form.return_value.__enter__ = MagicMock()
-    st.form.return_value.__exit__ = MagicMock()
-    st.form_submit_button = MagicMock(return_value=False)
-    
-    # Mock experimental functions
+    st.spinner = MagicMock()
+    st.spinner.return_value.__enter__ = MagicMock()
+    st.spinner.return_value.__exit__ = MagicMock(return_value=False)
     st.experimental_rerun = MagicMock()
-    
-    monkeypatch.setitem(sys.modules, 'streamlit', st)
+    monkeypatch.setitem(sys.modules, "streamlit", st)
     return st
 
 
 @pytest.fixture
 def mock_gather_requirements(monkeypatch):
-    """Mock the gather_requirements function."""
-    gather_mock = MagicMock(spec=object)
-    
-    try:
-        monkeypatch.setattr('devsynth.core.workflows.gather_requirements', gather_mock)
-        # Test code here
-    except ImportError:
-        # Handle import error if needed
-        pass
-    
+    gather_mock = MagicMock()
+    monkeypatch.setattr(
+        "devsynth.core.workflows.gather_requirements", gather_mock
+    )
     return gather_mock
 
 
-@pytest.fixture
-def clean_state():
-    # Set up clean state
-    yield
-    # Clean up state
-
-
 @pytest.mark.medium
-def test_gather_wizard_button_not_clicked_succeeds(stub_streamlit, mock_gather_requirements, clean_state):
-    """Test that gather_requirements is not called when button is not clicked.
-
-    ReqID: N/A"""
+def test_gather_wizard_start_button_not_clicked(
+    stub_streamlit, mock_gather_requirements
+):
     import importlib
-    from devsynth.interface import webui
-    # Reload the module to ensure clean state
-    importlib.reload(webui)
+    import devsynth.interface.webui as webui
 
+    importlib.reload(webui)
     from devsynth.interface.webui import WebUI
+
     stub_streamlit.button.return_value = False
     WebUI()._gather_wizard()
     mock_gather_requirements.assert_not_called()
     stub_streamlit.button.assert_called_once()
-    assert 'Start Requirements Plan Wizard' in stub_streamlit.button.call_args[1]['key']
+    assert (
+        stub_streamlit.button.call_args.kwargs["key"]
+        == "start_gather_wizard_button"
+    )
 
 
 @pytest.mark.medium
-def test_gather_wizard_button_clicked_succeeds(stub_streamlit, mock_gather_requirements):
-    """Test that gather_requirements is called when button is clicked.
-
-    ReqID: N/A"""
+def test_gather_wizard_finish_calls_gather_requirements(
+    stub_streamlit, mock_gather_requirements
+):
     import importlib
     import devsynth.interface.webui as webui
+
     importlib.reload(webui)
     from devsynth.interface.webui import WebUI
-    stub_streamlit.button.return_value = True
-    webui_instance = WebUI()
-    webui_instance._gather_wizard()
-    mock_gather_requirements.assert_called_once_with(webui_instance)
-    stub_streamlit.spinner.assert_called_once()
 
-
-@pytest.mark.medium
-def test_gather_wizard_import_error_fails(stub_streamlit, monkeypatch, clean_state):
-    """Test error handling when importing gather_requirements fails.
-
-    ReqID: N/A"""
-    import importlib
-    import devsynth.interface.webui as webui
-    importlib.reload(webui)
-    from devsynth.interface.webui import WebUI
-    stub_streamlit.button.return_value = True
-    original_import = __import__
-
-    def mock_import(name, *args, **kwargs):
-        if name == 'devsynth.core.workflows':
-            raise ImportError('Test import error')
-        return original_import(name, *args, **kwargs)
-    monkeypatch.setattr('builtins.__import__', mock_import)
-    webui_instance = WebUI()
-    webui_instance.display_result = MagicMock()
-    webui_instance._gather_wizard()
-    webui_instance.display_result.assert_called_once()
-    assert 'ERROR' in webui_instance.display_result.call_args[0][0]
-
-
-@pytest.mark.medium
-def test_gather_wizard_exception_fails(stub_streamlit, mock_gather_requirements, clean_state):
-    """Test error handling when gather_requirements raises an exception.
-
-    ReqID: N/A"""
-    import importlib
-    import devsynth.interface.webui as webui
-    importlib.reload(webui)
-    from devsynth.interface.webui import WebUI
-    stub_streamlit.button.return_value = True
-    mock_gather_requirements.side_effect = RuntimeError('Test error')
-    webui_instance = WebUI()
-    webui_instance.display_result = MagicMock()
-    webui_instance._gather_wizard()
-    mock_gather_requirements.assert_called_once_with(webui_instance)
-    webui_instance.display_result.assert_called_once()
-    assert 'ERROR' in webui_instance.display_result.call_args[0][0]
-    assert 'Test error' in webui_instance.display_result.call_args[0][0]
-
-
-@pytest.mark.medium
-def test_gather_wizard_with_state_succeeds(stub_streamlit, mock_gather_requirements, clean_state):
-    """Test that gather_requirements is called with state when button is clicked.
-
-    ReqID: N/A"""
-    import importlib
-    import devsynth.interface.webui as webui
-    importlib.reload(webui)
-    from devsynth.interface.webui import WebUI
-    stub_streamlit.button.return_value = True
-    stub_streamlit.session_state = {'key1': 'value1', 'key2': 'value2'}
-    webui_instance = WebUI()
-    webui_instance._gather_wizard()
-    mock_gather_requirements.assert_called_once_with(webui_instance)
-    stub_streamlit.spinner.assert_called_once()
-
-
-@pytest.mark.medium
-def test_gather_wizard_with_empty_state_succeeds(stub_streamlit, mock_gather_requirements, clean_state):
-    """Test that gather_requirements is called with empty state when button is clicked.
-
-    ReqID: N/A"""
-    import importlib
-    import devsynth.interface.webui as webui
-    importlib.reload(webui)
-    from devsynth.interface.webui import WebUI
-    stub_streamlit.button.return_value = True
-    stub_streamlit.session_state = {}
-    webui_instance = WebUI()
-    webui_instance._gather_wizard()
-    mock_gather_requirements.assert_called_once_with(webui_instance)
-    stub_streamlit.spinner.assert_called_once()
-
-
-@pytest.mark.medium
-def test_gather_wizard_with_none_state_succeeds(stub_streamlit, mock_gather_requirements, clean_state):
-    """Test that gather_requirements is called with None state when button is clicked.
-
-    ReqID: N/A"""
-    import importlib
-    import devsynth.interface.webui as webui
-    importlib.reload(webui)
-    from devsynth.interface.webui import WebUI
-    stub_streamlit.button.return_value = True
-    stub_streamlit.session_state = None
-    webui_instance = WebUI()
-    webui_instance._gather_wizard()
-    mock_gather_requirements.assert_called_once_with(webui_instance)
-    stub_streamlit.spinner.assert_called_once()
-
-
-@pytest.mark.medium
-def test_gather_wizard_with_complex_state_succeeds(stub_streamlit, mock_gather_requirements, clean_state):
-    """Test that gather_requirements is called with complex state when button is clicked.
-
-    ReqID: N/A"""
-    import importlib
-    import devsynth.interface.webui as webui
-    importlib.reload(webui)
-    from devsynth.interface.webui import WebUI
-    stub_streamlit.button.return_value = True
     stub_streamlit.session_state = {
-        'key1': 'value1',
-        'key2': 42,
-        'key3': [1, 2, 3],
-        'key4': {'a': 1, 'b': 2}
+        "gather_wizard_current_step": 3,
+        "gather_wizard_total_steps": 3,
+        "gather_wizard_completed": False,
+        "gather_wizard_wizard_started": True,
+        "gather_wizard_resource_type": "documentation",
+        "gather_wizard_resource_location": "/docs",
+        "gather_wizard_resource_metadata": {"author": "A", "version": "1.0"},
     }
-    webui_instance = WebUI()
-    webui_instance._gather_wizard()
-    mock_gather_requirements.assert_called_once_with(webui_instance)
-    stub_streamlit.spinner.assert_called_once()
+
+    def button_side_effect(label, key=None, **kwargs):
+        return key == "finish_button"
+
+    stub_streamlit.button.side_effect = button_side_effect
+    ui = WebUI()
+    ui._gather_wizard()
+    mock_gather_requirements.assert_called_once_with(ui)
+    assert stub_streamlit.spinner.called
+
+
+@pytest.mark.medium
+def test_gather_wizard_import_error(stub_streamlit, monkeypatch):
+    import importlib
+    import devsynth.interface.webui as webui
+
+    importlib.reload(webui)
+    from devsynth.interface.webui import WebUI
+
+    stub_streamlit.session_state = {
+        "gather_wizard_current_step": 3,
+        "gather_wizard_total_steps": 3,
+        "gather_wizard_completed": False,
+        "gather_wizard_wizard_started": True,
+        "gather_wizard_resource_type": "documentation",
+        "gather_wizard_resource_location": "/docs",
+        "gather_wizard_resource_metadata": {"author": "A", "version": "1.0"},
+    }
+    stub_streamlit.button.side_effect = lambda label, key=None, **kwargs: key == "finish_button"
+    monkeypatch.setattr(webui, "gather_requirements", None)
+    ui = WebUI()
+    ui.display_result = MagicMock()
+    ui._gather_wizard()
+    ui.display_result.assert_called_once()
+    assert "ERROR importing gather_requirements" in ui.display_result.call_args[0][0]
+
+
+@pytest.mark.medium
+def test_gather_wizard_exception(stub_streamlit, mock_gather_requirements):
+    import importlib
+    import devsynth.interface.webui as webui
+
+    importlib.reload(webui)
+    from devsynth.interface.webui import WebUI
+
+    stub_streamlit.session_state = {
+        "gather_wizard_current_step": 3,
+        "gather_wizard_total_steps": 3,
+        "gather_wizard_completed": False,
+        "gather_wizard_wizard_started": True,
+        "gather_wizard_resource_type": "documentation",
+        "gather_wizard_resource_location": "/docs",
+        "gather_wizard_resource_metadata": {"author": "A", "version": "1.0"},
+    }
+    stub_streamlit.button.side_effect = lambda label, key=None, **kwargs: key == "finish_button"
+    mock_gather_requirements.side_effect = RuntimeError("boom")
+    ui = WebUI()
+    ui.display_result = MagicMock()
+    ui._gather_wizard()
+    mock_gather_requirements.assert_called_once_with(ui)
+    ui.display_result.assert_called_once()
+    assert "ERROR processing resources" in ui.display_result.call_args[0][0]

--- a/tests/unit/interface/test_webui_wizard_state.py
+++ b/tests/unit/interface/test_webui_wizard_state.py
@@ -11,6 +11,8 @@ from unittest.mock import MagicMock, patch
 from types import ModuleType
 from pathlib import Path
 
+from devsynth.interface.wizard_state_manager import WizardStateManager
+
 # Import the fixtures
 fixtures_path = Path(__file__).parent.parent.parent / 'fixtures'
 sys.path.insert(0, str(fixtures_path))
@@ -31,8 +33,7 @@ def clean_state():
     yield
     # Clean up state
 
-def test_function(clean_state):
-    # Test with clean state
+def test_function(clean_state, wizard_state):
     """Test that the wizard state is properly initialized."""
     state, mock_st = wizard_state
     
@@ -248,6 +249,15 @@ def test_set_wizard_data(gather_wizard_state):
         "language": "Python",
         "lines": 1000
     }
+
+
+@pytest.mark.medium
+def test_manager_clears_temp_state(mock_streamlit):
+    """Ensure temporary state keys are removed by the manager."""
+    manager = WizardStateManager(mock_streamlit.session_state, "temp", 1)
+    mock_streamlit.session_state["temp_key"] = "value"
+    manager.clear_temporary_state(["temp_key"])
+    assert "temp_key" not in mock_streamlit.session_state
 
 @pytest.mark.medium
 def test_wizard_state_in_streamlit_context(gather_wizard_state):


### PR DESCRIPTION
## Summary
- centralize temporary wizard state handling in `WizardStateManager`
- rework WebUI gather wizard to use `WizardStateManager` and clear widget state
- update gather wizard tests with streamlined Streamlit mocks and state-aware flows

## Testing
- `poetry run pytest tests/unit/interface/test_webui_gather_wizard.py -q`
- `poetry run pytest tests/unit/interface/test_webui_wizard_state.py -q`
- `poetry run pytest tests/unit/interface/test_webui_gather_wizard_with_state_fixed.py -q`


------
https://chatgpt.com/codex/tasks/task_e_688fd61da4a88333a20bd59418e5f4b9