### PR TITLE
feat: add MVUU dashboard and CLI command

### DIFF
--- a/docs/analysis/index.md
+++ b/docs/analysis/index.md
@@ -27,6 +27,7 @@ This section contains various analysis documents related to the DevSynth project
 - **[Technical Deep Dive](technical_deep_dive.md)**: A detailed technical analysis of DevSynth.
 - **[Wide Sweep Analysis](wide_sweep_analysis.md)**: A broad analysis of the DevSynth project.
 - **[CLI and UI Improvement Plan](cli_ui_improvement_plan.md)**: Outline of upcoming usability enhancements.
+- **[MVUU Dashboard](mvuu_dashboard.md)**: Overview of the MVUU traceability dashboard.
 - **[Performance Benchmark Plan](performance_plan.md)**: Expected metrics for core components.
 
 ## Related Documentation

--- a/docs/analysis/mvuu_dashboard.md
+++ b/docs/analysis/mvuu_dashboard.md
@@ -1,0 +1,18 @@
+# MVUU Dashboard
+
+The MVUU dashboard provides an interactive view of commit traceability data
+stored in `traceability.json`. It lists available TraceIDs and shows the linked
+issue and affected files for each entry.
+
+![MVUU Dashboard](mvuu_dashboard.svg)
+
+## Usage
+
+Run the dashboard using the DevSynth CLI:
+
+```bash
+$ devsynth mvuu-dashboard
+```
+
+The command launches a Streamlit application that reads `traceability.json` and
+displays TraceIDs, affected files, and related issues.

--- a/docs/analysis/mvuu_dashboard.svg
+++ b/docs/analysis/mvuu_dashboard.svg
@@ -1,0 +1,12 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="600" height="400">
+  <rect width="600" height="400" fill="#ffffff" stroke="#000" />
+  <text x="20" y="30" font-size="24" font-family="sans-serif">MVUU Dashboard</text>
+  <rect x="20" y="50" width="200" height="300" fill="#f0f0f0" stroke="#000" />
+  <text x="30" y="70" font-size="14" font-family="sans-serif">Trace IDs</text>
+  <text x="30" y="100" font-size="12" font-family="monospace">T-1234</text>
+  <text x="30" y="120" font-size="12" font-family="monospace">T-5678</text>
+  <rect x="240" y="50" width="340" height="300" fill="#f0f0f0" stroke="#000" />
+  <text x="250" y="70" font-size="14" font-family="sans-serif">Issue: DS-1</text>
+  <text x="250" y="90" font-size="12" font-family="monospace">file_a.py</text>
+  <text x="250" y="110" font-size="12" font-family="monospace">file_b.py</text>
+</svg>

--- a/src/devsynth/adapters/cli/typer_adapter.py
+++ b/src/devsynth/adapters/cli/typer_adapter.py
@@ -38,6 +38,7 @@ from devsynth.application.cli.commands.alignment_metrics_cmd import (
 from devsynth.application.cli.commands.generate_docs_cmd import generate_docs_cmd
 from devsynth.application.cli.commands.inspect_config_cmd import inspect_config_cmd
 from devsynth.application.cli.commands.run_tests_cmd import run_tests_cmd
+from devsynth.application.cli.commands.mvuu_dashboard_cmd import mvuu_dashboard_cmd
 from devsynth.application.cli.commands.security_audit_cmd import security_audit_cmd
 from devsynth.application.cli.commands.test_metrics_cmd import test_metrics_cmd
 from devsynth.application.cli.commands.validate_manifest_cmd import (
@@ -466,6 +467,10 @@ def build_app() -> typer.Typer:
         name="apispec",
         help="Generate an API spec. Example: devsynth apispec",
     )(apispec_cmd)
+    app.command(
+        name="mvuu-dashboard",
+        help="Launch the MVUU traceability dashboard. Example: devsynth mvuu-dashboard",
+    )(mvuu_dashboard_cmd)
     app.command(
         name="serve",
         help="Run the DevSynth API server. Example: devsynth serve --port 8080",

--- a/src/devsynth/application/cli/commands/mvuu_dashboard_cmd.py
+++ b/src/devsynth/application/cli/commands/mvuu_dashboard_cmd.py
@@ -1,0 +1,18 @@
+"""CLI command to launch the MVUU dashboard."""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+
+def mvuu_dashboard_cmd() -> None:
+    """Launch the MVUU traceability dashboard."""
+    script_path = (
+        Path(__file__).resolve().parents[3] / "interface" / "mvuu_dashboard.py"
+    )
+    subprocess.run(["streamlit", "run", str(script_path)], check=False)
+
+
+if __name__ == "__main__":  # pragma: no cover - convenience for manual run
+    mvuu_dashboard_cmd()

--- a/src/devsynth/interface/mvuu_dashboard.py
+++ b/src/devsynth/interface/mvuu_dashboard.py
@@ -1,0 +1,62 @@
+"""Streamlit dashboard for MVUU traceability data."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import streamlit as st
+
+# Path to the traceability file relative to the repository root
+_DEFAULT_TRACE_PATH = Path(__file__).resolve().parents[3] / "traceability.json"
+
+
+def load_traceability(path: Path = _DEFAULT_TRACE_PATH) -> dict:
+    """Load traceability data from ``traceability.json``.
+
+    Parameters
+    ----------
+    path: Path
+        Optional path to the traceability JSON file. Defaults to the repository
+        root ``traceability.json``.
+
+    Returns
+    -------
+    dict
+        Parsed JSON content describing MVUU traceability information.
+    """
+    with path.open("r", encoding="utf-8") as f:
+        return json.load(f)
+
+
+def render_dashboard(data: dict) -> None:
+    """Render the MVUU dashboard using Streamlit."""
+    st.title("MVUU Traceability Dashboard")
+    st.sidebar.header("TraceIDs")
+
+    trace_ids = sorted(data.keys())
+    selected_id = st.sidebar.selectbox("Select TraceID", trace_ids)
+
+    entry = data.get(selected_id, {})
+
+    st.subheader(f"TraceID: {selected_id}")
+    st.markdown(f"**Linked Issue:** {entry.get('issue', 'N/A')}")
+
+    st.markdown("### Affected Files")
+    for file in entry.get("files", []):
+        st.write(file)
+
+    if entry.get("features"):
+        st.markdown("### Features")
+        for feature in entry["features"]:
+            st.write(f"- {feature}")
+
+
+def main(path: Path = _DEFAULT_TRACE_PATH) -> None:
+    """Entry point for ``streamlit run``."""
+    data = load_traceability(path)
+    render_dashboard(data)
+
+
+if __name__ == "__main__":  # pragma: no cover - executed via streamlit
+    main()

--- a/tests/unit/general/test_mvuu_dashboard_cli.py
+++ b/tests/unit/general/test_mvuu_dashboard_cli.py
@@ -1,0 +1,35 @@
+import click
+import typer
+import typer.main
+from typer.testing import CliRunner
+import pytest
+
+from devsynth.adapters.cli.typer_adapter import build_app
+from devsynth.interface.ux_bridge import UXBridge
+
+
+@pytest.fixture(autouse=True)
+def patch_typer_types(monkeypatch):
+    orig = typer.main.get_click_type
+
+    def patched_get_click_type(*, annotation, parameter_info):
+        if annotation in {UXBridge, typer.models.Context}:
+            return click.STRING
+        origin = getattr(annotation, "__origin__", None)
+        if (
+            origin in {UXBridge, typer.models.Context}
+            or annotation is dict
+            or origin is dict
+        ):
+            return click.STRING
+        return orig(annotation=annotation, parameter_info=parameter_info)
+
+    monkeypatch.setattr(typer.main, "get_click_type", patched_get_click_type)
+
+
+def test_mvuu_dashboard_help_succeeds():
+    runner = CliRunner()
+    app = build_app()
+    result = runner.invoke(app, ["mvuu-dashboard", "--help"])
+    assert result.exit_code == 0
+    assert "MVUU traceability dashboard" in result.output

--- a/tests/unit/interface/test_mvuu_dashboard.py
+++ b/tests/unit/interface/test_mvuu_dashboard.py
@@ -1,0 +1,8 @@
+from devsynth.interface.mvuu_dashboard import load_traceability
+
+
+def test_load_traceability_reads_default_file():
+    data = load_traceability()
+    assert "MVUU-0001" in data
+    entry = data["MVUU-0001"]
+    assert entry.get("mvuu") is True


### PR DESCRIPTION
## Summary
- build Streamlit MVUU dashboard reading `traceability.json`
- expose dashboard through new `devsynth mvuu-dashboard` CLI command
- document dashboard with usage and screenshot
- convert dashboard screenshot to SVG to avoid binary files
- test dashboard loader and CLI entrypoint

## Testing
- `poetry run pytest tests/unit/general/test_mvuu_dashboard_cli.py tests/unit/interface/test_mvuu_dashboard.py tests/unit/general/test_cli_commands.py`


------
https://chatgpt.com/codex/tasks/task_e_689136830a748333b9e3159eaab185b3