### PR TITLE
chore: categorize interface tests

### DIFF
--- a/tests/unit/interface/test_agentapi_class.py
+++ b/tests/unit/interface/test_agentapi_class.py
@@ -8,59 +8,61 @@ from devsynth.interface import agentapi
 
 def _setup(monkeypatch):
     """Set up the test environment with mocked CLI modules."""
-    cli_stub = ModuleType('devsynth.application.cli')
+    cli_stub = ModuleType("devsynth.application.cli")
 
-    def init_cmd(path='.', project_root=None, language=None, goals=None, *,
-        bridge):
-        bridge.display_result('init')
+    def init_cmd(path=".", project_root=None, language=None, goals=None, *, bridge):
+        bridge.display_result("init")
 
-    def gather_cmd(output_file='requirements_plan.yaml', *, bridge):
-        g = bridge.ask_question('g')
-        c = bridge.ask_question('c')
-        p = bridge.ask_question('p')
-        bridge.display_result(f'{g},{c},{p}')
+    def gather_cmd(output_file="requirements_plan.yaml", *, bridge):
+        g = bridge.ask_question("g")
+        c = bridge.ask_question("c")
+        p = bridge.ask_question("p")
+        bridge.display_result(f"{g},{c},{p}")
 
     def run_pipeline_cmd(target=None, *, bridge):
-        bridge.display_result(f'run:{target}')
+        bridge.display_result(f"run:{target}")
 
-    def spec_cmd(requirements_file='requirements.md', *, bridge):
-        bridge.display_result(f'spec:{requirements_file}')
-        
-    def test_cmd_succeeds(spec_file='specs.md', output_dir=None, *, bridge):
-        bridge.display_result(f'test:{spec_file}:{output_dir}')
+    def spec_cmd(requirements_file="requirements.md", *, bridge):
+        bridge.display_result(f"spec:{requirements_file}")
+
+    def test_cmd_succeeds(spec_file="specs.md", output_dir=None, *, bridge):
+        bridge.display_result(f"test:{spec_file}:{output_dir}")
 
     def code_cmd(output_dir=None, *, bridge):
-        bridge.display_result(f'code:{output_dir}')
+        bridge.display_result(f"code:{output_dir}")
 
-    def doctor_cmd(path='.', fix=False, *, bridge):
-        bridge.display_result(f'doctor:{path}:{fix}')
+    def doctor_cmd(path=".", fix=False, *, bridge):
+        bridge.display_result(f"doctor:{path}:{fix}")
 
     def edrr_cycle_cmd(prompt, context=None, max_iterations=3, *, bridge):
-        bridge.display_result(f'edrr:{prompt}:{context}:{max_iterations}')
-        
+        bridge.display_result(f"edrr:{prompt}:{context}:{max_iterations}")
+
     cli_stub.init_cmd = MagicMock(side_effect=init_cmd)
     cli_stub.gather_cmd = MagicMock(side_effect=gather_cmd)
     cli_stub.run_pipeline_cmd = MagicMock(side_effect=run_pipeline_cmd)
     cli_stub.spec_cmd = MagicMock(side_effect=spec_cmd)
     cli_stub.test_cmd = MagicMock(side_effect=test_cmd_succeeds)
     cli_stub.code_cmd = MagicMock(side_effect=code_cmd)
-    monkeypatch.setitem(sys.modules, 'devsynth.application.cli', cli_stub)
-    
-    doctor_module = ModuleType('devsynth.application.cli.commands.doctor_cmd')
+    monkeypatch.setitem(sys.modules, "devsynth.application.cli", cli_stub)
+
+    doctor_module = ModuleType("devsynth.application.cli.commands.doctor_cmd")
     doctor_module.doctor_cmd = MagicMock(side_effect=doctor_cmd)
-    monkeypatch.setitem(sys.modules,
-        'devsynth.application.cli.commands.doctor_cmd', doctor_module)
-    
-    edrr_module = ModuleType('devsynth.application.cli.commands.edrr_cycle_cmd')
+    monkeypatch.setitem(
+        sys.modules, "devsynth.application.cli.commands.doctor_cmd", doctor_module
+    )
+
+    edrr_module = ModuleType("devsynth.application.cli.commands.edrr_cycle_cmd")
     edrr_module.edrr_cycle_cmd = MagicMock(side_effect=edrr_cycle_cmd)
-    monkeypatch.setitem(sys.modules,
-        'devsynth.application.cli.commands.edrr_cycle_cmd', edrr_module)
-    
+    monkeypatch.setitem(
+        sys.modules, "devsynth.application.cli.commands.edrr_cycle_cmd", edrr_module
+    )
+
     from devsynth.interface import webui
+
     # Reload the modules to ensure clean state
     importlib.reload(webui)
     importlib.reload(agentapi)
-    
+
     return cli_stub, agentapi
 
 
@@ -72,7 +74,7 @@ def clean_state():
     # Clean up state
 
 
-@pytest.mark.medium
+@pytest.mark.slow
 def test_init_succeeds(monkeypatch, clean_state):
     """Test that init succeeds.
 
@@ -80,14 +82,15 @@ def test_init_succeeds(monkeypatch, clean_state):
     cli_stub, agentapi = _setup(monkeypatch)
     bridge = agentapi.APIBridge()
     api = agentapi.AgentAPI(bridge)
-    messages = api.init(path='p', project_root='r', language='py', goals='g')
-    assert messages == ['init']
-    assert agentapi.LATEST_MESSAGES == ['init']
-    cli_stub.init_cmd.assert_called_once_with(path='p', project_root='r',
-        language='py', goals='g', bridge=bridge)
+    messages = api.init(path="p", project_root="r", language="py", goals="g")
+    assert messages == ["init"]
+    assert agentapi.LATEST_MESSAGES == ["init"]
+    cli_stub.init_cmd.assert_called_once_with(
+        path="p", project_root="r", language="py", goals="g", bridge=bridge
+    )
 
 
-@pytest.mark.medium
+@pytest.mark.slow
 def test_gather_synthesize_status_succeeds(monkeypatch, clean_state):
     """Test that gather synthesize status.
 
@@ -95,18 +98,18 @@ def test_gather_synthesize_status_succeeds(monkeypatch, clean_state):
     cli_stub, agentapi = _setup(monkeypatch)
     bridge = agentapi.APIBridge()
     api = agentapi.AgentAPI(bridge)
-    messages = api.gather(goals='g1', constraints='c1', priority='high')
-    assert messages == ['g1,c1,high']
-    assert agentapi.LATEST_MESSAGES == ['g1,c1,high']
+    messages = api.gather(goals="g1", constraints="c1", priority="high")
+    assert messages == ["g1,c1,high"]
+    assert agentapi.LATEST_MESSAGES == ["g1,c1,high"]
     cli_stub.gather_cmd.assert_called_once_with(bridge=bridge)
-    synth = api.synthesize(target='unit')
-    assert synth == ['run:unit']
-    assert agentapi.LATEST_MESSAGES == ['run:unit']
-    cli_stub.run_pipeline_cmd.assert_called_once_with(target='unit', bridge=bridge)
-    assert api.status() == ['run:unit']
+    synth = api.synthesize(target="unit")
+    assert synth == ["run:unit"]
+    assert agentapi.LATEST_MESSAGES == ["run:unit"]
+    cli_stub.run_pipeline_cmd.assert_called_once_with(target="unit", bridge=bridge)
+    assert api.status() == ["run:unit"]
 
 
-@pytest.mark.medium
+@pytest.mark.slow
 def test_spec_succeeds(monkeypatch, clean_state):
     """Test that spec succeeds.
 
@@ -114,14 +117,15 @@ def test_spec_succeeds(monkeypatch, clean_state):
     cli_stub, agentapi = _setup(monkeypatch)
     bridge = agentapi.APIBridge()
     api = agentapi.AgentAPI(bridge)
-    messages = api.spec(requirements_file='custom_reqs.md')
-    assert messages == ['spec:custom_reqs.md']
-    assert agentapi.LATEST_MESSAGES == ['spec:custom_reqs.md']
-    cli_stub.spec_cmd.assert_called_once_with(requirements_file='custom_reqs.md', 
-        bridge=bridge)
+    messages = api.spec(requirements_file="custom_reqs.md")
+    assert messages == ["spec:custom_reqs.md"]
+    assert agentapi.LATEST_MESSAGES == ["spec:custom_reqs.md"]
+    cli_stub.spec_cmd.assert_called_once_with(
+        requirements_file="custom_reqs.md", bridge=bridge
+    )
 
 
-@pytest.mark.medium
+@pytest.mark.slow
 def test_test_succeeds(monkeypatch, clean_state):
     """Test that test succeeds.
 
@@ -129,14 +133,15 @@ def test_test_succeeds(monkeypatch, clean_state):
     cli_stub, agentapi = _setup(monkeypatch)
     bridge = agentapi.APIBridge()
     api = agentapi.AgentAPI(bridge)
-    messages = api.test(spec_file='custom_specs.md', output_dir='tests/output')
-    assert messages == ['test:custom_specs.md:tests/output']
-    assert agentapi.LATEST_MESSAGES == ['test:custom_specs.md:tests/output']
-    cli_stub.test_cmd.assert_called_once_with(spec_file='custom_specs.md',
-        output_dir='tests/output', bridge=bridge)
+    messages = api.test(spec_file="custom_specs.md", output_dir="tests/output")
+    assert messages == ["test:custom_specs.md:tests/output"]
+    assert agentapi.LATEST_MESSAGES == ["test:custom_specs.md:tests/output"]
+    cli_stub.test_cmd.assert_called_once_with(
+        spec_file="custom_specs.md", output_dir="tests/output", bridge=bridge
+    )
 
 
-@pytest.mark.medium
+@pytest.mark.slow
 def test_code_succeeds(monkeypatch, clean_state):
     """Test that code succeeds.
 
@@ -144,41 +149,43 @@ def test_code_succeeds(monkeypatch, clean_state):
     cli_stub, agentapi = _setup(monkeypatch)
     bridge = agentapi.APIBridge()
     api = agentapi.AgentAPI(bridge)
-    messages = api.code(output_dir='src/output')
-    assert messages == ['code:src/output']
-    assert agentapi.LATEST_MESSAGES == ['code:src/output']
-    cli_stub.code_cmd.assert_called_once_with(output_dir='src/output',
-        bridge=bridge)
+    messages = api.code(output_dir="src/output")
+    assert messages == ["code:src/output"]
+    assert agentapi.LATEST_MESSAGES == ["code:src/output"]
+    cli_stub.code_cmd.assert_called_once_with(output_dir="src/output", bridge=bridge)
 
 
-@pytest.mark.medium
+@pytest.mark.slow
 def test_doctor_succeeds(monkeypatch, clean_state):
     """Test that doctor succeeds.
 
     ReqID: N/A"""
     cli_stub, agentapi = _setup(monkeypatch)
-    doctor_module = sys.modules['devsynth.application.cli.commands.doctor_cmd']
+    doctor_module = sys.modules["devsynth.application.cli.commands.doctor_cmd"]
     bridge = agentapi.APIBridge()
     api = agentapi.AgentAPI(bridge)
-    messages = api.doctor(path='custom_path', fix=True)
-    assert messages == ['doctor:custom_path:True']
-    assert agentapi.LATEST_MESSAGES == ['doctor:custom_path:True']
-    doctor_module.doctor_cmd.assert_called_once_with(path='custom_path',
-        fix=True, bridge=bridge)
+    messages = api.doctor(path="custom_path", fix=True)
+    assert messages == ["doctor:custom_path:True"]
+    assert agentapi.LATEST_MESSAGES == ["doctor:custom_path:True"]
+    doctor_module.doctor_cmd.assert_called_once_with(
+        path="custom_path", fix=True, bridge=bridge
+    )
 
 
-@pytest.mark.medium
+@pytest.mark.slow
 def test_edrr_cycle_succeeds(monkeypatch, clean_state):
     """Test that edrr cycle.
 
     ReqID: N/A"""
     cli_stub, agentapi = _setup(monkeypatch)
-    edrr_module = sys.modules['devsynth.application.cli.commands.edrr_cycle_cmd']
+    edrr_module = sys.modules["devsynth.application.cli.commands.edrr_cycle_cmd"]
     bridge = agentapi.APIBridge()
     api = agentapi.AgentAPI(bridge)
-    messages = api.edrr_cycle(prompt='test prompt', context='test context',
-        max_iterations=5)
-    assert messages == ['edrr:test prompt:test context:5']
-    assert agentapi.LATEST_MESSAGES == ['edrr:test prompt:test context:5']
-    edrr_module.edrr_cycle_cmd.assert_called_once_with(prompt='test prompt',
-        context='test context', max_iterations=5, bridge=bridge)
+    messages = api.edrr_cycle(
+        prompt="test prompt", context="test context", max_iterations=5
+    )
+    assert messages == ["edrr:test prompt:test context:5"]
+    assert agentapi.LATEST_MESSAGES == ["edrr:test prompt:test context:5"]
+    edrr_module.edrr_cycle_cmd.assert_called_once_with(
+        prompt="test prompt", context="test context", max_iterations=5, bridge=bridge
+    )

--- a/tests/unit/interface/test_agentapi_class_fixed.py
+++ b/tests/unit/interface/test_agentapi_class_fixed.py
@@ -8,59 +8,61 @@ from devsynth.interface import agentapi
 
 def _setup(monkeypatch):
     """Set up the test environment with mocked CLI modules."""
-    cli_stub = ModuleType('devsynth.application.cli')
+    cli_stub = ModuleType("devsynth.application.cli")
 
-    def init_cmd(path='.', project_root=None, language=None, goals=None, *,
-        bridge):
-        bridge.display_result('init')
+    def init_cmd(path=".", project_root=None, language=None, goals=None, *, bridge):
+        bridge.display_result("init")
 
-    def gather_cmd(output_file='requirements_plan.yaml', *, bridge):
-        g = bridge.ask_question('g')
-        c = bridge.ask_question('c')
-        p = bridge.ask_question('p')
-        bridge.display_result(f'{g},{c},{p}')
+    def gather_cmd(output_file="requirements_plan.yaml", *, bridge):
+        g = bridge.ask_question("g")
+        c = bridge.ask_question("c")
+        p = bridge.ask_question("p")
+        bridge.display_result(f"{g},{c},{p}")
 
     def run_pipeline_cmd(target=None, *, bridge):
-        bridge.display_result(f'run:{target}')
+        bridge.display_result(f"run:{target}")
 
-    def spec_cmd(requirements_file='requirements.md', *, bridge):
-        bridge.display_result(f'spec:{requirements_file}')
-        
-    def test_cmd_succeeds(spec_file='specs.md', output_dir=None, *, bridge):
-        bridge.display_result(f'test:{spec_file}:{output_dir}')
+    def spec_cmd(requirements_file="requirements.md", *, bridge):
+        bridge.display_result(f"spec:{requirements_file}")
+
+    def test_cmd_succeeds(spec_file="specs.md", output_dir=None, *, bridge):
+        bridge.display_result(f"test:{spec_file}:{output_dir}")
 
     def code_cmd(output_dir=None, *, bridge):
-        bridge.display_result(f'code:{output_dir}')
+        bridge.display_result(f"code:{output_dir}")
 
-    def doctor_cmd(path='.', fix=False, *, bridge):
-        bridge.display_result(f'doctor:{path}:{fix}')
+    def doctor_cmd(path=".", fix=False, *, bridge):
+        bridge.display_result(f"doctor:{path}:{fix}")
 
     def edrr_cycle_cmd(prompt, context=None, max_iterations=3, *, bridge):
-        bridge.display_result(f'edrr:{prompt}:{context}:{max_iterations}')
-        
+        bridge.display_result(f"edrr:{prompt}:{context}:{max_iterations}")
+
     cli_stub.init_cmd = MagicMock(side_effect=init_cmd)
     cli_stub.gather_cmd = MagicMock(side_effect=gather_cmd)
     cli_stub.run_pipeline_cmd = MagicMock(side_effect=run_pipeline_cmd)
     cli_stub.spec_cmd = MagicMock(side_effect=spec_cmd)
     cli_stub.test_cmd = MagicMock(side_effect=test_cmd_succeeds)
     cli_stub.code_cmd = MagicMock(side_effect=code_cmd)
-    monkeypatch.setitem(sys.modules, 'devsynth.application.cli', cli_stub)
-    
-    doctor_module = ModuleType('devsynth.application.cli.commands.doctor_cmd')
+    monkeypatch.setitem(sys.modules, "devsynth.application.cli", cli_stub)
+
+    doctor_module = ModuleType("devsynth.application.cli.commands.doctor_cmd")
     doctor_module.doctor_cmd = MagicMock(side_effect=doctor_cmd)
-    monkeypatch.setitem(sys.modules,
-        'devsynth.application.cli.commands.doctor_cmd', doctor_module)
-    
-    edrr_module = ModuleType('devsynth.application.cli.commands.edrr_cycle_cmd')
+    monkeypatch.setitem(
+        sys.modules, "devsynth.application.cli.commands.doctor_cmd", doctor_module
+    )
+
+    edrr_module = ModuleType("devsynth.application.cli.commands.edrr_cycle_cmd")
     edrr_module.edrr_cycle_cmd = MagicMock(side_effect=edrr_cycle_cmd)
-    monkeypatch.setitem(sys.modules,
-        'devsynth.application.cli.commands.edrr_cycle_cmd', edrr_module)
-    
+    monkeypatch.setitem(
+        sys.modules, "devsynth.application.cli.commands.edrr_cycle_cmd", edrr_module
+    )
+
     from devsynth.interface import webui
+
     # Reload the modules to ensure clean state
     importlib.reload(webui)
     importlib.reload(agentapi)
-    
+
     return cli_stub, agentapi
 
 
@@ -72,7 +74,7 @@ def clean_state():
     # Clean up state
 
 
-@pytest.mark.medium
+@pytest.mark.slow
 def test_init_succeeds(monkeypatch, clean_state):
     """Test that init succeeds.
 
@@ -80,14 +82,15 @@ def test_init_succeeds(monkeypatch, clean_state):
     cli_stub, agentapi = _setup(monkeypatch)
     bridge = agentapi.APIBridge()
     api = agentapi.AgentAPI(bridge)
-    messages = api.init(path='p', project_root='r', language='py', goals='g')
-    assert messages == ['init']
-    assert agentapi.LATEST_MESSAGES == ['init']
-    cli_stub.init_cmd.assert_called_once_with(path='p', project_root='r',
-        language='py', goals='g', bridge=bridge)
+    messages = api.init(path="p", project_root="r", language="py", goals="g")
+    assert messages == ["init"]
+    assert agentapi.LATEST_MESSAGES == ["init"]
+    cli_stub.init_cmd.assert_called_once_with(
+        path="p", project_root="r", language="py", goals="g", bridge=bridge
+    )
 
 
-@pytest.mark.medium
+@pytest.mark.slow
 def test_gather_synthesize_status_succeeds(monkeypatch, clean_state):
     """Test that gather synthesize status.
 
@@ -95,18 +98,18 @@ def test_gather_synthesize_status_succeeds(monkeypatch, clean_state):
     cli_stub, agentapi = _setup(monkeypatch)
     bridge = agentapi.APIBridge()
     api = agentapi.AgentAPI(bridge)
-    messages = api.gather(goals='g1', constraints='c1', priority='high')
-    assert messages == ['g1,c1,high']
-    assert agentapi.LATEST_MESSAGES == ['g1,c1,high']
+    messages = api.gather(goals="g1", constraints="c1", priority="high")
+    assert messages == ["g1,c1,high"]
+    assert agentapi.LATEST_MESSAGES == ["g1,c1,high"]
     cli_stub.gather_cmd.assert_called_once_with(bridge=bridge)
-    synth = api.synthesize(target='unit')
-    assert synth == ['run:unit']
-    assert agentapi.LATEST_MESSAGES == ['run:unit']
-    cli_stub.run_pipeline_cmd.assert_called_once_with(target='unit', bridge=bridge)
-    assert api.status() == ['run:unit']
+    synth = api.synthesize(target="unit")
+    assert synth == ["run:unit"]
+    assert agentapi.LATEST_MESSAGES == ["run:unit"]
+    cli_stub.run_pipeline_cmd.assert_called_once_with(target="unit", bridge=bridge)
+    assert api.status() == ["run:unit"]
 
 
-@pytest.mark.medium
+@pytest.mark.slow
 def test_spec_succeeds(monkeypatch, clean_state):
     """Test that spec succeeds.
 
@@ -114,14 +117,15 @@ def test_spec_succeeds(monkeypatch, clean_state):
     cli_stub, agentapi = _setup(monkeypatch)
     bridge = agentapi.APIBridge()
     api = agentapi.AgentAPI(bridge)
-    messages = api.spec(requirements_file='custom_reqs.md')
-    assert messages == ['spec:custom_reqs.md']
-    assert agentapi.LATEST_MESSAGES == ['spec:custom_reqs.md']
-    cli_stub.spec_cmd.assert_called_once_with(requirements_file='custom_reqs.md', 
-        bridge=bridge)
+    messages = api.spec(requirements_file="custom_reqs.md")
+    assert messages == ["spec:custom_reqs.md"]
+    assert agentapi.LATEST_MESSAGES == ["spec:custom_reqs.md"]
+    cli_stub.spec_cmd.assert_called_once_with(
+        requirements_file="custom_reqs.md", bridge=bridge
+    )
 
 
-@pytest.mark.medium
+@pytest.mark.slow
 def test_test_succeeds(monkeypatch, clean_state):
     """Test that test succeeds.
 
@@ -129,14 +133,15 @@ def test_test_succeeds(monkeypatch, clean_state):
     cli_stub, agentapi = _setup(monkeypatch)
     bridge = agentapi.APIBridge()
     api = agentapi.AgentAPI(bridge)
-    messages = api.test(spec_file='custom_specs.md', output_dir='tests/output')
-    assert messages == ['test:custom_specs.md:tests/output']
-    assert agentapi.LATEST_MESSAGES == ['test:custom_specs.md:tests/output']
-    cli_stub.test_cmd.assert_called_once_with(spec_file='custom_specs.md',
-        output_dir='tests/output', bridge=bridge)
+    messages = api.test(spec_file="custom_specs.md", output_dir="tests/output")
+    assert messages == ["test:custom_specs.md:tests/output"]
+    assert agentapi.LATEST_MESSAGES == ["test:custom_specs.md:tests/output"]
+    cli_stub.test_cmd.assert_called_once_with(
+        spec_file="custom_specs.md", output_dir="tests/output", bridge=bridge
+    )
 
 
-@pytest.mark.medium
+@pytest.mark.slow
 def test_code_succeeds(monkeypatch, clean_state):
     """Test that code succeeds.
 
@@ -144,41 +149,43 @@ def test_code_succeeds(monkeypatch, clean_state):
     cli_stub, agentapi = _setup(monkeypatch)
     bridge = agentapi.APIBridge()
     api = agentapi.AgentAPI(bridge)
-    messages = api.code(output_dir='src/output')
-    assert messages == ['code:src/output']
-    assert agentapi.LATEST_MESSAGES == ['code:src/output']
-    cli_stub.code_cmd.assert_called_once_with(output_dir='src/output',
-        bridge=bridge)
+    messages = api.code(output_dir="src/output")
+    assert messages == ["code:src/output"]
+    assert agentapi.LATEST_MESSAGES == ["code:src/output"]
+    cli_stub.code_cmd.assert_called_once_with(output_dir="src/output", bridge=bridge)
 
 
-@pytest.mark.medium
+@pytest.mark.slow
 def test_doctor_succeeds(monkeypatch, clean_state):
     """Test that doctor succeeds.
 
     ReqID: N/A"""
     cli_stub, agentapi = _setup(monkeypatch)
-    doctor_module = sys.modules['devsynth.application.cli.commands.doctor_cmd']
+    doctor_module = sys.modules["devsynth.application.cli.commands.doctor_cmd"]
     bridge = agentapi.APIBridge()
     api = agentapi.AgentAPI(bridge)
-    messages = api.doctor(path='custom_path', fix=True)
-    assert messages == ['doctor:custom_path:True']
-    assert agentapi.LATEST_MESSAGES == ['doctor:custom_path:True']
-    doctor_module.doctor_cmd.assert_called_once_with(path='custom_path',
-        fix=True, bridge=bridge)
+    messages = api.doctor(path="custom_path", fix=True)
+    assert messages == ["doctor:custom_path:True"]
+    assert agentapi.LATEST_MESSAGES == ["doctor:custom_path:True"]
+    doctor_module.doctor_cmd.assert_called_once_with(
+        path="custom_path", fix=True, bridge=bridge
+    )
 
 
-@pytest.mark.medium
+@pytest.mark.slow
 def test_edrr_cycle_succeeds(monkeypatch, clean_state):
     """Test that edrr cycle.
 
     ReqID: N/A"""
     cli_stub, agentapi = _setup(monkeypatch)
-    edrr_module = sys.modules['devsynth.application.cli.commands.edrr_cycle_cmd']
+    edrr_module = sys.modules["devsynth.application.cli.commands.edrr_cycle_cmd"]
     bridge = agentapi.APIBridge()
     api = agentapi.AgentAPI(bridge)
-    messages = api.edrr_cycle(prompt='test prompt', context='test context',
-        max_iterations=5)
-    assert messages == ['edrr:test prompt:test context:5']
-    assert agentapi.LATEST_MESSAGES == ['edrr:test prompt:test context:5']
-    edrr_module.edrr_cycle_cmd.assert_called_once_with(prompt='test prompt',
-        context='test context', max_iterations=5, bridge=bridge)
+    messages = api.edrr_cycle(
+        prompt="test prompt", context="test context", max_iterations=5
+    )
+    assert messages == ["edrr:test prompt:test context:5"]
+    assert agentapi.LATEST_MESSAGES == ["edrr:test prompt:test context:5"]
+    edrr_module.edrr_cycle_cmd.assert_called_once_with(
+        prompt="test prompt", context="test context", max_iterations=5, bridge=bridge
+    )

--- a/tests/unit/interface/test_api_advanced.py
+++ b/tests/unit/interface/test_api_advanced.py
@@ -22,14 +22,14 @@ from devsynth.interface.agentapi import (
     DoctorRequest,
     EDRRCycleRequest,
     LATEST_MESSAGES,
-    ) # Uncommented closing parenthesis
+)  # Uncommented closing parenthesis
 
 
 @pytest.fixture
 def mock_settings():
     """Mock settings for testing."""
-    with patch('devsynth.api.settings') as mock_settings:
-        mock_settings.API_TOKEN = 'test_token'
+    with patch("devsynth.api.settings") as mock_settings:
+        mock_settings.API_TOKEN = "test_token"
         yield mock_settings
 
 
@@ -42,46 +42,49 @@ def client(mock_settings):
 @pytest.fixture
 def mock_cli_commands():
     """Mock CLI commands for testing."""
-    with patch('devsynth.application.cli.init_cmd') as mock_init_cmd, patch(
-        'devsynth.application.cli.gather_cmd') as mock_gather_cmd, patch(
-        'devsynth.application.cli.run_pipeline_cmd'
-        ) as mock_run_pipeline_cmd, patch('devsynth.application.cli.spec_cmd'
-        ) as mock_spec_cmd, patch('devsynth.application.cli.test_cmd'
-        ) as mock_test_cmd, patch('devsynth.application.cli.code_cmd'
-        ) as mock_code_cmd, patch(
-        'devsynth.application.cli.commands.doctor_cmd.doctor_cmd'
-        ) as mock_doctor_cmd, patch(
-        'devsynth.application.cli.commands.edrr_cycle_cmd.edrr_cycle_cmd'
-        ) as mock_edrr_cycle_cmd:
+    with (
+        patch("devsynth.application.cli.init_cmd") as mock_init_cmd,
+        patch("devsynth.application.cli.gather_cmd") as mock_gather_cmd,
+        patch("devsynth.application.cli.run_pipeline_cmd") as mock_run_pipeline_cmd,
+        patch("devsynth.application.cli.spec_cmd") as mock_spec_cmd,
+        patch("devsynth.application.cli.test_cmd") as mock_test_cmd,
+        patch("devsynth.application.cli.code_cmd") as mock_code_cmd,
+        patch(
+            "devsynth.application.cli.commands.doctor_cmd.doctor_cmd"
+        ) as mock_doctor_cmd,
+        patch(
+            "devsynth.application.cli.commands.edrr_cycle_cmd.edrr_cycle_cmd"
+        ) as mock_edrr_cycle_cmd,
+    ):
 
-        def update_bridge(bridge, message='Success'):
+        def update_bridge(bridge, message="Success"):
             bridge.display_result(message)
             return True
-            
+
         def mock_init_handler(**kwargs):
-            return update_bridge(kwargs['bridge'], 'Init successful')
-            
+            return update_bridge(kwargs["bridge"], "Init successful")
+
         def mock_gather_handler(**kwargs):
-            return update_bridge(kwargs['bridge'], 'Gather successful')
-            
+            return update_bridge(kwargs["bridge"], "Gather successful")
+
         def mock_run_pipeline_handler(**kwargs):
-            return update_bridge(kwargs['bridge'], 'Synthesize successful')
-            
+            return update_bridge(kwargs["bridge"], "Synthesize successful")
+
         def mock_spec_handler(**kwargs):
-            return update_bridge(kwargs['bridge'], 'Spec successful')
-            
+            return update_bridge(kwargs["bridge"], "Spec successful")
+
         def mock_test_handler(**kwargs):
-            return update_bridge(kwargs['bridge'], 'Test successful')
-            
+            return update_bridge(kwargs["bridge"], "Test successful")
+
         def mock_code_handler(**kwargs):
-            return update_bridge(kwargs['bridge'], 'Code successful')
-            
+            return update_bridge(kwargs["bridge"], "Code successful")
+
         def mock_doctor_handler(**kwargs):
-            return update_bridge(kwargs['bridge'], 'Doctor successful')
-            
+            return update_bridge(kwargs["bridge"], "Doctor successful")
+
         def mock_edrr_cycle_handler(**kwargs):
-            return update_bridge(kwargs['bridge'], 'EDRR cycle successful')
-            
+            return update_bridge(kwargs["bridge"], "EDRR cycle successful")
+
         mock_init_cmd.side_effect = mock_init_handler
         mock_gather_cmd.side_effect = mock_gather_handler
         mock_run_pipeline_cmd.side_effect = mock_run_pipeline_handler
@@ -90,11 +93,16 @@ def mock_cli_commands():
         mock_code_cmd.side_effect = mock_code_handler
         mock_doctor_cmd.side_effect = mock_doctor_handler
         mock_edrr_cycle_cmd.side_effect = mock_edrr_cycle_handler
-        yield {'init_cmd': mock_init_cmd, 'gather_cmd': mock_gather_cmd,
-            'run_pipeline_cmd': mock_run_pipeline_cmd, 'spec_cmd':
-            mock_spec_cmd, 'test_cmd': mock_test_cmd, 'code_cmd':
-            mock_code_cmd, 'doctor_cmd': mock_doctor_cmd, 'edrr_cycle_cmd':
-            mock_edrr_cycle_cmd}
+        yield {
+            "init_cmd": mock_init_cmd,
+            "gather_cmd": mock_gather_cmd,
+            "run_pipeline_cmd": mock_run_pipeline_cmd,
+            "spec_cmd": mock_spec_cmd,
+            "test_cmd": mock_test_cmd,
+            "code_cmd": mock_code_cmd,
+            "doctor_cmd": mock_doctor_cmd,
+            "edrr_cycle_cmd": mock_edrr_cycle_cmd,
+        }
 
 
 @pytest.fixture
@@ -102,222 +110,237 @@ def clean_state():
     """Set up clean state for tests."""
     # Store original state of LATEST_MESSAGES
     original_messages = LATEST_MESSAGES.copy()
-    
+
     # Clear any existing messages before test
     LATEST_MESSAGES.clear()
-    
+
     yield
-    
+
     # Clean up state after test
     LATEST_MESSAGES.clear()
-    
+
     # Restore original messages
     LATEST_MESSAGES.extend(original_messages)
 
 
-@pytest.mark.medium
+@pytest.mark.slow
 def test_error_handling_in_all_endpoints(mock_cli_commands, clean_state):
     """Test error handling in all endpoints.
 
     ReqID: N/A"""
-    mock_cli_commands['init_cmd'].side_effect = Exception('Init error')
-    request = InitRequest(path='.', project_root=None, language=None, goals
-        =None)
+    mock_cli_commands["init_cmd"].side_effect = Exception("Init error")
+    request = InitRequest(path=".", project_root=None, language=None, goals=None)
     with pytest.raises(HTTPException) as excinfo:
         init_endpoint(request, token=None)
     assert excinfo.value.status_code == 500
-    assert 'Failed to initialize project' in excinfo.value.detail
-    mock_cli_commands['gather_cmd'].side_effect = Exception('Gather error')
-    request = GatherRequest(goals='test goals', constraints=
-        'test constraints', priority='high')
+    assert "Failed to initialize project" in excinfo.value.detail
+    mock_cli_commands["gather_cmd"].side_effect = Exception("Gather error")
+    request = GatherRequest(
+        goals="test goals", constraints="test constraints", priority="high"
+    )
     with pytest.raises(HTTPException) as excinfo:
         gather_endpoint(request, token=None)
     assert excinfo.value.status_code == 500
-    assert 'Failed to gather requirements' in excinfo.value.detail
-    mock_cli_commands['run_pipeline_cmd'].side_effect = Exception(
-        'Synthesize error')
-    request = SynthesizeRequest(target='unit')
+    assert "Failed to gather requirements" in excinfo.value.detail
+    mock_cli_commands["run_pipeline_cmd"].side_effect = Exception("Synthesize error")
+    request = SynthesizeRequest(target="unit")
     with pytest.raises(HTTPException) as excinfo:
         synthesize_endpoint(request, token=None)
     assert excinfo.value.status_code == 500
-    assert 'Failed to run synthesis pipeline' in excinfo.value.detail
-    mock_cli_commands['spec_cmd'].side_effect = Exception('Spec error')
-    request = SpecRequest(requirements_file='requirements.md')
+    assert "Failed to run synthesis pipeline" in excinfo.value.detail
+    mock_cli_commands["spec_cmd"].side_effect = Exception("Spec error")
+    request = SpecRequest(requirements_file="requirements.md")
     with pytest.raises(HTTPException) as excinfo:
         spec_endpoint(request, token=None)
     assert excinfo.value.status_code == 500
-    assert 'Failed to generate spec' in excinfo.value.detail
-    mock_cli_commands['test_cmd'].side_effect = Exception('Test error')
-    request = APITestSpecRequest(spec_file='specs.md', output_dir=None)
+    assert "Failed to generate spec" in excinfo.value.detail
+    mock_cli_commands["test_cmd"].side_effect = Exception("Test error")
+    request = APITestSpecRequest(spec_file="specs.md", output_dir=None)
     with pytest.raises(HTTPException) as excinfo:
         test_endpoint(request, token=None)
     assert excinfo.value.status_code == 500
-    assert 'Failed to generate tests' in excinfo.value.detail
-    mock_cli_commands['code_cmd'].side_effect = Exception('Code error')
+    assert "Failed to generate tests" in excinfo.value.detail
+    mock_cli_commands["code_cmd"].side_effect = Exception("Code error")
     request = CodeRequest(output_dir=None)
     with pytest.raises(HTTPException) as excinfo:
         code_endpoint(request, token=None)
     assert excinfo.value.status_code == 500
-    assert 'Failed to generate code' in excinfo.value.detail
-    mock_cli_commands['doctor_cmd'].side_effect = Exception('Doctor error')
-    request = DoctorRequest(path='.', fix=False)
+    assert "Failed to generate code" in excinfo.value.detail
+    mock_cli_commands["doctor_cmd"].side_effect = Exception("Doctor error")
+    request = DoctorRequest(path=".", fix=False)
     with pytest.raises(HTTPException) as excinfo:
         doctor_endpoint(request, token=None)
     assert excinfo.value.status_code == 500
-    assert 'Failed to run diagnostics' in excinfo.value.detail
-    mock_cli_commands['edrr_cycle_cmd'].side_effect = Exception('EDRR error')
-    request = EDRRCycleRequest(prompt='test prompt', context=None,
-        max_iterations=3)
+    assert "Failed to run diagnostics" in excinfo.value.detail
+    mock_cli_commands["edrr_cycle_cmd"].side_effect = Exception("EDRR error")
+    request = EDRRCycleRequest(prompt="test prompt", context=None, max_iterations=3)
     with pytest.raises(HTTPException) as excinfo:
         edrr_cycle_endpoint(request, token=None)
     assert excinfo.value.status_code == 500
-    assert 'Failed to run EDRR cycle' in excinfo.value.detail
+    assert "Failed to run EDRR cycle" in excinfo.value.detail
 
 
-
-
-
-
-
-
-
-@pytest.mark.medium
+@pytest.mark.slow
 def test_all_endpoints_authentication_succeeds(client, clean_state):
     """Test authentication for all endpoints.
 
     ReqID: N/A"""
-    response = client.post('/api/init', json={'path': '.'})
+    response = client.post("/api/init", json={"path": "."})
     assert response.status_code == 401
-    response = client.post('/api/init', json={'path': '.'}, headers={
-        'Authorization': 'Bearer invalid_token'})
+    response = client.post(
+        "/api/init",
+        json={"path": "."},
+        headers={"Authorization": "Bearer invalid_token"},
+    )
     assert response.status_code == 401
-    response = client.post('/api/gather', json={'goals': 'test goals',
-        'constraints': 'test constraints', 'priority': 'high'})
+    response = client.post(
+        "/api/gather",
+        json={
+            "goals": "test goals",
+            "constraints": "test constraints",
+            "priority": "high",
+        },
+    )
     assert response.status_code == 401
-    response = client.post('/api/gather', json={'goals': 'test goals',
-        'constraints': 'test constraints', 'priority': 'high'}, headers={
-        'Authorization': 'Bearer invalid_token'})
+    response = client.post(
+        "/api/gather",
+        json={
+            "goals": "test goals",
+            "constraints": "test constraints",
+            "priority": "high",
+        },
+        headers={"Authorization": "Bearer invalid_token"},
+    )
     assert response.status_code == 401
-    response = client.post('/api/synthesize', json={'target': 'unit'})
+    response = client.post("/api/synthesize", json={"target": "unit"})
     assert response.status_code == 401
-    response = client.post('/api/synthesize', json={'target': 'unit'},
-        headers={'Authorization': 'Bearer invalid_token'})
+    response = client.post(
+        "/api/synthesize",
+        json={"target": "unit"},
+        headers={"Authorization": "Bearer invalid_token"},
+    )
     assert response.status_code == 401
-    response = client.post('/api/spec', json={'requirements_file':
-        'requirements.md'})
+    response = client.post("/api/spec", json={"requirements_file": "requirements.md"})
     assert response.status_code == 401
-    response = client.post('/api/spec', json={'requirements_file':
-        'requirements.md'}, headers={'Authorization': 'Bearer invalid_token'})
+    response = client.post(
+        "/api/spec",
+        json={"requirements_file": "requirements.md"},
+        headers={"Authorization": "Bearer invalid_token"},
+    )
     assert response.status_code == 401
-    response = client.post('/api/test', json={'spec_file': 'specs.md'})
+    response = client.post("/api/test", json={"spec_file": "specs.md"})
     assert response.status_code == 401
-    response = client.post('/api/test', json={'spec_file': 'specs.md'},
-        headers={'Authorization': 'Bearer invalid_token'})
+    response = client.post(
+        "/api/test",
+        json={"spec_file": "specs.md"},
+        headers={"Authorization": "Bearer invalid_token"},
+    )
     assert response.status_code == 401
-    response = client.post('/api/code', json={})
+    response = client.post("/api/code", json={})
     assert response.status_code == 401
-    response = client.post('/api/code', json={}, headers={'Authorization':
-        'Bearer invalid_token'})
+    response = client.post(
+        "/api/code", json={}, headers={"Authorization": "Bearer invalid_token"}
+    )
     assert response.status_code == 401
-    response = client.post('/api/doctor', json={'path': '.', 'fix': False})
+    response = client.post("/api/doctor", json={"path": ".", "fix": False})
     assert response.status_code == 401
-    response = client.post('/api/doctor', json={'path': '.', 'fix': False},
-        headers={'Authorization': 'Bearer invalid_token'})
+    response = client.post(
+        "/api/doctor",
+        json={"path": ".", "fix": False},
+        headers={"Authorization": "Bearer invalid_token"},
+    )
     assert response.status_code == 401
-    response = client.post('/api/edrr-cycle', json={'prompt': 'test prompt'})
+    response = client.post("/api/edrr-cycle", json={"prompt": "test prompt"})
     assert response.status_code == 401
-    response = client.post('/api/edrr-cycle', json={'prompt': 'test prompt'
-        }, headers={'Authorization': 'Bearer invalid_token'})
+    response = client.post(
+        "/api/edrr-cycle",
+        json={"prompt": "test prompt"},
+        headers={"Authorization": "Bearer invalid_token"},
+    )
     assert response.status_code == 401
-    response = client.get('/api/status')
+    response = client.get("/api/status")
     assert response.status_code == 401
-    response = client.get('/api/status', headers={'Authorization':
-        'Bearer invalid_token'})
+    response = client.get(
+        "/api/status", headers={"Authorization": "Bearer invalid_token"}
+    )
     assert response.status_code == 401
 
 
-
-
-
-
-@pytest.mark.medium
+@pytest.mark.slow
 def test_parameter_validation_is_valid(mock_cli_commands, clean_state):
     """Test validation of request parameters.
 
     ReqID: N/A"""
-    request = InitRequest(path=None, project_root=None, language=None,
-        goals=None)
+    request = InitRequest(path=None, project_root=None, language=None, goals=None)
     with pytest.raises(HTTPException) as excinfo:
         init_endpoint(request, token=None)
     assert excinfo.value.status_code == 400
-    assert 'path is required' in excinfo.value.detail
+    assert "path is required" in excinfo.value.detail
     request = GatherRequest(goals=None, constraints=None, priority=None)
     with pytest.raises(HTTPException) as excinfo:
         gather_endpoint(request, token=None)
     assert excinfo.value.status_code == 400
-    assert 'goals are required' in excinfo.value.detail
-    request = SynthesizeRequest(target='invalid')
+    assert "goals are required" in excinfo.value.detail
+    request = SynthesizeRequest(target="invalid")
     with pytest.raises(HTTPException) as excinfo:
         synthesize_endpoint(request, token=None)
     assert excinfo.value.status_code == 400
-    assert 'target must be one of' in excinfo.value.detail
+    assert "target must be one of" in excinfo.value.detail
     request = SpecRequest(requirements_file=None)
     with pytest.raises(HTTPException) as excinfo:
         spec_endpoint(request, token=None)
     assert excinfo.value.status_code == 400
-    assert 'requirements_file is required' in excinfo.value.detail
+    assert "requirements_file is required" in excinfo.value.detail
     request = APITestSpecRequest(spec_file=None, output_dir=None)
     with pytest.raises(HTTPException) as excinfo:
         test_endpoint(request, token=None)
     assert excinfo.value.status_code == 400
-    assert 'spec_file is required' in excinfo.value.detail
+    assert "spec_file is required" in excinfo.value.detail
     request = EDRRCycleRequest(prompt=None, context=None, max_iterations=3)
     with pytest.raises(HTTPException) as excinfo:
         edrr_cycle_endpoint(request, token=None)
     assert excinfo.value.status_code == 400
 
-    assert 'prompt is required' in excinfo.value.detail
+    assert "prompt is required" in excinfo.value.detail
 
 
-@pytest.mark.medium
+@pytest.mark.slow
 def test_edge_cases_succeeds(mock_cli_commands, clean_state):
     """Test edge cases for API endpoints.
 
     ReqID: N/A"""
-    request = InitRequest(path='', project_root=None, language=None, goals=None
-        )
+    request = InitRequest(path="", project_root=None, language=None, goals=None)
     with pytest.raises(HTTPException) as excinfo:
         init_endpoint(request, token=None)
     assert excinfo.value.status_code == 400
-    assert 'path cannot be empty' in excinfo.value.detail
-    request = GatherRequest(goals='', constraints=None, priority=None)
+    assert "path cannot be empty" in excinfo.value.detail
+    request = GatherRequest(goals="", constraints=None, priority=None)
     with pytest.raises(HTTPException) as excinfo:
         gather_endpoint(request, token=None)
     assert excinfo.value.status_code == 400
-    assert 'goals cannot be empty' in excinfo.value.detail
-    request = SynthesizeRequest(target='')
+    assert "goals cannot be empty" in excinfo.value.detail
+    request = SynthesizeRequest(target="")
     with pytest.raises(HTTPException) as excinfo:
         synthesize_endpoint(request, token=None)
     assert excinfo.value.status_code == 400
-    assert 'target cannot be empty' in excinfo.value.detail
-    request = SpecRequest(requirements_file='')
+    assert "target cannot be empty" in excinfo.value.detail
+    request = SpecRequest(requirements_file="")
     with pytest.raises(HTTPException) as excinfo:
         spec_endpoint(request, token=None)
     assert excinfo.value.status_code == 400
-    assert 'requirements_file cannot be empty' in excinfo.value.detail
-    request = APITestSpecRequest(spec_file='', output_dir=None)
+    assert "requirements_file cannot be empty" in excinfo.value.detail
+    request = APITestSpecRequest(spec_file="", output_dir=None)
     with pytest.raises(HTTPException) as excinfo:
         test_endpoint(request, token=None)
     assert excinfo.value.status_code == 400
-    assert 'spec_file cannot be empty' in excinfo.value.detail
-    request = EDRRCycleRequest(prompt='', context=None, max_iterations=3)
+    assert "spec_file cannot be empty" in excinfo.value.detail
+    request = EDRRCycleRequest(prompt="", context=None, max_iterations=3)
     with pytest.raises(HTTPException) as excinfo:
         edrr_cycle_endpoint(request, token=None)
     assert excinfo.value.status_code == 400
-    assert 'prompt cannot be empty' in excinfo.value.detail
-    request = EDRRCycleRequest(prompt='test prompt', context=None,
-        max_iterations=-1)
+    assert "prompt cannot be empty" in excinfo.value.detail
+    request = EDRRCycleRequest(prompt="test prompt", context=None, max_iterations=-1)
     with pytest.raises(HTTPException) as excinfo:
         edrr_cycle_endpoint(request, token=None)
     assert excinfo.value.status_code == 400
-    assert 'max_iterations must be positive' in excinfo.value.detail
+    assert "max_iterations must be positive" in excinfo.value.detail

--- a/tests/unit/interface/test_api_endpoints.py
+++ b/tests/unit/interface/test_api_endpoints.py
@@ -21,7 +21,7 @@ from devsynth.interface.agentapi import (
     CodeRequest,
     DoctorRequest,
     EDRRCycleRequest,
-    LATEST_MESSAGES
+    LATEST_MESSAGES,
 )
 
 
@@ -30,15 +30,15 @@ def clean_state():
     """Set up clean state for tests."""
     # Store original state of LATEST_MESSAGES
     original_messages = LATEST_MESSAGES.copy()
-    
+
     # Clear any existing messages before test
     LATEST_MESSAGES.clear()
-    
+
     yield
-    
+
     # Clean up state after test
     LATEST_MESSAGES.clear()
-    
+
     # Restore original messages
     LATEST_MESSAGES.extend(original_messages)
 
@@ -46,8 +46,8 @@ def clean_state():
 @pytest.fixture
 def mock_settings():
     """Mock settings with a test token."""
-    with patch('devsynth.api.settings') as mock_settings:
-        mock_settings.access_token = 'test_token'
+    with patch("devsynth.api.settings") as mock_settings:
+        mock_settings.access_token = "test_token"
         yield mock_settings
 
 
@@ -60,246 +60,245 @@ def client(mock_settings):
 @pytest.fixture
 def mock_cli_commands():
     """Mock the CLI command functions."""
-    with patch('devsynth.application.cli.init_cmd') as mock_init, \
-         patch('devsynth.application.cli.gather_cmd') as mock_gather, \
-         patch('devsynth.application.cli.run_pipeline_cmd') as mock_run, \
-         patch('devsynth.application.cli.spec_cmd') as mock_spec, \
-         patch('devsynth.application.cli.test_cmd') as mock_test, \
-         patch('devsynth.application.cli.code_cmd') as mock_code, \
-         patch('devsynth.application.cli.commands.doctor_cmd.doctor_cmd') as mock_doctor, \
-         patch('devsynth.application.cli.commands.edrr_cycle_cmd.edrr_cycle_cmd') as mock_edrr:
+    with (
+        patch("devsynth.application.cli.init_cmd") as mock_init,
+        patch("devsynth.application.cli.gather_cmd") as mock_gather,
+        patch("devsynth.application.cli.run_pipeline_cmd") as mock_run,
+        patch("devsynth.application.cli.spec_cmd") as mock_spec,
+        patch("devsynth.application.cli.test_cmd") as mock_test,
+        patch("devsynth.application.cli.code_cmd") as mock_code,
+        patch("devsynth.application.cli.commands.doctor_cmd.doctor_cmd") as mock_doctor,
+        patch(
+            "devsynth.application.cli.commands.edrr_cycle_cmd.edrr_cycle_cmd"
+        ) as mock_edrr,
+    ):
 
-        def update_bridge(bridge, message='Success'):
+        def update_bridge(bridge, message="Success"):
             bridge.display_result(message)
-            
+
         # Set up side effects for each mock
         mock_init.side_effect = lambda **kwargs: update_bridge(
-            kwargs['bridge'], 'Init successful')
+            kwargs["bridge"], "Init successful"
+        )
         mock_gather.side_effect = lambda **kwargs: update_bridge(
-            kwargs['bridge'], 'Gather successful')
+            kwargs["bridge"], "Gather successful"
+        )
         mock_run.side_effect = lambda **kwargs: update_bridge(
-            kwargs['bridge'], 'Synthesize successful')
+            kwargs["bridge"], "Synthesize successful"
+        )
         mock_spec.side_effect = lambda **kwargs: update_bridge(
-            kwargs['bridge'], 'Spec successful')
+            kwargs["bridge"], "Spec successful"
+        )
         mock_test.side_effect = lambda **kwargs: update_bridge(
-            kwargs['bridge'], 'Test successful')
+            kwargs["bridge"], "Test successful"
+        )
         mock_code.side_effect = lambda **kwargs: update_bridge(
-            kwargs['bridge'], 'Code successful')
+            kwargs["bridge"], "Code successful"
+        )
         mock_doctor.side_effect = lambda **kwargs: update_bridge(
-            kwargs['bridge'], 'Doctor successful')
+            kwargs["bridge"], "Doctor successful"
+        )
         mock_edrr.side_effect = lambda **kwargs: update_bridge(
-            kwargs['bridge'], 'EDRR cycle successful')
-            
+            kwargs["bridge"], "EDRR cycle successful"
+        )
+
         yield {
-            'init_cmd': mock_init,
-            'gather_cmd': mock_gather,
-            'run_pipeline_cmd': mock_run,
-            'spec_cmd': mock_spec,
-            'test_cmd': mock_test,
-            'code_cmd': mock_code,
-            'doctor_cmd': mock_doctor,
-            'edrr_cycle_cmd': mock_edrr
+            "init_cmd": mock_init,
+            "gather_cmd": mock_gather,
+            "run_pipeline_cmd": mock_run,
+            "spec_cmd": mock_spec,
+            "test_cmd": mock_test,
+            "code_cmd": mock_code,
+            "doctor_cmd": mock_doctor,
+            "edrr_cycle_cmd": mock_edrr,
         }
 
 
-@pytest.mark.medium
+@pytest.mark.slow
 def test_health_endpoint_requires_authentication_succeeds(client, clean_state):
     """Test that the health endpoint requires authentication.
 
     ReqID: N/A"""
-    response = client.get('/health')
+    response = client.get("/health")
     assert response.status_code == 401
-    
-    response = client.get('/health', headers={
-        'Authorization': 'Bearer invalid_token'
-    })
+
+    response = client.get("/health", headers={"Authorization": "Bearer invalid_token"})
     assert response.status_code == 401
-    
-    response = client.get('/health', headers={
-        'Authorization': 'Bearer test_token'
-    })
+
+    response = client.get("/health", headers={"Authorization": "Bearer test_token"})
     assert response.status_code == 200
-    assert response.json() == {'status': 'ok'}
+    assert response.json() == {"status": "ok"}
 
 
-@pytest.mark.medium
+@pytest.mark.slow
 def test_metrics_endpoint_requires_authentication_succeeds(client, clean_state):
     """Test that the metrics endpoint requires authentication.
 
     ReqID: N/A"""
-    response = client.get('/metrics')
+    response = client.get("/metrics")
     assert response.status_code == 401
-    
-    response = client.get('/metrics', headers={
-        'Authorization': 'Bearer invalid_token'
-    })
+
+    response = client.get("/metrics", headers={"Authorization": "Bearer invalid_token"})
     assert response.status_code == 401
-    
-    response = client.get('/metrics', headers={
-        'Authorization': 'Bearer test_token'
-    })
+
+    response = client.get("/metrics", headers={"Authorization": "Bearer test_token"})
     assert response.status_code == 200
 
 
-@pytest.mark.medium
+@pytest.mark.slow
 def test_init_endpoint_initializes_project_succeeds(mock_cli_commands, clean_state):
     """Test that the init endpoint initializes a project.
 
     ReqID: N/A"""
-    request = InitRequest(
-        path='.', 
-        project_root=None, 
-        language=None, 
-        goals=None
-    )
+    request = InitRequest(path=".", project_root=None, language=None, goals=None)
     response = init_endpoint(request, token=None)
-    assert response.messages == ['Init successful']
-    
-    mock_cli_commands['init_cmd'].assert_called_once_with(
-        path='.',
-        project_root=None, 
-        language=None, 
-        goals=None, 
-        bridge=mock_cli_commands['init_cmd'].call_args[1]['bridge']
+    assert response.messages == ["Init successful"]
+
+    mock_cli_commands["init_cmd"].assert_called_once_with(
+        path=".",
+        project_root=None,
+        language=None,
+        goals=None,
+        bridge=mock_cli_commands["init_cmd"].call_args[1]["bridge"],
     )
 
 
-@pytest.mark.medium
+@pytest.mark.slow
 def test_gather_endpoint_collects_requirements_succeeds(mock_cli_commands, clean_state):
     """Test that the gather endpoint collects requirements.
 
     ReqID: N/A"""
     request = GatherRequest(
-        goals='test goals', 
-        constraints='test constraints', 
-        priority='high'
+        goals="test goals", constraints="test constraints", priority="high"
     )
     response = gather_endpoint(request, token=None)
-    assert response.messages == ['Gather successful']
-    
-    mock_cli_commands['gather_cmd'].assert_called_once_with(
-        bridge=mock_cli_commands['gather_cmd'].call_args[1]['bridge']
+    assert response.messages == ["Gather successful"]
+
+    mock_cli_commands["gather_cmd"].assert_called_once_with(
+        bridge=mock_cli_commands["gather_cmd"].call_args[1]["bridge"]
     )
 
 
-@pytest.mark.medium
+@pytest.mark.slow
 def test_synthesize_endpoint_runs_pipeline_succeeds(mock_cli_commands, clean_state):
     """Test that the synthesize endpoint runs the pipeline.
 
     ReqID: N/A"""
-    request = SynthesizeRequest(target='unit')
+    request = SynthesizeRequest(target="unit")
     response = synthesize_endpoint(request, token=None)
-    assert response.messages == ['Synthesize successful']
+    assert response.messages == ["Synthesize successful"]
 
-    mock_cli_commands['run_pipeline_cmd'].assert_called_once_with(
-        target='unit', 
-        bridge=mock_cli_commands['run_pipeline_cmd'].call_args[1]['bridge']
+    mock_cli_commands["run_pipeline_cmd"].assert_called_once_with(
+        target="unit",
+        bridge=mock_cli_commands["run_pipeline_cmd"].call_args[1]["bridge"],
     )
 
 
-@pytest.mark.medium
-def test_spec_endpoint_generates_specifications_succeeds(mock_cli_commands, clean_state):
+@pytest.mark.slow
+def test_spec_endpoint_generates_specifications_succeeds(
+    mock_cli_commands, clean_state
+):
     """Test that the spec endpoint generates specifications from requirements.
 
     ReqID: N/A"""
-    request = SpecRequest(requirements_file='requirements.md')
+    request = SpecRequest(requirements_file="requirements.md")
     response = spec_endpoint(request, token=None)
-    assert response.messages == ['Spec successful']
-    
-    mock_cli_commands['spec_cmd'].assert_called_once_with(
-        requirements_file='requirements.md', 
-        bridge=mock_cli_commands['spec_cmd'].call_args[1]['bridge']
+    assert response.messages == ["Spec successful"]
+
+    mock_cli_commands["spec_cmd"].assert_called_once_with(
+        requirements_file="requirements.md",
+        bridge=mock_cli_commands["spec_cmd"].call_args[1]["bridge"],
     )
 
 
-@pytest.mark.medium
+@pytest.mark.slow
 def test_test_endpoint_generates_tests_succeeds(mock_cli_commands, clean_state):
     """Test that the test endpoint generates tests from specifications.
 
     ReqID: N/A"""
+
     def update_bridge(bridge, **kwargs):
-        bridge.display_result('Test successful')
+        bridge.display_result("Test successful")
         return True
-        
-    mock_cli_commands['test_cmd'].side_effect = update_bridge
-    
+
+    mock_cli_commands["test_cmd"].side_effect = update_bridge
+
     from devsynth.interface.agentapi import AgentAPI, APIBridge
+
     bridge = APIBridge()
     agent_api = AgentAPI(bridge)
-    messages = agent_api.test(spec_file='specs.md', output_dir=None)
+    messages = agent_api.test(spec_file="specs.md", output_dir=None)
 
-    assert messages == ['Test successful']
-    mock_cli_commands['test_cmd'].assert_called_once()
-    call_kwargs = mock_cli_commands['test_cmd'].call_args[1]
-    assert call_kwargs['spec_file'] == 'specs.md'
-    assert call_kwargs['output_dir'] is None
-    assert 'bridge' in call_kwargs
+    assert messages == ["Test successful"]
+    mock_cli_commands["test_cmd"].assert_called_once()
+    call_kwargs = mock_cli_commands["test_cmd"].call_args[1]
+    assert call_kwargs["spec_file"] == "specs.md"
+    assert call_kwargs["output_dir"] is None
+    assert "bridge" in call_kwargs
 
 
-@pytest.mark.medium
+@pytest.mark.slow
 def test_code_endpoint_generates_code_succeeds(mock_cli_commands, clean_state):
     """Test that the code endpoint generates code from tests.
 
     ReqID: N/A"""
     request = CodeRequest(output_dir=None)
     response = code_endpoint(request, token=None)
-    assert response.messages == ['Code successful']
-    
-    mock_cli_commands['code_cmd'].assert_called_once_with(
-        output_dir=None,
-        bridge=mock_cli_commands['code_cmd'].call_args[1]['bridge']
+    assert response.messages == ["Code successful"]
+
+    mock_cli_commands["code_cmd"].assert_called_once_with(
+        output_dir=None, bridge=mock_cli_commands["code_cmd"].call_args[1]["bridge"]
     )
 
 
-@pytest.mark.medium
+@pytest.mark.slow
 def test_doctor_endpoint_runs_diagnostics_succeeds(mock_cli_commands, clean_state):
     """Test that the doctor endpoint runs diagnostics.
 
     ReqID: N/A"""
-    request = DoctorRequest(path='.', fix=False)
+    request = DoctorRequest(path=".", fix=False)
     response = doctor_endpoint(request, token=None)
-    assert response.messages == ['Doctor successful']
-    
-    mock_cli_commands['doctor_cmd'].assert_called_once_with(
-        path='.', 
-        fix=False, 
-        bridge=mock_cli_commands['doctor_cmd'].call_args[1]['bridge']
+    assert response.messages == ["Doctor successful"]
+
+    mock_cli_commands["doctor_cmd"].assert_called_once_with(
+        path=".",
+        fix=False,
+        bridge=mock_cli_commands["doctor_cmd"].call_args[1]["bridge"],
     )
 
 
-@pytest.mark.medium
+@pytest.mark.slow
 def test_edrr_cycle_endpoint_runs_cycle_succeeds(mock_cli_commands, clean_state):
     """Test that the edrr_cycle endpoint runs an EDRR cycle.
 
     ReqID: N/A"""
-    request = EDRRCycleRequest(
-        prompt='test prompt', 
-        context=None,
-        max_iterations=3
-    )
+    request = EDRRCycleRequest(prompt="test prompt", context=None, max_iterations=3)
     response = edrr_cycle_endpoint(request, token=None)
-    assert response.messages == ['EDRR cycle successful']
-    
-    mock_cli_commands['edrr_cycle_cmd'].assert_called_once_with(
-        prompt='test prompt', 
-        context=None, 
-        max_iterations=3, 
-        bridge=mock_cli_commands['edrr_cycle_cmd'].call_args[1]['bridge']
+    assert response.messages == ["EDRR cycle successful"]
+
+    mock_cli_commands["edrr_cycle_cmd"].assert_called_once_with(
+        prompt="test prompt",
+        context=None,
+        max_iterations=3,
+        bridge=mock_cli_commands["edrr_cycle_cmd"].call_args[1]["bridge"],
     )
 
 
-@pytest.mark.medium
+@pytest.mark.slow
 def test_status_endpoint_returns_messages_returns_expected_result(clean_state):
     """Test that the status endpoint returns the latest messages.
 
     ReqID: N/A"""
     LATEST_MESSAGES.clear()
-    LATEST_MESSAGES.append('Status: running')
+    LATEST_MESSAGES.append("Status: running")
     response = status_endpoint(token=None)
-    assert response.messages == ['Status: running']
+    assert response.messages == ["Status: running"]
 
 
-@pytest.mark.skip(reason='This test is redundant with test_test_endpoint_generates_tests and causes naming conflicts')
+@pytest.mark.skip(
+    reason="This test is redundant with test_test_endpoint_generates_tests and causes naming conflicts"
+)
+@pytest.mark.slow
 def test_endpoint_succeeds(mock_cli_commands, clean_state):
     """This test is skipped because it's redundant with test_test_endpoint_generates_tests.
 
@@ -307,19 +306,15 @@ def test_endpoint_succeeds(mock_cli_commands, clean_state):
     pass
 
 
+@pytest.mark.slow
 @pytest.mark.medium
 def test_endpoints_handle_errors_properly_raises_error(mock_cli_commands, clean_state):
     """Test that the endpoints handle errors properly by returning appropriate HTTP exceptions.
 
     ReqID: N/A"""
-    mock_cli_commands['init_cmd'].side_effect = Exception('Test error')
-    request = InitRequest(
-        path='.', 
-        project_root=None, 
-        language=None, 
-        goals=None
-    )
+    mock_cli_commands["init_cmd"].side_effect = Exception("Test error")
+    request = InitRequest(path=".", project_root=None, language=None, goals=None)
     with pytest.raises(HTTPException) as excinfo:
         init_endpoint(request, token=None)
     assert excinfo.value.status_code == 500
-    assert 'Failed to initialize project' in excinfo.value.detail
+    assert "Failed to initialize project" in excinfo.value.detail

--- a/tests/unit/interface/test_bridge_conformance.py
+++ b/tests/unit/interface/test_bridge_conformance.py
@@ -102,7 +102,7 @@ def _make_dpg(monkeypatch):
     return DearPyGUIBridge()
 
 
-@pytest.mark.medium
+@pytest.mark.slow
 @pytest.mark.parametrize("factory", [_make_cli, _make_api, _make_web, _make_dpg])
 def test_bridge_implements_methods_succeeds(factory, monkeypatch):
     """Test that bridge implements methods succeeds.

--- a/tests/unit/interface/test_cli_components.py
+++ b/tests/unit/interface/test_cli_components.py
@@ -7,62 +7,59 @@ from devsynth.interface.cli import CLIUXBridge, CLIProgressIndicator
 
 
 @pytest.mark.medium
-
 @pytest.fixture
 def clean_state():
     # Set up clean state
     yield
     # Clean up state
 
+
+@pytest.mark.slow
 def test_function(clean_state):
     # Test with clean state
     """Test the create_progress method of CLIUXBridge.
 
     ReqID: N/A"""
     bridge = CLIUXBridge()
-    with patch('devsynth.interface.cli.CLIProgressIndicator'
-        ) as mock_indicator:
-        progress = bridge.create_progress('Test progress', total=50)
-        mock_indicator.assert_called_once_with(bridge.console,
-            'Test progress', 50)
-
-
-
+    with patch("devsynth.interface.cli.CLIProgressIndicator") as mock_indicator:
+        progress = bridge.create_progress("Test progress", total=50)
+        mock_indicator.assert_called_once_with(bridge.console, "Test progress", 50)
 
 
 @pytest.mark.medium
-
 @pytest.fixture
 def clean_state():
     # Set up clean state
     yield
     # Clean up state
 
+
+@pytest.mark.slow
 def test_cliprogressindicator_update_succeeds(clean_state):
     """Test the update method of CLIProgressIndicator.
 
     ReqID: N/A"""
     console = MagicMock()
     progress_mock = MagicMock(spec=ClassName)
-    with patch('rich.progress.Progress', return_value=progress_mock):
-        indicator = CLIProgressIndicator(console, 'Main task', 100)
+    with patch("rich.progress.Progress", return_value=progress_mock):
+        indicator = CLIProgressIndicator(console, "Main task", 100)
         indicator.update(advance=5)
-        progress_mock.update.assert_called_with(indicator._task, advance=5,
-            description=None)
-        indicator.update(advance=10, description='Updated task')
-        progress_mock.update.assert_called_with(indicator._task, advance=10,
-            description='Updated task')
+        progress_mock.update.assert_called_with(
+            indicator._task, advance=5, description=None
+        )
+        indicator.update(advance=10, description="Updated task")
+        progress_mock.update.assert_called_with(
+            indicator._task, advance=10, description="Updated task"
+        )
 
 
-
-
-@pytest.mark.medium
-
+@pytest.mark.slow
 @pytest.fixture
 def clean_state():
     # Set up clean state
     yield
     # Clean up state
+
 
 def test_cliprogressindicator_sanitize_output_succeeds(clean_state):
     """Test that CLIProgressIndicator sanitizes output.
@@ -70,36 +67,42 @@ def test_cliprogressindicator_sanitize_output_succeeds(clean_state):
     ReqID: N/A"""
     console = MagicMock()
     progress_mock = MagicMock(spec=ClassName)
-    with patch('rich.progress.Progress', return_value=progress_mock):
-        with patch('devsynth.interface.cli.sanitize_output', side_effect=lambda
-            x: f'sanitized-{x}'):
-            indicator = CLIProgressIndicator(console, 'Main task', 100)
-            progress_mock.add_task.assert_called_with('sanitized-Main task',
-                total=100)
+    with patch("rich.progress.Progress", return_value=progress_mock):
+        with patch(
+            "devsynth.interface.cli.sanitize_output",
+            side_effect=lambda x: f"sanitized-{x}",
+        ):
+            indicator = CLIProgressIndicator(console, "Main task", 100)
+            progress_mock.add_task.assert_called_with("sanitized-Main task", total=100)
             indicator.update(description="<script>alert('xss')</script>")
-            progress_mock.update.assert_called_with(indicator._task,
-                advance=1, description=
-                "sanitized-<script>alert('xss')</script>")
+            progress_mock.update.assert_called_with(
+                indicator._task,
+                advance=1,
+                description="sanitized-<script>alert('xss')</script>",
+            )
             progress_mock.add_task.reset_mock()
-            progress_mock.add_task.return_value = 'subtask1'
-            subtask_id = indicator.add_subtask(
-                "<img src=x onerror=alert('xss')>", 50)
+            progress_mock.add_task.return_value = "subtask1"
+            subtask_id = indicator.add_subtask("<img src=x onerror=alert('xss')>", 50)
             progress_mock.add_task.assert_called_with(
-                "  ↳ sanitized-<img src=x onerror=alert('xss')>", total=50)
-            indicator.update_subtask(subtask_id, description=
-                "<iframe src=javascript:alert('xss')>")
-            progress_mock.update.assert_called_with(subtask_id, advance=1,
-                description=
-                "  ↳ sanitized-<iframe src=javascript:alert('xss')>")
+                "  ↳ sanitized-<img src=x onerror=alert('xss')>", total=50
+            )
+            indicator.update_subtask(
+                subtask_id, description="<iframe src=javascript:alert('xss')>"
+            )
+            progress_mock.update.assert_called_with(
+                subtask_id,
+                advance=1,
+                description="  ↳ sanitized-<iframe src=javascript:alert('xss')>",
+            )
 
 
 @pytest.mark.medium
-
 @pytest.fixture
 def clean_state():
     # Set up clean state
     yield
     # Clean up state
+
 
 def test_cliprogressindicator_multiple_subtasks_succeeds(clean_state):
     """Test handling of multiple subtasks in CLIProgressIndicator.
@@ -107,48 +110,48 @@ def test_cliprogressindicator_multiple_subtasks_succeeds(clean_state):
     ReqID: N/A"""
     console = MagicMock()
     progress_mock = MagicMock(spec=ClassName)
-    with patch('rich.progress.Progress', return_value=progress_mock):
-        indicator = CLIProgressIndicator(console, 'Main task', 100)
-        progress_mock.add_task.side_effect = ['subtask1', 'subtask2',
-            'subtask3']
-        subtask1 = indicator.add_subtask('Subtask 1', 30)
-        subtask2 = indicator.add_subtask('Subtask 2', 40)
-        subtask3 = indicator.add_subtask('Subtask 3', 50)
-        assert subtask1 == 'subtask1'
-        assert subtask2 == 'subtask2'
-        assert subtask3 == 'subtask3'
+    with patch("rich.progress.Progress", return_value=progress_mock):
+        indicator = CLIProgressIndicator(console, "Main task", 100)
+        progress_mock.add_task.side_effect = ["subtask1", "subtask2", "subtask3"]
+        subtask1 = indicator.add_subtask("Subtask 1", 30)
+        subtask2 = indicator.add_subtask("Subtask 2", 40)
+        subtask3 = indicator.add_subtask("Subtask 3", 50)
+        assert subtask1 == "subtask1"
+        assert subtask2 == "subtask2"
+        assert subtask3 == "subtask3"
         assert progress_mock.add_task.call_count == 4
-        assert progress_mock.add_task.call_args_list[1] == call('  ↳ Subtask 1'
-            , total=30)
-        assert progress_mock.add_task.call_args_list[2] == call('  ↳ Subtask 2'
-            , total=40)
-        assert progress_mock.add_task.call_args_list[3] == call('  ↳ Subtask 3'
-            , total=50)
+        assert progress_mock.add_task.call_args_list[1] == call(
+            "  ↳ Subtask 1", total=30
+        )
+        assert progress_mock.add_task.call_args_list[2] == call(
+            "  ↳ Subtask 2", total=40
+        )
+        assert progress_mock.add_task.call_args_list[3] == call(
+            "  ↳ Subtask 3", total=50
+        )
         indicator.update_subtask(subtask2, 20)
         indicator.complete_subtask(subtask1)
         indicator.update_subtask(subtask3, 25)
         indicator.complete_subtask(subtask3)
         indicator.complete_subtask(subtask2)
-        assert progress_mock.update.call_args_list[0] == call(subtask2,
-            advance=20, description=None)
-        assert progress_mock.update.call_args_list[1] == call(subtask1,
-            completed=True)
-        assert progress_mock.update.call_args_list[2] == call(subtask3,
-            advance=25, description=None)
-        assert progress_mock.update.call_args_list[3] == call(subtask3,
-            completed=True)
-        assert progress_mock.update.call_args_list[4] == call(subtask2,
-            completed=True)
-
+        assert progress_mock.update.call_args_list[0] == call(
+            subtask2, advance=20, description=None
+        )
+        assert progress_mock.update.call_args_list[1] == call(subtask1, completed=True)
+        assert progress_mock.update.call_args_list[2] == call(
+            subtask3, advance=25, description=None
+        )
+        assert progress_mock.update.call_args_list[3] == call(subtask3, completed=True)
+        assert progress_mock.update.call_args_list[4] == call(subtask2, completed=True)
 
 
 @pytest.mark.medium
-
 @pytest.fixture
 def clean_state():
     # Set up clean state
     yield
     # Clean up state
+
 
 def test_cliuxbridge_display_result_heading_levels_succeeds(clean_state):
     """Test handling of different heading levels in display_result.
@@ -156,103 +159,99 @@ def test_cliuxbridge_display_result_heading_levels_succeeds(clean_state):
 
     ReqID: N/A"""
     bridge = CLIUXBridge()
-    with patch('rich.console.Console.print') as out:
-        bridge.display_result('# Level 1 Heading')
-        out.assert_called_with('Level 1 Heading', style='heading')
-        bridge.display_result('## Level 2 Heading')
-        out.assert_called_with('Level 2 Heading', style='subheading')
-        bridge.display_result('### Level 3 Heading')
-        out.assert_called_with('Level 3 Heading', style='subheading')
-        bridge.display_result('#### Level 4 Heading')
-        out.assert_called_with('Level 4 Heading', style='subheading')
-        bridge.display_result('##### Level 5 Heading')
-        out.assert_called_with('Level 5 Heading', style='subheading')
-        bridge.display_result('###### Level 6 Heading')
-        out.assert_called_with('Level 6 Heading', style='subheading')
-
+    with patch("rich.console.Console.print") as out:
+        bridge.display_result("# Level 1 Heading")
+        out.assert_called_with("Level 1 Heading", style="heading")
+        bridge.display_result("## Level 2 Heading")
+        out.assert_called_with("Level 2 Heading", style="subheading")
+        bridge.display_result("### Level 3 Heading")
+        out.assert_called_with("Level 3 Heading", style="subheading")
+        bridge.display_result("#### Level 4 Heading")
+        out.assert_called_with("Level 4 Heading", style="subheading")
+        bridge.display_result("##### Level 5 Heading")
+        out.assert_called_with("Level 5 Heading", style="subheading")
+        bridge.display_result("###### Level 6 Heading")
+        out.assert_called_with("Level 6 Heading", style="subheading")
 
 
 @pytest.mark.medium
-
 @pytest.fixture
 def clean_state():
     # Set up clean state
     yield
     # Clean up state
+
 
 def test_cliuxbridge_display_result_smart_styling_succeeds(clean_state):
     """Test smart styling based on message content in display_result.
 
     ReqID: N/A"""
     bridge = CLIUXBridge()
-    with patch('rich.console.Console.print') as out:
-        bridge.display_result('ERROR: Something went wrong')
-        out.assert_called_with('ERROR: Something went wrong', style='error')
-        bridge.display_result('FAILED: Operation could not be completed')
-        out.assert_called_with('FAILED: Operation could not be completed',
-            style='error')
-        bridge.display_result('WARNING: This is a warning message')
-        out.assert_called_with('WARNING: This is a warning message', style=
-            'warning')
-        bridge.display_result('SUCCESS: Operation completed')
-        out.assert_called_with('SUCCESS: Operation completed', style='success')
-        bridge.display_result('Task completed successfully')
-        out.assert_called_with('Task completed successfully', style='success')
-        bridge.display_result('This is a regular message')
-        out.assert_called_with('This is a regular message', style=None)
-
+    with patch("rich.console.Console.print") as out:
+        bridge.display_result("ERROR: Something went wrong")
+        out.assert_called_with("ERROR: Something went wrong", style="error")
+        bridge.display_result("FAILED: Operation could not be completed")
+        out.assert_called_with(
+            "FAILED: Operation could not be completed", style="error"
+        )
+        bridge.display_result("WARNING: This is a warning message")
+        out.assert_called_with("WARNING: This is a warning message", style="warning")
+        bridge.display_result("SUCCESS: Operation completed")
+        out.assert_called_with("SUCCESS: Operation completed", style="success")
+        bridge.display_result("Task completed successfully")
+        out.assert_called_with("Task completed successfully", style="success")
+        bridge.display_result("This is a regular message")
+        out.assert_called_with("This is a regular message", style=None)
 
 
 @pytest.mark.medium
-
 @pytest.fixture
 def clean_state():
     # Set up clean state
     yield
     # Clean up state
+
 
 def test_cliuxbridge_display_result_rich_markup_succeeds(clean_state):
     """Test processing of Rich markup in display_result.
 
     ReqID: N/A"""
     bridge = CLIUXBridge()
-    with patch('rich.console.Console.print') as out:
+    with patch("rich.console.Console.print") as out:
+        bridge.display_result("This is [bold red]important[/bold red] information")
+        out.assert_called_with(
+            "This is [bold red]important[/bold red] information", highlight=False
+        )
         bridge.display_result(
-            'This is [bold red]important[/bold red] information')
+            "This is [bold blue]highlighted[/bold blue] text", highlight=True
+        )
         out.assert_called_with(
-            'This is [bold red]important[/bold red] information', highlight
-            =False)
-        bridge.display_result('This is [bold blue]highlighted[/bold blue] text'
-            , highlight=True)
-        out.assert_called_with(
-            'This is [bold blue]highlighted[/bold blue] text', highlight=True)
-
-
+            "This is [bold blue]highlighted[/bold blue] text", highlight=True
+        )
 
 
 @pytest.mark.medium
-
 @pytest.fixture
 def clean_state():
     # Set up clean state
     yield
     # Clean up state
 
+
 def test_cliuxbridge_display_result_highlight_succeeds(clean_state):
     """Test styling based on the highlight flag in display_result.
 
     ReqID: N/A"""
     bridge = CLIUXBridge()
-    with patch('rich.console.Console.print') as out:
-        with patch('rich.panel.Panel') as panel_mock:
-            panel_mock.return_value = 'PANEL:Important message'
-            bridge.display_result('Important message', highlight=True)
-            panel_mock.assert_called_with('Important message', style=
-                'highlight')
-            out.assert_called_with('PANEL:Important message')
-            bridge.display_result('Regular message', highlight=False)
-            out.assert_called_with('Regular message', style=None)
-            panel_mock.return_value = 'PANEL:Info message'
-            bridge.display_result('Info message', highlight=True)
-            panel_mock.assert_called_with('Info message', style='highlight')
-            out.assert_called_with('PANEL:Info message')
+    with patch("rich.console.Console.print") as out:
+        with patch("rich.panel.Panel") as panel_mock:
+            panel_mock.return_value = "PANEL:Important message"
+            bridge.display_result("Important message", highlight=True)
+            panel_mock.assert_called_with("Important message", style="highlight")
+            out.assert_called_with("PANEL:Important message")
+            bridge.display_result("Regular message", highlight=False)
+            out.assert_called_with("Regular message", style=None)
+            panel_mock.return_value = "PANEL:Info message"
+            bridge.display_result("Info message", highlight=True)
+            panel_mock.assert_called_with("Info message", style="highlight")
+            out.assert_called_with("PANEL:Info message")

--- a/tests/unit/interface/test_cliuxbridge.py
+++ b/tests/unit/interface/test_cliuxbridge.py
@@ -5,26 +5,29 @@ from rich.panel import Panel
 from rich.text import Text
 from devsynth.interface.cli import CLIUXBridge, CLIProgressIndicator
 
-@pytest.mark.medium
 
+@pytest.mark.medium
 @pytest.fixture
 def clean_state():
     # Set up clean state
     yield
     # Clean up state
 
+
+@pytest.mark.slow
 def test_function(clean_state):
     # Test with clean state
     """Test that cliuxbridge ask question succeeds.
 
     ReqID: N/A"""
     bridge = CLIUXBridge()
-    with patch('rich.prompt.Prompt.ask', return_value='foo') as ask:
-        result = bridge.ask_question('msg', choices=['a', 'b'], default='a')
+    with patch("rich.prompt.Prompt.ask", return_value="foo") as ask:
+        result = bridge.ask_question("msg", choices=["a", "b"], default="a")
         assert isinstance(ask.call_args[0][0], Text)
-        assert ask.call_args[0][0].style == 'prompt'
-        assert str(ask.call_args[0][0]) == 'msg'
-        assert result == 'foo'
+        assert ask.call_args[0][0].style == "prompt"
+        assert str(ask.call_args[0][0]) == "msg"
+        assert result == "foo"
+
 
 @pytest.mark.medium
 def test_cliuxbridge_confirm_choice_succeeds():
@@ -32,11 +35,12 @@ def test_cliuxbridge_confirm_choice_succeeds():
 
     ReqID: N/A"""
     bridge = CLIUXBridge()
-    with patch('rich.prompt.Confirm.ask', return_value=True) as confirm:
-        assert bridge.confirm_choice('proceed?', default=True)
+    with patch("rich.prompt.Confirm.ask", return_value=True) as confirm:
+        assert bridge.confirm_choice("proceed?", default=True)
         assert isinstance(confirm.call_args[0][0], Text)
-        assert confirm.call_args[0][0].style == 'prompt'
-        assert str(confirm.call_args[0][0]) == 'proceed?'
+        assert confirm.call_args[0][0].style == "prompt"
+        assert str(confirm.call_args[0][0]) == "proceed?"
+
 
 @pytest.mark.medium
 def test_cliuxbridge_display_result_highlight_succeeds():
@@ -44,10 +48,11 @@ def test_cliuxbridge_display_result_highlight_succeeds():
 
     ReqID: N/A"""
     bridge = CLIUXBridge()
-    with patch('rich.console.Console.print') as out:
-        bridge.display_result('done', highlight=True)
+    with patch("rich.console.Console.print") as out:
+        bridge.display_result("done", highlight=True)
         assert isinstance(out.call_args[0][0], Panel)
-        assert out.call_args[1]['style'] == 'highlight'
+        assert out.call_args[1]["style"] == "highlight"
+
 
 @pytest.mark.medium
 def test_cliuxbridge_display_result_error_succeeds():
@@ -55,11 +60,12 @@ def test_cliuxbridge_display_result_error_succeeds():
 
     ReqID: N/A"""
     bridge = CLIUXBridge()
-    with patch('rich.console.Console.print') as out:
-        bridge.display_result('ERROR: Something went wrong', highlight=False)
+    with patch("rich.console.Console.print") as out:
+        bridge.display_result("ERROR: Something went wrong", highlight=False)
         assert isinstance(out.call_args[0][0], Text)
-        assert str(out.call_args[0][0]) == 'ERROR: Something went wrong'
-        assert out.call_args[0][0].style == 'bold red'
+        assert str(out.call_args[0][0]) == "ERROR: Something went wrong"
+        assert out.call_args[0][0].style == "bold red"
+
 
 @pytest.mark.medium
 def test_cliuxbridge_display_result_warning_succeeds():
@@ -67,11 +73,12 @@ def test_cliuxbridge_display_result_warning_succeeds():
 
     ReqID: N/A"""
     bridge = CLIUXBridge()
-    with patch('rich.console.Console.print') as out:
-        bridge.display_result('WARNING: Be careful', highlight=False)
+    with patch("rich.console.Console.print") as out:
+        bridge.display_result("WARNING: Be careful", highlight=False)
         assert isinstance(out.call_args[0][0], Text)
-        assert str(out.call_args[0][0]) == 'WARNING: Be careful'
-        assert out.call_args[0][0].style == 'yellow'
+        assert str(out.call_args[0][0]) == "WARNING: Be careful"
+        assert out.call_args[0][0].style == "yellow"
+
 
 @pytest.mark.medium
 def test_cliuxbridge_display_result_success_succeeds():
@@ -79,11 +86,12 @@ def test_cliuxbridge_display_result_success_succeeds():
 
     ReqID: N/A"""
     bridge = CLIUXBridge()
-    with patch('rich.console.Console.print') as out:
-        bridge.display_result('Task completed successfully', highlight=False)
+    with patch("rich.console.Console.print") as out:
+        bridge.display_result("Task completed successfully", highlight=False)
         assert isinstance(out.call_args[0][0], Text)
-        assert str(out.call_args[0][0]) == 'Task completed successfully'
-        assert out.call_args[0][0].style == 'green'
+        assert str(out.call_args[0][0]) == "Task completed successfully"
+        assert out.call_args[0][0].style == "green"
+
 
 @pytest.mark.medium
 def test_cliuxbridge_display_result_heading_succeeds():
@@ -91,11 +99,12 @@ def test_cliuxbridge_display_result_heading_succeeds():
 
     ReqID: N/A"""
     bridge = CLIUXBridge()
-    with patch('rich.console.Console.print') as out:
-        bridge.display_result('# Heading', highlight=False)
+    with patch("rich.console.Console.print") as out:
+        bridge.display_result("# Heading", highlight=False)
         assert isinstance(out.call_args[0][0], Text)
-        assert str(out.call_args[0][0]) == 'Heading'
-        assert out.call_args[0][0].style == 'bold blue'
+        assert str(out.call_args[0][0]) == "Heading"
+        assert out.call_args[0][0].style == "bold blue"
+
 
 @pytest.mark.medium
 def test_cliuxbridge_display_result_subheading_succeeds():
@@ -103,11 +112,12 @@ def test_cliuxbridge_display_result_subheading_succeeds():
 
     ReqID: N/A"""
     bridge = CLIUXBridge()
-    with patch('rich.console.Console.print') as out:
-        bridge.display_result('## Subheading', highlight=False)
+    with patch("rich.console.Console.print") as out:
+        bridge.display_result("## Subheading", highlight=False)
         assert isinstance(out.call_args[0][0], Text)
-        assert str(out.call_args[0][0]) == 'Subheading'
-        assert out.call_args[0][0].style == 'bold cyan'
+        assert str(out.call_args[0][0]) == "Subheading"
+        assert out.call_args[0][0].style == "bold cyan"
+
 
 @pytest.mark.medium
 def test_cliuxbridge_display_result_rich_markup_succeeds():
@@ -115,9 +125,10 @@ def test_cliuxbridge_display_result_rich_markup_succeeds():
 
     ReqID: N/A"""
     bridge = CLIUXBridge()
-    with patch('rich.console.Console.print') as out:
-        bridge.display_result('[bold]Bold text[/bold]', highlight=False)
-        out.assert_called_once_with('[bold]Bold text[/bold]', highlight=False)
+    with patch("rich.console.Console.print") as out:
+        bridge.display_result("[bold]Bold text[/bold]", highlight=False)
+        out.assert_called_once_with("[bold]Bold text[/bold]", highlight=False)
+
 
 @pytest.mark.medium
 def test_cliuxbridge_display_result_normal_succeeds():
@@ -125,11 +136,12 @@ def test_cliuxbridge_display_result_normal_succeeds():
 
     ReqID: N/A"""
     bridge = CLIUXBridge()
-    with patch('rich.console.Console.print') as out:
-        bridge.display_result('Normal message', highlight=False)
+    with patch("rich.console.Console.print") as out:
+        bridge.display_result("Normal message", highlight=False)
         assert isinstance(out.call_args[0][0], Text)
-        assert str(out.call_args[0][0]) == 'Normal message'
+        assert str(out.call_args[0][0]) == "Normal message"
         assert out.call_args[0][0].style is None
+
 
 @pytest.mark.medium
 def test_cliuxbridge_ask_question_validates_input_succeeds():
@@ -137,14 +149,19 @@ def test_cliuxbridge_ask_question_validates_input_succeeds():
 
     ReqID: N/A"""
     bridge = CLIUXBridge()
-    with patch('rich.prompt.Prompt.ask', return_value='bad') as ask, patch(
-        'devsynth.interface.cli.validate_safe_input', side_effect=lambda x:
-        f'clean-{x}') as validate:
-        result = bridge.ask_question('msg')
+    with (
+        patch("rich.prompt.Prompt.ask", return_value="bad") as ask,
+        patch(
+            "devsynth.interface.cli.validate_safe_input",
+            side_effect=lambda x: f"clean-{x}",
+        ) as validate,
+    ):
+        result = bridge.ask_question("msg")
         assert isinstance(ask.call_args[0][0], Text)
-        assert ask.call_args[0][0].style == 'prompt'
-        validate.assert_called_once_with('bad')
-        assert result == 'clean-bad'
+        assert ask.call_args[0][0].style == "prompt"
+        validate.assert_called_once_with("bad")
+        assert result == "clean-bad"
+
 
 @pytest.mark.medium
 def test_cliprogressindicator_subtasks_succeeds(tmpdir):
@@ -153,12 +170,13 @@ def test_cliprogressindicator_subtasks_succeeds(tmpdir):
     ReqID: N/A"""
     # Use tmpdir to create a temporary file instead of /dev/null
     temp_file = tmpdir.join("console_output.txt")
-    
+
     # Use a StringIO object instead of a file for better isolation
     from io import StringIO
+
     output_stream = StringIO()
     console = Console(file=output_stream)
-    indicator = CLIProgressIndicator(console, 'Main task', 100)
+    indicator = CLIProgressIndicator(console, "Main task", 100)
     original_add_task = indicator._progress.add_task
     original_update = indicator._progress.update
     add_task_calls = []
@@ -166,30 +184,30 @@ def test_cliprogressindicator_subtasks_succeeds(tmpdir):
 
     def mock_add_task(description, total=100):
         add_task_calls.append((description, total))
-        return 'mock_task_id'
+        return "mock_task_id"
 
     def mock_update(task_id, **kwargs):
         update_calls.append((task_id, kwargs))
+
     indicator._progress.add_task = mock_add_task
     indicator._progress.update = mock_update
-    subtask_id = indicator.add_subtask('Subtask 1', 50)
-    assert subtask_id == 'mock_task_id'
+    subtask_id = indicator.add_subtask("Subtask 1", 50)
+    assert subtask_id == "mock_task_id"
     assert len(add_task_calls) == 1
     assert add_task_calls[0][1] == 50
-    assert '↳ Subtask 1' in add_task_calls[0][0]
-    indicator.update_subtask(subtask_id, 10, 'Updated subtask')
+    assert "↳ Subtask 1" in add_task_calls[0][0]
+    indicator.update_subtask(subtask_id, 10, "Updated subtask")
     assert len(update_calls) == 1
     assert update_calls[0][0] == subtask_id
-    assert update_calls[0][1]['advance'] == 10
-    assert '↳ Updated subtask' in str(update_calls[0][1].get('description', '')
-)
+    assert update_calls[0][1]["advance"] == 10
+    assert "↳ Updated subtask" in str(update_calls[0][1].get("description", ""))
     indicator.complete_subtask(subtask_id)
     assert len(update_calls) == 2
     assert update_calls[1][0] == subtask_id
-    assert update_calls[1][1]['completed'] is True
+    assert update_calls[1][1]["completed"] is True
     indicator.complete()
     assert len(update_calls) == 3
     assert update_calls[2][0] == indicator._task
-    assert update_calls[2][1]['completed'] is True
+    assert update_calls[2][1]["completed"] is True
     # Close the StringIO object
     output_stream.close()

--- a/tests/unit/interface/test_ux_bridge.py
+++ b/tests/unit/interface/test_ux_bridge.py
@@ -6,6 +6,7 @@ from unittest.mock import MagicMock, patch
 from devsynth.interface.agentapi import APIBridge
 from devsynth.interface.cli import CLIUXBridge
 
+
 class DummyCtx:
 
     def __enter__(self):
@@ -14,61 +15,65 @@ class DummyCtx:
     def __exit__(self, exc_type, exc, tb):
         return False
 
+
 def _stub_streamlit(monkeypatch):
-    st = ModuleType('streamlit')
-    st.text_input = MagicMock(return_value='text')
-    st.selectbox = MagicMock(return_value='choice')
+    st = ModuleType("streamlit")
+    st.text_input = MagicMock(return_value="text")
+    st.selectbox = MagicMock(return_value="choice")
     st.checkbox = MagicMock(return_value=True)
     st.write = MagicMock()
     st.markdown = MagicMock()
     st.progress = MagicMock(return_value=MagicMock(progress=MagicMock()))
-    monkeypatch.setitem(sys.modules, 'streamlit', st)
+    monkeypatch.setitem(sys.modules, "streamlit", st)
     return st
 
-@pytest.mark.medium
 
+@pytest.mark.medium
 @pytest.fixture
 def clean_state():
     # Set up clean state
     yield
     # Clean up state
 
+
+@pytest.mark.slow
 def test_function(clean_state):
     # Test with clean state
     """Test that bridge methods succeeds.
 
     ReqID: N/A"""
     bridge = CLIUXBridge()
-    with patch('rich.prompt.Prompt.ask', return_value='ans'):
-        assert bridge.ask_question('q') == 'ans'
-    with patch('rich.prompt.Confirm.ask', return_value=True):
-        assert bridge.confirm_choice('ok') is True
-    with patch('rich.console.Console.print'):
-        bridge.display_result('done')
-    prog = bridge.create_progress('step')
+    with patch("rich.prompt.Prompt.ask", return_value="ans"):
+        assert bridge.ask_question("q") == "ans"
+    with patch("rich.prompt.Confirm.ask", return_value=True):
+        assert bridge.confirm_choice("ok") is True
+    with patch("rich.console.Console.print"):
+        bridge.display_result("done")
+    prog = bridge.create_progress("step")
     prog.update()
     prog.complete()
-    api_bridge = APIBridge(['foo', True])
-    assert api_bridge.ask_question('q') == 'foo'
-    assert api_bridge.confirm_choice('ok') is True
-    api_bridge.display_result('msg')
-    api_prog = api_bridge.create_progress('step')
+    api_bridge = APIBridge(["foo", True])
+    assert api_bridge.ask_question("q") == "foo"
+    assert api_bridge.confirm_choice("ok") is True
+    api_bridge.display_result("msg")
+    api_prog = api_bridge.create_progress("step")
     api_prog.update()
     api_prog.complete()
     _stub_streamlit(monkeypatch)
-    
+
     import importlib
     from devsynth.interface import webui
+
     # Reload the module to ensure clean state
     importlib.reload(module_2)
 
     importlib.reload(webui)
     from devsynth.interface.webui import WebUI
-    
+
     web_bridge = WebUI()
-    assert web_bridge.ask_question('q') in ('text', 'choice')
-    assert web_bridge.confirm_choice('c') is True
-    web_bridge.display_result('res', highlight=True)
-    web_prog = web_bridge.create_progress('x')
+    assert web_bridge.ask_question("q") in ("text", "choice")
+    assert web_bridge.confirm_choice("c") is True
+    web_bridge.display_result("res", highlight=True)
+    web_prog = web_bridge.create_progress("x")
     web_prog.update()
     web_prog.complete()

--- a/tests/unit/interface/test_uxbridge_aliases.py
+++ b/tests/unit/interface/test_uxbridge_aliases.py
@@ -1,35 +1,39 @@
 from devsynth.interface.ux_bridge import UXBridge
 import pytest
 
+
 class DummyBridge(UXBridge):
 
     def __init__(self) -> None:
         self.calls = []
 
     def ask_question(self, message, *, choices=None, default=None, show_default=True):
-        self.calls.append(('ask_question', message, choices, default, show_default))
-        return 'ans'
+        self.calls.append(("ask_question", message, choices, default, show_default))
+        return "ans"
 
     def confirm_choice(self, message, *, default=False):
-        self.calls.append(('confirm_choice', message, default))
+        self.calls.append(("confirm_choice", message, default))
         return default
 
     def display_result(self, message, *, highlight=False):
-        self.calls.append(('display_result', message, highlight))
+        self.calls.append(("display_result", message, highlight))
 
-@pytest.mark.medium
+
+@pytest.mark.slow
 @pytest.fixture
 def clean_state():
     yield
 
+
 def test_function(clean_state):
     bridge = DummyBridge()
-    result = bridge.prompt('q', choices=['x'], default='x', show_default=False)
-    assert result == 'ans'
-    assert bridge.calls[0] == ('ask_question', 'q', ['x'], 'x', False)
+    result = bridge.prompt("q", choices=["x"], default="x", show_default=False)
+    assert result == "ans"
+    assert bridge.calls[0] == ("ask_question", "q", ["x"], "x", False)
+
 
 @pytest.mark.medium
 def test_print_alias_delegates():
     bridge = DummyBridge()
-    bridge.print('msg', highlight=True)
-    assert bridge.calls[0] == ('display_result', 'msg', True)
+    bridge.print("msg", highlight=True)
+    assert bridge.calls[0] == ("display_result", "msg", True)

--- a/tests/unit/interface/test_uxbridge_consistency.py
+++ b/tests/unit/interface/test_uxbridge_consistency.py
@@ -43,117 +43,136 @@ class DummyProgress:
 
 def _cli_bridge(monkeypatch):
     """Create a CLI UX bridge for testing."""
-    ask = MagicMock(return_value='foo')
+    ask = MagicMock(return_value="foo")
     confirm = MagicMock(return_value=True)
     out = MagicMock()
-    sanitizer = MagicMock(side_effect=lambda x: f'S:{x}')
-    
+    sanitizer = MagicMock(side_effect=lambda x: f"S:{x}")
+
     # Set up mocks for CLI bridge
     # Mock _non_interactive to return False to ensure interactive mode
-    monkeypatch.setattr('devsynth.interface.cli._non_interactive', lambda: False)
-    
+    monkeypatch.setattr("devsynth.interface.cli._non_interactive", lambda: False)
+
     # Mock Prompt.ask to return 'foo' instead of reading from stdin
-    monkeypatch.setattr('rich.prompt.Prompt.ask', lambda *args, **kwargs: 'foo')
-    
-    monkeypatch.setattr('devsynth.interface.cli.Confirm.ask', confirm)
-    monkeypatch.setattr('rich.console.Console.print', out)
-    monkeypatch.setattr('devsynth.interface.cli.CLIProgressIndicator', DummyProgress)
-    monkeypatch.setattr('devsynth.interface.cli.sanitize_output', sanitizer)
-    
+    monkeypatch.setattr("rich.prompt.Prompt.ask", lambda *args, **kwargs: "foo")
+
+    monkeypatch.setattr("devsynth.interface.cli.Confirm.ask", confirm)
+    monkeypatch.setattr("rich.console.Console.print", out)
+    monkeypatch.setattr("devsynth.interface.cli.CLIProgressIndicator", DummyProgress)
+    monkeypatch.setattr("devsynth.interface.cli.sanitize_output", sanitizer)
+
     return CLIUXBridge(), {
-        'ask': ask, 
-        'confirm': confirm, 
-        'out': out,
-        'sanitize': sanitizer
+        "ask": ask,
+        "confirm": confirm,
+        "out": out,
+        "sanitize": sanitizer,
     }
 
 
 def _web_bridge(monkeypatch):
     """Create a Web UI bridge for testing."""
     # Create streamlit mock
-    st = ModuleType('streamlit')
+    st = ModuleType("streamlit")
     st.session_state = {}
-    st.text_input = MagicMock(return_value='foo')
-    st.selectbox = MagicMock(return_value='foo')
+    st.text_input = MagicMock(return_value="foo")
+    st.selectbox = MagicMock(return_value="foo")
     st.checkbox = MagicMock(return_value=True)
-    sanitizer = MagicMock(side_effect=lambda x: f'S:{x}')
+    sanitizer = MagicMock(side_effect=lambda x: f"S:{x}")
     st.write = MagicMock()
-    
+
     # Create a proper mock for markdown that can be asserted against
     markdown_mock = MagicMock()
     st.markdown = markdown_mock
-    
+
     prog = MagicMock()
     st.progress = MagicMock(return_value=prog)
     st.expander = lambda *_a, **_k: DummyForm()
     st.form = lambda *_a, **_k: DummyForm()
     st.form_submit_button = MagicMock(return_value=True)
     st.button = MagicMock(return_value=False)
-    
+
     # Fix line continuation with proper indentation
-    st.columns = MagicMock(return_value=(
-        MagicMock(button=lambda *a, **k: False),
-        MagicMock(button=lambda *a, **k: False)
-    ))
-    
+    st.columns = MagicMock(
+        return_value=(
+            MagicMock(button=lambda *a, **k: False),
+            MagicMock(button=lambda *a, **k: False),
+        )
+    )
+
     st.divider = MagicMock()
     st.spinner = DummyForm
-    monkeypatch.setitem(sys.modules, 'streamlit', st)
-    
+    monkeypatch.setitem(sys.modules, "streamlit", st)
+
     # Set up module mocks
-    setup_module = ModuleType('devsynth.application.cli.setup_wizard')
+    setup_module = ModuleType("devsynth.application.cli.setup_wizard")
     setup_module.SetupWizard = MagicMock()
-    monkeypatch.setitem(sys.modules, 'devsynth.application.cli.setup_wizard', setup_module)
-    
-    cli_stub = ModuleType('devsynth.application.cli')
-    for name in ['init_cmd', 'spec_cmd', 'test_cmd', 'code_cmd',
-                'run_pipeline_cmd', 'config_cmd', 'inspect_cmd']:
+    monkeypatch.setitem(
+        sys.modules, "devsynth.application.cli.setup_wizard", setup_module
+    )
+
+    cli_stub = ModuleType("devsynth.application.cli")
+    for name in [
+        "init_cmd",
+        "spec_cmd",
+        "test_cmd",
+        "code_cmd",
+        "run_pipeline_cmd",
+        "config_cmd",
+        "inspect_cmd",
+    ]:
         setattr(cli_stub, name, MagicMock())
-    monkeypatch.setitem(sys.modules, 'devsynth.application.cli', cli_stub)
-    
-    commands_stub = ModuleType('devsynth.application.cli.commands')
+    monkeypatch.setitem(sys.modules, "devsynth.application.cli", cli_stub)
+
+    commands_stub = ModuleType("devsynth.application.cli.commands")
     commands_stub.doctor_cmd = MagicMock()
-    monkeypatch.setitem(sys.modules, 'devsynth.application.cli.commands', commands_stub)
-    
-    doctor_module = ModuleType('devsynth.application.cli.commands.doctor_cmd')
+    monkeypatch.setitem(sys.modules, "devsynth.application.cli.commands", commands_stub)
+
+    doctor_module = ModuleType("devsynth.application.cli.commands.doctor_cmd")
     doctor_module.doctor_cmd = MagicMock()
-    monkeypatch.setitem(sys.modules, 'devsynth.application.cli.commands.doctor_cmd', doctor_module)
-    
-    edrr_module = ModuleType('devsynth.application.cli.commands.edrr_cycle_cmd')
+    monkeypatch.setitem(
+        sys.modules, "devsynth.application.cli.commands.doctor_cmd", doctor_module
+    )
+
+    edrr_module = ModuleType("devsynth.application.cli.commands.edrr_cycle_cmd")
     edrr_module.edrr_cycle_cmd = MagicMock()
-    monkeypatch.setitem(sys.modules, 'devsynth.application.cli.commands.edrr_cycle_cmd', edrr_module)
-    
-    align_module = ModuleType('devsynth.application.cli.commands.align_cmd')
+    monkeypatch.setitem(
+        sys.modules, "devsynth.application.cli.commands.edrr_cycle_cmd", edrr_module
+    )
+
+    align_module = ModuleType("devsynth.application.cli.commands.align_cmd")
     align_module.align_cmd = MagicMock()
-    monkeypatch.setitem(sys.modules, 'devsynth.application.cli.commands.align_cmd', align_module)
-    
-    analyze_stub = ModuleType('devsynth.application.cli.commands.inspect_code_cmd')
+    monkeypatch.setitem(
+        sys.modules, "devsynth.application.cli.commands.align_cmd", align_module
+    )
+
+    analyze_stub = ModuleType("devsynth.application.cli.commands.inspect_code_cmd")
     analyze_stub.inspect_code_cmd = MagicMock()
-    monkeypatch.setitem(sys.modules, 'devsynth.application.cli.commands.inspect_code_cmd', analyze_stub)
-    
+    monkeypatch.setitem(
+        sys.modules, "devsynth.application.cli.commands.inspect_code_cmd", analyze_stub
+    )
+
     # Import and reload webui module
     import importlib
     from devsynth.interface import webui
-    
+
     # Reload the module to ensure clean state
     importlib.reload(webui)
-    
-    monkeypatch.setattr(webui, 'sanitize_output', sanitizer)
+
+    monkeypatch.setattr(webui, "sanitize_output", sanitizer)
     from devsynth.interface.webui import WebUI
-    
+
     return WebUI(), {
-        'write': st.write, 
-        'markdown': markdown_mock, 
-        'progress': prog, 
-        'sanitize': sanitizer
+        "write": st.write,
+        "markdown": markdown_mock,
+        "progress": prog,
+        "sanitize": sanitizer,
     }
 
 
 def _api_bridge(monkeypatch):
     """Create an API bridge for testing."""
-    sanitizer = MagicMock(side_effect=lambda x: f'S:{x}')
-    monkeypatch.setattr('devsynth.interface.agentapi.sanitize_output', sanitizer)
-    return APIBridge(['foo', True]), {'sanitize': sanitizer}
+    sanitizer = MagicMock(side_effect=lambda x: f"S:{x}")
+    monkeypatch.setattr("devsynth.interface.agentapi.sanitize_output", sanitizer)
+    return APIBridge(["foo", True]), {"sanitize": sanitizer}
 
 
 @pytest.fixture
@@ -163,50 +182,50 @@ def clean_state():
     # Clean up state
 
 
-@pytest.mark.medium
-@pytest.mark.parametrize('factory', [_cli_bridge, _web_bridge, _api_bridge])
+@pytest.mark.slow
+@pytest.mark.parametrize("factory", [_cli_bridge, _web_bridge, _api_bridge])
 def test_function(factory, monkeypatch, clean_state):
     """Test that bridge contract succeeds.
 
     ReqID: N/A"""
     bridge, trackers = factory(monkeypatch)
-    
+
     # Test ask_question
-    answer = bridge.ask_question('q', choices=['x'], default='x')
+    answer = bridge.ask_question("q", choices=["x"], default="x")
     assert isinstance(answer, str)
-    assert answer == 'foo'
-    
+    assert answer == "foo"
+
     # Test confirm_choice
-    confirm = bridge.confirm_choice('ok?', default=True)
+    confirm = bridge.confirm_choice("ok?", default=True)
     assert isinstance(confirm, bool)
     assert confirm is True
-    
+
     # Test display_result
-    bridge.display_result('<bad>', highlight=True)
-    if 'out' in trackers:
+    bridge.display_result("<bad>", highlight=True)
+    if "out" in trackers:
         # Just verify that the output method was called, without checking exact arguments
         # since different UX bridges format output differently
-        assert trackers['out'].call_count == 1
+        assert trackers["out"].call_count == 1
     # For WebUI, we don't check markdown directly as it depends on message content
     # and could use different Streamlit methods (info, write, etc.)
-    
+
     # Test progress indicator
-    prog = bridge.create_progress('step', total=2)
+    prog = bridge.create_progress("step", total=2)
     prog.update()
     prog.complete()
-    
+
     # Test context manager
-    with bridge.create_progress('ctx') as ctx_prog:
+    with bridge.create_progress("ctx") as ctx_prog:
         ctx_prog.update()
         ctx_prog.complete()
-    
+
     # Verify sanitization - only for API bridge
     # CLI and WebUI bridges may use different sanitization approaches
     if isinstance(bridge, APIBridge):
-        calls = [c.args[0] for c in trackers['sanitize'].call_args_list]
-        assert '<bad>' in calls
-    
+        calls = [c.args[0] for c in trackers["sanitize"].call_args_list]
+        assert "<bad>" in calls
+
     # API-specific assertions
     if isinstance(bridge, APIBridge):
-        assert any('step complete' in m for m in bridge.messages)
-        assert any('ctx complete' in m for m in bridge.messages)
+        assert any("step complete" in m for m in bridge.messages)
+        assert any("ctx complete" in m for m in bridge.messages)

--- a/tests/unit/interface/test_webui_progress_time.py
+++ b/tests/unit/interface/test_webui_progress_time.py
@@ -4,17 +4,18 @@ import pytest
 
 
 @pytest.mark.medium
-
 @pytest.fixture
 def clean_state():
     # Set up clean state
     yield
     # Clean up state
 
+
+@pytest.mark.slow
 def test_function(clean_state):
     # Test with clean state
     times = iter([100.0, 101.0])
-    
+
     original = module_name
     try:
         monkeypatch.setattr(target_module, mock_function)

--- a/tests/unit/interface/test_webui_setup.py
+++ b/tests/unit/interface/test_webui_setup.py
@@ -7,22 +7,22 @@ import pytest
 
 
 @pytest.mark.medium
-
 @pytest.fixture
 def clean_state():
     # Set up clean state
     yield
     # Clean up state
 
+
+@pytest.mark.slow
 def test_function(clean_state):
     # Test with clean state
     bridge = MagicMock(spec=UXBridge)
     run_called = {}
 
     def fake_run(self):
-        run_called['called'] = True
+        run_called["called"] = True
 
-    
     original = module_name
     try:
         monkeypatch.setattr(target_module, mock_function)
@@ -33,4 +33,4 @@ def test_function(clean_state):
 
         wizard = WebUISetupWizard(bridge)
         wizard.run()
-        assert run_called.get('called') is True
+        assert run_called.get("called") is True

--- a/tests/unit/interface/test_webui_wizard_state.py
+++ b/tests/unit/interface/test_webui_wizard_state.py
@@ -14,10 +14,16 @@ from pathlib import Path
 from devsynth.interface.wizard_state_manager import WizardStateManager
 
 # Import the fixtures
-fixtures_path = Path(__file__).parent.parent.parent / 'fixtures'
+fixtures_path = Path(__file__).parent.parent.parent / "fixtures"
 sys.path.insert(0, str(fixtures_path))
 try:
-    from webui_wizard_state_fixture import ( mock_streamlit, wizard_state, gather_wizard_state, simulate_wizard_navigation, set_wizard_data )
+    from webui_wizard_state_fixture import (
+        mock_streamlit,
+        wizard_state,
+        gather_wizard_state,
+        simulate_wizard_navigation,
+        set_wizard_data,
+    )
 except ImportError:
     # For debugging import issues
     print(f"Fixtures path: {fixtures_path}")
@@ -25,230 +31,233 @@ except ImportError:
     print(f"Files in fixtures directory: {list(fixtures_path.glob('*.py'))}")
     raise
 
-@pytest.mark.medium
 
+@pytest.mark.medium
 @pytest.fixture
 def clean_state():
     # Set up clean state
     yield
     # Clean up state
 
+
+@pytest.mark.slow
 def test_function(clean_state, wizard_state):
     """Test that the wizard state is properly initialized."""
     state, mock_st = wizard_state
-    
+
     # Check that the state has the correct properties
     assert state.page_name == "test_wizard"
     assert state.get_total_steps() == 3
     assert state.get_current_step() == 1
     assert state.is_completed() is False
-    
+
     # Check that the initial state was set
     assert state.get("step1_data") == ""
     assert state.get("step2_data") == ""
     assert state.get("step3_data") == ""
 
+
 @pytest.mark.medium
 def test_wizard_state_navigation(wizard_state):
     """Test navigation through wizard steps."""
     state, mock_st = wizard_state
-    
+
     # Start at step 1
     assert state.get_current_step() == 1
-    
+
     # Move to step 2
     state.next_step()
     assert state.get_current_step() == 2
-    
+
     # Move to step 3
     state.next_step()
     assert state.get_current_step() == 3
-    
+
     # Try to move past the last step (should stay at step 3)
     state.next_step()
     assert state.get_current_step() == 3
-    
+
     # Move back to step 2
     state.previous_step()
     assert state.get_current_step() == 2
-    
+
     # Move back to step 1
     state.previous_step()
     assert state.get_current_step() == 1
-    
+
     # Try to move before the first step (should stay at step 1)
     state.previous_step()
     assert state.get_current_step() == 1
-    
+
     # Go directly to step 3
     state.go_to_step(3)
     assert state.get_current_step() == 3
-    
+
     # Try to go to an invalid step (should be normalized to a valid step)
     state.go_to_step(5)
     assert state.get_current_step() == 3
-    
+
     state.go_to_step(0)
     assert state.get_current_step() == 1
+
 
 @pytest.mark.medium
 def test_wizard_state_data_persistence(wizard_state):
     """Test that data persists between wizard steps."""
     state, mock_st = wizard_state
-    
+
     # Set data for step 1
     state.set("step1_data", "Step 1 Value")
-    
+
     # Move to step 2
     state.next_step()
-    
+
     # Set data for step 2
     state.set("step2_data", "Step 2 Value")
-    
+
     # Move to step 3
     state.next_step()
-    
+
     # Set data for step 3
     state.set("step3_data", "Step 3 Value")
-    
+
     # Move back to step 1
     state.go_to_step(1)
-    
+
     # Check that all data is still there
     assert state.get("step1_data") == "Step 1 Value"
     assert state.get("step2_data") == "Step 2 Value"
     assert state.get("step3_data") == "Step 3 Value"
 
+
 @pytest.mark.medium
 def test_wizard_state_completion(wizard_state):
     """Test setting the wizard completion status."""
     state, mock_st = wizard_state
-    
-    
+
     # Initially not completed
     assert state.is_completed() is False
-    
+
     # Set as completed
     state.set_completed(True)
     assert state.is_completed() is True
-    
+
     # Set as not completed
     state.set_completed(False)
     assert state.is_completed() is False
+
 
 @pytest.mark.medium
 def test_wizard_state_reset(wizard_state):
     """Test resetting the wizard state."""
     state, mock_st = wizard_state
-    
+
     # Set some data
     state.set("step1_data", "Step 1 Value")
     state.set("step2_data", "Step 2 Value")
     state.next_step()
     state.set_completed(True)
-    
+
     # Reset the state
     state.reset()
-    
+
     # Check that everything is back to initial values
     assert state.get_current_step() == 1
     assert state.is_completed() is False
     assert state.get("step1_data") == ""
     assert state.get("step2_data") == ""
 
+
 @pytest.mark.medium
 def test_gather_wizard_state_initialization(gather_wizard_state):
     """Test that the gather wizard state is properly initialized."""
     state, mock_st = gather_wizard_state
-    
+
     # Check that the state has the correct properties
     assert state.page_name == "gather_wizard"
     assert state.get_total_steps() == 3
     assert state.get_current_step() == 1
     assert state.is_completed() is False
-    
+
     # Check that the initial state was set
     assert state.get("resource_type") == ""
     assert state.get("resource_location") == ""
     assert isinstance(state.get("resource_metadata"), dict)
 
+
 @pytest.mark.medium
 def test_gather_wizard_workflow(gather_wizard_state):
     """Test a complete gather wizard workflow with state persistence."""
     state, mock_st = gather_wizard_state
-    
+
     # Step 1: Set resource type
     assert state.get_current_step() == 1
     state.set("resource_type", "documentation")
-    
+
     # Move to step 2
     state.next_step()
     assert state.get_current_step() == 2
-    
+
     # Step 2: Set resource location
     state.set("resource_location", "/path/to/docs")
-    
+
     # Move to step 3
     state.next_step()
     assert state.get_current_step() == 3
-    
+
     # Step 3: Set resource metadata
     metadata = {
         "author": "Test User",
         "version": "1.0",
-        "tags": ["test", "documentation"]
+        "tags": ["test", "documentation"],
     }
     state.set("resource_metadata", metadata)
-    
+
     # Complete the wizard
     state.set_completed(True)
-    
+
     # Check that all data is still there
     assert state.get("resource_type") == "documentation"
     assert state.get("resource_location") == "/path/to/docs"
     assert state.get("resource_metadata") == metadata
     assert state.is_completed() is True
 
+
 @pytest.mark.medium
 def test_simulate_wizard_navigation(gather_wizard_state):
     """Test the simulate_wizard_navigation helper function."""
     state, mock_st = gather_wizard_state
-    
+
     # Define a navigation sequence
-    navigation_steps = ['next', 'next', 'previous', 'next', 'goto_1', 'next']
-    
+    navigation_steps = ["next", "next", "previous", "next", "goto_1", "next"]
+
     # Simulate the navigation
     final_step = simulate_wizard_navigation(state, mock_st, navigation_steps)
-    
+
     # Check the final step
     assert final_step == 2
     assert state.get_current_step() == 2
+
 
 @pytest.mark.medium
 def test_set_wizard_data(gather_wizard_state):
     """Test the set_wizard_data helper function."""
     state, mock_st = gather_wizard_state
-    
+
     # Define data for multiple steps
     step_data = {
         "resource_type": "code",
         "resource_location": "/path/to/code",
-        "resource_metadata": {
-            "language": "Python",
-            "lines": 1000
-        }
+        "resource_metadata": {"language": "Python", "lines": 1000},
     }
-    
+
     # Set the data
     set_wizard_data(state, step_data)
-    
+
     # Check that all data was set
     assert state.get("resource_type") == "code"
     assert state.get("resource_location") == "/path/to/code"
-    assert state.get("resource_metadata") == {
-        "language": "Python",
-        "lines": 1000
-    }
+    assert state.get("resource_metadata") == {"language": "Python", "lines": 1000}
 
 
 @pytest.mark.medium
@@ -259,55 +268,64 @@ def test_manager_clears_temp_state(mock_streamlit):
     manager.clear_temporary_state(["temp_key"])
     assert "temp_key" not in mock_streamlit.session_state
 
+
 @pytest.mark.medium
 def test_wizard_state_in_streamlit_context(gather_wizard_state):
     """Test using the wizard state in a simulated Streamlit context."""
     state, mock_st = gather_wizard_state
-    
+
     # Track which buttons should be clicked
     clicked_buttons = set()
-    
+
     # Mock Streamlit UI elements with controlled button behavior
     def mock_button(text, key=None, **kwargs):
         button_id = f"{text}_{key}"
         return button_id in clicked_buttons
-    
+
     mock_st.button.side_effect = mock_button
-    
+
     # Simulate a Streamlit app with wizard state
     def run_wizard_step():
         current_step = state.get_current_step()
-        
+
         if current_step == 1:
             mock_st.header("Step 1: Resource Type")
-            resource_type = mock_st.selectbox( "Select resource type", ["documentation", "code", "data"], key="resource_type_select" )
+            resource_type = mock_st.selectbox(
+                "Select resource type",
+                ["documentation", "code", "data"],
+                key="resource_type_select",
+            )
             state.set("resource_type", resource_type)
-            
+
         elif current_step == 2:
             mock_st.header("Step 2: Resource Location")
-            resource_location = mock_st.text_input( "Enter resource location", key="resource_location_input" )
+            resource_location = mock_st.text_input(
+                "Enter resource location", key="resource_location_input"
+            )
             state.set("resource_location", resource_location)
-            
+
         elif current_step == 3:
             mock_st.header("Step 3: Resource Metadata")
             author = mock_st.text_input("Author", key="author_input")
             version = mock_st.text_input("Version", key="version_input")
             tags = mock_st.text_input("Tags (comma-separated)", key="tags_input")
-            
+
             metadata = {
                 "author": author,
                 "version": version,
-                "tags": tags.split(",") if tags else []
+                "tags": tags.split(",") if tags else [],
             }
             state.set("resource_metadata", metadata)
-        
+
         # Navigation buttons
         col1, col2 = mock_st.columns(2)
-        
+
         with col1:
-            if current_step > 1 and mock_st.button("Previous", key=f"prev_step_{current_step}"):
+            if current_step > 1 and mock_st.button(
+                "Previous", key=f"prev_step_{current_step}"
+            ):
                 state.previous_step()
-                
+
         with col2:
             if current_step < state.get_total_steps():
                 if mock_st.button("Next", key=f"next_step_{current_step}"):
@@ -315,60 +333,60 @@ def test_wizard_state_in_streamlit_context(gather_wizard_state):
             else:
                 if mock_st.button("Finish", key="finish_button"):
                     state.set_completed(True)
-    
+
     # Step 1: Set resource type
     mock_st.selectbox.return_value = "documentation"
     run_wizard_step()
-    
+
     # Check that the state was updated
     assert state.get("resource_type") == "documentation"
     assert state.get_current_step() == 1
-    
+
     # Simulate clicking the Next button for step 1
     clicked_buttons.add(f"Next_next_step_1")
     run_wizard_step()
-    
+
     # Check that we moved to step 2
     assert state.get_current_step() == 2
-    
+
     # Step 2: Set resource location
     mock_st.text_input.return_value = "/path/to/docs"
     # Clear clicked buttons to ensure no automatic advancement
     clicked_buttons.clear()
     run_wizard_step()
-    
+
     # Check that the state was updated but we're still at step 2
     assert state.get("resource_location") == "/path/to/docs"
     assert state.get_current_step() == 2
-    
+
     # Simulate clicking the Next button for step 2
     clicked_buttons.add(f"Next_next_step_2")
     run_wizard_step()
-    
+
     # Check that we moved to step 3
     assert state.get_current_step() == 3
-    
+
     # Step 3: Set resource metadata
     mock_st.text_input.side_effect = ["Test User", "1.0", "test,documentation"]
     # Clear clicked buttons to ensure no automatic advancement
     clicked_buttons.clear()
     run_wizard_step()
-    
+
     # Check that the state was updated
     assert state.get("resource_metadata") == {
         "author": "Test User",
         "version": "1.0",
-        "tags": ["test", "documentation"]
+        "tags": ["test", "documentation"],
     }
-    
+
     # Reset the text_input mock to avoid StopIteration error
     # Use a simple return value instead of side_effect for the final step
     mock_st.text_input.side_effect = None
     mock_st.text_input.return_value = "Test Value"
-    
+
     # Simulate clicking the Finish button
     clicked_buttons.add(f"Finish_finish_button")
     run_wizard_step()
-    
+
     # Check that the wizard was completed
     assert state.is_completed() is True


### PR DESCRIPTION
## Summary
- mark interface tests with speed markers using incremental categorization
- update API endpoints and CLI tests with `@pytest.mark.slow` and `@pytest.mark.medium`

## Testing
- `poetry run pytest tests/unit/interface/test_api_endpoints.py::test_health_endpoint_requires_authentication_succeeds --maxfail=1 --no-cov`
- `devsynth test-metrics` *(fails: Type not yet supported: typing.Dict[str, bool])* 
- `poetry run python scripts/test_metrics.py --skip-coverage`


------
https://chatgpt.com/codex/tasks/task_e_68936913fdb48333bb70fbb70f7fad3b