### PR TITLE
docs: clarify disabled workflow policy

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,6 +30,10 @@ poetry run pytest
 
 Running hooks and tests through `poetry run` ensures they execute inside the project's virtual environment and prevents missing-package errors. Always invoke the pre-commit hooks on the files you are about to commit using the `--files` option shown above.
 
+## GitHub Actions Workflows
+
+All GitHub Actions workflows are disabled at this time. You may add or modify workflow files under `.github/workflows/`, but they must remain disabled. Never enable any workflow; all new workflows must be created in a disabled state.
+
 ## Module-Level AGENTS.md Files
 
 Some directories include their own `AGENTS.md` with additional, more specific instructions. To locate them:


### PR DESCRIPTION
## Summary
- clarify that GitHub Actions workflows may be added or modified but must remain disabled

## Testing
- `poetry run pre-commit run --files AGENTS.md` *(fails: No such option: --quiet)*
- `poetry run pytest` *(fails: KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_689507d73aa8833395d42b7f2ff9b691