### PR TITLE
docs: document GUI extra installation and add Dear PyGui tests

### DIFF
--- a/docs/getting_started/installation.md
+++ b/docs/getting_started/installation.md
@@ -48,6 +48,15 @@ poetry install --without dev --without docs
 ```
 
 Extras may be added later using `poetry install --extras llm --extras api --extras offline --extras gui`.
+
+### Enable GUI support
+
+Install the optional desktop interface by including the `gui` extra:
+
+```bash
+poetry install --extras gui
+```
+
 Install the optional `gpu` extra for hardware-accelerated models:
 `poetry install --extras gpu`.
 

--- a/docs/user_guides/dearpygui.md
+++ b/docs/user_guides/dearpygui.md
@@ -21,7 +21,7 @@ The Dear PyGui interface provides a lightweight desktop client for DevSynth. It 
 
 ## Installation
 
-Install the GUI extra and run the interface module:
+Install the `gui` extra to pull in Dear PyGui and run the interface module:
 
 ```bash
 poetry install --extras gui


### PR DESCRIPTION
## Summary
- document how to install the `gui` extra for the optional Dear PyGui interface
- add tests ensuring `dpg_cmd` reports missing GUI support and runs when the extra is present
- confirm the `gui` Poetry extra maps to `dearpygui`

## Testing
- `pre-commit run --files docs/getting_started/installation.md docs/user_guides/dearpygui.md tests/unit/general/test_dpg_flag.py`
- `poetry run pytest tests/unit/general/test_dpg_flag.py`


------
https://chatgpt.com/codex/tasks/task_e_689186a1078c83339315a2c550e04fe8