### PR TITLE
Refactor progress helpers and streamline init prompts

### DIFF
--- a/docs/getting_started/basic_usage.md
+++ b/docs/getting_started/basic_usage.md
@@ -33,6 +33,16 @@ DevSynth follows a structured workflow that takes you from requirements to worki
 
 If you prefer a graphical interface, start the WebUI with `devsynth webui`. The WebUI provides pages that correspond to the CLI commands described below.
 
+## Enable Shell Completion
+
+DevSynth can generate shell completion scripts to speed up command entry:
+
+```bash
+devsynth completion --install
+```
+
+Run the above command to install completion for your current shell or omit `--install` to print the script path.
+
 ## Initialize a Project
 
 Start by creating a new DevSynth project:

--- a/src/devsynth/application/cli/commands/completion_cmd.py
+++ b/src/devsynth/application/cli/commands/completion_cmd.py
@@ -15,6 +15,7 @@ from devsynth.interface.cli import CLIUXBridge
 from devsynth.interface.ux_bridge import UXBridge
 from devsynth.logging_setup import DevSynthLogger
 from devsynth.interface.enhanced_error_handler import improved_error_handler
+from devsynth.interface.progress_utils import run_with_progress
 
 logger = DevSynthLogger(__name__)
 bridge: UXBridge = CLIUXBridge()
@@ -279,7 +280,12 @@ def completion_cmd(
         if install:
             # Install the completion script
             try:
-                install_path = install_completion_script(shell)
+                install_path = run_with_progress(
+                    "Installing completion script",
+                    lambda: install_completion_script(shell),
+                    ux_bridge,
+                    total=1,
+                )
                 ux_bridge.display_result(
                     f"Shell completion script installed to: {install_path}",
                     message_type="success"
@@ -314,7 +320,12 @@ def completion_cmd(
         else:
             # Generate the completion script
             try:
-                script_path = generate_completion_script(shell, output)
+                script_path = run_with_progress(
+                    "Generating completion script",
+                    lambda: generate_completion_script(shell, output),
+                    ux_bridge,
+                    total=1,
+                )
                 
                 if output:
                     ux_bridge.display_result(

--- a/src/devsynth/application/cli/commands/init_cmd.py
+++ b/src/devsynth/application/cli/commands/init_cmd.py
@@ -1,0 +1,145 @@
+"""Initialize a new DevSynth project with streamlined prompts."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Optional, List
+
+import typer
+
+from devsynth.config.loader import ConfigModel, _find_config_path, save_config
+from devsynth.config.unified_loader import UnifiedConfigLoader
+from devsynth.core.workflows import init_project
+from devsynth.interface.ux_bridge import UXBridge
+from devsynth.logging_setup import DevSynthLogger
+
+# Reuse helper functions from cli_commands to avoid duplication
+from devsynth.application.cli import cli_commands as _cli
+
+logger = DevSynthLogger(__name__)
+
+
+def init_cmd(
+    wizard: bool = False,
+    *,
+    root: Optional[str] = None,
+    language: Optional[str] = None,
+    goals: Optional[str] = None,
+    memory_backend: Optional[str] = None,
+    offline_mode: Optional[bool] = None,
+    features: Optional[List[str]] = typer.Option(
+        None,
+        help=(
+            "Features to enable. Provide multiple --features options or a JSON mapping string."
+        ),
+    ),
+    auto_confirm: Optional[bool] = None,
+    bridge: Optional[UXBridge] = None,
+) -> None:
+    """Initialize a new project with fewer interactive steps."""
+
+    bridge = _cli._resolve_bridge(bridge)
+    auto_confirm = (
+        _cli._env_flag("DEVSYNTH_AUTO_CONFIRM") if auto_confirm is None else auto_confirm
+    )
+
+    try:
+        if wizard:
+            from devsynth.application.cli.setup_wizard import SetupWizard
+
+            SetupWizard(bridge).run()
+            return
+
+        if _find_config_path(Path.cwd()) is not None:
+            bridge.display_result("[yellow]Project already initialized[/yellow]")
+            return
+
+        config = UnifiedConfigLoader.load().config
+
+        root = root or os.environ.get("DEVSYNTH_INIT_ROOT")
+        if root is None:
+            root = bridge.ask_question(
+                "Project root directory?", default=str(Path.cwd())
+            )
+
+        root_path = Path(root)
+        if not root_path.exists():
+            try:
+                root_path.mkdir(parents=True, exist_ok=True)
+            except OSError as exc:  # pragma: no cover - defensive
+                bridge.display_result(
+                    f"[red]Failed to create directory '{root}': {exc}[/red]",
+                    message_type="error",
+                )
+                return
+
+        language = language or os.environ.get("DEVSYNTH_INIT_LANGUAGE")
+        if language is None:
+            language = bridge.ask_question("Primary language?", default="python")
+
+        goals = goals or os.environ.get("DEVSYNTH_INIT_GOALS", "")
+        if not goals and not auto_confirm:
+            goals = bridge.ask_question("Project goals?", default="")
+
+        memory_backend = memory_backend or os.environ.get(
+            "DEVSYNTH_INIT_MEMORY_BACKEND"
+        )
+        if memory_backend is None:
+            memory_backend = bridge.ask_question(
+                "Select memory backend",
+                choices=["memory", "file", "kuzu", "chromadb"],
+                default="memory",
+            )
+        if memory_backend not in {"memory", "file", "kuzu", "chromadb"}:
+            bridge.display_result(
+                f"[red]Invalid memory backend: {memory_backend}[/red]",
+                message_type="error",
+            )
+            return
+
+        if offline_mode is None:
+            env_offline = _cli._env_flag("DEVSYNTH_INIT_OFFLINE_MODE")
+            if env_offline is not None:
+                offline_mode = env_offline
+            else:
+                offline_mode = bridge.confirm_choice(
+                    "Enable offline mode?", default=False
+                )
+
+        if features is None:
+            env_feats = os.environ.get("DEVSYNTH_INIT_FEATURES")
+            features_map = _cli._parse_features(env_feats) if env_feats else {}
+        else:
+            features_map = _cli._parse_features(features)
+
+        config.project_root = root
+        config.language = language
+        config.goals = goals
+        config.memory_store_type = memory_backend
+        config.offline_mode = offline_mode
+        config.features = features_map or {}
+
+        try:
+            save_config(
+                ConfigModel(**config.as_dict()),
+                use_pyproject=(Path("pyproject.toml").exists()),
+            )
+            init_project(
+                root=root,
+                structure=config.structure,
+                language=language,
+                goals=goals,
+                memory_backend=memory_backend,
+                offline_mode=offline_mode,
+                features=features_map,
+            )
+            bridge.display_result(
+                "[green]Initialization complete[/green]",
+                highlight=True,
+            )
+        except Exception as save_err:  # pragma: no cover - defensive
+            _cli._handle_error(bridge, save_err)
+    except Exception as err:  # pragma: no cover - defensive
+        _cli._handle_error(bridge, err)
+

--- a/src/devsynth/application/cli/progress.py
+++ b/src/devsynth/application/cli/progress.py
@@ -22,6 +22,7 @@ from rich.markdown import Markdown
 
 from devsynth.interface.ux_bridge import ProgressIndicator, UXBridge
 from devsynth.interface.cli import CLIProgressIndicator
+from devsynth.interface.progress_utils import run_with_progress
 
 
 class EnhancedProgressIndicator(CLIProgressIndicator):
@@ -263,41 +264,3 @@ def create_task_table(tasks: List[Dict[str, Any]], title: str = "Tasks") -> Tabl
     return table
 
 
-def run_with_progress(
-    task_name: str,
-    task_fn: Callable[[], Any],
-    bridge: UXBridge,
-    total: int = 100,
-    subtasks: Optional[List[Dict[str, Any]]] = None
-) -> Any:
-    """Run a task with a progress indicator.
-
-    Args:
-        task_name: The name of the task
-        task_fn: The function to run
-        bridge: The UXBridge to use for creating progress indicators
-        total: The total number of steps in the task
-        subtasks: Optional list of subtasks with their descriptions and totals
-
-    Returns:
-        The result of the task function
-    """
-    # Create a progress indicator for the task
-    progress = bridge.create_progress(task_name, total=total)
-
-    try:
-        # If we have an enhanced progress indicator and subtasks, add them
-        if isinstance(progress, EnhancedProgressIndicator) and subtasks:
-            for subtask in subtasks:
-                progress.add_subtask(
-                    subtask.get("name", "Subtask"),
-                    total=subtask.get("total", 100)
-                )
-
-        # Run the task function
-        result = task_fn()
-
-        return result
-    finally:
-        # Mark the task as complete, even if an exception occurs
-        progress.complete()

--- a/src/devsynth/interface/progress_utils.py
+++ b/src/devsynth/interface/progress_utils.py
@@ -286,3 +286,37 @@ def with_progress(bridge: UXBridge, description: str, total: int = 100) -> Calla
     """
     manager = ProgressManager(bridge)
     return manager.with_progress(description, total)
+
+
+def run_with_progress(
+    task_name: str,
+    task_fn: Callable[[], T],
+    bridge: UXBridge,
+    total: int = 100,
+    subtasks: Optional[List[Dict[str, Any]]] = None,
+) -> T:
+    """Run a task while displaying a progress indicator.
+
+    Args:
+        task_name: Description of the task to display.
+        task_fn: Function executing the task.
+        bridge: UXBridge used to create progress indicators.
+        total: Total number of steps for the task.
+        subtasks: Optional list of subtasks with ``name`` and ``total`` keys.
+
+    Returns:
+        Result of ``task_fn``.
+    """
+
+    progress = bridge.create_progress(task_name, total=total)
+    try:
+        if subtasks:
+            for subtask in subtasks:
+                progress.add_subtask(
+                    subtask.get("name", "Subtask"),
+                    total=subtask.get("total", 100),
+                )
+
+        return task_fn()
+    finally:
+        progress.complete()

--- a/src/devsynth/interface/webui.py
+++ b/src/devsynth/interface/webui.py
@@ -41,6 +41,7 @@ from devsynth.logging_setup import DevSynthLogger
 from devsynth.config import load_project_config, save_config
 from devsynth.domain.models.requirement import RequirementPriority, RequirementType
 from devsynth.interface.ux_bridge import ProgressIndicator, UXBridge, sanitize_output
+from devsynth.interface.progress_utils import run_with_progress
 
 import streamlit as st
 
@@ -1261,8 +1262,11 @@ class WebUI(UXBridge):
                                     raise ImportError(
                                         "gather_requirements function not available"
                                     )
-                                with st.spinner("Processing resources..."):
-                                    gather_requirements(self)
+                                run_with_progress(
+                                    "Processing resources...",
+                                    lambda: gather_requirements(self),
+                                    self,
+                                )
                                 self.display_result(
                                     "[green]Resources gathered successfully![/green]",
                                     highlight=False,


### PR DESCRIPTION
## Summary
- centralize `run_with_progress` helper for CLI and WebUI
- streamline `devsynth init` prompts and validate inputs
- add shell completion generation with progress and docs

## Testing
- `pre-commit run --files src/devsynth/interface/progress_utils.py src/devsynth/application/cli/progress.py src/devsynth/application/cli/cli_commands.py src/devsynth/application/cli/commands/init_cmd.py src/devsynth/interface/webui.py src/devsynth/application/cli/commands/completion_cmd.py docs/getting_started/basic_usage.md` *(failed: command not found)*
- `pytest tests/unit/application/cli/test_init_cmd.py tests/unit/cli/test_init_features_option.py tests/unit/interface/test_webui_error_handling.py` *(failed: No module named 'pytest_bdd')*

------
https://chatgpt.com/codex/tasks/task_e_6894c6da66608333904c0654c46f0571