### PR TITLE
Expose kuzu embedded setting and use live config

### DIFF
--- a/src/devsynth/application/memory/kuzu_store.py
+++ b/src/devsynth/application/memory/kuzu_store.py
@@ -98,17 +98,12 @@ class KuzuStore(MemoryStore):
         except Exception:  # pragma: no cover - optional
             self.tokenizer = None
 
-        # ``settings_module`` refers to ``devsynth.config.settings`` which
-        # exposes a `_settings` instance.  The module itself does not define a
-        # ``kuzu_embedded`` attribute which previously caused attribute errors
-        # when initializing the store.  Read the value from the exported
-        # constant via ``devsynth.config`` instead of the module attribute.
+        # Determine whether the embedded Kuzu backend should be used.  When no
+        # explicit value is provided, consult the live settings to honour any
+        # environment variable overrides that may have been applied after the
+        # module was imported.
         raw_embedded = (
-            getattr(
-                settings_module,
-                "KUZU_EMBEDDED",
-                settings_module._settings.kuzu_embedded,
-            )
+            settings_module.get_settings().kuzu_embedded
             if use_embedded is None
             else use_embedded
         )

--- a/src/devsynth/config/settings.py
+++ b/src/devsynth/config/settings.py
@@ -188,6 +188,8 @@ class Settings(BaseSettings):
     kuzu_db_path: Optional[str] = Field(
         default=None, json_schema_extra={"env": "DEVSYNTH_KUZU_DB_PATH"}
     )
+    # Enable or disable the embedded KuzuDB backend. When set to ``False``
+    # the system will always fall back to the in-memory implementation.
     kuzu_embedded: bool = Field(
         default=True, json_schema_extra={"env": "DEVSYNTH_KUZU_EMBEDDED"}
     )


### PR DESCRIPTION
## Summary
- document `kuzu_embedded` setting for toggling embedded KuzuDB support
- consult live settings when deciding whether to use embedded Kuzu, respecting env overrides

## Testing
- `poetry run pytest --no-cov tests/integration/general/test_kuzu_memory_integration.py -q` *(fails: Fatal Python error: gilstate_tss_set: failed to set current tstate (TSS))*

------
https://chatgpt.com/codex/tasks/task_e_6894176174ac83338ab2998aa4b73219