### PR TITLE
feat: add mvuu traceability hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,6 +26,18 @@ repos:
       entry: python scripts/find_syntax_errors.py
       language: system
       pass_filenames: false
+    - id: verify-mvuu-references
+      name: verify mvuu references
+      entry: python scripts/verify_mvuu_references.py
+      language: system
+      pass_filenames: false
+      stages: [push]
+    - id: update-traceability
+      name: update traceability
+      entry: python scripts/update_traceability.py
+      language: system
+      pass_filenames: false
+      stages: [post-commit]
     - id: commit-message-lint
       name: commit message lint
       entry: python scripts/commit_linter.py

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -28,3 +28,15 @@
   entry: python scripts/find_syntax_errors.py
   language: system
   pass_filenames: false
+- id: verify-mvuu-references
+  name: verify mvuu references
+  description: "Ensure MVUU references are valid"
+  entry: python scripts/verify_mvuu_references.py
+  language: system
+  pass_filenames: false
+- id: update-traceability
+  name: update traceability
+  description: "Update traceability data"
+  entry: python scripts/update_traceability.py
+  language: system
+  pass_filenames: false


### PR DESCRIPTION
## Summary
- add pre-push and post-commit hooks for MVUU reference verification and traceability updates
- document new hooks in `.pre-commit-hooks.yaml`

## Testing
- `SKIP=black,isort,flake8 poetry run pre-commit run --all-files` *(fails: could not determine a constructor for the tag 'tag:yaml.org,2002:python/name:material.extensions.emoji.twemoji')*


------
https://chatgpt.com/codex/tasks/task_e_689122b0f1848333964a8c25dc52e401