### PR TITLE
feat: expose mvuu dashboard CLI entry and add tests

### DIFF
--- a/docs/roadmap/release_plan.md
+++ b/docs/roadmap/release_plan.md
@@ -62,11 +62,13 @@ git push origin v0.1.0-alpha.1
 - Introduce plugin interfaces for third-party provider integration.
 - Iterate on memory system scalability and performance.
 
+### MVUU Dashboard
+- Launch Streamlit MVUU traceability dashboard accessible via `devsynth mvuu-dashboard`.
+
 ### 0.2.0+
 - Implement feature flags for experimental modules.
 - Automate project-board synchronization with release milestones.
 - Introduce a Jira adapter for issue tracking integration.
-- Develop the MVUU dashboard for monitoring and analytics.
 
 ### 0.3.0
 - Reach full feature parity with Dear PyGui across advanced workflows.

--- a/docs/user_guides/dearpygui.md
+++ b/docs/user_guides/dearpygui.md
@@ -40,6 +40,16 @@ The table below shows how common CLI commands map to Dear PyGui actions.
 
 For a full mapping of commands across interfaces, see the [CLI to WebUI and Dear PyGUI Command Mapping](../architecture/cli_webui_mapping.md).
 
+## MVUU Dashboard
+
+Launch the MVUU traceability dashboard to explore commit links:
+
+```bash
+devsynth mvuu-dashboard
+```
+
+The dashboard uses Streamlit to visualize traceability information.
+
 ## Screenshots
 
 ![Main window](../images/dearpygui/main_window.svg)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -189,6 +189,7 @@ dev = [
 
 [tool.poetry.scripts]
 devsynth = "devsynth.adapters.cli:run_cli"
+mvuu-dashboard = "devsynth.application.cli.commands.mvuu_dashboard_cmd:mvuu_dashboard_cmd"
 
 [tool.mypy]
 python_version = "3.12"

--- a/tests/unit/interface/test_mvuu_dashboard.py
+++ b/tests/unit/interface/test_mvuu_dashboard.py
@@ -1,8 +1,49 @@
-from devsynth.interface.mvuu_dashboard import load_traceability
+"""Tests for the MVUU dashboard interface."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from devsynth.interface import mvuu_dashboard
 
 
 def test_load_traceability_reads_default_file():
-    data = load_traceability()
-    assert "MVUU-0001" in data
-    entry = data["MVUU-0001"]
+    data = mvuu_dashboard.load_traceability()
+    assert "DSY-0001" in data
+    entry = data["DSY-0001"]
     assert entry.get("mvuu") is True
+
+
+def test_load_traceability_reads_specified_file(tmp_path: Path):
+    sample = {"MVUU-9999": {"mvuu": True}}
+    path = tmp_path / "trace.json"
+    path.write_text(json.dumps(sample), encoding="utf-8")
+
+    data = mvuu_dashboard.load_traceability(path)
+    assert data == sample
+
+
+def test_render_dashboard_invokes_streamlit(monkeypatch: pytest.MonkeyPatch):
+    data = {"MVUU-0001": {"mvuu": True, "issue": "DSY-0001", "files": ["file.txt"], "features": []}}
+
+    mock_sidebar = MagicMock()
+    mock_sidebar.selectbox.return_value = "MVUU-0001"
+
+    mock_st = MagicMock()
+    mock_st.sidebar = mock_sidebar
+
+    monkeypatch.setattr(mvuu_dashboard, "st", mock_st)
+
+    mvuu_dashboard.render_dashboard(data)
+
+    mock_st.title.assert_called_once_with("MVUU Traceability Dashboard")
+    mock_sidebar.header.assert_called_once_with("TraceIDs")
+    mock_sidebar.selectbox.assert_called_once_with("Select TraceID", ["MVUU-0001"])
+    mock_st.subheader.assert_called_once_with("TraceID: MVUU-0001")
+    mock_st.markdown.assert_any_call("**Linked Issue:** DSY-0001")
+    mock_st.markdown.assert_any_call("### Affected Files")
+    mock_st.write.assert_called_once_with("file.txt")

--- a/traceability.json
+++ b/traceability.json
@@ -28,5 +28,24 @@
     "issue": "DSY-0002",
     "mvuu": true,
     "notes": "Added format description and updated traceability entry."
+  },
+  "DSY-0003": {
+    "features": [
+      "Added MVUU dashboard tests and CLI entry with documentation."
+    ],
+    "files": [
+      "tests/unit/interface/test_mvuu_dashboard.py",
+      "pyproject.toml",
+      "docs/user_guides/dearpygui.md",
+      "docs/roadmap/release_plan.md",
+      "traceability.json"
+    ],
+    "tests": [
+      "poetry run pytest tests/unit/interface/test_mvuu_dashboard.py",
+      "poetry run pytest tests/unit/general/test_mvuu_dashboard_cli.py"
+    ],
+    "issue": "DSY-0003",
+    "mvuu": true,
+    "notes": "MVUU dashboard CLI exposure and tests."
   }
 }


### PR DESCRIPTION
## Summary
- add mvuu dashboard CLI entry
- test load_traceability and render_dashboard
- document mvuu dashboard command and roadmap milestone

## Testing
- `poetry run pytest tests/unit/interface/test_mvuu_dashboard.py tests/unit/general/test_mvuu_dashboard_cli.py`


------
https://chatgpt.com/codex/tasks/task_e_689155314a6c8333a6a88151cf52be95