### PR TITLE
Fix logging exc_info handling and requirements tests

### DIFF
--- a/src/devsynth/logging_setup.py
+++ b/src/devsynth/logging_setup.py
@@ -414,7 +414,11 @@ class DevSynthLogger:
             else:
                 extra.update(safe_kwargs)
 
-        log_kwargs: dict[str, Any] = {"exc_info": exc, "extra": extra}
+        log_kwargs: dict[str, Any] = {}
+        if exc is not None:
+            log_kwargs["exc_info"] = exc
+        if extra is not None:
+            log_kwargs["extra"] = extra
         if stack_info is not None:
             log_kwargs["stack_info"] = stack_info
         if stacklevel is not None:

--- a/tests/behavior/steps/test_requirements_gathering_steps.py
+++ b/tests/behavior/steps/test_requirements_gathering_steps.py
@@ -1,15 +1,16 @@
 import os
-from typing import Sequence, Optional
+import sys
 from types import ModuleType
+from typing import Optional, Sequence
 from unittest.mock import MagicMock
 
+import pytest
 import yaml
-import sys
-from pytest_bdd import scenarios, given, when, then
+from pytest_bdd import given, scenarios, then, when
 
 from devsynth.interface.ux_bridge import UXBridge
+
 from .webui_steps import webui_context
-import pytest
 
 pytest_plugins = ["tests.fixtures.webui_test_utils"]
 
@@ -75,11 +76,15 @@ def given_webui_initialized(webui_context):
 @when("I run the requirements gathering wizard in the WebUI")
 def run_webui_wizard(tmp_project_dir, webui_context):
     webui_context["st"].sidebar.radio.return_value = "Requirements"
-    webui_context["st"].text_area.side_effect = [
-        "Goal one,Goal two",
-        "Constraint A,Constraint B",
-    ]
-    webui_context["st"].selectbox.return_value = "high"
+    answers = iter(
+        [
+            "Goal one,Goal two",
+            "Constraint A,Constraint B",
+            "high",
+        ]
+    )
+    webui_context["ui"].ask_question = lambda *a, **k: next(answers)
+    webui_context["ui"].confirm = lambda *a, **k: True
     with open(
         os.path.join(tmp_project_dir, "pyproject.toml"), "w", encoding="utf-8"
     ) as f:

--- a/tests/integration/general/test_requirements_gathering.py
+++ b/tests/integration/general/test_requirements_gathering.py
@@ -4,6 +4,8 @@ from types import ModuleType
 
 import yaml
 
+# Ensures gather_requirements persists priority, goals, and constraints
+
 # Stub optional heavy dependencies for test isolation
 for _name in [
     "langgraph",

--- a/tests/unit/general/test_logging_setup.py
+++ b/tests/unit/general/test_logging_setup.py
@@ -1,20 +1,45 @@
 import logging
-from devsynth.logging_setup import configure_logging, get_logger, set_request_context, clear_request_context
+
 from _pytest.logging import LogCaptureHandler
+
+from devsynth.logging_setup import (
+    clear_request_context,
+    configure_logging,
+    get_logger,
+    set_request_context,
+)
 
 
 def test_log_records_include_request_context_succeeds(caplog, monkeypatch):
     """Test that log records include request context succeeds.
 
-ReqID: N/A"""
-    monkeypatch.setenv('DEVSYNTH_NO_FILE_LOGGING', '1')
+    ReqID: N/A"""
+    monkeypatch.setenv("DEVSYNTH_NO_FILE_LOGGING", "1")
     configure_logging(create_dir=False)
     logger = get_logger(__name__)
     handler = LogCaptureHandler()
     logging.getLogger().addHandler(handler)
-    set_request_context('req-123', 'EXPAND')
-    logger.info('hello')
+    set_request_context("req-123", "EXPAND")
+    logger.info("hello")
     clear_request_context()
     logging.getLogger().removeHandler(handler)
-    assert ('req-123', 'EXPAND') in [(rec.request_id, rec.phase) for rec in
-        handler.records]
+    assert ("req-123", "EXPAND") in [
+        (rec.request_id, rec.phase) for rec in handler.records
+    ]
+
+
+def test_exc_info_passes_through_succeeds(caplog, monkeypatch):
+    """DevSynthLogger should forward exc_info to logging."""
+
+    monkeypatch.setenv("DEVSYNTH_NO_FILE_LOGGING", "1")
+    configure_logging(create_dir=False)
+    logger = get_logger(__name__)
+    handler = LogCaptureHandler()
+    logging.getLogger().addHandler(handler)
+    try:
+        raise ValueError("boom")
+    except ValueError as err:  # pragma: no cover - demonstration
+        logger.error("oops", exc_info=err)
+    logging.getLogger().removeHandler(handler)
+    record = handler.records[0]
+    assert record.exc_info and record.exc_info[0] is ValueError


### PR DESCRIPTION
## Summary
- ensure DevSynthLogger forwards `exc_info` and related kwargs
- add regression test for `exc_info` handling
- repair requirements gathering tests and behavior steps

## Testing
- `poetry run pytest tests/unit/general/test_logging_setup.py::test_exc_info_passes_through_succeeds -q -p no:cov -o addopts=''`
- `poetry run pytest tests/integration/general/test_requirements_gathering.py -q -p no:cov -o addopts=''`
- `poetry run pytest tests/behavior/steps/test_requirements_gathering_steps.py -q -p no:cov -o addopts=''`
- `SKIP=devsynth-align poetry run pre-commit run black --files src/devsynth/logging_setup.py tests/unit/general/test_logging_setup.py tests/integration/general/test_requirements_gathering.py tests/behavior/steps/test_requirements_gathering_steps.py`
- `SKIP=devsynth-align poetry run pre-commit run isort --files src/devsynth/logging_setup.py tests/unit/general/test_logging_setup.py tests/integration/general/test_requirements_gathering.py tests/behavior/steps/test_requirements_gathering_steps.py`
- `SKIP=devsynth-align poetry run pre-commit run flake8 --files src/devsynth/logging_setup.py tests/unit/general/test_logging_setup.py tests/integration/general/test_requirements_gathering.py tests/behavior/steps/test_requirements_gathering_steps.py`


------
https://chatgpt.com/codex/tasks/task_e_6894ed9e9ff883338d1c8c7148b9b79d