### PR TITLE
Improve Codex setup offline checks

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,19 +35,34 @@ Fix the script and rerun it offline to finish provisioning:
    `--minimal` variant) and verifies key packages such as `pytest-bdd` are
    available.
 2. Run `bash scripts/codex_setup.sh` (without network access) until it completes
-   without errors. After it finishes, verify the environment and dependencies:
+   without errors. After it finishes, verify the environment, dependencies,
+   and extras:
 
-   ```bash
-   poetry env info --path
-   poetry run pip check
-   # Ensure extras required for tests are installed
-   poetry run python - <<'EOF'
+ ```bash
+  poetry env info --path
+  poetry run pip check
+  # Ensure extras required for tests are installed. These imports
+  # confirm retrieval, chromadb, GUI, and API extras are available offline.
+  poetry run python - <<'EOF'
 import importlib, sys
-for pkg in ("fastapi", "streamlit", "lmstudio", "tinydb", "duckdb", "lmdb", "chromadb"):
+for pkg in (
+    "fastapi",
+    "streamlit",
+    "lmstudio",
+    "tinydb",
+    "duckdb",
+    "lmdb",
+    "chromadb",
+    "kuzu",
+    "faiss",
+    "prometheus_client",
+    "httpx",
+    "dearpygui",
+):
     importlib.import_module(pkg)
 EOF
-   poetry run pip list | grep pytest-bdd
-   ```
+  poetry run pip list | grep pytest-bdd
+  ```
 3. Remove the failure marker with `rm CODEX_ENVIRONMENT_SETUP_FAILED`.
 4. Execute `poetry run pytest --maxfail=1` to verify the environment quickly.
 5. If the tests fail, rerun the setup script and repeat until


### PR DESCRIPTION
## Summary
- allow `scripts/codex_setup.sh` to skip pipx/CLI installs when rerun without network
- verify retrieval, chromadb, and other extras by importing their modules
- document offline verification steps in `AGENTS.md`

## Testing
- `poetry run pre-commit run --files AGENTS.md scripts/codex_setup.sh`
- `poetry run pytest tests/behavior/steps/test_alignment_metrics_steps.py --maxfail=1` *(fails: Required test coverage of 25% not reached)*

------
https://chatgpt.com/codex/tasks/task_e_6892e187491c8333bfa4de5397883b2c