### PR TITLE
docs: add Dear PyGui parity milestones

### DIFF
--- a/docs/roadmap/release_plan.md
+++ b/docs/roadmap/release_plan.md
@@ -42,8 +42,13 @@ git push origin v0.1.0-alpha.1
 - Prepare packaging and automation for a tagged stable release.
 
 ### 0.2.0
+- Achieve baseline Dear PyGui parity for core workflows via the desktop interface; requires the `gui` optional extras (`devsynth[gui]`). See the [Dear PyGui User Guide](../user_guides/dearpygui.md).
 - Expand WebUI features with enhanced requirements workflows.
 - Introduce plugin interfaces for third-party provider integration.
 - Iterate on memory system scalability and performance.
+
+### 0.3.0
+- Reach full feature parity with Dear PyGui across advanced workflows.
+- Refine plugin architecture and cross-platform GUI support.
 
 Future milestones will be appended to this document as they are defined. For implementation status of individual features, consult the [Feature Status Matrix](../implementation/feature_status_matrix.md).


### PR DESCRIPTION
## Summary
- document Dear PyGui parity goals for 0.2.0 and 0.3.0 releases
- highlight dependency on `gui` optional extras and link to the Dear PyGui user guide

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*


------
https://chatgpt.com/codex/tasks/task_e_689046783db88333b66da4aca7abb101