### PR TITLE
feat: add MVU init command

### DIFF
--- a/docs/requirements_traceability.md
+++ b/docs/requirements_traceability.md
@@ -61,6 +61,16 @@ Example:
 
 > **Note:** `traceability.json` is ignored by version control and should remain local to each contributor.
 
+## MVU Configuration
+
+Initialize MVU support by creating `.devsynth/mvu.yml`:
+
+```bash
+devsynth mvu init
+```
+
+This file stores the default schema path and storage settings for MVUU records.
+
 ## MVUU Database Integration
 
 Traceability entries correspond to detailed MVUU records stored in

--- a/docs/user_guides/cli_reference.md
+++ b/docs/user_guides/cli_reference.md
@@ -57,6 +57,7 @@ This document provides a comprehensive reference for the DevSynth Command Line I
   - [ingest](#ingest)
   - [apispec](#apispec)
   - [serve](#serve)
+  - [mvu](#mvu)
 - [Environment Variables](#environment-variables)
 - [Configuration File](#configuration-file)
 - [Examples](#examples)
@@ -122,6 +123,7 @@ test-metrics
 generate-docs
 ingest
 apispec
+mvu
 serve
 ```
 
@@ -615,7 +617,20 @@ test-metrics
 generate-docs
 ingest
 apispec
+mvu
 serve
+```
+
+### mvu
+
+Utilities for Minimal Viable Useful Unit configuration.
+
+#### init
+
+Scaffold `.devsynth/mvu.yml` with default schema path and storage settings.
+
+```bash
+devsynth mvu init
 ```
 
 ## Environment Variables

--- a/src/devsynth/adapters/cli/typer_adapter.py
+++ b/src/devsynth/adapters/cli/typer_adapter.py
@@ -39,6 +39,7 @@ from devsynth.application.cli.commands.generate_docs_cmd import generate_docs_cm
 from devsynth.application.cli.commands.inspect_config_cmd import inspect_config_cmd
 from devsynth.application.cli.commands.run_tests_cmd import run_tests_cmd
 from devsynth.application.cli.commands.mvuu_dashboard_cmd import mvuu_dashboard_cmd
+from devsynth.application.cli.commands.mvu_init_cmd import mvu_init_cmd
 from devsynth.application.cli.commands.security_audit_cmd import security_audit_cmd
 from devsynth.application.cli.commands.test_metrics_cmd import test_metrics_cmd
 from devsynth.application.cli.commands.validate_manifest_cmd import (
@@ -471,6 +472,9 @@ def build_app() -> typer.Typer:
         name="mvuu-dashboard",
         help="Launch the MVUU traceability dashboard. Example: devsynth mvuu-dashboard",
     )(mvuu_dashboard_cmd)
+    mvu_app = typer.Typer(help="MVU utilities")
+    mvu_app.command("init", help="Scaffold MVU configuration")(mvu_init_cmd)
+    app.add_typer(mvu_app, name="mvu")
     app.command(
         name="serve",
         help="Run the DevSynth API server. Example: devsynth serve --port 8080",

--- a/src/devsynth/application/cli/commands/mvu_init_cmd.py
+++ b/src/devsynth/application/cli/commands/mvu_init_cmd.py
@@ -1,0 +1,42 @@
+"""CLI command to scaffold MVU configuration."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Optional
+
+import yaml
+
+from devsynth.interface.cli import CLIUXBridge
+from devsynth.interface.ux_bridge import UXBridge
+from devsynth.logging_setup import DevSynthLogger
+
+logger = DevSynthLogger(__name__)
+bridge: UXBridge = CLIUXBridge()
+
+_DEFAULT_CONFIG = {
+    "schema": "docs/specifications/mvuuschema.json",
+    "storage": {
+        "path": "docs/specifications/mvuu_database.json",
+        "format": "json",
+    },
+}
+
+
+def mvu_init_cmd(*, bridge: Optional[UXBridge] = None) -> None:
+    """Create a default `.devsynth/mvu.yml` configuration file."""
+    bridge = bridge or CLIUXBridge()
+    cfg_path = Path(".devsynth") / "mvu.yml"
+    if cfg_path.exists():
+        bridge.print("[green]MVU configuration already exists.[/green]")
+        return
+
+    cfg_path.parent.mkdir(parents=True, exist_ok=True)
+    with cfg_path.open("w", encoding="utf-8") as f:
+        yaml.safe_dump(_DEFAULT_CONFIG, f, sort_keys=False)
+
+    bridge.print(f"[green]Created {cfg_path}[/green]")
+
+
+if __name__ == "__main__":  # pragma: no cover - convenience for manual run
+    mvu_init_cmd()

--- a/src/devsynth/core/config_loader.py
+++ b/src/devsynth/core/config_loader.py
@@ -24,6 +24,7 @@ class CoreConfig:
     directories: Dict[str, list[str]] | None = None
     features: Dict[str, bool] | None = None
     resources: Dict[str, Any] | None = None
+    mvuu: Dict[str, Any] | None = None
 
     def as_dict(self) -> Dict[str, Any]:
         return {
@@ -41,6 +42,7 @@ class CoreConfig:
             },
             "features": self.features or {},
             "resources": self.resources or {},
+            "mvuu": self.mvuu or {},
         }
 
 
@@ -120,6 +122,13 @@ def load_config(start_path: Optional[str] = None) -> CoreConfig:
             config_data.update(_load_yaml(project_cfg))
         else:
             config_data.update(_load_toml(project_cfg))
+
+    # MVUU configuration
+    mvu_cfg = root / ".devsynth" / "mvu.yml"
+    if not mvu_cfg.exists():
+        mvu_cfg = root / ".devsynth" / "mvu.yaml"
+    if mvu_cfg.exists():
+        config_data["mvuu"] = _load_yaml(mvu_cfg)
 
     # Environment overrides
     config_data.update(_parse_env(defaults))

--- a/tests/unit/core/test_config_loader_mvu.py
+++ b/tests/unit/core/test_config_loader_mvu.py
@@ -1,0 +1,13 @@
+import yaml
+from pathlib import Path
+
+from devsynth.core.config_loader import load_config
+
+
+def test_load_config_merges_mvuu_settings(tmp_path):
+    mvu_cfg = {"schema": "s.json", "storage": {"path": "db.json", "format": "json"}}
+    dev_dir = tmp_path / ".devsynth"
+    dev_dir.mkdir()
+    (dev_dir / "mvu.yml").write_text(yaml.safe_dump(mvu_cfg))
+    cfg = load_config(start_path=str(tmp_path))
+    assert cfg.mvuu == mvu_cfg

--- a/tests/unit/general/test_mvu_init_cmd.py
+++ b/tests/unit/general/test_mvu_init_cmd.py
@@ -1,0 +1,15 @@
+import runpy
+from pathlib import Path
+import yaml
+
+
+def test_mvu_init_cmd_creates_file(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    repo_root = Path(__file__).resolve().parents[3]
+    module = runpy.run_path(
+        repo_root / "src/devsynth/application/cli/commands/mvu_init_cmd.py"
+    )
+    module["mvu_init_cmd"]()
+    cfg = yaml.safe_load((tmp_path / ".devsynth" / "mvu.yml").read_text())
+    assert cfg["schema"] == "docs/specifications/mvuuschema.json"
+    assert cfg["storage"]["path"] == "docs/specifications/mvuu_database.json"


### PR DESCRIPTION
## Summary
- add `mvu init` command to scaffold `.devsynth/mvu.yml`
- wire new command into CLI via `mvu` sub-app
- load MVU settings from `.devsynth/mvu.yml`
- document MVU CLI usage and traceability setup

## Testing
- `pytest tests/unit/general/test_mvu_init_cmd.py tests/unit/core/test_config_loader_mvu.py -q`


------
https://chatgpt.com/codex/tasks/task_e_6891a1a30dac8333b39e4f165dad8574