### PR TITLE
Fix wizard start state and expose kuzu adapter

### DIFF
--- a/src/devsynth/application/memory/adapters/__init__.py
+++ b/src/devsynth/application/memory/adapters/__init__.py
@@ -3,12 +3,25 @@ Memory Adapters Package
 
 This package provides adapters for different memory storage backends.
 """
+from devsynth.logging_setup import DevSynthLogger
+
 from .graph_memory_adapter import GraphMemoryAdapter
 from .vector_memory_adapter import VectorMemoryAdapter
 from .tinydb_memory_adapter import TinyDBMemoryAdapter
+
+logger = DevSynthLogger(__name__)
+
+try:  # pragma: no cover - optional dependency
+    from devsynth.adapters.memory.kuzu_adapter import KuzuAdapter
+except Exception as exc:  # pragma: no cover - missing optional dependency
+    KuzuAdapter = None
+    logger.warning("KuzuAdapter not available: %s", exc)
 
 __all__ = [
     'GraphMemoryAdapter',
     'VectorMemoryAdapter',
     'TinyDBMemoryAdapter',
 ]
+
+if KuzuAdapter is not None:
+    __all__.append('KuzuAdapter')

--- a/src/devsynth/interface/webui.py
+++ b/src/devsynth/interface/webui.py
@@ -1200,6 +1200,10 @@ class WebUI(UXBridge):
                 return
 
             if start_button_clicked:
+                # Reset any previous wizard state to ensure a clean start
+                wizard_manager.reset_wizard_state()
+                # Clear temporary widget values that may have lingered
+                wizard_manager.clear_temporary_state(temp_keys)
                 wizard_manager.set_value("wizard_started", True)
 
             st.header("Resource Gathering Wizard")


### PR DESCRIPTION
## Summary
- reset gather wizard state when starting to avoid stale navigation
- expose `KuzuAdapter` via memory adapters package with optional import
- add regression tests for gather wizard reset and kuzu memory fallback

## Testing
- `poetry run pytest tests/integration/interface/test_webui_cli_lookup.py` *(fails: Required test coverage of 25% not reached. Total coverage: 0.00%)*
- `poetry run pytest tests/integration/memory/test_kuzu_memory_integration.py` *(fails: file or directory not found)*
- `poetry run pytest tests/unit/interface/test_webui_gather_wizard_with_state_fixed.py::test_gather_wizard_start_resets_state` *(fails: Required test coverage of 25% not reached. Total coverage: 0.00%)*
- `poetry run pytest tests/integration/general/test_kuzu_memory_fallback.py` *(fails: TypeError: Can't instantiate abstract class KuzuMemoryStore without an implementation for abstract methods 'begin_transaction', 'commit_transaction', 'is_transaction_active', 'rollback_transaction')*

------
https://chatgpt.com/codex/tasks/task_e_68929741170083339e934e2473b1c237