### PR TITLE
Add deployment helpers and container publish workflow

### DIFF
--- a/.github/workflows/build-and-push.yml.disabled
+++ b/.github/workflows/build-and-push.yml.disabled
@@ -1,0 +1,34 @@
+# This workflow is disabled by default. Rename the file to build-and-push.yml to enable it.
+name: Build and Push Container
+
+on:
+  push:
+    branches: [ main ]
+    paths:
+      - 'Dockerfile'
+      - '.github/workflows/build-and-push.yml'
+      - 'deployment/**'
+  workflow_dispatch:
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build and push
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: true
+          tags: ghcr.io/${{ github.repository }}:latest

--- a/deployment/README.md
+++ b/deployment/README.md
@@ -1,13 +1,21 @@
 # Deployment Configurations
 
-This directory contains Docker Compose files for running DevSynth and its dependencies.
+This directory contains Docker Compose files and helper scripts for running DevSynth and its dependencies.
 
 - `docker-compose.yml` – core services (DevSynth API and ChromaDB)
 - `docker-compose.monitoring.yml` – optional monitoring stack with Prometheus and Grafana
+- `bootstrap_env.sh` – build and start DevSynth with monitoring
+- `health_check.sh` – verify running services
 
 Use these files together to spin up a complete local environment:
 
 ```bash
 # Start DevSynth with monitoring
-docker compose -f deployment/docker-compose.yml -f deployment/docker-compose.monitoring.yml up -d
+./deployment/bootstrap_env.sh
+```
+
+Check service status:
+
+```bash
+./deployment/health_check.sh
 ```

--- a/deployment/bootstrap_env.sh
+++ b/deployment/bootstrap_env.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Bootstrap the local DevSynth environment.
+# Builds and starts DevSynth along with monitoring stack.
+
+docker compose -f deployment/docker-compose.yml -f deployment/docker-compose.monitoring.yml up -d --build

--- a/deployment/health_check.sh
+++ b/deployment/health_check.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Check the health of DevSynth services.
+# Verifies API and monitoring endpoints respond successfully.
+
+curl -fsS http://localhost:8000/health > /dev/null
+curl -fsS http://localhost:3000/api/health > /dev/null
+
+echo "All services are healthy"

--- a/tests/unit/deployment/test_deployment_scripts.py
+++ b/tests/unit/deployment/test_deployment_scripts.py
@@ -1,0 +1,18 @@
+import os
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[3]
+
+
+def test_bootstrap_script_exists():
+    """Bootstrap script should be present and executable."""
+    script = ROOT / "deployment/bootstrap_env.sh"
+    assert script.is_file()
+    assert os.access(script, os.X_OK)
+
+
+def test_health_check_script_exists():
+    """Health check script should be present and executable."""
+    script = ROOT / "deployment/health_check.sh"
+    assert script.is_file()
+    assert os.access(script, os.X_OK)


### PR DESCRIPTION
## Summary
- add bootstrap and health check scripts under `deployment/`
- document deployment helpers and add GHCR build-and-push workflow (disabled by default)
- test for presence of new deployment scripts

## Testing
- `pytest --no-cov tests/unit/deployment/test_deployment_scripts.py`


------
https://chatgpt.com/codex/tasks/task_e_6893f7d965a083338c84f11678f3ebd7