### PR TITLE
feat: add circuit breaker metrics

### DIFF
--- a/tests/unit/fallback/test_retry_logic.py
+++ b/tests/unit/fallback/test_retry_logic.py
@@ -1,0 +1,73 @@
+"""Tests for retry conditions and circuit breaker integration."""
+
+from unittest.mock import Mock
+
+import pytest
+
+from devsynth.exceptions import DevSynthError
+from devsynth.fallback import (
+    CircuitBreaker,
+    circuit_breaker_state_counter,
+    reset_prometheus_metrics,
+    retry_with_exponential_backoff,
+)
+
+
+@pytest.mark.medium
+def test_retry_conditions_respected_with_circuit_breaker() -> None:
+    """Retry stops if conditions fail even when circuit breaker is present."""
+
+    reset_prometheus_metrics()
+    breaker = CircuitBreaker(failure_threshold=3, recovery_timeout=60)
+
+    func = Mock(side_effect=Exception("boom"))
+    func.__name__ = "func"
+
+    wrapped = retry_with_exponential_backoff(
+        max_retries=5,
+        initial_delay=0,
+        jitter=False,
+        retry_conditions=[lambda exc: "retry" in str(exc)],
+        circuit_breaker=breaker,
+    )(func)
+
+    with pytest.raises(Exception):
+        wrapped()
+
+    assert func.call_count == 1
+    assert (
+        circuit_breaker_state_counter.labels(
+            function="func", state=CircuitBreaker.OPEN
+        )._value.get()
+        == 0
+    )
+
+
+@pytest.mark.medium
+def test_circuit_breaker_opens_and_records_metrics() -> None:
+    """Circuit breaker transitions to OPEN and emits Prometheus metrics."""
+
+    reset_prometheus_metrics()
+    breaker = CircuitBreaker(failure_threshold=2, recovery_timeout=60)
+
+    func = Mock(side_effect=Exception("fail"))
+    func.__name__ = "func"
+
+    wrapped = retry_with_exponential_backoff(
+        max_retries=5,
+        initial_delay=0,
+        jitter=False,
+        circuit_breaker=breaker,
+    )(func)
+
+    with pytest.raises(DevSynthError) as err:
+        wrapped()
+
+    assert err.value.error_code == "CIRCUIT_OPEN"
+    assert func.call_count == 2
+    assert (
+        circuit_breaker_state_counter.labels(
+            function="func", state=CircuitBreaker.OPEN
+        )._value.get()
+        == 2
+    )


### PR DESCRIPTION
## Summary
- expose optional circuit breaker in retry decorator with configurable retry conditions
- add Prometheus metrics for circuit breaker state transitions
- cover retry and circuit breaker behaviour with regression tests

## Testing
- `poetry run pre-commit run --files src/devsynth/fallback.py tests/unit/fallback/test_retry_logic.py`
- `poetry run pytest tests/unit/fallback/test_retry_logic.py --no-cov`
- `poetry run pytest tests/unit/fallback/test_condition_callbacks_prometheus.py --no-cov -n 0` *(fails: Duplicated timeseries in CollectorRegistry)*

------
https://chatgpt.com/codex/tasks/task_e_6894ed7c11e48333ac2531faa0c6914b