### PR TITLE
feat: add kuzu embedded config and improve test setup

### DIFF
--- a/src/devsynth/adapters/kuzu_memory_store.py
+++ b/src/devsynth/adapters/kuzu_memory_store.py
@@ -77,10 +77,9 @@ class KuzuMemoryStore(MemoryStore):
                 # If we still can't create it, we'll let the store initialization handle it
                 pass
 
-        # Explicitly determine whether to use embedded mode
-        use_embedded = getattr(settings_module, "kuzu_embedded", True)
-        if isinstance(use_embedded, str):
-            use_embedded = use_embedded.lower() in {"1", "true", "yes"}
+        # Determine embedded mode from the configuration settings
+        # ``get_settings`` ensures the latest environment configuration is used
+        use_embedded = settings_module.get_settings().kuzu_embedded
 
         # Initialize stores with consistent error handling
         store_initialized = False

--- a/src/devsynth/config/settings.py
+++ b/src/devsynth/config/settings.py
@@ -151,7 +151,10 @@ class Settings(BaseSettings):
                 "DEVSYNTH_MEMORY_STORE", "memory"
             ),
             "kuzu_db_path": lambda s: os.environ.get("DEVSYNTH_KUZU_DB_PATH", None),
-            "kuzu_embedded": "kuzu_embedded",
+            "kuzu_embedded": lambda s: _parse_bool_env(
+                os.environ.get("DEVSYNTH_KUZU_EMBEDDED", s.kuzu_embedded),
+                "kuzu_embedded",
+            ),
             "openai_api_key": lambda s: os.environ.get("OPENAI_API_KEY", None),
             "access_token": lambda s: os.environ.get("DEVSYNTH_ACCESS_TOKEN", None),
         }

--- a/tests/integration/general/test_kuzu_memory_integration.py
+++ b/tests/integration/general/test_kuzu_memory_integration.py
@@ -15,6 +15,7 @@ from devsynth.domain.models.memory import MemoryItem, MemoryType
 @pytest.fixture
 def no_kuzu(monkeypatch):
     """Ensure tests run without the real ``kuzu`` dependency."""
+    monkeypatch.setenv("DEVSYNTH_KUZU_EMBEDDED", "true")
     monkeypatch.delitem(sys.modules, "kuzu", raising=False)
     monkeypatch.setattr(KuzuMemoryStore, "__abstractmethods__", frozenset())
     monkeypatch.setattr(KuzuStore, "__abstractmethods__", frozenset())
@@ -36,6 +37,7 @@ def fake_kuzu(monkeypatch):
             return None
 
     fake = types.SimpleNamespace(Database=Database, Connection=Connection)
+    monkeypatch.setenv("DEVSYNTH_KUZU_EMBEDDED", "true")
     monkeypatch.setitem(sys.modules, "kuzu", fake)
     monkeypatch.setattr(KuzuMemoryStore, "__abstractmethods__", frozenset())
     monkeypatch.setattr(KuzuStore, "__abstractmethods__", frozenset())
@@ -67,8 +69,10 @@ def mock_embed():
             "devsynth.adapters.kuzu_memory_store.embed", return_value=[[0.1, 0.2, 0.3]]
         ),
         patch(
-            "devsynth.adapters.kuzu_memory_store.embedding_functions.DefaultEmbeddingFunction",
-            lambda: (lambda x: [0.0] * 5),
+            "devsynth.adapters.kuzu_memory_store.embedding_functions",
+            types.SimpleNamespace(
+                DefaultEmbeddingFunction=lambda: (lambda x: [0.0] * 5)
+            ),
         ),
     ):
         yield

--- a/tests/unit/adapters/test_kuzu_memory_store.py
+++ b/tests/unit/adapters/test_kuzu_memory_store.py
@@ -18,6 +18,7 @@ KUZU_ADAPTER_PATH = ROOT / "src/devsynth/adapters/kuzu_memory_store.py"
 @pytest.fixture
 def KuzuMemoryStoreClass(monkeypatch):
     """Load ``KuzuMemoryStore`` and its dependencies from source."""
+    monkeypatch.setenv("DEVSYNTH_KUZU_EMBEDDED", "true")
     fake_pkg = ModuleType("devsynth.application.memory")
     fake_pkg.__path__ = [str(KUZU_STORE_PATH.parent)]
     monkeypatch.setitem(sys.modules, "devsynth.application.memory", fake_pkg)


### PR DESCRIPTION
## Summary
- expose kuzu_embedded setting through config with env override
- initialize KuzuMemoryStore using dynamic settings
- refresh kuzu integration fixtures to work without real kuzu or chromadb

## Testing
- `pytest tests/unit/adapters/test_kuzu_memory_store.py tests/integration/general/test_kuzu_memory_integration.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689031acd800833387abf30b37019365