### PR TITLE
docs: add pre-commit hook samples

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,7 +9,7 @@ tags:
   - "guidelines"
 status: "published"
 author: "DevSynth Team"
-last_reviewed: "2025-07-10"
+last_reviewed: "2025-08-04"
 ---
 
 # Contributing to DevSynth
@@ -57,6 +57,8 @@ pre-commit run devsynth-align --all-files
 
 The `devsynth-align` hook runs `devsynth align --quiet` and will block commits
 if alignment issues are detected.
+
+For examples of additional hooks, including link checking and formatting, see [pre-commit hook samples](docs/developer_guides/pre_commit_samples.md).
 
 ## Testing
 

--- a/docs/developer_guides/pre_commit_samples.md
+++ b/docs/developer_guides/pre_commit_samples.md
@@ -1,0 +1,66 @@
+---
+title: "Pre-commit Hook Samples"
+date: "2025-08-04"
+version: "0.1.0"
+tags:
+  - "pre-commit"
+  - "hooks"
+  - "tooling"
+status: "published"
+author: "DevSynth Team"
+last_reviewed: "2025-08-04"
+---
+
+<div class="breadcrumbs">
+<a href="../index.md">Documentation</a> &gt; <a href="index.md">Developer Guides</a> &gt; Pre-commit Hook Samples
+</div>
+
+<div class="breadcrumbs">
+<a href="../index.md">Documentation</a> &gt; <a href="index.md">Developer Guides</a> &gt; Pre-commit Hook Samples
+</div>
+
+# Pre-commit Hook Samples
+
+## Overview
+
+The DevSynth project uses [pre-commit](https://pre-commit.com/) to run automated checks before code is committed. This guide highlights common hooks used in the repository and provides a sample configuration to help you get started.
+
+## Common Hooks
+
+### devsynth align
+
+Ensures files conform to project alignment rules using `devsynth align --quiet`. This hook blocks commits that introduce misaligned content.
+
+### Link Checker
+
+Validates external and internal links to keep documentation up to date. A typical configuration uses the [`lychee`](https://github.com/lycheeverse/lychee) hook with `--no-progress` to keep output concise.
+
+### Formatting
+
+Formats code and documentation automatically. The project relies on [`black`](https://github.com/psf/black) for Python code and optionally [`isort`](https://github.com/pycqa/isort) to order imports.
+
+## Example `.pre-commit-config.yaml`
+
+```yaml
+repos:
+  - repo: local
+    hooks:
+      - id: devsynth-align
+        name: devsynth align
+        entry: devsynth align --quiet
+        language: system
+        pass_filenames: false
+
+  - repo: https://github.com/lycheeverse/lychee
+    rev: v0.15.1
+    hooks:
+      - id: lychee
+        args: [--no-progress, --verbose]
+
+  - repo: https://github.com/psf/black
+    rev: 25.1.0
+    hooks:
+      - id: black
+```
+
+Use `pre-commit install` to enable these hooks locally and `pre-commit run --all-files` to run them across the entire codebase.


### PR DESCRIPTION
## Summary
- add pre-commit hook samples guide for devsynth align, link checker, and formatting
- link new guide from contributing documentation

## Testing
- `bash scripts/codex_setup.sh` *(fails: Group(s) not found: gpu, offline)*
- `poetry run pytest --maxfail=1` *(fails: ModuleNotFoundError: No module named 'pytest_bdd')*
- `PATH="$(poetry env info --path)/bin:$PATH" pre-commit run --files docs/developer_guides/pre_commit_samples.md CONTRIBUTING.md` *(fails: Executable `devsynth` not found)*

------
https://chatgpt.com/codex/tasks/task_e_688fe1751f708333a61baade920ceda7