### PR TITLE
chore: add release build tasks and documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -84,6 +84,17 @@ Good documentation is essential. Please update relevant documentation for any ch
 3. Push your changes and create a pull request
 4. Respond to review feedback
 
+## Release Process
+
+Maintainers preparing a tagged release should build distributable artifacts and
+run a quick smoke test before tagging:
+
+```bash
+task release:prep
+git tag v0.1.0-alpha.1
+git push origin v0.1.0-alpha.1
+```
+
 ## Code of Conduct
 
 We are committed to providing a friendly, safe, and welcoming environment for all contributors. Please be respectful, inclusive, and collaborative.

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -50,6 +50,11 @@ tasks:
     cmds:
       - poetry run pytest {{.PYTEST_COV_ARGS}} {{.PYTEST_ARGS}}
 
+  test:smoke:
+    desc: Run a minimal smoke test suite
+    cmds:
+      - poetry run pytest --maxfail=1
+
   # Performance benchmarking tasks
   bench:
     desc: Run performance benchmarks
@@ -112,6 +117,16 @@ tasks:
     cmds:
       - poetry build
 
+  build:wheel:
+    desc: Build wheel distribution
+    cmds:
+      - poetry build --format wheel
+
+  build:sdist:
+    desc: Build source distribution
+    cmds:
+      - poetry build --format sdist
+
   clean:
     desc: Clean build artifacts
     cmds:
@@ -122,6 +137,14 @@ tasks:
       - rm -rf site
       - find . -type d -name __pycache__ -exec rm -rf {} +
       - find . -name '*\,cover' -delete
+
+  release:prep:
+    desc: Build distributions and run smoke tests before tagging a release
+    cmds:
+      - task: clean
+      - task: build:wheel
+      - task: build:sdist
+      - task: test:smoke
 
   # Development workflow tasks
   dev:

--- a/docs/roadmap/release_plan.md
+++ b/docs/roadmap/release_plan.md
@@ -20,6 +20,17 @@ This release plan defines version milestones for DevSynth starting with the upco
 
 ## Milestones
 
+### 0.1.0-alpha.1
+
+Before publishing the first alpha tag, ensure the artifacts build and the
+project passes a quick smoke test:
+
+```bash
+task release:prep
+git tag v0.1.0-alpha.1
+git push origin v0.1.0-alpha.1
+```
+
 ### 0.1.0-beta.1
 - Refresh system architecture diagrams under `docs/architecture/`.
 - Standardize metadata headers across all project documentation.


### PR DESCRIPTION
## Summary
- add Taskfile tasks to build wheel and sdist, run smoke tests, and prepare releases
- document alpha release steps in roadmap
- note release prep in contributing guide

## Testing
- `poetry build --format wheel`
- `poetry build --format sdist`
- `poetry run pytest --maxfail=1` *(fails: ModuleNotFoundError: No module named 'pytest_bdd')*
- `pre-commit run --files Taskfile.yml docs/roadmap/release_plan.md CONTRIBUTING.md` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688feb073e008333a79440559f037b67