### PR TITLE
feat: add critique agent

### DIFF
--- a/examples/critique_agent_example.py
+++ b/examples/critique_agent_example.py
@@ -1,0 +1,27 @@
+"""Orchestration example demonstrating ``CritiqueAgent`` usage."""
+
+from devsynth.agents.critique_agent import CritiqueAgent
+
+
+class MainAgent:
+    """Trivial main agent that produces a code snippet."""
+
+    def generate(self) -> str:
+        """Return a code sample that intentionally needs work."""
+        return "def add(a, b):\n    return a + b  # TODO"
+
+
+def run() -> None:
+    """Run a simple workflow passing results to the critic."""
+    main_agent = MainAgent()
+    critic = CritiqueAgent()
+
+    produced = main_agent.generate()
+    critique = critic.review(produced)
+
+    print("Generated code:\n", produced)
+    print("\nCritique:", critique)
+
+
+if __name__ == "__main__":
+    run()

--- a/src/devsynth/agents/__init__.py
+++ b/src/devsynth/agents/__init__.py
@@ -1,0 +1,5 @@
+"""Agent package exposing core agent utilities."""
+
+from .critique_agent import CritiqueAgent, Critique
+
+__all__ = ["CritiqueAgent", "Critique"]

--- a/src/devsynth/agents/critique_agent.py
+++ b/src/devsynth/agents/critique_agent.py
@@ -1,0 +1,48 @@
+"""Simple critique agent for reviewing code or test outputs."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import List
+
+from devsynth.logging_setup import DevSynthLogger
+
+logger = DevSynthLogger(__name__)
+
+
+@dataclass
+class Critique:
+    """Result returned by :class:`CritiqueAgent`."""
+
+    approved: bool
+    issues: List[str]
+
+
+class CritiqueAgent:
+    """Agent that provides lightweight feedback on generated artifacts.
+
+    The agent inspects source code or test output and returns a
+    :class:`Critique` describing potential problems.
+    """
+
+    def review(self, content: str) -> Critique:
+        """Analyze ``content`` and return a :class:`Critique`.
+
+        The review currently performs very small heuristics:
+
+        * Flags unfinished work marked with ``TODO``.
+        * Detects failing tests via ``FAIL`` or ``error`` keywords.
+        * Warns when a function definition lacks a docstring.
+        """
+        issues: List[str] = []
+        lower = content.lower()
+
+        if "todo" in lower:
+            issues.append("Found TODO marker indicating unfinished work.")
+        if "fail" in lower or "error" in lower:
+            issues.append("Test failures or errors detected.")
+        if "def " in content and '"""' not in content:
+            issues.append("Function missing docstring.")
+
+        logger.debug("Critique issues: %s", issues)
+        return Critique(approved=not issues, issues=issues)

--- a/tests/unit/agents/test_critique_agent.py
+++ b/tests/unit/agents/test_critique_agent.py
@@ -1,0 +1,28 @@
+"""Tests for :mod:`devsynth.agents.critique_agent`."""
+
+from devsynth.agents.critique_agent import CritiqueAgent
+
+
+def test_feedback_loop() -> None:
+    """The agent flags issues and approves once addressed."""
+    agent = CritiqueAgent()
+
+    draft = "def add(a, b):\n    return a + b  # TODO"
+    critique = agent.review(draft)
+    assert not critique.approved
+    assert any("TODO" in issue or "unfinished" in issue for issue in critique.issues)
+
+    revised = 'def add(a, b):\n    """Add two numbers."""\n    return a + b\n'
+    critique = agent.review(revised)
+    assert critique.approved
+    assert critique.issues == []
+
+
+def test_detects_test_failures() -> None:
+    """The agent notices failing test output."""
+    agent = CritiqueAgent()
+
+    test_output = "test_add PASSED\ntest_subtract FAILED: AssertionError"
+    critique = agent.review(test_output)
+    assert not critique.approved
+    assert any("Test failures" in issue for issue in critique.issues)


### PR DESCRIPTION
## Summary
- add CritiqueAgent to review code or test outputs
- show orchestration of a main agent handing work to the critic
- test critique feedback loop

## Testing
- `poetry run pytest tests/unit/agents/test_critique_agent.py`


------
https://chatgpt.com/codex/tasks/task_e_688fe192e01483339b035f584fe50268