### PR TITLE
feat: add issue adapters and MVU enrichment

### DIFF
--- a/docs/user_guides/mvu_init.md
+++ b/docs/user_guides/mvu_init.md
@@ -1,0 +1,35 @@
+---
+title: "MVU Initialization"
+date: "2025-08-20"
+version: "0.1.0"
+tags:
+  - "mvuu"
+  - "configuration"
+status: "draft"
+author: "DevSynth Team"
+last_reviewed: "2025-08-20"
+---
+
+<div class="breadcrumbs">
+<a href="../index.md">Documentation</a> &gt; <a href="index.md">User Guides</a> &gt; MVU Initialization
+</div>
+
+# MVU Initialization
+
+Use `devsynth mvu init` to create the `.devsynth/mvu.yml` configuration file. The generated file now includes optional settings for issue tracking integrations:
+
+```yaml
+schema: docs/specifications/mvuuschema.json
+storage:
+  path: docs/specifications/mvuu_database.json
+  format: json
+issues:
+  github:
+    base_url: https://api.github.com/repos/ORG/REPO
+    token: YOUR_GITHUB_TOKEN
+  jira:
+    base_url: https://jira.example.com
+    token: YOUR_JIRA_TOKEN
+```
+
+Populate the placeholders with the correct API endpoints and tokens for your project. When configured, MVU utilities can fetch ticket titles and acceptance criteria from GitHub or Jira when a commit's `TraceID` references an external ticket.

--- a/src/devsynth/adapters/issues/__init__.py
+++ b/src/devsynth/adapters/issues/__init__.py
@@ -1,0 +1,6 @@
+"""Issue tracking adapters."""
+
+from .github_adapter import GitHubIssueAdapter
+from .jira_adapter import JiraIssueAdapter
+
+__all__ = ["GitHubIssueAdapter", "JiraIssueAdapter"]

--- a/src/devsynth/adapters/issues/github_adapter.py
+++ b/src/devsynth/adapters/issues/github_adapter.py
@@ -1,0 +1,50 @@
+"""GitHub issue metadata adapter."""
+
+from __future__ import annotations
+
+from typing import Dict, Optional
+
+import requests
+
+from devsynth.logging_setup import DevSynthLogger
+
+
+class GitHubIssueAdapter:
+    """Adapter for fetching issue metadata from GitHub."""
+
+    def __init__(self, base_url: str, token: str) -> None:
+        """Initialize the adapter with authentication details.
+
+        Args:
+            base_url: Base API URL for the repository, e.g. ``https://api.github.com/repos/org/repo``.
+            token: Personal access token used for authentication.
+        """
+        self.base_url = base_url.rstrip("/")
+        self.token = token
+        self.logger = DevSynthLogger(__name__)
+
+    def fetch(self, issue_ref: str) -> Optional[Dict[str, str]]:
+        """Fetch title and acceptance criteria for the given issue.
+
+        Args:
+            issue_ref: Issue reference such as ``"#123"`` or ``"123"``.
+
+        Returns:
+            Mapping with ``title`` and ``acceptance_criteria`` if successful, otherwise ``None``.
+        """
+        issue_number = issue_ref.lstrip("#")
+        url = f"{self.base_url}/issues/{issue_number}"
+        headers = {
+            "Authorization": f"Bearer {self.token}",
+            "Accept": "application/vnd.github+json",
+        }
+        try:
+            resp = requests.get(url, headers=headers, timeout=10)
+            resp.raise_for_status()
+        except Exception as exc:  # pragma: no cover - network failure
+            self.logger.error("GitHub issue fetch failed: %s", exc)
+            return None
+        data = resp.json()
+        title = data.get("title", "")
+        body = data.get("body", "") or ""
+        return {"title": title, "acceptance_criteria": body}

--- a/src/devsynth/adapters/issues/jira_adapter.py
+++ b/src/devsynth/adapters/issues/jira_adapter.py
@@ -1,0 +1,50 @@
+"""Jira issue metadata adapter."""
+
+from __future__ import annotations
+
+from typing import Dict, Optional
+
+import requests
+
+from devsynth.logging_setup import DevSynthLogger
+
+
+class JiraIssueAdapter:
+    """Adapter for fetching issue metadata from Jira."""
+
+    def __init__(self, base_url: str, token: str) -> None:
+        """Initialize the adapter with authentication details.
+
+        Args:
+            base_url: Base URL of the Jira instance, e.g. ``https://jira.example.com``.
+            token: API token or bearer token for authentication.
+        """
+        self.base_url = base_url.rstrip("/")
+        self.token = token
+        self.logger = DevSynthLogger(__name__)
+
+    def fetch(self, issue_key: str) -> Optional[Dict[str, str]]:
+        """Fetch title and acceptance criteria for the given issue key.
+
+        Args:
+            issue_key: Jira issue key such as ``"PROJ-123"``.
+
+        Returns:
+            Mapping with ``title`` and ``acceptance_criteria`` if successful, otherwise ``None``.
+        """
+        url = f"{self.base_url}/rest/api/2/issue/{issue_key}"
+        headers = {
+            "Authorization": f"Bearer {self.token}",
+            "Accept": "application/json",
+        }
+        try:
+            resp = requests.get(url, headers=headers, timeout=10)
+            resp.raise_for_status()
+        except Exception as exc:  # pragma: no cover - network failure
+            self.logger.error("Jira issue fetch failed: %s", exc)
+            return None
+        data = resp.json()
+        fields = data.get("fields", {})
+        title = fields.get("summary", "")
+        description = fields.get("description", "") or ""
+        return {"title": title, "acceptance_criteria": description}

--- a/src/devsynth/application/cli/commands/mvu_init_cmd.py
+++ b/src/devsynth/application/cli/commands/mvu_init_cmd.py
@@ -20,6 +20,16 @@ _DEFAULT_CONFIG = {
         "path": "docs/specifications/mvuu_database.json",
         "format": "json",
     },
+    "issues": {
+        "github": {
+            "base_url": "https://api.github.com/repos/ORG/REPO",
+            "token": "YOUR_GITHUB_TOKEN",
+        },
+        "jira": {
+            "base_url": "https://jira.example.com",
+            "token": "YOUR_JIRA_TOKEN",
+        },
+    },
 }
 
 

--- a/src/devsynth/core/mvu/api.py
+++ b/src/devsynth/core/mvu/api.py
@@ -4,15 +4,55 @@ from __future__ import annotations
 
 import subprocess
 from datetime import datetime
+from functools import lru_cache
 from typing import Iterator, List, Tuple
+
+from devsynth.adapters.issues import GitHubIssueAdapter, JiraIssueAdapter
+from devsynth.core.config_loader import load_config
 
 from .models import MVUU
 from .parser import parse_commit_message
 from .storage import read_commit_message
 
 
-def iter_mvuu_commits(ref: str = "HEAD") -> Iterator[Tuple[str, MVUU]]:
-    """Yield commits containing MVUU metadata starting from ``ref``."""
+@lru_cache(maxsize=1)
+def _issue_adapters() -> dict[str, object]:
+    """Instantiate issue adapters based on configuration."""
+    cfg = load_config().mvuu or {}
+    issues_cfg = cfg.get("issues", {})
+    adapters = {}
+    gh = issues_cfg.get("github")
+    if gh and gh.get("token") and gh.get("base_url"):
+        adapters["github"] = GitHubIssueAdapter(gh["base_url"], gh["token"])
+    jr = issues_cfg.get("jira")
+    if jr and jr.get("token") and jr.get("base_url"):
+        adapters["jira"] = JiraIssueAdapter(jr["base_url"], jr["token"])
+    return adapters
+
+
+def _enrich_mvuu(mvuu: MVUU) -> None:
+    """Populate MVUU with external issue metadata when available."""
+    adapters = _issue_adapters()
+    trace = mvuu.TraceID
+    meta = None
+    if trace.startswith("#") and "github" in adapters:
+        meta = adapters["github"].fetch(trace)  # type: ignore[attr-defined]
+    elif "-" in trace and "jira" in adapters:
+        meta = adapters["jira"].fetch(trace)  # type: ignore[attr-defined]
+    if meta:
+        mvuu.issue_title = meta.get("title")
+        mvuu.acceptance_criteria = meta.get("acceptance_criteria")
+
+
+def iter_mvuu_commits(
+    ref: str = "HEAD", enrich: bool = False
+) -> Iterator[Tuple[str, MVUU]]:
+    """Yield commits containing MVUU metadata starting from ``ref``.
+
+    Args:
+        ref: Git reference to start from.
+        enrich: When ``True``, populate MVUU entries with external issue metadata.
+    """
     revs = subprocess.check_output(["git", "rev-list", ref], text=True)
     for commit in revs.strip().splitlines():
         try:
@@ -20,31 +60,56 @@ def iter_mvuu_commits(ref: str = "HEAD") -> Iterator[Tuple[str, MVUU]]:
             mvuu = parse_commit_message(message)
         except Exception:
             continue
+        if enrich:
+            _enrich_mvuu(mvuu)
         yield commit, mvuu
 
 
-def get_by_trace_id(trace_id: str, ref: str = "HEAD") -> List[Tuple[str, MVUU]]:
-    """Return commits whose MVUU TraceID matches ``trace_id``."""
+def get_by_trace_id(
+    trace_id: str, ref: str = "HEAD", *, enrich: bool = False
+) -> List[Tuple[str, MVUU]]:
+    """Return commits whose MVUU TraceID matches ``trace_id``.
+
+    Args:
+        trace_id: Trace identifier to search for.
+        ref: Git reference to start from.
+        enrich: When ``True``, populate MVUU entries with external issue metadata.
+    """
     return [
         (commit, mvuu)
-        for commit, mvuu in iter_mvuu_commits(ref)
+        for commit, mvuu in iter_mvuu_commits(ref, enrich=enrich)
         if mvuu.TraceID == trace_id
     ]
 
 
-def get_by_affected_path(path: str, ref: str = "HEAD") -> List[Tuple[str, MVUU]]:
-    """Return commits whose MVUU affected files include ``path``."""
+def get_by_affected_path(
+    path: str, ref: str = "HEAD", *, enrich: bool = False
+) -> List[Tuple[str, MVUU]]:
+    """Return commits whose MVUU affected files include ``path``.
+
+    Args:
+        path: File path to search for.
+        ref: Git reference to start from.
+        enrich: When ``True``, populate MVUU entries with external issue metadata.
+    """
     return [
         (commit, mvuu)
-        for commit, mvuu in iter_mvuu_commits(ref)
+        for commit, mvuu in iter_mvuu_commits(ref, enrich=enrich)
         if path in mvuu.affected_files
     ]
 
 
 def get_by_date_range(
-    start: datetime, end: datetime, ref: str = "HEAD"
+    start: datetime, end: datetime, ref: str = "HEAD", *, enrich: bool = False
 ) -> List[Tuple[str, MVUU]]:
-    """Return commits within a date range containing MVUU metadata."""
+    """Return commits within a date range containing MVUU metadata.
+
+    Args:
+        start: Start of date range.
+        end: End of date range.
+        ref: Git reference to search.
+        enrich: When ``True``, populate MVUU entries with external issue metadata.
+    """
     revs = subprocess.check_output(
         [
             "git",
@@ -66,5 +131,7 @@ def get_by_date_range(
             mvuu = parse_commit_message(message)
         except Exception:
             continue
+        if enrich:
+            _enrich_mvuu(mvuu)
         results.append((commit, mvuu))
     return results

--- a/tests/unit/adapters/issues/test_github_adapter.py
+++ b/tests/unit/adapters/issues/test_github_adapter.py
@@ -1,0 +1,19 @@
+"""Tests for the GitHubIssueAdapter."""
+
+import responses
+
+from devsynth.adapters.issues import GitHubIssueAdapter
+
+
+@responses.activate
+def test_fetch_github_issue() -> None:
+    """Adapter returns title and body from the GitHub API."""
+    adapter = GitHubIssueAdapter("https://api.github.com/repos/org/repo", "token")
+    responses.add(
+        responses.GET,
+        "https://api.github.com/repos/org/repo/issues/1",
+        json={"title": "Bug fix", "body": "do things"},
+        status=200,
+    )
+    data = adapter.fetch("#1")
+    assert data == {"title": "Bug fix", "acceptance_criteria": "do things"}

--- a/tests/unit/adapters/issues/test_jira_adapter.py
+++ b/tests/unit/adapters/issues/test_jira_adapter.py
@@ -1,0 +1,19 @@
+"""Tests for the JiraIssueAdapter."""
+
+import responses
+
+from devsynth.adapters.issues import JiraIssueAdapter
+
+
+@responses.activate
+def test_fetch_jira_issue() -> None:
+    """Adapter returns title and description from the Jira API."""
+    adapter = JiraIssueAdapter("https://jira.example.com", "token")
+    responses.add(
+        responses.GET,
+        "https://jira.example.com/rest/api/2/issue/PROJ-1",
+        json={"fields": {"summary": "Bug", "description": "criteria"}},
+        status=200,
+    )
+    data = adapter.fetch("PROJ-1")
+    assert data == {"title": "Bug", "acceptance_criteria": "criteria"}

--- a/tests/unit/adapters/issues/test_mvu_enrichment.py
+++ b/tests/unit/adapters/issues/test_mvu_enrichment.py
@@ -1,0 +1,64 @@
+"""Integration test for MVU enrichment using issue adapters."""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import responses
+
+from devsynth.core import mvu
+
+
+def _init_repo(path: Path) -> None:
+    subprocess.check_call(["git", "init"], cwd=path)
+    subprocess.check_call(["git", "config", "user.email", "test@example.com"], cwd=path)
+    subprocess.check_call(["git", "config", "user.name", "Test User"], cwd=path)
+
+
+@responses.activate
+def test_get_by_trace_id_enriches(tmp_path, monkeypatch) -> None:
+    """get_by_trace_id attaches issue metadata when configured."""
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _init_repo(repo)
+    cfg_dir = repo / ".devsynth"
+    cfg_dir.mkdir()
+    cfg_dir.joinpath("mvu.yml").write_text(
+        """schema: docs/specifications/mvuuschema.json
+storage:
+  path: db.json
+  format: json
+issues:
+  github:
+    base_url: https://api.github.com/repos/org/repo
+    token: token
+""",
+        encoding="utf-8",
+    )
+    mvuu_data = mvu.MVUU(
+        utility_statement="test",
+        affected_files=["file.txt"],
+        tests=["pytest"],
+        TraceID="#1",
+        mvuu=True,
+        issue="#1",
+    )
+    message = "feat: add file\n\n" + mvu.format_mvuu_footer(mvuu_data)
+    (repo / "file.txt").write_text("content", encoding="utf-8")
+    subprocess.check_call(["git", "add", "file.txt"], cwd=repo)
+    subprocess.check_call(["git", "commit", "-m", message], cwd=repo)
+
+    responses.add(
+        responses.GET,
+        "https://api.github.com/repos/org/repo/issues/1",
+        json={"title": "Issue 1", "body": "AC"},
+        status=200,
+    )
+
+    monkeypatch.chdir(repo)
+    results = mvu.get_by_trace_id("#1", enrich=True)
+    assert results
+    mvuu_loaded = results[0][1]
+    assert getattr(mvuu_loaded, "issue_title") == "Issue 1"
+    assert getattr(mvuu_loaded, "acceptance_criteria") == "AC"


### PR DESCRIPTION
## Summary
- add GitHub and Jira issue adapters to retrieve ticket metadata
- enrich MVU API with external issue data when available
- document new API token configuration for MVU utilities
- remove stray project-specific `.devsynth` config from version control

## Testing
- `SKIP=devsynth-align,check-frontmatter,fix-code-blocks poetry run pre-commit run --files .gitignore`
- `poetry run pytest tests/unit/adapters/issues tests/unit/general/test_mvu_init_cmd.py tests/unit/core/test_config_loader_mvu.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68921a9fa00c8333a932bfc7c533b520