### PR TITLE
Refactor MVUU scripts to use core utilities

### DIFF
--- a/tests/unit/scripts/test_verify_mvuu_references.py
+++ b/tests/unit/scripts/test_verify_mvuu_references.py
@@ -53,7 +53,7 @@ def test_verify_mvuu_affected_files_valid():
 def test_verify_mvuu_affected_files_missing():
     """Missing affected file should produce an error."""
     errors = verify_mvuu_affected_files(VALID_MESSAGE, ["other.txt"])
-    assert any("missing entries" in e for e in errors)
+    assert any("missing files" in e for e in errors)
 
 
 def test_verify_mvuu_affected_files_missing_issue():


### PR DESCRIPTION
## Summary
- Delegate MVUU parsing in `update_traceability.py` to `devsynth.core.mvu`
- Use core MVUU validation helpers in `verify_mvuu_references.py`
- Update script unit tests for new error messages and imports

## Testing
- `pytest tests/unit/scripts -q`


------
https://chatgpt.com/codex/tasks/task_e_689230e6c1a88333b5e4ea286262f01a