### PR TITLE
feat: centralize feature flag checks

### DIFF
--- a/docs/developer_guides/configuration_reference.md
+++ b/docs/developer_guides/configuration_reference.md
@@ -1,0 +1,32 @@
+# Configuration Reference
+
+## Feature Flags
+
+DevSynth exposes several optional capabilities through feature flags. Flags are
+stored in `.devsynth/project.yaml` (or the `devsynth` section of
+`pyproject.toml`) under the `features` key.
+
+### `experimental_features`
+
+Enables opt‑in, unstable functionality. When disabled the application skips
+code paths guarded by this flag, such as experimental DuckDB persistence
+settings.
+
+Use the CLI to toggle flags:
+
+```bash
+$ devsynth config enable-feature experimental_features
+```
+
+Programmatic checks are available via :mod:`devsynth.core.feature_flags`:
+
+```python
+from devsynth.core import feature_flags
+
+if feature_flags.experimental_enabled():
+    # execute experimental logic
+    ...
+```
+
+After changing flag values, call :func:`feature_flags.refresh` to reload the
+cached configuration.

--- a/src/devsynth/application/cli/cli_commands.py
+++ b/src/devsynth/application/cli/cli_commands.py
@@ -12,6 +12,7 @@ from devsynth.config import config_key_autocomplete as loader_autocomplete
 from devsynth.config import get_settings
 from devsynth.config.loader import ConfigModel, _find_config_path, save_config
 from devsynth.config.unified_loader import UnifiedConfigLoader
+from devsynth.core import feature_flags
 from devsynth.core import workflows
 from devsynth.core.workflows import (
     filter_args,
@@ -1062,6 +1063,7 @@ def enable_feature_cmd(name: str, *, bridge: Optional[UXBridge] = None) -> None:
             use_pyproject=(Path("pyproject.toml").exists()),
         )
 
+        feature_flags.refresh()
         bridge.display_result(f"Feature '{name}' enabled.")
     except Exception as err:
         bridge.display_result(f"[red]Error:[/red] {err}", highlight=False)

--- a/src/devsynth/application/memory/duckdb_store.py
+++ b/src/devsynth/application/memory/duckdb_store.py
@@ -30,6 +30,7 @@ from devsynth.exceptions import (
     MemoryStoreError,
     MemoryItemNotFoundError,
 )
+from devsynth.core import feature_flags
 
 # Create a logger for this module
 logger = DevSynthLogger(__name__)
@@ -147,10 +148,11 @@ class DuckDBStore(MemoryStore, VectorStore):
             # Configure HNSW parameters if enabled and vector extension is available
             if self.enable_hnsw and self.vector_extension_available:
                 try:
-                    # Enable experimental persistence for HNSW indexes
-                    self.conn.execute(
-                        "SET hnsw_enable_experimental_persistence = true;"
-                    )
+                    if feature_flags.experimental_enabled():
+                        # Enable experimental persistence for HNSW indexes
+                        self.conn.execute(
+                            "SET hnsw_enable_experimental_persistence = true;"
+                        )
 
                     # Set HNSW parameters
                     self.conn.execute(f"SET hnsw_M = {self.hnsw_config['M']};")

--- a/src/devsynth/core/feature_flags.py
+++ b/src/devsynth/core/feature_flags.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+"""Helpers for querying feature flags.
+
+This module centralizes access to feature flag checks. Feature flags are
+defined in the project configuration and may be toggled via the DevSynth CLI.
+"""
+
+from functools import lru_cache
+from typing import Dict
+
+from devsynth.config.loader import load_config
+
+
+@lru_cache(maxsize=1)
+def _feature_map() -> Dict[str, bool]:
+    """Return the feature flag mapping from configuration.
+
+    The configuration is loaded lazily and cached for future lookups. Use
+    :func:`refresh` after modifying configuration to ensure subsequent calls
+    reflect the latest values.
+    """
+
+    cfg = load_config()
+    return cfg.features or {}
+
+
+def is_enabled(name: str) -> bool:
+    """Return ``True`` if the named feature flag is enabled."""
+
+    return bool(_feature_map().get(name, False))
+
+
+def experimental_enabled() -> bool:
+    """Convenience wrapper for the ``experimental_features`` flag."""
+
+    return is_enabled("experimental_features")
+
+
+def refresh() -> None:
+    """Clear cached feature flags.
+
+    Call this after persisting configuration changes so that future checks use
+    updated values.
+    """
+
+    _feature_map.cache_clear()


### PR DESCRIPTION
## Summary
- add feature flag helpers and refresh logic
- gate HNSW experimental persistence behind flag
- document and test feature flag behavior

## Testing
- `pytest tests/unit/general/test_unit_cli_commands.py::TestCLICommands::test_enable_feature_cmd_persists_existing_flags -q`
- `pytest tests/unit/application/memory/test_duckdb_store.py tests/unit/application/memory/test_duckdb_store_hnsw.py tests/unit/general/test_unit_cli_commands.py::TestCLICommands::test_enable_feature_cmd_persists_existing_flags -q` *(fails: Can't instantiate abstract class DuckDBStore without transaction methods)*


------
https://chatgpt.com/codex/tasks/task_e_6890f4449a888333a2ca39e2e751816a