### PR TITLE
docs: add agent tools guide

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -146,6 +146,7 @@ Refer to `docs/architecture/agent_system.md` and `docs/architecture/wsde_agent_m
 - [Black](https://black.readthedocs.io/)
 - [pytest](https://docs.pytest.org/)
 - Project documentation in `docs/`
+- [Agent Tools Guide](docs/developer_guides/agent_tools.md) - Using the tool registry and adding new tools
 - Agent architecture: `docs/architecture/agent_system.md`, `docs/architecture/wsde_agent_model.md`
 
 ## Feedback

--- a/docs/developer_guides/agent_tools.md
+++ b/docs/developer_guides/agent_tools.md
@@ -2,7 +2,7 @@
 author: DevSynth Team
 date: '2025-07-12'
 last_reviewed: '2025-07-12'
-status: draft
+status: published
 tags:
 - developer-guide
 title: Agent Tools
@@ -12,41 +12,75 @@ version: 0.1.0
 <div class="breadcrumbs">
 <a href="../index.md">Documentation</a> &gt; <a href="index.md">Developer Guides</a> &gt; Agent Tools
 </div>
+ 
+# Agent Tools
 
-# Agent Tools Security Model
+DevSynth agents rely on a registry of sandboxed tools to extend their
+behaviour. This guide describes the tools that ship with DevSynth, how to work
+with the registry and the steps for adding new tools.
 
-Agent tools are executed inside a sandbox to minimize the impact of untrusted
-code.
+## Existing Tools
 
-## File System Restrictions
+| Name | Description |
+|------|-------------|
+| `alignment_metrics` | Collects code alignment metrics and optionally writes a report. |
+| `run_tests` | Executes the project's pytest suites and returns their output. |
 
-Tools may only read and write within the DevSynth project directory. Attempts to
-access paths outside the repository raise a ``PermissionError``.
+You can inspect the registry programmatically:
 
-## Shell Command Restrictions
+```python
+from devsynth.agents.tools import get_tool_registry
 
-Shell commands are blocked by default. A tool can opt into shell access during
-registration by setting ``allow_shell=True``. Without this flag any use of
-``subprocess.run`` or ``subprocess.Popen`` raises ``PermissionError``.
+registry = get_tool_registry()
+for name, meta in registry.list_tools().items():
+    print(name, meta["description"])
+```
 
-## Usage
+## Adding a New Tool
+
+1. Implement the tool as a plain function.
+2. Register it with ``tool_registry.register``.
+3. Describe the parameters using a JSON schema dictionary.
+4. Set ``allow_shell=True`` only if the tool must execute shell commands.
 
 ```python
 from devsynth.agents.tools import tool_registry
 
-
-def my_tool():
-    ...
-
+def shout(text: str) -> str:
+    return text.upper()
 
 tool_registry.register(
-    "example",
-    my_tool,
+    "shout",
+    shout,
     description="Example tool",
-    parameters={},
+    parameters={
+        "type": "object",
+        "properties": {
+            "text": {
+                "type": "string",
+                "description": "Text to convert",
+            }
+        },
+        "required": ["text"],
+    },
     allow_shell=False,
 )
 ```
 
-This model ensures tools operate with least privilege while still supporting
-explicitly authorized commands.
+## Invoking Tools
+
+```python
+from devsynth.agents.tools import get_tool_registry
+
+registry = get_tool_registry()
+run_tests = registry.get("run_tests")
+result = run_tests(target="unit-tests")
+print(result["output"])
+```
+
+## Security Model
+
+All tools execute within a sandbox that limits file system access to the
+repository and blocks shell commands unless ``allow_shell=True`` is specified.
+This design enforces least privilege while still enabling explicitly authorised
+commands.

--- a/docs/developer_guides/index.md
+++ b/docs/developer_guides/index.md
@@ -33,6 +33,7 @@ This section is for developers contributing to the DevSynth project or those loo
 - **[Dependency Strategy](dependencies.md)**: Overview of optional extras and CI checks.
 - **[Repository Structure](../repo_structure.md)**: An overview of how the DevSynth repository is organized.
 - **[Requirements Wizard Structure](requirements_wizard_structure.md)**: Overview of the requirements wizard helpers.
+- **[Agent Tools](agent_tools.md)**: Overview of the tool registry and how to add new tools.
 
 ## Testing Guides
 


### PR DESCRIPTION
## Summary
- document built-in agent tools and the global tool registry
- show how to register and invoke new tools
- link guide from `AGENTS.md` and developer guide index

## Testing
- `pre-commit run --files docs/developer_guides/agent_tools.md docs/developer_guides/index.md AGENTS.md` *(fails: command not found)*
- `poetry run pytest tests/unit/agents/test_alignment_metrics_tool.py tests/unit/agents/test_run_tests_tool.py` *(fails: No module named 'pytest_bdd')*


------
https://chatgpt.com/codex/tasks/task_e_688feb3102b083339f35294d72922807