### PR TITLE
docs: document MVUU engine usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ tags:
   - "readme"
 status: "published"
 author: "DevSynth Team"
-last_reviewed: "2025-08-02"
+last_reviewed: "2025-08-05"
 ---
 
 > Special note: LLMs have synthesized this project, with minimal manual editing, using a dialectical HITL methodology.
@@ -276,6 +276,27 @@ Use `devsynth align` and `devsynth validate-manifest` for alignment checks and
 manifest validation. These CLI commands replace the legacy helper scripts and
 will fully supersede them in a future release.
 
+## Minimum Viable Utility Units (MVUU) Engine
+
+The MVUU engine records the smallest useful change so you can trace
+requirements and tests across commits. Initialize it for a project with:
+
+```bash
+devsynth mvu init
+```
+
+This command scaffolds `.devsynth/mvu.yml` and enables MVUU tracking. After
+initialization you can lint commits, generate reports, or rewrite history:
+
+```bash
+devsynth mvu lint --range origin/main..HEAD
+devsynth mvu report --since origin/main --format html --output report.html
+devsynth mvu rewrite --path . --branch-name atomic
+```
+
+DevSynth itself continues using an ad‑hoc workflow until v0.4, so MVUU is
+optional for now.
+
 ## Documentation Structure
 
 The documentation is organized for clarity and ease of navigation, following a comprehensive structure. Key directories:
@@ -329,4 +350,4 @@ DevSynth is released under the MIT License. See [LICENSE](LICENSE) for details.
 
 ---
 
-_Last updated: August 2, 2025_
+_Last updated: August 5, 2025_


### PR DESCRIPTION
## Summary
- note MVUU engine and how to enable it in README
- include sample `mvu` commands and mention ad-hoc workflow until v0.4

## Testing
- `poetry run pre-commit run --files README.md` *(failed: devsynth-align RuntimeError: Type not yet supported: typing.Dict[str, bool])* 
- `poetry run pytest tests/unit/general/test_mvu_init_cmd.py::test_mvu_init_cmd_creates_file -q` *(failed: coverage 0.00% < 25%)*

------
https://chatgpt.com/codex/tasks/task_e_68927156c3088333a5ead3854ed7414a