### PR TITLE
feat: add MVUU commit message linter

### DIFF
--- a/.github/workflows.disabled/commit_message_lint.yml
+++ b/.github/workflows.disabled/commit_message_lint.yml
@@ -1,0 +1,28 @@
+name: Commit Message Lint
+
+on:
+  pull_request:
+    paths:
+      - '.github/workflows/commit_message_lint.yml'
+      - 'scripts/commit_linter.py'
+  workflow_dispatch:
+
+jobs:
+  commit-lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.12'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e .[dev,docs]
+      - name: Lint commit messages
+        run: |
+          git fetch origin main
+          python scripts/commit_linter.py --range origin/main..HEAD

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,6 +26,12 @@ repos:
       entry: python scripts/find_syntax_errors.py
       language: system
       pass_filenames: false
+    - id: commit-message-lint
+      name: commit message lint
+      entry: python scripts/commit_linter.py
+      language: system
+      stages: [commit-msg]
+      pass_filenames: true
 - repo: https://github.com/pre-commit/pre-commit-hooks
   rev: v4.4.0
   hooks:

--- a/docs/developer_guides/contributing.md
+++ b/docs/developer_guides/contributing.md
@@ -305,6 +305,26 @@ If you find a bug or have a feature request, please create an issue on GitHub:
 - Keep commits focused on a single change
 - Use present tense ("Add feature" not "Added feature")
 
+Every commit message must include an MVUU JSON block that documents the utility,
+affected files, tests, and traceability information.
+
+### Commit template
+
+```text
+type(scope): short summary
+
+Optional detailed description
+```
+
+```json
+{
+  "utility_statement": "Explain the utility provided by this change.",
+  "affected_files": ["path/to/file"],
+  "tests": ["poetry run pytest tests/..."],
+  "TraceID": "MVUU-0000"
+}
+```
+
 
 Example commit message:
 

--- a/scripts/commit_linter.py
+++ b/scripts/commit_linter.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env python3
+"""Lint commit messages for MVUU compliance."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+from pathlib import Path
+from typing import List
+
+import jsonschema
+
+ROOT = Path(__file__).resolve().parents[1]
+SCHEMA_PATH = ROOT / "docs/specifications/mvuuschema.json"
+
+CONVENTIONAL_RE = re.compile(
+    r"^(build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test)(\([\w\-]+\))?: .+"
+)
+
+
+def _load_schema() -> dict:
+    """Return the MVUU JSON schema."""
+    return json.loads(SCHEMA_PATH.read_text(encoding="utf-8"))
+
+
+SCHEMA = _load_schema()
+
+
+def _extract_mvuu_json(message: str) -> dict:
+    """Extract the MVUU JSON block from a commit message."""
+    pattern = re.compile(r"```json\n(.*?)\n```", re.DOTALL)
+    match = pattern.search(message)
+    if not match:
+        raise ValueError("Missing MVUU JSON block fenced with ```json … ```")
+    try:
+        return json.loads(match.group(1))
+    except json.JSONDecodeError as exc:  # pragma: no cover - defensive
+        raise ValueError(f"MVUU JSON is not valid JSON: {exc.msg}") from exc
+
+
+def lint_commit_message(message: str) -> List[str]:
+    """Validate a commit message against conventional and MVUU rules."""
+    errors: List[str] = []
+    header = message.splitlines()[0]
+    if not CONVENTIONAL_RE.match(header):
+        errors.append(
+            "Commit message header must follow Conventional Commits, e.g. 'feat: …'"
+        )
+    try:
+        mvuu = _extract_mvuu_json(message)
+        jsonschema.validate(mvuu, SCHEMA)
+        trace_id = str(mvuu.get("TraceID", ""))
+        if not trace_id.startswith("MVUU-"):
+            errors.append("TraceID must start with 'MVUU-'")
+    except ValueError as exc:
+        errors.append(str(exc))
+    except jsonschema.ValidationError as exc:  # pragma: no cover - passthrough
+        errors.append(f"MVUU JSON invalid: {exc.message}")
+    return errors
+
+
+def lint_range(rev_range: str) -> List[str]:
+    """Lint all commit messages within a git revision range."""
+    errors: List[str] = []
+    hashes = (
+        subprocess.check_output(["git", "rev-list", rev_range], text=True)
+        .strip()
+        .splitlines()
+    )
+    for commit_hash in reversed(hashes):
+        message = subprocess.check_output(
+            ["git", "log", "-1", "--pretty=%B", commit_hash], text=True
+        )
+        commit_errors = lint_commit_message(message)
+        if commit_errors:
+            errors.append(f"{commit_hash[:7]}:\n" + "\n".join(commit_errors))
+    return errors
+
+
+def main() -> int:
+    """Command-line entry point for commit message linting."""
+    parser = argparse.ArgumentParser(
+        description="Lint commit messages using MVUU schema."
+    )
+    parser.add_argument("message_file", nargs="?", help="Path to commit message file.")
+    parser.add_argument(
+        "--range",
+        dest="rev_range",
+        help="Git revision range to lint, e.g. origin/main..HEAD.",
+    )
+    args = parser.parse_args()
+
+    if args.rev_range:
+        errors = lint_range(args.rev_range)
+        if errors:
+            print("\n\n".join(errors), file=sys.stderr)
+            return 1
+        return 0
+
+    if not args.message_file:
+        parser.error("provide a commit message file or --range")
+    message = Path(args.message_file).read_text(encoding="utf-8")
+    errors = lint_commit_message(message)
+    if errors:
+        print("\n".join(errors), file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/unit/scripts/test_commit_linter.py
+++ b/tests/unit/scripts/test_commit_linter.py
@@ -1,0 +1,30 @@
+import sys
+
+sys.path.append("scripts")
+
+from commit_linter import lint_commit_message  # type: ignore
+
+VALID_MESSAGE = (
+    "feat: add example\n\n"
+    "```json\n"
+    "{\n"
+    '  "utility_statement": "Example",\n'
+    '  "affected_files": ["file.txt"],\n'
+    '  "tests": ["pytest tests/example.py"],\n'
+    '  "TraceID": "MVUU-0001"\n'
+    "}\n"
+    "```\n"
+)
+
+INVALID_MESSAGE = "feat: missing block"
+
+
+def test_lint_commit_message_valid():
+    """Valid commit messages should produce no errors."""
+    assert lint_commit_message(VALID_MESSAGE) == []
+
+
+def test_lint_commit_message_missing_block():
+    """Missing MVUU block should produce an error."""
+    errors = lint_commit_message(INVALID_MESSAGE)
+    assert any("Missing MVUU" in e for e in errors)


### PR DESCRIPTION
## Summary
- validate commit messages against MVUU schema
- integrate commit linter with pre-commit and CI
- document MVUU commit template

## Testing
- `SKIP=devsynth-align,check-frontmatter,fix-code-blocks pre-commit run --files scripts/commit_linter.py .pre-commit-config.yaml .github/workflows.disabled/commit_message_lint.yml docs/developer_guides/contributing.md tests/unit/scripts/test_commit_linter.py`
- `pytest tests/unit/scripts/test_commit_linter.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6890ce8a62348333ab204525e4376708