### PR TITLE
test: verify CLI command modules import

### DIFF
--- a/tests/unit/application/cli/commands/test_module_imports.py
+++ b/tests/unit/application/cli/commands/test_module_imports.py
@@ -1,0 +1,26 @@
+"""Ensure CLI command modules import successfully."""
+
+from __future__ import annotations
+
+import importlib
+import pkgutil
+
+import pytest
+
+import devsynth.application.cli.commands as commands_pkg
+
+MODULE_NAMES = sorted(
+    [
+        module.name
+        for module in pkgutil.iter_modules(
+            commands_pkg.__path__, commands_pkg.__name__ + "."
+        )
+    ]
+)
+
+
+@pytest.mark.parametrize("module_name", MODULE_NAMES)
+def test_command_module_import(module_name: str) -> None:
+    """Each CLI command module should be importable."""
+
+    importlib.import_module(module_name)

--- a/tests/unit/application/cli/test_serve_cmd.py
+++ b/tests/unit/application/cli/test_serve_cmd.py
@@ -1,47 +1,35 @@
+"""Tests for the ``serve_cmd`` CLI command."""
+
+from __future__ import annotations
+
 import builtins
-import importlib.util
-import sys
-from types import ModuleType
-from pathlib import Path
-from unittest.mock import MagicMock
+import importlib
+
 import pytest
-mock_httpx_aiohttp = MagicMock()
-mock_httpx_aiohttp.HttpxAiohttpClient = object
-sys.modules['httpx_aiohttp'] = mock_httpx_aiohttp
-MODULE_ATTRS = {'langgraph.checkpoint.base': {'BaseCheckpointSaver': object, 'empty_checkpoint': None}, 'langgraph.graph': {'END': object(), 'StateGraph': object}, 'openai': {'OpenAI': object, 'AsyncOpenAI': object}, 'tinydb': {'TinyDB': object, 'Query': object}, 'tinydb.storages': {'JSONStorage': object}, 'tiktoken': {}, 'numpy': {'array': lambda x: x}, 'duckdb': {}, 'devsynth.application.orchestration.refactor_workflow': {'refactor_workflow_manager': object}, 'httpx_aiohttp': {'HttpxAiohttpClient': object}}
+
 
 @pytest.mark.medium
-def test_serve_cmd_missing_uvicorn_succeeds(monkeypatch, tmp_path):
-    """Test that serve cmd missing uvicorn succeeds.
+def test_serve_cmd_missing_uvicorn_succeeds(monkeypatch):
+    """``serve_cmd`` should warn when ``uvicorn`` is missing."""
 
-ReqID: N/A"""
-    path = tmp_path / 'cli_commands.py'
-    src_path = Path(__file__).parents[4] / 'src' / 'devsynth' / 'application' / 'cli' / 'cli_commands.py'
-    content = src_path.read_text()
-    content = content.replace('from ..orchestration.refactor_workflow import refactor_workflow_manager', '# Mock for refactor_workflow_manager\nrefactor_workflow_manager = object()')
-    content = content.replace('from .commands.edrr_cycle_cmd import edrr_cycle_cmd', '# Mock for edrr_cycle_cmd\nedrr_cycle_cmd = object()')
-    content = content.replace('from .commands.doctor_cmd import doctor_cmd', '# Mock for doctor_cmd\ndoctor_cmd = object()')
-    path.write_text(content)
-    outputs = []
-    sys.modules.pop('uvicorn', None)
+    outputs: list[str] = []
     real_import = builtins.__import__
 
-    def fake_import(name, globals=None, locals=None, fromlist=(), level=0):
-        if name.split('.')[0] == 'uvicorn':
+    def fake_import(name, *args, **kwargs):
+        if name.split(".")[0] == "uvicorn":
             raise ImportError("No module named 'uvicorn'")
-        try:
-            return real_import(name, globals, locals, fromlist, level)
-        except ModuleNotFoundError:
-            mod = ModuleType(name)
-            for attr, val in MODULE_ATTRS.get(name, {}).items():
-                setattr(mod, attr, val)
-            sys.modules[name] = mod
-            return mod
-    monkeypatch.setattr(builtins, '__import__', fake_import)
-    spec = importlib.util.spec_from_file_location('cli_commands', path)
-    module = importlib.util.module_from_spec(spec)
-    assert spec and spec.loader
-    spec.loader.exec_module(module)
-    monkeypatch.setattr(module.bridge, 'display_result', lambda msg, *, highlight=False: outputs.append(msg))
-    module.serve_cmd(bridge=module.bridge)
-    assert any(('uvicorn' in msg.lower() for msg in outputs))
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+
+    module = importlib.import_module("devsynth.application.cli.commands.serve_cmd")
+
+    class DummyBridge:
+        def display_result(
+            self, msg: str, *, highlight: bool = False
+        ) -> None:  # noqa: FBT001, FBT002
+            outputs.append(msg)
+
+    module.serve_cmd(bridge=DummyBridge())
+
+    assert any("uvicorn" in msg.lower() for msg in outputs)


### PR DESCRIPTION
## Summary
- ensure each CLI command module imports without error
- simplify serve command test to use new module path

## Testing
- `poetry run pre-commit run --files tests/unit/application/cli/commands/test_module_imports.py tests/unit/application/cli/test_serve_cmd.py`
- `poetry run pytest tests/unit/application/cli/commands/test_module_imports.py tests/unit/application/cli/test_serve_cmd.py`


------
https://chatgpt.com/codex/tasks/task_e_68952acf4bec83339bc1f86d62d9e4bc