### PR TITLE
feat(gui): add progress hooks and wizard dialogs

### DIFF
--- a/docs/user_guides/dearpygui.md
+++ b/docs/user_guides/dearpygui.md
@@ -28,6 +28,18 @@ poetry install --extras gui
 poetry run python -m devsynth.interface.dpg_ui
 ```
 
+## Using the GUI
+
+Launching the module opens a window that mirrors the DevSynth CLI. Every
+available command is exposed as a button. Clicking a button runs the same
+workflow as the CLI while displaying a modal progress dialog. Commands that
+require additional input present wizard-style forms that guide you through the
+necessary steps.
+
+Long‑running operations update the progress bar automatically so you can track
+completion without blocking the interface. Errors are reported in modal
+dialogs, allowing you to retry or inspect the output.
+
 ## Command Mapping
 
 The table below shows how common CLI commands map to Dear PyGui actions.


### PR DESCRIPTION
## Summary
- add progress and error hooks to DearPyGUI bridge
- run CLI commands in GUI with progress wizards
- document Dear PyGui interface and progress features

## Testing
- `pytest tests/unit/interface/test_dpg_bridge.py tests/unit/interface/test_dpg_ui.py`

------
https://chatgpt.com/codex/tasks/task_e_689178978d748333a96035d946526a37