### PR TITLE
docs: add development workflow overview

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,9 +118,23 @@ You can install DevSynth in a few different ways:
    devsynth dpg
    ```
 
-   Use pip or pipx only when installing from PyPI.
+Use pip or pipx only when installing from PyPI.
 
 For more on Docker deployment, see the [Deployment Guide](docs/deployment/deployment_guide.md).
+
+## Development Workflow
+
+Run all development commands inside the Poetry-managed virtual environment. A
+typical workflow is:
+
+```bash
+poetry install
+poetry run pre-commit run --files <files>
+poetry run pytest
+```
+
+`scripts/codex_setup.sh` is exclusively for provisioning the Codex environment
+and must not be referenced outside that context.
 
 ## Optional Dependencies
 


### PR DESCRIPTION
## Summary
- document core development workflow using Poetry and pre-commit
- clarify that `scripts/codex_setup.sh` is for Codex provisioning only

## Testing
- `SKIP=fix-code-blocks poetry run pre-commit run --files README.md`
- `poetry run pytest` *(fails: KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_68954ff222b88333a6dcd916cd862c85