### PR TITLE
docs: refine release roadmap

### DIFF
--- a/docs/roadmap/release_plan.md
+++ b/docs/roadmap/release_plan.md
@@ -31,10 +31,25 @@ git tag v0.1.0-alpha.1
 git push origin v0.1.0-alpha.1
 ```
 
+- MVUU JSON schema finalization
+- Commit-message linter enforcement
+- Traceability automation and ticket linkage
+- Baseline Dear PyGui parity tasks:
+  - Wizard forms
+  - Progress UI
+  - CLI mapping
+
 ### 0.1.0-beta.1
 - Refresh system architecture diagrams under `docs/architecture/`.
 - Standardize metadata headers across all project documentation.
 - Publish the consolidated release plan for team-wide alignment.
+- MVUU JSON schema finalization
+- Commit-message linter enforcement
+- Traceability automation and ticket linkage
+- Baseline Dear PyGui parity tasks:
+  - Wizard forms
+  - Progress UI
+  - CLI mapping
 
 ### 0.1.0
 - Stabilize core agent APIs and complete critical test coverage.
@@ -46,6 +61,12 @@ git push origin v0.1.0-alpha.1
 - Expand WebUI features with enhanced requirements workflows.
 - Introduce plugin interfaces for third-party provider integration.
 - Iterate on memory system scalability and performance.
+
+### 0.2.0+
+- Implement feature flags for experimental modules.
+- Automate project-board synchronization with release milestones.
+- Introduce a Jira adapter for issue tracking integration.
+- Develop the MVUU dashboard for monitoring and analytics.
 
 ### 0.3.0
 - Reach full feature parity with Dear PyGui across advanced workflows.


### PR DESCRIPTION
## Summary
- detail additional alpha and beta pre-release tasks for MVUU schema, commit-message lint, traceability, and baseline Dear PyGui parity
- outline post-0.2.0 priorities for feature flags, project board sync, Jira adapter, and MVUU dashboard

## Testing
- `task docs:fmt` *(fails: command not found)*
- `poetry run pre-commit run check-frontmatter --files docs/roadmap/release_plan.md` *(fails: frontmatter formatting issues found in many files)*

------
https://chatgpt.com/codex/tasks/task_e_6890f4152bcc8333a871a059e5631924