### PR TITLE
feat: add MVU report generation

### DIFF
--- a/docs/requirements_traceability.md
+++ b/docs/requirements_traceability.md
@@ -98,6 +98,17 @@ ln -s ../../scripts/hooks/pre-push-traceability.sh .git/hooks/pre-push
 The hook runs the test suite and updates your local `traceability.json` when the
 tests complete successfully.
 
+### Reporting
+
+Generate a matrix from MVUU metadata stored in commit history:
+
+```bash
+devsynth mvu report --since origin/main --format markdown --output trace.md
+```
+
+Use `--format html` to produce an HTML table. Omitting `--output` prints the
+report to standard output.
+
 | Requirement ID | Description | Design/Doc Reference | Code Module(s) | Test(s) | Status |
 |---------------|-------------|----------------------|---------------|---------|--------|
 | FR-01 | System initialization with required configuration | [DevSynth Technical Specification](specifications/devsynth_specification.md) | src/devsynth/application/cli/commands/init_cmd.py | tests/behavior/features/cli_commands.feature | Implemented |

--- a/docs/user_guides/mvu_report.md
+++ b/docs/user_guides/mvu_report.md
@@ -1,0 +1,38 @@
+---
+title: "MVU Report"
+date: "2025-08-20"
+version: "0.1.0"
+tags:
+  - "mvuu"
+  - "user-guide"
+  - "traceability"
+status: "draft"
+author: "DevSynth Team"
+last_reviewed: "2025-08-20"
+---
+
+<div class="breadcrumbs">
+<a href="../index.md">Documentation</a> &gt; <a href="index.md">User Guides</a> &gt; MVU Report
+</div>
+
+# MVU Report
+
+The `mvu report` command scans git history for MVUU metadata and produces a
+traceability matrix linking TraceIDs to files, tests, and issues.
+
+## Usage
+
+```bash
+devsynth mvu report --since origin/main --format html --output report.html
+```
+
+### Options
+
+- `--since`: Git revision to start scanning from. When omitted, the entire
+  history reachable from `HEAD` is processed.
+- `--format`: Output format, either `markdown` or `html` (default: `markdown`).
+- `--output`: Destination file path. If omitted, the report is printed to
+  standard output.
+
+The generated matrix lists each TraceID alongside its utility statement,
+affected files, tests, related issue, and the originating commit hash.

--- a/src/devsynth/adapters/cli/typer_adapter.py
+++ b/src/devsynth/adapters/cli/typer_adapter.py
@@ -41,6 +41,7 @@ from devsynth.application.cli.commands.run_tests_cmd import run_tests_cmd
 from devsynth.application.cli.commands.mvuu_dashboard_cmd import mvuu_dashboard_cmd
 from devsynth.application.cli.commands.mvu_init_cmd import mvu_init_cmd
 from devsynth.application.cli.commands.mvu_lint_cmd import mvu_lint_cmd
+from devsynth.application.cli.commands.mvu_report_cmd import mvu_report_cmd
 from devsynth.application.cli.commands.security_audit_cmd import security_audit_cmd
 from devsynth.application.cli.commands.test_metrics_cmd import test_metrics_cmd
 from devsynth.application.cli.commands.validate_manifest_cmd import (
@@ -482,6 +483,10 @@ def build_app() -> typer.Typer:
             "Examples:\n  devsynth mvu lint --range origin/main..HEAD"
         ),
     )(mvu_lint_cmd)
+    mvu_app.command(
+        "report",
+        help="Generate MVU traceability reports.",
+    )(mvu_report_cmd)
     app.add_typer(mvu_app, name="mvu")
     app.command(
         name="serve",

--- a/src/devsynth/application/cli/commands/mvu_report_cmd.py
+++ b/src/devsynth/application/cli/commands/mvu_report_cmd.py
@@ -1,0 +1,43 @@
+"""CLI command to generate MVU traceability reports."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Optional, TYPE_CHECKING
+
+import typer
+
+from devsynth.core.mvu.report import generate_report
+
+if TYPE_CHECKING:  # pragma: no cover - type checking import
+    from devsynth.interface.ux_bridge import UXBridge
+else:  # pragma: no cover - fallback for optional dependency
+    UXBridge = object  # type: ignore[misc,assignment]
+
+
+def mvu_report_cmd(
+    since: Optional[str] = typer.Option(
+        None,
+        "--since",
+        help="Git revision to start scanning from (e.g. origin/main).",
+    ),
+    fmt: str = typer.Option(
+        "markdown",
+        "--format",
+        help="Output format: markdown or html.",
+    ),
+    output: Optional[Path] = typer.Option(
+        None,
+        "--output",
+        help="Destination file. Prints to stdout when omitted.",
+    ),
+    *,
+    bridge: Optional[UXBridge] = None,
+) -> None:
+    """Generate a traceability matrix from MVU metadata in git history."""
+
+    content = generate_report(since, fmt)
+    if output is not None:
+        output.write_text(content, encoding="utf-8")
+    else:
+        print(content)

--- a/src/devsynth/core/mvu/report.py
+++ b/src/devsynth/core/mvu/report.py
@@ -1,0 +1,107 @@
+"""Generate MVU traceability reports from git history."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable, List
+
+from .api import iter_mvuu_commits
+from .models import MVUU
+
+
+@dataclass
+class TraceRecord:
+    """MVU traceability record associated with a commit."""
+
+    commit: str
+    mvuu: MVUU
+
+
+def scan_history(since: str | None = None) -> List[TraceRecord]:
+    """Return MVU records starting from ``since`` until ``HEAD``.
+
+    Args:
+        since: Optional git revision to start scanning from. When ``None``, the
+            entire commit history reachable from ``HEAD`` is scanned.
+
+    Returns:
+        List of :class:`TraceRecord` objects in chronological order.
+    """
+
+    rev = "HEAD" if since is None else f"{since}..HEAD"
+    commits = list(iter_mvuu_commits(rev))
+    commits.reverse()  # oldest first for reporting
+    return [TraceRecord(commit=c, mvuu=m) for c, m in commits]
+
+
+def _markdown_table(records: Iterable[TraceRecord]) -> str:
+    """Return a Markdown table for ``records``."""
+
+    headers = [
+        "TraceID",
+        "Utility Statement",
+        "Affected Files",
+        "Tests",
+        "Issue",
+        "Commit",
+    ]
+    lines = [
+        "| " + " | ".join(headers) + " |",
+        "|" + " | ".join(["---"] * len(headers)) + "|",
+    ]
+    for rec in records:
+        mvuu = rec.mvuu
+        lines.append(
+            "| {tid} | {util} | {files} | {tests} | {issue} | {commit} |".format(
+                tid=mvuu.TraceID,
+                util=mvuu.utility_statement,
+                files=", ".join(mvuu.affected_files),
+                tests=", ".join(mvuu.tests),
+                issue=mvuu.issue,
+                commit=rec.commit[:7],
+            )
+        )
+    return "\n".join(lines) + "\n"
+
+
+def _html_table(records: Iterable[TraceRecord]) -> str:
+    """Return an HTML table for ``records``."""
+
+    lines = [
+        "<table>",
+        "  <thead>",
+        "    <tr><th>TraceID</th><th>Utility Statement</th><th>Affected Files</th><th>Tests</th><th>Issue</th><th>Commit</th></tr>",
+        "  </thead>",
+        "  <tbody>",
+    ]
+    for rec in records:
+        mvuu = rec.mvuu
+        lines.append(
+            "    <tr><td>{tid}</td><td>{util}</td><td>{files}</td><td>{tests}</td><td>{issue}</td><td>{commit}</td></tr>".format(
+                tid=mvuu.TraceID,
+                util=mvuu.utility_statement,
+                files=", ".join(mvuu.affected_files),
+                tests=", ".join(mvuu.tests),
+                issue=mvuu.issue,
+                commit=rec.commit[:7],
+            )
+        )
+    lines.extend(["  </tbody>", "</table>"])
+    return "\n".join(lines)
+
+
+def generate_report(since: str | None = None, fmt: str = "markdown") -> str:
+    """Generate a traceability report.
+
+    Args:
+        since: Optional git revision to start scanning from.
+        fmt: Output format, ``"markdown"`` or ``"html"``.
+
+    Returns:
+        Report content as a string.
+    """
+
+    records = scan_history(since)
+    if fmt.lower() == "html":
+        return _html_table(records)
+    return _markdown_table(records)

--- a/tests/integration/mvu/test_report_generation.py
+++ b/tests/integration/mvu/test_report_generation.py
@@ -1,0 +1,96 @@
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+
+import click
+import pytest
+import typer
+from typer.testing import CliRunner
+
+# Load the command module directly to avoid package side effects
+import importlib.util
+import sys
+
+MODULE_PATH = (
+    Path(__file__).resolve().parents[3]
+    / "src"
+    / "devsynth"
+    / "application"
+    / "cli"
+    / "commands"
+    / "mvu_report_cmd.py"
+)
+spec = importlib.util.spec_from_file_location("mvu_report_cmd", MODULE_PATH)
+mvu_module = importlib.util.module_from_spec(spec)
+sys.modules["mvu_report_cmd"] = mvu_module
+assert spec.loader is not None
+spec.loader.exec_module(mvu_module)
+mvu_report_cmd = mvu_module.mvu_report_cmd
+
+
+@pytest.fixture(autouse=True)
+def patch_typer_types(monkeypatch):
+    """Allow Typer to handle custom parameter types."""
+    orig = typer.main.get_click_type
+
+    def patched_get_click_type(*, annotation, parameter_info):
+        try:
+            return orig(annotation=annotation, parameter_info=parameter_info)
+        except Exception:
+            return click.STRING
+
+    monkeypatch.setattr(typer.main, "get_click_type", patched_get_click_type)
+
+
+def _write_commit(path: Path, message: str) -> None:
+    subprocess.run(["git", "add", path.name], check=True)
+    subprocess.run(["git", "commit", "-m", message], check=True)
+
+
+def _mvuu_message(trace_id: str, file_name: str) -> str:
+    data = {
+        "utility_statement": f"Add {file_name}",
+        "affected_files": [file_name],
+        "tests": ["pytest"],
+        "TraceID": trace_id,
+        "mvuu": True,
+        "issue": trace_id,
+    }
+    return "feat: add\n\n```json\n" + json.dumps(data, indent=2) + "\n```"
+
+
+def test_report_generation(tmp_path, monkeypatch):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    subprocess.run(["git", "init", "-b", "main"], cwd=repo, check=True)
+    monkeypatch.chdir(repo)
+
+    file1 = repo / "one.txt"
+    file1.write_text("1", encoding="utf-8")
+    _write_commit(file1, _mvuu_message("DSY-0001", "one.txt"))
+
+    file2 = repo / "two.txt"
+    file2.write_text("2", encoding="utf-8")
+    _write_commit(file2, _mvuu_message("DSY-0002", "two.txt"))
+
+    runner = CliRunner()
+    app = typer.Typer()
+    mvu_app = typer.Typer()
+    mvu_app.command("report")(mvu_report_cmd)
+    app.add_typer(mvu_app, name="mvu")
+
+    result = runner.invoke(app, ["mvu", "report", "--format", "markdown"])
+    assert result.exit_code == 0
+    assert "| TraceID |" in result.stdout
+    assert "DSY-0001" in result.stdout
+
+    html_file = repo / "report.html"
+    result = runner.invoke(
+        app,
+        ["mvu", "report", "--format", "html", "--output", str(html_file)],
+    )
+    assert result.exit_code == 0
+    html = html_file.read_text(encoding="utf-8")
+    assert "<table>" in html and "DSY-0002" in html


### PR DESCRIPTION
## Summary
- implement MVU traceability report generation for markdown and HTML
- expose new `mvu report` CLI command
- document MVU report usage and traceability workflow

## Testing
- `pytest tests/integration/mvu/test_report_generation.py tests/unit/core/mvu/test_linter.py`

------
https://chatgpt.com/codex/tasks/task_e_68921a8c669c8333a00bd1da522c15ae