### PR TITLE
feat: add security audit and doctor tools

### DIFF
--- a/docs/developer_guides/agent_tools.md
+++ b/docs/developer_guides/agent_tools.md
@@ -25,6 +25,8 @@ with the registry and the steps for adding new tools.
 |------|-------------|
 | `alignment_metrics` | Collects code alignment metrics and optionally writes a report. |
 | `run_tests` | Executes the project's pytest suites and returns their output. |
+| `security_audit` | Runs static analysis and dependency checks to surface security issues. |
+| `doctor` | Validates configuration files and environment setup. |
 
 You can inspect the registry programmatically:
 
@@ -34,6 +36,14 @@ from devsynth.agents.tools import get_tool_registry
 registry = get_tool_registry()
 for name, meta in registry.list_tools().items():
     print(name, meta["description"])
+```
+
+Tool metadata can also be exported in OpenAI's function-call format:
+
+```python
+from devsynth.agents.tools import get_openai_tools
+
+openai_tools = get_openai_tools()
 ```
 
 ## Adding a New Tool

--- a/tests/unit/agents/test_doctor_tool.py
+++ b/tests/unit/agents/test_doctor_tool.py
@@ -1,0 +1,55 @@
+"""Tests for the doctor_tool."""
+
+from types import ModuleType
+from unittest.mock import patch
+
+from devsynth.agents.tools import doctor_tool, get_tool_registry
+
+
+def test_doctor_tool_returns_structure() -> None:
+    """doctor_tool should return success and captured output."""
+
+    module = ModuleType("doctor_cmd")
+
+    def _stub(config_dir="config", quick=False, *, bridge) -> None:
+        bridge.display_result("ok")
+
+    module.doctor_cmd = _stub
+    with patch.dict(
+        "sys.modules",
+        {
+            "devsynth.application": ModuleType("application"),
+            "devsynth.application.cli": ModuleType("cli"),
+            "devsynth.application.cli.commands": ModuleType("commands"),
+            "devsynth.application.cli.commands.doctor_cmd": module,
+        },
+    ):
+        result = doctor_tool()
+    assert result == {"success": True, "output": "ok"}
+
+
+def test_doctor_tool_registered() -> None:
+    """The tool should be present in the global registry."""
+
+    registry = get_tool_registry()
+    func = registry.get("doctor")
+    assert func is not None
+
+    module = ModuleType("doctor_cmd")
+    called = {}
+
+    def _stub(config_dir="config", quick=False, *, bridge) -> None:
+        called["flag"] = True
+
+    module.doctor_cmd = _stub
+    with patch.dict(
+        "sys.modules",
+        {
+            "devsynth.application": ModuleType("application"),
+            "devsynth.application.cli": ModuleType("cli"),
+            "devsynth.application.cli.commands": ModuleType("commands"),
+            "devsynth.application.cli.commands.doctor_cmd": module,
+        },
+    ):
+        func()
+    assert called.get("flag")

--- a/tests/unit/agents/test_security_audit_tool.py
+++ b/tests/unit/agents/test_security_audit_tool.py
@@ -1,0 +1,70 @@
+"""Tests for the security_audit_tool."""
+
+from types import ModuleType
+from unittest.mock import patch
+
+from devsynth.agents.tools import get_tool_registry, security_audit_tool
+
+
+def test_security_audit_tool_returns_structure() -> None:
+    """security_audit_tool should return success and captured output."""
+
+    module = ModuleType("security_audit_cmd")
+
+    def _stub(
+        skip_static=False,
+        skip_safety=False,
+        skip_secrets=False,
+        skip_owasp=False,
+        *,
+        bridge,
+    ) -> None:
+        bridge.display_result("ok")
+
+    module.security_audit_cmd = _stub
+    with patch.dict(
+        "sys.modules",
+        {
+            "devsynth.application": ModuleType("application"),
+            "devsynth.application.cli": ModuleType("cli"),
+            "devsynth.application.cli.commands": ModuleType("commands"),
+            "devsynth.application.cli.commands.security_audit_cmd": module,
+        },
+    ):
+        result = security_audit_tool()
+    assert result == {"success": True, "output": "ok"}
+
+
+def test_security_audit_tool_registered() -> None:
+    """The tool should be present in the global registry."""
+
+    registry = get_tool_registry()
+    func = registry.get("security_audit")
+    assert func is not None
+
+    module = ModuleType("security_audit_cmd")
+
+    called = {}
+
+    def _stub(
+        skip_static=False,
+        skip_safety=False,
+        skip_secrets=False,
+        skip_owasp=False,
+        *,
+        bridge,
+    ) -> None:
+        called["flag"] = True
+
+    module.security_audit_cmd = _stub
+    with patch.dict(
+        "sys.modules",
+        {
+            "devsynth.application": ModuleType("application"),
+            "devsynth.application.cli": ModuleType("cli"),
+            "devsynth.application.cli.commands": ModuleType("commands"),
+            "devsynth.application.cli.commands.security_audit_cmd": module,
+        },
+    ):
+        func()
+    assert called.get("flag")

--- a/tests/unit/agents/test_tools.py
+++ b/tests/unit/agents/test_tools.py
@@ -30,3 +30,27 @@ def test_unknown_tool_returns_none() -> None:
     registry = ToolRegistry()
     assert registry.get("missing") is None
     assert registry.get_metadata("missing") is None
+
+
+def test_export_for_openai_formats_tools() -> None:
+    registry = ToolRegistry()
+    registry.register(
+        "adder",
+        sample_tool,
+        description="Add one to the input",
+        parameters={"type": "object", "properties": {"x": {"type": "integer"}}},
+    )
+    exported = registry.export_for_openai()
+    assert exported == [
+        {
+            "type": "function",
+            "function": {
+                "name": "adder",
+                "description": "Add one to the input",
+                "parameters": {
+                    "type": "object",
+                    "properties": {"x": {"type": "integer"}},
+                },
+            },
+        }
+    ]


### PR DESCRIPTION
## Summary
- add registry export helper for OpenAI function calling
- implement security audit and configuration doctor tools
- document new tools in developer guide

## Testing
- `PYTEST_ADDOPTS="-p no:tests.fixtures.ports -p no:tests.fixtures.kuzu" poetry run pytest tests/unit/agents/test_security_audit_tool.py tests/unit/agents/test_doctor_tool.py tests/unit/agents/test_tools.py`

------
https://chatgpt.com/codex/tasks/task_e_688ff531292c8333b73acea10fbfc0fa