### PR TITLE
chore(ci): automate traceability updates after tests

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -160,6 +160,7 @@ tasks:
       - task: manifest:validate
       - task: lint
       - task: test:coverage
+      - poetry run python scripts/update_traceability.py
       - task: docs:build
 
   # Python-specific tasks

--- a/docs/requirements_traceability.md
+++ b/docs/requirements_traceability.md
@@ -59,6 +59,22 @@ Example:
 }
 ```
 
+## Update Procedure
+
+Run `scripts/update_traceability.py` after tests pass to append MVUU metadata
+from the latest commit into `traceability.json`.
+
+### Git Hook
+
+Enable the `pre-push` hook to automate this step:
+
+```bash
+ln -s ../../scripts/hooks/pre-push-traceability.sh .git/hooks/pre-push
+```
+
+The hook runs the test suite and updates `traceability.json` when the tests
+complete successfully.
+
 | Requirement ID | Description | Design/Doc Reference | Code Module(s) | Test(s) | Status |
 |---------------|-------------|----------------------|---------------|---------|--------|
 | FR-01 | System initialization with required configuration | [DevSynth Technical Specification](specifications/devsynth_specification.md) | src/devsynth/application/cli/commands/init_cmd.py | tests/behavior/features/cli_commands.feature | Implemented |
@@ -143,7 +159,7 @@ Example:
 | FR-92 | Multi-language code generation agent | [DevSynth Technical Specification](specifications/devsynth_specification.md) | src/devsynth/application/agents/multi_language_code.py | tests/unit/application/agents/test_multi_language_code.py | Implemented |
 | FR-93 | Embedded Kuzu graph memory store support | [Memory System Architecture](architecture/memory_system.md) | src/devsynth/application/memory/kuzu_store.py, src/devsynth/adapters/kuzu_memory_store.py | tests/unit/application/memory/test_kuzu_store.py, tests/integration/general/test_kuzu_memory_integration.py, tests/integration/general/test_kuzu_memory_fallback.py | Implemented |
 
-_Last updated: August 29, 2025_
+_Last updated: September 1, 2025_
 ## Implementation Status
 
 Several requirements remain **partially implemented**. Consult the status column

--- a/scripts/hooks/pre-push-traceability.sh
+++ b/scripts/hooks/pre-push-traceability.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(git rev-parse --show-toplevel)"
+cd "$repo_root"
+
+poetry run pytest
+poetry run python scripts/update_traceability.py
+

--- a/traceability.json
+++ b/traceability.json
@@ -47,5 +47,23 @@
     "issue": "DSY-0003",
     "mvuu": true,
     "notes": "MVUU dashboard CLI exposure and tests."
+  },
+  "DSY-0004": {
+    "features": [
+      "Automated traceability updates via CI and pre-push hook with documentation."
+    ],
+    "files": [
+      "Taskfile.yml",
+      "scripts/hooks/pre-push-traceability.sh",
+      "docs/requirements_traceability.md",
+      "traceability.json"
+    ],
+    "tests": [
+      "poetry run pytest --maxfail=1",
+      "poetry run python scripts/verify_requirements_traceability.py docs/requirements_traceability.md"
+    ],
+    "issue": "DSY-0004",
+    "mvuu": true,
+    "notes": "Integrates update_traceability after successful tests."
   }
 }


### PR DESCRIPTION
## Summary
- run update_traceability.py in CI after test coverage
- add pre-push hook to run tests then update traceability
- document traceability update procedure and record DSY-0004

## Testing
- `poetry run pytest --maxfail=1`
- `poetry run python scripts/verify_requirements_traceability.py docs/requirements_traceability.md`


------
https://chatgpt.com/codex/tasks/task_e_68916c0fdea8833382040d9404f259e0