### PR TITLE
Add devsynth alignment pre-commit hook

### DIFF
--- a/docs/developer_guides/pre_commit_samples.md
+++ b/docs/developer_guides/pre_commit_samples.md
@@ -64,3 +64,13 @@ repos:
 ```
 
 Use `pre-commit install` to enable these hooks locally and `pre-commit run --all-files` to run them across the entire codebase.
+
+## Manual installation
+
+If you prefer not to use the pre-commit framework, you can install the alignment hook directly:
+
+```bash
+ln -s ../../scripts/hooks/pre-commit-align.sh .git/hooks/pre-commit
+```
+
+This symlink runs `devsynth align --quiet` from the repository root before each commit.

--- a/scripts/hooks/pre-commit-align.sh
+++ b/scripts/hooks/pre-commit-align.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(git rev-parse --show-toplevel)"
+cd "$repo_root"
+
+exec devsynth align --quiet


### PR DESCRIPTION
## Summary
- add `scripts/hooks/pre-commit-align.sh` to run `devsynth align --quiet`
- document manual installation of align hook in developer guide

## Testing
- `poetry run pre-commit run --files scripts/hooks/pre-commit-align.sh docs/developer_guides/pre_commit_samples.md` *(fails: Executable `devsynth` not found)*
- `poetry run pytest tests -q` *(fails: ModuleNotFoundError: No module named 'pytest_bdd')*

------
https://chatgpt.com/codex/tasks/task_e_688feb4e7cb88333b321ba4ac338ff90