### PR TITLE
refactor: deprecate security audit script

### DIFF
--- a/docs/archived/PHASE_1_COMPLETION_SUMMARY.md
+++ b/docs/archived/PHASE_1_COMPLETION_SUMMARY.md
@@ -45,6 +45,6 @@ This phase is **complete**. All Phase 1 success criteria have been validated, in
 | Configuration management system | ✅ Environment-specific YAML files with validation script |
 | Basic monitoring and health checks | ✅ `/metrics` and `/health` endpoints with Prometheus integration |
 | Provider abstraction | ✅ `adapters/provider_system.py` supports multiple LLMs |
-| Basic security measures & tests | ✅ `security_audit.py` script and access token checks |
+| Basic security measures & tests | ✅ `devsynth security-audit` command and access token checks |
 | Input validation and data protection | ✅ Settings flags and validation utilities |
 

--- a/docs/developer_guides/security.md
+++ b/docs/developer_guides/security.md
@@ -15,8 +15,10 @@ last_reviewed: "2025-07-21"---
 
 # Security Audit
 
-The `security_audit.py` script aggregates multiple scanners to help protect the
-project. By default all checks run.
+The `devsynth security-audit` command aggregates multiple scanners to help
+protect the project. By default all checks run. The legacy
+`scripts/security_audit.py` wrapper is deprecated and will be removed in a
+future release.
 
 ## Checks
 
@@ -31,14 +33,13 @@ project. By default all checks run.
 Run all checks:
 
 ```bash
-python scripts/security_audit.py
+devsynth security-audit
 ```
 
 Skip specific scanners using flags:
 
 ```bash
-python scripts/security_audit.py --skip-bandit --skip-secrets --skip-owasp --skip-safety
+devsynth security-audit --skip-bandit --skip-secrets --skip-owasp --skip-safety
 ```
 
-`--skip-static` is retained as an alias for `--skip-bandit` for backward
-compatibility.
+`--skip-static` remains an alias for `--skip-bandit` for backward compatibility.

--- a/docs/policies/security.md
+++ b/docs/policies/security.md
@@ -112,7 +112,7 @@ and routine dependency and static analysis checks in CI.
 ## Implementation Status
 Security configuration flags and basic encryption utilities are implemented.
 Automated audits and basic monitoring are provided via the
-`security-audit` command (also available as `scripts/security_audit.py`).
+  `security-audit` command, available via `devsynth security-audit`.
 Memory stores support encryption at rest and emit audit logs for store, retrieve,
 and delete operations.
 Runtime checks in [`src/devsynth/config/settings.py`](../../src/devsynth/config/settings.py)

--- a/scripts/security_audit.py
+++ b/scripts/security_audit.py
@@ -1,93 +1,25 @@
-"""Security audit and monitoring automation."""
+"""Deprecated wrapper for the security audit command.
+
+This script is retained for backward compatibility and simply invokes
+``devsynth security-audit``. It will be removed in a future release.
+"""
 
 from __future__ import annotations
 
 import argparse
-import os
-import re
 import subprocess
 import sys
+from typing import Sequence
 
 from devsynth.logger import setup_logging
-
-from devsynth.exceptions import ConfigurationError, DevSynthError
-
-REQUIRED_ENV_VARS = ["DEVSYNTH_ACCESS_TOKEN"]
-
 
 logger = setup_logging(__name__)
 
 
-def run_safety() -> None:
-    """Run dependency vulnerability scan using safety."""
-    logger.info("Running dependency vulnerability scan using safety")
-    subprocess.check_call(["python", "scripts/dependency_safety_check.py"])
-
-
-def run_bandit() -> None:
-    """Run Bandit static analysis over the src directory."""
-    logger.info("Running Bandit static analysis over the src directory")
-    subprocess.check_call(["bandit", "-r", "src", "-ll"])
-
-
-def run_secrets_scan() -> None:
-    """Detect potential API keys or secrets in the repository."""
-    logger.info("Running secrets scan for potential API keys")
-    pattern = re.compile(
-        r"(?:api_key|token|secret)[\'\"]?\s*[:=]\s*[\'\"][A-Za-z0-9-_]{16,}[\'\"]",
-        re.IGNORECASE,
-    )
-    findings: list[str] = []
-    for root, _dirs, files in os.walk("."):
-        for name in files:
-            if not name.endswith(
-                (".py", ".env", ".txt", ".md", ".cfg", ".ini", ".yaml", ".yml", ".json")
-            ):
-                continue
-            path = os.path.join(root, name)
-            try:
-                with open(path, "r", encoding="utf-8", errors="ignore") as handle:
-                    for lineno, line in enumerate(handle, start=1):
-                        if pattern.search(line):
-                            findings.append(f"{path}:{lineno}")
-            except OSError:
-                continue
-    if findings:
-        raise RuntimeError("Potential secrets detected:\n" + "\n".join(findings))
-
-
-def run_owasp_dependency_check() -> None:
-    """Run OWASP Dependency Check if available."""
-    logger.info("Running OWASP Dependency Check")
-    try:
-        subprocess.check_call(
-            [
-                "dependency-check",
-                "--project",
-                "DevSynth",
-                "--format",
-                "JSON",
-                "--out",
-                "owasp_report",
-            ]
-        )
-    except FileNotFoundError as exc:  # pragma: no cover - external tool
-        raise RuntimeError("dependency-check executable not found") from exc
-
-
-def check_required_env() -> None:
-    """Ensure required security environment variables are set."""
-    missing = [name for name in REQUIRED_ENV_VARS if not os.getenv(name)]
-    if missing:
-        raise ConfigurationError(
-            message=f"Missing required environment variables: {', '.join(missing)}"
-        )
-    logger.debug("All required security environment variables are set")
-
-
-def main() -> None:
+def main(argv: Sequence[str] | None = None) -> None:
+    """Parse arguments and invoke ``devsynth security-audit``."""
     parser = argparse.ArgumentParser(
-        description="Execute security audits and monitoring checks.",
+        description="Deprecated wrapper for `devsynth security-audit`.",
     )
     parser.add_argument(
         "--skip-bandit",
@@ -114,31 +46,30 @@ def main() -> None:
         action="store_true",
         help="Skip OWASP Dependency Check",
     )
-    args = parser.parse_args()
+    args = parser.parse_args(argv)
 
-    check_required_env()
-    logger.info("Starting security audit")
+    cmd = ["devsynth", "security-audit"]
+    if args.skip_bandit or args.skip_static:
+        cmd.append("--skip-static")
+    if args.skip_safety:
+        cmd.append("--skip-safety")
+    if args.skip_secrets:
+        cmd.append("--skip-secrets")
+    if args.skip_owasp:
+        cmd.append("--skip-owasp")
 
-    from devsynth.application.cli.commands.security_audit_cmd import security_audit_cmd
-
-    security_audit_cmd(
-        skip_static=args.skip_bandit or args.skip_static,
-        skip_safety=args.skip_safety,
-        skip_secrets=args.skip_secrets,
-        skip_owasp=args.skip_owasp,
-    )
+    logger.info("Invoking devsynth security-audit")
+    subprocess.run(cmd, check=True)
     logger.info("Security audit completed successfully")
 
 
 if __name__ == "__main__":
     try:
         main()
-    except DevSynthError:
-        logger.exception("Security audit failed")
-        sys.exit(1)
     except subprocess.CalledProcessError as exc:
         logger.exception("Security audit failed with code %s", exc.returncode)
         sys.exit(exc.returncode)
     except Exception:  # pragma: no cover - unexpected errors
         logger.exception("Unexpected error during security audit")
         sys.exit(1)
+


### PR DESCRIPTION
## Summary
- mark `scripts/security_audit.py` as deprecated and shell out to `devsynth security-audit`
- update security docs to reference `devsynth security-audit`
- adjust tests for new wrapper

## Testing
- `pytest tests/unit/security/test_security_audit.py tests/unit/scripts/test_security_ops.py`

------
https://chatgpt.com/codex/tasks/task_e_688ff4cf086c833398541d1cac8a999f