### PR TITLE
feat(cli): allow feature flags via list or JSON string

### DIFF
--- a/tests/unit/application/cli/test_init_cmd.py
+++ b/tests/unit/application/cli/test_init_cmd.py
@@ -106,10 +106,12 @@ def test_cli_help_lists_renamed_commands_succeeds(capsys, monkeypatch):
     orig_get_click_type = typer.main.get_click_type
 
     def patched_get_click_type(*, annotation, parameter_info):  # pragma: no cover
-        if annotation in {UXBridge, typer.models.Context}:
+        if annotation in {UXBridge, typer.models.Context, object}:
             return click.STRING
         origin = getattr(annotation, "__origin__", None)
-        if origin in {UXBridge, typer.models.Context, dict} or annotation is dict:
+        if origin in {UXBridge, typer.models.Context, dict, list}:
+            return click.STRING
+        if annotation in {dict, list}:
             return click.STRING
         return orig_get_click_type(annotation=annotation, parameter_info=parameter_info)
 
@@ -130,4 +132,3 @@ def test_cli_help_lists_renamed_commands_succeeds(capsys, monkeypatch):
     assert all(
         not line.startswith("analyze ") and " analyze " not in line for line in lines
     )
-

--- a/tests/unit/cli/test_cli_entry.py
+++ b/tests/unit/cli/test_cli_entry.py
@@ -15,7 +15,7 @@ def patch_typer_types(monkeypatch):
         if annotation in {UXBridge, typer.models.Context}:
             return click.STRING
         origin = getattr(annotation, "__origin__", None)
-        if origin in {UXBridge, typer.models.Context} or annotation is dict or origin is dict:
+        if origin in {UXBridge, typer.models.Context}:
             return click.STRING
         return orig(annotation=annotation, parameter_info=parameter_info)
 
@@ -26,9 +26,10 @@ def test_cli_entry_invokes_run_cli():
     """Ensure the CLI module calls run_cli when executed as __main__."""
     with patch("devsynth.adapters.cli.typer_adapter.run_cli") as mock_run:
         import sys
+
         orig = sys.argv
         sys.argv = ["devsynth"]
-        
+
         try:
             runpy.run_module("devsynth.cli", run_name="__main__")
         except SystemExit:

--- a/tests/unit/cli/test_init_features_option.py
+++ b/tests/unit/cli/test_init_features_option.py
@@ -1,0 +1,38 @@
+from devsynth.application.cli.cli_commands import init_cmd
+from devsynth.interface.cli import CLIUXBridge
+from devsynth.config.unified_loader import UnifiedConfigLoader
+
+
+def _run_init(tmp_path, features, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(
+        "devsynth.application.cli.cli_commands.init_project", lambda **kwargs: None
+    )
+    bridge = CLIUXBridge()
+    init_cmd(
+        root=str(tmp_path),
+        language="python",
+        goals="do stuff",
+        memory_backend="memory",
+        offline_mode=False,
+        features=features,
+        auto_confirm=True,
+        bridge=bridge,
+    )
+    return UnifiedConfigLoader.load(tmp_path).config
+
+
+def test_init_cmd_accepts_feature_list(tmp_path, monkeypatch):
+    cfg = _run_init(tmp_path, ["code_generation", "test_generation"], monkeypatch)
+    assert cfg.features["code_generation"] is True
+    assert cfg.features["test_generation"] is True
+
+
+def test_init_cmd_accepts_feature_json(tmp_path, monkeypatch):
+    cfg = _run_init(
+        tmp_path,
+        ['{"code_generation": true, "test_generation": false}'],
+        monkeypatch,
+    )
+    assert cfg.features["code_generation"] is True
+    assert cfg.features["test_generation"] is False


### PR DESCRIPTION
## Summary
- support parsing feature flags from repeated `--features` options or a JSON mapping
- extend setup wizard to accept feature lists or JSON input
- add tests for feature flag parsing and adjust existing CLI tests

## Testing
- `poetry run pytest tests/unit/cli tests/unit/application/cli/test_setup_wizard.py tests/unit/application/cli/test_init_cmd.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6894b42eb7e48333b0b057e3e5a63ff2