### PR TITLE
docs: document pipx setup for devsynth

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -56,6 +56,13 @@ Development and test commands may fail until the setup script completes
 successfully, the marker file is removed, and the tests pass.
 
 
+### pipx installation
+
+- `scripts/codex_setup.sh` installs `pipx`.
+- The DevSynth CLI is installed using `pipx install --editable .`.
+- The script adds `~/.local/bin` to `PATH` so the `devsynth` command is available.
+- Contributors must keep the `pipx` installation steps in sync with project requirements.
+
 ## Project Structure
 
 ```


### PR DESCRIPTION
## Summary
- document pipx-based CLI install details in the root AGENTS file

## Testing
- `pre-commit run devsynth-align --files AGENTS.md` *(fails: Type not yet supported: typing.Dict[str, bool)*
- `poetry run pytest tests/` *(fails: IndentationError in tests/unit/application/cli/test_init_cmd.py)*

------
https://chatgpt.com/codex/tasks/task_e_6890157149d48333a756cdeb98ddee88