### PR TITLE
refactor: replace setup_logging with DevSynthLogger in scripts

### DIFF
--- a/scripts/run_all_tests.py
+++ b/scripts/run_all_tests.py
@@ -17,12 +17,13 @@ import logging
 import sys
 import time
 
-from devsynth.logger import setup_logging
+from devsynth.logging_setup import DevSynthLogger, configure_logging
 
 from devsynth.exceptions import DevSynthError
 from devsynth.testing.run_tests import run_tests
 
-logger = setup_logging(__name__)
+configure_logging()
+logger = DevSynthLogger(__name__)
 
 
 def parse_args():

--- a/scripts/security_audit.py
+++ b/scripts/security_audit.py
@@ -11,9 +11,10 @@ import subprocess
 import sys
 from typing import Sequence
 
-from devsynth.logger import setup_logging
+from devsynth.logging_setup import DevSynthLogger, configure_logging
 
-logger = setup_logging(__name__)
+configure_logging()
+logger = DevSynthLogger(__name__)
 
 
 def main(argv: Sequence[str] | None = None) -> None:


### PR DESCRIPTION
## Summary
- replace deprecated `setup_logging` helper with `DevSynthLogger` in `security_audit.py` and `run_all_tests.py`
- configure logging once per script and construct loggers via `DevSynthLogger(__name__)`

## Testing
- `pytest tests/unit/general/test_logger.py::test_configure_logging_creates_rotating_handler -q` *(fails: UnboundLocalError: cannot access local variable 'ds_logger')*
- `PYTHONPATH=src python scripts/run_all_tests.py --target unit-tests --fast --no-parallel --segment --segment-size 1` *(interrupted after verifying log output)*


------
https://chatgpt.com/codex/tasks/task_e_688ff91b92848333b74b5bd9b415041a