### PR TITLE
feat: add security scanners to audit script

### DIFF
--- a/docs/developer_guides/security.md
+++ b/docs/developer_guides/security.md
@@ -1,0 +1,44 @@
+---
+title: "Security Audit"
+date: "2025-07-21"
+version: "0.1.0"
+tags:
+  - "developer-guide"
+  - "security"
+status: "published"
+author: "DevSynth Team"
+last_reviewed: "2025-07-21"---
+
+<div class="breadcrumbs">
+<a href="../index.md">Documentation</a> &gt; <a href="index.md">Developer Guides</a> &gt; Security Audit
+</div>
+
+# Security Audit
+
+The `security_audit.py` script aggregates multiple scanners to help protect the
+project. By default all checks run.
+
+## Checks
+
+- **Safety** – Python dependency vulnerability scan.
+- **Bandit** – static analysis for common security issues.
+- **Secrets scan** – searches the repository for strings resembling API keys.
+- **OWASP Dependency Check** – invokes the OWASP Dependency-Check tool for
+  third-party library analysis.
+
+## Usage
+
+Run all checks:
+
+```bash
+python scripts/security_audit.py
+```
+
+Skip specific scanners using flags:
+
+```bash
+python scripts/security_audit.py --skip-bandit --skip-secrets --skip-owasp --skip-safety
+```
+
+`--skip-static` is retained as an alias for `--skip-bandit` for backward
+compatibility.

--- a/src/devsynth/adapters/cli/typer_adapter.py
+++ b/src/devsynth/adapters/cli/typer_adapter.py
@@ -451,7 +451,7 @@ def build_app() -> typer.Typer:
     )(generate_docs_cmd)
     app.command(
         name="security-audit",
-        help="Run security checks. Example: devsynth security-audit --skip-static",
+        help="Run security checks. Example: devsynth security-audit --skip-owasp",
     )(security_audit_cmd)
     app.command(
         name="ingest",


### PR DESCRIPTION
## Summary
- integrate secrets scanning and OWASP dependency-check into security audit
- add CLI switches to toggle Safety, Bandit, secrets and OWASP scans
- document security audit usage and checks

## Testing
- `pytest tests/unit/security/test_security_audit.py -q` *(fails: ModuleNotFoundError: No module named 'pytest_bdd')*
- `PYTHONPATH=src DEVSYNTH_ACCESS_TOKEN=dummy python scripts/security_audit.py --skip-bandit --skip-safety --skip-secrets --skip-owasp` *(fails: ModuleNotFoundError: No module named 'typer')*


------
https://chatgpt.com/codex/tasks/task_e_688feb1d78348333beb0e594cad4c2c5