### PR TITLE
chore: refine codex setup script

### DIFF
--- a/scripts/codex_setup.sh
+++ b/scripts/codex_setup.sh
@@ -15,6 +15,7 @@ poetry env info --path >/dev/null
 poetry install \
   --with dev,docs \
   --all-extras \
+  --without offline,gpu \
   --no-interaction
 
 # Validate dependency installation
@@ -37,15 +38,15 @@ import importlib
 import sys
 
 required = ["pytest", "pytest_bdd", "pydantic", "yaml", "typer", "tiktoken", "chromadb"]
-  missing = []
-  for pkg in required:
-      try:
-          importlib.import_module(pkg)
-      except Exception:
-          missing.append(pkg)
-  if missing:
-      sys.exit("Missing packages: " + ", ".join(missing))
-  EOF
+missing = []
+for pkg in required:
+    try:
+        importlib.import_module(pkg)
+    except Exception:
+        missing.append(pkg)
+if missing:
+    sys.exit("Missing packages: " + ", ".join(missing))
+EOF
 
 # Kuzu is optional; skip related tests if it's not installed
 if ! poetry run python -c "import kuzu" >/dev/null 2>&1; then


### PR DESCRIPTION
## Summary
- clean up indentation in codex_setup.py embedded Python block
- exclude heavy offline/gpu extras during poetry install

## Testing
- `SKIP=devsynth-align poetry run pre-commit run --files scripts/codex_setup.sh`
- `poetry run python - <<'EOF' ... EOF`
- `poetry run pytest --maxfail=1` *(fails: IndentationError in tests/unit/application/cli/test_init_cmd.py)*


------
https://chatgpt.com/codex/tasks/task_e_688fd5dc9c388333850f3eeaa05323b5