### PR TITLE
feat: add MVU commit linter CLI

### DIFF
--- a/scripts/commit_linter.py
+++ b/scripts/commit_linter.py
@@ -1,123 +1,13 @@
 #!/usr/bin/env python3
-"""Lint commit messages for MVUU compliance."""
+"""Deprecated commit message linter script.
+
+Use ``devsynth mvu lint`` instead of this script.
+"""
 
 from __future__ import annotations
 
-import argparse
-import json
-import re
-import subprocess
-import sys
-from pathlib import Path
-from typing import List
-
-import jsonschema
-
-ROOT = Path(__file__).resolve().parents[1]
-SCHEMA_PATH = ROOT / "docs/specifications/mvuuschema.json"
-
-CONVENTIONAL_RE = re.compile(
-    r"^(build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test)(\([\w\-]+\))?: .+"
-)
+from devsynth.core.mvu.linter import main
 
 
-def _load_schema() -> dict:
-    """Return the MVUU JSON schema."""
-    return json.loads(SCHEMA_PATH.read_text(encoding="utf-8"))
-
-
-SCHEMA = _load_schema()
-
-
-def _extract_mvuu_json(message: str) -> dict:
-    """Extract the MVUU JSON block from a commit message."""
-    pattern = re.compile(r"```json\n(.*?)\n```", re.DOTALL)
-    match = pattern.search(message)
-    if not match:
-        raise ValueError("Missing MVUU JSON block fenced with ```json … ```")
-    try:
-        return json.loads(match.group(1))
-    except json.JSONDecodeError as exc:  # pragma: no cover - defensive
-        raise ValueError(f"MVUU JSON is not valid JSON: {exc.msg}") from exc
-
-
-def lint_commit_message(message: str) -> List[str]:
-    """Validate a commit message against conventional and MVUU rules."""
-    errors: List[str] = []
-    header = message.splitlines()[0]
-    if not CONVENTIONAL_RE.match(header):
-        errors.append(
-            "Commit message header must follow Conventional Commits, e.g. 'feat: …'"
-        )
-    try:
-        mvuu = _extract_mvuu_json(message)
-
-        trace_id = str(mvuu.get("TraceID", ""))
-        if not re.fullmatch(r"DSY-\d+", trace_id):
-            errors.append("TraceID must match pattern 'DSY-<number>'")
-
-        if mvuu.get("mvuu") is not True:
-            errors.append("'mvuu' must be true")
-
-        if "issue" not in mvuu:
-            errors.append("Missing required field 'issue'")
-
-        try:
-            jsonschema.validate(mvuu, SCHEMA)
-        except jsonschema.ValidationError as exc:  # pragma: no cover - passthrough
-            errors.append(f"MVUU JSON invalid: {exc.message}")
-    except ValueError as exc:
-        errors.append(str(exc))
-    return errors
-
-
-def lint_range(rev_range: str) -> List[str]:
-    """Lint all commit messages within a git revision range."""
-    errors: List[str] = []
-    hashes = (
-        subprocess.check_output(["git", "rev-list", rev_range], text=True)
-        .strip()
-        .splitlines()
-    )
-    for commit_hash in reversed(hashes):
-        message = subprocess.check_output(
-            ["git", "log", "-1", "--pretty=%B", commit_hash], text=True
-        )
-        commit_errors = lint_commit_message(message)
-        if commit_errors:
-            errors.append(f"{commit_hash[:7]}:\n" + "\n".join(commit_errors))
-    return errors
-
-
-def main() -> int:
-    """Command-line entry point for commit message linting."""
-    parser = argparse.ArgumentParser(
-        description="Lint commit messages using MVUU schema."
-    )
-    parser.add_argument("message_file", nargs="?", help="Path to commit message file.")
-    parser.add_argument(
-        "--range",
-        dest="rev_range",
-        help="Git revision range to lint, e.g. origin/main..HEAD.",
-    )
-    args = parser.parse_args()
-
-    if args.rev_range:
-        errors = lint_range(args.rev_range)
-        if errors:
-            print("\n\n".join(errors), file=sys.stderr)
-            return 1
-        return 0
-
-    if not args.message_file:
-        parser.error("provide a commit message file or --range")
-    message = Path(args.message_file).read_text(encoding="utf-8")
-    errors = lint_commit_message(message)
-    if errors:
-        print("\n".join(errors), file=sys.stderr)
-        return 1
-    return 0
-
-
-if __name__ == "__main__":
+if __name__ == "__main__":  # pragma: no cover - thin wrapper
     raise SystemExit(main())

--- a/src/devsynth/adapters/cli/typer_adapter.py
+++ b/src/devsynth/adapters/cli/typer_adapter.py
@@ -40,6 +40,7 @@ from devsynth.application.cli.commands.inspect_config_cmd import inspect_config_
 from devsynth.application.cli.commands.run_tests_cmd import run_tests_cmd
 from devsynth.application.cli.commands.mvuu_dashboard_cmd import mvuu_dashboard_cmd
 from devsynth.application.cli.commands.mvu_init_cmd import mvu_init_cmd
+from devsynth.application.cli.commands.mvu_lint_cmd import mvu_lint_cmd
 from devsynth.application.cli.commands.security_audit_cmd import security_audit_cmd
 from devsynth.application.cli.commands.test_metrics_cmd import test_metrics_cmd
 from devsynth.application.cli.commands.validate_manifest_cmd import (
@@ -474,6 +475,13 @@ def build_app() -> typer.Typer:
     )(mvuu_dashboard_cmd)
     mvu_app = typer.Typer(help="MVU utilities")
     mvu_app.command("init", help="Scaffold MVU configuration")(mvu_init_cmd)
+    mvu_app.command(
+        "lint",
+        help=(
+            "Lint commit messages for MVUU compliance.\n\n"
+            "Examples:\n  devsynth mvu lint --range origin/main..HEAD"
+        ),
+    )(mvu_lint_cmd)
     app.add_typer(mvu_app, name="mvu")
     app.command(
         name="serve",

--- a/src/devsynth/application/cli/commands/mvu_lint_cmd.py
+++ b/src/devsynth/application/cli/commands/mvu_lint_cmd.py
@@ -1,0 +1,39 @@
+"""CLI command to lint commit messages for MVUU compliance."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Optional
+
+import typer
+
+from devsynth.core.mvu.linter import lint_commit_message, lint_range
+from devsynth.interface.cli import CLIUXBridge
+from devsynth.interface.ux_bridge import UXBridge
+
+
+def mvu_lint_cmd(
+    message_file: Optional[Path] = typer.Option(
+        None,
+        "--message-file",
+        help="Path to commit message file to lint.",
+    ),
+    rev_range: str = typer.Option(
+        "origin/main..HEAD",
+        "--range",
+        help="Git revision range to lint, e.g. origin/main..HEAD.",
+    ),
+    *,
+    bridge: Optional[UXBridge] = None,
+) -> None:
+    """Lint commit messages for MVUU compliance."""
+    ux_bridge = bridge or CLIUXBridge()
+    if message_file is not None:
+        message = message_file.read_text(encoding="utf-8")
+        errors = lint_commit_message(message)
+    else:
+        errors = lint_range(rev_range)
+    if errors:
+        ux_bridge.print("\n\n".join(errors))
+        raise typer.Exit(code=1)
+    ux_bridge.print("[green]All commit messages valid[/green]")

--- a/src/devsynth/core/mvu/__init__.py
+++ b/src/devsynth/core/mvu/__init__.py
@@ -8,6 +8,7 @@ from .validator import (
     validate_commit_message,
     validate_affected_files,
 )
+from .linter import lint_commit_message, lint_range
 from .storage import (
     format_mvuu_footer,
     read_commit_message,
@@ -32,6 +33,8 @@ __all__ = [
     "validate_data",
     "validate_commit_message",
     "validate_affected_files",
+    "lint_commit_message",
+    "lint_range",
     "format_mvuu_footer",
     "read_commit_message",
     "read_mvuu_from_commit",

--- a/src/devsynth/core/mvu/linter.py
+++ b/src/devsynth/core/mvu/linter.py
@@ -1,0 +1,108 @@
+"""Commit message linter for MVUU compliance."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import jsonschema
+import re
+import subprocess
+import sys
+from pathlib import Path
+from typing import List, Optional
+
+from .schema import MVUU_SCHEMA
+
+CONVENTIONAL_RE = re.compile(
+    r"^(build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test)(\([\w\-]+\))?: .+"
+)
+
+
+def _extract_mvuu_json(message: str) -> dict:
+    """Extract the MVUU JSON block from a commit message."""
+    pattern = re.compile(r"```json\n(.*?)\n```", re.DOTALL)
+    match = pattern.search(message)
+    if not match:
+        raise ValueError("Missing MVUU JSON block fenced with ```json … ```")
+    try:
+        return json.loads(match.group(1))
+    except json.JSONDecodeError as exc:  # pragma: no cover - defensive
+        raise ValueError(f"MVUU JSON is not valid JSON: {exc.msg}") from exc
+
+
+def lint_commit_message(message: str) -> List[str]:
+    """Validate a commit message against conventional and MVUU rules."""
+    errors: List[str] = []
+    header = message.splitlines()[0]
+    if not CONVENTIONAL_RE.match(header):
+        errors.append(
+            "Commit message header must follow Conventional Commits, e.g. 'feat: …'"
+        )
+    try:
+        mvuu = _extract_mvuu_json(message)
+
+        trace_id = str(mvuu.get("TraceID", ""))
+        if not re.fullmatch(r"DSY-\d+", trace_id):
+            errors.append("TraceID must match pattern 'DSY-<number>'")
+
+        if mvuu.get("mvuu") is not True:
+            errors.append("'mvuu' must be true")
+
+        if "issue" not in mvuu:
+            errors.append("Missing required field 'issue'")
+
+        try:
+            jsonschema.validate(mvuu, MVUU_SCHEMA)
+        except jsonschema.ValidationError as exc:  # pragma: no cover - passthrough
+            errors.append(f"MVUU JSON invalid: {exc.message}")
+    except ValueError as exc:
+        errors.append(str(exc))
+    return errors
+
+
+def lint_range(rev_range: str) -> List[str]:
+    """Lint all commit messages within a git revision range."""
+    errors: List[str] = []
+    hashes = (
+        subprocess.check_output(["git", "rev-list", rev_range], text=True)
+        .strip()
+        .splitlines()
+    )
+    for commit_hash in reversed(hashes):
+        message = subprocess.check_output(
+            ["git", "log", "-1", "--pretty=%B", commit_hash], text=True
+        )
+        commit_errors = lint_commit_message(message)
+        if commit_errors:
+            errors.append(f"{commit_hash[:7]}:\n" + "\n".join(commit_errors))
+    return errors
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    """Command-line entry point for commit message linting."""
+    parser = argparse.ArgumentParser(
+        description="Lint commit messages using MVUU schema."
+    )
+    parser.add_argument("message_file", nargs="?", help="Path to commit message file.")
+    parser.add_argument(
+        "--range",
+        dest="rev_range",
+        help="Git revision range to lint, e.g. origin/main..HEAD.",
+    )
+    args = parser.parse_args(argv)
+
+    if args.rev_range:
+        errors = lint_range(args.rev_range)
+        if errors:
+            print("\n\n".join(errors), file=sys.stderr)
+            return 1
+        return 0
+
+    if not args.message_file:
+        parser.error("provide a commit message file or --range")
+    message = Path(args.message_file).read_text(encoding="utf-8")
+    errors = lint_commit_message(message)
+    if errors:
+        print("\n".join(errors), file=sys.stderr)
+        return 1
+    return 0

--- a/tests/unit/core/mvu/test_linter.py
+++ b/tests/unit/core/mvu/test_linter.py
@@ -1,8 +1,4 @@
-import sys
-
-sys.path.append("scripts")
-
-from commit_linter import lint_commit_message  # type: ignore
+from devsynth.core.mvu.linter import lint_commit_message
 
 VALID_MESSAGE = (
     "feat: add example\n\n"

--- a/tests/unit/general/test_mvu_lint_cli.py
+++ b/tests/unit/general/test_mvu_lint_cli.py
@@ -1,0 +1,50 @@
+import click
+import typer
+import typer.main
+from typer.testing import CliRunner
+import pytest
+
+from devsynth.adapters.cli.typer_adapter import build_app
+from devsynth.interface.ux_bridge import UXBridge
+
+
+@pytest.fixture(autouse=True)
+def patch_typer_types(monkeypatch):
+    """Allow Typer to handle custom parameter types."""
+    orig = typer.main.get_click_type
+
+    def patched_get_click_type(*, annotation, parameter_info):
+        if annotation in {UXBridge, typer.models.Context}:
+            return click.STRING
+        origin = getattr(annotation, "__origin__", None)
+        if origin in {UXBridge, typer.models.Context} or annotation is dict or origin is dict:
+            return click.STRING
+        return orig(annotation=annotation, parameter_info=parameter_info)
+
+    monkeypatch.setattr(typer.main, "get_click_type", patched_get_click_type)
+
+
+def test_mvu_lint_cli_success(monkeypatch):
+    """CLI should report success when no errors are returned."""
+    runner = CliRunner()
+    app = build_app()
+    monkeypatch.setattr(
+        "devsynth.application.cli.commands.mvu_lint_cmd.lint_range",
+        lambda _rev: [],
+    )
+    result = runner.invoke(app, ["mvu", "lint"])
+    assert result.exit_code == 0
+    assert "All commit messages valid" in result.output
+
+
+def test_mvu_lint_cli_failure(monkeypatch):
+    """CLI should exit with error when linter reports problems."""
+    runner = CliRunner()
+    app = build_app()
+    monkeypatch.setattr(
+        "devsynth.application.cli.commands.mvu_lint_cmd.lint_range",
+        lambda _rev: ["abc123: error"],
+    )
+    result = runner.invoke(app, ["mvu", "lint"])
+    assert result.exit_code == 1
+    assert "abc123" in result.output


### PR DESCRIPTION
## Summary
- move commit linter logic into core and expose library functions
- add `devsynth mvu lint` command using new linter
- wrap old `scripts/commit_linter.py` to call library version

## Testing
- `poetry run pytest tests/unit/core/mvu/test_linter.py tests/unit/general/test_mvu_lint_cli.py`

------
https://chatgpt.com/codex/tasks/task_e_6892131e4dc483338c5c00e60a072d3a