### PR TITLE
test: expand mvuu schema tests

### DIFF
--- a/scripts/verify_mvuu_references.py
+++ b/scripts/verify_mvuu_references.py
@@ -22,10 +22,14 @@ def _extract_mvuu_json(message: str) -> dict:
 def verify_mvuu_affected_files(message: str, changed_files: Iterable[str]) -> List[str]:
     """Return errors if changed files lack MVUU references."""
     mvuu = _extract_mvuu_json(message)
+    errors: List[str] = []
+    if mvuu.get("mvuu") is not True:
+        errors.append("'mvuu' must be true")
+    if "issue" not in mvuu:
+        errors.append("Missing required field 'issue'")
     affected = set(mvuu.get("affected_files", []))
     changed = set(changed_files)
     missing = changed - affected
-    errors: List[str] = []
     if missing:
         errors.append(
             "MVUU affected_files missing entries for: " + ", ".join(sorted(missing))

--- a/tests/unit/scripts/test_commit_linter.py
+++ b/tests/unit/scripts/test_commit_linter.py
@@ -48,6 +48,19 @@ MISSING_ISSUE_MESSAGE = (
     "```\n"
 )
 
+MISSING_MVUU_MESSAGE = (
+    "feat: no mvuu\n\n"
+    "```json\n"
+    "{\n"
+    '  "utility_statement": "Example",\n'
+    '  "affected_files": ["file.txt"],\n'
+    '  "tests": ["pytest tests/example.py"],\n'
+    '  "TraceID": "DSY-0001",\n'
+    '  "issue": "#1"\n'
+    "}\n"
+    "```\n"
+)
+
 MVUU_FALSE_MESSAGE = (
     "feat: mvuu false\n\n"
     "```json\n"
@@ -89,4 +102,10 @@ def test_lint_commit_message_missing_issue():
 def test_lint_commit_message_mvuu_false():
     """mvuu field set to false should produce an error."""
     errors = lint_commit_message(MVUU_FALSE_MESSAGE)
+    assert any("mvuu" in e for e in errors)
+
+
+def test_lint_commit_message_missing_mvuu():
+    """Missing mvuu field should produce an error."""
+    errors = lint_commit_message(MISSING_MVUU_MESSAGE)
     assert any("mvuu" in e for e in errors)

--- a/tests/unit/scripts/test_verify_mvuu_references.py
+++ b/tests/unit/scripts/test_verify_mvuu_references.py
@@ -11,7 +11,35 @@ VALID_MESSAGE = (
     '  "utility_statement": "Example",\n'
     '  "affected_files": ["file.txt"],\n'
     '  "tests": ["pytest tests/example.py"],\n'
-    '  "TraceID": "MVUU-0001"\n'
+    '  "TraceID": "DSY-0001",\n'
+    '  "mvuu": true,\n'
+    '  "issue": "#1"\n'
+    "}\n"
+    "```\n"
+)
+
+MISSING_ISSUE_MESSAGE = (
+    "feat: example\n\n"
+    "```json\n"
+    "{\n"
+    '  "utility_statement": "Example",\n'
+    '  "affected_files": ["file.txt"],\n'
+    '  "tests": ["pytest tests/example.py"],\n'
+    '  "TraceID": "DSY-0001",\n'
+    '  "mvuu": true\n'
+    "}\n"
+    "```\n"
+)
+
+MISSING_MVUU_MESSAGE = (
+    "feat: example\n\n"
+    "```json\n"
+    "{\n"
+    '  "utility_statement": "Example",\n'
+    '  "affected_files": ["file.txt"],\n'
+    '  "tests": ["pytest tests/example.py"],\n'
+    '  "TraceID": "DSY-0001",\n'
+    '  "issue": "#1"\n'
     "}\n"
     "```\n"
 )
@@ -26,3 +54,15 @@ def test_verify_mvuu_affected_files_missing():
     """Missing affected file should produce an error."""
     errors = verify_mvuu_affected_files(VALID_MESSAGE, ["other.txt"])
     assert any("missing entries" in e for e in errors)
+
+
+def test_verify_mvuu_affected_files_missing_issue():
+    """Missing issue field should produce an error."""
+    errors = verify_mvuu_affected_files(MISSING_ISSUE_MESSAGE, ["file.txt"])
+    assert any("issue" in e for e in errors)
+
+
+def test_verify_mvuu_affected_files_missing_mvuu():
+    """Missing mvuu flag should produce an error."""
+    errors = verify_mvuu_affected_files(MISSING_MVUU_MESSAGE, ["file.txt"])
+    assert any("mvuu" in e for e in errors)


### PR DESCRIPTION
## Summary
- expand `verify_mvuu_references` to check for required `mvuu` and `issue` fields
- update commit linter tests for expanded MVUU schema and missing field cases
- validate MVUU reference tests against required fields

## Testing
- `poetry run pytest tests/unit/scripts/`


------
https://chatgpt.com/codex/tasks/task_e_6890ff91d56c8333ac7d8ef92b7a717d