### PR TITLE
Add Bandit and Safety checks to CI

### DIFF
--- a/.github/workflows.disabled/ci.yml
+++ b/.github/workflows.disabled/ci.yml
@@ -30,6 +30,12 @@ jobs:
       - name: Verify MVUU references
         run: |
           python scripts/verify_mvuu_references.py origin/main..HEAD
+      - name: Run Bandit
+        run: |
+          poetry run bandit -q -r src
+      - name: Run Safety
+        run: |
+          python scripts/dependency_safety_check.py
       - name: Build package
         run: |
           poetry build

--- a/docs/policies/security.md
+++ b/docs/policies/security.md
@@ -2,7 +2,7 @@
 
 author: DevSynth Team
 date: '2025-07-07'
-last_reviewed: "2025-07-10"
+last_reviewed: "2025-08-07"
 status: published
 tags:
 
@@ -10,6 +10,7 @@ tags:
 
 title: Security Policy
 version: "0.1.0-alpha.1"
+review_cadence: quarterly
 ---
 <div class="breadcrumbs">
 <a href="../index.md">Documentation</a> &gt; <a href="index.md">Policies</a> &gt; Security Policy
@@ -22,6 +23,10 @@ version: "0.1.0-alpha.1"
 # Security Policy
 
 This policy outlines security design principles and operational guidelines for DevSynth.
+
+## Review Cadence
+
+This policy is reviewed quarterly by the DevSynth team to ensure it remains current and effective.
 
 ## Design Guidelines
 

--- a/tests/unit/security/test_security_audit.py
+++ b/tests/unit/security/test_security_audit.py
@@ -1,4 +1,4 @@
-"""Tests for the deprecated security audit wrapper."""
+"""Tests for the security audit script."""
 
 import sys
 from unittest.mock import patch
@@ -8,28 +8,19 @@ sys.path.append("scripts")
 import security_audit  # type: ignore
 
 
-@patch("security_audit.subprocess.run")
-def test_main_invokes_cli(mock_run) -> None:
-    """The wrapper should invoke the devsynth CLI without flags."""
+@patch("security_audit.run_safety")
+@patch("security_audit.run_bandit")
+def test_main_runs_all_checks(mock_bandit, mock_safety) -> None:
+    """The script should execute Bandit and Safety by default."""
     security_audit.main([])
-    mock_run.assert_called_once_with(["devsynth", "security-audit"], check=True)
+    mock_bandit.assert_called_once()
+    mock_safety.assert_called_once()
 
 
-@patch("security_audit.subprocess.run")
-def test_main_passes_flags(mock_run) -> None:
-    """Flags should be forwarded to the CLI command."""
-    security_audit.main(
-        ["--skip-bandit", "--skip-safety", "--skip-secrets", "--skip-owasp"]
-    )
-    mock_run.assert_called_once_with(
-        [
-            "devsynth",
-            "security-audit",
-            "--skip-static",
-            "--skip-safety",
-            "--skip-secrets",
-            "--skip-owasp",
-        ],
-        check=True,
-    )
-
+@patch("security_audit.run_safety")
+@patch("security_audit.run_bandit")
+def test_main_respects_skip_flags(mock_bandit, mock_safety) -> None:
+    """Skip flags should prevent running the associated tools."""
+    security_audit.main(["--skip-bandit", "--skip-safety"])
+    mock_bandit.assert_not_called()
+    mock_safety.assert_not_called()


### PR DESCRIPTION
## Summary
- run Bandit and Safety as part of CI
- refactor `security_audit.py` to execute Bandit and Safety directly
- document quarterly review cadence in security policy

## Testing
- `SKIP=devsynth-align,fix-code-blocks poetry run pre-commit run --files .github/workflows.disabled/ci.yml scripts/security_audit.py docs/policies/security.md tests/unit/security/test_security_audit.py`
- `poetry run pytest --no-cov tests/unit/security/test_security_audit.py tests/unit/scripts/test_security_ops.py tests/unit/agents/test_security_audit_tool.py`


------
https://chatgpt.com/codex/tasks/task_e_68940e8de3ec83338a0a74253cd74742