### PR TITLE
docs: add stabilization script examples

### DIFF
--- a/docs/developer_guides/test_stabilization_tools.md
+++ b/docs/developer_guides/test_stabilization_tools.md
@@ -17,6 +17,12 @@ To address these issues, we created three scripts:
 2. `fix_test_method_signatures.py`: Fixes inconsistent method signatures in test classes
 3. `fix_test_syntax_errors.py`: Fixes common syntax errors in test files
 
+Additional tools assist with broader stabilization tasks:
+
+4. `fix_flaky_tests.py`: Detects and resolves common flaky-test patterns
+5. `incremental_test_categorization.py`: Measures runtime and applies `fast`, `medium`, or `slow` markers
+6. `run_all_tests.py`: Runs categorized tests with optional parallelism and HTML reporting
+
 ## Usage
 
 ### Fix Missing Pytest Imports
@@ -64,6 +70,30 @@ Example:
 python scripts/fix_test_syntax_errors.py tests/behavior/steps
 ```
 
+### Fix Flaky Tests
+
+```bash
+python scripts/fix_flaky_tests.py --module tests/unit/interface --pattern isolation
+```
+
+This script scans tests for mocking, isolation, and state issues that can cause nondeterministic failures. Use `--dry-run` to preview changes or `--report` to generate a summary of detected problems.
+
+### Incremental Test Categorization
+
+```bash
+python scripts/incremental_test_categorization.py --update --batch-size 10
+```
+
+The categorization tool measures execution time in batches and updates test files with speed markers. Progress is saved to `.test_categorization_progress.json`, allowing subsequent runs to continue where they left off.
+
+### Run All Tests
+
+```bash
+python scripts/run_all_tests.py --fast --medium --report
+```
+
+This wrapper around `pytest` respects speed markers, can segment tests for faster feedback, and optionally produces an HTML report under `test_reports/`.
+
 ## Common Test Issues and Solutions
 
 ### Missing Pytest Imports
@@ -97,7 +127,7 @@ def test_something():
 class TestSomething:
     def test_method1(self):
         pass
-        
+
     def test_method2():  # Missing 'self'
         pass
 
@@ -105,7 +135,7 @@ class TestSomething:
 class TestSomething:
     def test_method1(self):
         pass
-        
+
     def test_method2(self):  # Added 'self'
         pass
 ```

--- a/docs/developer_guides/testing.md
+++ b/docs/developer_guides/testing.md
@@ -128,7 +128,7 @@ Example of test isolation (from `tests/behavior/conftest.py`):
 @pytest.fixture(autouse=True)
 def patch_env_and_cleanup(tmp_project_dir):
     """
-    Patch environment variables for LLM providers and ensure all logs/artifacts 
+    Patch environment variables for LLM providers and ensure all logs/artifacts
     are isolated and cleaned up.
     """
     # Save old environment and set test environment
@@ -316,6 +316,8 @@ reports with `pytest-html`.
 ```
 
 Combine options (for example, integration tests with a report) as needed.
+
+For utilities that fix flaky tests and categorize runtime, refer to [Test Stabilization Tools](test_stabilization_tools.md).
 
 ### Running Specific Test Types
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -321,6 +321,8 @@ poetry run python scripts/run_all_tests.py --target unit-tests  # run only unit 
 poetry run python scripts/run_all_tests.py --report             # generate HTML report under test_reports/
 ```
 
+For additional utilities like flaky-test fixes and incremental categorization, see [Test Stabilization Tools](../docs/developer_guides/test_stabilization_tools.md).
+
 ## Referencing Requirements in Tests
 
 All tests should include the requirement ID they verify in the test's docstring. This links the test back to the relevant entry in `docs/requirements_traceability.md`.


### PR DESCRIPTION
## Summary
- document fix_flaky_tests, incremental test categorization, and run_all_tests utilities
- link test stabilization tools from testing guide and test README

## Testing
- `pre-commit run --files docs/developer_guides/test_stabilization_tools.md docs/developer_guides/testing.md tests/README.md` *(fails: ImportError: LMDBStore requires the 'lmdb' package)*
- `poetry run pytest -q` *(fails: ModuleNotFoundError: No module named 'chromadb'; 119 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_688fe831372883339ba6f637c2a1b208