### PR TITLE
Refine logging and requirements wizard persistence

### DIFF
--- a/src/devsynth/logging_setup.py
+++ b/src/devsynth/logging_setup.py
@@ -5,15 +5,15 @@ This module provides a centralized logging configuration with structured logging
 capabilities, ensuring consistent error reporting across the application.
 """
 
-import os
-import sys
 import json
 import logging
+import os
+import sys
 import traceback
+from contextvars import ContextVar
 from datetime import datetime
 from pathlib import Path
-from typing import Dict, Any, Optional, Union, List
-from contextvars import ContextVar
+from typing import Any, Dict, List, Optional, Union
 
 # We'll import DevSynthError later to avoid circular imports
 
@@ -384,10 +384,35 @@ class DevSynthLogger:
             exc = (exc.__class__, exc, exc.__traceback__)
 
         if kwargs:
+            RESERVED = {
+                "name",
+                "msg",
+                "args",
+                "levelname",
+                "levelno",
+                "pathname",
+                "filename",
+                "module",
+                "exc_info",
+                "exc_text",
+                "stack_info",
+                "lineno",
+                "funcName",
+                "created",
+                "msecs",
+                "relativeCreated",
+                "thread",
+                "threadName",
+                "processName",
+                "process",
+                "message",
+                "asctime",
+            }
+            safe_kwargs = {k: v for k, v in kwargs.items() if k not in RESERVED}
             if extra is None:
-                extra = kwargs
+                extra = safe_kwargs
             else:
-                extra.update(kwargs)
+                extra.update(safe_kwargs)
 
         log_kwargs: dict[str, Any] = {"exc_info": exc, "extra": extra}
         if stack_info is not None:

--- a/tests/integration/general/test_requirements_gathering.py
+++ b/tests/integration/general/test_requirements_gathering.py
@@ -1,6 +1,7 @@
 import os
 import sys
 from types import ModuleType
+
 import yaml
 
 # Stub optional heavy dependencies for test isolation
@@ -30,11 +31,12 @@ for _name in [
 from devsynth.application.requirements.interactions import gather_requirements
 
 
-def test_gather_updates_config_succeeds(tmp_path):
+def test_gather_updates_config_succeeds(tmp_path, monkeypatch):
     """Test that gather updates config succeeds.
 
     ReqID: N/A"""
     os.chdir(tmp_path)
+    monkeypatch.setenv("DEVSYNTH_PROJECT_DIR", str(tmp_path))
     os.makedirs(".devsynth", exist_ok=True)
     with open(".devsynth/project.yaml", "w", encoding="utf-8") as f:
         f.write("{}")


### PR DESCRIPTION
## Summary
- filter reserved logging attributes to prevent unexpected `LogRecord` errors
- ensure requirements wizard output paths respect project directory isolation
- update requirements gathering test to set project root

## Testing
- `pre-commit run --files src/devsynth/logging_setup.py src/devsynth/application/cli/requirements_commands.py tests/integration/general/test_requirements_gathering.py`
- `poetry run pytest tests/integration/general/test_requirements_gathering.py tests/unit/core/mvu/test_api.py -q`


------
https://chatgpt.com/codex/tasks/task_e_6894b044b6dc8333afbb65680604a68b