### PR TITLE
Register CLI commands from registry

### DIFF
--- a/src/devsynth/adapters/cli/typer_adapter.py
+++ b/src/devsynth/adapters/cli/typer_adapter.py
@@ -223,14 +223,14 @@ def build_app() -> typer.Typer:
         context_settings={"help_option_names": ["--help", "-h"]},
     )
 
-    app.add_typer(requirements_app, name="requirements")
-    app.add_typer(config_app, name="config", help="Manage configuration settings")
-
     for name, cmd in COMMAND_REGISTRY.items():
         if name in {"config", "enable-feature"}:
             continue
         override = globals().get(f"{name.replace('-', '_')}_cmd", cmd)
         app.command(name)(override)
+
+    app.add_typer(requirements_app, name="requirements")
+    app.add_typer(config_app, name="config", help="Manage configuration settings")
 
     @app.callback(invoke_without_command=True)
     def main(ctx: typer.Context):

--- a/tests/unit/cli/test_command_registry.py
+++ b/tests/unit/cli/test_command_registry.py
@@ -1,0 +1,29 @@
+import typer
+from typer.testing import CliRunner
+
+import devsynth.adapters.cli.typer_adapter as adapter
+
+
+def test_build_app_registers_commands_from_registry(monkeypatch):
+    """Commands in COMMAND_REGISTRY should be registered with the CLI."""
+    called = {}
+
+    def sample_cmd():
+        called["ran"] = True
+
+    monkeypatch.setattr(adapter, "COMMAND_REGISTRY", {"sample": sample_cmd})
+    monkeypatch.setattr(adapter, "config_app", typer.Typer())
+    monkeypatch.setattr(adapter, "requirements_app", typer.Typer())
+    monkeypatch.setattr(adapter, "_patch_typer_types", lambda: None)
+
+    app = adapter.build_app()
+    result = CliRunner().invoke(app, ["sample"])
+    assert result.exit_code == 0
+    assert called.get("ran")
+
+
+def test_enable_feature_not_top_level():
+    """The enable-feature command is managed under config and not at top level."""
+    app = adapter.build_app()
+    result = CliRunner().invoke(app, ["--help"])
+    assert "enable-feature" not in result.output


### PR DESCRIPTION
## Summary
- Build Typer CLI from `COMMAND_REGISTRY`
- Register requirement and config subcommands after registry commands
- Add tests ensuring registry commands are registered and `enable-feature` remains a config subcommand

## Testing
- `poetry run pre-commit run --files src/devsynth/adapters/cli/typer_adapter.py tests/unit/cli/test_command_registry.py`
- `poetry run pytest tests/unit/general/test_cli.py tests/unit/cli` *(fails: Coverage failure: total of 0 is less than fail-under=25)*
- `poetry run pytest --no-cov tests/unit/general/test_cli.py tests/unit/cli`


------
https://chatgpt.com/codex/tasks/task_e_68954762242483338e0e262d5d5cd1a7