### PR TITLE
Add speed markers to uncategorized tests

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -87,6 +87,20 @@ poetry run pytest
 Running `pytest` directly may fail because required plugins (for example
 `pytest-bdd`) are installed only in the Poetry virtual environment.
 
+## Test Speed Categories
+
+Tests are grouped by runtime using pytest markers:
+
+- `@pytest.mark.fast` – completes in under **1 second**
+- `@pytest.mark.medium` – completes in under **5 seconds**
+- `@pytest.mark.slow` – takes **5 seconds or more**
+
+These markers make it easy to select subsets of the suite. For example:
+
+```bash
+poetry run python scripts/run_all_tests.py --fast --medium
+```
+
 ## Conditional Test Execution
 
 The test framework includes a mechanism for conditionally skipping tests based on resource availability. This is useful for tests that depend on external resources like LM Studio or other services that might not always be available.

--- a/tests/unit/docs/test_feature_matrix.py
+++ b/tests/unit/docs/test_feature_matrix.py
@@ -1,28 +1,32 @@
+import os
 import re
 from pathlib import Path
-import os
-ALLOWED = {'Complete', 'Partial', 'Missing'}
+
+import pytest
+
+ALLOWED = {"Complete", "Partial", "Missing"}
 
 
+@pytest.mark.medium
 def test_feature_rows_have_status_succeeds():
     """Test that feature rows have status succeeds.
 
-ReqID: N/A"""
-    repo_root = Path(os.environ.get('ORIGINAL_CWD', Path.cwd()))
-    path = repo_root / 'docs' / 'implementation' / 'feature_status_matrix.md'
+    ReqID: N/A"""
+    repo_root = Path(os.environ.get("ORIGINAL_CWD", Path.cwd()))
+    path = repo_root / "docs" / "implementation" / "feature_status_matrix.md"
     lines = path.read_text().splitlines()
     in_table = False
     for line in lines:
-        if line.startswith('| Feature | Status'):
+        if line.startswith("| Feature | Status"):
             in_table = True
             continue
         if in_table:
-            if line.startswith('## '):
+            if line.startswith("## "):
                 break
-            if not line.startswith('|') or line.startswith('|---------'):
+            if not line.startswith("|") or line.startswith("|---------"):
                 continue
-            cells = [c.strip() for c in line.strip().strip('|').split('|')]
+            cells = [c.strip() for c in line.strip().strip("|").split("|")]
             if len(cells) < 2:
                 continue
             status = cells[1]
-            assert status in ALLOWED, f'Row status invalid or missing: {line}'
+            assert status in ALLOWED, f"Row status invalid or missing: {line}"

--- a/tests/unit/security/test_argon2_hash.py
+++ b/tests/unit/security/test_argon2_hash.py
@@ -1,6 +1,9 @@
+import pytest
+
 from devsynth.security.authentication import hash_password, verify_password
 
 
+@pytest.mark.medium
 def test_argon2_hash_roundtrip():
     password = "S3cret!"
     hashed = hash_password(password)

--- a/tests/unit/security/test_authentication.py
+++ b/tests/unit/security/test_authentication.py
@@ -1,34 +1,43 @@
-from devsynth.security.authentication import hash_password, verify_password, authenticate
+import pytest
+
 from devsynth.exceptions import AuthenticationError
+from devsynth.security.authentication import (
+    authenticate,
+    hash_password,
+    verify_password,
+)
 
 
+@pytest.mark.medium
 def test_hash_and_verify_password_succeeds():
     """Test that hash and verify password succeeds.
 
-ReqID: N/A"""
-    password = 'Secret123!'
+    ReqID: N/A"""
+    password = "Secret123!"
     hashed = hash_password(password)
     assert password not in hashed
     assert verify_password(hashed, password)
-    assert not verify_password(hashed, 'wrong')
+    assert not verify_password(hashed, "wrong")
 
 
+@pytest.mark.medium
 def test_authenticate_success_succeeds():
     """Test that authenticate success succeeds.
 
-ReqID: N/A"""
-    pwd = 'password'
-    creds = {'alice': hash_password(pwd)}
-    assert authenticate('alice', pwd, creds)
+    ReqID: N/A"""
+    pwd = "password"
+    creds = {"alice": hash_password(pwd)}
+    assert authenticate("alice", pwd, creds)
 
 
+@pytest.mark.medium
 def test_authenticate_failure_succeeds():
     """Test that authenticate failure succeeds.
 
-ReqID: N/A"""
-    creds = {'bob': hash_password('password')}
+    ReqID: N/A"""
+    creds = {"bob": hash_password("password")}
     try:
-        authenticate('bob', 'bad', creds)
+        authenticate("bob", "bad", creds)
     except AuthenticationError:
         assert True
     else:

--- a/tests/unit/security/test_authorization.py
+++ b/tests/unit/security/test_authorization.py
@@ -1,131 +1,134 @@
 import pytest
-from devsynth.security.authorization import is_authorized, require_authorization
+
 from devsynth.exceptions import AuthorizationError
-ACL = {'admin': ['read', 'write'], 'user': ['read'], 'superuser': ['*']}
+from devsynth.security.authorization import is_authorized, require_authorization
+
+ACL = {"admin": ["read", "write"], "user": ["read"], "superuser": ["*"]}
 EMPTY_ACL = {}
-CASE_SENSITIVE_ACL = {'Admin': ['Read', 'Write'], 'user': ['read']}
+CASE_SENSITIVE_ACL = {"Admin": ["Read", "Write"], "user": ["read"]}
 
 
+@pytest.mark.medium
 def test_is_authorized_true_returns_expected_result():
     """Test that is_authorized returns True when the user has the required role.
 
-ReqID: N/A"""
-    assert is_authorized(['admin'], 'write', ACL)
+    ReqID: N/A"""
+    assert is_authorized(["admin"], "write", ACL)
 
 
 def test_is_authorized_false_returns_expected_result():
     """Test that is_authorized returns False when the user doesn't have the required role.
 
-ReqID: N/A"""
-    assert not is_authorized(['user'], 'write', ACL)
+    ReqID: N/A"""
+    assert not is_authorized(["user"], "write", ACL)
 
 
 def test_is_authorized_multiple_roles_succeeds():
     """Test that is_authorized works with multiple roles.
 
-ReqID: N/A"""
-    assert is_authorized(['user', 'admin'], 'write', ACL)
-    assert is_authorized(['guest', 'user'], 'read', ACL)
-    assert not is_authorized(['guest', 'user'], 'delete', ACL)
+    ReqID: N/A"""
+    assert is_authorized(["user", "admin"], "write", ACL)
+    assert is_authorized(["guest", "user"], "read", ACL)
+    assert not is_authorized(["guest", "user"], "delete", ACL)
 
 
 def test_is_authorized_wildcard_succeeds():
     """Test that is_authorized works with wildcard actions.
 
-ReqID: N/A"""
-    assert is_authorized(['superuser'], 'read', ACL)
-    assert is_authorized(['superuser'], 'write', ACL)
-    assert is_authorized(['superuser'], 'delete', ACL)
+    ReqID: N/A"""
+    assert is_authorized(["superuser"], "read", ACL)
+    assert is_authorized(["superuser"], "write", ACL)
+    assert is_authorized(["superuser"], "delete", ACL)
 
 
 def test_is_authorized_role_not_in_acl_returns_expected_result():
     """Test that is_authorized returns False when the role doesn't exist in the ACL.
 
-ReqID: N/A"""
-    assert not is_authorized(['guest'], 'read', ACL)
-    assert not is_authorized(['unknown'], 'write', ACL)
+    ReqID: N/A"""
+    assert not is_authorized(["guest"], "read", ACL)
+    assert not is_authorized(["unknown"], "write", ACL)
 
 
 def test_is_authorized_empty_roles_returns_expected_result():
     """Test that is_authorized returns False when the user has no roles.
 
-ReqID: N/A"""
-    assert not is_authorized([], 'read', ACL)
-    assert not is_authorized([], 'write', ACL)
+    ReqID: N/A"""
+    assert not is_authorized([], "read", ACL)
+    assert not is_authorized([], "write", ACL)
 
 
 def test_is_authorized_empty_acl_returns_expected_result():
     """Test that is_authorized returns False when the ACL is empty.
 
-ReqID: N/A"""
-    assert not is_authorized(['admin'], 'read', EMPTY_ACL)
-    assert not is_authorized(['user'], 'write', EMPTY_ACL)
+    ReqID: N/A"""
+    assert not is_authorized(["admin"], "read", EMPTY_ACL)
+    assert not is_authorized(["user"], "write", EMPTY_ACL)
 
 
 def test_is_authorized_case_sensitivity_succeeds():
     """Test that is_authorized is case-sensitive for roles and actions.
 
-ReqID: N/A"""
-    assert not is_authorized(['Admin'], 'write', ACL)
-    assert is_authorized(['Admin'], 'Write', CASE_SENSITIVE_ACL)
-    assert not is_authorized(['admin'], 'Write', ACL)
-    assert is_authorized(['Admin'], 'Write', CASE_SENSITIVE_ACL)
-    assert not is_authorized(['user'], 'Read', ACL)
+    ReqID: N/A"""
+    assert not is_authorized(["Admin"], "write", ACL)
+    assert is_authorized(["Admin"], "Write", CASE_SENSITIVE_ACL)
+    assert not is_authorized(["admin"], "Write", ACL)
+    assert is_authorized(["Admin"], "Write", CASE_SENSITIVE_ACL)
+    assert not is_authorized(["user"], "Read", ACL)
 
 
 def test_is_authorized_iterable_roles_succeeds():
     """Test that is_authorized works with different iterable types for roles.
 
-ReqID: N/A"""
-    assert is_authorized(['admin'], 'write', ACL)
-    assert is_authorized(('admin',), 'write', ACL)
-    assert is_authorized({'admin'}, 'write', ACL)
-
+    ReqID: N/A"""
+    assert is_authorized(["admin"], "write", ACL)
+    assert is_authorized(("admin",), "write", ACL)
+    assert is_authorized({"admin"}, "write", ACL)
 
     class RolesIterable:
 
         def __iter__(self):
-            return iter(['admin'])
-    assert is_authorized(RolesIterable(), 'write', ACL)
+            return iter(["admin"])
+
+    assert is_authorized(RolesIterable(), "write", ACL)
 
 
 def test_require_authorization_raises():
     """Test that require_authorization raises an AuthorizationError when the user doesn't have the required role.
 
-ReqID: N/A"""
+    ReqID: N/A"""
     with pytest.raises(AuthorizationError) as excinfo:
-        require_authorization(['user'], 'write', ACL)
-    assert excinfo.value.message == 'Permission denied'
-    assert excinfo.value.details['roles'] == ['user']
-    assert excinfo.value.details['action'] == 'write'
+        require_authorization(["user"], "write", ACL)
+    assert excinfo.value.message == "Permission denied"
+    assert excinfo.value.details["roles"] == ["user"]
+    assert excinfo.value.details["action"] == "write"
 
 
 def test_require_authorization_no_exception_raises_error():
     """Test that require_authorization doesn't raise an exception when the user is authorized.
 
-ReqID: N/A"""
-    require_authorization(['admin'], 'write', ACL)
-    require_authorization(['user'], 'read', ACL)
-    require_authorization(['superuser'], 'delete', ACL)
+    ReqID: N/A"""
+    require_authorization(["admin"], "write", ACL)
+    require_authorization(["user"], "read", ACL)
+    require_authorization(["superuser"], "delete", ACL)
 
 
 def test_require_authorization_empty_roles_raises_error():
     """Test that require_authorization raises an AuthorizationError when the user has no roles.
 
-ReqID: N/A"""
+    ReqID: N/A"""
     with pytest.raises(AuthorizationError) as excinfo:
-        require_authorization([], 'read', ACL)
-    assert excinfo.value.message == 'Permission denied'
-    assert excinfo.value.details['roles'] == []
-    assert excinfo.value.details['action'] == 'read'
+        require_authorization([], "read", ACL)
+    assert excinfo.value.message == "Permission denied"
+    assert excinfo.value.details["roles"] == []
+    assert excinfo.value.details["action"] == "read"
 
 
 def test_require_authorization_empty_acl_raises_error():
     """Test that require_authorization raises an AuthorizationError when the ACL is empty.
 
-ReqID: N/A"""
+    ReqID: N/A"""
     with pytest.raises(AuthorizationError) as excinfo:
-        require_authorization(['admin'], 'read', EMPTY_ACL)
-    assert excinfo.value.message == 'Permission denied'
-    assert excinfo.value.details['roles'] == ['admin']
-    assert excinfo.value.details['action'] == 'read'
+        require_authorization(["admin"], "read", EMPTY_ACL)
+    assert excinfo.value.message == "Permission denied"
+    assert excinfo.value.details["roles"] == ["admin"]
+    assert excinfo.value.details["action"] == "read"


### PR DESCRIPTION
## Summary
- categorize previously unmarked tests in docs and security modules using incremental test categorization
- document test speed categories and their markers in tests/README

## Testing
- `poetry run pytest tests/unit/docs/test_feature_matrix.py tests/unit/security/test_argon2_hash.py tests/unit/security/test_authentication.py::test_hash_and_verify_password_succeeds tests/unit/security/test_authentication.py::test_authenticate_success_succeeds tests/unit/security/test_authentication.py::test_authenticate_failure_succeeds tests/unit/security/test_authorization.py::test_is_authorized_true_returns_expected_result -q`
- `poetry run pre-commit run --files tests/unit/docs/test_feature_matrix.py tests/unit/security/test_argon2_hash.py tests/unit/security/test_authentication.py tests/unit/security/test_authorization.py tests/README.md` *(fails: LMStudioProvider requires the 'lmstudio' package)*

------
https://chatgpt.com/codex/tasks/task_e_688fe459451883339deed0c4837ee549