### PR TITLE
Fix requirements wizard state persistence

### DIFF
--- a/tests/unit/interface/test_webui_requirements.py
+++ b/tests/unit/interface/test_webui_requirements.py
@@ -1,121 +1,109 @@
+import importlib
 import sys
 from types import ModuleType
-from unittest.mock import MagicMock, patch, call, mock_open
+from unittest.mock import MagicMock, mock_open, patch
+
 import pytest
+
 from tests.unit.interface.test_webui_enhanced import _mock_streamlit
+
 
 @pytest.fixture
 def mock_streamlit(monkeypatch):
-    """Fixture to mock streamlit for testing."""
+    """Provide a mocked streamlit module for tests."""
     st = _mock_streamlit()
-
-    class SS(dict):
-        pass
-    st.session_state = SS()
-    st.session_state.wizard_step = 0
-    state.set('wizard_step', 0)
-    0
-    st.session_state.wizard_data = {'title': '', 'description': '', 'type': 'functional', 'priority': 'medium', 'constraints': ''}
-    st.session_state['wizard_data'] = st.session_state.wizard_data
-    st.button = MagicMock(return_value=False)
-    st.text_area = MagicMock(return_value='desc')
-    col1_mock = MagicMock(button=MagicMock(return_value=False))
-    col2_mock = MagicMock(button=MagicMock(return_value=False))
-    st.columns = MagicMock(return_value=(col1_mock, col2_mock))
-    st._col1 = col1_mock
-    st._col2 = col2_mock
-    st.form = MagicMock()
-    st.form.return_value.__enter__ = MagicMock(return_value=MagicMock())
-    st.form.return_value.__exit__ = MagicMock(return_value=None)
+    # Ensure deterministic inputs for the requirements page
+    st.text_input = MagicMock(return_value="requirements.md")
+    st.text_area = MagicMock(return_value="desc")
     st.form_submit_button = MagicMock(return_value=False)
-    st.expander = MagicMock()
-    st.expander.return_value.__enter__ = MagicMock(return_value=MagicMock())
-    st.expander.return_value.__exit__ = MagicMock(return_value=None)
-    st.spinner = MagicMock()
+    st.button = MagicMock(return_value=False)
 
-def mock_function(*args, **kwargs):
+    def _columns(n: int):
+        return tuple(MagicMock(button=MagicMock(return_value=False)) for _ in range(n))
+
+    st.columns = MagicMock(side_effect=_columns)
+    monkeypatch.setitem(sys.modules, "streamlit", st)
     return st
-    monkeypatch.setattr(target, mock_function)
-    monkeypatch.setitem(sys.modules, 'streamlit', st)
-    return st
+
 
 @pytest.fixture
 def mock_spec_cmd(monkeypatch):
-    """Fixture to mock spec_cmd for testing."""
+    """Stub out CLI commands used by the requirements page."""
     spec_cmd = MagicMock()
     inspect_cmd = MagicMock()
-    cli_module = ModuleType('devsynth.application.cli')
+    cli_module = ModuleType("devsynth.application.cli")
     cli_module.spec_cmd = spec_cmd
     cli_module.inspect_cmd = inspect_cmd
-    monkeypatch.setitem(sys.modules, 'devsynth.application.cli', cli_module)
+    monkeypatch.setitem(sys.modules, "devsynth.application.cli", cli_module)
     return spec_cmd
 
-@pytest.fixture
-def mock_requirement_types(monkeypatch):
-    """Fixture to mock RequirementType and RequirementPriority enums."""
-    req_module = ModuleType('devsynth.domain.models.requirement')
-
-    class _Enum:
-
-        def __init__(self, value):
-            self.value = value
-
-    class MockRequirementType:
-        FUNCTIONAL = _Enum('functional')
-        NON_FUNCTIONAL = _Enum('non_functional')
-        CONSTRAINT = _Enum('constraint')
-
-    class MockRequirementPriority:
-        MUST_HAVE = _Enum('must_have')
-        SHOULD_HAVE = _Enum('should_have')
-        COULD_HAVE = _Enum('could_have')
-        WONT_HAVE = _Enum('wont_have')
-        MEDIUM = _Enum('medium')
-    req_module.RequirementType = MockRequirementType
-    req_module.RequirementPriority = MockRequirementPriority
-    monkeypatch.setitem(sys.modules, 'devsynth.domain.models.requirement', req_module)
 
 @pytest.mark.medium
-def test_requirements_page_succeeds(mock_streamlit, mock_spec_cmd, mock_requirement_types):
-    """Test the requirements_page method.
+def test_requirements_page_succeeds(mock_streamlit, mock_spec_cmd):
+    """requirements_page renders and invokes spec_cmd on submission."""
 
-    ReqID: N/A"""
-    import importlib
     import devsynth.interface.webui as webui
+
     importlib.reload(webui)
     from devsynth.interface.webui import WebUI
-    bridge = WebUI()
-    bridge.requirements_page()
-    mock_streamlit.header.assert_called_with('Requirements Gathering')
-    assert mock_streamlit.form.called
+
+    ui = WebUI()
+    with (
+        patch.object(WebUI, "_requirements_wizard"),
+        patch.object(WebUI, "_gather_wizard"),
+        patch("pathlib.Path.exists", return_value=True),
+    ):
+        ui.requirements_page()
+
+    mock_streamlit.header.assert_any_call("Requirements Gathering")
+
     mock_streamlit.form_submit_button.return_value = True
-    bridge.requirements_page()
+    with (
+        patch.object(WebUI, "_requirements_wizard"),
+        patch.object(WebUI, "_gather_wizard"),
+        patch("pathlib.Path.exists", return_value=True),
+    ):
+        ui.requirements_page()
+
     assert mock_spec_cmd.called
 
-@pytest.mark.medium
-def test_requirements_wizard_succeeds(mock_streamlit, mock_requirement_types):
-    """Test the _requirements_wizard method.
 
-    ReqID: N/A"""
-    import importlib
+@pytest.mark.medium
+def test_requirements_wizard_succeeds(mock_streamlit):
+    """The requirements wizard advances steps and saves state."""
+
     import devsynth.interface.webui as webui
+
     importlib.reload(webui)
     from devsynth.interface.webui import WebUI
-    bridge = WebUI()
-    bridge._requirements_wizard()
-    assert 'wizard_step' in mock_streamlit.session_state
-    assert 'wizard_data' in mock_streamlit.session_state
-    mock_streamlit.session_state['wizard_step'] = 0
-    mock_streamlit.session_state.wizard_step = 0
-    mock_streamlit._col2.button.return_value = True
-    bridge._requirements_wizard()
-    assert mock_streamlit.session_state.wizard_step == 1
-    mock_streamlit._col2.button.return_value = False
-    mock_streamlit.session_state['wizard_step'] = 4
-    mock_streamlit.session_state.wizard_step = 4
-    mock_streamlit.button.return_value = True
+
+    st = mock_streamlit
+    st.text_input.return_value = "Title"
+    st.text_area.return_value = "Description"
+    st.selectbox.side_effect = ["functional", "medium"]
+
+    ui = WebUI()
+
+    # Advance to step 2
+    col1 = MagicMock(button=MagicMock(return_value=False))
+    col2 = MagicMock(button=MagicMock(return_value=True))
+    col3 = MagicMock(button=MagicMock(return_value=False))
+    st.columns.side_effect = None
+    st.columns.return_value = (col1, col2, col3)
+    ui._requirements_wizard()
+    assert st.session_state["requirements_wizard_current_step"] == 2
+
+    # Jump to final step and save
+    st.columns.return_value = (
+        MagicMock(button=MagicMock(return_value=False)),
+        MagicMock(button=MagicMock(return_value=True)),
+        MagicMock(button=MagicMock(return_value=False)),
+    )
+    st.session_state["requirements_wizard_current_step"] = 5
+    st.text_area.return_value = "c1,c2"
     m = mock_open()
-    with patch('builtins.open', m):
-        result = bridge._requirements_wizard()
-    assert result is not None
+    with patch("builtins.open", m):
+        result = ui._requirements_wizard()
+
     assert isinstance(result, dict)
+    assert st.session_state["requirements_wizard_current_step"] == 1

--- a/tests/unit/interface/test_webui_requirements_wizard.py
+++ b/tests/unit/interface/test_webui_requirements_wizard.py
@@ -41,7 +41,7 @@ def clean_state():
 @pytest.mark.medium
 def test_requirements_wizard_initialization(stub_streamlit, clean_state):
     import importlib
-    from devsynth.interface import webui
+    import devsynth.interface.webui as webui
 
     importlib.reload(webui)
     from devsynth.interface.webui import WebUI
@@ -116,12 +116,13 @@ def test_handle_requirements_navigation_next(stub_streamlit):
     manager = MagicMock()
     state = MagicMock()
     state.get_total_steps.return_value = 5
+    state.get_current_step.return_value = 1
     stub_streamlit.columns.return_value = (
         MagicMock(button=MagicMock(return_value=False)),
         MagicMock(button=MagicMock(return_value=True)),
         MagicMock(button=MagicMock(return_value=False)),
     )
-    ui._handle_requirements_navigation(manager, state, 1)
+    ui._handle_requirements_navigation(manager, state)
     manager.next_step.assert_called_once()
 
 


### PR DESCRIPTION
## Summary
- ensure requirements wizard navigation pulls current step from stored state
- add tests and fixtures for multi-step requirements flows
- update tests for new navigation signature

## Testing
- `poetry run ruff check src/devsynth/interface/webui.py tests/unit/interface/test_webui_requirements.py tests/unit/interface/test_webui_requirements_wizard.py`
- `poetry run pytest tests/unit/interface/test_webui_requirements* -q` *(fails: Coverage failure: total of 0 is less than fail-under=25)*

------
https://chatgpt.com/codex/tasks/task_e_6892b9e04d388333aebf5ce69341c14c