### PR TITLE
chore: add documentation pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,6 +11,21 @@ repos:
       entry: python scripts/fix_frontmatter.py --check
       language: system
       pass_filenames: false
+    - id: check-internal-links
+      name: check internal links
+      entry: python scripts/check_internal_links.py
+      language: system
+      pass_filenames: false
+    - id: fix-code-blocks
+      name: fix code blocks
+      entry: python scripts/fix_code_blocks.py --check
+      language: system
+      pass_filenames: false
+    - id: find-syntax-errors
+      name: find syntax errors
+      entry: python scripts/find_syntax_errors.py
+      language: system
+      pass_filenames: false
 - repo: https://github.com/pre-commit/pre-commit-hooks
   rev: v4.4.0
   hooks:

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -10,3 +10,21 @@
   entry: python scripts/fix_frontmatter.py --check
   language: system
   pass_filenames: false
+- id: check-internal-links
+  name: check internal links
+  description: "Detect broken internal links in Markdown files"
+  entry: python scripts/check_internal_links.py
+  language: system
+  pass_filenames: false
+- id: fix-code-blocks
+  name: fix code blocks
+  description: "Ensure Markdown code blocks are formatted correctly"
+  entry: python scripts/fix_code_blocks.py --check
+  language: system
+  pass_filenames: false
+- id: find-syntax-errors
+  name: find syntax errors
+  description: "Detect Python syntax errors across the repository"
+  entry: python scripts/find_syntax_errors.py
+  language: system
+  pass_filenames: false

--- a/docs/developer_guides/pre_commit_usage.md
+++ b/docs/developer_guides/pre_commit_usage.md
@@ -1,0 +1,44 @@
+---
+title: "Pre-commit Usage"
+date: "2025-08-05"
+version: "0.1.0"
+tags:
+  - "pre-commit"
+  - "hooks"
+status: "published"
+author: "DevSynth Team"
+last_reviewed: "2025-08-05"
+---
+
+<div class="breadcrumbs">
+<a href="../index.md">Documentation</a> &gt; <a href="index.md">Developer Guides</a> &gt; Pre-commit Usage
+</div>
+
+# Pre-commit Usage
+
+The DevSynth project uses [pre-commit](https://pre-commit.com/) to run checks before code is committed.
+Install the hooks with:
+
+```bash
+pre-commit install
+```
+
+Run all checks with:
+
+```bash
+pre-commit run --all-files
+```
+
+## Custom Hooks
+
+### check internal links
+
+Runs `python scripts/check_internal_links.py` to verify that Markdown files do not contain broken internal links.
+
+### fix code blocks
+
+Runs `python scripts/fix_code_blocks.py --check` to ensure code block formatting is consistent.
+
+### find syntax errors
+
+Runs `python scripts/find_syntax_errors.py` to detect Python syntax errors across the repository.


### PR DESCRIPTION
## Summary
- add check-internal-links, fix-code-blocks, and find-syntax-errors hooks to pre-commit configuration
- document available pre-commit hooks and how to run them

## Testing
- `pre-commit run --files .pre-commit-config.yaml .pre-commit-hooks.yaml docs/developer_guides/pre_commit_usage.md` *(fails: Frontmatter formatting issues, Python syntax errors)*
- `poetry run pytest --maxfail=1` *(fails: ModuleNotFoundError: No module named 'pytest_bdd')*

------
https://chatgpt.com/codex/tasks/task_e_688ff90ba6288333a923f7fc37c80ed2