### PR TITLE
feat: introduce logging helper for scripts

### DIFF
--- a/docs/developer_guides/error_handling.md
+++ b/docs/developer_guides/error_handling.md
@@ -128,6 +128,35 @@ can set a request identifier and the current EDRR phase with `set_request_contex
 These values are automatically attached to all log records, enabling correlation
 across components.
 
+For standalone scripts, a helper at `scripts/utils/logging_setup.py` simplifies
+this process and encourages consistent exception handling:
+
+```python
+import sys
+
+from utils.logging_setup import setup_logging
+from devsynth.exceptions import DevSynthError
+
+logger = setup_logging(__name__)
+
+def main() -> None:
+    ...  # script logic
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except DevSynthError:
+        logger.exception("Script failed")
+        sys.exit(1)
+    except Exception:  # pragma: no cover - unexpected errors
+        logger.exception("Unexpected error")
+        sys.exit(1)
+```
+
+This pattern ensures logs are routed through the DevSynth logger and that
+errors are surfaced with clear, actionable messages.
+
 ## Error Handling Patterns
 
 ### Validation Errors

--- a/scripts/security_audit.py
+++ b/scripts/security_audit.py
@@ -7,16 +7,25 @@ import os
 import subprocess
 import sys
 
+from utils.logging_setup import setup_logging
+
+from devsynth.exceptions import ConfigurationError, DevSynthError
+
 REQUIRED_ENV_VARS = ["DEVSYNTH_ACCESS_TOKEN"]
+
+
+logger = setup_logging(__name__)
 
 
 def run_safety() -> None:
     """Run dependency vulnerability scan using safety."""
+    logger.info("Running dependency vulnerability scan using safety")
     subprocess.check_call(["python", "scripts/dependency_safety_check.py"])
 
 
 def run_bandit() -> None:
     """Run Bandit static analysis over the src directory."""
+    logger.info("Running Bandit static analysis over the src directory")
     subprocess.check_call(["bandit", "-r", "src", "-ll"])
 
 
@@ -24,9 +33,10 @@ def check_required_env() -> None:
     """Ensure required security environment variables are set."""
     missing = [name for name in REQUIRED_ENV_VARS if not os.getenv(name)]
     if missing:
-        raise RuntimeError(
-            f"Missing required environment variables: {', '.join(missing)}"
+        raise ConfigurationError(
+            message=f"Missing required environment variables: {', '.join(missing)}"
         )
+    logger.debug("All required security environment variables are set")
 
 
 def main() -> None:
@@ -40,14 +50,24 @@ def main() -> None:
     )
     args = parser.parse_args()
 
+    check_required_env()
+    logger.info("Starting security audit")
+
     from devsynth.application.cli.commands.security_audit_cmd import security_audit_cmd
 
     security_audit_cmd(skip_static=args.skip_static)
+    logger.info("Security audit completed successfully")
 
 
 if __name__ == "__main__":
     try:
         main()
+    except DevSynthError:
+        logger.exception("Security audit failed")
+        sys.exit(1)
     except subprocess.CalledProcessError as exc:
-        print(f"Security audit failed with code {exc.returncode}")
+        logger.exception("Security audit failed with code %s", exc.returncode)
         sys.exit(exc.returncode)
+    except Exception:  # pragma: no cover - unexpected errors
+        logger.exception("Unexpected error during security audit")
+        sys.exit(1)

--- a/scripts/utils/__init__.py
+++ b/scripts/utils/__init__.py
@@ -1,0 +1,3 @@
+"""Utility modules for DevSynth scripts."""
+
+__all__: list[str] = []

--- a/scripts/utils/logging_setup.py
+++ b/scripts/utils/logging_setup.py
@@ -1,0 +1,25 @@
+"""Helper utilities for configuring DevSynth logging in scripts."""
+
+from __future__ import annotations
+
+from devsynth.logging_setup import DevSynthLogger, configure_logging, get_logger
+
+
+def setup_logging(name: str) -> DevSynthLogger:
+    """Configure logging and return a :class:`DevSynthLogger` instance.
+
+    This helper ensures scripts consistently initialize the DevSynth logging
+    system before obtaining a logger.
+
+    Args:
+        name: Name to associate with the logger, typically ``__name__``.
+
+    Returns:
+        A configured :class:`DevSynthLogger` instance.
+    """
+
+    configure_logging()
+    return get_logger(name)
+
+
+__all__ = ["setup_logging", "DevSynthLogger"]


### PR DESCRIPTION
## Summary
- add `scripts/utils/logging_setup` helper to configure DevSynth logger
- refactor `run_all_tests.py` and `security_audit.py` to use logger and consistent error handling
- document script logging pattern in error handling guide

## Testing
- `poetry run pre-commit run --files scripts/run_all_tests.py scripts/security_audit.py scripts/utils/logging_setup.py scripts/utils/__init__.py docs/developer_guides/error_handling.md` *(fails: Executable `devsynth` not found)*
- `poetry run pytest tests/unit/general/test_logging_setup.py` *(fails: No module named 'rich')*

------
https://chatgpt.com/codex/tasks/task_e_688fe46c7be8833394235342e5f4bf84