### PR TITLE
feat: add internal link check

### DIFF
--- a/.github/workflows.disabled/check_internal_links.yml
+++ b/.github/workflows.disabled/check_internal_links.yml
@@ -1,0 +1,26 @@
+name: Check Internal Links
+
+on:
+  pull_request:
+    branches: [ main, master ]
+    paths:
+      - '**.md'
+      - 'scripts/check_internal_links.py'
+      - '.github/workflows/check_internal_links.yml'
+  workflow_dispatch:
+
+jobs:
+  link-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.12'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e .[dev,docs]
+      - name: Check internal links
+        run: python scripts/check_internal_links.py

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,6 +6,12 @@ repos:
       entry: devsynth align --quiet
       language: system
       pass_filenames: false
+    - id: check-internal-links
+      name: check internal links
+      entry: python scripts/check_internal_links.py
+      language: system
+      pass_filenames: false
+      files: ^docs/.*\.md$
 - repo: https://github.com/pre-commit/pre-commit-hooks
   rev: v4.4.0
   hooks:

--- a/scripts/check_internal_links.py
+++ b/scripts/check_internal_links.py
@@ -15,8 +15,8 @@ This script:
 
 import os
 import re
-from pathlib import Path
 import urllib.parse
+from pathlib import Path
 
 
 def slugify(text: str) -> str:
@@ -109,7 +109,7 @@ def check_internal_links(file_path, docs_dir):
     return broken_links
 
 
-def main():
+def main() -> int:
     """Main function to check internal links in all Markdown files."""
     docs_dir = Path("docs")
 
@@ -139,6 +139,8 @@ def main():
         f"\nFound {total_broken_links} broken links in {files_with_broken_links} files"
     )
 
+    return 1 if total_broken_links else 0
+
 
 if __name__ == "__main__":
-    main()
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- fail link check script when broken links are detected
- run link check via pre-commit
- add CI workflow to verify internal links on pull requests

## Testing
- `SKIP=devsynth-align poetry run pre-commit run --files scripts/check_internal_links.py .pre-commit-config.yaml .github/workflows.disabled/check_internal_links.yml`
- `python scripts/check_internal_links.py` *(fails: link check failed)*
- `poetry run pytest tests/` *(fails: ModuleNotFoundError: No module named 'pytest_bdd')*

------
https://chatgpt.com/codex/tasks/task_e_688ff51929a08333832890360480b3cb