### PR TITLE
docs: describe traceability JSON format

### DIFF
--- a/docs/requirements_traceability.md
+++ b/docs/requirements_traceability.md
@@ -24,6 +24,41 @@ last_reviewed: "2025-08-03"---
 
 This matrix links requirements to design, code modules, and tests, ensuring bidirectional traceability and coverage. Update this file as requirements, code, and tests evolve.
 
+## Traceability JSON Format
+
+Traceability metadata is stored in `traceability.json` with each entry keyed by a `TraceID` such as `DSY-0001`. Entries capture:
+
+| Field | Description |
+|-------|-------------|
+| `features` | Summary of the feature or change. |
+| `files` | List of affected file paths. |
+| `tests` | Commands or references validating the change. |
+| `issue` | Related issue identifier in `DSY-<id>` format. |
+| `mvuu` | Set to `true` when the commit follows MVUU guidelines. |
+| `notes` | Optional context for reviewers. |
+
+Example:
+
+```json
+{
+  "DSY-0001": {
+    "features": [
+      "Documented MVUU schema for tracking minimal updates."
+    ],
+    "files": [
+      "docs/specifications/mvuuschema.json",
+      "docs/specifications/mvuu_example.json"
+    ],
+    "tests": [
+      "poetry run pytest tests/"
+    ],
+    "issue": "DSY-0001",
+    "mvuu": true,
+    "notes": "Initial schema documentation."
+  }
+}
+```
+
 | Requirement ID | Description | Design/Doc Reference | Code Module(s) | Test(s) | Status |
 |---------------|-------------|----------------------|---------------|---------|--------|
 | FR-01 | System initialization with required configuration | [DevSynth Technical Specification](specifications/devsynth_specification.md) | src/devsynth/application/cli/commands/init_cmd.py | tests/behavior/features/cli_commands.feature | Implemented |

--- a/traceability.json
+++ b/traceability.json
@@ -1,5 +1,5 @@
 {
-  "MVUU-0001": {
+  "DSY-0001": {
     "features": [
       "Documented MVUU schema for tracking minimal updates."
     ],
@@ -10,8 +10,23 @@
     "tests": [
       "poetry run pytest tests/"
     ],
-    "issue": "#1",
+    "issue": "DSY-0001",
     "mvuu": true,
     "notes": "Initial schema documentation."
+  },
+  "DSY-0002": {
+    "features": [
+      "Documented traceability JSON format and converted MVUU entry to DSY."
+    ],
+    "files": [
+      "traceability.json",
+      "docs/requirements_traceability.md"
+    ],
+    "tests": [
+      "poetry run python scripts/verify_requirements_traceability.py docs/requirements_traceability.md"
+    ],
+    "issue": "DSY-0002",
+    "mvuu": true,
+    "notes": "Added format description and updated traceability entry."
   }
 }


### PR DESCRIPTION
## Summary
- convert traceability entry to DSY identifier scheme and add new DSY-0002 entry with mvuu metadata
- document traceability.json format in requirements_traceability.md

## Testing
- `poetry run python scripts/verify_requirements_traceability.py docs/requirements_traceability.md`
- `poetry run pytest tests/unit/scripts/test_commit_linter.py::test_lint_commit_message_valid -q`


------
https://chatgpt.com/codex/tasks/task_e_68913671d82c83339887a2914975305c