### PR TITLE
Add sandboxed execution for agent tools

### DIFF
--- a/docs/developer_guides/agent_tools.md
+++ b/docs/developer_guides/agent_tools.md
@@ -1,0 +1,52 @@
+---
+author: DevSynth Team
+date: '2025-07-12'
+last_reviewed: '2025-07-12'
+status: draft
+tags:
+- developer-guide
+title: Agent Tools
+version: 0.1.0
+---
+
+<div class="breadcrumbs">
+<a href="../index.md">Documentation</a> &gt; <a href="index.md">Developer Guides</a> &gt; Agent Tools
+</div>
+
+# Agent Tools Security Model
+
+Agent tools are executed inside a sandbox to minimize the impact of untrusted
+code.
+
+## File System Restrictions
+
+Tools may only read and write within the DevSynth project directory. Attempts to
+access paths outside the repository raise a ``PermissionError``.
+
+## Shell Command Restrictions
+
+Shell commands are blocked by default. A tool can opt into shell access during
+registration by setting ``allow_shell=True``. Without this flag any use of
+``subprocess.run`` or ``subprocess.Popen`` raises ``PermissionError``.
+
+## Usage
+
+```python
+from devsynth.agents.tools import tool_registry
+
+
+def my_tool():
+    ...
+
+
+tool_registry.register(
+    "example",
+    my_tool,
+    description="Example tool",
+    parameters={},
+    allow_shell=False,
+)
+```
+
+This model ensures tools operate with least privilege while still supporting
+explicitly authorized commands.

--- a/src/devsynth/agents/sandbox.py
+++ b/src/devsynth/agents/sandbox.py
@@ -1,0 +1,72 @@
+"""Sandbox utilities for restricting tool execution."""
+
+from __future__ import annotations
+
+import builtins
+import subprocess
+from contextlib import ContextDecorator
+from functools import wraps
+from pathlib import Path
+from typing import Any, Callable
+
+# Determine the project root (three levels up from this file)
+PROJECT_ROOT = Path(__file__).resolve().parents[3]
+
+
+class Sandbox(ContextDecorator):
+    """Context manager that restricts file and subprocess access."""
+
+    def __init__(self, *, allow_shell: bool = False) -> None:
+        """Initialize the sandbox.
+
+        Args:
+            allow_shell: Whether to permit shell command execution.
+        """
+        self.allow_shell = allow_shell
+        self._original_open = builtins.open
+        self._original_popen = subprocess.Popen
+        self._original_run = subprocess.run
+
+    @staticmethod
+    def _in_project(path: Path) -> bool:
+        """Return True if the path is within the project root."""
+        resolved = path.resolve()
+        return PROJECT_ROOT == resolved or PROJECT_ROOT in resolved.parents
+
+    def _safe_open(self, file: str | Path, *args: Any, **kwargs: Any):
+        if not self._in_project(Path(file)):
+            raise PermissionError("Access outside project directory is not allowed")
+        return self._original_open(file, *args, **kwargs)
+
+    def _blocked_popen(self, *args: Any, **kwargs: Any):
+        if not self.allow_shell:
+            raise PermissionError("Shell commands are not permitted")
+        return self._original_popen(*args, **kwargs)
+
+    def _blocked_run(self, *args: Any, **kwargs: Any):
+        if not self.allow_shell:
+            raise PermissionError("Shell commands are not permitted")
+        return self._original_run(*args, **kwargs)
+
+    def __enter__(self):  # pragma: no cover - trivial
+        builtins.open = self._safe_open
+        subprocess.Popen = self._blocked_popen
+        subprocess.run = self._blocked_run
+        return self
+
+    def __exit__(self, exc_type, exc, tb):  # pragma: no cover - trivial
+        builtins.open = self._original_open
+        subprocess.Popen = self._original_popen
+        subprocess.run = self._original_run
+        return False
+
+
+def sandboxed(func: Callable[..., Any], *, allow_shell: bool = False) -> Callable[..., Any]:
+    """Return ``func`` wrapped to execute inside a :class:`Sandbox`."""
+
+    @wraps(func)
+    def wrapper(*args: Any, **kwargs: Any):
+        with Sandbox(allow_shell=allow_shell):
+            return func(*args, **kwargs)
+
+    return wrapper

--- a/src/devsynth/agents/tools.py
+++ b/src/devsynth/agents/tools.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from typing import Any, Callable, Dict, Optional, Sequence
 
+from devsynth.agents.sandbox import sandboxed
+
 from devsynth.logging_setup import DevSynthLogger
 from devsynth.testing.run_tests import run_tests
 
@@ -23,10 +25,18 @@ class ToolRegistry:
         func: Callable[..., Any],
         description: str,
         parameters: Dict[str, Any],
+        *,
+        allow_shell: bool = False,
     ) -> None:
-        """Register a tool with its callable and metadata."""
+        """Register a tool with its callable and metadata.
+
+        Tools are automatically wrapped so they execute inside a sandbox that
+        restricts file system access to the project directory and blocks shell
+        command execution unless ``allow_shell`` is ``True``.
+        """
+        wrapped = sandboxed(func, allow_shell=allow_shell)
         self._tools[name] = {
-            "func": func,
+            "func": wrapped,
             "description": description,
             "parameters": parameters,
         }
@@ -142,4 +152,5 @@ _tool_registry.register(
         },
         "required": [],
     },
+    allow_shell=True,
 )

--- a/tests/unit/agents/test_run_tests_tool.py
+++ b/tests/unit/agents/test_run_tests_tool.py
@@ -16,4 +16,8 @@ def test_run_tests_tool_returns_structure() -> None:
 def test_run_tests_tool_registered() -> None:
     """The tool should be registered in the global registry."""
     registry = get_tool_registry()
-    assert registry.get("run_tests") is run_tests_tool
+    func = registry.get("run_tests")
+    assert func is not None
+    with patch("devsynth.agents.tools.run_tests", return_value=(True, "ok")) as mock_run:
+        func(target="unit-tests")
+        mock_run.assert_called_once()

--- a/tests/unit/agents/test_tool_sandbox.py
+++ b/tests/unit/agents/test_tool_sandbox.py
@@ -1,0 +1,63 @@
+"""Tests for sandboxed tool execution."""
+
+from pathlib import Path
+import subprocess
+
+import pytest
+
+from devsynth.agents.tools import ToolRegistry
+
+
+def bad_file_tool() -> None:
+    with open(Path('/etc/passwd'), 'r', encoding='utf-8'):
+        pass
+
+
+def bad_shell_tool() -> None:
+    subprocess.run(['echo', 'hi'], check=False)
+
+
+def good_shell_tool() -> str:
+    result = subprocess.run(
+        ['echo', 'hi'], check=False, capture_output=True, text=True
+    )
+    return result.stdout.strip()
+
+
+def test_file_access_restricted() -> None:
+    registry = ToolRegistry()
+    registry.register(
+        'bad_file',
+        bad_file_tool,
+        description='attempts to read outside project',
+        parameters={},
+    )
+    func = registry.get('bad_file')
+    with pytest.raises(PermissionError):
+        func()
+
+
+def test_shell_commands_blocked() -> None:
+    registry = ToolRegistry()
+    registry.register(
+        'bad_shell',
+        bad_shell_tool,
+        description='attempts shell command',
+        parameters={},
+    )
+    func = registry.get('bad_shell')
+    with pytest.raises(PermissionError):
+        func()
+
+
+def test_shell_commands_allowed() -> None:
+    registry = ToolRegistry()
+    registry.register(
+        'good_shell',
+        good_shell_tool,
+        description='allowed shell command',
+        parameters={},
+        allow_shell=True,
+    )
+    func = registry.get('good_shell')
+    assert func() == 'hi'

--- a/tests/unit/agents/test_tools.py
+++ b/tests/unit/agents/test_tools.py
@@ -17,7 +17,8 @@ def test_register_and_get_tool() -> None:
     )
 
     func = registry.get("adder")
-    assert func is sample_tool
+    assert func is not None
+    assert func(1) == 2
     metadata = registry.get_metadata("adder")
     assert metadata == {
         "description": "Add one to the input",


### PR DESCRIPTION
## Summary
- add sandbox utilities that restrict file I/O to the project directory and block shell commands by default
- wrap tool registrations with the sandbox and allow explicit shell access when required
- document the Agent Tools security model

## Testing
- `pytest -p no:tests.fixtures.ports tests/unit/agents/test_tools.py tests/unit/agents/test_run_tests_tool.py tests/unit/agents/test_tool_sandbox.py`


------
https://chatgpt.com/codex/tasks/task_e_688fd48cfc748333978608550d143992