### PR TITLE
test: add metrics module unit tests

### DIFF
--- a/tests/unit/test_metrics_module.py
+++ b/tests/unit/test_metrics_module.py
@@ -1,0 +1,36 @@
+import pytest
+
+from devsynth import metrics
+
+
+def test_memory_metrics_increment_and_reset():
+    metrics.reset_metrics()
+    metrics.inc_memory("read")
+    metrics.inc_memory("read")
+    metrics.inc_memory("write")
+    assert metrics.get_memory_metrics() == {"read": 2, "write": 1}
+    metrics.reset_metrics()
+    assert metrics.get_memory_metrics() == {}
+
+
+def test_provider_and_retry_metrics():
+    metrics.reset_metrics()
+    metrics.inc_provider("openai")
+    metrics.inc_retry("fetch")
+    metrics.inc_retry_count("func")
+    metrics.inc_retry_error("TimeoutError")
+    assert metrics.get_provider_metrics() == {"openai": 1}
+    assert metrics.get_retry_metrics() == {"fetch": 1}
+    assert metrics.get_retry_count_metrics() == {"func": 1}
+    assert metrics.get_retry_error_metrics() == {"TimeoutError": 1}
+    metrics.reset_metrics()
+    assert metrics.get_provider_metrics() == {}
+    assert metrics.get_retry_metrics() == {}
+    assert metrics.get_retry_count_metrics() == {}
+    assert metrics.get_retry_error_metrics() == {}
+
+
+def test_inc_memory_unhashable_raises_type_error():
+    metrics.reset_metrics()
+    with pytest.raises(TypeError):
+        metrics.inc_memory([])  # type: ignore[arg-type]


### PR DESCRIPTION
## Summary
- add comprehensive tests for devsynth.metrics counters and reset handling
- cover TypeError path for unhashable metric keys

## Testing
- `PYTHONPATH=src pytest tests/unit/test_metrics_module.py --cov=devsynth.metrics --cov-report=term-missing --cov-fail-under=0 -q`


------
https://chatgpt.com/codex/tasks/task_e_6890de02d600833393bc2788ae02bf4b