### PR TITLE
feat: sync GitHub project board

### DIFF
--- a/src/devsynth/adapters/github_project.py
+++ b/src/devsynth/adapters/github_project.py
@@ -2,6 +2,8 @@
 
 from typing import Any, Dict
 
+import requests
+
 from devsynth.logging_setup import DevSynthLogger
 
 
@@ -20,6 +22,21 @@ class GitHubProjectAdapter:
         self.organization = organization
         self.project_number = project_number
         self.logger = DevSynthLogger(__name__)
+        self._endpoint = "https://api.github.com/graphql"
+        self._headers = {"Authorization": f"bearer {token}"}
+
+    def _graphql(self, query: str, variables: Dict[str, Any]) -> Dict[str, Any]:
+        """Execute a GraphQL query against the GitHub API."""
+        response = requests.post(
+            self._endpoint,
+            json={"query": query, "variables": variables},
+            headers=self._headers,
+        )
+        response.raise_for_status()
+        payload = response.json()
+        if "errors" in payload:
+            raise RuntimeError(f"GitHub GraphQL error: {payload['errors']}")
+        return payload["data"]
 
     def sync_board(self, board_state: Dict[str, Any]) -> None:
         """Synchronize the local board state with GitHub Projects.
@@ -27,4 +44,60 @@ class GitHubProjectAdapter:
         Args:
             board_state: Dictionary describing columns and cards to sync.
         """
-        raise NotImplementedError("Board synchronization not yet implemented.")
+
+        project_query = """
+        query($org: String!, $number: Int!) {
+            organization(login: $org) {
+                project(number: $number) {
+                    id
+                    columns(first: 100) {
+                        nodes {
+                            id
+                            name
+                            cards(first: 100) { nodes { id note } }
+                        }
+                    }
+                }
+            }
+        }
+        """
+        data = self._graphql(
+            project_query, {"org": self.organization, "number": self.project_number}
+        )
+        project = data["organization"]["project"]
+        existing_columns = {c["name"]: c for c in project["columns"]["nodes"]}
+
+        for column in board_state.get("columns", []):
+            name = column["name"]
+            if name in existing_columns:
+                column_id = existing_columns[name]["id"]
+                existing_cards = {
+                    card["note"]: card
+                    for card in existing_columns[name]["cards"]["nodes"]
+                }
+            else:
+                add_column = """
+                mutation($projectId: ID!, $name: String!) {
+                    addProjectColumn(input: {projectId: $projectId, name: $name}) {
+                        column { id }
+                    }
+                }
+                """
+                result = self._graphql(
+                    add_column, {"projectId": project["id"], "name": name}
+                )
+                column_id = result["addProjectColumn"]["column"]["id"]
+                existing_cards = {}
+
+            for card in column.get("cards", []):
+                note = card["note"]
+                if note in existing_cards:
+                    continue
+                add_card = """
+                mutation($columnId: ID!, $note: String!) {
+                    addProjectCard(input: {columnId: $columnId, note: $note}) {
+                        cardEdge { node { id } }
+                    }
+                }
+                """
+                self._graphql(add_card, {"columnId": column_id, "note": note})

--- a/tests/unit/adapters/test_github_project_adapter.py
+++ b/tests/unit/adapters/test_github_project_adapter.py
@@ -1,0 +1,82 @@
+"""Tests for the GitHubProjectAdapter."""
+
+import json
+
+import responses
+
+from devsynth.adapters.github_project import GitHubProjectAdapter
+
+
+@responses.activate
+def test_sync_board_creates_columns_and_cards() -> None:
+    """Missing columns and cards are created via GraphQL mutations."""
+    adapter = GitHubProjectAdapter("token", "org", 1)
+
+    responses.add(
+        responses.POST,
+        "https://api.github.com/graphql",
+        json={
+            "data": {
+                "organization": {"project": {"id": "proj1", "columns": {"nodes": []}}}
+            }
+        },
+        status=200,
+    )
+    responses.add(
+        responses.POST,
+        "https://api.github.com/graphql",
+        json={"data": {"addProjectColumn": {"column": {"id": "col1"}}}},
+        status=200,
+    )
+    responses.add(
+        responses.POST,
+        "https://api.github.com/graphql",
+        json={"data": {"addProjectCard": {"cardEdge": {"node": {"id": "card1"}}}}},
+        status=200,
+    )
+
+    board = {"columns": [{"name": "Todo", "cards": [{"note": "Task"}]}]}
+    adapter.sync_board(board)
+
+    assert len(responses.calls) == 3
+    body_query = json.loads(responses.calls[1].request.body)
+    assert "addProjectColumn" in body_query["query"]
+    body_card = json.loads(responses.calls[2].request.body)
+    assert "addProjectCard" in body_card["query"]
+
+
+@responses.activate
+def test_sync_board_skips_existing_items() -> None:
+    """No mutations are issued when columns and cards already exist."""
+    adapter = GitHubProjectAdapter("token", "org", 1)
+
+    responses.add(
+        responses.POST,
+        "https://api.github.com/graphql",
+        json={
+            "data": {
+                "organization": {
+                    "project": {
+                        "id": "proj1",
+                        "columns": {
+                            "nodes": [
+                                {
+                                    "id": "col1",
+                                    "name": "Todo",
+                                    "cards": {
+                                        "nodes": [{"id": "card1", "note": "Task"}]
+                                    },
+                                }
+                            ]
+                        },
+                    }
+                }
+            }
+        },
+        status=200,
+    )
+
+    board = {"columns": [{"name": "Todo", "cards": [{"note": "Task"}]}]}
+    adapter.sync_board(board)
+
+    assert len(responses.calls) == 1


### PR DESCRIPTION
## Summary
- sync project columns and cards to GitHub Project boards via GraphQL
- add tests for GitHubProjectAdapter

## Testing
- `SKIP=devsynth-align,fix-code-blocks poetry run pre-commit run --files src/devsynth/adapters/github_project.py tests/unit/adapters/test_github_project_adapter.py`
- `poetry run pytest tests/unit/adapters/test_github_project_adapter.py --cov-fail-under=0`


------
https://chatgpt.com/codex/tasks/task_e_6892e191eaa88333a47a23e6af20697d