### PR TITLE
Integrate sprint planning with requirement analysis and retrospectives

### DIFF
--- a/docs/methodology/sprint_edrr_integration.md
+++ b/docs/methodology/sprint_edrr_integration.md
@@ -1,0 +1,17 @@
+# Sprint-EDRR Integration Guide
+
+This guide explains how the `SprintAdapter` connects traditional sprint practices with DevSynth's Expand, Differentiate, Refine, Retrospect (EDRR) methodology.
+
+## Requirement Analysis
+
+During the **Expand** phase, requirement analysis results feed directly into sprint planning. After each cycle, the adapter updates the upcoming sprint plan and records the actual scope delivered.
+
+## Retrospective Evaluation
+
+Retrospective data is automatically reviewed at the end of the cycle. Evaluation metrics are stored for later inspection alongside positive notes, improvement areas, and action items.
+
+## Usage
+
+1. Configure DevSynth to use the sprint methodology.
+2. Run an EDRR cycle. Requirement analysis outcomes will populate the next sprint plan.
+3. After the Retrospect phase, evaluation results are logged into sprint metrics for continuous improvement.

--- a/tests/integration/general/test_sprint_edrr_integration.py
+++ b/tests/integration/general/test_sprint_edrr_integration.py
@@ -1,0 +1,48 @@
+import pytest
+
+from devsynth.methodology.sprint import SprintAdapter
+
+
+def test_requirements_analysis_updates_sprint_plan():
+    """SprintAdapter aligns planning with requirement analysis results."""
+    adapter = SprintAdapter({"settings": {"sprintDuration": 1}})
+    adapter.before_cycle()
+
+    results = {
+        "expand": {
+            "processed_artifacts": ["feature"],
+            "requirements_analysis": {
+                "recommended_scope": ["feature"],
+                "objectives": ["obj"],
+                "success_criteria": ["done"],
+            },
+        },
+        "retrospect": {},
+    }
+
+    adapter.after_cycle(results)
+
+    assert adapter.sprint_plan["planned_scope"] == ["feature"]
+    assert adapter.metrics["planned_scope"][0] == ["feature"]
+    assert adapter.metrics["actual_scope"][0] == ["feature"]
+
+
+def test_retrospective_evaluation_logged():
+    """Retrospective evaluations are captured in sprint metrics."""
+    adapter = SprintAdapter({"settings": {"sprintDuration": 1}})
+    adapter.before_cycle()
+
+    retro_results = {
+        "positives": ["good"],
+        "improvements": ["better"],
+        "action_items": ["fix"],
+        "evaluation": {"quality": "high"},
+    }
+    results = {"expand": {}, "retrospect": retro_results}
+
+    adapter.after_cycle(results)
+
+    assert adapter.metrics["retrospective_reviews"][0]["action_items"] == ["fix"]
+    assert adapter.metrics["quality_metrics"][adapter.current_sprint_number] == {
+        "quality": "high"
+    }


### PR DESCRIPTION
## Summary
- track actual sprint scope and quality metrics during cycle completion
- verify sprint planning and retrospective evaluation through integration tests
- document how sprint methodology interfaces with EDRR

## Testing
- `SKIP=devsynth-align,fix-code-blocks poetry run pre-commit run --files src/devsynth/methodology/sprint.py tests/integration/general/test_sprint_edrr_integration.py docs/methodology/sprint_edrr_integration.md`
- `poetry run pytest tests/integration/general/test_sprint_edrr_integration.py tests/unit/methodology/test_sprint_adapter.py tests/unit/methodology/test_sprint_hooks.py --no-cov`


------
https://chatgpt.com/codex/tasks/task_e_6894ed7533348333a3c4d3a185c2595d