### PR TITLE
refactor test fixtures to use packages

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -8,9 +8,9 @@ the package has been installed via Poetry.
 
 from __future__ import annotations
 
+import os
 import sys
 from pathlib import Path
-import os
 from types import ModuleType
 
 
@@ -77,4 +77,6 @@ if "httpx" not in sys.modules:
 pytest_plugins = [
     "tests.fixtures.ports",
     "tests.fixtures.kuzu",
+    "tests.fixtures.state_access_fixture",
+    "tests.fixtures.webui_wizard_state_fixture",
 ]

--- a/tests/fixtures/__init__.py
+++ b/tests/fixtures/__init__.py
@@ -1,6 +1,1 @@
 """Shared test fixtures for DevSynth."""
-
-pytest_plugins = [
-    "tests.fixtures.ports",
-    "tests.fixtures.kuzu",
-]

--- a/tests/fixtures/state_access_fixture.py
+++ b/tests/fixtures/state_access_fixture.py
@@ -5,20 +5,20 @@ This module provides fixtures for testing the state_access module and
 the WizardStateManager class with proper session state mocking.
 """
 
-import sys
 from types import ModuleType
 from unittest.mock import MagicMock, patch
+
 import pytest
 
 
 class MockSessionState(dict):
     """A mock session state that behaves like both a dictionary and an object with attributes."""
-    
+
     def __getattr__(self, name):
         if name in self:
             return self[name]
         return None
-        
+
     def __setattr__(self, name, value):
         self[name] = value
 
@@ -38,11 +38,11 @@ def mock_session_state():
 def mock_streamlit_for_state():
     """
     Create a mock streamlit module with session state for testing.
-    
+
     This is similar to the mock_streamlit fixture in webui_wizard_state_fixture.py,
     but focused specifically on session state for testing state_access functions.
     """
-    st = ModuleType('streamlit')
+    st = ModuleType("streamlit")
     st.session_state = create_mock_session_state()
     return st
 
@@ -51,28 +51,24 @@ def mock_streamlit_for_state():
 def wizard_state_manager(mock_session_state):
     """
     Create a WizardStateManager instance for testing.
-    
+
     Args:
         mock_session_state: The mock session state fixture
-        
+
     Returns:
         A tuple containing the WizardStateManager instance and the mock session state
     """
     # Import WizardStateManager here to avoid circular imports
     from devsynth.interface.wizard_state_manager import WizardStateManager
-    
+
     # Initialize the wizard state manager with a name, number of steps, and initial state
     wizard_name = "test_wizard"
     steps = 3
-    initial_state = {
-        "step1_data": "",
-        "step2_data": "",
-        "step3_data": ""
-    }
-    
+    initial_state = {"step1_data": "", "step2_data": "", "step3_data": ""}
+
     # Create the WizardStateManager instance
     manager = WizardStateManager(mock_session_state, wizard_name, steps, initial_state)
-    
+
     # Return the manager and the mock session state
     return manager, mock_session_state
 
@@ -81,28 +77,28 @@ def wizard_state_manager(mock_session_state):
 def gather_wizard_state_manager(mock_session_state):
     """
     Create a WizardStateManager instance specifically for testing the gather wizard.
-    
+
     Args:
         mock_session_state: The mock session state fixture
-        
+
     Returns:
         A tuple containing the WizardStateManager instance and the mock session state
     """
     # Import WizardStateManager here to avoid circular imports
     from devsynth.interface.wizard_state_manager import WizardStateManager
-    
+
     # Initialize the wizard state manager with a name, number of steps, and initial state
     wizard_name = "gather_wizard"
     steps = 3
     initial_state = {
         "resource_type": "",
         "resource_location": "",
-        "resource_metadata": {}
+        "resource_metadata": {},
     }
-    
+
     # Create the WizardStateManager instance
     manager = WizardStateManager(mock_session_state, wizard_name, steps, initial_state)
-    
+
     # Return the manager and the mock session state
     return manager, mock_session_state
 
@@ -110,30 +106,30 @@ def gather_wizard_state_manager(mock_session_state):
 def simulate_wizard_manager_navigation(manager, navigation_steps):
     """
     Simulate navigation through a wizard with the given steps using a WizardStateManager.
-    
+
     Args:
         manager: The WizardStateManager instance
         navigation_steps: A list of navigation actions ('next', 'previous', 'goto_X')
-    
+
     Returns:
         The final step number
     """
     for action in navigation_steps:
-        if action == 'next':
+        if action == "next":
             manager.next_step()
-        elif action == 'previous':
+        elif action == "previous":
             manager.previous_step()
-        elif action.startswith('goto_'):
-            step = int(action.split('_')[1])
+        elif action.startswith("goto_"):
+            step = int(action.split("_")[1])
             manager.go_to_step(step)
-    
+
     return manager.get_current_step()
 
 
 def set_wizard_manager_data(manager, step_data):
     """
     Set data for specific steps in the wizard using a WizardStateManager.
-    
+
     Args:
         manager: The WizardStateManager instance
         step_data: A dictionary mapping step keys to values

--- a/tests/fixtures/webui_wizard_state_fixture.py
+++ b/tests/fixtures/webui_wizard_state_fixture.py
@@ -6,28 +6,28 @@ It uses the WizardState class from webui_state.py to ensure consistent state
 persistence between wizard steps.
 """
 
-import sys
 from types import ModuleType
 from unittest.mock import MagicMock, patch
+
 import pytest
 
 
 def create_mock_streamlit():
     """Create a mock streamlit module with session state for testing."""
-    st = ModuleType('streamlit')
-    
+    st = ModuleType("streamlit")
+
     # Create a session state that behaves like a dictionary
     class SessionState(dict):
         def __getattr__(self, name):
             if name in self:
                 return self[name]
             return None
-            
+
         def __setattr__(self, name, value):
             self[name] = value
-    
+
     st.session_state = SessionState()
-    
+
     # Mock common streamlit functions
     st.button = MagicMock(return_value=False)
     st.text_input = MagicMock(return_value="")
@@ -43,7 +43,7 @@ def create_mock_streamlit():
     st.time_input = MagicMock(return_value=None)
     st.file_uploader = MagicMock(return_value=None)
     st.color_picker = MagicMock(return_value="")
-    
+
     # Mock display functions
     st.write = MagicMock()
     st.markdown = MagicMock()
@@ -55,26 +55,26 @@ def create_mock_streamlit():
     st.warning = MagicMock()
     st.info = MagicMock()
     st.success = MagicMock()
-    
+
     # Mock layout functions
     st.columns = MagicMock(return_value=[MagicMock(), MagicMock()])
     st.expander = MagicMock()
     st.container = MagicMock()
     st.sidebar = MagicMock()
     st.sidebar.button = MagicMock(return_value=False)
-    
+
     # Mock progress functions
     st.progress = MagicMock()
     st.spinner = MagicMock()
     st.spinner.return_value.__enter__ = MagicMock()
     st.spinner.return_value.__exit__ = MagicMock()
-    
+
     # Mock form functions
     st.form = MagicMock()
     st.form.return_value.__enter__ = MagicMock()
     st.form.return_value.__exit__ = MagicMock()
     st.form_submit_button = MagicMock(return_value=False)
-    
+
     return st
 
 
@@ -82,19 +82,21 @@ def create_mock_streamlit():
 def mock_streamlit():
     """
     Create a mock streamlit module and patch it in the webui_state and webui modules.
-    
+
     This ensures that both the WizardState class and the WebUI class use our mock
     streamlit module instead of the real one.
     """
     # Create the mock streamlit module
     mock_st = create_mock_streamlit()
-    
+
     # Add experimental_rerun method to mock streamlit
     mock_st.experimental_rerun = MagicMock()
-    
+
     # Patch the streamlit module in both webui_state and webui modules
-    with patch('devsynth.interface.webui_state.st', mock_st), \
-         patch('devsynth.interface.webui.st', mock_st):
+    with (
+        patch("devsynth.interface.webui_state.st", mock_st),
+        patch("devsynth.interface.webui.st", mock_st),
+    ):
         yield mock_st
 
 
@@ -103,19 +105,15 @@ def wizard_state(mock_streamlit):
     """Create a WizardState instance for testing wizards with multiple steps."""
     # Import WizardState after patching streamlit to ensure it uses our mock
     from devsynth.interface.webui_state import WizardState
-    
+
     # Initialize the wizard state with a name, number of steps, and initial state
     wizard_name = "test_wizard"
     steps = 3
-    initial_state = {
-        "step1_data": "",
-        "step2_data": "",
-        "step3_data": ""
-    }
-    
+    initial_state = {"step1_data": "", "step2_data": "", "step3_data": ""}
+
     # Create the WizardState instance
     state = WizardState(wizard_name, steps, initial_state)
-    
+
     # Return the state and the mock streamlit module
     return state, mock_streamlit
 
@@ -125,19 +123,19 @@ def gather_wizard_state(mock_streamlit):
     """Create a WizardState instance specifically for testing the gather wizard."""
     # Import WizardState after patching streamlit to ensure it uses our mock
     from devsynth.interface.webui_state import WizardState
-    
+
     # Initialize the wizard state with a name, number of steps, and initial state
     wizard_name = "gather_wizard"
     steps = 3
     initial_state = {
         "resource_type": "",
         "resource_location": "",
-        "resource_metadata": {}
+        "resource_metadata": {},
     }
-    
+
     # Create the WizardState instance
     state = WizardState(wizard_name, steps, initial_state)
-    
+
     # Return the state and the mock streamlit module
     return state, mock_streamlit
 
@@ -145,31 +143,31 @@ def gather_wizard_state(mock_streamlit):
 def simulate_wizard_navigation(state, mock_streamlit, navigation_steps):
     """
     Simulate navigation through a wizard with the given steps.
-    
+
     Args:
         state: The WizardState instance
         mock_streamlit: The mock streamlit module
         navigation_steps: A list of navigation actions ('next', 'previous', 'goto_X')
-    
+
     Returns:
         The final step number
     """
     for action in navigation_steps:
-        if action == 'next':
+        if action == "next":
             state.next_step()
-        elif action == 'previous':
+        elif action == "previous":
             state.previous_step()
-        elif action.startswith('goto_'):
-            step = int(action.split('_')[1])
+        elif action.startswith("goto_"):
+            step = int(action.split("_")[1])
             state.go_to_step(step)
-    
+
     return state.get_current_step()
 
 
 def set_wizard_data(state, step_data):
     """
     Set data for specific steps in the wizard.
-    
+
     Args:
         state: The WizardState instance
         step_data: A dictionary mapping step keys to values

--- a/tests/unit/interface/test_state_access.py
+++ b/tests/unit/interface/test_state_access.py
@@ -5,185 +5,192 @@ This module tests the functions in the state_access module, including
 get_session_value, set_session_value, is_session_state_available, and handle_state_error.
 """
 
-import pytest
 from unittest.mock import MagicMock, patch
 
-# Import the fixtures
-import sys
-from pathlib import Path
-fixtures_path = Path(__file__).parent.parent.parent / 'fixtures'
-sys.path.insert(0, str(fixtures_path))
-try:
-    from state_access_fixture import mock_session_state, mock_streamlit_for_state
-except ImportError:
-    # For debugging import issues
-    print(f"Fixtures path: {fixtures_path}")
-    print(f"Fixtures path exists: {fixtures_path.exists()}")
-    print(f"Files in fixtures directory: {list(fixtures_path.glob('*.py'))}")
-    raise
+import pytest
 
 # Import the module to test
-from devsynth.interface.state_access import ( get_session_value, set_session_value, is_session_state_available, handle_state_error )
+from devsynth.interface.state_access import (
+    get_session_value,
+    handle_state_error,
+    is_session_state_available,
+    set_session_value,
+)
+
 
 @pytest.mark.medium
-
 @pytest.fixture
 def clean_state():
     """Set up clean state for tests."""
     # Store any global state that might be modified during tests
-    
+
     # Reset any module-level state before test
     # No specific global state to reset in this module
-    
+
     yield
-    
+
     # Clean up state after test
     # Reset any module-level state that might have been modified
+
 
 def test_is_session_state_available(clean_state):
     """Test the is_session_state_available function."""
     # Test with None
     assert is_session_state_available(None) is False
-    
+
     # Test with a valid session state
     assert is_session_state_available({}) is True
     assert is_session_state_available(MagicMock()) is True
+
 
 @pytest.mark.medium
 def test_handle_state_error(clean_state):
     """Test the handle_state_error function."""
     # Mock the logger
-    with patch('devsynth.interface.state_access.logger') as mock_logger:
+    with patch("devsynth.interface.state_access.logger") as mock_logger:
         # Call the function
         handle_state_error("testing", "test_key", ValueError("Test error"))
-        
+
         # Check that the logger was called with the expected message
-        mock_logger.warning.assert_called_once_with( "Error testing session state key 'test_key': Test error" )
+        mock_logger.warning.assert_called_once_with(
+            "Error testing session state key 'test_key': Test error"
+        )
+
 
 @pytest.mark.medium
-
 def test_get_session_value_with_none_session_state(clean_state):
     """Test get_session_value with None session state."""
     # Mock the logger
-    with patch('devsynth.interface.state_access.logger') as mock_logger:
+    with patch("devsynth.interface.state_access.logger") as mock_logger:
         # Call the function with None session state
         result = get_session_value(None, "test_key", "default_value")
-        
+
         # Check that the function returns the default value
         assert result == "default_value"
-        
+
         # Check that the logger was called with the expected message
-        mock_logger.warning.assert_called_once_with( "Session state not available, returning default for test_key" )
+        mock_logger.warning.assert_called_once_with(
+            "Session state not available, returning default for test_key"
+        )
+
 
 @pytest.mark.medium
-
 def test_get_session_value_with_attribute_access(mock_session_state, clean_state):
     """Test get_session_value with attribute access."""
     # Set a value in the session state
     mock_session_state.test_key = "test_value"
-    
+
     # Call the function
     result = get_session_value(mock_session_state, "test_key", "default_value")
-    
+
     # Check that the function returns the expected value
     assert result == "test_value"
+
 
 @pytest.mark.medium
 def test_get_session_value_with_dict_access(mock_session_state, clean_state):
     """Test get_session_value with dictionary access."""
     # Set a value in the session state
     mock_session_state["test_key"] = "test_value"
-    
+
     # Call the function
     result = get_session_value(mock_session_state, "test_key", "default_value")
-    
+
     # Check that the function returns the expected value
     assert result == "test_value"
 
-@pytest.mark.medium
 
+@pytest.mark.medium
 def test_get_session_value_with_missing_key(mock_session_state, clean_state):
     """Test get_session_value with a missing key."""
     # Call the function with a key that doesn't exist
     result = get_session_value(mock_session_state, "missing_key", "default_value")
-    
+
     # Check that the function returns the default value
     assert result == "default_value"
+
 
 @pytest.mark.medium
 def test_get_session_value_with_exception(clean_state):
     """Test get_session_value with an exception."""
+
     # Create a custom mock class that raises an exception when attributes are accessed
     class ExceptionSessionState:
         def __getattr__(self, name):
             raise Exception("Test error")
-        
+
         def __getitem__(self, key):
             raise Exception("Test error")
-    
+
     session_state = ExceptionSessionState()
-    
+
     # Mock the logger
-    with patch('devsynth.interface.state_access.logger') as mock_logger:
+    with patch("devsynth.interface.state_access.logger") as mock_logger:
         # Call the function
         result = get_session_value(session_state, "test_key", "default_value")
-        
+
         # Check that the function returns the default value
         assert result == "default_value"
-        
+
         # Check that the logger was called with the expected message
-        mock_logger.warning.assert_called_once_with( "Error accessing session state key 'test_key': Test error" )
+        mock_logger.warning.assert_called_once_with(
+            "Error accessing session state key 'test_key': Test error"
+        )
+
 
 @pytest.mark.medium
-
 def test_set_session_value_with_none_session_state(clean_state):
     """Test set_session_value with None session state."""
     # Mock the logger
-    with patch('devsynth.interface.state_access.logger') as mock_logger:
+    with patch("devsynth.interface.state_access.logger") as mock_logger:
         # Call the function with None session state
         result = set_session_value(None, "test_key", "test_value")
-        
+
         # Check that the function returns False
         assert result is False
-        
+
         # Check that the logger was called with the expected message
-        mock_logger.warning.assert_called_once_with( "Session state not available, cannot set test_key" )
+        mock_logger.warning.assert_called_once_with(
+            "Session state not available, cannot set test_key"
+        )
+
 
 @pytest.mark.medium
-
 def test_set_session_value_with_attribute_access(mock_session_state, clean_state):
     """Test set_session_value with attribute access."""
     # Call the function
     result = set_session_value(mock_session_state, "test_key", "test_value")
-    
+
     # Check that the function returns True
     assert result is True
-    
+
     # Check that the value was set in the session state
     assert mock_session_state.test_key == "test_value"
+
 
 @pytest.mark.medium
 def test_set_session_value_with_dict_access(mock_session_state, clean_state):
     """Test set_session_value with dictionary access."""
     # Call the function
     result = set_session_value(mock_session_state, "test_key", "test_value")
-    
+
     # Check that the function returns True
     assert result is True
-    
+
     # Check that the value was set in the session state
     assert mock_session_state["test_key"] == "test_value"
 
-@pytest.mark.medium
 
+@pytest.mark.medium
 def test_set_session_value_with_attribute_exception(clean_state):
     """Test set_session_value with an exception during attribute access."""
+
     # Create a custom mock class that raises an exception when attributes are set
     # but allows item access to succeed
     class AttributeExceptionSessionState:
         def __init__(self):
             self.items = {}
-            
+
         def __setattr__(self, name, value):
             if name == "items":
                 # Allow setting the items dictionary
@@ -191,34 +198,37 @@ def test_set_session_value_with_attribute_exception(clean_state):
             else:
                 # Raise exception for other attributes
                 raise Exception("Test error")
-        
+
         def __setitem__(self, key, value):
             # Allow item access to succeed
             self.items[key] = value
-    
+
     session_state = AttributeExceptionSessionState()
-    
+
     # Mock the logger
-    with patch('devsynth.interface.state_access.logger') as mock_logger:
+    with patch("devsynth.interface.state_access.logger") as mock_logger:
         # Call the function
         result = set_session_value(session_state, "test_key", "test_value")
-        
+
         # Check that the function returns True because item access succeeds
         # even though attribute access fails
         assert result is True
-        
+
         # Check that the logger was called with the expected message
-        mock_logger.warning.assert_called_once_with( "Error setting session state key 'test_key': Test error" )
+        mock_logger.warning.assert_called_once_with(
+            "Error setting session state key 'test_key': Test error"
+        )
+
 
 @pytest.mark.medium
-
 def test_set_session_value_with_dict_exception(clean_state):
     """Test set_session_value with an exception during dictionary access."""
+
     # Create a custom mock class that allows attribute access but raises an exception for item access
     class DictExceptionSessionState:
         def __init__(self):
             self.attributes = {}
-            
+
         def __setattr__(self, name, value):
             if name == "attributes":
                 # Allow setting the attributes dictionary
@@ -226,69 +236,82 @@ def test_set_session_value_with_dict_exception(clean_state):
             else:
                 # Store other attributes in the dictionary
                 self.attributes[name] = value
-                
+
         def __getattr__(self, name):
             if name in self.attributes:
                 return self.attributes[name]
-            raise AttributeError(f"'{self.__class__.__name__}' object has no attribute '{name}'")
-            
+            raise AttributeError(
+                f"'{self.__class__.__name__}' object has no attribute '{name}'"
+            )
+
         def __setitem__(self, key, value):
             raise Exception("Test error")
-    
+
     session_state = DictExceptionSessionState()
-    
+
     # Mock the logger
-    with patch('devsynth.interface.state_access.logger') as mock_logger:
+    with patch("devsynth.interface.state_access.logger") as mock_logger:
         # Call the function
         result = set_session_value(session_state, "test_key", "test_value")
-        
+
         # Check that the function returns True (attribute access succeeded)
         assert result is True
-        
+
         # Check that the logger was called with the expected message
-        mock_logger.warning.assert_called_once_with( "Error setting via item session state key 'test_key': Test error" )
+        mock_logger.warning.assert_called_once_with(
+            "Error setting via item session state key 'test_key': Test error"
+        )
+
 
 @pytest.mark.medium
-
 def test_set_session_value_with_both_exceptions(clean_state):
     """Test set_session_value with exceptions during both attribute and dictionary access."""
+
     # Create a custom mock class that raises exceptions for both attribute and item access
     class BothExceptionsSessionState:
         def __setattr__(self, name, value):
             raise Exception("Attribute error")
-            
+
         def __setitem__(self, key, value):
             raise Exception("Item error")
-    
+
     session_state = BothExceptionsSessionState()
-    
+
     # Mock the logger
-    with patch('devsynth.interface.state_access.logger') as mock_logger:
+    with patch("devsynth.interface.state_access.logger") as mock_logger:
         # Call the function
         result = set_session_value(session_state, "test_key", "test_value")
-        
+
         # Check that the function returns False
         assert result is False
-        
+
         # Check that the logger was called with the expected messages
-        mock_logger.warning.assert_any_call( "Error setting session state key 'test_key': Attribute error" )
-        mock_logger.warning.assert_any_call( "Error setting via item session state key 'test_key': Item error" )
+        mock_logger.warning.assert_any_call(
+            "Error setting session state key 'test_key': Attribute error"
+        )
+        mock_logger.warning.assert_any_call(
+            "Error setting via item session state key 'test_key': Item error"
+        )
+
 
 @pytest.mark.medium
-
 def test_integration_with_streamlit(mock_streamlit_for_state, clean_state):
     """Test integration with streamlit."""
     # Set a value using set_session_value
-    result = set_session_value(mock_streamlit_for_state.session_state, "test_key", "test_value")
-    
+    result = set_session_value(
+        mock_streamlit_for_state.session_state, "test_key", "test_value"
+    )
+
     # Check that the function returns True
     assert result is True
-    
+
     # Check that the value was set in the session state
     assert mock_streamlit_for_state.session_state.test_key == "test_value"
-    
+
     # Get the value using get_session_value
-    value = get_session_value(mock_streamlit_for_state.session_state, "test_key", "default_value")
-    
+    value = get_session_value(
+        mock_streamlit_for_state.session_state, "test_key", "default_value"
+    )
+
     # Check that the function returns the expected value
     assert value == "test_value"

--- a/tests/unit/interface/test_webui_gather_wizard_with_state.py
+++ b/tests/unit/interface/test_webui_gather_wizard_with_state.py
@@ -1,49 +1,34 @@
-"""
-Tests for the gather wizard implementation with WizardState.
+"""Tests for the gather wizard implementation with ``WizardState``."""
 
-This module tests the gather wizard implementation that uses the WizardState class
-for state management and multi-step navigation.
-"""
-
-import sys
-from types import ModuleType
 from unittest.mock import MagicMock, patch
+
 import pytest
-from pathlib import Path
 
-# Import the fixtures
-fixtures_path = Path(__file__).parent.parent.parent / 'fixtures'
-sys.path.insert(0, str(fixtures_path))
-try:
-    from webui_wizard_state_fixture import (
-        mock_streamlit,
-        gather_wizard_state,
-        simulate_wizard_navigation,
-        set_wizard_data
-    )
+from tests.fixtures.webui_wizard_state_fixture import (
+    set_wizard_data,
+    simulate_wizard_navigation,
+)
 
-    # Helper functions for button side effects to replace lambda functions
-    def next_button_handler(text, key=None, **kwargs):
-        """Handler for next button clicks."""
-        return key == "next_button"
 
-    def previous_button_handler(text, key=None, **kwargs):
-        """Handler for previous button clicks."""
-        return key == "previous_button"
+# Helper functions for button side effects to replace lambda functions
+def next_button_handler(text, key=None, **kwargs):
+    """Handler for next button clicks."""
+    return key == "next_button"
 
-    def finish_button_handler(text, key=None, **kwargs):
-        """Handler for finish button clicks."""
-        return key == "finish_button"
 
-    def cancel_button_handler(text, key=None, **kwargs):
-        """Handler for cancel button clicks."""
-        return key == "cancel_button"
-except ImportError:
-    # For debugging import issues
-    print(f"Fixtures path: {fixtures_path}")
-    print(f"Fixtures path exists: {fixtures_path.exists()}")
-    print(f"Files in fixtures directory: {list(fixtures_path.glob('*.py'))}")
-    raise
+def previous_button_handler(text, key=None, **kwargs):
+    """Handler for previous button clicks."""
+    return key == "previous_button"
+
+
+def finish_button_handler(text, key=None, **kwargs):
+    """Handler for finish button clicks."""
+    return key == "finish_button"
+
+
+def cancel_button_handler(text, key=None, **kwargs):
+    """Handler for cancel button clicks."""
+    return key == "cancel_button"
 
 
 @pytest.fixture
@@ -64,31 +49,27 @@ def clean_state():
 @pytest.mark.medium
 def test_gather_wizard_initialization_with_state(gather_wizard_state, clean_state):
     """Test that the gather wizard is properly initialized with WizardState."""
-    # Import the WebUI class after patching streamlit
-    import importlib
-    from devsynth.interface import webui
-    # Reload the module to ensure clean state
-    importlib.reload(webui)
+    # Import the WebUI class after the streamlit module is patched
     from devsynth.interface.webui import WebUI
-    
+
     state, mock_st = gather_wizard_state
-    
+
     # Create a WebUI instance with a mock display_result method
     webui_instance = WebUI()
     webui_instance.display_result = MagicMock()
-    
+
     # Mock the button to be clicked
     mock_st.button.return_value = True
-    
+
     # Run the gather wizard
     webui_instance._gather_wizard()
-    
+
     # Verify that the wizard state was initialized correctly
     assert state.page_name == "gather_wizard"
     assert state.get_total_steps() == 3
     assert state.get_current_step() == 1
     assert state.is_completed() is False
-    
+
     # Verify that the initial state was set
     assert state.get("resource_type") == ""
     assert state.get("resource_location") == ""
@@ -96,141 +77,141 @@ def test_gather_wizard_initialization_with_state(gather_wizard_state, clean_stat
 
 
 @pytest.mark.medium
-def test_gather_wizard_navigation_with_state(gather_wizard_state, mock_gather_requirements, clean_state):
+def test_gather_wizard_navigation_with_state(
+    gather_wizard_state, mock_gather_requirements, clean_state
+):
     """Test navigation through gather wizard steps with WizardState."""
-    # Import the WebUI class after patching streamlit
-    import importlib
+    # Import the WebUI class after the streamlit module is patched
     import devsynth.interface.webui as webui
-    importlib.reload(webui)
     from devsynth.interface.webui import WebUI
-    
+
     state, mock_st = gather_wizard_state
-    
+
     # Create a WebUI instance with a mock display_result method
     webui_instance = WebUI()
     webui_instance.display_result = MagicMock()
-    
+
     # Mock the validation method to always return True
     webui_instance._validate_gather_step = MagicMock(return_value=True)
-    
+
     # Mock experimental_rerun to do nothing
     mock_st.experimental_rerun = MagicMock()
-    
+
     # Set data for step 1 to pass validation
     state.set("resource_type", "documentation")
-    
+
     # Mock the button to be clicked to start the wizard
     mock_st.button.return_value = True
-    
+
     # Run the gather wizard to initialize it
     webui_instance._gather_wizard()
-    
+
     # Verify we're at step 1
     assert state.get_current_step() == 1
-    
+
     # Simulate clicking the Next button
     mock_st.button.side_effect = next_button_handler
     webui_instance._gather_wizard()
-    
+
     # Manually advance the step since we're mocking experimental_rerun
     state.next_step()
-    
+
     # Verify we moved to step 2
     assert state.get_current_step() == 2
-    
+
     # Set data for step 2 to pass validation
     state.set("resource_location", "/path/to/docs")
-    
+
     # Simulate clicking the Next button again
     webui_instance._gather_wizard()
-    
+
     # Manually advance the step again
     state.next_step()
-    
+
     # Verify we moved to step 3
     assert state.get_current_step() == 3
-    
+
     # Simulate clicking the Previous button
     mock_st.button.side_effect = previous_button_handler
     webui_instance._gather_wizard()
-    
+
     # Manually go back a step
     state.previous_step()
-    
+
     # Verify we moved back to step 2
     assert state.get_current_step() == 2
 
 
 @pytest.mark.medium
-def test_gather_wizard_data_persistence_with_state(gather_wizard_state, mock_gather_requirements, clean_state):
+def test_gather_wizard_data_persistence_with_state(
+    gather_wizard_state, mock_gather_requirements, clean_state
+):
     """Test that data persists between gather wizard steps with WizardState."""
-    # Import the WebUI class after patching streamlit
-    import importlib
+    # Import the WebUI class after the streamlit module is patched
     import devsynth.interface.webui as webui
-    importlib.reload(webui)
     from devsynth.interface.webui import WebUI
-    
+
     state, mock_st = gather_wizard_state
-    
+
     # Create a WebUI instance with a mock display_result method
     webui_instance = WebUI()
     webui_instance.display_result = MagicMock()
-    
+
     # Mock the validation method to always return True
     webui_instance._validate_gather_step = MagicMock(return_value=True)
-    
+
     # Mock experimental_rerun to do nothing
     mock_st.experimental_rerun = MagicMock()
-    
+
     # Mock the button to be clicked to start the wizard
     mock_st.button.return_value = True
-    
+
     # Run the gather wizard to initialize it
     webui_instance._gather_wizard()
-    
+
     # Set data for step 1
     state.set("resource_type", "documentation")
-    
+
     # Simulate clicking the Next button
     mock_st.button.side_effect = next_button_handler
     webui_instance._gather_wizard()
-    
+
     # Manually advance the step since we're mocking experimental_rerun
     state.next_step()
-    
+
     # Verify we moved to step 2
     assert state.get_current_step() == 2
-    
+
     # Set data for step 2
     state.set("resource_location", "/path/to/docs")
-    
+
     # Simulate clicking the Next button again
     webui_instance._gather_wizard()
-    
+
     # Manually advance the step again
     state.next_step()
-    
+
     # Verify we moved to step 3
     assert state.get_current_step() == 3
-    
+
     # Set data for step 3
     metadata = {
         "author": "Test User",
         "version": "1.0",
-        "tags": ["test", "documentation"]
+        "tags": ["test", "documentation"],
     }
     state.set("resource_metadata", metadata)
-    
+
     # Simulate clicking the Previous button
     mock_st.button.side_effect = previous_button_handler
     webui_instance._gather_wizard()
-    
+
     # Manually go back a step
     state.previous_step()
-    
+
     # Verify we moved back to step 2
     assert state.get_current_step() == 2
-    
+
     # Verify that all data is still there
     assert state.get("resource_type") == "documentation"
     assert state.get("resource_location") == "/path/to/docs"
@@ -238,92 +219,88 @@ def test_gather_wizard_data_persistence_with_state(gather_wizard_state, mock_gat
 
 
 @pytest.mark.medium
-def test_gather_wizard_completion_with_state(gather_wizard_state, mock_gather_requirements, clean_state):
+def test_gather_wizard_completion_with_state(
+    gather_wizard_state, mock_gather_requirements, clean_state
+):
     """Test completing the gather wizard with WizardState."""
     # Import the WebUI class after patching streamlit
-    import importlib
     import devsynth.interface.webui as webui
-    
+    from devsynth.interface.webui import WebUI
+
     # Create a simple mock function that we can track
     def mock_gather_fn(webui_instance):
         return True
-    
+
     mock_gather_requirements.side_effect = mock_gather_fn
-    
+
     # Directly patch the gather_requirements in the webui module
     original_gather = webui.gather_requirements
     webui.gather_requirements = mock_gather_requirements
-    
+
     try:
-        # Reload the module to ensure our patch takes effect
-        importlib.reload(webui)
-        from devsynth.interface.webui import WebUI
-        
         # Verify that our patch worked
         assert webui.gather_requirements is mock_gather_requirements
-        
+
         state, mock_st = gather_wizard_state
-        
+
         # Create a WebUI instance with a mock display_result method
         webui_instance = WebUI()
         webui_instance.display_result = MagicMock()
-        
+
         # Mock the validation method to always return True
         webui_instance._validate_gather_step = MagicMock(return_value=True)
-        
+
         # Mock experimental_rerun to do nothing
         mock_st.experimental_rerun = MagicMock()
-        
+
         # Mock spinner to do nothing and return False for __exit__ to indicate no exception
         mock_st.spinner = MagicMock()
         spinner_context = MagicMock()
         mock_st.spinner.return_value = spinner_context
         spinner_context.__enter__ = MagicMock()
         spinner_context.__exit__ = MagicMock(return_value=False)
-        
+
         # Set data for all steps
         state.set("resource_type", "documentation")
         state.set("resource_location", "/path/to/docs")
-        state.set("resource_metadata", {
-            "author": "Test User",
-            "version": "1.0",
-            "tags": ["test", "documentation"]
-        })
-        
+        state.set(
+            "resource_metadata",
+            {
+                "author": "Test User",
+                "version": "1.0",
+                "tags": ["test", "documentation"],
+            },
+        )
+
         # Navigate to step 3
         state.go_to_step(3)
-            
+
         # Ensure the wizard is marked as started
         state.set("wizard_started", True)
-            
+
         # Mock the button to simulate the Finish button being clicked
         # First, reset any previous side_effect
         mock_st.button.reset_mock()
         mock_st.button.side_effect = None
-        
+
         # Set up the button mock to return True only for the Finish button
         mock_st.button.side_effect = finish_button_handler
-        
+
         # Run the gather wizard with the Finish button clicked
-        try:
-            # Call the method
-            webui_instance._gather_wizard()
-        except Exception as e:
-            # If there's an exception, print it for debugging
-            print(f"Exception in _gather_wizard: {e}")
-        
+        webui_instance._gather_wizard()
+
         # Manually mark the wizard as completed for testing
         # This is necessary because the actual completion happens in the _gather_wizard method
         # which we can't fully simulate in the test
         state.set_completed(True)
-        
+
         # Verify the wizard is completed
         assert state.is_completed() is True
-        
+
         # Since _gather_wizard is not calling gather_requirements, let's call it directly
         # to verify that our mock is working correctly
         webui.gather_requirements(webui_instance)
-        
+
         # Verify gather_requirements was called with the correct data
         mock_gather_requirements.assert_called_with(webui_instance)
     finally:
@@ -334,95 +311,97 @@ def test_gather_wizard_completion_with_state(gather_wizard_state, mock_gather_re
 @pytest.mark.medium
 def test_gather_wizard_error_handling_with_state(gather_wizard_state, clean_state):
     """Test error handling in the gather wizard with WizardState."""
-    # Import the WebUI class after patching streamlit
-    import importlib
+    # Import the WebUI class after the streamlit module is patched
     import devsynth.interface.webui as webui
-    importlib.reload(webui)
     from devsynth.interface.webui import WebUI
-    
+
     state, mock_st = gather_wizard_state
-    
+
     # Create a WebUI instance with a mock display_result method
     webui_instance = WebUI()
     webui_instance.display_result = MagicMock()
-    
+
     # Mock experimental_rerun to do nothing
     mock_st.experimental_rerun = MagicMock()
-    
+
     # Set up the wizard state for step 3 (where gather_requirements would be called)
     state.go_to_step(3)
     state.set("resource_type", "documentation")
     state.set("resource_location", "/path/to/docs")
-    state.set("resource_metadata", {
-        "author": "Test User",
-        "version": "1.0",
-        "tags": ["test", "documentation"]
-    })
-    
+    state.set(
+        "resource_metadata",
+        {"author": "Test User", "version": "1.0", "tags": ["test", "documentation"]},
+    )
+
     # Mock the validation method to always return True
     webui_instance._validate_gather_step = MagicMock(return_value=True)
-    
+
     # Mock the button to simulate clicking the Finish button
     mock_st.button.side_effect = finish_button_handler
-    
+
     # Mock gather_requirements to raise an exception
-    with patch('devsynth.core.workflows.gather_requirements', 
-               side_effect=RuntimeError("Test runtime error")):
+    with patch(
+        "devsynth.core.workflows.gather_requirements",
+        side_effect=RuntimeError("Test runtime error"),
+    ):
         # Instead of running the gather wizard, directly call the error handling code
         try:
             # Directly call gather_requirements to trigger the exception
             from devsynth.core.workflows import gather_requirements
+
             gather_requirements(webui_instance)
         except RuntimeError as exc:
             # Manually call display_result with the error message
             webui_instance.display_result(
                 f"[red]ERROR processing resources: {exc}[/red]",
                 highlight=False,
-                message_type="error"
+                message_type="error",
             )
             # Set the wizard as not completed
             state.set_completed(False)
-    
+
             # Verify that the error was handled and displayed
             webui_instance.display_result.assert_called_once()
-            assert "error" in webui_instance.display_result.call_args[1].get("message_type", "")
+            assert "error" in webui_instance.display_result.call_args[1].get(
+                "message_type", ""
+            )
             assert "Test runtime error" in webui_instance.display_result.call_args[0][0]
-    
+
             # Verify the wizard state is reset
             assert state.is_completed() is False
 
 
 @pytest.mark.medium
-def test_gather_wizard_cancel_with_state(gather_wizard_state, mock_gather_requirements, clean_state):
+def test_gather_wizard_cancel_with_state(
+    gather_wizard_state, mock_gather_requirements, clean_state
+):
     """Test canceling the gather wizard with WizardState."""
-    # Import the WebUI class after patching streamlit
-    import importlib
+    # Import the WebUI class after the streamlit module is patched
     import devsynth.interface.webui as webui
-    importlib.reload(webui)
     from devsynth.interface.webui import WebUI
-    
+
     state, mock_st = gather_wizard_state
-    
+
     # Create a WebUI instance with a mock display_result method
     webui_instance = WebUI()
     webui_instance.display_result = MagicMock()
-    
+
     # Mock experimental_rerun to do nothing
     mock_st.experimental_rerun = MagicMock()
-    
+
     # Mock the button to be clicked to start the wizard
     mock_st.button.return_value = True
-    
+
     # Run the gather wizard to initialize it
     webui_instance._gather_wizard()
-    
+
     # Set some data
     state.set("resource_type", "documentation")
-    
+
     # Simulate clicking the Cancel button
     mock_st.button.side_effect = cancel_button_handler
     webui_instance._gather_wizard()
-    
+
     # Manually reset the state since we're mocking experimental_rerun
     state.reset()
     state.set("resource_type", "")
@@ -430,55 +409,55 @@ def test_gather_wizard_cancel_with_state(gather_wizard_state, mock_gather_requir
     state.set("resource_metadata", {})
     state.set_completed(False)
     state.go_to_step(1)
-    
+
     # Verify the wizard state is reset
     assert state.get("resource_type") == ""
     assert state.get_current_step() == 1
     assert state.is_completed() is False
-    
+
     # Verify gather_requirements was not called
     mock_gather_requirements.assert_not_called()
-    
+
     # Verify that the cancellation message was displayed
     webui_instance.display_result.assert_called_once()
     assert "info" in webui_instance.display_result.call_args[1].get("message_type", "")
 
 
 @pytest.mark.medium
-def test_gather_wizard_validation_with_state(gather_wizard_state, mock_gather_requirements, clean_state):
+def test_gather_wizard_validation_with_state(
+    gather_wizard_state, mock_gather_requirements, clean_state
+):
     """Test validation in the gather wizard with WizardState."""
-    # Import the WebUI class after patching streamlit
-    import importlib
+    # Import the WebUI class after the streamlit module is patched
     import devsynth.interface.webui as webui
-    importlib.reload(webui)
     from devsynth.interface.webui import WebUI
-    
+
     state, mock_st = gather_wizard_state
-    
+
     # Create a WebUI instance with a mock display_result method
     webui_instance = WebUI()
     webui_instance.display_result = MagicMock()
-    
+
     # Mock experimental_rerun to do nothing
     mock_st.experimental_rerun = MagicMock()
-    
+
     # Mock the button to be clicked to start the wizard
     mock_st.button.return_value = True
-    
+
     # Run the gather wizard to initialize it
     webui_instance._gather_wizard()
-    
+
     # Ensure we're on step 1 with no data (which should fail validation)
     state.go_to_step(1)
     state.set("resource_type", "")
-    
+
     # Simulate clicking the Next button
     mock_st.button.side_effect = next_button_handler
     webui_instance._gather_wizard()
-    
+
     # Verify we're still at step 1 (validation failed)
     assert state.get_current_step() == 1
-    
+
     # Verify an error message was displayed
     webui_instance.display_result.assert_called_once()
     assert "error" in webui_instance.display_result.call_args[1].get("message_type", "")

--- a/tests/unit/interface/test_webui_gather_wizard_with_state_fixed.py
+++ b/tests/unit/interface/test_webui_gather_wizard_with_state_fixed.py
@@ -1,32 +1,13 @@
-"""
-Tests for the gather wizard implementation with WizardState.
+"""Tests for the gather wizard implementation with ``WizardState``."""
 
-This module tests the gather wizard implementation that uses the WizardState class
-for state management and multi-step navigation.
-"""
-
-import sys
-from types import ModuleType
 from unittest.mock import MagicMock, patch
-import pytest
-from pathlib import Path
 
-# Import the fixtures
-fixtures_path = Path(__file__).parent.parent.parent / 'fixtures'
-sys.path.insert(0, str(fixtures_path))
-try:
-    from webui_wizard_state_fixture import (
-        mock_streamlit,
-        gather_wizard_state,
-        simulate_wizard_navigation,
-        set_wizard_data
-    )
-except ImportError:
-    # For debugging import issues
-    print(f"Fixtures path: {fixtures_path}")
-    print(f"Fixtures path exists: {fixtures_path.exists()}")
-    print(f"Files in fixtures directory: {list(fixtures_path.glob('*.py'))}")
-    raise
+import pytest
+
+from tests.fixtures.webui_wizard_state_fixture import (
+    set_wizard_data,
+    simulate_wizard_navigation,
+)
 
 
 @pytest.fixture
@@ -47,31 +28,27 @@ def clean_state():
 @pytest.mark.medium
 def test_gather_wizard_initialization_with_state(gather_wizard_state, clean_state):
     """Test that the gather wizard is properly initialized with WizardState."""
-    # Import the WebUI class after patching streamlit
-    import importlib
-    from devsynth.interface import webui
-    # Reload the module to ensure clean state
-    importlib.reload(webui)
+    # Import the WebUI class after the streamlit module is patched
     from devsynth.interface.webui import WebUI
-    
+
     state, mock_st = gather_wizard_state
-    
+
     # Create a WebUI instance with a mock display_result method
     webui_instance = WebUI()
     webui_instance.display_result = MagicMock()
-    
+
     # Mock the button to be clicked
     mock_st.button.return_value = True
-    
+
     # Run the gather wizard
     webui_instance._gather_wizard()
-    
+
     # Verify that the wizard state was initialized correctly
     assert state.page_name == "gather_wizard"
     assert state.get_total_steps() == 3
     assert state.get_current_step() == 1
     assert state.is_completed() is False
-    
+
     # Verify that the initial state was set
     assert state.get("resource_type") == ""
     assert state.get("resource_location") == ""
@@ -79,141 +56,145 @@ def test_gather_wizard_initialization_with_state(gather_wizard_state, clean_stat
 
 
 @pytest.mark.medium
-def test_gather_wizard_navigation_with_state(gather_wizard_state, mock_gather_requirements, clean_state):
+def test_gather_wizard_navigation_with_state(
+    gather_wizard_state, mock_gather_requirements, clean_state
+):
     """Test navigation through gather wizard steps with WizardState."""
-    # Import the WebUI class after patching streamlit
-    import importlib
+    # Import the WebUI class after the streamlit module is patched
     import devsynth.interface.webui as webui
-    importlib.reload(webui)
     from devsynth.interface.webui import WebUI
-    
+
     state, mock_st = gather_wizard_state
-    
+
     # Create a WebUI instance with a mock display_result method
     webui_instance = WebUI()
     webui_instance.display_result = MagicMock()
-    
+
     # Mock the validation method to always return True
     webui_instance._validate_gather_step = MagicMock(return_value=True)
-    
+
     # Mock experimental_rerun to do nothing
     mock_st.experimental_rerun = MagicMock()
-    
+
     # Set data for step 1 to pass validation
     state.set("resource_type", "documentation")
-    
+
     # Mock the button to be clicked to start the wizard
     mock_st.button.return_value = True
-    
+
     # Run the gather wizard to initialize it
     webui_instance._gather_wizard()
-    
+
     # Verify we're at step 1
     assert state.get_current_step() == 1
-    
+
     # Simulate clicking the Next button
     mock_st.button.side_effect = lambda text, key=None, **kwargs: key == "next_button"
     webui_instance._gather_wizard()
-    
+
     # Manually advance the step since we're mocking experimental_rerun
     state.next_step()
-    
+
     # Verify we moved to step 2
     assert state.get_current_step() == 2
-    
+
     # Set data for step 2 to pass validation
     state.set("resource_location", "/path/to/docs")
-    
+
     # Simulate clicking the Next button again
     webui_instance._gather_wizard()
-    
+
     # Manually advance the step again
     state.next_step()
-    
+
     # Verify we moved to step 3
     assert state.get_current_step() == 3
-    
+
     # Simulate clicking the Previous button
-    mock_st.button.side_effect = lambda text, key=None, **kwargs: key == "previous_button"
+    mock_st.button.side_effect = (
+        lambda text, key=None, **kwargs: key == "previous_button"
+    )
     webui_instance._gather_wizard()
-    
+
     # Manually go back a step
     state.previous_step()
-    
+
     # Verify we moved back to step 2
     assert state.get_current_step() == 2
 
 
 @pytest.mark.medium
-def test_gather_wizard_data_persistence_with_state(gather_wizard_state, mock_gather_requirements, clean_state):
+def test_gather_wizard_data_persistence_with_state(
+    gather_wizard_state, mock_gather_requirements, clean_state
+):
     """Test that data persists between gather wizard steps with WizardState."""
-    # Import the WebUI class after patching streamlit
-    import importlib
+    # Import the WebUI class after the streamlit module is patched
     import devsynth.interface.webui as webui
-    importlib.reload(webui)
     from devsynth.interface.webui import WebUI
-    
+
     state, mock_st = gather_wizard_state
-    
+
     # Create a WebUI instance with a mock display_result method
     webui_instance = WebUI()
     webui_instance.display_result = MagicMock()
-    
+
     # Mock the validation method to always return True
     webui_instance._validate_gather_step = MagicMock(return_value=True)
-    
+
     # Mock experimental_rerun to do nothing
     mock_st.experimental_rerun = MagicMock()
-    
+
     # Mock the button to be clicked to start the wizard
     mock_st.button.return_value = True
-    
+
     # Run the gather wizard to initialize it
     webui_instance._gather_wizard()
-    
+
     # Set data for step 1
     state.set("resource_type", "documentation")
-    
+
     # Simulate clicking the Next button
     mock_st.button.side_effect = lambda text, key=None, **kwargs: key == "next_button"
     webui_instance._gather_wizard()
-    
+
     # Manually advance the step since we're mocking experimental_rerun
     state.next_step()
-    
+
     # Verify we moved to step 2
     assert state.get_current_step() == 2
-    
+
     # Set data for step 2
     state.set("resource_location", "/path/to/docs")
-    
+
     # Simulate clicking the Next button again
     webui_instance._gather_wizard()
-    
+
     # Manually advance the step again
     state.next_step()
-    
+
     # Verify we moved to step 3
     assert state.get_current_step() == 3
-    
+
     # Set data for step 3
     metadata = {
         "author": "Test User",
         "version": "1.0",
-        "tags": ["test", "documentation"]
+        "tags": ["test", "documentation"],
     }
     state.set("resource_metadata", metadata)
-    
+
     # Simulate clicking the Previous button
-    mock_st.button.side_effect = lambda text, key=None, **kwargs: key == "previous_button"
+    mock_st.button.side_effect = (
+        lambda text, key=None, **kwargs: key == "previous_button"
+    )
     webui_instance._gather_wizard()
-    
+
     # Manually go back a step
     state.previous_step()
-    
+
     # Verify we moved back to step 2
     assert state.get_current_step() == 2
-    
+
     # Verify that all data is still there
     assert state.get("resource_type") == "documentation"
     assert state.get("resource_location") == "/path/to/docs"
@@ -222,18 +203,18 @@ def test_gather_wizard_data_persistence_with_state(gather_wizard_state, mock_gat
 
 @pytest.mark.medium
 @pytest.mark.skip(reason="completion flow covered by other tests")
-def test_gather_wizard_completion_with_state(gather_wizard_state, mock_gather_requirements, clean_state):
+def test_gather_wizard_completion_with_state(
+    gather_wizard_state, mock_gather_requirements, clean_state
+):
     """Test completing the gather wizard with WizardState."""
-    import importlib
     import devsynth.interface.webui as webui
+    from devsynth.interface.webui import WebUI
 
     def mock_gather_fn(webui_instance):
         return True
 
     mock_gather_requirements.side_effect = mock_gather_fn
-    importlib.reload(webui)
     webui.gather_requirements = mock_gather_requirements
-    from devsynth.interface.webui import WebUI
 
     state, mock_st = gather_wizard_state
     webui_instance = WebUI()
@@ -265,74 +246,76 @@ def test_gather_wizard_completion_with_state(gather_wizard_state, mock_gather_re
 @pytest.mark.medium
 def test_gather_wizard_error_handling_with_state(gather_wizard_state, clean_state):
     """Test error handling in the gather wizard with WizardState."""
-    # Import the WebUI class after patching streamlit
-    import importlib
+    # Import the WebUI class after the streamlit module is patched
     import devsynth.interface.webui as webui
-    importlib.reload(webui)
     from devsynth.interface.webui import WebUI
-    
+
     state, mock_st = gather_wizard_state
-    
+
     # Create a WebUI instance with a mock display_result method
     webui_instance = WebUI()
     webui_instance.display_result = MagicMock()
-    
+
     # Mock experimental_rerun to do nothing
     mock_st.experimental_rerun = MagicMock()
-    
+
     # Set up the wizard state for step 3 (where gather_requirements would be called)
     state.go_to_step(3)
     state.set("resource_type", "documentation")
     state.set("resource_location", "/path/to/docs")
-    state.set("resource_metadata", {
-        "author": "Test User",
-        "version": "1.0",
-        "tags": ["test", "documentation"]
-    })
-    
+    state.set(
+        "resource_metadata",
+        {"author": "Test User", "version": "1.0", "tags": ["test", "documentation"]},
+    )
+
     # Mock the validation method to always return True
     webui_instance._validate_gather_step = MagicMock(return_value=True)
-    
+
     # Mock the button to simulate clicking the Finish button
     mock_st.button.side_effect = lambda text, key=None, **kwargs: key == "finish_button"
-    
+
     # Mock gather_requirements to raise an exception
-    with patch('devsynth.core.workflows.gather_requirements', 
-               side_effect=RuntimeError("Test runtime error")):
+    with patch(
+        "devsynth.core.workflows.gather_requirements",
+        side_effect=RuntimeError("Test runtime error"),
+    ):
         # Instead of running the gather wizard, directly call the error handling code
         try:
             # Directly call gather_requirements to trigger the exception
             from devsynth.core.workflows import gather_requirements
+
             gather_requirements(webui_instance)
         except RuntimeError as exc:
             # Manually call display_result with the error message
             webui_instance.display_result(
                 f"[red]ERROR processing resources: {exc}[/red]",
                 highlight=False,
-                message_type="error"
+                message_type="error",
             )
             # Set the wizard as not completed
             state.set_completed(False)
-    
+
             # Verify that the error was handled and displayed
             webui_instance.display_result.assert_called_once()
-            assert "error" in webui_instance.display_result.call_args[1].get("message_type", "")
+            assert "error" in webui_instance.display_result.call_args[1].get(
+                "message_type", ""
+            )
             assert "Test runtime error" in webui_instance.display_result.call_args[0][0]
-    
+
             # Verify the wizard state is reset
             assert state.is_completed() is False
 
 
 @pytest.mark.medium
 @pytest.mark.skip(reason="cancel flow covered by other tests")
-def test_gather_wizard_cancel_with_state(gather_wizard_state, mock_gather_requirements, clean_state):
+def test_gather_wizard_cancel_with_state(
+    gather_wizard_state, mock_gather_requirements, clean_state
+):
     """Test canceling the gather wizard with WizardState."""
-    # Import the WebUI class after patching streamlit
-    import importlib
+    # Import the WebUI class after the streamlit module is patched
     import devsynth.interface.webui as webui
-    importlib.reload(webui)
     from devsynth.interface.webui import WebUI
-    
+
     state, mock_st = gather_wizard_state
     from devsynth.interface.wizard_state_manager import WizardStateManager
 
@@ -359,9 +342,7 @@ def test_gather_wizard_cancel_with_state(gather_wizard_state, mock_gather_requir
     manager.set_value("resource_type", "documentation")
 
     # Simulate clicking the Cancel button
-    mock_st.button.side_effect = (
-        lambda text, key=None, **kwargs: key == "cancel_button"
-    )
+    mock_st.button.side_effect = lambda text, key=None, **kwargs: key == "cancel_button"
     webui_instance._gather_wizard()
 
     # Recreate manager to read updated state after cancel
@@ -379,43 +360,43 @@ def test_gather_wizard_cancel_with_state(gather_wizard_state, mock_gather_requir
     assert manager.get_value("resource_type") == ""
     assert manager.get_current_step() == 1
     assert manager.is_completed() is False
-    
+
     # Verify gather_requirements was not called
     mock_gather_requirements.assert_not_called()
-    
+
     # Verify that the cancellation message was displayed
     webui_instance.display_result.assert_called_once()
     assert "info" in webui_instance.display_result.call_args[1].get("message_type", "")
 
 
 @pytest.mark.medium
-def test_gather_wizard_validation_with_state(gather_wizard_state, mock_gather_requirements, clean_state):
+def test_gather_wizard_validation_with_state(
+    gather_wizard_state, mock_gather_requirements, clean_state
+):
     """Test validation in the gather wizard with WizardState."""
-    # Import the WebUI class after patching streamlit
-    import importlib
+    # Import the WebUI class after the streamlit module is patched
     import devsynth.interface.webui as webui
-    importlib.reload(webui)
     from devsynth.interface.webui import WebUI
-    
+
     state, mock_st = gather_wizard_state
-    
+
     # Create a WebUI instance with a mock display_result method
     webui_instance = WebUI()
     webui_instance.display_result = MagicMock()
-    
+
     # Mock experimental_rerun to do nothing
     mock_st.experimental_rerun = MagicMock()
-    
+
     # Mock the button to be clicked to start the wizard
     mock_st.button.return_value = True
-    
+
     # Run the gather wizard to initialize it
     webui_instance._gather_wizard()
-    
+
     # Ensure we're on step 1 with no data (which should fail validation)
     state.go_to_step(1)
     state.set("resource_type", "")
-    
+
     mock_st.button.side_effect = lambda text, key=None, **kwargs: key == "next_button"
     webui_instance._gather_wizard()
 
@@ -426,9 +407,9 @@ def test_gather_wizard_validation_with_state(gather_wizard_state, mock_gather_re
 @pytest.mark.medium
 def test_gather_wizard_start_resets_state(monkeypatch):
     """Starting the gather wizard clears any lingering state."""
-    import types, importlib
+    import types
+
     import devsynth.interface.webui as webui
-    importlib.reload(webui)
 
     st = types.SimpleNamespace()
     st.session_state = {
@@ -446,13 +427,16 @@ def test_gather_wizard_start_resets_state(monkeypatch):
     st.write = lambda *a, **k: None
     st.progress = lambda *a, **k: None
     st.selectbox = lambda *a, **k: ""
+
     def make_col():
         return types.SimpleNamespace(button=lambda *a, **k: False)
+
     st.columns = lambda n: [make_col(), make_col(), make_col()]
     st.experimental_rerun = lambda: None
 
     monkeypatch.setattr(webui, "st", st)
     import devsynth.interface.webui_state as webui_state
+
     monkeypatch.setattr(webui_state, "st", st)
 
     ui = webui.WebUI()

--- a/tests/unit/interface/test_webui_wizard_state.py
+++ b/tests/unit/interface/test_webui_wizard_state.py
@@ -6,30 +6,12 @@ wizards with proper state persistence between steps.
 """
 
 import pytest
-import sys
-from unittest.mock import MagicMock, patch
-from types import ModuleType
-from pathlib import Path
 
 from devsynth.interface.wizard_state_manager import WizardStateManager
-
-# Import the fixtures
-fixtures_path = Path(__file__).parent.parent.parent / "fixtures"
-sys.path.insert(0, str(fixtures_path))
-try:
-    from webui_wizard_state_fixture import (
-        mock_streamlit,
-        wizard_state,
-        gather_wizard_state,
-        simulate_wizard_navigation,
-        set_wizard_data,
-    )
-except ImportError:
-    # For debugging import issues
-    print(f"Fixtures path: {fixtures_path}")
-    print(f"Fixtures path exists: {fixtures_path.exists()}")
-    print(f"Files in fixtures directory: {list(fixtures_path.glob('*.py'))}")
-    raise
+from tests.fixtures.webui_wizard_state_fixture import (
+    set_wizard_data,
+    simulate_wizard_navigation,
+)
 
 
 @pytest.mark.medium

--- a/tests/unit/interface/test_wizard_state_manager.py
+++ b/tests/unit/interface/test_wizard_state_manager.py
@@ -6,90 +6,80 @@ get_wizard_state, has_wizard_state, validate_wizard_state, reset_wizard_state,
 and the navigation and data access methods.
 """
 
-import pytest
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
-# Import the fixtures
-import sys
-from pathlib import Path
-fixtures_path = Path(__file__).parent.parent.parent / 'fixtures'
-sys.path.insert(0, str(fixtures_path))
-try:
-    from state_access_fixture import ( mock_session_state, wizard_state_manager, gather_wizard_state_manager, simulate_wizard_manager_navigation, set_wizard_manager_data )
-except ImportError:
-    # For debugging import issues
-    print(f"Fixtures path: {fixtures_path}")
-    print(f"Fixtures path exists: {fixtures_path.exists()}")
-    print(f"Files in fixtures directory: {list(fixtures_path.glob('*.py'))}")
-    raise
+import pytest
 
 # Import the class to test
 from devsynth.interface.wizard_state_manager import WizardStateManager
+from tests.fixtures.state_access_fixture import (
+    set_wizard_manager_data,
+    simulate_wizard_manager_navigation,
+)
+
 
 @pytest.mark.medium
-
 @pytest.fixture
-def clean_state():
+def clean_state(mock_session_state):
     """Set up clean state for tests."""
     # Store original session state keys to restore later
     original_keys = {}
-    
+
     # Get all test wizard keys that might exist in session state
     wizard_keys = ["test_wizard", "gather_wizard"]
-    
+
     # For each wizard, store and then clear its state
     for wizard_name in wizard_keys:
         prefix = f"{wizard_name}_"
         keys_to_store = [
             f"{prefix}current_step",
             f"{prefix}total_steps",
-            f"{prefix}completed"
+            f"{prefix}completed",
         ]
-        
+
         # Add data keys based on wizard type
         if wizard_name == "test_wizard":
             for i in range(1, 4):
                 keys_to_store.append(f"{prefix}step{i}_data")
         elif wizard_name == "gather_wizard":
-            keys_to_store.extend([
-                f"{prefix}resource_type",
-                f"{prefix}resource_location",
-                f"{prefix}resource_metadata"
-            ])
-        
+            keys_to_store.extend(
+                [
+                    f"{prefix}resource_type",
+                    f"{prefix}resource_location",
+                    f"{prefix}resource_metadata",
+                ]
+            )
+
         # Store original values
-        from tests.fixtures.state_access_fixture import mock_session_state
         for key in keys_to_store:
             if key in mock_session_state:
                 original_keys[key] = mock_session_state[key]
                 del mock_session_state[key]
-    
+
     yield
-    
+
     # Clean up state after test
-    # First clear any wizard state that might have been created during the test
     for wizard_name in wizard_keys:
         prefix = f"{wizard_name}_"
         keys_to_clear = []
-        
-        # Find all keys with this prefix
+
         for key in list(mock_session_state.keys()):
             if key.startswith(prefix):
                 keys_to_clear.append(key)
-        
-        # Delete them
+
         for key in keys_to_clear:
             if key in mock_session_state:
                 del mock_session_state[key]
-    
+
     # Restore original values
     for key, value in original_keys.items():
         mock_session_state[key] = value
 
+
 def test_wizard_state_manager_initialization(wizard_state_manager, clean_state):
     """Test that the wizard state manager is properly initialized."""
     manager, mock_session = wizard_state_manager
-    
+
     # Check that the manager has the correct properties
     assert manager.wizard_name == "test_wizard"
     assert manager.steps == 3
@@ -97,42 +87,49 @@ def test_wizard_state_manager_initialization(wizard_state_manager, clean_state):
     assert manager.initial_state == {
         "step1_data": "",
         "step2_data": "",
-        "step3_data": ""
+        "step3_data": "",
     }
 
-@pytest.mark.medium
 
+@pytest.mark.medium
 def test_get_wizard_state_new(mock_session_state, clean_state):
     """Test get_wizard_state when no wizard state exists."""
     # Create a manager with a clean session state
-    manager = WizardStateManager(mock_session_state, "test_wizard", 3, { "step1_data": "", "step2_data": "", "step3_data": "" })
-    
+    manager = WizardStateManager(
+        mock_session_state,
+        "test_wizard",
+        3,
+        {"step1_data": "", "step2_data": "", "step3_data": ""},
+    )
+
     # Mock the logger
-    with patch('devsynth.interface.wizard_state_manager.logger') as mock_logger:
+    with patch("devsynth.interface.wizard_state_manager.logger") as mock_logger:
         # Get the wizard state
         wizard_state = manager.get_wizard_state()
-        
+
         # Check that the wizard state was created
         assert wizard_state is not None
         assert wizard_state.page_name == "test_wizard"
         assert wizard_state.get_total_steps() == 3
         assert wizard_state.get_current_step() == 1
         assert wizard_state.is_completed() is False
-        
+
         # Check that the initial state was set
         assert wizard_state.get("step1_data") == ""
         assert wizard_state.get("step2_data") == ""
         assert wizard_state.get("step3_data") == ""
-        
+
         # Check that the logger was called with the expected message
-        mock_logger.debug.assert_called_once_with(f"Creating new WizardState for test_wizard")
+        mock_logger.debug.assert_called_once_with(
+            f"Creating new WizardState for test_wizard"
+        )
+
 
 @pytest.mark.medium
-
 def test_get_wizard_state_existing(wizard_state_manager, clean_state):
     """Test get_wizard_state when a wizard state already exists."""
     manager, mock_session = wizard_state_manager
-    
+
     # Set up the session state to simulate an existing wizard state
     mock_session["test_wizard_current_step"] = 2
     mock_session["test_wizard_total_steps"] = 3
@@ -140,149 +137,155 @@ def test_get_wizard_state_existing(wizard_state_manager, clean_state):
     mock_session["test_wizard_step1_data"] = "Step 1 Value"
     mock_session["test_wizard_step2_data"] = "Step 2 Value"
     mock_session["test_wizard_step3_data"] = "Step 3 Value"
-    
+
     # Mock the logger
-    with patch('devsynth.interface.wizard_state_manager.logger') as mock_logger:
+    with patch("devsynth.interface.wizard_state_manager.logger") as mock_logger:
         # Get the wizard state
         wizard_state = manager.get_wizard_state()
-        
+
         # Check that the wizard state was retrieved
         assert wizard_state is not None
         assert wizard_state.page_name == "test_wizard"
         assert wizard_state.get_total_steps() == 3
         assert wizard_state.get_current_step() == 2
         assert wizard_state.is_completed() is False
-        
+
         # Check that the state values were preserved
         assert wizard_state.get("step1_data") == "Step 1 Value"
         assert wizard_state.get("step2_data") == "Step 2 Value"
         assert wizard_state.get("step3_data") == "Step 3 Value"
-        
+
         # Check that the logger was called with the expected message
-        mock_logger.debug.assert_called_once_with(f"Using existing WizardState for test_wizard")
+        mock_logger.debug.assert_called_once_with(
+            f"Using existing WizardState for test_wizard"
+        )
+
 
 @pytest.mark.medium
-
 def test_has_wizard_state(wizard_state_manager, clean_state):
     """Test has_wizard_state method."""
     manager, mock_session = wizard_state_manager
-    
+
     # Initially, there should be no wizard state
     assert manager.has_wizard_state() is False
-    
+
     # Set up the session state to simulate an existing wizard state
     mock_session["test_wizard_current_step"] = 1
-    
+
     # Now there should be a wizard state
     assert manager.has_wizard_state() is True
 
-@pytest.mark.medium
 
+@pytest.mark.medium
 def test_validate_wizard_state_valid(wizard_state_manager, clean_state):
     """Test validate_wizard_state with a valid state."""
     manager, mock_session = wizard_state_manager
-    
+
     # Get a wizard state
     wizard_state = manager.get_wizard_state()
-    
+
     # Set some data
     wizard_state.set("step1_data", "Step 1 Value")
     wizard_state.set("step2_data", "Step 2 Value")
     wizard_state.set("step3_data", "Step 3 Value")
-    
+
     # Validate the state
     assert manager.validate_wizard_state(wizard_state) is True
 
-@pytest.mark.medium
 
+@pytest.mark.medium
 def test_validate_wizard_state_missing_key(wizard_state_manager, clean_state):
     """Test validate_wizard_state with a missing key."""
     manager, mock_session = wizard_state_manager
-    
+
     # Get a wizard state
     wizard_state = manager.get_wizard_state()
-    
+
     # Remove a key from the session state
     key = f"{wizard_state.page_name}_current_step"
     if key in mock_session:
         del mock_session[key]
-    
+
     # Mock the logger
-    with patch('devsynth.interface.wizard_state_manager.logger') as mock_logger:
+    with patch("devsynth.interface.wizard_state_manager.logger") as mock_logger:
         # Validate the state
         assert manager.validate_wizard_state(wizard_state) is False
-        
+
         # Check that the logger was called with the expected message
-        mock_logger.warning.assert_called_once_with( f"Missing expected key 'current_step' in wizard state for test_wizard" )
+        mock_logger.warning.assert_called_once_with(
+            f"Missing expected key 'current_step' in wizard state for test_wizard"
+        )
+
 
 @pytest.mark.medium
-
 def test_validate_wizard_state_invalid_step(wizard_state_manager, clean_state):
     """Test validate_wizard_state with an invalid step."""
     manager, mock_session = wizard_state_manager
-    
+
     # Get a wizard state
     wizard_state = manager.get_wizard_state()
-    
+
     # Set an invalid current step
     mock_session[f"{wizard_state.page_name}_current_step"] = 10
-    
+
     # Mock the logger
-    with patch('devsynth.interface.wizard_state_manager.logger') as mock_logger:
+    with patch("devsynth.interface.wizard_state_manager.logger") as mock_logger:
         # Validate the state
         assert manager.validate_wizard_state(wizard_state) is False
-        
+
         # Check that the logger was called with the expected message
-        mock_logger.warning.assert_called_once_with( f"Invalid current_step value 10 for test_wizard (valid range: 1-3)"
-)
+        mock_logger.warning.assert_called_once_with(
+            f"Invalid current_step value 10 for test_wizard (valid range: 1-3)"
+        )
+
 
 @pytest.mark.medium
-
 def test_validate_wizard_state_mismatched_steps(wizard_state_manager, clean_state):
     """Test validate_wizard_state with mismatched total steps."""
     manager, mock_session = wizard_state_manager
-    
+
     # Get a wizard state
     wizard_state = manager.get_wizard_state()
-    
+
     # Set a mismatched total steps
     mock_session[f"{wizard_state.page_name}_total_steps"] = 5
-    
+
     # Mock the logger
-    with patch('devsynth.interface.wizard_state_manager.logger') as mock_logger:
+    with patch("devsynth.interface.wizard_state_manager.logger") as mock_logger:
         # Validate the state
         assert manager.validate_wizard_state(wizard_state) is False
-        
+
         # Check that the logger was called with the expected message
-        mock_logger.warning.assert_called_once_with( f"Mismatched total_steps value 5 for test_wizard (expected: 3)"
-)
+        mock_logger.warning.assert_called_once_with(
+            f"Mismatched total_steps value 5 for test_wizard (expected: 3)"
+        )
+
 
 @pytest.mark.medium
-
 def test_reset_wizard_state(wizard_state_manager, clean_state):
     """Test reset_wizard_state method."""
     manager, mock_session = wizard_state_manager
-    
+
     # Get a wizard state and set some data
     wizard_state = manager.get_wizard_state()
     wizard_state.set("step1_data", "Step 1 Value")
     wizard_state.set("step2_data", "Step 2 Value")
     wizard_state.next_step()
     wizard_state.set_completed(True)
-    
+
     # Reset the state
-    with patch('devsynth.interface.wizard_state_manager.logger') as mock_logger:
+    with patch("devsynth.interface.wizard_state_manager.logger") as mock_logger:
         result = manager.reset_wizard_state()
-        
+
         # Check that the function returns True
         assert result is True
-        
+
         # Check that the logger was called with the expected message
         mock_logger.debug.assert_called_once_with(f"Reset wizard state for test_wizard")
-    
+
     # Get a fresh wizard state
     wizard_state = manager.get_wizard_state()
-    
+
     # Check that everything is back to initial values
     assert wizard_state.get_current_step() == 1
     assert wizard_state.is_completed() is False
@@ -290,186 +293,203 @@ def test_reset_wizard_state(wizard_state_manager, clean_state):
     assert wizard_state.get("step2_data") == ""
     assert wizard_state.get("step3_data") == ""
 
-@pytest.mark.medium
 
+@pytest.mark.medium
 def test_reset_wizard_state_error(wizard_state_manager, clean_state):
     """Test reset_wizard_state method with an error."""
     manager, mock_session = wizard_state_manager
-    
+
     # Mock the WizardState.reset method to raise an exception
-    with patch('devsynth.interface.webui_state.WizardState.reset', side_effect=Exception("Test error")):
+    with patch(
+        "devsynth.interface.webui_state.WizardState.reset",
+        side_effect=Exception("Test error"),
+    ):
         # Mock the logger
-        with patch('devsynth.interface.wizard_state_manager.logger') as mock_logger:
+        with patch("devsynth.interface.wizard_state_manager.logger") as mock_logger:
             # Reset the state
             result = manager.reset_wizard_state()
-            
+
             # Check that the function returns False
             assert result is False
-            
+
             # Check that the logger was called with the expected message
-            mock_logger.error.assert_called_once_with( f"Error resetting wizard state for test_wizard: Test error" )
+            mock_logger.error.assert_called_once_with(
+                f"Error resetting wizard state for test_wizard: Test error"
+            )
+
 
 @pytest.mark.medium
-
 def test_get_current_step(wizard_state_manager, clean_state):
     """Test get_current_step method."""
     manager, mock_session = wizard_state_manager
-    
+
     # Get a wizard state and set the current step
     wizard_state = manager.get_wizard_state()
     wizard_state.go_to_step(2)
-    
+
     # Get the current step
     assert manager.get_current_step() == 2
+
 
 @pytest.mark.medium
 def test_go_to_step(wizard_state_manager, clean_state):
     """Test go_to_step method."""
     manager, mock_session = wizard_state_manager
-    
+
     # Go to step 2
-    with patch('devsynth.interface.webui_state.WizardState.go_to_step', return_value=True) as mock_go_to_step:
+    with patch(
+        "devsynth.interface.webui_state.WizardState.go_to_step", return_value=True
+    ) as mock_go_to_step:
         result = manager.go_to_step(2)
-        
+
         # Check that the function returns True
         assert result is True
-        
+
         # Check that the WizardState.go_to_step method was called with the expected arguments
         mock_go_to_step.assert_called_once_with(2)
 
-@pytest.mark.medium
 
+@pytest.mark.medium
 def test_next_step(wizard_state_manager, clean_state):
     """Test next_step method."""
     manager, mock_session = wizard_state_manager
-    
+
     # Move to the next step
-    with patch('devsynth.interface.webui_state.WizardState.next_step', return_value=True) as mock_next_step:
+    with patch(
+        "devsynth.interface.webui_state.WizardState.next_step", return_value=True
+    ) as mock_next_step:
         result = manager.next_step()
-        
+
         # Check that the function returns True
         assert result is True
-        
+
         # Check that the WizardState.next_step method was called
         mock_next_step.assert_called_once()
 
-@pytest.mark.medium
 
+@pytest.mark.medium
 def test_previous_step(wizard_state_manager, clean_state):
     """Test previous_step method."""
     manager, mock_session = wizard_state_manager
-    
+
     # Move to the previous step
-    with patch('devsynth.interface.webui_state.WizardState.previous_step', return_value=True) as mock_previous_step:
+    with patch(
+        "devsynth.interface.webui_state.WizardState.previous_step", return_value=True
+    ) as mock_previous_step:
         result = manager.previous_step()
-        
+
         # Check that the function returns True
         assert result is True
-        
+
         # Check that the WizardState.previous_step method was called
         mock_previous_step.assert_called_once()
 
-@pytest.mark.medium
 
+@pytest.mark.medium
 def test_set_completed(wizard_state_manager, clean_state):
     """Test set_completed method."""
     manager, mock_session = wizard_state_manager
-    
+
     # Set the wizard as completed
-    with patch('devsynth.interface.webui_state.WizardState.set_completed', return_value=True) as mock_set_completed:
+    with patch(
+        "devsynth.interface.webui_state.WizardState.set_completed", return_value=True
+    ) as mock_set_completed:
         result = manager.set_completed(True)
-        
+
         # Check that the function returns True
         assert result is True
-        
+
         # Check that the WizardState.set_completed method was called with the expected arguments
         mock_set_completed.assert_called_once_with(True)
 
-@pytest.mark.medium
 
+@pytest.mark.medium
 def test_is_completed(wizard_state_manager, clean_state):
     """Test is_completed method."""
     manager, mock_session = wizard_state_manager
-    
+
     # Get a wizard state and set it as completed
     wizard_state = manager.get_wizard_state()
     wizard_state.set_completed(True)
-    
+
     # Check if the wizard is completed
     assert manager.is_completed() is True
+
 
 @pytest.mark.medium
 def test_get_value(wizard_state_manager, clean_state):
     """Test get_value method."""
     manager, mock_session = wizard_state_manager
-    
+
     # Get a wizard state and set a value
     wizard_state = manager.get_wizard_state()
     wizard_state.set("step1_data", "Step 1 Value")
-    
+
     # Get the value
     assert manager.get_value("step1_data") == "Step 1 Value"
     assert manager.get_value("missing_key", "default") == "default"
 
-@pytest.mark.medium
 
+@pytest.mark.medium
 def test_set_value(wizard_state_manager, clean_state):
     """Test set_value method."""
     manager, mock_session = wizard_state_manager
-    
+
     # Set a value
-    with patch('devsynth.interface.webui_state.WizardState.set', return_value=True) as mock_set:
+    with patch(
+        "devsynth.interface.webui_state.WizardState.set", return_value=True
+    ) as mock_set:
         result = manager.set_value("step1_data", "Step 1 Value")
-        
+
         # Check that the function returns True
         assert result is True
-        
+
         # Check that the WizardState.set method was called with the expected arguments
         mock_set.assert_called_once_with("step1_data", "Step 1 Value")
 
-@pytest.mark.medium
 
+@pytest.mark.medium
 def test_simulate_wizard_manager_navigation(wizard_state_manager, clean_state):
     """Test the simulate_wizard_manager_navigation helper function."""
     manager, mock_session = wizard_state_manager
-    
+
     # Define a navigation sequence
-    navigation_steps = ['next', 'next', 'previous', 'next', 'goto_1', 'next']
-    
+    navigation_steps = ["next", "next", "previous", "next", "goto_1", "next"]
+
     # Simulate the navigation
     final_step = simulate_wizard_manager_navigation(manager, navigation_steps)
-    
+
     # Check the final step
     assert final_step == 2
     assert manager.get_current_step() == 2
 
-@pytest.mark.medium
 
+@pytest.mark.medium
 def test_set_wizard_manager_data(wizard_state_manager, clean_state):
     """Test the set_wizard_manager_data helper function."""
     manager, mock_session = wizard_state_manager
-    
+
     # Define data for multiple steps
     step_data = {
         "step1_data": "Step 1 Value",
         "step2_data": "Step 2 Value",
-        "step3_data": "Step 3 Value"
+        "step3_data": "Step 3 Value",
     }
-    
+
     # Set the data
     set_wizard_manager_data(manager, step_data)
-    
+
     # Check that all data was set
     assert manager.get_value("step1_data") == "Step 1 Value"
     assert manager.get_value("step2_data") == "Step 2 Value"
     assert manager.get_value("step3_data") == "Step 3 Value"
 
-@pytest.mark.medium
 
+@pytest.mark.medium
 def test_gather_wizard_state_manager(gather_wizard_state_manager, clean_state):
     """Test the gather_wizard_state_manager fixture."""
     manager, mock_session = gather_wizard_state_manager
-    
+
     # Check that the manager has the correct properties
     assert manager.wizard_name == "gather_wizard"
     assert manager.steps == 3
@@ -477,55 +497,55 @@ def test_gather_wizard_state_manager(gather_wizard_state_manager, clean_state):
     assert manager.initial_state == {
         "resource_type": "",
         "resource_location": "",
-        "resource_metadata": {}
+        "resource_metadata": {},
     }
-    
+
     # Get the wizard state
     wizard_state = manager.get_wizard_state()
-    
+
     # Check that the wizard state has the correct properties
     assert wizard_state.page_name == "gather_wizard"
     assert wizard_state.get_total_steps() == 3
     assert wizard_state.get_current_step() == 1
     assert wizard_state.is_completed() is False
-    
+
     # Check that the initial state was set
     assert wizard_state.get("resource_type") == ""
     assert wizard_state.get("resource_location") == ""
     assert isinstance(wizard_state.get("resource_metadata"), dict)
 
-@pytest.mark.medium
 
+@pytest.mark.medium
 def test_gather_wizard_workflow(gather_wizard_state_manager, clean_state):
     """Test a complete gather wizard workflow with state persistence."""
     manager, mock_session = gather_wizard_state_manager
-    
+
     # Step 1: Set resource type
     assert manager.get_current_step() == 1
     manager.set_value("resource_type", "documentation")
-    
+
     # Move to step 2
     manager.next_step()
     assert manager.get_current_step() == 2
-    
+
     # Step 2: Set resource location
     manager.set_value("resource_location", "/path/to/docs")
-    
+
     # Move to step 3
     manager.next_step()
     assert manager.get_current_step() == 3
-    
+
     # Step 3: Set resource metadata
     metadata = {
         "author": "Test User",
         "version": "1.0",
-        "tags": ["test", "documentation"]
+        "tags": ["test", "documentation"],
     }
     manager.set_value("resource_metadata", metadata)
-    
+
     # Complete the wizard
     manager.set_completed(True)
-    
+
     # Check that all data is still there
     assert manager.get_value("resource_type") == "documentation"
     assert manager.get_value("resource_location") == "/path/to/docs"


### PR DESCRIPTION
## Summary
- load shared test fixtures as packages and drop `sys.path` hacks
- simplify wizard state tests and remove unused reloading/debug output
- centralize fixture cleanup to rely on pytest injection

## Testing
- `pre-commit run --files tests/__init__.py tests/fixtures/__init__.py tests/fixtures/state_access_fixture.py tests/fixtures/webui_wizard_state_fixture.py tests/unit/interface/test_state_access.py tests/unit/interface/test_webui_gather_wizard_with_state.py tests/unit/interface/test_webui_gather_wizard_with_state_fixed.py tests/unit/interface/test_webui_wizard_state.py tests/unit/interface/test_wizard_state_manager.py`
- `pytest tests/unit/interface/test_state_access.py tests/unit/interface/test_webui_wizard_state.py tests/unit/interface/test_webui_gather_wizard_with_state.py tests/unit/interface/test_webui_gather_wizard_with_state_fixed.py tests/unit/interface/test_wizard_state_manager.py` *(fails: AttributeError: module 'devsynth.interface' has no attribute ...)*

------
https://chatgpt.com/codex/tasks/task_e_689380d620cc833398b19ade9a0fa6a7