### PR TITLE
docs: add deprecation policy reference

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,7 +55,8 @@ version has been published yet.
   hybrid memory architecture, and basic metrics system.
 ### Deprecated
 - `scripts/alignment_check.py` and `scripts/validate_manifest.py` replaced by
-  CLI commands `devsynth align` and `devsynth validate-manifest`.
+  CLI commands `devsynth align` and `devsynth validate-manifest`. These scripts
+  will be removed in v1.0 per the deprecation policy.
 ### Fixed
 - Optional tiktoken dependency no longer breaks Kuzu memory initialization
 - Added missing step definitions for enhanced memory scenarios

--- a/docs/policies/deprecation_policy.md
+++ b/docs/policies/deprecation_policy.md
@@ -1,0 +1,35 @@
+---
+author: DevSynth Team
+date: '2025-07-31'
+last_reviewed: '2025-07-31'
+status: draft
+tags:
+- policy
+title: Deprecation Policy
+version: 0.1.0---
+
+<div class="breadcrumbs">
+<a href="../index.md">Documentation</a> &gt; <a href="index.md">Policies</a> &gt; Deprecation Policy
+</div>
+
+<div class="breadcrumbs">
+<a href="../index.md">Documentation</a> &gt; <a href="index.md">Policies</a> &gt; Deprecation Policy
+</div>
+
+# Deprecation Policy
+
+DevSynth deprecates scripts and features prior to their removal. Deprecated
+components remain available for the current minor release series and are
+removed in the next major release.
+
+## Schedule
+- Announce deprecations with alternatives.
+- Maintain deprecated items for the remainder of the current minor release
+  series.
+- Remove deprecated items in the next major release (v1.0).
+
+For example, `scripts/alignment_check.py` and `scripts/validate_manifest.py`
+are deprecated and scheduled for removal in v1.0.
+
+Developers should migrate to the recommended replacements before the removal
+version.

--- a/scripts/alignment_check.py
+++ b/scripts/alignment_check.py
@@ -1,9 +1,11 @@
 #!/usr/bin/env python3
-# DEPRECATED: use `devsynth align` instead. This script will be removed in a future release.
+# DEPRECATED: use `devsynth align` instead. This script will be removed in the
+# next major release. See docs/policies/deprecation_policy.md for details.
 """Run the DevSynth alignment check as a pre-commit hook.
 
-Deprecated: use ``devsynth align`` instead. This wrapper exists only for
-backward compatibility and will be removed in a future release.
+DEPRECATED: use ``devsynth align`` instead. This wrapper exists only for
+backward compatibility and will be removed in the next major release. See
+``docs/policies/deprecation_policy.md`` for details.
 
 This script is a thin wrapper around the project's CLI alignment command. It
 executes the same alignment logic to ensure consistent behaviour with the

--- a/scripts/validate_manifest.py
+++ b/scripts/validate_manifest.py
@@ -1,12 +1,15 @@
-# DEPRECATED: use `devsynth validate-manifest` instead. This script will be removed in a future release.
+# DEPRECATED: use `devsynth validate-manifest` instead. This script will be
+# removed in the next major release. See docs/policies/deprecation_policy.md for
+# details.
 """Wrapper for validating DevSynth project manifests.
 
-Deprecated: use ``devsynth validate-manifest`` instead. This script remains for
-backward compatibility and will be removed in a future release. Older automation
-that invoked ``scripts/validate_manifest.py`` directly should transition to the
-CLI command. The heavy lifting now lives in
+DEPRECATED: use ``devsynth validate-manifest`` instead. This script remains for
+backward compatibility and will be removed in the next major release. Older
+automation that invoked ``scripts/validate_manifest.py`` directly should
+transition to the CLI command. The heavy lifting now lives in
 :mod:`devsynth.application.cli.commands.validate_manifest_cmd`, so this file
-simply forwards arguments to that command.
+simply forwards arguments to that command. See
+``docs/policies/deprecation_policy.md`` for the deprecation schedule.
 """
 
 from __future__ import annotations


### PR DESCRIPTION
## Summary
- document deprecation schedule and next-major-removal policy
- reference deprecation policy in deprecated scripts
- note planned script removal in changelog

## Testing
- `poetry env info --path`
- `poetry run pip check`
- `poetry run pip list | grep pytest-bdd`
- `poetry run pytest tests/` *(fails: ImportError: cannot import name 'configure_logging' from 'devsynth.logging_setup')*

------
https://chatgpt.com/codex/tasks/task_e_688feb985ef88333854c6d28516fbabb