### PR TITLE
feat: add dialectical reasoning orchestrator

### DIFF
--- a/src/devsynth/application/orchestration/dialectical_reasoner.py
+++ b/src/devsynth/application/orchestration/dialectical_reasoner.py
@@ -1,0 +1,33 @@
+"""Dialectical reasoning orchestrator with consensus failure logging."""
+
+from typing import Any, Dict, Optional
+
+from devsynth.exceptions import ConsensusError
+from devsynth.logging_setup import DevSynthLogger
+
+logger = DevSynthLogger(__name__)
+
+
+class DialecticalReasoner:
+    """Run dialectical reasoning via an EDRR coordinator."""
+
+    def __init__(self, coordinator: Any) -> None:
+        self.coordinator = coordinator
+
+    def run(
+        self,
+        task: Dict[str, Any],
+        critic_agent: Any,
+        memory_integration: Optional[Any] = None,
+    ) -> Optional[Dict[str, Any]]:
+        """Execute dialectical reasoning and log consensus failures."""
+        try:
+            return self.coordinator.apply_dialectical_reasoning(
+                task, critic_agent, memory_integration
+            )
+        except ConsensusError as exc:  # pragma: no cover - logging path
+            logger.error(
+                "Consensus failure during dialectical reasoning",
+                extra={"error": str(exc)},
+            )
+            return None

--- a/src/devsynth/application/orchestration/edrr_coordinator.py
+++ b/src/devsynth/application/orchestration/edrr_coordinator.py
@@ -1,0 +1,38 @@
+"""EDRR coordinator with dialectical reasoning integration."""
+
+from typing import Any, Dict, Optional
+
+from devsynth.domain.models.wsde_dialectical import (
+    apply_dialectical_reasoning as _apply_dialectical_reasoning,
+)
+from devsynth.logging_setup import DevSynthLogger
+
+logger = DevSynthLogger(__name__)
+
+
+class EDRRCoordinator:
+    """Coordinate EDRR cycles with dialectical reasoning helpers."""
+
+    def __init__(self, wsde_team: Any) -> None:
+        self.wsde_team = wsde_team
+
+    def apply_dialectical_reasoning(
+        self,
+        task: Dict[str, Any],
+        critic_agent: Any,
+        memory_integration: Optional[Any] = None,
+    ) -> Dict[str, Any]:
+        """Delegate dialectical reasoning to WSDE helpers.
+
+        Args:
+            task: Task containing a proposed solution.
+            critic_agent: Agent providing critiques.
+            memory_integration: Optional memory component.
+
+        Returns:
+            Result from :func:`apply_dialectical_reasoning`.
+        """
+        logger.info("EDRRCoordinator invoking dialectical reasoning")
+        return _apply_dialectical_reasoning(
+            self.wsde_team, task, critic_agent, memory_integration
+        )

--- a/tests/unit/application/orchestration/test_dialectical_reasoner.py
+++ b/tests/unit/application/orchestration/test_dialectical_reasoner.py
@@ -1,0 +1,52 @@
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from devsynth.application.collaboration.exceptions import ConsensusError
+from devsynth.application.orchestration.dialectical_reasoner import DialecticalReasoner
+from devsynth.application.orchestration.edrr_coordinator import EDRRCoordinator
+
+
+class DummyConsensusError(ConsensusError):
+    def __init__(self, message: str):  # pragma: no cover - simple helper
+        Exception.__init__(self, message)
+
+
+@pytest.mark.medium
+def test_edrr_coordinator_delegates_to_helper():
+    team = MagicMock()
+    coordinator = EDRRCoordinator(team)
+    task = {"solution": {}}
+    critic = MagicMock()
+    with patch(
+        "devsynth.application.orchestration.edrr_coordinator._apply_dialectical_reasoning",
+        return_value={"ok": True},
+    ) as helper:
+        result = coordinator.apply_dialectical_reasoning(task, critic)
+    helper.assert_called_once_with(team, task, critic, None)
+    assert result == {"ok": True}
+
+
+@pytest.mark.medium
+def test_dialectical_reasoner_returns_result():
+    coordinator = MagicMock()
+    coordinator.apply_dialectical_reasoning.return_value = {"done": True}
+    reasoner = DialecticalReasoner(coordinator)
+    task = {"solution": {}}
+    critic = MagicMock()
+    assert reasoner.run(task, critic) == {"done": True}
+    coordinator.apply_dialectical_reasoning.assert_called_once_with(task, critic, None)
+
+
+@pytest.mark.medium
+def test_dialectical_reasoner_logs_consensus_failure(caplog):
+    coordinator = MagicMock()
+    coordinator.apply_dialectical_reasoning.side_effect = DummyConsensusError(
+        "no consensus"
+    )
+    reasoner = DialecticalReasoner(coordinator)
+    task = {"solution": {}}
+    critic = MagicMock()
+    with caplog.at_level("ERROR"):
+        assert reasoner.run(task, critic) is None
+    assert "Consensus failure" in caplog.text


### PR DESCRIPTION
## Summary
- integrate wsde dialectical reasoning helpers into an EDRR coordinator wrapper
- add dialectical reasoner orchestration with consensus failure logging
- test orchestrators for delegation and consensus failure handling

## Testing
- `poetry run pre-commit run --files src/devsynth/application/orchestration/edrr_coordinator.py src/devsynth/application/orchestration/dialectical_reasoner.py tests/unit/application/orchestration/test_dialectical_reasoner.py`
- `poetry run pytest --no-cov tests/unit/application/orchestration/test_dialectical_reasoner.py`

------
https://chatgpt.com/codex/tasks/task_e_6894ed6f49f08333b58a6d6e8bfa62ef