### PR TITLE
chore: document failing tests

### DIFF
--- a/issues/115.md
+++ b/issues/115.md
@@ -1,0 +1,5 @@
+# Issue 115: run-tests CLI fails due to unsupported Dict[str, bool] parameter
+
+Running `devsynth run-tests` or the deprecated `scripts/run_all_tests.py` crashes before executing tests. The Typer CLI raises `RuntimeError: Type not yet supported: typing.Dict[str, bool]` while building commands.
+
+This prevents running any tests via the provided scripts. Update CLI parameter annotations (e.g., features) or adjust dependencies so Typer can handle `Dict[str, bool]` parameters.

--- a/issues/116.md
+++ b/issues/116.md
@@ -1,0 +1,21 @@
+# Issue 116: Multiple test failures and suite termination
+
+Running the full pytest suite (`pytest tests/unit tests/integration tests/behavior tests/performance tests/property`) shows numerous early failures and the process terminates with `Killed` before completion, suggesting resource exhaustion.
+
+Observed failing modules include:
+- `tests/unit/adapters/memory/test_memory_adapter.py`
+- `tests/unit/adapters/memory/test_memory_adapter_factory.py`
+- `tests/unit/adapters/providers/test_provider_factory.py`
+- `tests/unit/adapters/test_chromadb_vector_adapter.py`
+- `tests/unit/adapters/test_provider_system.py`
+- `tests/unit/agents/test_alignment_metrics_tool.py`
+- `tests/unit/application/cli/test_config_validation.py`
+- `tests/unit/application/cli/test_doctor_cmd.py`
+- `tests/unit/application/cli/test_init_cmd.py`
+- `tests/unit/application/cli/test_metrics_commands.py`
+- `tests/unit/application/cli/test_serve_cmd.py`
+- `tests/unit/application/cli/test_setup_wizard.py`
+- `tests/unit/application/code_analysis/test_repo_analyzer.py`
+- `tests/unit/application/code_analysis/test_transformer.py`
+
+Investigate these failing tests and determine why the suite is being killed mid-run.


### PR DESCRIPTION
## Summary
- note run-tests CLI failure caused by unsupported Dict[str, bool]
- list failing test modules and suite termination

## Testing
- `poetry run python scripts/run_all_tests.py` *(fails: Type not yet supported: typing.Dict[str, bool])* 
- `poetry run pytest tests/unit tests/integration tests/behavior tests/performance tests/property` *(killed mid-run)*
- `poetry run pre-commit run --files issues/115.md issues/116.md`


------
https://chatgpt.com/codex/tasks/task_e_6892897617e083339d8426a7b49cfbac