### PR TITLE
docs: reference CLI commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,9 @@ version has been published yet.
 ### Changed
 - Updated documentation to reflect implementation of WebUI, CLI overhaul,
   hybrid memory architecture, and basic metrics system.
+### Deprecated
+- `scripts/alignment_check.py` and `scripts/validate_manifest.py` replaced by
+  CLI commands `devsynth align` and `devsynth validate-manifest`.
 ### Fixed
 - Optional tiktoken dependency no longer breaks Kuzu memory initialization
 - Added missing step definitions for enhanced memory scenarios

--- a/README.md
+++ b/README.md
@@ -259,12 +259,11 @@ suite or specific groups of tests and optionally generate an HTML report:
 
 See [docs/developer_guides/testing.md](docs/developer_guides/testing.md) for detailed testing guidance.
 
-## Deprecated Scripts
+## Alignment and Manifest Validation
 
-The helper scripts `scripts/alignment_check.py` and `scripts/validate_manifest.py`
-are deprecated. Use `devsynth align` and `devsynth validate-manifest`
-respectively. These wrappers will be removed in a future release once users
-transition to the corresponding CLI commands.
+Use `devsynth align` and `devsynth validate-manifest` for alignment checks and
+manifest validation. These CLI commands replace the legacy helper scripts and
+will fully supersede them in a future release.
 
 ## Documentation Structure
 


### PR DESCRIPTION
## Summary
- direct users to `devsynth align` and `devsynth validate-manifest` instead of legacy scripts
- document deprecation of old helper scripts in changelog

## Testing
- `poetry run pytest tests -q` *(fails: ModuleNotFoundError: No module named 'pytest_bdd')*


------
https://chatgpt.com/codex/tasks/task_e_688fe18180548333af452405fc4c784a