### PR TITLE
feat: propagate tool metadata to agents

### DIFF
--- a/src/devsynth/agents/graph_state.py
+++ b/src/devsynth/agents/graph_state.py
@@ -1,7 +1,7 @@
-"""
-Defines the state for LangGraph agent workflows.
-"""
-from typing import TypedDict, Optional, List
+"""Defines the state for LangGraph agent workflows."""
+
+from typing import Any, Dict, List, Optional, TypedDict
+
 
 class AgentState(TypedDict):
     """
@@ -14,11 +14,13 @@ class AgentState(TypedDict):
         intermediate_steps: A list of intermediate steps or tool outputs (optional).
         final_output: The final formatted response from the agent.
         error: Any error message encountered during the workflow (optional).
+        available_tools: Tool metadata available to the agent (optional).
     """
+
     input_request: str
     processed_input: Optional[str]
     llm_response: Optional[str]
     intermediate_steps: Optional[List[str]]
     final_output: Optional[str]
     error: Optional[str]
-
+    available_tools: Optional[List[Dict[str, Any]]]

--- a/tests/integration/general/test_agent_system_integration.py
+++ b/tests/integration/general/test_agent_system_integration.py
@@ -1,83 +1,128 @@
 """
 Integration tests for the LangGraph base_agent_graph.
 """
+
 import pytest
 from unittest.mock import patch, MagicMock
 from devsynth.agents.graph_state import AgentState
-from devsynth.agents.base_agent_graph import base_agent_graph
+from devsynth.agents.base_agent_graph import (
+    base_agent_graph,
+    get_available_tools,
+)
 from devsynth.adapters.provider_system import ProviderError
 
 
-@patch('devsynth.agents.base_agent_graph.llm_complete')
+@patch("devsynth.agents.base_agent_graph.llm_complete")
 @pytest.mark.medium
 def test_base_agent_graph_successful_invocation_succeeds(mock_llm_complete):
     """Test a successful end-to-end invocation of the base_agent_graph.
 
-ReqID: N/A"""
-    mock_llm_complete.return_value = 'Mocked LLM response'
-    initial_state = AgentState(input_request='Test input request',
-        processed_input=None, llm_response=None, intermediate_steps=None,
-        final_output=None, error=None)
+    ReqID: N/A"""
+    mock_llm_complete.return_value = "Mocked LLM response"
+    initial_state = AgentState(
+        input_request="Test input request",
+        processed_input=None,
+        llm_response=None,
+        intermediate_steps=None,
+        final_output=None,
+        error=None,
+    )
     final_state = base_agent_graph.invoke(initial_state)
-    assert final_state['processed_input'] == 'Test input request'
-    mock_llm_complete.assert_called_once_with(prompt='Test input request',
-        system_prompt='You are a helpful AI assistant.', fallback=True)
-    assert final_state['llm_response'] == 'Mocked LLM response'
-    assert final_state['final_output'] == 'Mocked LLM response'
-    assert final_state.get('error') is None
+    expected_tools = get_available_tools()
+    assert final_state["processed_input"] == "Test input request"
+    mock_llm_complete.assert_called_once_with(
+        prompt="Test input request",
+        system_prompt="You are a helpful AI assistant.",
+        fallback=True,
+        parameters={"tools": expected_tools},
+    )
+    assert final_state["llm_response"] == "Mocked LLM response"
+    assert final_state["final_output"] == "Mocked LLM response"
+    assert final_state.get("error") is None
+    assert final_state["available_tools"] == expected_tools
 
 
-@patch('devsynth.agents.base_agent_graph.llm_complete')
+@patch("devsynth.agents.base_agent_graph.llm_complete")
 @pytest.mark.medium
-def test_base_agent_graph_error_in_input_processing_raises_error(
-    mock_llm_complete):
+def test_base_agent_graph_error_in_input_processing_raises_error(mock_llm_complete):
     """Test graph behavior when process_input_node sets an error.
 
-ReqID: N/A"""
-    initial_state = AgentState(input_request='', processed_input=None,
-        llm_response=None, intermediate_steps=None, final_output=None,
-        error=None)
+    ReqID: N/A"""
+    initial_state = AgentState(
+        input_request="",
+        processed_input=None,
+        llm_response=None,
+        intermediate_steps=None,
+        final_output=None,
+        error=None,
+    )
     final_state = base_agent_graph.invoke(initial_state)
-    assert 'Input request cannot be empty' in final_state.get('error', '')
-    assert final_state.get('processed_input') is None
+    assert "Input request cannot be empty" in final_state.get("error", "")
+    assert final_state.get("processed_input") is None
     mock_llm_complete.assert_not_called()
-    assert final_state.get('llm_response') is None
-    assert final_state.get('final_output') is None
+    assert final_state.get("llm_response") is None
+    assert final_state.get("final_output") is None
+    assert final_state["available_tools"] == get_available_tools()
 
 
-@patch('devsynth.agents.base_agent_graph.llm_complete')
+@patch("devsynth.agents.base_agent_graph.llm_complete")
 @pytest.mark.medium
 def test_base_agent_graph_error_in_llm_call_raises_error(mock_llm_complete):
     """Test graph behavior when llm_call_node encounters an LLM error.
 
-ReqID: N/A"""
-    mock_llm_complete.side_effect = ProviderError('LLM API is down')
-    initial_state = AgentState(input_request='Valid input', processed_input
-        =None, llm_response=None, intermediate_steps=None, final_output=
-        None, error=None)
+    ReqID: N/A"""
+    mock_llm_complete.side_effect = ProviderError("LLM API is down")
+    initial_state = AgentState(
+        input_request="Valid input",
+        processed_input=None,
+        llm_response=None,
+        intermediate_steps=None,
+        final_output=None,
+        error=None,
+    )
     final_state = base_agent_graph.invoke(initial_state)
-    assert final_state['processed_input'] == 'Valid input'
-    mock_llm_complete.assert_called_once_with(prompt='Valid input',
-        system_prompt='You are a helpful AI assistant.', fallback=True)
-    assert 'LLM call failed: LLM API is down' in final_state.get('error', '')
-    assert final_state.get('llm_response') is None
-    assert final_state.get('final_output') is None
+    expected_tools = get_available_tools()
+    assert final_state["processed_input"] == "Valid input"
+    mock_llm_complete.assert_called_once_with(
+        prompt="Valid input",
+        system_prompt="You are a helpful AI assistant.",
+        fallback=True,
+        parameters={"tools": expected_tools},
+    )
+    assert "LLM call failed: LLM API is down" in final_state.get("error", "")
+    assert final_state.get("llm_response") is None
+    assert final_state.get("final_output") is None
+    assert final_state["available_tools"] == expected_tools
 
 
-@patch('devsynth.agents.base_agent_graph.llm_complete')
+@patch("devsynth.agents.base_agent_graph.llm_complete")
 @pytest.mark.medium
 def test_base_agent_graph_llm_response_is_none_for_parsing_raises_error(
-    mock_llm_complete):
+    mock_llm_complete,
+):
     """Test graph behavior when llm_response is None before parse_output_node.
-This simulates a scenario where llm_call_node might not set llm_response correctly,
-though our current llm_call_node always sets an error or a response.
-This test ensures parse_output_node handles it gracefully.
+    This simulates a scenario where llm_call_node might not set llm_response correctly,
+    though our current llm_call_node always sets an error or a response.
+    This test ensures parse_output_node handles it gracefully.
 
-ReqID: N/A"""
-    mock_llm_complete.return_value = '  Proper LLM Response  '
-    initial_state = AgentState(input_request='Another test',
-        processed_input=None, llm_response=None, intermediate_steps=None,
-        final_output=None, error=None)
+    ReqID: N/A"""
+    mock_llm_complete.return_value = "  Proper LLM Response  "
+    initial_state = AgentState(
+        input_request="Another test",
+        processed_input=None,
+        llm_response=None,
+        intermediate_steps=None,
+        final_output=None,
+        error=None,
+    )
     final_state = base_agent_graph.invoke(initial_state)
-    assert final_state['final_output'] == 'Proper LLM Response'
-    assert final_state.get('error') is None
+    expected_tools = get_available_tools()
+    mock_llm_complete.assert_called_once_with(
+        prompt="Another test",
+        system_prompt="You are a helpful AI assistant.",
+        fallback=True,
+        parameters={"tools": expected_tools},
+    )
+    assert final_state["final_output"] == "Proper LLM Response"
+    assert final_state.get("error") is None
+    assert final_state["available_tools"] == expected_tools

--- a/tests/unit/general/test_agent_system.py
+++ b/tests/unit/general/test_agent_system.py
@@ -1,142 +1,230 @@
 """
 Unit tests for the LangGraph agent system components.
 """
+
 import pytest
 from unittest.mock import patch, MagicMock
 from devsynth.agents.graph_state import AgentState
-from devsynth.agents.base_agent_graph import process_input_node, llm_call_node, parse_output_node, base_agent_graph
+from devsynth.agents.base_agent_graph import (
+    process_input_node,
+    llm_call_node,
+    parse_output_node,
+    base_agent_graph,
+    get_available_tools,
+)
 from devsynth.adapters.provider_system import ProviderError
 
 
 def test_agent_state_keys_has_expected():
     """Test that AgentState can be created and has expected keys.
 
-ReqID: N/A"""
-    state = AgentState(input_request='test', processed_input=None,
-        llm_response=None, intermediate_steps=None, final_output=None,
-        error=None)
-    assert 'input_request' in state
-    assert state['input_request'] == 'test'
+    ReqID: N/A"""
+    state = AgentState(
+        input_request="test",
+        processed_input=None,
+        llm_response=None,
+        intermediate_steps=None,
+        final_output=None,
+        error=None,
+    )
+    assert "input_request" in state
+    assert state["input_request"] == "test"
 
 
 def test_process_input_node_success_is_valid():
     """Test process_input_node with valid input.
 
-ReqID: N/A"""
-    initial_state = AgentState(input_request='  hello world  ',
-        processed_input=None, llm_response=None, intermediate_steps=None,
-        final_output=None, error=None)
+    ReqID: N/A"""
+    initial_state = AgentState(
+        input_request="  hello world  ",
+        processed_input=None,
+        llm_response=None,
+        intermediate_steps=None,
+        final_output=None,
+        error=None,
+    )
     updated_state = process_input_node(initial_state)
-    assert updated_state['processed_input'] == 'hello world'
-    assert updated_state.get('error') is None
+    assert updated_state["processed_input"] == "hello world"
+    assert updated_state.get("error") is None
 
 
 def test_process_input_node_empty_input_succeeds():
     """Test process_input_node with empty input.
 
-ReqID: N/A"""
-    initial_state = AgentState(input_request='', processed_input=None,
-        llm_response=None, intermediate_steps=None, final_output=None,
-        error=None)
+    ReqID: N/A"""
+    initial_state = AgentState(
+        input_request="",
+        processed_input=None,
+        llm_response=None,
+        intermediate_steps=None,
+        final_output=None,
+        error=None,
+    )
     updated_state = process_input_node(initial_state)
-    assert 'Input request cannot be empty' in updated_state.get('error', '')
-    assert updated_state.get('processed_input') is None
+    assert "Input request cannot be empty" in updated_state.get("error", "")
+    assert updated_state.get("processed_input") is None
 
 
-@patch('devsynth.agents.base_agent_graph.llm_complete')
+def test_process_input_node_adds_tool_list():
+    """Process node should add available tools to state."""
+    initial_state = AgentState(
+        input_request="tools test",
+        processed_input=None,
+        llm_response=None,
+        intermediate_steps=None,
+        final_output=None,
+        error=None,
+    )
+    updated_state = process_input_node(initial_state)
+    assert updated_state.get("available_tools") == get_available_tools()
+
+
+@patch("devsynth.agents.base_agent_graph.llm_complete")
 def test_llm_call_node_success_succeeds(mock_llm_complete):
     """Test llm_call_node with successful LLM call.
 
-ReqID: N/A"""
-    mock_llm_complete.return_value = 'LLM says hello'
-    initial_state = AgentState(input_request='test', processed_input=
-        'test prompt', llm_response=None, intermediate_steps=None,
-        final_output=None, error=None)
-    updated_state = llm_call_node(initial_state)
-    mock_llm_complete.assert_called_once_with(prompt='test prompt',
-        system_prompt='You are a helpful AI assistant.', fallback=True)
-    assert updated_state['llm_response'] == 'LLM says hello'
-    assert updated_state.get('error') is None
+    ReqID: N/A"""
+    mock_llm_complete.return_value = "LLM says hello"
+    state = process_input_node(
+        AgentState(
+            input_request="test prompt",
+            processed_input=None,
+            llm_response=None,
+            intermediate_steps=None,
+            final_output=None,
+            error=None,
+        )
+    )
+    updated_state = llm_call_node(state)
+    expected_tools = state["available_tools"]
+    mock_llm_complete.assert_called_once_with(
+        prompt="test prompt",
+        system_prompt="You are a helpful AI assistant.",
+        fallback=True,
+        parameters={"tools": expected_tools},
+    )
+    assert updated_state["llm_response"] == "LLM says hello"
+    assert updated_state.get("error") is None
 
 
-@patch('devsynth.agents.base_agent_graph.llm_complete')
+@patch("devsynth.agents.base_agent_graph.llm_complete")
 def test_llm_call_node_llm_failure_fails(mock_llm_complete):
     """Test llm_call_node when LLM call fails.
 
-ReqID: N/A"""
-    mock_llm_complete.side_effect = ProviderError('LLM unavailable')
-    initial_state = AgentState(input_request='test', processed_input=
-        'test prompt', llm_response=None, intermediate_steps=None,
-        final_output=None, error=None)
-    updated_state = llm_call_node(initial_state)
-    assert 'LLM call failed: LLM unavailable' in updated_state.get('error', '')
-    assert updated_state.get('llm_response') is None
+    ReqID: N/A"""
+    mock_llm_complete.side_effect = ProviderError("LLM unavailable")
+    state = process_input_node(
+        AgentState(
+            input_request="test prompt",
+            processed_input=None,
+            llm_response=None,
+            intermediate_steps=None,
+            final_output=None,
+            error=None,
+        )
+    )
+    updated_state = llm_call_node(state)
+    expected_tools = state["available_tools"]
+    mock_llm_complete.assert_called_once_with(
+        prompt="test prompt",
+        system_prompt="You are a helpful AI assistant.",
+        fallback=True,
+        parameters={"tools": expected_tools},
+    )
+    assert "LLM call failed: LLM unavailable" in updated_state.get("error", "")
+    assert updated_state.get("llm_response") is None
 
 
 def test_llm_call_node_skip_on_prior_error_raises_error():
     """Test llm_call_node skips if there's a prior error in state.
 
-ReqID: N/A"""
-    initial_state = AgentState(input_request='test', processed_input=
-        'test prompt', llm_response=None, intermediate_steps=None,
-        final_output=None, error='Previous error')
+    ReqID: N/A"""
+    initial_state = AgentState(
+        input_request="test",
+        processed_input="test prompt",
+        llm_response=None,
+        intermediate_steps=None,
+        final_output=None,
+        error="Previous error",
+    )
     updated_state = llm_call_node(initial_state)
-    assert updated_state['error'] == 'Previous error'
-    assert updated_state.get('llm_response') is None
+    assert updated_state["error"] == "Previous error"
+    assert updated_state.get("llm_response") is None
 
 
 def test_llm_call_node_missing_processed_input_succeeds():
     """Test llm_call_node if processed_input is missing.
 
-ReqID: N/A"""
-    initial_state = AgentState(input_request='test', processed_input=None,
-        llm_response=None, intermediate_steps=None, final_output=None,
-        error=None)
+    ReqID: N/A"""
+    initial_state = AgentState(
+        input_request="test",
+        processed_input=None,
+        llm_response=None,
+        intermediate_steps=None,
+        final_output=None,
+        error=None,
+        available_tools=get_available_tools(),
+    )
     updated_state = llm_call_node(initial_state)
-    assert 'Processed input is missing for LLM call' in updated_state.get(
-        'error', '')
-    assert updated_state.get('llm_response') is None
+    assert "Processed input is missing for LLM call" in updated_state.get("error", "")
+    assert updated_state.get("llm_response") is None
 
 
 def test_parse_output_node_success_is_valid():
     """Test parse_output_node with valid LLM response.
 
-ReqID: N/A"""
-    initial_state = AgentState(input_request='test', processed_input='test',
-        llm_response='  parsed output  ', intermediate_steps=None,
-        final_output=None, error=None)
+    ReqID: N/A"""
+    initial_state = AgentState(
+        input_request="test",
+        processed_input="test",
+        llm_response="  parsed output  ",
+        intermediate_steps=None,
+        final_output=None,
+        error=None,
+    )
     updated_state = parse_output_node(initial_state)
-    assert updated_state['final_output'] == 'parsed output'
-    assert updated_state.get('error') is None
+    assert updated_state["final_output"] == "parsed output"
+    assert updated_state.get("error") is None
 
 
 def test_parse_output_node_missing_llm_response_succeeds():
     """Test parse_output_node if llm_response is missing.
 
-ReqID: N/A"""
-    initial_state = AgentState(input_request='test', processed_input='test',
-        llm_response=None, intermediate_steps=None, final_output=None,
-        error=None)
+    ReqID: N/A"""
+    initial_state = AgentState(
+        input_request="test",
+        processed_input="test",
+        llm_response=None,
+        intermediate_steps=None,
+        final_output=None,
+        error=None,
+    )
     updated_state = parse_output_node(initial_state)
-    assert updated_state['final_output'] == ''
+    assert updated_state["final_output"] == ""
 
 
 def test_parse_output_node_skip_on_prior_error_raises_error():
     """Test parse_output_node skips if there's a prior error in state.
 
-ReqID: N/A"""
-    initial_state = AgentState(input_request='test', processed_input='test',
-        llm_response='response', intermediate_steps=None, final_output=None,
-        error='Previous error')
+    ReqID: N/A"""
+    initial_state = AgentState(
+        input_request="test",
+        processed_input="test",
+        llm_response="response",
+        intermediate_steps=None,
+        final_output=None,
+        error="Previous error",
+    )
     updated_state = parse_output_node(initial_state)
-    assert updated_state['error'] == 'Previous error'
-    assert updated_state.get('final_output') is None
+    assert updated_state["error"] == "Previous error"
+    assert updated_state.get("final_output") is None
 
 
 def test_base_agent_graph_compiles_raises_error():
     """Test that the base_agent_graph compiles without errors.
 
-ReqID: N/A"""
+    ReqID: N/A"""
     assert base_agent_graph is not None
-    assert hasattr(base_agent_graph, 'invoke'
-        ), 'Compiled graph should have an invoke method'
+    assert hasattr(
+        base_agent_graph, "invoke"
+    ), "Compiled graph should have an invoke method"


### PR DESCRIPTION
## Summary
- fetch and format registered tool metadata on agent startup
- forward tool specs to the LLM as function-calling configuration
- test that agent state includes tools and LLM calls receive them

## Testing
- `poetry run pytest tests/unit/general/test_agent_system.py tests/integration/general/test_agent_system_integration.py -p no:tests.fixtures.ports -q`

------
https://chatgpt.com/codex/tasks/task_e_688ff54087e48333b0a2a8b3ff4ea066