### PR TITLE
feat: extend MVUU schema with issue metadata

### DIFF
--- a/docs/specifications/mvuu_example.json
+++ b/docs/specifications/mvuu_example.json
@@ -7,5 +7,8 @@
   "tests": [
     "poetry run pytest tests/"
   ],
-  "TraceID": "MVUU-0001"
+  "TraceID": "MVUU-0001",
+  "mvuu": true,
+  "issue": "#1",
+  "notes": "Initial schema documentation."
 }

--- a/docs/specifications/mvuuschema.json
+++ b/docs/specifications/mvuuschema.json
@@ -2,25 +2,37 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "MVUU Schema",
   "type": "object",
-  "required": ["utility_statement", "affected_files", "tests", "TraceID"],
+  "required": ["utility_statement", "affected_files", "tests", "TraceID", "mvuu", "issue"],
   "properties": {
     "utility_statement": {
       "type": "string",
-      "description": "Summary of the utility provided by the change."
+      "description": "Commit utility statement summarizing the change."
     },
     "affected_files": {
       "type": "array",
       "items": {"type": "string"},
-      "description": "List of file paths impacted by the update."
+      "description": "Paths to files modified in this commit."
     },
     "tests": {
       "type": "array",
       "items": {"type": "string"},
-      "description": "References to tests validating the change."
+      "description": "Commands or references to tests validating the change."
     },
     "TraceID": {
       "type": "string",
-      "description": "Identifier used for traceability."
+      "description": "Traceability identifier in the form MVUU-0000."
+    },
+    "mvuu": {
+      "type": "boolean",
+      "description": "Set to true to confirm this commit uses the MVUU format."
+    },
+    "issue": {
+      "type": "string",
+      "description": "Related issue identifier (e.g., '#123')."
+    },
+    "notes": {
+      "type": "string",
+      "description": "Optional additional context for reviewers."
     }
   },
   "additionalProperties": false

--- a/scripts/update_traceability.py
+++ b/scripts/update_traceability.py
@@ -33,7 +33,9 @@ def build_entry(metadata: Dict[str, Any]) -> Dict[str, Any]:
         "features": [metadata.get("utility_statement", "")],
         "files": metadata.get("affected_files", []),
         "tests": metadata.get("tests", []),
-        "issue": metadata.get("issue"),
+        "issue": metadata.get("issue", ""),
+        "mvuu": metadata.get("mvuu", False),
+        "notes": metadata.get("notes"),
     }
 
 

--- a/tests/unit/scripts/test_commit_linter.py
+++ b/tests/unit/scripts/test_commit_linter.py
@@ -11,7 +11,10 @@ VALID_MESSAGE = (
     '  "utility_statement": "Example",\n'
     '  "affected_files": ["file.txt"],\n'
     '  "tests": ["pytest tests/example.py"],\n'
-    '  "TraceID": "MVUU-0001"\n'
+    '  "TraceID": "MVUU-0001",\n'
+    '  "mvuu": true,\n'
+    '  "issue": "#1",\n'
+    '  "notes": "demo"\n'
     "}\n"
     "```\n"
 )

--- a/traceability.json
+++ b/traceability.json
@@ -10,6 +10,8 @@
     "tests": [
       "poetry run pytest tests/"
     ],
-    "issue": null
+    "issue": "#1",
+    "mvuu": true,
+    "notes": "Initial schema documentation."
   }
 }


### PR DESCRIPTION
## Summary
- add `mvuu`, `issue`, and optional `notes` to the MVUU schema and example
- update traceability entries and commit linter test for new fields
- capture new metadata in the traceability update script

## Testing
- `poetry run black scripts/update_traceability.py tests/unit/scripts/test_commit_linter.py`
- `poetry run pytest tests/unit/scripts/test_commit_linter.py`


------
https://chatgpt.com/codex/tasks/task_e_6890f4239b68833395deea0d521fd102