### PR TITLE
feat: add MVUU core utilities

### DIFF
--- a/src/devsynth/core/mvu/__init__.py
+++ b/src/devsynth/core/mvu/__init__.py
@@ -1,0 +1,45 @@
+"""MVUU core utilities."""
+
+from .schema import MVUU_SCHEMA, load_schema
+from .models import MVUU
+from .parser import parse_commit_message, parse_file
+from .validator import (
+    validate_data,
+    validate_commit_message,
+    validate_affected_files,
+)
+from .storage import (
+    format_mvuu_footer,
+    read_commit_message,
+    read_mvuu_from_commit,
+    append_mvuu_footer,
+    read_note,
+    write_note,
+)
+from .api import (
+    iter_mvuu_commits,
+    get_by_trace_id,
+    get_by_affected_path,
+    get_by_date_range,
+)
+
+__all__ = [
+    "MVUU_SCHEMA",
+    "load_schema",
+    "MVUU",
+    "parse_commit_message",
+    "parse_file",
+    "validate_data",
+    "validate_commit_message",
+    "validate_affected_files",
+    "format_mvuu_footer",
+    "read_commit_message",
+    "read_mvuu_from_commit",
+    "append_mvuu_footer",
+    "read_note",
+    "write_note",
+    "iter_mvuu_commits",
+    "get_by_trace_id",
+    "get_by_affected_path",
+    "get_by_date_range",
+]

--- a/src/devsynth/core/mvu/api.py
+++ b/src/devsynth/core/mvu/api.py
@@ -1,0 +1,70 @@
+"""Query API for MVUU metadata."""
+
+from __future__ import annotations
+
+import subprocess
+from datetime import datetime
+from typing import Iterator, List, Tuple
+
+from .models import MVUU
+from .parser import parse_commit_message
+from .storage import read_commit_message
+
+
+def iter_mvuu_commits(ref: str = "HEAD") -> Iterator[Tuple[str, MVUU]]:
+    """Yield commits containing MVUU metadata starting from ``ref``."""
+    revs = subprocess.check_output(["git", "rev-list", ref], text=True)
+    for commit in revs.strip().splitlines():
+        try:
+            message = read_commit_message(commit)
+            mvuu = parse_commit_message(message)
+        except Exception:
+            continue
+        yield commit, mvuu
+
+
+def get_by_trace_id(trace_id: str, ref: str = "HEAD") -> List[Tuple[str, MVUU]]:
+    """Return commits whose MVUU TraceID matches ``trace_id``."""
+    return [
+        (commit, mvuu)
+        for commit, mvuu in iter_mvuu_commits(ref)
+        if mvuu.TraceID == trace_id
+    ]
+
+
+def get_by_affected_path(path: str, ref: str = "HEAD") -> List[Tuple[str, MVUU]]:
+    """Return commits whose MVUU affected files include ``path``."""
+    return [
+        (commit, mvuu)
+        for commit, mvuu in iter_mvuu_commits(ref)
+        if path in mvuu.affected_files
+    ]
+
+
+def get_by_date_range(
+    start: datetime, end: datetime, ref: str = "HEAD"
+) -> List[Tuple[str, MVUU]]:
+    """Return commits within a date range containing MVUU metadata."""
+    revs = subprocess.check_output(
+        [
+            "git",
+            "log",
+            "--since",
+            start.isoformat(),
+            "--until",
+            end.isoformat(),
+            "--format=%H",
+            ref,
+        ],
+        text=True,
+    )
+    commits = revs.strip().splitlines()
+    results: List[Tuple[str, MVUU]] = []
+    for commit in commits:
+        try:
+            message = read_commit_message(commit)
+            mvuu = parse_commit_message(message)
+        except Exception:
+            continue
+        results.append((commit, mvuu))
+    return results

--- a/src/devsynth/core/mvu/models.py
+++ b/src/devsynth/core/mvu/models.py
@@ -1,0 +1,38 @@
+"""Data models for MVUU metadata."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import List, Optional, Dict, Any
+
+
+@dataclass
+class MVUU:
+    """Dataclass representing MVUU metadata."""
+
+    utility_statement: str
+    affected_files: List[str]
+    tests: List[str]
+    TraceID: str
+    mvuu: bool
+    issue: str
+    notes: Optional[str] = None
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "MVUU":
+        """Create an MVUU instance from a dictionary."""
+        return cls(**data)
+
+    def as_dict(self) -> Dict[str, Any]:
+        """Return metadata as a dictionary."""
+        data: Dict[str, Any] = {
+            "utility_statement": self.utility_statement,
+            "affected_files": self.affected_files,
+            "tests": self.tests,
+            "TraceID": self.TraceID,
+            "mvuu": self.mvuu,
+            "issue": self.issue,
+        }
+        if self.notes is not None:
+            data["notes"] = self.notes
+        return data

--- a/src/devsynth/core/mvu/parser.py
+++ b/src/devsynth/core/mvu/parser.py
@@ -1,0 +1,41 @@
+"""Parsing helpers for MVUU metadata."""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from .models import MVUU
+
+JSON_FENCE_RE = re.compile(r"```(?:json|yaml)\n(.*?)\n```", re.DOTALL)
+
+
+def parse_commit_message(message: str) -> MVUU:
+    """Extract MVUU metadata from a commit message."""
+    match = JSON_FENCE_RE.search(message)
+    if not match:
+        raise ValueError("Missing MVUU block fenced with ```json ... ```")
+    block = match.group(1)
+    try:
+        data = json.loads(block)
+    except json.JSONDecodeError:
+        data = yaml.safe_load(block)
+    if not isinstance(data, dict):
+        raise ValueError("MVUU block does not contain an object")
+    return MVUU.from_dict(data)
+
+
+def parse_file(path: Path) -> MVUU:
+    """Load MVUU metadata from a JSON or YAML file."""
+    text = path.read_text(encoding="utf-8")
+    if path.suffix in {".yaml", ".yml"}:
+        data: Any = yaml.safe_load(text)
+    else:
+        data = json.loads(text)
+    if not isinstance(data, dict):
+        raise ValueError("MVUU file must contain a JSON/YAML object")
+    return MVUU.from_dict(data)

--- a/src/devsynth/core/mvu/schema.py
+++ b/src/devsynth/core/mvu/schema.py
@@ -1,0 +1,19 @@
+"""MVUU schema loader."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Dict
+
+# Repository root resolved from this file's location
+ROOT = Path(__file__).resolve().parents[4]
+SCHEMA_PATH = ROOT / "docs" / "specifications" / "mvuuschema.json"
+
+
+def load_schema() -> Dict[str, Any]:
+    """Return the MVUU schema as a dictionary."""
+    return json.loads(SCHEMA_PATH.read_text(encoding="utf-8"))
+
+
+MVUU_SCHEMA = load_schema()

--- a/src/devsynth/core/mvu/storage.py
+++ b/src/devsynth/core/mvu/storage.py
@@ -1,0 +1,59 @@
+"""Storage helpers for MVUU metadata."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from typing import Optional
+
+from .models import MVUU
+from .parser import parse_commit_message
+
+
+def format_mvuu_footer(mvuu: MVUU) -> str:
+    """Return a canonical commit message footer for MVUU metadata."""
+    return "```json\n" + json.dumps(mvuu.as_dict(), indent=2) + "\n```"
+
+
+def read_commit_message(commit: str) -> str:
+    """Return the commit message for a given commit hash."""
+    return subprocess.check_output(
+        ["git", "log", "-1", "--pretty=%B", commit], text=True
+    )
+
+
+def read_mvuu_from_commit(commit: str) -> Optional[MVUU]:
+    """Return MVUU metadata embedded in a commit message."""
+    try:
+        message = read_commit_message(commit)
+        return parse_commit_message(message)
+    except Exception:
+        return None
+
+
+def append_mvuu_footer(message: str, mvuu: MVUU) -> str:
+    """Append MVUU metadata to a commit message."""
+    footer = format_mvuu_footer(mvuu)
+    if message.endswith("\n"):
+        return message + footer + "\n"
+    return message + "\n" + footer + "\n"
+
+
+def read_note(commit: str) -> Optional[MVUU]:
+    """Read MVUU metadata from a git note if present."""
+    try:
+        note = subprocess.check_output(
+            ["git", "notes", "show", commit], text=True
+        ).strip()
+    except subprocess.CalledProcessError:
+        return None
+    if not note:
+        return None
+    data = json.loads(note)
+    return MVUU.from_dict(data)
+
+
+def write_note(commit: str, mvuu: MVUU) -> None:
+    """Write MVUU metadata to a git note."""
+    json_data = json.dumps(mvuu.as_dict(), indent=2)
+    subprocess.check_call(["git", "notes", "add", "-f", "-m", json_data, commit])

--- a/src/devsynth/core/mvu/validator.py
+++ b/src/devsynth/core/mvu/validator.py
@@ -1,0 +1,50 @@
+"""Validation utilities for MVUU metadata."""
+
+from __future__ import annotations
+
+import re
+from typing import Iterable, List, Dict, Any
+
+import jsonschema
+
+from .models import MVUU
+from .parser import parse_commit_message
+from .schema import MVUU_SCHEMA
+
+CONVENTIONAL_RE = re.compile(
+    r"^(build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test)(\([\w\-]+\))?: .+"
+)
+
+
+def validate_data(data: MVUU | Dict[str, Any]) -> MVUU:
+    """Validate MVUU data against the JSON schema."""
+    if isinstance(data, MVUU):
+        payload = data.as_dict()
+    else:
+        payload = data
+    jsonschema.validate(payload, MVUU_SCHEMA)
+    return MVUU.from_dict(payload)
+
+
+def validate_commit_message(message: str) -> MVUU:
+    """Validate MVUU metadata contained in a commit message."""
+    header = message.splitlines()[0]
+    if not CONVENTIONAL_RE.match(header):
+        raise ValueError("Commit header must follow Conventional Commits")
+    mvuu = parse_commit_message(message)
+    return validate_data(mvuu)
+
+
+def validate_affected_files(mvuu: MVUU, changed_files: Iterable[str]) -> List[str]:
+    """Return discrepancies between MVUU affected files and actual changes."""
+    affected = set(mvuu.affected_files)
+    changed = set(changed_files)
+    errors: List[str] = []
+    if affected != changed:
+        missing = changed - affected
+        extra = affected - changed
+        if missing:
+            errors.append(f"missing files: {sorted(missing)}")
+        if extra:
+            errors.append(f"extra files: {sorted(extra)}")
+    return errors

--- a/tests/unit/core/test_mvu.py
+++ b/tests/unit/core/test_mvu.py
@@ -1,0 +1,54 @@
+"""Tests for MVUU core utilities."""
+
+from __future__ import annotations
+
+import subprocess
+from datetime import datetime, timedelta
+from pathlib import Path
+
+from devsynth.core import mvu
+
+
+def _init_repo(path: Path) -> None:
+    subprocess.check_call(["git", "init"], cwd=path)
+    subprocess.check_call(["git", "config", "user.email", "test@example.com"], cwd=path)
+    subprocess.check_call(["git", "config", "user.name", "Test User"], cwd=path)
+
+
+def test_schema_has_required_fields() -> None:
+    """Schema should expose required top-level properties."""
+    assert "utility_statement" in mvu.MVUU_SCHEMA["properties"]
+
+
+def test_end_to_end_mvu_flow(tmp_path: Path, monkeypatch) -> None:
+    """MVUU data can be parsed, validated, stored, and queried."""
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _init_repo(repo)
+
+    mvuu_data = mvu.MVUU(
+        utility_statement="test",
+        affected_files=["file.txt"],
+        tests=["pytest"],
+        TraceID="DSY-1234",
+        mvuu=True,
+        issue="#1234",
+    )
+    message = "feat: add file\n\n" + mvu.format_mvuu_footer(mvuu_data)
+    (repo / "file.txt").write_text("content", encoding="utf-8")
+    subprocess.check_call(["git", "add", "file.txt"], cwd=repo)
+    subprocess.check_call(["git", "commit", "-m", message], cwd=repo)
+
+    monkeypatch.chdir(repo)
+    commit = subprocess.check_output(["git", "rev-parse", "HEAD"], text=True).strip()
+
+    mvuu_loaded = mvu.read_mvuu_from_commit(commit)
+    assert mvuu_loaded is not None
+    assert mvuu_loaded.TraceID == "DSY-1234"
+    assert mvu.validate_affected_files(mvuu_loaded, ["file.txt"]) == []
+
+    assert mvu.get_by_trace_id("DSY-1234")
+    assert mvu.get_by_affected_path("file.txt")
+    now = datetime.utcnow()
+    results = mvu.get_by_date_range(now - timedelta(days=1), now + timedelta(days=1))
+    assert results


### PR DESCRIPTION
## Summary
- add MVUU schema loader, models, parser, validator, storage, and query APIs
- include end-to-end tests for MVUU parsing and retrieval

## Testing
- `poetry run pytest tests/unit/core/test_mvu.py`


------
https://chatgpt.com/codex/tasks/task_e_689199c73ca48333a7bd3c87885c3cfa