### PR TITLE
Ensure deterministic provider selection with disabled provider workflow

### DIFF
--- a/.github/workflows/provider-tests.yml.disabled
+++ b/.github/workflows/provider-tests.yml.disabled
@@ -1,0 +1,25 @@
+name: Provider Test Suite
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+
+jobs:
+  test-providers:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - name: Install Poetry
+        uses: abatilo/actions-poetry@v2
+      - name: Install dependencies
+        run: poetry install --with dev --extras "llm lmstudio"
+      - name: Run provider tests
+        run: >-
+          poetry run pytest
+          tests/unit/adapters/providers/test_provider_factory.py
+          tests/integration/general/test_provider_system*.py

--- a/src/devsynth/application/llm/provider_factory.py
+++ b/src/devsynth/application/llm/provider_factory.py
@@ -1,0 +1,59 @@
+"""Deterministic LLM provider factory."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Optional
+
+from .providers import (
+    AnthropicProvider,
+    LocalProvider,
+    OfflineProvider,
+    OpenAIProvider,
+    SimpleLLMProviderFactory,
+    ValidationError,
+)
+
+try:  # pragma: no cover - optional dependency
+    from .lmstudio_provider import LMStudioProvider
+except ImportError:  # pragma: no cover - fallback path
+    LMStudioProvider = None
+
+
+class ProviderFactory(SimpleLLMProviderFactory):
+    """Factory that selects providers in a deterministic order."""
+
+    _order = ("openai", "anthropic", "lmstudio", "local", "offline")
+
+    def create_provider(
+        self,
+        provider_type: Optional[str] = None,
+        config: Optional[Dict[str, Any]] = None,
+    ):
+        """Create a provider instance.
+
+        When ``provider_type`` is ``None``, providers are selected in the
+        order defined by :attr:`_order` falling back to the alphabetically
+        first registered provider.
+        """
+
+        if provider_type:
+            return super().create_provider(provider_type.lower(), config)
+
+        for name in self._order:
+            if name in self.provider_types:
+                return super().create_provider(name, config)
+
+        if not self.provider_types:
+            raise ValidationError("No providers registered")
+
+        first = next(iter(sorted(self.provider_types)))
+        return super().create_provider(first, config)
+
+
+factory = ProviderFactory()
+factory.register_provider_type("openai", OpenAIProvider)
+factory.register_provider_type("anthropic", AnthropicProvider)
+if LMStudioProvider is not None:  # pragma: no cover - optional dependency
+    factory.register_provider_type("lmstudio", LMStudioProvider)
+factory.register_provider_type("local", LocalProvider)
+factory.register_provider_type("offline", OfflineProvider)

--- a/tests/integration/general/test_provider_system_configurations.py
+++ b/tests/integration/general/test_provider_system_configurations.py
@@ -4,22 +4,24 @@ This test verifies that the provider system works correctly with different LLM c
 including different models, parameters, and provider combinations.
 """
 
-import pytest
-import os
-from unittest.mock import patch, MagicMock
-import responses
 import json
+import os
+from unittest.mock import MagicMock, patch
+
+import pytest
+import responses
+
 from devsynth.adapters.provider_system import (
-    get_provider_config,
-    ProviderFactory,
-    OpenAIProvider,
-    LMStudioProvider,
     FallbackProvider,
-    get_provider,
+    LMStudioProvider,
+    OpenAIProvider,
+    ProviderError,
+    ProviderFactory,
+    ProviderType,
     complete,
     embed,
-    ProviderType,
-    ProviderError,
+    get_provider,
+    get_provider_config,
 )
 
 
@@ -119,7 +121,7 @@ class TestProviderConfigurations:
         ReqID: N/A"""
         responses.add(
             responses.POST,
-            "http://127.0.0.1:1234/v1/completions",
+            "http://127.0.0.1:1234/v1/chat/completions",
             json=mock_lm_studio_response,
             status=200,
         )
@@ -130,7 +132,7 @@ class TestProviderConfigurations:
         responses.reset()
         responses.add(
             responses.POST,
-            "http://custom-endpoint:5678/v1/completions",
+            "http://custom-endpoint:5678/v1/chat/completions",
             json=mock_lm_studio_response,
             status=200,
         )
@@ -151,7 +153,7 @@ class TestProviderConfigurations:
         ReqID: N/A"""
         responses.add(
             responses.POST,
-            "http://127.0.0.1:1234/v1/completions",
+            "http://127.0.0.1:1234/v1/chat/completions",
             json=mock_lm_studio_response,
             status=200,
         )
@@ -162,7 +164,7 @@ class TestProviderConfigurations:
         responses.reset()
         responses.add(
             responses.POST,
-            "http://127.0.0.1:1234/v1/completions",
+            "http://127.0.0.1:1234/v1/chat/completions",
             json=mock_lm_studio_response,
             status=200,
         )
@@ -190,7 +192,7 @@ class TestProviderConfigurations:
         )
         responses.add(
             responses.POST,
-            "http://127.0.0.1:1234/v1/completions",
+            "http://127.0.0.1:1234/v1/chat/completions",
             json=mock_lm_studio_response,
             status=200,
         )
@@ -217,7 +219,7 @@ class TestProviderConfigurations:
         )
         responses.add(
             responses.POST,
-            "http://127.0.0.1:1234/v1/completions",
+            "http://127.0.0.1:1234/v1/chat/completions",
             json=mock_lm_studio_response,
             status=200,
         )
@@ -260,7 +262,7 @@ class TestProviderConfigurations:
         responses.reset()
         responses.add(
             responses.POST,
-            "http://127.0.0.1:1234/v1/completions",
+            "http://127.0.0.1:1234/v1/chat/completions",
             json=mock_lm_studio_response,
             status=200,
         )

--- a/tests/unit/application/llm/test_provider_factory.py
+++ b/tests/unit/application/llm/test_provider_factory.py
@@ -1,0 +1,30 @@
+from devsynth.application.llm.provider_factory import factory
+
+
+def test_default_selection_is_deterministic(monkeypatch):
+    """Factory should fall back to the next provider in order."""
+
+    class DummyOpenAI:
+        def __init__(self, config=None):
+            self.config = config
+
+    class DummyAnthropic:
+        def __init__(self, config=None):
+            self.config = config
+
+    monkeypatch.setattr(
+        factory, "provider_types", {"openai": DummyOpenAI, "anthropic": DummyAnthropic}
+    )
+    monkeypatch.delitem(factory.provider_types, "openai", raising=False)
+    provider = factory.create_provider()
+    assert isinstance(provider, DummyAnthropic)
+
+
+def test_case_insensitive_selection(monkeypatch):
+    class DummyOpenAI:
+        def __init__(self, config=None):
+            self.config = config
+
+    monkeypatch.setattr(factory, "provider_types", {"openai": DummyOpenAI})
+    provider = factory.create_provider("OPENAI")
+    assert isinstance(provider, DummyOpenAI)


### PR DESCRIPTION
## Summary
- safeguard provider config reload and TLS setup in ProviderFactory
- add deterministic LLM provider factory with selection tests
- include provider test workflow in repo but keep it disabled

## Testing
- `SKIP=devsynth-align,fix-code-blocks poetry run pre-commit run --files .github/workflows/provider-tests.yml.disabled`
- `poetry run pytest --override-ini "addopts=-p no:cov -n auto" tests/unit/adapters/providers/test_provider_factory.py tests/integration/general/test_provider_system*.py tests/unit/application/llm/test_provider_factory.py`

------
https://chatgpt.com/codex/tasks/task_e_6894d02912d48333b430876c9d728d7f