### PR TITLE
feat: gate dpg cli behind gui flag

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -112,6 +112,10 @@ performance:
     max_workers: 4
     timeout: 300  # seconds
 
+# GUI settings
+gui:
+  enabled: false
+
 # Formal verification settings
 formalVerification:
   propertyTesting: false

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -34,6 +34,15 @@ This guide explains the feature flags available in `config/*.yml` files and how 
 
 For the UX design rationale behind gradually exposing these capabilities, see the [Progressive Complexity UX Design section](analysis/dialectical_evaluation.md#synthesis-progressive-complexity-ux-design).
 
+## GUI Configuration
+
+DevSynth includes an optional Dear PyGUI interface. To prevent unintended GUI launches in headless environments this interface is disabled by default. Set `gui.enabled` to `true` to enable the `dpg` CLI command:
+
+```yaml
+gui:
+  enabled: true
+```
+
 ## Enabling Flags
 
 1. **CLI**: use the `config` command to set a flag:

--- a/src/devsynth/application/cli/cli_commands.py
+++ b/src/devsynth/application/cli/cli_commands.py
@@ -1833,6 +1833,12 @@ def webui_cmd(*, bridge: UXBridge = bridge) -> None:
 
 def dpg_cmd(*, bridge: UXBridge = bridge) -> None:
     """Launch the Dear PyGUI interface."""
+    settings = get_settings(reload=True)
+    if not getattr(settings, "gui_enabled", False):
+        bridge.display_result(
+            "[yellow]GUI support is disabled. Enable 'gui.enabled' in configuration to use this command.[/yellow]"
+        )
+        return
     try:
         if run_dpg_ui is None:
             raise ImportError("Dear PyGUI interface is unavailable")

--- a/src/devsynth/config/settings.py
+++ b/src/devsynth/config/settings.py
@@ -222,6 +222,11 @@ class Settings(BaseSettings):
         json_schema_extra={"env": "ENABLE_CHROMADB"},
     )
 
+    # GUI settings
+    gui_enabled: bool = Field(
+        default=False, json_schema_extra={"env": "DEVSYNTH_GUI_ENABLED"}
+    )
+
     # Path settings
     log_dir: str = Field(default=None, json_schema_extra={"env": "DEVSYNTH_LOG_DIR"})
     project_dir: str = Field(

--- a/tests/unit/general/test_dpg_flag.py
+++ b/tests/unit/general/test_dpg_flag.py
@@ -1,0 +1,78 @@
+import sys
+import types
+import pytest
+
+# Stub heavy optional dependencies before importing cli_commands
+langgraph = types.ModuleType("langgraph")
+checkpoint = types.ModuleType("langgraph.checkpoint")
+checkpoint_base = types.ModuleType("langgraph.checkpoint.base")
+checkpoint_base.BaseCheckpointSaver = object  # type: ignore[attr-defined]
+checkpoint_base.empty_checkpoint = None  # type: ignore[attr-defined]
+checkpoint_sqlite = types.ModuleType("langgraph.checkpoint.sqlite")
+graph_mod = types.ModuleType("langgraph.graph")
+graph_mod.END = None  # type: ignore[attr-defined]
+graph_mod.StateGraph = object  # type: ignore[attr-defined]
+langgraph.graph = graph_mod  # type: ignore[attr-defined]
+
+tinydb_mod = types.ModuleType("tinydb")
+tinydb_mod.TinyDB = object  # type: ignore[attr-defined]
+tinydb_mod.Query = object  # type: ignore[attr-defined]
+
+tinydb_storages = types.ModuleType("tinydb.storages")
+tinydb_storages.MemoryStorage = object  # type: ignore[attr-defined]
+tinydb_storages.JSONStorage = object  # type: ignore[attr-defined]
+tinydb_storages.Storage = object  # type: ignore[attr-defined]
+tinydb_storages.touch = lambda *_, **__: None  # type: ignore[attr-defined]
+
+
+tinydb_middlewares = types.ModuleType("tinydb.middlewares")
+tinydb_middlewares.CachingMiddleware = object  # type: ignore[attr-defined]
+tqdm_mod = types.ModuleType("tqdm")
+tqdm_mod.tqdm = lambda *args, **kwargs: None  # type: ignore[attr-defined]
+lmstudio_mod = types.ModuleType("lmstudio")
+
+# Register stubs
+for mod, name in [
+    (langgraph, "langgraph"),
+    (checkpoint, "langgraph.checkpoint"),
+    (checkpoint_base, "langgraph.checkpoint.base"),
+    (checkpoint_sqlite, "langgraph.checkpoint.sqlite"),
+    (graph_mod, "langgraph.graph"),
+    (tinydb_mod, "tinydb"),
+    (tinydb_storages, "tinydb.storages"),
+    (tinydb_middlewares, "tinydb.middlewares"),
+    (types.ModuleType("tiktoken"), "tiktoken"),
+    (types.ModuleType("chromadb"), "chromadb"),
+    (types.ModuleType("duckdb"), "duckdb"),
+    (types.ModuleType("faiss"), "faiss"),
+    (types.ModuleType("lmdb"), "lmdb"),
+    (tqdm_mod, "tqdm"),
+    (lmstudio_mod, "lmstudio"),
+]:
+    sys.modules.setdefault(name, mod)
+
+from devsynth.application.cli import cli_commands as cc
+
+
+class DummyBridge:
+    def __init__(self) -> None:
+        self.messages: list[str] = []
+
+    def display_result(self, message: str, **_: object) -> None:
+        self.messages.append(message)
+
+
+def test_dpg_command_disabled(monkeypatch):
+    monkeypatch.setattr(cc, "get_settings", lambda reload=True: types.SimpleNamespace(gui_enabled=False))
+    monkeypatch.setattr(cc, "run_dpg_ui", lambda: None)
+    bridge = DummyBridge()
+    cc.dpg_cmd(bridge=bridge)
+    assert any("GUI support is disabled" in m for m in bridge.messages)
+
+
+def test_dpg_command_enabled(monkeypatch):
+    called: list[bool] = []
+    monkeypatch.setattr(cc, "get_settings", lambda reload=True: types.SimpleNamespace(gui_enabled=True))
+    monkeypatch.setattr(cc, "run_dpg_ui", lambda: called.append(True))
+    cc.dpg_cmd(bridge=DummyBridge())
+    assert called == [True]


### PR DESCRIPTION
## Summary
- add gui.enabled flag to default configuration
- honor gui.enabled before running dpg GUI command
- document gui configuration and add tests for dpg flag

## Testing
- `pytest tests/unit/general/test_dpg_flag.py -q`


------
https://chatgpt.com/codex/tasks/task_e_6890d21a33908333bde93681e160185b