### PR TITLE
feat: add run-tests CLI command

### DIFF
--- a/scripts/run_all_tests.py
+++ b/scripts/run_all_tests.py
@@ -1,205 +1,31 @@
-#!/usr/bin/env python3
-"""Script to execute DevSynth tests.
+"""Deprecated test runner wrapper.
 
-This script wraps the shared :func:`devsynth.testing.run_tests` helper and
-provides a command line interface similar to the DevSynth CLI.
-
-Usage:
-    python scripts/run_all_tests.py [--target TARGET]
-                                   [--fast] [--medium] [--slow]
-                                   [--report] [--verbose]
-                                   [--no-parallel] [--segment]
-                                   [--segment-size SIZE]
+This script is deprecated in favor of the ``devsynth run-tests`` CLI command.
+It simply forwards all arguments to that command.
 """
 
-import argparse
-import logging
+from __future__ import annotations
+
+import subprocess
 import sys
-import time
-
-from devsynth.logger import setup_logging
-
-from devsynth.exceptions import DevSynthError
-from devsynth.testing.run_tests import run_tests
-
-logger = setup_logging(__name__)
-
-
-def parse_args():
-    """Parse command line arguments."""
-    parser = argparse.ArgumentParser(description="Run DevSynth tests")
-
-    parser.add_argument(
-        "--target",
-        choices=["unit-tests", "integration-tests", "behavior-tests", "all-tests"],
-        help="Test target to run",
-    )
-    # Backwards compatibility flags
-    parser.add_argument("--unit", action="store_true", help=argparse.SUPPRESS)
-    parser.add_argument("--integration", action="store_true", help=argparse.SUPPRESS)
-    parser.add_argument("--behavior", action="store_true", help=argparse.SUPPRESS)
-    parser.add_argument("--all", action="store_true", help=argparse.SUPPRESS)
-
-    speed_group = parser.add_argument_group("Speed Category")
-    speed_group.add_argument(
-        "--fast", action="store_true", help="Run only fast tests (execution time < 1s)"
-    )
-    speed_group.add_argument(
-        "--medium",
-        action="store_true",
-        help="Run only medium tests (execution time between 1s and 5s)",
-    )
-    speed_group.add_argument(
-        "--slow", action="store_true", help="Run only slow tests (execution time > 5s)"
-    )
-
-    parser.add_argument("--report", action="store_true", help="Generate HTML report")
-    parser.add_argument("--verbose", action="store_true", help="Show verbose output")
-
-    parser.add_argument(
-        "--no-parallel", action="store_true", help="Disable parallel test execution"
-    )
-    parser.add_argument(
-        "--segment",
-        action="store_true",
-        help="Run tests in smaller batches to improve performance",
-    )
-    parser.add_argument(
-        "--segment-size",
-        type=int,
-        default=50,
-        help="Number of tests per batch when using segmentation",
-    )
-
-    args = parser.parse_args()
-
-    if not args.target:
-        targets = []
-        if args.unit:
-            targets.append("unit-tests")
-        if args.integration:
-            targets.append("integration-tests")
-        if args.behavior:
-            targets.append("behavior-tests")
-        if args.all or not targets:
-            targets = ["all-tests"]
-        args.targets = targets
-    else:
-        args.targets = [args.target]
-
-    if not (args.fast or args.medium or args.slow):
-        args.fast = args.medium = args.slow = True
-
-    return args
+import warnings
 
 
 def main() -> int:
-    """Main function to run tests based on command line arguments."""
-    args = parse_args()
-
-    if args.verbose:
-        logging.getLogger().setLevel(logging.DEBUG)
-
-    if args.report:
-        try:
-            import pytest_html  # noqa: F401
-        except ImportError:
-            logger.error(
-                "pytest-html is required for HTML reports. Please install development dependencies:"
-            )
-            logger.error("  poetry install --with dev,docs --all-extras")
-            return 1
-
-    if not args.no_parallel:
-        try:
-            import xdist  # noqa: F401
-        except ImportError:
-            logger.error(
-                "pytest-xdist is required for parallel test execution. Please install development dependencies:"
-            )
-            logger.error("  poetry install --with dev,docs --all-extras")
-            return 1
-
-    parallel = not args.no_parallel
-    speed_categories = []
-    if args.fast:
-        speed_categories.append("fast")
-    if args.medium:
-        speed_categories.append("medium")
-    if args.slow:
-        speed_categories.append("slow")
-
-    separator = "=" * 80
-    logger.info("\n%s", separator)
-    logger.info("TEST EXECUTION PLAN")
-    logger.info(separator)
-    logger.info("Targets: %s", ", ".join(args.targets))
-    logger.info("Speed Categories: %s", ", ".join(speed_categories))
-    logger.info("Parallel Execution: %s", "Disabled" if args.no_parallel else "Enabled")
-    logger.info("Test Segmentation: %s", "Enabled" if args.segment else "Disabled")
-    if args.segment:
-        logger.info("Segment Size: %d", args.segment_size)
-    logger.info("Report Generation: %s", "Enabled" if args.report else "Disabled")
-    logger.info("Verbose Output: %s", "Enabled" if args.verbose else "Disabled")
-
-    start_time = time.time()
-    overall_success = True
-    results = {}
-
-    for target in args.targets:
-        success, _ = run_tests(
-            target,
-            speed_categories,
-            args.verbose,
-            args.report,
-            parallel,
-            args.segment,
-            args.segment_size,
-        )
-        overall_success = overall_success and success
-        results[target] = success
-
-    end_time = time.time()
-    execution_time = end_time - start_time
-
-    logger.info("\n%s", separator)
-    logger.info("TEST SUMMARY")
-    logger.info(separator)
-    for target, success in results.items():
-        status = "PASSED" if success else "FAILED"
-        logger.info("%s: %s", target.upper(), status)
-
-    logger.info("OVERALL STATUS: %s", "PASSED" if overall_success else "FAILED")
-    logger.info(
-        "EXECUTION TIME: %.2f seconds (%.2f minutes)",
-        execution_time,
-        execution_time / 60,
+    """Invoke the ``devsynth run-tests`` CLI command with passed arguments."""
+    warnings.warn(
+        "scripts/run_all_tests.py is deprecated; use 'devsynth run-tests' instead.",
+        DeprecationWarning,
     )
-
-    if execution_time > 60:
-        logger.info("\nTips for faster test execution:")
-        if not args.fast and not args.medium:
-            logger.info("- Run only fast tests during development: --fast")
-        if not args.segment:
-            logger.info("- Enable test segmentation: --segment")
-        if args.targets == ["all-tests"]:
-            logger.info(
-                "- Run only specific test types with --target (unit-tests, integration-tests, behavior-tests)"
-            )
-        if not parallel:
-            logger.info(
-                "- Enable parallel execution (if disabled): remove --no-parallel"
-            )
-
-    return 0 if overall_success else 1
+    result = subprocess.run(
+        [
+            "devsynth",
+            "run-tests",
+            *sys.argv[1:],
+        ]
+    )
+    return result.returncode
 
 
-if __name__ == "__main__":
-    try:
-        sys.exit(main())
-    except DevSynthError:
-        logger.exception("Test execution failed")
-        sys.exit(1)
-    except Exception:  # pragma: no cover - unexpected errors
-        logger.exception("Unexpected error during test execution")
-        sys.exit(1)
+if __name__ == "__main__":  # pragma: no cover - script entry
+    sys.exit(main())

--- a/src/devsynth/adapters/cli/typer_adapter.py
+++ b/src/devsynth/adapters/cli/typer_adapter.py
@@ -1,55 +1,56 @@
 import inspect
-import typer
-import click
-from typing import Optional, Dict, List, Any
-from rich.console import Console
-from rich.panel import Panel
-from rich.markdown import Markdown
-from rich.table import Table
-from rich.box import ROUNDED
+from typing import Any, Dict, List, Optional
 
-from devsynth.logging_setup import DevSynthLogger
-from devsynth.core.config_loader import load_config
-from devsynth.interface.cli import DEVSYNTH_THEME
+import click
+import typer
+from rich.box import ROUNDED
+from rich.console import Console
+from rich.markdown import Markdown
+from rich.panel import Panel
+from rich.table import Table
 
 from devsynth.application.cli import (
-    init_cmd,
-    spec_cmd,
-    test_cmd,
     code_cmd,
-    run_pipeline_cmd,
-    config_cmd,
-    enable_feature_cmd,
-    gather_cmd,
     config_app,
-    inspect_cmd,
-    webapp_cmd,
-    webui_cmd,
-    dpg_cmd,
+    config_cmd,
     dbschema_cmd,
     doctor_cmd,
-    refactor_cmd,
-    inspect_code_cmd,
+    dpg_cmd,
     edrr_cycle_cmd,
+    enable_feature_cmd,
+    gather_cmd,
+    init_cmd,
+    inspect_cmd,
+    inspect_code_cmd,
+    refactor_cmd,
+    run_pipeline_cmd,
     serve_cmd,
+    spec_cmd,
+    test_cmd,
+    webapp_cmd,
+    webui_cmd,
 )
-from devsynth.application.cli.ingest_cmd import ingest_cmd
 from devsynth.application.cli.apispec import apispec_cmd
 from devsynth.application.cli.commands.align_cmd import align_cmd
 from devsynth.application.cli.commands.alignment_metrics_cmd import (
     alignment_metrics_cmd,
 )
+from devsynth.application.cli.commands.generate_docs_cmd import generate_docs_cmd
 from devsynth.application.cli.commands.inspect_config_cmd import inspect_config_cmd
+from devsynth.application.cli.commands.run_tests_cmd import run_tests_cmd
+from devsynth.application.cli.commands.security_audit_cmd import security_audit_cmd
+from devsynth.application.cli.commands.test_metrics_cmd import test_metrics_cmd
 from devsynth.application.cli.commands.validate_manifest_cmd import (
     validate_manifest_cmd,
 )
 from devsynth.application.cli.commands.validate_metadata_cmd import (
     validate_metadata_cmd,
 )
-from devsynth.application.cli.commands.test_metrics_cmd import test_metrics_cmd
-from devsynth.application.cli.commands.generate_docs_cmd import generate_docs_cmd
-from devsynth.application.cli.commands.security_audit_cmd import security_audit_cmd
+from devsynth.application.cli.ingest_cmd import ingest_cmd
 from devsynth.application.cli.requirements_commands import requirements_app
+from devsynth.core.config_loader import load_config
+from devsynth.interface.cli import DEVSYNTH_THEME
+from devsynth.logging_setup import DevSynthLogger
 
 logger = DevSynthLogger(__name__)
 
@@ -367,6 +368,10 @@ def build_app() -> typer.Typer:
         name="run-pipeline",
         help=run_pipeline_help.format(),
     )(run_pipeline_cmd)
+    app.command(
+        name="run-tests",
+        help="Run test suites. Example: devsynth run-tests --target unit-tests",
+    )(run_tests_cmd)
     app.add_typer(config_app, name="config", help="Manage configuration settings")
     app.command(
         name="inspect",

--- a/src/devsynth/application/cli/commands/run_tests_cmd.py
+++ b/src/devsynth/application/cli/commands/run_tests_cmd.py
@@ -1,0 +1,76 @@
+"""CLI command to run DevSynth tests.
+
+Wraps :func:`devsynth.testing.run_tests` to provide a `devsynth run-tests`
+command. This command mirrors the options exposed by the underlying helper.
+
+Example:
+    `devsynth run-tests --target unit-tests --fast`
+"""
+
+from __future__ import annotations
+
+from typing import Optional
+
+import typer
+
+from devsynth.interface.cli import CLIUXBridge
+from devsynth.interface.ux_bridge import UXBridge
+from devsynth.logging_setup import DevSynthLogger
+from devsynth.testing.run_tests import run_tests
+
+logger = DevSynthLogger(__name__)
+bridge: UXBridge = CLIUXBridge()
+
+
+def run_tests_cmd(
+    target: str = typer.Option(
+        "all-tests",
+        "--target",
+        help="Test target to run",
+    ),
+    fast: bool = typer.Option(False, "--fast", help="Run only fast tests"),
+    medium: bool = typer.Option(False, "--medium", help="Run only medium tests"),
+    slow: bool = typer.Option(False, "--slow", help="Run only slow tests"),
+    report: bool = typer.Option(False, "--report", help="Generate HTML report"),
+    verbose: bool = typer.Option(False, "--verbose", help="Show verbose output"),
+    no_parallel: bool = typer.Option(
+        False, "--no-parallel", help="Disable parallel test execution"
+    ),
+    segment: bool = typer.Option(
+        False, "--segment", help="Run tests in smaller batches"
+    ),
+    segment_size: int = typer.Option(
+        50, "--segment-size", help="Number of tests per batch when segmenting"
+    ),
+    *,
+    bridge: Optional[UXBridge] = None,
+) -> None:
+    """Run DevSynth test suites."""
+
+    ux_bridge = bridge or globals()["bridge"]
+
+    speed_categories = []
+    if fast:
+        speed_categories.append("fast")
+    if medium:
+        speed_categories.append("medium")
+    if slow:
+        speed_categories.append("slow")
+    if not speed_categories:
+        speed_categories = None
+
+    success, _ = run_tests(
+        target,
+        speed_categories,
+        verbose,
+        report,
+        not no_parallel,
+        segment,
+        segment_size,
+    )
+
+    if success:
+        ux_bridge.print("[green]Tests completed successfully[/green]")
+    else:
+        ux_bridge.print("[red]Tests failed[/red]")
+        raise typer.Exit(code=1)

--- a/tests/unit/application/cli/commands/test_run_tests_cmd.py
+++ b/tests/unit/application/cli/commands/test_run_tests_cmd.py
@@ -1,0 +1,79 @@
+"""Tests for the run_tests_cmd CLI wrapper."""
+
+import importlib.util
+import sys
+from pathlib import Path
+from types import ModuleType
+from unittest.mock import patch
+
+import pytest
+import typer
+
+# Create minimal stubs to avoid importing heavy modules when loading run_tests_cmd
+cli_stub = ModuleType("devsynth.interface.cli")
+
+
+class _Bridge:
+    def print(self, *args, **kwargs):
+        pass
+
+
+cli_stub.CLIUXBridge = _Bridge
+sys.modules["devsynth.interface.cli"] = cli_stub
+
+ux_stub = ModuleType("devsynth.interface.ux_bridge")
+ux_stub.UXBridge = object
+sys.modules["devsynth.interface.ux_bridge"] = ux_stub
+
+logging_stub = ModuleType("devsynth.logging_setup")
+
+
+class _Logger:
+    def __init__(self, *args, **kwargs):
+        pass
+
+
+logging_stub.DevSynthLogger = _Logger
+logging_stub.configure_logging = lambda *a, **k: None
+sys.modules["devsynth.logging_setup"] = logging_stub
+
+run_tests_module = ModuleType("devsynth.testing.run_tests")
+run_tests_module.run_tests = lambda *a, **k: (True, "")
+sys.modules["devsynth.testing.run_tests"] = run_tests_module
+
+spec = importlib.util.spec_from_file_location(
+    "run_tests_cmd",
+    Path(__file__).resolve().parents[5]
+    / "src"
+    / "devsynth"
+    / "application"
+    / "cli"
+    / "commands"
+    / "run_tests_cmd.py",
+)
+run_tests_cmd = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(run_tests_cmd)
+
+
+class DummyBridge:
+    def print(self, *args, **kwargs):  # pragma: no cover - simple stub
+        pass
+
+
+def test_run_tests_cmd_invokes_runner() -> None:
+    """run_tests_cmd should call the underlying run_tests helper."""
+    with patch.object(
+        run_tests_cmd, "run_tests", return_value=(True, "ok")
+    ) as mock_run:
+        run_tests_cmd.run_tests_cmd(
+            target="unit-tests", fast=True, bridge=DummyBridge()
+        )
+        mock_run.assert_called_once()
+
+
+def test_run_tests_cmd_nonzero_exit() -> None:
+    """run_tests_cmd exits with code 1 when tests fail."""
+    with patch.object(run_tests_cmd, "run_tests", return_value=(False, "bad")):
+        with pytest.raises(typer.Exit) as exc:
+            run_tests_cmd.run_tests_cmd(target="unit-tests", bridge=DummyBridge())
+        assert exc.value.exit_code == 1


### PR DESCRIPTION
## Summary
- add `run-tests` command wrapping `devsynth.testing.run_tests`
- expose new command through CLI and deprecate `scripts/run_all_tests.py`
- add basic tests for new command

## Testing
- `pre-commit run --files src/devsynth/application/cli/commands/run_tests_cmd.py src/devsynth/application/cli/cli_commands.py src/devsynth/adapters/cli/typer_adapter.py scripts/run_all_tests.py tests/unit/application/cli/commands/test_run_tests_cmd.py` *(fails: Executable `devsynth` not found)*
- `pytest tests/unit/application/cli/commands/test_run_tests_cmd.py -p no:tests.fixtures.ports`


------
https://chatgpt.com/codex/tasks/task_e_688ff4e46aa08333abcffa22dc840a33