### PR TITLE
test: mark memory adapter tests as memory-intensive and limit xdist workers

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,5 +1,6 @@
 [pytest]
-addopts = -p no:warnings --cov=src/devsynth/core/mvu --cov-report=term-missing --cov-fail-under=25 -n auto --dist loadfile
+# Limit parallel workers to reduce memory usage during test runs
+addopts = -p no:warnings --cov=src/devsynth/core/mvu --cov-report=term-missing --cov-fail-under=25 -n 4 --dist loadfile
 norecursedirs = templates
 # Run tests from the tests directory only
 # This prevents template files from being collected as tests.

--- a/tests/unit/adapters/memory/test_memory_adapter.py
+++ b/tests/unit/adapters/memory/test_memory_adapter.py
@@ -6,6 +6,11 @@ from unittest.mock import MagicMock, patch
 import numpy as np
 import pytest
 
+# These tests exercise multiple backend implementations and can consume
+# significant memory when run in parallel.  Mark them so they can be
+# executed with reduced concurrency when needed.
+pytestmark = [pytest.mark.memory_intensive]
+
 # Import duckdb safely
 try:
     import duckdb
@@ -337,6 +342,7 @@ class TestMemorySystemAdapter:
     @pytest.mark.medium
     @pytest.mark.requires_resource("lmdb")
     @pytest.mark.requires_resource("faiss")
+    @pytest.mark.isolation
     def test_sync_manager_coordinated_backends(self, tmp_path, monkeypatch):
         """SyncManager should propagate between LMDB, FAISS and Kuzu."""
 


### PR DESCRIPTION
## Summary
- mark memory adapter tests as memory-intensive and isolate sync backend test
- restrict pytest-xdist to 4 workers to reduce memory pressure

## Testing
- `poetry run pytest tests/unit/adapters/memory/test_memory_adapter.py tests/unit/application/cli/test_init_cmd.py`


------
https://chatgpt.com/codex/tasks/task_e_68950d803ca48333a93a1dbdcd2fad10