### PR TITLE
feat: add MVUU dashboard and GUI feature flags

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -31,17 +31,24 @@ This guide explains the feature flags available in `config/*.yml` files and how 
 | `test_generation` | Enables automatic test creation features. |
 | `documentation_generation` | Provides automated documentation generation. |
 | `experimental_features` | Gates bleeding edge functionality; off in most configs. |
+| `mvuu_dashboard` | Enables the MVUU traceability dashboard. |
+| `gui` | Enables the Dear PyGui desktop client. |
 
 For the UX design rationale behind gradually exposing these capabilities, see the [Progressive Complexity UX Design section](analysis/dialectical_evaluation.md#synthesis-progressive-complexity-ux-design).
 
 ## GUI Configuration
 
-DevSynth includes an optional Dear PyGUI interface. To prevent unintended GUI launches in headless environments this interface is disabled by default. Set `gui.enabled` to `true` to enable the `dpg` CLI command:
+DevSynth includes an optional Dear PyGUI interface. To prevent unintended GUI launches in headless environments this interface is disabled by default. Set `gui.enabled` to `true` to enable the `dpg` CLI command and activate related feature flags:
 
 ```yaml
 gui:
   enabled: true
+features:
+  gui: true
+  mvuu_dashboard: true
 ```
+
+This example enables both the desktop client and the MVUU traceability dashboard.
 
 ## Enabling Flags
 

--- a/docs/roadmap/release_plan.md
+++ b/docs/roadmap/release_plan.md
@@ -70,6 +70,7 @@ Streamlit MVUU traceability dashboard accessible via `devsynth mvuu-dashboard`.
 
 ### 0.2.0+ (Future Features)
 - Implement feature flags for experimental modules.
+- Introduce feature flags for the MVUU dashboard and Dear PyGui interface.
 - Automate project-board synchronization with release milestones.
 - Introduce a Jira adapter for issue tracking integration.
 

--- a/docs/user_guides/dearpygui.md
+++ b/docs/user_guides/dearpygui.md
@@ -50,6 +50,14 @@ devsynth mvuu-dashboard
 
 The dashboard uses Streamlit to visualize traceability information.
 
+Enable the dashboard and desktop client by setting feature flags in your configuration:
+
+```yaml
+features:
+  gui: true
+  mvuu_dashboard: true
+```
+
 ## Screenshots
 
 ![Main window](../images/dearpygui/main_window.svg)

--- a/src/devsynth/config/loader.py
+++ b/src/devsynth/config/loader.py
@@ -49,6 +49,8 @@ class ConfigModel:
             "wsde_consensus_voting": False,
             "uxbridge_webui": False,
             "uxbridge_agent_api": False,
+            "gui": False,
+            "mvuu_dashboard": False,
         }
     )
     memory_store_type: str = "memory"
@@ -126,6 +128,8 @@ _VALID_FEATURE_FLAGS = {
     "wsde_consensus_voting",
     "uxbridge_webui",
     "uxbridge_agent_api",
+    "gui",
+    "mvuu_dashboard",
 }
 
 
@@ -202,7 +206,7 @@ def load_config(path: Optional[str | Path] = None) -> ConfigModel:
                 logger.error("Malformed YAML configuration: %s", exc)
                 raise ConfigurationError(
                     f"Malformed YAML configuration in {cfg_path}. Please check the syntax and formatting.",
-                    config_key=str(cfg_path)
+                    config_key=str(cfg_path),
                 ) from exc
         else:
             try:
@@ -212,7 +216,7 @@ def load_config(path: Optional[str | Path] = None) -> ConfigModel:
                 logger.error("Malformed TOML configuration: %s", exc)
                 raise ConfigurationError(
                     f"Malformed TOML configuration in {cfg_path}. Please check the syntax and formatting.",
-                    config_key=str(cfg_path)
+                    config_key=str(cfg_path),
                 ) from exc
 
         # Support legacy ``memory_backend`` key used in older docs
@@ -232,7 +236,7 @@ def load_config(path: Optional[str | Path] = None) -> ConfigModel:
         logger.error("Invalid configuration values: %s", exc)
         raise ConfigurationError(
             f"Invalid configuration values: {exc}. Please check the configuration documentation for valid options.",
-            config_key="validation"
+            config_key="validation",
         ) from exc
 
     # Validate version
@@ -246,11 +250,15 @@ def load_config(path: Optional[str | Path] = None) -> ConfigModel:
     # Validate EDRR settings
     if config.features.get("edrr_framework", False):
         if config.edrr_settings.get("max_recursion_depth", 0) < 1:
-            logger.warning("max_recursion_depth should be at least 1, setting to default (3)")
+            logger.warning(
+                "max_recursion_depth should be at least 1, setting to default (3)"
+            )
             config.edrr_settings["max_recursion_depth"] = 3
 
         if not isinstance(config.edrr_settings.get("phase_weights", {}), dict):
-            logger.warning("phase_weights should be a dictionary, setting to default values")
+            logger.warning(
+                "phase_weights should be a dictionary, setting to default values"
+            )
             config.edrr_settings["phase_weights"] = {
                 "expand": 1.0,
                 "differentiate": 1.0,
@@ -265,7 +273,9 @@ def load_config(path: Optional[str | Path] = None) -> ConfigModel:
             config.wsde_settings["team_size"] = 5
 
         if not isinstance(config.wsde_settings.get("voting_weights", {}), dict):
-            logger.warning("voting_weights should be a dictionary, setting to default values")
+            logger.warning(
+                "voting_weights should be a dictionary, setting to default values"
+            )
             config.wsde_settings["voting_weights"] = {
                 "expertise": 0.6,
                 "historical": 0.3,
@@ -273,13 +283,25 @@ def load_config(path: Optional[str | Path] = None) -> ConfigModel:
             }
 
     # Validate UXBridge settings
-    if config.features.get("uxbridge_webui", False) or config.features.get("uxbridge_agent_api", False):
-        if config.uxbridge_settings.get("webui_port", 0) < 1024 or config.uxbridge_settings.get("webui_port", 0) > 65535:
-            logger.warning("webui_port should be between 1024 and 65535, setting to default (8501)")
+    if config.features.get("uxbridge_webui", False) or config.features.get(
+        "uxbridge_agent_api", False
+    ):
+        if (
+            config.uxbridge_settings.get("webui_port", 0) < 1024
+            or config.uxbridge_settings.get("webui_port", 0) > 65535
+        ):
+            logger.warning(
+                "webui_port should be between 1024 and 65535, setting to default (8501)"
+            )
             config.uxbridge_settings["webui_port"] = 8501
 
-        if config.uxbridge_settings.get("api_port", 0) < 1024 or config.uxbridge_settings.get("api_port", 0) > 65535:
-            logger.warning("api_port should be between 1024 and 65535, setting to default (8000)")
+        if (
+            config.uxbridge_settings.get("api_port", 0) < 1024
+            or config.uxbridge_settings.get("api_port", 0) > 65535
+        ):
+            logger.warning(
+                "api_port should be between 1024 and 65535, setting to default (8000)"
+            )
             config.uxbridge_settings["api_port"] = 8000
 
     return config

--- a/tests/unit/config/test_feature_flags_mvuu_gui.py
+++ b/tests/unit/config/test_feature_flags_mvuu_gui.py
@@ -1,0 +1,27 @@
+import pytest
+from pathlib import Path
+import textwrap
+from devsynth.config.unified_loader import UnifiedConfigLoader
+
+
+@pytest.mark.medium
+def test_gui_and_mvuu_dashboard_flags_recognized(tmp_path: Path) -> None:
+    """Test that gui and mvuu_dashboard feature flags are recognized.
+
+    ReqID: N/A"""
+    cfg_dir = tmp_path / ".devsynth"
+    cfg_dir.mkdir()
+    cfg_file = cfg_dir / "project.yaml"
+    cfg_file.write_text(
+        textwrap.dedent(
+            """
+            version: "1.0"
+            features:
+              gui: true
+              mvuu_dashboard: true
+            """
+        )
+    )
+    config = UnifiedConfigLoader.load(path=str(tmp_path))
+    assert config.config.features["gui"] is True
+    assert config.config.features["mvuu_dashboard"] is True


### PR DESCRIPTION
## Summary
- document enabling MVUU dashboard and Dear PyGui features
- recognize `gui` and `mvuu_dashboard` in configuration loader
- cover new flags with a unit test
- track feature flag rollout in release plan

## Testing
- `poetry run black src/devsynth/config/loader.py tests/unit/config/test_feature_flags_mvuu_gui.py`
- `poetry run pytest tests/unit/config/test_feature_flags_mvuu_gui.py`

------
https://chatgpt.com/codex/tasks/task_e_689175da30348333850cbc8550e426fc