### PR TITLE
Link alpha tasks to milestone and update status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,3 +63,4 @@ version has been published yet.
 ### Fixed
 - Optional tiktoken dependency no longer breaks Kuzu memory initialization
 - Added missing step definitions for enhanced memory scenarios
+- Linked remaining alpha tasks (WebUI, Kuzu memory, WSDE collaboration, CLI ingestion) to milestone `0.1.0-alpha.1` and updated development status.

--- a/docs/roadmap/development_status.md
+++ b/docs/roadmap/development_status.md
@@ -405,8 +405,7 @@ The completion of Phase 1 produced several key artifacts:
 7. **Metrics Commands Implemented**:
    - Added `alignment_metrics` and `test_metrics` CLI commands
    - Commands generate alignment and test-first development reports
-   - Latest coverage reports show approximately **15%** line coverage across the
-     codebase.
+   - Latest coverage run encountered failures before generating a new report; baseline coverage remains roughly **15%** line coverage across the codebase.
 
 ### Remaining Test Failures
 
@@ -442,9 +441,10 @@ All phases of the DevSynth Repository Harmonization Plan have been successfully 
 - ~~Finalize unit tests for the `MemoryType` enum and resolve any remaining failures.~~
 - ~~Verify that the EDRR coordinator and AST code analysis features fully match their BDD scenarios.~~
 - ~~Complete WSDE agent collaboration capabilities.~~
-- Investigate failing Web UI and Kuzu-related tests; implement fixes for the requirements wizard and memory initialization logic.
-- Complete WSDE collaboration integration with the memory system; finalize peer review workflow and cross-store synchronization.
-- Some CLI and ingestion workflows still require interactive prompts. Related unit tests now run unconditionally in the hermetic test environment and no longer depend on the `DEVSYNTH_RUN_INGEST_TESTS` or `DEVSYNTH_RUN_WSDE_TESTS` flags.
+- [Issue 102](../../issues/102.md): refine WebUI and interactive CLI flows, resolving requirements wizard navigation bugs.
+- [Issue 113](../../issues/113.md): stabilize Kuzu-backed memory initialization and related tests.
+- [Issue 112](../../issues/112.md): complete WSDE collaboration with memory synchronization.
+- [Issue 117](../../issues/117.md): remove interactive prompts from CLI ingestion to support automation.
 
 For updated scheduling, see the [Consolidated Roadmap](CONSOLIDATED_ROADMAP.md).
 ## Implementation Status

--- a/issues/102.md
+++ b/issues/102.md
@@ -1,4 +1,5 @@
 # Issue 102: CLI and UI improvements
+Milestone: 0.1.0-alpha.1
 
 This issue tracks tasks for refining the interactive CLI and planned WebUI.
 

--- a/issues/112.md
+++ b/issues/112.md
@@ -1,4 +1,5 @@
 # Issue 112: WSDE collaboration test failures
+Milestone: 0.1.0-alpha.1
 
 Recent test runs show multiple failures in the WSDE/EDRR integration suites:
 - `tests/integration/general/test_wsde_edrr_component_interactions.py`

--- a/issues/113.md
+++ b/issues/113.md
@@ -1,4 +1,5 @@
 # Issue 113: Kuzu memory integration errors
+Milestone: 0.1.0-alpha.1
 
 The Kuzu backed memory store fails during test setup:
 ```

--- a/issues/117.md
+++ b/issues/117.md
@@ -1,0 +1,5 @@
+# Issue 117: CLI ingestion remains interactive
+
+Milestone: 0.1.0-alpha.1
+
+The documentation ingestion workflow still requires user prompts, blocking automation and hermetic tests. Provide non-interactive flags and sensible defaults so projects can be ingested via the CLI without manual input.


### PR DESCRIPTION
## Summary
- track WebUI, Kuzu, WSDE, and CLI ingestion tasks with milestone notes
- refresh development status with links and coverage note
- update changelog for upcoming alpha release

## Testing
- `poetry run pytest --cov=src` *(fails: 551 failed, 406 passed, 98 skipped, 4 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68939dd96d4c833398ca9bd106120945