### PR TITLE
Scaffold GitHub and Jira adapters

### DIFF
--- a/config/github_project.yml
+++ b/config/github_project.yml
@@ -1,0 +1,5 @@
+# Example configuration for the GitHub Project adapter
+github_project:
+  token: "YOUR_GITHUB_TOKEN"
+  organization: "my-org"
+  project_number: 1

--- a/config/jira.yml
+++ b/config/jira.yml
@@ -1,0 +1,6 @@
+# Example configuration for the Jira adapter
+jira:
+  url: "https://example.atlassian.net"
+  email: "user@example.com"
+  token: "YOUR_JIRA_TOKEN"
+  project_key: "PROJ"

--- a/docs/technical_reference/methodology_integration_framework.md
+++ b/docs/technical_reference/methodology_integration_framework.md
@@ -91,6 +91,20 @@ DevSynth provides built-in support for several common development approaches:
 - Documentation for creating adapters
 - Example implementations
 
+### Project Management Tool Adapters
+
+DevSynth also ships with scaffolding for integrating external project
+tracking systems. These adapters allow methodology progress to be
+synchronized with tools that teams already use:
+
+- **GitHub Project Adapter** – synchronizes EDRR tasks with GitHub
+  Projects boards. Configure via `config/github_project.yml`.
+- **Jira Adapter** – provides hooks for creating and transitioning Jira
+  issues. Configure via `config/jira.yml`.
+
+Both adapters currently focus on configuration loading and provide
+placeholders for future network operations.
+
 
 ## Configuring Your Preferred Methodology
 

--- a/src/devsynth/adapters/github_project.py
+++ b/src/devsynth/adapters/github_project.py
@@ -1,0 +1,30 @@
+"""GitHub Project integration adapter."""
+
+from typing import Any, Dict
+
+from devsynth.logging_setup import DevSynthLogger
+
+
+class GitHubProjectAdapter:
+    """Adapter for synchronizing DevSynth tasks with GitHub Projects boards."""
+
+    def __init__(self, token: str, organization: str, project_number: int) -> None:
+        """Initialize the adapter with authentication details.
+
+        Args:
+            token: GitHub personal access token.
+            organization: GitHub organization name.
+            project_number: Numeric identifier of the project board.
+        """
+        self.token = token
+        self.organization = organization
+        self.project_number = project_number
+        self.logger = DevSynthLogger(__name__)
+
+    def sync_board(self, board_state: Dict[str, Any]) -> None:
+        """Synchronize the local board state with GitHub Projects.
+
+        Args:
+            board_state: Dictionary describing columns and cards to sync.
+        """
+        raise NotImplementedError("Board synchronization not yet implemented.")

--- a/src/devsynth/adapters/jira_adapter.py
+++ b/src/devsynth/adapters/jira_adapter.py
@@ -1,0 +1,30 @@
+"""Jira integration adapter."""
+
+from devsynth.logging_setup import DevSynthLogger
+
+
+class JiraAdapter:
+    """Adapter for interacting with Jira issues."""
+
+    def __init__(self, url: str, email: str, token: str, project_key: str) -> None:
+        """Initialize the Jira adapter.
+
+        Args:
+            url: Base URL of the Jira instance.
+            email: User email for authentication.
+            token: API token for Jira.
+            project_key: Project key to operate on.
+        """
+        self.url = url
+        self.email = email
+        self.token = token
+        self.project_key = project_key
+        self.logger = DevSynthLogger(__name__)
+
+    def create_issue(self, summary: str, description: str, issue_type: str = "Task") -> str:
+        """Create an issue in Jira and return its key."""
+        raise NotImplementedError("Jira issue creation not yet implemented.")
+
+    def transition_issue(self, issue_key: str, status: str) -> None:
+        """Transition an issue to a new status."""
+        raise NotImplementedError("Jira issue transition not yet implemented.")

--- a/tests/integration/adapters/test_github_project_adapter.py
+++ b/tests/integration/adapters/test_github_project_adapter.py
@@ -1,0 +1,26 @@
+from pathlib import Path
+
+import yaml
+
+from devsynth.adapters.github_project import GitHubProjectAdapter
+
+
+def test_github_project_adapter_config_loading(tmp_path: Path) -> None:
+    """Ensure the GitHub adapter reads configuration values."""
+    cfg = tmp_path / "github_project.yml"
+    cfg.write_text(
+        "github_project:\n"
+        "  token: token\n"
+        "  organization: org\n"
+        "  project_number: 1\n"
+    )
+    data = yaml.safe_load(cfg.read_text())["github_project"]
+
+    adapter = GitHubProjectAdapter(
+        token=data["token"],
+        organization=data["organization"],
+        project_number=data["project_number"],
+    )
+
+    assert adapter.organization == "org"
+    assert adapter.project_number == 1

--- a/tests/integration/adapters/test_jira_adapter.py
+++ b/tests/integration/adapters/test_jira_adapter.py
@@ -1,0 +1,25 @@
+import yaml
+
+from devsynth.adapters.jira_adapter import JiraAdapter
+
+
+def test_jira_adapter_config_loading(tmp_path) -> None:
+    """Ensure the Jira adapter reads configuration values."""
+    cfg = tmp_path / "jira.yml"
+    cfg.write_text(
+        "jira:\n"
+        "  url: https://example.atlassian.net\n"
+        "  email: user@example.com\n"
+        "  token: token\n"
+        "  project_key: TEST\n"
+    )
+    data = yaml.safe_load(cfg.read_text())["jira"]
+
+    adapter = JiraAdapter(
+        url=data["url"],
+        email=data["email"],
+        token=data["token"],
+        project_key=data["project_key"],
+    )
+
+    assert adapter.project_key == "TEST"


### PR DESCRIPTION
## Summary
- scaffold GitHub Project adapter for board synchronization
- scaffold Jira adapter with basic issue management hooks
- document project management tool adapters and add config examples
- add integration tests for new adapters

## Testing
- `poetry run pytest tests/integration/adapters -q`

------
https://chatgpt.com/codex/tasks/task_e_6890fb8b275483338032f95a664f8cb3