### PR TITLE
feat: summarize consensus and persist reasoning

### DIFF
--- a/tests/unit/behavior/test_wsde_team_extended.py
+++ b/tests/unit/behavior/test_wsde_team_extended.py
@@ -1,0 +1,27 @@
+import pytest
+from devsynth.application.collaboration.wsde_team_extended import CollaborativeWSDETeam
+from devsynth.domain.models.memory import MemoryType
+
+
+class DummyMemoryManager:
+    def __init__(self):
+        self.calls = []
+
+    def store_with_edrr_phase(self, content, memory_type, edrr_phase, metadata=None):
+        self.calls.append((content, memory_type, edrr_phase, metadata))
+        return "mem-ref"
+
+
+@pytest.mark.medium
+def test_summarize_and_store_consensus():
+    team = CollaborativeWSDETeam()
+    team.memory_manager = DummyMemoryManager()
+    task = {"id": "t1"}
+    consensus = {"method": "synthesis", "synthesis": {"text": "do x"}}
+
+    result = team._summarize_and_store_consensus(task, consensus)
+
+    assert "summary" in result
+    assert "synthesis consensus" in result["summary"].lower()
+    assert result["memory_reference"] == "mem-ref"
+    assert team.memory_manager.calls[0][1] == MemoryType.TEAM_STATE

--- a/tests/unit/methodology/test_dialectical_reasoner.py
+++ b/tests/unit/methodology/test_dialectical_reasoner.py
@@ -1,0 +1,67 @@
+import pytest
+from uuid import uuid4
+
+from devsynth.application.requirements.dialectical_reasoner import DialecticalReasonerService
+from devsynth.domain.interfaces.requirement import (
+    RequirementRepositoryInterface,
+    DialecticalReasoningRepositoryInterface,
+    ImpactAssessmentRepositoryInterface,
+    ChatRepositoryInterface,
+)
+from devsynth.domain.models.requirement import RequirementChange
+from devsynth.domain.models.memory import MemoryType
+
+
+class DummyNotification:
+    def notify_change_proposed(self, change):
+        pass
+
+    def notify_change_approved(self, change):
+        pass
+
+    def notify_change_rejected(self, change):
+        pass
+
+    def notify_impact_assessment_completed(self, assessment):
+        pass
+
+
+class DummyLLM:
+    def query(self, prompt: str) -> str:
+        return "text"
+
+
+class DummyMemoryManager:
+    def __init__(self):
+        self.calls = []
+
+    def store_with_edrr_phase(self, content, memory_type, edrr_phase, metadata=None):
+        self.calls.append((content, memory_type, edrr_phase, metadata))
+        return "mem-1"
+
+
+@pytest.mark.medium
+def test_evaluate_change_persists_reasoning_to_memory():
+    memory = DummyMemoryManager()
+    service = DialecticalReasonerService(
+        requirement_repository=RequirementRepositoryInterface(),
+        reasoning_repository=DialecticalReasoningRepositoryInterface(),
+        impact_repository=ImpactAssessmentRepositoryInterface(),
+        chat_repository=ChatRepositoryInterface(),
+        notification_service=DummyNotification(),
+        llm_service=DummyLLM(),
+        memory_manager=memory,
+    )
+
+    # Simplify generation steps
+    service._generate_thesis = lambda change: "thesis"
+    service._generate_antithesis = lambda change: "antithesis"
+    service._generate_arguments = lambda change, thesis, antithesis: []
+    service._generate_synthesis = lambda change, arguments: "synthesis"
+    service._generate_conclusion_and_recommendation = lambda change, syn: ("conclusion", "recommendation")
+
+    change = RequirementChange(requirement_id=uuid4(), created_by="user")
+    service.evaluate_change(change)
+
+    assert memory.calls
+    assert memory.calls[0][1] == MemoryType.DIALECTICAL_REASONING


### PR DESCRIPTION
## Summary
- add consensus summarization and memory persistence to collaborative WSDE team
- support memory hooks in dialectical reasoner service
- cover new behaviors with targeted unit tests

## Testing
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -p no:tests.fixtures.ports tests/unit/behavior/test_wsde_team_extended.py tests/unit/methodology/test_dialectical_reasoner.py`

------
https://chatgpt.com/codex/tasks/task_e_688fe141858c833399d1f5a4633dcf38