### PR TITLE
docs: stabilize pre-release version references

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ version has been published yet.
 - Updated cross-references in documentation
 - Renamed CLI commands: `adaptive`→`refactor`, `analyze`→`inspect`, `run`→`run-pipeline`, `replay`→`retrace`
 - Synchronized feature status reports with latest implementation
+- Stabilized pre-release references to maintain version `0.1.0-alpha.1` across configuration and documentation
 
 ### Fixed
 - Improved error handling in the EDRR coordinator
@@ -59,4 +60,3 @@ version has been published yet.
 ### Fixed
 - Optional tiktoken dependency no longer breaks Kuzu memory initialization
 - Added missing step definitions for enhanced memory scenarios
-

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ---
 title: "DevSynth"
 date: "2025-05-20"
-version: "0.1.0"
+version: "0.1.0-alpha.1"
 tags:
   - "devsynth"
   - "overview"

--- a/docs/documentation_index.md
+++ b/docs/documentation_index.md
@@ -1,7 +1,7 @@
 ---
 title: "Documentation Index"
 date: "2025-07-07"
-version: "0.1.0"
+version: "0.1.0-alpha.1"
 tags:
   - "documentation"
 

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -1,7 +1,7 @@
 ---
 title: "DevSynth Glossary"
 date: "2025-08-02"
-version: "0.1.0"
+version: "0.1.0-alpha.1"
 tags:
   - "glossary"
   - "terminology"
@@ -9,7 +9,8 @@ tags:
   - "reference"
 status: "published"
 author: "DevSynth Team"
-last_reviewed: "2025-08-02"---
+last_reviewed: "2025-08-02"
+---
 
 <div class="breadcrumbs">
 <a href="../index.md">Documentation</a> &gt; DevSynth Glossary

--- a/docs/roadmap/CONSOLIDATED_ROADMAP.md
+++ b/docs/roadmap/CONSOLIDATED_ROADMAP.md
@@ -1,7 +1,7 @@
 ---
 title: "DevSynth Consolidated Roadmap"
 date: "2025-08-02"
-version: "0.1.0"
+version: "0.1.0-alpha.1"
 tags:
   - "roadmap"
   - "release"

--- a/docs/roadmap/FINAL_SUMMARY.md
+++ b/docs/roadmap/FINAL_SUMMARY.md
@@ -1,7 +1,7 @@
 ---
 title: "DevSynth Repository Harmonization Final Summary"
 date: "2025-07-10"
-version: "0.1.0"
+version: "0.1.0-alpha.1"
 status: "published"
 tags:
   - roadmap

--- a/docs/roadmap/development_plan.md
+++ b/docs/roadmap/development_plan.md
@@ -1,7 +1,7 @@
 ---
 title: "DevSynth Development Plan"
 date: "2025-06-01"
-version: "0.1.0"
+version: "0.1.0-alpha.1"
 tags:
   - "development"
   - "planning"

--- a/docs/roadmap/development_status.md
+++ b/docs/roadmap/development_status.md
@@ -12,7 +12,7 @@ tags:
 - foundation-stabilization
 
 title: DevSynth Development Status
-version: 0.1.0---
+version: 0.1.0-alpha.1
 
 <div class="breadcrumbs">
 <a href="../index.md">Documentation</a> &gt; <a href="index.md">Roadmap</a> &gt; DevSynth Development Status

--- a/docs/roadmap/post_mvp_roadmap.md
+++ b/docs/roadmap/post_mvp_roadmap.md
@@ -1,7 +1,7 @@
 ---
 title: "DevSynth Post-MVP Development Roadmap"
 date: "2025-07-07"
-version: "0.1.0"
+version: "0.1.0-alpha.1"
 tags:
   - "specification"
 

--- a/docs/roadmap/release_plan.md
+++ b/docs/roadmap/release_plan.md
@@ -1,7 +1,7 @@
 ---
 title: "DevSynth Release Plan"
 date: "2025-08-20"
-version: "0.1.0"
+version: "0.1.0-alpha.1"
 tags:
   - roadmap
   - release


### PR DESCRIPTION
## Summary
- ensure package metadata and documentation keep version `0.1.0-alpha.1`
- add changelog entry for pre-release stabilization
- normalize version headers in README and roadmap docs

## Testing
- `pre-commit run --files CHANGELOG.md README.md docs/roadmap/release_plan.md docs/documentation_index.md docs/glossary.md docs/roadmap/CONSOLIDATED_ROADMAP.md docs/roadmap/post_mvp_roadmap.md docs/roadmap/development_plan.md docs/roadmap/FINAL_SUMMARY.md docs/roadmap/development_status.md`
- `poetry run pytest --maxfail=1` *(fails: ModuleNotFoundError: No module named 'requests')*


------
https://chatgpt.com/codex/tasks/task_e_688fece95a2c8333b739d1568e75bf91