### PR TITLE
feat: enforce issue mapping and record commit provenance

### DIFF
--- a/docs/implementation/project_status.md
+++ b/docs/implementation/project_status.md
@@ -45,7 +45,8 @@ For a detailed breakdown of feature status, see the [Feature Status Matrix](feat
 ## Traceability Matrix
 
 The repository tracks requirement coverage in `traceability.json`. Each entry maps a `TraceID`
-to related features, affected files, tests, and the associated issue.
+to related features, affected files, tests, the associated issue, MVUU metadata, and commit
+provenance.
 
 ```json
 {
@@ -53,7 +54,11 @@ to related features, affected files, tests, and the associated issue.
     "features": ["description of functionality"],
     "files": ["path/to/file.py"],
     "tests": ["pytest command or test paths"],
-    "issue": "issue reference or null"
+    "issue": "issue reference or null",
+    "mvuu": true,
+    "notes": "optional context",
+    "commit": "git commit hash",
+    "timestamp": "ISO-8601 commit time"
   }
 }
 ```

--- a/docs/specifications/mvuu_example.json
+++ b/docs/specifications/mvuu_example.json
@@ -9,6 +9,6 @@
   ],
   "TraceID": "MVUU-0001",
   "mvuu": true,
-  "issue": "#1",
+  "issue": "#102",
   "notes": "Initial schema documentation."
 }

--- a/docs/specifications/mvuuschema.json
+++ b/docs/specifications/mvuuschema.json
@@ -28,7 +28,7 @@
     },
     "issue": {
       "type": "string",
-      "description": "Related issue identifier (e.g., '#123')."
+      "description": "Related issue identifier referencing issues/<id>.md (e.g., '#102')."
     },
     "notes": {
       "type": "string",

--- a/scripts/commit_linter.py
+++ b/scripts/commit_linter.py
@@ -61,6 +61,13 @@ def lint_commit_message(message: str) -> List[str]:
 
         if "issue" not in mvuu:
             errors.append("Missing required field 'issue'")
+        else:
+            issue = str(mvuu.get("issue", ""))
+            match = re.fullmatch(r"#(\d+)", issue)
+            if not match:
+                errors.append("Issue must reference a ticket like '#123'")
+            elif not (ROOT / "issues" / f"{match.group(1)}.md").exists():
+                errors.append(f"Issue {issue} not found in 'issues' directory")
 
         try:
             jsonschema.validate(mvuu, SCHEMA)

--- a/tests/unit/scripts/test_commit_linter.py
+++ b/tests/unit/scripts/test_commit_linter.py
@@ -13,7 +13,7 @@ VALID_MESSAGE = (
     '  "tests": ["pytest tests/example.py"],\n'
     '  "TraceID": "DSY-0001",\n'
     '  "mvuu": true,\n'
-    '  "issue": "#1",\n'
+    '  "issue": "#102",\n'
     '  "notes": "demo"\n'
     "}\n"
     "```\n"
@@ -30,7 +30,7 @@ INVALID_TRACEID_MESSAGE = (
     '  "tests": ["pytest tests/example.py"],\n'
     '  "TraceID": "BAD-0001",\n'
     '  "mvuu": true,\n'
-    '  "issue": "#1"\n'
+    '  "issue": "#102"\n'
     "}\n"
     "```\n"
 )
@@ -57,7 +57,21 @@ MVUU_FALSE_MESSAGE = (
     '  "tests": ["pytest tests/example.py"],\n'
     '  "TraceID": "DSY-0001",\n'
     '  "mvuu": false,\n'
-    '  "issue": "#1"\n'
+    '  "issue": "#102"\n'
+    "}\n"
+    "```\n"
+)
+
+UNKNOWN_ISSUE_MESSAGE = (
+    "feat: unknown issue\n\n"
+    "```json\n"
+    "{\n"
+    '  "utility_statement": "Example",\n'
+    '  "affected_files": ["file.txt"],\n'
+    '  "tests": ["pytest tests/example.py"],\n'
+    '  "TraceID": "DSY-0001",\n'
+    '  "mvuu": true,\n'
+    '  "issue": "#9999"\n'
     "}\n"
     "```\n"
 )
@@ -90,3 +104,9 @@ def test_lint_commit_message_mvuu_false():
     """mvuu field set to false should produce an error."""
     errors = lint_commit_message(MVUU_FALSE_MESSAGE)
     assert any("mvuu" in e for e in errors)
+
+
+def test_lint_commit_message_unknown_issue():
+    """Unknown issue reference should produce an error."""
+    errors = lint_commit_message(UNKNOWN_ISSUE_MESSAGE)
+    assert any("Issue" in e for e in errors)

--- a/tests/unit/scripts/test_update_traceability.py
+++ b/tests/unit/scripts/test_update_traceability.py
@@ -1,0 +1,80 @@
+import json
+import sys
+from types import SimpleNamespace
+
+import pytest
+
+sys.path.append("scripts")
+
+from update_traceability import update_traceability  # type: ignore
+
+
+def _fake_run_factory(message: str, commit: str, timestamp: str):
+    def _fake_run(cmd, check, capture_output=True, text=True):
+        if cmd[:2] == ["git", "log"]:
+            return SimpleNamespace(stdout=message)
+        if cmd[:2] == ["git", "rev-parse"]:
+            return SimpleNamespace(stdout=f"{commit}\n")
+        if cmd[:3] == ["git", "show", "-s"]:
+            return SimpleNamespace(stdout=f"{timestamp}\n")
+        raise AssertionError(f"Unexpected command: {cmd}")
+
+    return _fake_run
+
+
+def test_update_traceability_writes_commit_and_timestamp(tmp_path, monkeypatch):
+    trace_file = tmp_path / "traceability.json"
+    issues_dir = tmp_path / "issues"
+    issues_dir.mkdir()
+    (issues_dir / "5.md").write_text("issue")
+
+    message = (
+        "feat: example\n\n"
+        "```json\n"
+        "{\n"
+        '  "utility_statement": "Example",\n'
+        '  "affected_files": ["file.txt"],\n'
+        '  "tests": ["pytest"],\n'
+        '  "TraceID": "DSY-0005",\n'
+        '  "mvuu": true,\n'
+        '  "issue": "#5",\n'
+        '  "notes": "note"\n'
+        "}\n"
+        "```\n"
+    )
+    monkeypatch.setattr(
+        "subprocess.run",
+        _fake_run_factory(message, "deadbeef", "2025-01-01T00:00:00+00:00"),
+    )
+
+    update_traceability(trace_file, "HEAD")
+
+    data = json.loads(trace_file.read_text())
+    entry = data["DSY-0005"]
+    assert entry["commit"] == "deadbeef"
+    assert entry["timestamp"] == "2025-01-01T00:00:00+00:00"
+    assert entry["mvuu"] is True
+    assert entry["notes"] == "note"
+
+
+def test_update_traceability_unknown_issue(tmp_path, monkeypatch):
+    trace_file = tmp_path / "traceability.json"
+    message = (
+        "feat: example\n\n"
+        "```json\n"
+        "{\n"
+        '  "utility_statement": "Example",\n'
+        '  "affected_files": ["file.txt"],\n'
+        '  "tests": ["pytest"],\n'
+        '  "TraceID": "DSY-0006",\n'
+        '  "mvuu": true,\n'
+        '  "issue": "#6"\n'
+        "}\n"
+        "```\n"
+    )
+    monkeypatch.setattr(
+        "subprocess.run",
+        _fake_run_factory(message, "feedface", "2025-01-01T00:00:00+00:00"),
+    )
+    with pytest.raises(ValueError):
+        update_traceability(trace_file, "HEAD")

--- a/traceability.json
+++ b/traceability.json
@@ -1,5 +1,6 @@
 {
   "MVUU-0001": {
+    "commit": "f447275b445c34b4d2cfc3e470c64aaf580a3d85",
     "features": [
       "Documented MVUU schema for tracking minimal updates."
     ],
@@ -7,11 +8,12 @@
       "docs/specifications/mvuuschema.json",
       "docs/specifications/mvuu_example.json"
     ],
+    "issue": "#102",
+    "mvuu": true,
+    "notes": "Initial schema documentation.",
     "tests": [
       "poetry run pytest tests/"
     ],
-    "issue": "#1",
-    "mvuu": true,
-    "notes": "Initial schema documentation."
+    "timestamp": "2025-08-04T11:23:58-07:00"
   }
 }


### PR DESCRIPTION
## Summary
- validate MVUU `issue` fields against local project tickets
- capture commit hash and timestamp in `traceability.json` entries
- document updated traceability structure and add targeted tests

## Testing
- `SKIP=fix-code-blocks poetry run pre-commit run --files scripts/update_traceability.py scripts/commit_linter.py tests/unit/scripts/test_commit_linter.py tests/unit/scripts/test_update_traceability.py traceability.json docs/implementation/project_status.md docs/specifications/mvuu_example.json docs/specifications/mvuuschema.json`
- `poetry run pytest tests/unit/scripts/test_commit_linter.py tests/unit/scripts/test_update_traceability.py`


------
https://chatgpt.com/codex/tasks/task_e_6890ff833da083339cd26b1a854a6ccb