### PR TITLE
refactor: update WSDE imports

### DIFF
--- a/src/devsynth/application/agents/wsde_memory_integration.py
+++ b/src/devsynth/application/agents/wsde_memory_integration.py
@@ -5,16 +5,16 @@ This module provides integration between the WSDE model and the memory system,
 allowing WSDE teams to store and retrieve information from memory.
 """
 
-from typing import Dict, Any, List, Optional
 import json
 import uuid
 from datetime import datetime
+from typing import Any, Dict, List, Optional
 
-from devsynth.domain.models.memory import MemoryItem, MemoryType
 from devsynth.adapters.memory.memory_adapter import MemorySystemAdapter
-from devsynth.domain.models.wsde import WSDETeam
 from devsynth.application.agents.agent_memory_integration import AgentMemoryIntegration
 from devsynth.application.memory.memory_manager import MemoryManager
+from devsynth.domain.models.memory import MemoryItem, MemoryType
+from devsynth.domain.models.wsde_facade import WSDETeam
 from devsynth.logging_setup import DevSynthLogger
 
 # Create a logger for this module
@@ -34,14 +34,21 @@ class WSDEMemoryIntegration:
         """Initialize the WSDE memory integration."""
         self.memory_adapter = memory_adapter
         self.wsde_team = wsde_team
-        self.agent_memory = agent_memory or AgentMemoryIntegration(memory_adapter, wsde_team)
+        self.agent_memory = agent_memory or AgentMemoryIntegration(
+            memory_adapter, wsde_team
+        )
         self.context_manager = memory_adapter.get_context_manager()
         self.memory_manager = memory_manager
 
         logger.info("WSDE memory integration initialized")
 
-    def store_dialectical_process(self, task: Dict[str, Any], thesis: Dict[str, Any], 
-                                 antithesis: Dict[str, Any], synthesis: Dict[str, Any]) -> str:
+    def store_dialectical_process(
+        self,
+        task: Dict[str, Any],
+        thesis: Dict[str, Any],
+        antithesis: Dict[str, Any],
+        synthesis: Dict[str, Any],
+    ) -> str:
         """
         Store a dialectical process in memory.
 
@@ -84,8 +91,13 @@ class WSDEMemoryIntegration:
             logger.info(f"No dialectical process found for task {task_id}")
             return {}
 
-    def store_agent_solution(self, agent_id: str, task: Dict[str, Any], solution: Dict[str, Any], 
-                               edrr_phase: Optional[str] = None) -> str:
+    def store_agent_solution(
+        self,
+        agent_id: str,
+        task: Dict[str, Any],
+        solution: Dict[str, Any],
+        edrr_phase: Optional[str] = None,
+    ) -> str:
         """Store an agent solution in memory."""
 
         if self.memory_manager is not None:
@@ -161,7 +173,9 @@ class WSDEMemoryIntegration:
                         items = store.search({"memory_type": MemoryType.SOLUTION})
                     except Exception:
                         try:
-                            items = store.search({"memory_type": MemoryType.SOLUTION.value})
+                            items = store.search(
+                                {"memory_type": MemoryType.SOLUTION.value}
+                            )
                         except Exception:
                             items = []
                 for item in items:
@@ -222,7 +236,9 @@ class WSDEMemoryIntegration:
         logger.info(f"Found {len(similar_vectors)} similar solutions for query")
         return similar_vectors
 
-    def retrieve_solutions_by_edrr_phase(self, task_id: str, edrr_phase: str) -> List[MemoryItem]:
+    def retrieve_solutions_by_edrr_phase(
+        self, task_id: str, edrr_phase: str
+    ) -> List[MemoryItem]:
         """
         Retrieve agent solutions for a specific task filtered by EDRR phase.
 
@@ -246,7 +262,9 @@ class WSDEMemoryIntegration:
         )
         return filtered_solutions
 
-    def query_knowledge_graph(self, query: str, limit: int = 10) -> List[Dict[str, Any]]:
+    def query_knowledge_graph(
+        self, query: str, limit: int = 10
+    ) -> List[Dict[str, Any]]:
         """
         Query the knowledge graph for information.
 
@@ -266,14 +284,20 @@ class WSDEMemoryIntegration:
         # Check if the memory store supports knowledge graph queries
         if hasattr(memory_store, "query_graph"):
             results = memory_store.query_graph(query, limit=limit)
-            logger.info(f"Queried knowledge graph with '{query}', found {len(results)} results")
+            logger.info(
+                f"Queried knowledge graph with '{query}', found {len(results)} results"
+            )
             return results
         else:
-            error_msg = "Knowledge graph querying is not supported by the current memory store"
+            error_msg = (
+                "Knowledge graph querying is not supported by the current memory store"
+            )
             logger.error(error_msg)
             raise ValueError(error_msg)
 
-    def query_related_concepts(self, concept: str, limit: int = 10) -> List[Dict[str, Any]]:
+    def query_related_concepts(
+        self, concept: str, limit: int = 10
+    ) -> List[Dict[str, Any]]:
         """
         Query the knowledge graph for concepts related to a given concept.
 
@@ -299,10 +323,14 @@ class WSDEMemoryIntegration:
 
         # Execute the query
         results = self.query_knowledge_graph(query, limit=limit)
-        logger.info(f"Queried for concepts related to '{concept}', found {len(results)} results")
+        logger.info(
+            f"Queried for concepts related to '{concept}', found {len(results)} results"
+        )
         return results
 
-    def query_concept_relationships(self, concept1: str, concept2: str) -> List[Dict[str, Any]]:
+    def query_concept_relationships(
+        self, concept1: str, concept2: str
+    ) -> List[Dict[str, Any]]:
         """
         Query the knowledge graph for relationships between two concepts.
 
@@ -334,10 +362,14 @@ class WSDEMemoryIntegration:
 
         # Execute the query
         results = self.query_knowledge_graph(query)
-        logger.info(f"Queried for relationships between '{concept1}' and '{concept2}', found {len(results)} results")
+        logger.info(
+            f"Queried for relationships between '{concept1}' and '{concept2}', found {len(results)} results"
+        )
         return results
 
-    def query_by_concept_type(self, concept_type: str, limit: int = 10) -> List[Dict[str, Any]]:
+    def query_by_concept_type(
+        self, concept_type: str, limit: int = 10
+    ) -> List[Dict[str, Any]]:
         """
         Query the knowledge graph for concepts of a specific type.
 
@@ -366,10 +398,14 @@ class WSDEMemoryIntegration:
 
         # Execute the query
         results = self.query_knowledge_graph(query, limit=limit)
-        logger.info(f"Queried for concepts of type '{concept_type}', found {len(results)} results")
+        logger.info(
+            f"Queried for concepts of type '{concept_type}', found {len(results)} results"
+        )
         return results
 
-    def query_knowledge_for_task(self, task: Dict[str, Any], limit: int = 10) -> List[Dict[str, Any]]:
+    def query_knowledge_for_task(
+        self, task: Dict[str, Any], limit: int = 10
+    ) -> List[Dict[str, Any]]:
         """
         Query the knowledge graph for knowledge relevant to a specific task.
 
@@ -393,12 +429,27 @@ class WSDEMemoryIntegration:
                     keywords.extend(req.lower().split())
 
         # Remove common words and duplicates
-        common_words = {"a", "an", "the", "and", "or", "but", "for", "in", "on", "at", "to", "with"}
+        common_words = {
+            "a",
+            "an",
+            "the",
+            "and",
+            "or",
+            "but",
+            "for",
+            "in",
+            "on",
+            "at",
+            "to",
+            "with",
+        }
         keywords = [kw for kw in keywords if kw not in common_words]
         keywords = list(set(keywords))
 
         # Create a query to find relevant concepts
-        keyword_filters = " || ".join([f'CONTAINS(LCASE(STR(?concept)), "{kw}")' for kw in keywords])
+        keyword_filters = " || ".join(
+            [f'CONTAINS(LCASE(STR(?concept)), "{kw}")' for kw in keywords]
+        )
         query = f"""
         SELECT ?concept (COUNT(?match) AS ?relevance)
         WHERE {{
@@ -413,7 +464,9 @@ class WSDEMemoryIntegration:
 
         # Execute the query
         results = self.query_knowledge_graph(query, limit=limit)
-        logger.info(f"Queried for knowledge relevant to task, found {len(results)} results")
+        logger.info(
+            f"Queried for knowledge relevant to task, found {len(results)} results"
+        )
         return results
 
     def integrate_knowledge_from_dialectical_process(
@@ -435,7 +488,9 @@ class WSDEMemoryIntegration:
         Returns:
             A dictionary containing the integrated knowledge with categorization and metadata
         """
-        logger.info(f"Integrating knowledge from dialectical process for task {task_id}")
+        logger.info(
+            f"Integrating knowledge from dialectical process for task {task_id}"
+        )
 
         # Extract components from the dialectical process
         thesis = dialectical_process.get("thesis", {})
@@ -450,7 +505,7 @@ class WSDEMemoryIntegration:
             "key_insights": [],
             "domain_categories": {},
             "relevance_scores": {},
-            "knowledge_graph_entries": []
+            "knowledge_graph_entries": [],
         }
 
         # Extract key insights from the synthesis
@@ -471,7 +526,10 @@ class WSDEMemoryIntegration:
 
         if "weaknesses" in evaluation:
             integrated_knowledge["key_insights"].extend(
-                [f"Area for improvement: {weakness}" for weakness in evaluation["weaknesses"]]
+                [
+                    f"Area for improvement: {weakness}"
+                    for weakness in evaluation["weaknesses"]
+                ]
             )
 
         # Extract insights from the antithesis
@@ -496,17 +554,16 @@ class WSDEMemoryIntegration:
                     "text": insight,
                     "task_id": task_id,
                     "timestamp": datetime.now().isoformat(),
-                    "source": "dialectical_process"
+                    "source": "dialectical_process",
                 },
-                "relationships": []
+                "relationships": [],
             }
 
             # Add domain categorization as a relationship
             domain = self._categorize_insight_by_domain(insight)
-            entry["relationships"].append({
-                "type": "categorized_as",
-                "target": f"domain:{domain}"
-            })
+            entry["relationships"].append(
+                {"type": "categorized_as", "target": f"domain:{domain}"}
+            )
 
             # Add relevance as a property
             relevance = integrated_knowledge["relevance_scores"].get(insight, 0.5)
@@ -517,7 +574,9 @@ class WSDEMemoryIntegration:
         # Store the integrated knowledge in the memory system
         self._store_integrated_knowledge(integrated_knowledge)
 
-        logger.info(f"Successfully integrated {len(integrated_knowledge['key_insights'])} insights from dialectical process")
+        logger.info(
+            f"Successfully integrated {len(integrated_knowledge['key_insights'])} insights from dialectical process"
+        )
         return integrated_knowledge
 
     def _categorize_insight_by_domain(self, insight: str) -> str:
@@ -535,13 +594,75 @@ class WSDEMemoryIntegration:
 
         # Define domain keywords for categorization
         domain_keywords = {
-            "security": ["security", "authentication", "authorization", "vulnerability", "exploit", "password", "encryption", "csrf", "xss"],
-            "performance": ["performance", "speed", "latency", "throughput", "optimization", "efficient", "slow", "fast", "bottleneck"],
-            "maintainability": ["maintainability", "readability", "documentation", "comment", "structure", "organization", "clean", "technical debt"],
-            "reliability": ["reliability", "error handling", "exception", "fault tolerance", "recovery", "robustness", "stability"],
-            "usability": ["usability", "user experience", "ux", "interface", "accessibility", "intuitive", "user-friendly"],
-            "scalability": ["scalability", "scale", "load", "concurrent", "distributed", "horizontal", "vertical"],
-            "testability": ["testability", "test", "mock", "stub", "assertion", "coverage", "unit test", "integration test"]
+            "security": [
+                "security",
+                "authentication",
+                "authorization",
+                "vulnerability",
+                "exploit",
+                "password",
+                "encryption",
+                "csrf",
+                "xss",
+            ],
+            "performance": [
+                "performance",
+                "speed",
+                "latency",
+                "throughput",
+                "optimization",
+                "efficient",
+                "slow",
+                "fast",
+                "bottleneck",
+            ],
+            "maintainability": [
+                "maintainability",
+                "readability",
+                "documentation",
+                "comment",
+                "structure",
+                "organization",
+                "clean",
+                "technical debt",
+            ],
+            "reliability": [
+                "reliability",
+                "error handling",
+                "exception",
+                "fault tolerance",
+                "recovery",
+                "robustness",
+                "stability",
+            ],
+            "usability": [
+                "usability",
+                "user experience",
+                "ux",
+                "interface",
+                "accessibility",
+                "intuitive",
+                "user-friendly",
+            ],
+            "scalability": [
+                "scalability",
+                "scale",
+                "load",
+                "concurrent",
+                "distributed",
+                "horizontal",
+                "vertical",
+            ],
+            "testability": [
+                "testability",
+                "test",
+                "mock",
+                "stub",
+                "assertion",
+                "coverage",
+                "unit test",
+                "integration test",
+            ],
         }
 
         # Check each domain for keyword matches
@@ -552,7 +673,9 @@ class WSDEMemoryIntegration:
         # Default domain if no matches found
         return "general"
 
-    def _calculate_insight_relevance(self, insight: str, synthesis: Dict[str, Any]) -> float:
+    def _calculate_insight_relevance(
+        self, insight: str, synthesis: Dict[str, Any]
+    ) -> float:
         """
         Calculate the relevance score of an insight based on whether it was addressed in the synthesis.
 
@@ -582,7 +705,11 @@ class WSDEMemoryIntegration:
         if "content" in synthesis:
             insight_words = set(insight.lower().split())
             content_words = set(synthesis["content"].lower().split())
-            word_overlap = len(insight_words.intersection(content_words)) / len(insight_words) if insight_words else 0
+            word_overlap = (
+                len(insight_words.intersection(content_words)) / len(insight_words)
+                if insight_words
+                else 0
+            )
             if word_overlap > 0.5:
                 relevance = max(relevance, 0.7)
 
@@ -605,8 +732,8 @@ class WSDEMemoryIntegration:
                 "timestamp": integrated_knowledge["timestamp"],
                 "source": "dialectical_process",
                 "num_insights": len(integrated_knowledge["key_insights"]),
-                "domains": list(integrated_knowledge["domain_categories"].keys())
-            }
+                "domains": list(integrated_knowledge["domain_categories"].keys()),
+            },
         )
 
         # Store the knowledge in memory
@@ -620,11 +747,11 @@ class WSDEMemoryIntegration:
             for entry in integrated_knowledge["knowledge_graph_entries"]:
                 try:
                     memory_store.add_to_graph(
-                        entry["concept"],
-                        entry["properties"],
-                        entry["relationships"]
+                        entry["concept"], entry["properties"], entry["relationships"]
                     )
-                    logger.info(f"Added knowledge graph entry for concept {entry['concept']}")
+                    logger.info(
+                        f"Added knowledge graph entry for concept {entry['concept']}"
+                    )
                 except Exception as e:
                     logger.error(f"Failed to add knowledge graph entry: {str(e)}")
 
@@ -645,7 +772,7 @@ class WSDEMemoryIntegration:
         query = {
             "memory_type": MemoryType.KNOWLEDGE,
             "metadata.task_id": task_id,
-            "metadata.source": "dialectical_process"
+            "metadata.source": "dialectical_process",
         }
 
         # Execute the query
@@ -658,7 +785,11 @@ class WSDEMemoryIntegration:
                 content = json.loads(result.content)
                 knowledge_items.append(content)
             except json.JSONDecodeError:
-                logger.warning(f"Failed to parse integrated knowledge content for item {result.id}")
+                logger.warning(
+                    f"Failed to parse integrated knowledge content for item {result.id}"
+                )
 
-        logger.info(f"Retrieved {len(knowledge_items)} integrated knowledge items for task {task_id}")
+        logger.info(
+            f"Retrieved {len(knowledge_items)} integrated knowledge items for task {task_id}"
+        )
         return knowledge_items

--- a/src/devsynth/application/cli/commands/edrr_cycle_cmd.py
+++ b/src/devsynth/application/cli/commands/edrr_cycle_cmd.py
@@ -1,30 +1,30 @@
-from pathlib import Path
 import json
 import time
-from typing import Dict, Any, Optional, List, Union
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Union
+
 from tqdm import tqdm
 
-from devsynth.interface.cli import CLIUXBridge
-from devsynth.interface.ux_bridge import UXBridge
-
-from devsynth.application.memory.memory_manager import MemoryManager
-from devsynth.application.memory.adapters.tinydb_memory_adapter import (
-    TinyDBMemoryAdapter,
-)
-from devsynth.domain.models.wsde import WSDETeam
 from devsynth.application.code_analysis.analyzer import CodeAnalyzer
 from devsynth.application.code_analysis.ast_transformer import AstTransformer
-from devsynth.application.prompts.prompt_manager import PromptManager
 from devsynth.application.documentation.documentation_manager import (
     DocumentationManager,
 )
 from devsynth.application.edrr.coordinator import EDRRCoordinator
 from devsynth.application.edrr.edrr_coordinator_enhanced import EnhancedEDRRCoordinator
+from devsynth.application.memory.adapters.tinydb_memory_adapter import (
+    TinyDBMemoryAdapter,
+)
+from devsynth.application.memory.memory_manager import MemoryManager
+from devsynth.application.prompts.prompt_manager import PromptManager
 from devsynth.core import run_pipeline
-from devsynth.methodology.base import Phase
-from devsynth.logging_setup import DevSynthLogger
-from devsynth.exceptions import DevSynthError
 from devsynth.core.config_loader import load_config
+from devsynth.domain.models.wsde_facade import WSDETeam
+from devsynth.exceptions import DevSynthError
+from devsynth.interface.cli import CLIUXBridge
+from devsynth.interface.ux_bridge import UXBridge
+from devsynth.logging_setup import DevSynthLogger
+from devsynth.methodology.base import Phase
 
 logger = DevSynthLogger(__name__)
 # Default bridge for CLI output
@@ -32,12 +32,12 @@ bridge: UXBridge = CLIUXBridge()
 
 
 def edrr_cycle_cmd(
-    manifest: Optional[str] = None, 
+    manifest: Optional[str] = None,
     prompt: Optional[str] = None,
     context: Optional[str] = None,
     max_iterations: int = 3,
     auto: bool = True,
-    bridge: Optional[UXBridge] = None
+    bridge: Optional[UXBridge] = None,
 ) -> None:
     """Run an enhanced EDRR cycle from a manifest file or a prompt.
 
@@ -78,7 +78,9 @@ def edrr_cycle_cmd(
     try:
         # Validate input parameters
         if not manifest and not prompt:
-            ux_bridge.print("[red]Error:[/red] Either manifest or prompt must be provided")
+            ux_bridge.print(
+                "[red]Error:[/red] Either manifest or prompt must be provided"
+            )
             return
 
         # Initialize components
@@ -119,7 +121,9 @@ def edrr_cycle_cmd(
                 ux_bridge.print(f"[red]Manifest file not found:[/red] {manifest_path}")
                 return
 
-            ux_bridge.print(f"[bold]Starting EDRR cycle from manifest:[/bold] {manifest}")
+            ux_bridge.print(
+                f"[bold]Starting EDRR cycle from manifest:[/bold] {manifest}"
+            )
             coordinator.start_cycle_from_manifest(manifest_path, is_file=True)
         else:
             # Create a task dictionary from the prompt and context

--- a/src/devsynth/application/cli/ingest_cmd.py
+++ b/src/devsynth/application/cli/ingest_cmd.py
@@ -24,7 +24,7 @@ from devsynth.application.memory.adapters.tinydb_memory_adapter import (
 from devsynth.application.memory.memory_manager import MemoryManager
 from devsynth.config.unified_loader import UnifiedConfigLoader
 from devsynth.domain.models.project import ProjectModel
-from devsynth.domain.models.wsde import WSDETeam
+from devsynth.domain.models.wsde_facade import WSDETeam
 from devsynth.exceptions import DevSynthError, IngestionError, ManifestError
 from devsynth.interface.cli import CLIUXBridge
 from devsynth.interface.ux_bridge import UXBridge

--- a/src/devsynth/application/edrr/coordinator.py
+++ b/src/devsynth/application/edrr/coordinator.py
@@ -14,6 +14,7 @@ import uuid
 from datetime import datetime
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Set, Tuple, Union
+from unittest.mock import MagicMock
 
 import yaml
 
@@ -27,10 +28,9 @@ from devsynth.application.edrr.wsde_team_proxy import WSDETeamProxy
 from devsynth.application.memory.memory_manager import MemoryManager
 from devsynth.application.requirements.prompt_manager import PromptManager
 from devsynth.core import CoreValues, check_report_for_value_conflicts
-from devsynth.domain.models.wsde import WSDETeam
 from devsynth.domain.models.memory import MemoryType
+from devsynth.domain.models.wsde_facade import WSDETeam
 from devsynth.exceptions import DevSynthError
-from unittest.mock import MagicMock
 from devsynth.logging_setup import DevSynthLogger
 from devsynth.methodology.base import Phase
 

--- a/src/devsynth/application/edrr/coordinator_core.py
+++ b/src/devsynth/application/edrr/coordinator_core.py
@@ -14,6 +14,7 @@ import uuid
 from datetime import datetime
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Set, Tuple, Union
+from unittest.mock import MagicMock
 
 import yaml
 
@@ -27,12 +28,11 @@ from devsynth.application.edrr.wsde_team_proxy import WSDETeamProxy
 from devsynth.application.memory.memory_manager import MemoryManager
 from devsynth.application.requirements.prompt_manager import PromptManager
 from devsynth.core import CoreValues, check_report_for_value_conflicts
-from devsynth.domain.models.wsde import WSDETeam
 from devsynth.domain.models.memory import MemoryType
+from devsynth.domain.models.wsde_facade import WSDETeam
 from devsynth.exceptions import DevSynthError
 from devsynth.logging_setup import DevSynthLogger
 from devsynth.methodology.base import Phase
-from unittest.mock import MagicMock
 
 
 class EDRRCoordinatorError(DevSynthError):

--- a/src/devsynth/application/edrr/edrr_coordinator_enhanced.py
+++ b/src/devsynth/application/edrr/edrr_coordinator_enhanced.py
@@ -5,9 +5,9 @@ This module extends the EDRRCoordinator class with enhanced phase transition
 logic, quality scoring, and metrics collection.
 """
 
-from typing import Any, Dict, List, Optional, Tuple, Union
 from datetime import datetime
 from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple, Union
 
 from devsynth.application.code_analysis.analyzer import CodeAnalyzer
 from devsynth.application.code_analysis.ast_transformer import AstTransformer
@@ -22,8 +22,8 @@ from devsynth.application.edrr.edrr_phase_transitions import (
 )
 from devsynth.application.memory.memory_manager import MemoryManager
 from devsynth.application.requirements.prompt_manager import PromptManager
-from devsynth.domain.models.wsde import WSDETeam
 from devsynth.domain.models.memory import MemoryType
+from devsynth.domain.models.wsde_facade import WSDETeam
 from devsynth.logging_setup import DevSynthLogger
 from devsynth.methodology.base import Phase
 

--- a/src/devsynth/application/ingestion.py
+++ b/src/devsynth/application/ingestion.py
@@ -5,32 +5,32 @@ This module implements the "Expand, Differentiate, Refine, Retrospect" methodolo
 enabling DevSynth to understand and adapt to project structures as defined in .devsynth/project.yaml.
 """
 
-import os
 import json
-import yaml
-from pathlib import Path
-from typing import Dict, List, Optional, Any, Union
+import os
 import time
 from datetime import datetime
-import networkx as nx
 from enum import Enum, auto
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Union
 
-from devsynth.application.edrr.coordinator import EDRRCoordinator
-from devsynth.application.memory.memory_manager import MemoryManager
-from devsynth.application.memory.adapters.tinydb_memory_adapter import (
-    TinyDBMemoryAdapter,
-)
-from devsynth.domain.models.wsde import WSDETeam
+import networkx as nx
+import yaml
+
 from devsynth.application.code_analysis.analyzer import CodeAnalyzer
 from devsynth.application.code_analysis.ast_transformer import AstTransformer
-from devsynth.application.prompts.prompt_manager import PromptManager
 from devsynth.application.documentation.documentation_manager import (
     DocumentationManager,
 )
-from devsynth.methodology.base import Phase
-
+from devsynth.application.edrr.coordinator import EDRRCoordinator
+from devsynth.application.memory.adapters.tinydb_memory_adapter import (
+    TinyDBMemoryAdapter,
+)
+from devsynth.application.memory.memory_manager import MemoryManager
+from devsynth.application.prompts.prompt_manager import PromptManager
+from devsynth.domain.models.wsde_facade import WSDETeam
 from devsynth.exceptions import IngestionError, ManifestError
 from devsynth.logging_setup import get_logger
+from devsynth.methodology.base import Phase
 
 # Initialize logger
 logger = get_logger(__name__)

--- a/src/devsynth/domain/models/__init__.py
+++ b/src/devsynth/domain/models/__init__.py
@@ -1,5 +1,6 @@
-from devsynth.logging_setup import DevSynthLogger
+from devsynth.domain.models.wsde_facade import WSDE, WSDETeam
 from devsynth.exceptions import DevSynthError
+from devsynth.logging_setup import DevSynthLogger
 
 # Create a logger for this module
 logger = DevSynthLogger(__name__)
@@ -7,3 +8,4 @@ logger = DevSynthLogger(__name__)
 # Import wsde_summarization to ensure the WSDETeam class is patched with summarization methods
 import devsynth.domain.models.wsde_summarization
 
+__all__ = ["WSDE", "WSDETeam"]

--- a/src/devsynth/domain/models/wsde_summarization.py
+++ b/src/devsynth/domain/models/wsde_summarization.py
@@ -5,7 +5,7 @@ This module provides methods for summarizing consensus and voting results.
 It adds these methods to the WSDETeam class through monkey patching.
 """
 
-from typing import Dict, Any, List
+from typing import Any, Dict, List
 
 
 # Forward declaration for type hints
@@ -16,27 +16,27 @@ class WSDETeam:
 def summarize_consensus_result(self, consensus_result: Dict[str, Any]) -> str:
     """
     Summarize a consensus result in a human-readable format.
-    
+
     Args:
         consensus_result: The consensus result to summarize
-        
+
     Returns:
         A string summary of the consensus result
     """
     if not consensus_result:
         return "No consensus result available."
-        
+
     summary_parts = []
-    
+
     # Add the consensus method
     method = consensus_result.get("method", "unknown")
     summary_parts.append(f"Consensus was reached using {method}.")
-    
+
     # Add the majority opinion if available
     if "majority_opinion" in consensus_result:
         majority_opinion = consensus_result["majority_opinion"]
         summary_parts.append(f"The majority opinion is: {majority_opinion}")
-        
+
     # Add synthesis information if available
     if "synthesis" in consensus_result:
         synthesis = consensus_result["synthesis"]
@@ -44,7 +44,7 @@ def summarize_consensus_result(self, consensus_result: Dict[str, Any]) -> str:
             summary_parts.append(f"Synthesis: {synthesis['text']}")
         elif isinstance(synthesis, str):
             summary_parts.append(f"Synthesis: {synthesis}")
-            
+
     # Add information about conflicts if available
     if "conflicts_identified" in consensus_result:
         conflicts = consensus_result["conflicts_identified"]
@@ -52,12 +52,12 @@ def summarize_consensus_result(self, consensus_result: Dict[str, Any]) -> str:
             summary_parts.append("1 conflict was identified and resolved.")
         else:
             summary_parts.append(f"{conflicts} conflicts were identified and resolved.")
-            
+
     # Add stakeholder explanation if available
     if "stakeholder_explanation" in consensus_result:
         explanation = consensus_result["stakeholder_explanation"]
         summary_parts.append(f"Explanation: {explanation}")
-        
+
     # Join all parts with newlines
     return "\n".join(summary_parts)
 
@@ -65,31 +65,31 @@ def summarize_consensus_result(self, consensus_result: Dict[str, Any]) -> str:
 def summarize_voting_result(self, voting_result: Dict[str, Any]) -> str:
     """
     Summarize a voting result in a human-readable format.
-    
+
     Args:
         voting_result: The voting result to summarize
-        
+
     Returns:
         A string summary of the voting result
     """
     if not voting_result:
         return "No voting result available."
-        
+
     summary_parts = []
-    
+
     # Check if voting was completed
     status = voting_result.get("status", "unknown")
     if status != "completed":
         return f"Voting is not complete. Current status: {status}"
-        
+
     # Get the result information
     result = voting_result.get("result", {})
     method = result.get("method", "unknown")
     winner = result.get("winner", "unknown")
-    
+
     summary_parts.append(f"Voting was completed using {method}.")
     summary_parts.append(f"The winning option is: {winner}")
-    
+
     # Add vote counts if available
     if "vote_counts" in voting_result:
         vote_counts = voting_result["vote_counts"]
@@ -97,7 +97,7 @@ def summarize_voting_result(self, voting_result: Dict[str, Any]) -> str:
         for option, count in vote_counts.items():
             count_parts.append(f"{option}: {count} votes")
         summary_parts.append("Vote distribution: " + ", ".join(count_parts))
-        
+
     # Add vote weights if available
     if "vote_weights" in voting_result:
         weights = voting_result["vote_weights"]
@@ -105,11 +105,13 @@ def summarize_voting_result(self, voting_result: Dict[str, Any]) -> str:
         for agent, weight in weights.items():
             weight_parts.append(f"{agent}: {weight:.2f}")
         summary_parts.append("Vote weights: " + ", ".join(weight_parts))
-        
+
     # Add tie-breaking information if applicable
     if result.get("tie_broken", False):
-        summary_parts.append(f"A tie was broken using {result.get('tie_breaker_method', 'unknown')}.")
-        
+        summary_parts.append(
+            f"A tie was broken using {result.get('tie_breaker_method', 'unknown')}."
+        )
+
     # Join all parts with newlines
     return "\n".join(summary_parts)
 
@@ -122,25 +124,28 @@ def _patch_wsde_team():
     """
     try:
         # Import the WSDETeam class
-        from devsynth.domain.models.wsde import WSDETeam as ActualWSDETeam
-        
+        from devsynth.domain.models.wsde_facade import WSDETeam as ActualWSDETeam
+
         # Add the summarization methods to the WSDETeam class
-        if not hasattr(ActualWSDETeam, 'summarize_consensus_result'):
+        if not hasattr(ActualWSDETeam, "summarize_consensus_result"):
             ActualWSDETeam.summarize_consensus_result = summarize_consensus_result
-            
-        if not hasattr(ActualWSDETeam, 'summarize_voting_result'):
+
+        if not hasattr(ActualWSDETeam, "summarize_voting_result"):
             ActualWSDETeam.summarize_voting_result = summarize_voting_result
-            
+
         # Log that the methods were added
         from devsynth.logging_setup import DevSynthLogger
+
         logger = DevSynthLogger(__name__)
         logger.info("Added summarization methods to WSDETeam class")
-        
+
     except ImportError as e:
         # Log the error but don't raise it
         from devsynth.logging_setup import DevSynthLogger
+
         logger = DevSynthLogger(__name__)
         logger.warning(f"Failed to patch WSDETeam class: {e}")
-        
+
+
 # Call the patch function when this module is imported
 _patch_wsde_team()

--- a/tests/behavior/steps/delegate_task_steps.py
+++ b/tests/behavior/steps/delegate_task_steps.py
@@ -10,7 +10,7 @@ import pytest
 from pytest_bdd import given, scenarios, then, when
 
 from devsynth.application.collaboration.coordinator import AgentCoordinatorImpl
-from devsynth.domain.models.wsde import WSDETeam
+from devsynth.domain.models.wsde_facade import WSDETeam
 
 scenarios("../features/general/delegate_task.feature")
 
@@ -141,4 +141,3 @@ def method_consensus(context) -> None:
 def dialectical_reasoning_applied(context) -> None:
     team: SimpleTeam = context.coordinator.team  # type: ignore[assignment]
     assert team.dialectical_called is True
-

--- a/tests/behavior/steps/edrr_coordinator_steps.py
+++ b/tests/behavior/steps/edrr_coordinator_steps.py
@@ -1,33 +1,32 @@
 """Step definitions for the ``edrr_coordinator.feature`` file."""
 
-from pytest_bdd import scenarios, given, when, then, parsers
+from pytest_bdd import given, parsers, scenarios, then, when
 
 # Content from test_edrr_coordinator_steps.py inlined here
 """Step definitions for the EDRR Coordinator feature."""
 
-from __future__ import annotations
-from pytest_bdd import given, when, then, parsers
-from pytest_bdd import scenarios
 import pytest
+from pytest_bdd import given, parsers, scenarios, then, when
 
 scenarios("../features/general/edrr_coordinator.feature")
-import os
 import json
+import os
 import tempfile
 from pathlib import Path
 from typing import Dict, Tuple
-from devsynth.methodology.base import Phase
-from devsynth.application.memory.memory_manager import MemoryManager
-from devsynth.domain.models.memory import MemoryType
-from devsynth.domain.models.wsde import WSDETeam
+
 from devsynth.application.code_analysis.analyzer import CodeAnalyzer
 from devsynth.application.code_analysis.ast_transformer import AstTransformer
-from devsynth.application.requirements.prompt_manager import PromptManager
 from devsynth.application.documentation.documentation_manager import (
     DocumentationManager,
 )
 from devsynth.application.edrr.coordinator import EDRRCoordinator
 from devsynth.application.edrr.manifest_parser import ManifestParser
+from devsynth.application.memory.memory_manager import MemoryManager
+from devsynth.application.requirements.prompt_manager import PromptManager
+from devsynth.domain.models.memory import MemoryType
+from devsynth.domain.models.wsde_facade import WSDETeam
+from devsynth.methodology.base import Phase
 
 
 @pytest.fixture
@@ -937,7 +936,9 @@ def verify_performance_metrics(context):
         assert "code_analyzer" in component_calls
         assert "prompt_manager" in component_calls
         assert "documentation_manager" in component_calls
-  # noqa: F401,F403
+
+
+# noqa: F401,F403
 
 
 scenarios("../features/general/edrr_coordinator.feature")

--- a/tests/behavior/steps/edrr_enhanced_memory_integration_steps.py
+++ b/tests/behavior/steps/edrr_enhanced_memory_integration_steps.py
@@ -9,34 +9,34 @@ import pytest
 
 pytest.skip("Placeholder feature not implemented", allow_module_level=True)
 
-from pytest_bdd import given, when, then, parsers
-from pytest_bdd import scenarios
+from pytest_bdd import given, parsers, scenarios, then, when
+
 # Content from test_edrr_coordinator_steps.py inlined here
 """Step definitions for the EDRR Coordinator feature."""
 
-from __future__ import annotations
-from pytest_bdd import given, when, then, parsers
-from pytest_bdd import scenarios
+
 import pytest
+from pytest_bdd import given, parsers, scenarios, then, when
 
 scenarios("../features/general/edrr_coordinator.feature")
-import os
 import json
+import os
 import tempfile
 from pathlib import Path
 from typing import Dict, Tuple
-from devsynth.methodology.base import Phase
-from devsynth.application.memory.memory_manager import MemoryManager
-from devsynth.domain.models.memory import MemoryType
-from devsynth.domain.models.wsde import WSDETeam
+
 from devsynth.application.code_analysis.analyzer import CodeAnalyzer
 from devsynth.application.code_analysis.ast_transformer import AstTransformer
-from devsynth.application.requirements.prompt_manager import PromptManager
 from devsynth.application.documentation.documentation_manager import (
     DocumentationManager,
 )
 from devsynth.application.edrr.coordinator import EDRRCoordinator
 from devsynth.application.edrr.manifest_parser import ManifestParser
+from devsynth.application.memory.memory_manager import MemoryManager
+from devsynth.application.requirements.prompt_manager import PromptManager
+from devsynth.domain.models.memory import MemoryType
+from devsynth.domain.models.wsde_facade import WSDETeam
+from devsynth.methodology.base import Phase
 
 
 @pytest.fixture
@@ -946,9 +946,12 @@ def verify_performance_metrics(context):
         assert "code_analyzer" in component_calls
         assert "prompt_manager" in component_calls
         assert "documentation_manager" in component_calls
-  # noqa: F401,F403
-import pytest
+
+
 import logging
+
+# noqa: F401,F403
+import pytest
 
 # Import the scenarios from the feature file
 scenarios("../features/general/edrr_enhanced_memory_integration.feature")
@@ -958,23 +961,23 @@ from unittest.mock import MagicMock, patch
 
 logger = logging.getLogger(__name__)
 
-from devsynth.application.edrr.coordinator import EDRRCoordinator
-from devsynth.application.memory.memory_manager import MemoryManager
-from devsynth.application.memory.adapters.graph_memory_adapter import GraphMemoryAdapter
-from devsynth.application.memory.adapters.enhanced_graph_memory_adapter import (
-    EnhancedGraphMemoryAdapter,
-)
-from devsynth.application.memory.adapters.tinydb_memory_adapter import (
-    TinyDBMemoryAdapter,
-)
-from devsynth.domain.models.wsde import WSDETeam
-from devsynth.domain.models.memory import MemoryType
 from devsynth.application.code_analysis.analyzer import CodeAnalyzer
 from devsynth.application.code_analysis.ast_transformer import AstTransformer
-from devsynth.application.requirements.prompt_manager import PromptManager
 from devsynth.application.documentation.documentation_manager import (
     DocumentationManager,
 )
+from devsynth.application.edrr.coordinator import EDRRCoordinator
+from devsynth.application.memory.adapters.enhanced_graph_memory_adapter import (
+    EnhancedGraphMemoryAdapter,
+)
+from devsynth.application.memory.adapters.graph_memory_adapter import GraphMemoryAdapter
+from devsynth.application.memory.adapters.tinydb_memory_adapter import (
+    TinyDBMemoryAdapter,
+)
+from devsynth.application.memory.memory_manager import MemoryManager
+from devsynth.application.requirements.prompt_manager import PromptManager
+from devsynth.domain.models.memory import MemoryType
+from devsynth.domain.models.wsde_facade import WSDETeam
 from devsynth.methodology.base import Phase
 
 
@@ -1387,6 +1390,6 @@ def step_coordinator_evolves_over_time(context):
 
 # Additional scenarios (Multi-modal memory and Memory with temporal awareness) would be implemented similarly
 # For brevity, I'm omitting them here, but they would follow the same pattern
-  # noqa: F401,F403
+# noqa: F401,F403
 
 scenarios("../features/general/edrr_enhanced_memory_integration.feature")

--- a/tests/behavior/steps/edrr_enhanced_phase_transitions_steps.py
+++ b/tests/behavior/steps/edrr_enhanced_phase_transitions_steps.py
@@ -5,35 +5,35 @@ from pytest_bdd import scenarios
 # Content from test_edrr_enhanced_phase_transitions_steps.py inlined here
 """Step definitions for the Enhanced EDRR Phase Transitions feature."""
 
-from __future__ import annotations
-from pytest_bdd import given, when, then, parsers
-from pytest_bdd import scenarios
+
+from pytest_bdd import given, parsers, scenarios, then, when
+
 # Content from test_edrr_coordinator_steps.py inlined here
 """Step definitions for the EDRR Coordinator feature."""
 
-from __future__ import annotations
-from pytest_bdd import given, when, then, parsers
-from pytest_bdd import scenarios
+
 import pytest
+from pytest_bdd import given, parsers, scenarios, then, when
 
 scenarios("../features/general/edrr_coordinator.feature")
-import os
 import json
+import os
 import tempfile
 from pathlib import Path
 from typing import Dict, Tuple
-from devsynth.methodology.base import Phase
-from devsynth.application.memory.memory_manager import MemoryManager
-from devsynth.domain.models.memory import MemoryType
-from devsynth.domain.models.wsde import WSDETeam
+
 from devsynth.application.code_analysis.analyzer import CodeAnalyzer
 from devsynth.application.code_analysis.ast_transformer import AstTransformer
-from devsynth.application.requirements.prompt_manager import PromptManager
 from devsynth.application.documentation.documentation_manager import (
     DocumentationManager,
 )
 from devsynth.application.edrr.coordinator import EDRRCoordinator
 from devsynth.application.edrr.manifest_parser import ManifestParser
+from devsynth.application.memory.memory_manager import MemoryManager
+from devsynth.application.requirements.prompt_manager import PromptManager
+from devsynth.domain.models.memory import MemoryType
+from devsynth.domain.models.wsde_facade import WSDETeam
+from devsynth.methodology.base import Phase
 
 
 @pytest.fixture
@@ -943,23 +943,26 @@ def verify_performance_metrics(context):
         assert "code_analyzer" in component_calls
         assert "prompt_manager" in component_calls
         assert "documentation_manager" in component_calls
-  # noqa: F401,F403
-import pytest
-from unittest.mock import MagicMock, patch
+
+
 import time
 from datetime import datetime, timedelta
+from unittest.mock import MagicMock, patch
+
+# noqa: F401,F403
+import pytest
 
 scenarios("../features/general/edrr_enhanced_phase_transitions.feature")
-from devsynth.methodology.base import Phase
-from devsynth.application.memory.memory_manager import MemoryManager
-from devsynth.domain.models.wsde import WSDETeam
 from devsynth.application.code_analysis.analyzer import CodeAnalyzer
 from devsynth.application.code_analysis.ast_transformer import AstTransformer
-from devsynth.application.requirements.prompt_manager import PromptManager
 from devsynth.application.documentation.documentation_manager import (
     DocumentationManager,
 )
 from devsynth.application.edrr.coordinator import EDRRCoordinator
+from devsynth.application.memory.memory_manager import MemoryManager
+from devsynth.application.requirements.prompt_manager import PromptManager
+from devsynth.domain.models.wsde_facade import WSDETeam
+from devsynth.methodology.base import Phase
 
 
 @pytest.fixture
@@ -1788,6 +1791,8 @@ def verify_phase_has_access_to_context(context, phase_name):
     assert "key_insights" in previous_phase_context
     assert "constraints" in previous_phase_context
     assert "approaches" in previous_phase_context
-  # noqa: F401,F403
+
+
+# noqa: F401,F403
 
 scenarios("../features/general/edrr_enhanced_phase_transitions.feature")

--- a/tests/behavior/steps/edrr_enhanced_recursion_steps.py
+++ b/tests/behavior/steps/edrr_enhanced_recursion_steps.py
@@ -5,36 +5,35 @@ from pytest_bdd import scenarios
 # Content from test_edrr_enhanced_recursion_steps.py inlined here
 """Step definitions for the Enhanced EDRR Recursion Handling feature."""
 
-from __future__ import annotations
 
-from pytest_bdd import given, when, then, parsers
-from pytest_bdd import scenarios
+from pytest_bdd import given, parsers, scenarios, then, when
+
 # Content from test_edrr_coordinator_steps.py inlined here
 """Step definitions for the EDRR Coordinator feature."""
 
-from __future__ import annotations
-from pytest_bdd import given, when, then, parsers
-from pytest_bdd import scenarios
+
 import pytest
+from pytest_bdd import given, parsers, scenarios, then, when
 
 scenarios("../features/general/edrr_coordinator.feature")
-import os
 import json
+import os
 import tempfile
 from pathlib import Path
 from typing import Dict, Tuple
-from devsynth.methodology.base import Phase
-from devsynth.application.memory.memory_manager import MemoryManager
-from devsynth.domain.models.memory import MemoryType
-from devsynth.domain.models.wsde import WSDETeam
+
 from devsynth.application.code_analysis.analyzer import CodeAnalyzer
 from devsynth.application.code_analysis.ast_transformer import AstTransformer
-from devsynth.application.requirements.prompt_manager import PromptManager
 from devsynth.application.documentation.documentation_manager import (
     DocumentationManager,
 )
 from devsynth.application.edrr.coordinator import EDRRCoordinator
 from devsynth.application.edrr.manifest_parser import ManifestParser
+from devsynth.application.memory.memory_manager import MemoryManager
+from devsynth.application.requirements.prompt_manager import PromptManager
+from devsynth.domain.models.memory import MemoryType
+from devsynth.domain.models.wsde_facade import WSDETeam
+from devsynth.methodology.base import Phase
 
 
 @pytest.fixture
@@ -944,26 +943,30 @@ def verify_performance_metrics(context):
         assert "code_analyzer" in component_calls
         assert "prompt_manager" in component_calls
         assert "documentation_manager" in component_calls
-  # noqa: F401,F403
-import pytest
-from unittest.mock import MagicMock, patch
+
+
 import time
 from datetime import datetime, timedelta
+from unittest.mock import MagicMock, patch
+
+# noqa: F401,F403
+import pytest
 
 # Import the scenarios from the feature file
 scenarios("../features/general/edrr_enhanced_recursion.feature")
 
-# Import the necessary components
-from devsynth.methodology.base import Phase
-from devsynth.application.memory.memory_manager import MemoryManager
-from devsynth.domain.models.wsde import WSDETeam
 from devsynth.application.code_analysis.analyzer import CodeAnalyzer
 from devsynth.application.code_analysis.ast_transformer import AstTransformer
-from devsynth.application.requirements.prompt_manager import PromptManager
 from devsynth.application.documentation.documentation_manager import (
     DocumentationManager,
 )
 from devsynth.application.edrr.coordinator import EDRRCoordinator
+from devsynth.application.memory.memory_manager import MemoryManager
+from devsynth.application.requirements.prompt_manager import PromptManager
+from devsynth.domain.models.wsde_facade import WSDETeam
+
+# Import the necessary components
+from devsynth.methodology.base import Phase
 
 
 @pytest.fixture
@@ -2153,6 +2156,8 @@ def verify_progress_tracking_accessible(context):
     assert progress_data == context.progress_tracking
     assert context.task["id"] in progress_data
     assert "completion_percentage" in progress_data[context.task["id"]]
-  # noqa: F401,F403
+
+
+# noqa: F401,F403
 
 scenarios("../features/general/edrr_enhanced_recursion.feature")

--- a/tests/behavior/steps/micro_edrr_cycle_steps.py
+++ b/tests/behavior/steps/micro_edrr_cycle_steps.py
@@ -1,36 +1,38 @@
 """Step definitions for the ``micro_edrr_cycle.feature`` file."""
 
-from pytest_bdd import scenarios
-
 # Content from test_micro_edrr_cycle_steps.py inlined here
 from __future__ import annotations
 
-from pytest_bdd import given, when, then, parsers
-from pytest_bdd import scenarios
 import pytest
+from pytest_bdd import given, parsers, scenarios, then, when
 
 # Import the scenarios from the feature file
-scenarios('../features/general/micro_edrr_cycle.feature')
+scenarios("../features/general/micro_edrr_cycle.feature")
+
+import json
 
 # Import the necessary components
 import os
-import json
 import tempfile
 from pathlib import Path
 from typing import Dict, Tuple
-from devsynth.methodology.base import Phase
-from devsynth.application.memory.memory_manager import MemoryManager
-from devsynth.domain.models.wsde import WSDETeam
+
 from devsynth.application.code_analysis.analyzer import CodeAnalyzer
 from devsynth.application.code_analysis.ast_transformer import AstTransformer
-from devsynth.application.requirements.prompt_manager import PromptManager
-from devsynth.application.documentation.documentation_manager import DocumentationManager
+from devsynth.application.documentation.documentation_manager import (
+    DocumentationManager,
+)
 from devsynth.application.edrr.coordinator import EDRRCoordinator
+from devsynth.application.memory.memory_manager import MemoryManager
+from devsynth.application.requirements.prompt_manager import PromptManager
+from devsynth.domain.models.wsde_facade import WSDETeam
+from devsynth.methodology.base import Phase
 
 
 @pytest.fixture
 def context():
     """Fixture that provides a context object for the tests."""
+
     class Context:
         def __init__(self):
             """Initialize the context with empty attributes."""
@@ -92,7 +94,9 @@ def edrr_coordinator_initialized(context):
 
     # Initialize documentation manager
     context.documentation_manager = DocumentationManager()
-    assert context.documentation_manager is not None, "Documentation manager initialization failed"
+    assert (
+        context.documentation_manager is not None
+    ), "Documentation manager initialization failed"
 
     # Initialize EDRR coordinator
     context.edrr_coordinator = EDRRCoordinator(
@@ -102,9 +106,11 @@ def edrr_coordinator_initialized(context):
         ast_transformer=context.ast_transformer,
         prompt_manager=context.prompt_manager,
         documentation_manager=context.documentation_manager,
-        enable_enhanced_logging=True
+        enable_enhanced_logging=True,
     )
-    assert context.edrr_coordinator is not None, "EDRR coordinator initialization failed"
+    assert (
+        context.edrr_coordinator is not None
+    ), "EDRR coordinator initialization failed"
 
     # Store the parent cycle for later reference
     context.parent_cycle = context.edrr_coordinator
@@ -133,11 +139,19 @@ def start_edrr_cycle(context, task_description):
 
     # Verify that the cycle was started successfully
     assert context.cycle_id is not None, "EDRR cycle ID should not be None"
-    assert context.edrr_coordinator.current_phase is not None, "EDRR cycle should have a current phase"
-    assert context.edrr_coordinator.results is not None, "EDRR cycle should have results dictionary initialized"
+    assert (
+        context.edrr_coordinator.current_phase is not None
+    ), "EDRR cycle should have a current phase"
+    assert (
+        context.edrr_coordinator.results is not None
+    ), "EDRR cycle should have results dictionary initialized"
 
 
-@when(parsers.parse('I create a micro cycle for "{sub_task_description}" in phase "{phase_name}"'))
+@when(
+    parsers.parse(
+        'I create a micro cycle for "{sub_task_description}" in phase "{phase_name}"'
+    )
+)
 def create_micro_cycle(context, sub_task_description, phase_name):
     """
     Create a micro cycle for the given sub-task in the specified phase.
@@ -160,20 +174,21 @@ def create_micro_cycle(context, sub_task_description, phase_name):
         context.edrr_coordinator.progress_to_phase(context.phase)
 
     # Verify that we're in the correct phase
-    assert context.edrr_coordinator.current_phase == context.phase, \
-        f"Expected to be in phase {context.phase}, but current phase is {context.edrr_coordinator.current_phase}"
+    assert (
+        context.edrr_coordinator.current_phase == context.phase
+    ), f"Expected to be in phase {context.phase}, but current phase is {context.edrr_coordinator.current_phase}"
 
     # Create the micro cycle
     context.micro_cycle = context.edrr_coordinator.create_micro_cycle(
-        {"description": sub_task_description},
-        context.phase
+        {"description": sub_task_description}, context.phase
     )
 
     # Verify that the micro cycle was created successfully
     assert context.micro_cycle is not None, "Micro cycle should not be None"
     assert context.micro_cycle.cycle_id is not None, "Micro cycle ID should not be None"
-    assert context.micro_cycle.parent_cycle_id == context.edrr_coordinator.cycle_id, \
-        "Micro cycle should have the parent cycle ID as its parent_cycle_id"
+    assert (
+        context.micro_cycle.parent_cycle_id == context.edrr_coordinator.cycle_id
+    ), "Micro cycle should have the parent cycle ID as its parent_cycle_id"
 
 
 @then(parsers.parse("the micro cycle should have recursion depth {depth:d}"))
@@ -193,12 +208,14 @@ def verify_recursion_depth(context, depth):
     assert context.micro_cycle is not None, "Micro cycle was not created"
 
     # Verify that the micro cycle has the expected recursion depth
-    assert context.micro_cycle.recursion_depth == depth, \
-        f"Expected recursion depth {depth}, but got {context.micro_cycle.recursion_depth}"
+    assert (
+        context.micro_cycle.recursion_depth == depth
+    ), f"Expected recursion depth {depth}, but got {context.micro_cycle.recursion_depth}"
 
     # Verify that the recursion depth is greater than the parent cycle's recursion depth
-    assert context.micro_cycle.recursion_depth > context.parent_cycle.recursion_depth, \
-        "Micro cycle recursion depth should be greater than parent cycle recursion depth"
+    assert (
+        context.micro_cycle.recursion_depth > context.parent_cycle.recursion_depth
+    ), "Micro cycle recursion depth should be greater than parent cycle recursion depth"
 
 
 @then("the parent cycle should include the micro cycle")
@@ -220,28 +237,45 @@ def verify_parent_includes_micro(context):
     assert context.micro_cycle is not None, "Micro cycle was not created"
 
     # Verify that the micro cycle is in the parent cycle's child_cycles list
-    assert context.micro_cycle.cycle_id in [cycle.cycle_id for cycle in context.parent_cycle.child_cycles], \
-        "Parent cycle does not include the micro cycle in its child_cycles list"
+    assert context.micro_cycle.cycle_id in [
+        cycle.cycle_id for cycle in context.parent_cycle.child_cycles
+    ], "Parent cycle does not include the micro cycle in its child_cycles list"
 
     # Verify that the micro cycle is stored in the parent's results
     phase_key = context.phase.name
-    assert phase_key in context.parent_cycle.results, \
-        f"Phase {phase_key} not found in parent cycle results"
-    assert "micro_cycle_results" in context.parent_cycle.results[phase_key], \
-        "micro_cycle_results not found in parent cycle phase results"
-    assert context.micro_cycle.cycle_id in context.parent_cycle.results[phase_key]["micro_cycle_results"], \
-        "Micro cycle ID not found in parent cycle micro_cycle_results"
+    assert (
+        phase_key in context.parent_cycle.results
+    ), f"Phase {phase_key} not found in parent cycle results"
+    assert (
+        "micro_cycle_results" in context.parent_cycle.results[phase_key]
+    ), "micro_cycle_results not found in parent cycle phase results"
+    assert (
+        context.micro_cycle.cycle_id
+        in context.parent_cycle.results[phase_key]["micro_cycle_results"]
+    ), "Micro cycle ID not found in parent cycle micro_cycle_results"
 
     # Verify that the micro cycle task is stored correctly
-    assert "task" in context.parent_cycle.results[phase_key]["micro_cycle_results"][context.micro_cycle.cycle_id], \
-        "Task not found in micro cycle results"
-    assert context.parent_cycle.results[phase_key]["micro_cycle_results"][context.micro_cycle.cycle_id]["task"]["description"] == context.sub_task_description, \
-        "Micro cycle task description does not match"
+    assert (
+        "task"
+        in context.parent_cycle.results[phase_key]["micro_cycle_results"][
+            context.micro_cycle.cycle_id
+        ]
+    ), "Task not found in micro cycle results"
+    assert (
+        context.parent_cycle.results[phase_key]["micro_cycle_results"][
+            context.micro_cycle.cycle_id
+        ]["task"]["description"]
+        == context.sub_task_description
+    ), "Micro cycle task description does not match"
 
     # Verify that the parent cycle has a reference to the micro cycle's memory items
     # This is important for result aggregation
-    memory_items = context.memory_manager.query_by_metadata({"cycle_id": context.micro_cycle.cycle_id})
+    memory_items = context.memory_manager.query_by_metadata(
+        {"cycle_id": context.micro_cycle.cycle_id}
+    )
     assert len(memory_items) > 0, "Micro cycle should have memory items"
-  # noqa: F401,F403
+
+
+# noqa: F401,F403
 
 scenarios("../features/general/micro_edrr_cycle.feature")

--- a/tests/behavior/steps/recursive_edrr_coordinator_steps.py
+++ b/tests/behavior/steps/recursive_edrr_coordinator_steps.py
@@ -5,32 +5,36 @@ from pytest_bdd import scenarios
 # Content from test_recursive_edrr_coordinator_steps.py inlined here
 """Step definitions for the Recursive EDRR Coordinator feature."""
 
-from pytest_bdd import given, when, then, parsers
-from pytest_bdd import scenarios
 import pytest
+from pytest_bdd import given, parsers, scenarios, then, when
 
 # Import the scenarios from the feature file
-scenarios('../features/general/recursive_edrr_coordinator.feature')
+scenarios("../features/general/recursive_edrr_coordinator.feature")
 
 # Import the necessary components
 
-import os
 import json
+import os
 import tempfile
 from pathlib import Path
-from devsynth.methodology.base import Phase
-from devsynth.application.memory.memory_manager import MemoryManager
-from devsynth.domain.models.wsde import WSDETeam
+
 from devsynth.application.code_analysis.analyzer import CodeAnalyzer
 from devsynth.application.code_analysis.ast_transformer import AstTransformer
-from devsynth.application.requirements.prompt_manager import PromptManager
-from devsynth.application.documentation.documentation_manager import DocumentationManager
+from devsynth.application.documentation.documentation_manager import (
+    DocumentationManager,
+)
 from devsynth.application.edrr.coordinator import EDRRCoordinator, EDRRCoordinatorError
 from devsynth.application.edrr.manifest_parser import ManifestParser
+from devsynth.application.memory.memory_manager import MemoryManager
+from devsynth.application.requirements.prompt_manager import PromptManager
+from devsynth.domain.models.wsde_facade import WSDETeam
+from devsynth.methodology.base import Phase
+
 
 @pytest.fixture
 def context():
     """Fixture to provide a context object for storing test state between steps."""
+
     class Context:
         def __init__(self):
             self.memory_manager = None
@@ -52,7 +56,10 @@ def context():
 def edrr_coordinator_initialized_with_recursion(context):
     """Initialize the EDRR coordinator with recursion support."""
     # Initialize memory adapter
-    from devsynth.application.memory.adapters.tinydb_memory_adapter import TinyDBMemoryAdapter
+    from devsynth.application.memory.adapters.tinydb_memory_adapter import (
+        TinyDBMemoryAdapter,
+    )
+
     memory_adapter = TinyDBMemoryAdapter()  # Use in-memory database for testing
 
     # Initialize actual dependencies
@@ -62,8 +69,7 @@ def edrr_coordinator_initialized_with_recursion(context):
     context.ast_transformer = AstTransformer()
     context.prompt_manager = PromptManager(storage_path="tests/fixtures/prompts")
     context.documentation_manager = DocumentationManager(
-        memory_manager=context.memory_manager,
-        storage_path="tests/fixtures/docs"
+        memory_manager=context.memory_manager, storage_path="tests/fixtures/docs"
     )
 
     # Initialize the EDRRCoordinator with recursion support
@@ -74,16 +80,16 @@ def edrr_coordinator_initialized_with_recursion(context):
         ast_transformer=context.ast_transformer,
         prompt_manager=context.prompt_manager,
         documentation_manager=context.documentation_manager,
-        enable_enhanced_logging=True
+        enable_enhanced_logging=True,
     )
 
     # Verify recursion support attributes
-    assert hasattr(context.edrr_coordinator, 'parent_cycle_id')
-    assert hasattr(context.edrr_coordinator, 'recursion_depth')
-    assert hasattr(context.edrr_coordinator, 'child_cycles')
-    assert hasattr(context.edrr_coordinator, 'max_recursion_depth')
-    assert hasattr(context.edrr_coordinator, 'should_terminate_recursion')
-    assert hasattr(context.edrr_coordinator, 'create_micro_cycle')
+    assert hasattr(context.edrr_coordinator, "parent_cycle_id")
+    assert hasattr(context.edrr_coordinator, "recursion_depth")
+    assert hasattr(context.edrr_coordinator, "child_cycles")
+    assert hasattr(context.edrr_coordinator, "max_recursion_depth")
+    assert hasattr(context.edrr_coordinator, "should_terminate_recursion")
+    assert hasattr(context.edrr_coordinator, "create_micro_cycle")
 
 
 @given("the memory system is available")
@@ -125,7 +131,9 @@ def documentation_manager_available(context):
     """Make the documentation manager available."""
     # The documentation manager is already initialized in edrr_coordinator_initialized
     assert context.documentation_manager is not None
-    assert context.edrr_coordinator.documentation_manager is context.documentation_manager
+    assert (
+        context.edrr_coordinator.documentation_manager is context.documentation_manager
+    )
 
 
 @when(parsers.parse('I start the EDRR cycle with a task to "{task_description}"'))
@@ -146,18 +154,35 @@ def phase_completed(context, phase_name):
     phase = Phase[phase_name.upper()]
 
     # Set up necessary data for each phase
-    if phase == Phase.EXPAND or phase == Phase.DIFFERENTIATE or phase == Phase.REFINE or phase == Phase.RETROSPECT:
+    if (
+        phase == Phase.EXPAND
+        or phase == Phase.DIFFERENTIATE
+        or phase == Phase.REFINE
+        or phase == Phase.RETROSPECT
+    ):
         # Set up data for EXPAND phase
         context.edrr_coordinator.results[Phase.EXPAND] = {
             "completed": True,
             "approaches": [
-                {"id": "approach-1", "description": "First approach", "code": "def approach1(): pass"},
-                {"id": "approach-2", "description": "Second approach", "code": "def approach2(): pass"}
-            ]
+                {
+                    "id": "approach-1",
+                    "description": "First approach",
+                    "code": "def approach1(): pass",
+                },
+                {
+                    "id": "approach-2",
+                    "description": "Second approach",
+                    "code": "def approach2(): pass",
+                },
+            ],
         }
         context.edrr_coordinator.progress_to_phase(Phase.EXPAND)
 
-    if phase == Phase.DIFFERENTIATE or phase == Phase.REFINE or phase == Phase.RETROSPECT:
+    if (
+        phase == Phase.DIFFERENTIATE
+        or phase == Phase.REFINE
+        or phase == Phase.RETROSPECT
+    ):
         # Set up data for DIFFERENTIATE phase
         context.edrr_coordinator.results[Phase.DIFFERENTIATE] = {
             "completed": True,
@@ -165,9 +190,9 @@ def phase_completed(context, phase_name):
                 "selected_approach": {
                     "id": "approach-1",
                     "description": "Selected approach",
-                    "code": "def example(): pass"
+                    "code": "def example(): pass",
                 }
-            }
+            },
         }
         context.edrr_coordinator.progress_to_phase(Phase.DIFFERENTIATE)
 
@@ -177,8 +202,8 @@ def phase_completed(context, phase_name):
             "completed": True,
             "implementation": {
                 "code": "def example(): return 'Hello, World!'",
-                "description": "Implemented solution"
-            }
+                "description": "Implemented solution",
+            },
         }
         context.edrr_coordinator.progress_to_phase(Phase.REFINE)
 
@@ -187,10 +212,13 @@ def phase_completed(context, phase_name):
         context.edrr_coordinator.progress_to_phase(Phase.RETROSPECT)
 
     # Ensure the phase is marked as completed
-    if phase not in context.edrr_coordinator.results or not context.edrr_coordinator.results[phase].get("completed", False):
+    if (
+        phase not in context.edrr_coordinator.results
+        or not context.edrr_coordinator.results[phase].get("completed", False)
+    ):
         context.edrr_coordinator.results[phase] = {
             "completed": True,
-            "outputs": [{"type": "approach", "content": "Sample approach"}]
+            "outputs": [{"type": "approach", "content": "Sample approach"}],
         }
 
 
@@ -206,7 +234,11 @@ def verify_phase(context, phase_name):
     assert context.edrr_coordinator.current_phase == Phase[phase_name.upper()]
 
 
-@when(parsers.parse('I create a micro-EDRR cycle for "{task_description}" within the "{phase_name}" phase'))
+@when(
+    parsers.parse(
+        'I create a micro-EDRR cycle for "{task_description}" within the "{phase_name}" phase'
+    )
+)
 def create_micro_cycle(context, task_description, phase_name):
     """Create a micro-EDRR cycle within the specified phase."""
     micro_task = {"description": task_description}
@@ -220,7 +252,11 @@ def create_micro_cycle(context, task_description, phase_name):
     context.current_micro_cycle = micro_cycle
 
 
-@when(parsers.parse('I create a micro-EDRR cycle for "{task_description}" within the "{phase_name}" phase of the "{parent_task}" cycle'))
+@when(
+    parsers.parse(
+        'I create a micro-EDRR cycle for "{task_description}" within the "{phase_name}" phase of the "{parent_task}" cycle'
+    )
+)
 def create_nested_micro_cycle(context, task_description, phase_name, parent_task):
     """Create a nested micro-EDRR cycle within the specified phase of a parent micro cycle."""
     micro_task = {"description": task_description}
@@ -247,7 +283,9 @@ def verify_micro_cycle_created(context):
 @then("the micro cycle should have the parent cycle ID set correctly")
 def verify_parent_cycle_id(context):
     """Verify the micro cycle has the correct parent cycle ID."""
-    assert context.current_micro_cycle.parent_cycle_id == context.edrr_coordinator.cycle_id
+    assert (
+        context.current_micro_cycle.parent_cycle_id == context.edrr_coordinator.cycle_id
+    )
 
 
 @then("the micro cycle should have recursion depth of 1")
@@ -273,7 +311,7 @@ def execute_micro_cycle_phase(context, phase_name):
     context.current_micro_cycle.execute_current_phase()
 
 
-@when("the micro cycle progresses to the \"Differentiate\" phase")
+@when('the micro cycle progresses to the "Differentiate" phase')
 def progress_micro_cycle_to_differentiate(context):
     """Progress the micro cycle to the Differentiate phase."""
     context.current_micro_cycle.progress_to_phase(Phase.DIFFERENTIATE)
@@ -297,8 +335,12 @@ def verify_micro_cycle_ideas(context, task_description):
     """Verify the micro cycle generates ideas for the specified task."""
     # Check that the micro cycle has results for the Expand phase
     phase_key = Phase.EXPAND.name
-    assert phase_key in context.current_micro_cycle.results, f"Phase key '{phase_key}' not in results: {list(context.current_micro_cycle.results.keys())}"
-    assert "ideas" in context.current_micro_cycle.results[phase_key], f"'ideas' not in results[{phase_key}]: {list(context.current_micro_cycle.results[phase_key].keys())}"
+    assert (
+        phase_key in context.current_micro_cycle.results
+    ), f"Phase key '{phase_key}' not in results: {list(context.current_micro_cycle.results.keys())}"
+    assert (
+        "ideas" in context.current_micro_cycle.results[phase_key]
+    ), f"'ideas' not in results[{phase_key}]: {list(context.current_micro_cycle.results[phase_key].keys())}"
     assert len(context.current_micro_cycle.results[phase_key]["ideas"]) > 0
 
 
@@ -307,25 +349,42 @@ def verify_micro_cycle_evaluation(context, task_description):
     """Verify the micro cycle evaluates options for the specified task."""
     # Check that the micro cycle has results for the Differentiate phase
     phase_key = Phase.DIFFERENTIATE.name
-    assert phase_key in context.current_micro_cycle.results, f"Phase key '{phase_key}' not in results: {list(context.current_micro_cycle.results.keys())}"
-    assert "evaluated_options" in context.current_micro_cycle.results[phase_key], f"'evaluated_options' not in results[{phase_key}]: {list(context.current_micro_cycle.results[phase_key].keys())}"
+    assert (
+        phase_key in context.current_micro_cycle.results
+    ), f"Phase key '{phase_key}' not in results: {list(context.current_micro_cycle.results.keys())}"
+    assert (
+        "evaluated_options" in context.current_micro_cycle.results[phase_key]
+    ), f"'evaluated_options' not in results[{phase_key}]: {list(context.current_micro_cycle.results[phase_key].keys())}"
     assert len(context.current_micro_cycle.results[phase_key]["evaluated_options"]) > 0
 
 
-@then(parsers.parse('the micro cycle should produce an implementation for "{task_description}"'))
+@then(
+    parsers.parse(
+        'the micro cycle should produce an implementation for "{task_description}"'
+    )
+)
 def verify_micro_cycle_implementation(context, task_description):
     """Verify the micro cycle produces an implementation for the specified task."""
     # Check that the micro cycle has results for the Refine phase
     phase_key = Phase.REFINE.name
-    assert phase_key in context.current_micro_cycle.results, f"Phase key '{phase_key}' not in results: {list(context.current_micro_cycle.results.keys())}"
+    assert (
+        phase_key in context.current_micro_cycle.results
+    ), f"Phase key '{phase_key}' not in results: {list(context.current_micro_cycle.results.keys())}"
 
     # Check for either 'implementation' or other implementation-related keys
     refine_results = context.current_micro_cycle.results[phase_key]
-    implementation_keys = ['implementation', 'selected_option', 'detailed_plan', 'optimized_implementation']
+    implementation_keys = [
+        "implementation",
+        "selected_option",
+        "detailed_plan",
+        "optimized_implementation",
+    ]
 
     # Check if at least one of the implementation keys exists
     has_implementation = any(key in refine_results for key in implementation_keys)
-    assert has_implementation, f"No implementation-related keys found in results[{phase_key}]: {list(refine_results.keys())}"
+    assert (
+        has_implementation
+    ), f"No implementation-related keys found in results[{phase_key}]: {list(refine_results.keys())}"
 
     # Verify that the implementation data is not empty
     for key in implementation_keys:
@@ -336,13 +395,19 @@ def verify_micro_cycle_implementation(context, task_description):
     assert False, f"No valid implementation data found in results[{phase_key}]"
 
 
-@then(parsers.parse('the micro cycle should produce learnings for "{task_description}"'))
+@then(
+    parsers.parse('the micro cycle should produce learnings for "{task_description}"')
+)
 def verify_micro_cycle_learnings(context, task_description):
     """Verify the micro cycle produces learnings for the specified task."""
     # Check that the micro cycle has results for the Retrospect phase
     phase_key = Phase.RETROSPECT.name
-    assert phase_key in context.current_micro_cycle.results, f"Phase key '{phase_key}' not in results: {list(context.current_micro_cycle.results.keys())}"
-    assert "learnings" in context.current_micro_cycle.results[phase_key], f"'learnings' not in results[{phase_key}]: {list(context.current_micro_cycle.results[phase_key].keys())}"
+    assert (
+        phase_key in context.current_micro_cycle.results
+    ), f"Phase key '{phase_key}' not in results: {list(context.current_micro_cycle.results.keys())}"
+    assert (
+        "learnings" in context.current_micro_cycle.results[phase_key]
+    ), f"'learnings' not in results[{phase_key}]: {list(context.current_micro_cycle.results[phase_key].keys())}"
     assert len(context.current_micro_cycle.results[phase_key]["learnings"]) > 0
 
 
@@ -355,15 +420,24 @@ def verify_results_integration(context):
 
     # Ensure the phase key exists in the results
     assert phase_key is not None, "Parent phase is None"
-    assert phase_key in context.edrr_coordinator.results, f"Phase key '{phase_key}' not in results: {list(context.edrr_coordinator.results.keys())}"
+    assert (
+        phase_key in context.edrr_coordinator.results
+    ), f"Phase key '{phase_key}' not in results: {list(context.edrr_coordinator.results.keys())}"
 
     # The integration mechanism will depend on the specific implementation
     # For now, we'll check that there's a "micro_cycle_results" key in the parent phase results
-    assert "micro_cycle_results" in context.edrr_coordinator.results[phase_key], f"'micro_cycle_results' not in results[{phase_key}]: {list(context.edrr_coordinator.results[phase_key].keys())}"
-    assert context.current_micro_cycle.cycle_id in context.edrr_coordinator.results[phase_key]["micro_cycle_results"], f"Cycle ID {context.current_micro_cycle.cycle_id} not in micro_cycle_results: {list(context.edrr_coordinator.results[phase_key]['micro_cycle_results'].keys())}"
+    assert (
+        "micro_cycle_results" in context.edrr_coordinator.results[phase_key]
+    ), f"'micro_cycle_results' not in results[{phase_key}]: {list(context.edrr_coordinator.results[phase_key].keys())}"
+    assert (
+        context.current_micro_cycle.cycle_id
+        in context.edrr_coordinator.results[phase_key]["micro_cycle_results"]
+    ), f"Cycle ID {context.current_micro_cycle.cycle_id} not in micro_cycle_results: {list(context.edrr_coordinator.results[phase_key]['micro_cycle_results'].keys())}"
 
 
-@then("attempting to create another micro cycle should fail due to recursion depth limits")
+@then(
+    "attempting to create another micro cycle should fail due to recursion depth limits"
+)
 def verify_recursion_depth_limit(context):
     """Verify that attempting to create a micro cycle beyond the recursion depth limit fails."""
     # Attempt to create a micro cycle beyond the recursion depth limit
@@ -406,17 +480,25 @@ def verify_complex_task_allowed(context):
 
     # Attempt to create a micro cycle
     try:
-        micro_cycle = context.edrr_coordinator.create_micro_cycle(complex_task, Phase.EXPAND)
+        micro_cycle = context.edrr_coordinator.create_micro_cycle(
+            complex_task, Phase.EXPAND
+        )
         assert micro_cycle is not None
     except Exception as e:
-        pytest.fail(f"Creating a micro cycle for a complex task raised an exception: {e}")
+        pytest.fail(
+            f"Creating a micro cycle for a complex task raised an exception: {e}"
+        )
 
 
 @then("creating a micro cycle for a high-cost low-benefit task should be prevented")
 def verify_cost_benefit_analysis(context):
     """Verify that creating a micro cycle for a high-cost low-benefit task is prevented."""
     # Create a high-cost low-benefit task
-    costly_task = {"description": "High cost task", "cost_score": 0.9, "benefit_score": 0.2}
+    costly_task = {
+        "description": "High cost task",
+        "cost_score": 0.9,
+        "benefit_score": 0.2,
+    }
 
     # Attempt to create a micro cycle
     try:
@@ -434,17 +516,27 @@ def verify_cost_benefit_analysis(context):
 def verify_beneficial_task_allowed(context):
     """Verify that creating a micro cycle for a low-cost high-benefit task is allowed."""
     # Create a low-cost high-benefit task
-    beneficial_task = {"description": "High benefit task", "cost_score": 0.3, "benefit_score": 0.8}
+    beneficial_task = {
+        "description": "High benefit task",
+        "cost_score": 0.3,
+        "benefit_score": 0.8,
+    }
 
     # Attempt to create a micro cycle
     try:
-        micro_cycle = context.edrr_coordinator.create_micro_cycle(beneficial_task, Phase.EXPAND)
+        micro_cycle = context.edrr_coordinator.create_micro_cycle(
+            beneficial_task, Phase.EXPAND
+        )
         assert micro_cycle is not None
     except Exception as e:
-        pytest.fail(f"Creating a micro cycle for a beneficial task raised an exception: {e}")
+        pytest.fail(
+            f"Creating a micro cycle for a beneficial task raised an exception: {e}"
+        )
 
 
-@then("creating a micro cycle for a task that already meets quality thresholds should be prevented")
+@then(
+    "creating a micro cycle for a task that already meets quality thresholds should be prevented"
+)
 def verify_quality_threshold(context):
     """Verify that creating a micro cycle for a task that already meets quality thresholds is prevented."""
     # Create a high-quality task
@@ -462,7 +554,9 @@ def verify_quality_threshold(context):
     assert "quality" in str(context.exception).lower()
 
 
-@then("creating a micro cycle for a task that needs quality improvement should be allowed")
+@then(
+    "creating a micro cycle for a task that needs quality improvement should be allowed"
+)
 def verify_low_quality_task_allowed(context):
     """Verify that creating a micro cycle for a task that needs quality improvement is allowed."""
     # Create a low-quality task
@@ -470,22 +564,31 @@ def verify_low_quality_task_allowed(context):
 
     # Attempt to create a micro cycle
     try:
-        micro_cycle = context.edrr_coordinator.create_micro_cycle(low_quality_task, Phase.EXPAND)
+        micro_cycle = context.edrr_coordinator.create_micro_cycle(
+            low_quality_task, Phase.EXPAND
+        )
         assert micro_cycle is not None
     except Exception as e:
-        pytest.fail(f"Creating a micro cycle for a low quality task raised an exception: {e}")
+        pytest.fail(
+            f"Creating a micro cycle for a low quality task raised an exception: {e}"
+        )
 
 
 @then("creating a micro cycle for a resource-intensive task should be prevented")
 def verify_resource_limits(context):
     """Verify that creating a micro cycle for a resource-intensive task is prevented."""
     # Create a resource-intensive task
-    resource_intensive_task = {"description": "Resource intensive task", "resource_usage": 0.9}
+    resource_intensive_task = {
+        "description": "Resource intensive task",
+        "resource_usage": 0.9,
+    }
 
     # Attempt to create a micro cycle
     try:
         context.exception = None
-        context.edrr_coordinator.create_micro_cycle(resource_intensive_task, Phase.EXPAND)
+        context.edrr_coordinator.create_micro_cycle(
+            resource_intensive_task, Phase.EXPAND
+        )
     except EDRRCoordinatorError as e:
         context.exception = e
 
@@ -502,10 +605,14 @@ def verify_lightweight_task_allowed(context):
 
     # Attempt to create a micro cycle
     try:
-        micro_cycle = context.edrr_coordinator.create_micro_cycle(lightweight_task, Phase.EXPAND)
+        micro_cycle = context.edrr_coordinator.create_micro_cycle(
+            lightweight_task, Phase.EXPAND
+        )
         assert micro_cycle is not None
     except Exception as e:
-        pytest.fail(f"Creating a micro cycle for a lightweight task raised an exception: {e}")
+        pytest.fail(
+            f"Creating a micro cycle for a lightweight task raised an exception: {e}"
+        )
 
 
 @then("creating a micro cycle with human override to terminate should be prevented")
@@ -534,10 +641,16 @@ def verify_human_override_continue(context):
 
     # Attempt to create a micro cycle
     try:
-        micro_cycle = context.edrr_coordinator.create_micro_cycle(override_task, Phase.EXPAND)
+        micro_cycle = context.edrr_coordinator.create_micro_cycle(
+            override_task, Phase.EXPAND
+        )
         assert micro_cycle is not None
     except Exception as e:
-        pytest.fail(f"Creating a micro cycle with human override to continue raised an exception: {e}")
-  # noqa: F401,F403
+        pytest.fail(
+            f"Creating a micro cycle with human override to continue raised an exception: {e}"
+        )
+
+
+# noqa: F401,F403
 
 scenarios("../features/general/recursive_edrr_coordinator.feature")

--- a/tests/behavior/steps/test_code_transformer_steps.py
+++ b/tests/behavior/steps/test_code_transformer_steps.py
@@ -5,25 +5,28 @@ This module contains the step definitions for the Code Transformer behavior test
 """
 
 import os
-import pytest
 import tempfile
 from pathlib import Path
-from pytest_bdd import given, when, then, parsers
-from unittest.mock import patch, MagicMock
+from unittest.mock import MagicMock, patch
+
+import pytest
+from pytest_bdd import given, parsers, then, when
 
 from devsynth.application.code_analysis.transformer import CodeTransformer
 from devsynth.application.edrr.edrr_coordinator_enhanced import EnhancedEDRRCoordinator
-from devsynth.domain.models.wsde import WSDETeam
+from devsynth.domain.models.wsde_facade import WSDETeam
 from devsynth.methodology.base import Phase
 
-
 # Import the feature file
-scenarios = pytest.importorskip("pytest_bdd").scenarios("../features/general/code_transformer.feature")
+scenarios = pytest.importorskip("pytest_bdd").scenarios(
+    "../features/general/code_transformer.feature"
+)
 
 
 @pytest.fixture
 def context():
     """Create a context object for sharing data between steps."""
+
     class Context:
         def __init__(self):
             self.transformer = None
@@ -33,7 +36,7 @@ def context():
             self.result = None
             self.edrr_coordinator = None
             self.wsde_team = None
-    
+
     return Context()
 
 
@@ -80,9 +83,15 @@ def transform_code(context, transformation):
 @then("the transformed code should not contain unused imports")
 def verify_no_unused_imports(context):
     """Verify that the transformed code does not contain unused imports."""
-    assert "import re" not in context.result.transformed_code, "Unused import 're' still present"
-    assert "import os" in context.result.transformed_code, "Import 'os' was removed but it's used"
-    assert "import sys" in context.result.transformed_code, "Import 'sys' was removed but it's used"
+    assert (
+        "import re" not in context.result.transformed_code
+    ), "Unused import 're' still present"
+    assert (
+        "import os" in context.result.transformed_code
+    ), "Import 'os' was removed but it's used"
+    assert (
+        "import sys" in context.result.transformed_code
+    ), "Import 'sys' was removed but it's used"
 
 
 @pytest.mark.medium
@@ -92,8 +101,12 @@ def verify_functionality_maintained(context):
     # This would require executing the code, which is beyond the scope of this test
     # Instead, we'll check that the main function is still present
     assert "def main():" in context.result.transformed_code, "Main function is missing"
-    assert "print(os.path.join" in context.result.transformed_code, "os.path.join call is missing"
-    assert "print(sys.version)" in context.result.transformed_code, "sys.version call is missing"
+    assert (
+        "print(os.path.join" in context.result.transformed_code
+    ), "os.path.join call is missing"
+    assert (
+        "print(sys.version)" in context.result.transformed_code
+    ), "sys.version call is missing"
 
 
 @pytest.mark.medium
@@ -121,8 +134,12 @@ def calculate_sum(a, b):
 @then("the transformed code should not contain redundant assignments")
 def verify_no_redundant_assignments(context):
     """Verify that the transformed code does not contain redundant assignments."""
-    assert "result = a + b" not in context.result.transformed_code, "Redundant assignment still present"
-    assert "return a + b" in context.result.transformed_code, "Direct return not present"
+    assert (
+        "result = a + b" not in context.result.transformed_code
+    ), "Redundant assignment still present"
+    assert (
+        "return a + b" in context.result.transformed_code
+    ), "Direct return not present"
 
 
 # Scenario: Transform code with unused variables
@@ -134,10 +151,10 @@ def python_code_with_unused_variables(context):
 def process_data(data):
     result = []
     count = 0  # This variable is unused
-    
+
     for item in data:
         result.append(item * 2)
-    
+
     return result
 """
 
@@ -146,8 +163,12 @@ def process_data(data):
 @then("the transformed code should not contain unused variables")
 def verify_no_unused_variables(context):
     """Verify that the transformed code does not contain unused variables."""
-    assert "count = 0" not in context.result.transformed_code, "Unused variable 'count' still present"
-    assert "result = []" in context.result.transformed_code, "Variable 'result' was removed but it's used"
+    assert (
+        "count = 0" not in context.result.transformed_code
+    ), "Unused variable 'count' still present"
+    assert (
+        "result = []" in context.result.transformed_code
+    ), "Variable 'result' was removed but it's used"
 
 
 # Scenario: Transform code with string literals
@@ -166,12 +187,16 @@ def greet(name):
 @then("the transformed code should contain optimized string literals")
 def verify_optimized_string_literals(context):
     """Verify that the transformed code contains optimized string literals."""
-    assert '"Hello, " + name + "!"' not in context.result.transformed_code, "Unoptimized string concatenation still present"
-    assert any([
-        f'"Hello, {name}!"' in context.result.transformed_code,
-        "f'Hello, {name}!'" in context.result.transformed_code,
-        'f"Hello, {name}!"' in context.result.transformed_code
-    ]), "Optimized string not present"
+    assert (
+        '"Hello, " + name + "!"' not in context.result.transformed_code
+    ), "Unoptimized string concatenation still present"
+    assert any(
+        [
+            f'"Hello, {name}!"' in context.result.transformed_code,
+            "f'Hello, {name}!'" in context.result.transformed_code,
+            'f"Hello, {name}!"' in context.result.transformed_code,
+        ]
+    ), "Optimized string not present"
 
 
 # Scenario: Transform code with style issues
@@ -223,16 +248,18 @@ def main():
 
 
 @pytest.mark.medium
-@when(parsers.parse("I transform the code using the following transformations:\n{table}"))
+@when(
+    parsers.parse("I transform the code using the following transformations:\n{table}")
+)
 def transform_code_with_multiple_transformations(context, table):
     """Transform the code using multiple transformations."""
     # Parse the table
-    rows = [line.strip().split('|') for line in table.strip().split('\n')]
+    rows = [line.strip().split("|") for line in table.strip().split("\n")]
     rows = [[cell.strip() for cell in row if cell.strip()] for row in rows]
-    
+
     # Skip the header row
     transformations = [row[0] for row in rows[1:]]
-    
+
     # Apply the transformations
     context.result = context.transformer.transform_code(context.code, transformations)
 
@@ -242,16 +269,24 @@ def transform_code_with_multiple_transformations(context, table):
 def verify_all_issues_addressed(context):
     """Verify that the transformed code addresses all issues."""
     # Check for unused imports
-    assert "import re" not in context.result.transformed_code, "Unused import 're' still present"
-    
+    assert (
+        "import re" not in context.result.transformed_code
+    ), "Unused import 're' still present"
+
     # Check for redundant assignments
-    assert "result = a + b" not in context.result.transformed_code, "Redundant assignment still present"
-    
+    assert (
+        "result = a + b" not in context.result.transformed_code
+    ), "Redundant assignment still present"
+
     # Check for unused variables
-    assert "z = 15" not in context.result.transformed_code, "Unused variable 'z' still present"
-    
+    assert (
+        "z = 15" not in context.result.transformed_code
+    ), "Unused variable 'z' still present"
+
     # Check for string literals
-    assert '"Hello, " + "world!"' not in context.result.transformed_code, "Unoptimized string concatenation still present"
+    assert (
+        '"Hello, " + "world!"' not in context.result.transformed_code
+    ), "Unoptimized string concatenation still present"
 
 
 @pytest.mark.medium
@@ -260,13 +295,21 @@ def verify_all_changes_recorded(context):
     """Verify that the transformation records all changes made."""
     assert hasattr(context.result, "changes"), "No changes recorded"
     assert len(context.result.changes) > 0, "No changes recorded"
-    
+
     # Check that changes for different transformations were recorded
     change_descriptions = [change["description"] for change in context.result.changes]
-    assert any("import" in desc.lower() for desc in change_descriptions), "No import-related changes recorded"
-    assert any("assignment" in desc.lower() for desc in change_descriptions), "No assignment-related changes recorded"
-    assert any("variable" in desc.lower() for desc in change_descriptions), "No variable-related changes recorded"
-    assert any("string" in desc.lower() for desc in change_descriptions), "No string-related changes recorded"
+    assert any(
+        "import" in desc.lower() for desc in change_descriptions
+    ), "No import-related changes recorded"
+    assert any(
+        "assignment" in desc.lower() for desc in change_descriptions
+    ), "No assignment-related changes recorded"
+    assert any(
+        "variable" in desc.lower() for desc in change_descriptions
+    ), "No variable-related changes recorded"
+    assert any(
+        "string" in desc.lower() for desc in change_descriptions
+    ), "No string-related changes recorded"
 
 
 # Scenario: Transform a file
@@ -277,10 +320,11 @@ def python_file_with_code_issues(context):
     # Create a temporary file
     fd, context.file_path = tempfile.mkstemp(suffix=".py")
     os.close(fd)
-    
+
     # Write code with issues to the file
     with open(context.file_path, "w") as f:
-        f.write("""
+        f.write(
+            """
 import os
 import sys
 import re  # This import is unused
@@ -288,23 +332,32 @@ import re  # This import is unused
 def main():
     print(os.path.join("a", "b"))
     print(sys.version)
-""")
+"""
+        )
 
 
 @pytest.mark.medium
 @when(parsers.parse('I transform the file using the "{transformation}" transformation'))
 def transform_file(context, transformation):
     """Transform the file using the specified transformation."""
-    context.result = context.transformer.transform_file(context.file_path, [transformation])
+    context.result = context.transformer.transform_file(
+        context.file_path, [transformation]
+    )
 
 
 @pytest.mark.medium
 @then("the transformed file should not contain unused imports")
 def verify_file_no_unused_imports(context):
     """Verify that the transformed file does not contain unused imports."""
-    assert "import re" not in context.result.transformed_code, "Unused import 're' still present"
-    assert "import os" in context.result.transformed_code, "Import 'os' was removed but it's used"
-    assert "import sys" in context.result.transformed_code, "Import 'sys' was removed but it's used"
+    assert (
+        "import re" not in context.result.transformed_code
+    ), "Unused import 're' still present"
+    assert (
+        "import os" in context.result.transformed_code
+    ), "Import 'os' was removed but it's used"
+    assert (
+        "import sys" in context.result.transformed_code
+    ), "Import 'sys' was removed but it's used"
 
 
 @pytest.mark.medium
@@ -314,8 +367,12 @@ def verify_file_functionality_maintained(context):
     # This would require executing the code, which is beyond the scope of this test
     # Instead, we'll check that the main function is still present
     assert "def main():" in context.result.transformed_code, "Main function is missing"
-    assert "print(os.path.join" in context.result.transformed_code, "os.path.join call is missing"
-    assert "print(sys.version)" in context.result.transformed_code, "sys.version call is missing"
+    assert (
+        "print(os.path.join" in context.result.transformed_code
+    ), "os.path.join call is missing"
+    assert (
+        "print(sys.version)" in context.result.transformed_code
+    ), "sys.version call is missing"
 
 
 @pytest.mark.medium
@@ -333,41 +390,57 @@ def directory_with_python_files(context):
     """Set up a directory with Python files."""
     # Create a temporary directory
     context.dir_path = tempfile.mkdtemp()
-    
+
     # Create Python files with issues
     with open(os.path.join(context.dir_path, "file1.py"), "w") as f:
-        f.write("""
+        f.write(
+            """
 import os
 import re  # This import is unused
 
 def main():
     print(os.path.join("a", "b"))
-""")
-    
+"""
+        )
+
     with open(os.path.join(context.dir_path, "file2.py"), "w") as f:
-        f.write("""
+        f.write(
+            """
 import sys
 import re  # This import is unused
 
 def main():
     print(sys.version)
-""")
+"""
+        )
 
 
 @pytest.mark.medium
-@when(parsers.parse('I transform the directory using the "{transformation}" transformation'))
+@when(
+    parsers.parse(
+        'I transform the directory using the "{transformation}" transformation'
+    )
+)
 def transform_directory(context, transformation):
     """Transform the directory using the specified transformation."""
-    context.result = context.transformer.transform_directory(context.dir_path, recursive=False, transformations=[transformation])
+    context.result = context.transformer.transform_directory(
+        context.dir_path, recursive=False, transformations=[transformation]
+    )
 
 
 @pytest.mark.medium
 @then("all Python files in the directory should be transformed")
 def verify_all_files_transformed(context):
     """Verify that all Python files in the directory were transformed."""
-    assert len(context.result) == 2, f"Expected 2 files to be transformed, but got {len(context.result)}"
-    assert any("file1.py" in result.file_path for result in context.result), "file1.py was not transformed"
-    assert any("file2.py" in result.file_path for result in context.result), "file2.py was not transformed"
+    assert (
+        len(context.result) == 2
+    ), f"Expected 2 files to be transformed, but got {len(context.result)}"
+    assert any(
+        "file1.py" in result.file_path for result in context.result
+    ), "file1.py was not transformed"
+    assert any(
+        "file2.py" in result.file_path for result in context.result
+    ), "file2.py was not transformed"
 
 
 @pytest.mark.medium
@@ -375,7 +448,9 @@ def verify_all_files_transformed(context):
 def verify_no_files_with_unused_imports(context):
     """Verify that none of the transformed files contain unused imports."""
     for result in context.result:
-        assert "import re" not in result.transformed_code, f"Unused import 're' still present in {result.file_path}"
+        assert (
+            "import re" not in result.transformed_code
+        ), f"Unused import 're' still present in {result.file_path}"
 
 
 @pytest.mark.medium
@@ -383,11 +458,17 @@ def verify_no_files_with_unused_imports(context):
 def verify_all_files_functionality_maintained(context):
     """Verify that all transformed files maintain their original functionality."""
     for result in context.result:
-        assert "def main():" in result.transformed_code, f"Main function is missing in {result.file_path}"
+        assert (
+            "def main():" in result.transformed_code
+        ), f"Main function is missing in {result.file_path}"
         if "file1.py" in result.file_path:
-            assert "print(os.path.join" in result.transformed_code, "os.path.join call is missing in file1.py"
+            assert (
+                "print(os.path.join" in result.transformed_code
+            ), "os.path.join call is missing in file1.py"
         if "file2.py" in result.file_path:
-            assert "print(sys.version)" in result.transformed_code, "sys.version call is missing in file2.py"
+            assert (
+                "print(sys.version)" in result.transformed_code
+            ), "sys.version call is missing in file2.py"
 
 
 @pytest.mark.medium
@@ -406,45 +487,61 @@ def directory_with_python_files_and_subdirectories(context):
     """Set up a directory with Python files and subdirectories."""
     # Create a temporary directory
     context.dir_path = tempfile.mkdtemp()
-    
+
     # Create Python files with issues in the main directory
     with open(os.path.join(context.dir_path, "file1.py"), "w") as f:
-        f.write("""
+        f.write(
+            """
 import os
 import re  # This import is unused
 
 def main():
     print(os.path.join("a", "b"))
-""")
-    
+"""
+        )
+
     # Create a subdirectory with Python files
     subdir = os.path.join(context.dir_path, "subdir")
     os.mkdir(subdir)
-    
+
     with open(os.path.join(subdir, "file2.py"), "w") as f:
-        f.write("""
+        f.write(
+            """
 import sys
 import re  # This import is unused
 
 def main():
     print(sys.version)
-""")
+"""
+        )
 
 
 @pytest.mark.medium
-@when(parsers.parse('I transform the directory recursively using the "{transformation}" transformation'))
+@when(
+    parsers.parse(
+        'I transform the directory recursively using the "{transformation}" transformation'
+    )
+)
 def transform_directory_recursively(context, transformation):
     """Transform the directory recursively using the specified transformation."""
-    context.result = context.transformer.transform_directory(context.dir_path, recursive=True, transformations=[transformation])
+    context.result = context.transformer.transform_directory(
+        context.dir_path, recursive=True, transformations=[transformation]
+    )
 
 
 @pytest.mark.medium
 @then("all Python files in the directory and its subdirectories should be transformed")
 def verify_all_files_and_subdirs_transformed(context):
     """Verify that all Python files in the directory and its subdirectories were transformed."""
-    assert len(context.result) == 2, f"Expected 2 files to be transformed, but got {len(context.result)}"
-    assert any("file1.py" in result.file_path for result in context.result), "file1.py was not transformed"
-    assert any("file2.py" in result.file_path for result in context.result), "file2.py was not transformed"
+    assert (
+        len(context.result) == 2
+    ), f"Expected 2 files to be transformed, but got {len(context.result)}"
+    assert any(
+        "file1.py" in result.file_path for result in context.result
+    ), "file1.py was not transformed"
+    assert any(
+        "file2.py" in result.file_path for result in context.result
+    ), "file2.py was not transformed"
 
 
 # Scenario: Validate syntax before and after transformation
@@ -491,7 +588,9 @@ def verify_transformation_proceeds_if_valid(context):
 def verify_transformed_code_valid_syntax(context):
     """Verify that the transformed code has valid syntax."""
     # We can use the transformer's validate_syntax method to check
-    assert context.transformer.validate_syntax(context.result.transformed_code), "Transformed code has invalid syntax"
+    assert context.transformer.validate_syntax(
+        context.result.transformed_code
+    ), "Transformed code has invalid syntax"
 
 
 # Scenario: Handle syntax errors gracefully
@@ -511,7 +610,9 @@ def attempt_to_transform_code(context):
     """Attempt to transform the code."""
     # We'll use a try-except block to catch any exceptions
     try:
-        context.result = context.transformer.transform_code(context.code, ["remove_unused_imports"])
+        context.result = context.transformer.transform_code(
+            context.code, ["remove_unused_imports"]
+        )
         context.exception = None
     except Exception as e:
         context.exception = e
@@ -542,7 +643,9 @@ def verify_transformation_not_proceeded(context):
     """Verify that the transformer does not proceed with the transformation."""
     # If the transformation failed, context.result should be None
     # If it succeeded despite the syntax errors, context.result should not be None
-    assert context.result is None or not hasattr(context.result, "transformed_code"), "Transformation proceeded despite syntax errors"
+    assert context.result is None or not hasattr(
+        context.result, "transformed_code"
+    ), "Transformation proceeded despite syntax errors"
 
 
 # Scenario: Integrate with EDRR workflow
@@ -559,14 +662,20 @@ def edrr_workflow_configured(context):
 def initiate_code_transformation_task(context):
     """Initiate a code transformation task."""
     # Mock the execution of a code transformation task
-    context.result = {"task": "code_transformation", "phase": "refinement", "status": "completed"}
+    context.result = {
+        "task": "code_transformation",
+        "phase": "refinement",
+        "status": "completed",
+    }
 
 
 @pytest.mark.medium
 @then("the system should use code transformation in the Refinement phase")
 def verify_refinement_phase(context):
     """Verify that code transformation is used in the Refinement phase."""
-    assert context.result["phase"] == "refinement", "Code transformation not used in Refinement phase"
+    assert (
+        context.result["phase"] == "refinement"
+    ), "Code transformation not used in Refinement phase"
 
 
 @pytest.mark.medium
@@ -574,15 +683,21 @@ def verify_refinement_phase(context):
 def verify_appropriate_transformations(context):
     """Verify that appropriate transformations are applied based on the code analysis."""
     # This is a placeholder verification
-    assert context.result["task"] == "code_transformation", "Code transformation task not executed"
+    assert (
+        context.result["task"] == "code_transformation"
+    ), "Code transformation task not executed"
 
 
 @pytest.mark.medium
-@then("the memory system should store transformation results with appropriate EDRR phase tags")
+@then(
+    "the memory system should store transformation results with appropriate EDRR phase tags"
+)
 def verify_results_stored_with_phase_tags(context):
     """Verify that transformation results are stored with appropriate EDRR phase tags."""
     # This is a placeholder verification
-    assert context.result["phase"] == "refinement", "Results not stored with Refinement phase tag"
+    assert (
+        context.result["phase"] == "refinement"
+    ), "Results not stored with Refinement phase tag"
 
 
 # Scenario: Integrate with WSDE team
@@ -599,7 +714,11 @@ def wsde_team_configured(context):
 def assign_code_transformation_task(context):
     """Assign a code transformation task to the WSDE team."""
     # Mock the assignment of a code transformation task
-    context.result = {"task": "code_transformation", "assigned_to": "wsde_team", "status": "completed"}
+    context.result = {
+        "task": "code_transformation",
+        "assigned_to": "wsde_team",
+        "status": "completed",
+    }
 
 
 @pytest.mark.medium
@@ -607,7 +726,9 @@ def assign_code_transformation_task(context):
 def verify_team_collaboration(context):
     """Verify that the team collaborates to transform different aspects of the code."""
     # This is a placeholder verification
-    assert context.result["assigned_to"] == "wsde_team", "Task not assigned to WSDE team"
+    assert (
+        context.result["assigned_to"] == "wsde_team"
+    ), "Task not assigned to WSDE team"
 
 
 @pytest.mark.medium
@@ -623,4 +744,6 @@ def verify_results_shared(context):
 def verify_consolidated_code(context):
     """Verify that the team produces consolidated transformed code."""
     # This is a placeholder verification
-    assert context.result["task"] == "code_transformation", "Code transformation task not executed"
+    assert (
+        context.result["task"] == "code_transformation"
+    ), "Code transformation task not executed"

--- a/tests/behavior/steps/test_consensus_building_steps.py
+++ b/tests/behavior/steps/test_consensus_building_steps.py
@@ -4,16 +4,20 @@ Step Definitions for Consensus Building BDD Tests
 This file implements the step definitions for the consensus building
 feature file, testing the consensus building capabilities of the WSDE model.
 """
-import pytest
-from pytest_bdd import given, when, then, parsers, scenarios
+
 from unittest.mock import MagicMock, patch
-from devsynth.domain.models.wsde import WSDETeam
+
+import pytest
+from pytest_bdd import given, parsers, scenarios, then, when
+
 from devsynth.application.agents.base import BaseAgent
 from devsynth.application.agents.unified_agent import UnifiedAgent
 from devsynth.domain.models.agent import AgentConfig, AgentType
+from devsynth.domain.models.wsde_facade import WSDETeam
 
 # Import the feature file
-scenarios('../features/general/consensus_building.feature')
+scenarios("../features/general/consensus_building.feature")
+
 
 # Define a fixture for the context
 @pytest.fixture
@@ -28,7 +32,9 @@ def context():
             self.decision = None
             self.conflict_resolution = None
             self.decision_history = []
+
     return Context()
+
 
 # Helper function to create a mock agent with expertise
 def create_mock_agent(name, expertise, experience_level=5):
@@ -41,6 +47,7 @@ def create_mock_agent(name, expertise, experience_level=5):
     agent.has_been_primus = False
     return agent
 
+
 # Background steps
 @pytest.mark.medium
 @given("a WSDE team with multiple agents")
@@ -49,11 +56,21 @@ def wsde_team_with_multiple_agents(context):
     context.team = WSDETeam(name="ConsensusTeam")
 
     # Create agents with different expertise areas
-    backend_agent = create_mock_agent("BackendAgent", ["python", "databases", "api_design"], 8)
-    frontend_agent = create_mock_agent("FrontendAgent", ["javascript", "ui_design", "accessibility"], 7)
-    security_agent = create_mock_agent("SecurityAgent", ["security", "authentication", "encryption"], 9)
-    devops_agent = create_mock_agent("DevOpsAgent", ["deployment", "containerization", "ci_cd"], 6)
-    qa_agent = create_mock_agent("QAAgent", ["testing", "quality_assurance", "automation"], 7)
+    backend_agent = create_mock_agent(
+        "BackendAgent", ["python", "databases", "api_design"], 8
+    )
+    frontend_agent = create_mock_agent(
+        "FrontendAgent", ["javascript", "ui_design", "accessibility"], 7
+    )
+    security_agent = create_mock_agent(
+        "SecurityAgent", ["security", "authentication", "encryption"], 9
+    )
+    devops_agent = create_mock_agent(
+        "DevOpsAgent", ["deployment", "containerization", "ci_cd"], 6
+    )
+    qa_agent = create_mock_agent(
+        "QAAgent", ["testing", "quality_assurance", "automation"], 7
+    )
 
     # Add agents to the team
     context.team.add_agent(backend_agent)
@@ -69,6 +86,7 @@ def wsde_team_with_multiple_agents(context):
     context.agents["devops_agent"] = devops_agent
     context.agents["qa_agent"] = qa_agent
 
+
 @pytest.mark.medium
 @given("each agent has different expertise areas")
 def agents_with_different_expertise(context):
@@ -82,6 +100,7 @@ def agents_with_different_expertise(context):
             if i != j:
                 assert exp1 != exp2, f"Agents {i} and {j} have identical expertise"
 
+
 @pytest.mark.medium
 @given("the team is configured for consensus building")
 def team_configured_for_consensus_building(context):
@@ -92,6 +111,7 @@ def team_configured_for_consensus_building(context):
     # Verify that the team is configured for consensus building
     assert context.team.consensus_mode == "enabled"
 
+
 # Scenario: Voting mechanisms for critical decisions
 @pytest.mark.medium
 @given("a critical decision with multiple options")
@@ -101,7 +121,7 @@ def critical_decision_with_options(context):
         "id": "architecture_decision",
         "type": "decision_task",
         "description": "Select the architecture for the new microservices system",
-        "criticality": "high"
+        "criticality": "high",
     }
 
     context.options = [
@@ -110,33 +130,50 @@ def critical_decision_with_options(context):
             "name": "Kubernetes-based microservices",
             "description": "Deploy microservices on Kubernetes for scalability and container orchestration",
             "pros": ["Highly scalable", "Good orchestration", "Industry standard"],
-            "cons": ["Complex setup", "Steep learning curve", "Resource intensive"]
+            "cons": ["Complex setup", "Steep learning curve", "Resource intensive"],
         },
         {
             "id": "option_2",
             "name": "Serverless architecture",
             "description": "Use serverless functions for microservices to reduce operational overhead",
-            "pros": ["Low operational overhead", "Pay-per-use pricing", "Automatic scaling"],
-            "cons": ["Vendor lock-in", "Cold start latency", "Limited execution time"]
+            "pros": [
+                "Low operational overhead",
+                "Pay-per-use pricing",
+                "Automatic scaling",
+            ],
+            "cons": ["Vendor lock-in", "Cold start latency", "Limited execution time"],
         },
         {
             "id": "option_3",
             "name": "Docker Compose with Swarm",
             "description": "Use Docker Compose with Swarm for simpler container orchestration",
-            "pros": ["Simpler than Kubernetes", "Good for smaller teams", "Less resource intensive"],
-            "cons": ["Less scalable", "Fewer features", "Less community support"]
+            "pros": [
+                "Simpler than Kubernetes",
+                "Good for smaller teams",
+                "Less resource intensive",
+            ],
+            "cons": ["Less scalable", "Fewer features", "Less community support"],
         },
         {
             "id": "option_4",
             "name": "Traditional VMs with service mesh",
             "description": "Deploy services on VMs with a service mesh for communication",
-            "pros": ["Familiar infrastructure", "Mature tooling", "Predictable performance"],
-            "cons": ["Less efficient resource usage", "Manual scaling", "Higher maintenance"]
-        }
+            "pros": [
+                "Familiar infrastructure",
+                "Mature tooling",
+                "Predictable performance",
+            ],
+            "cons": [
+                "Less efficient resource usage",
+                "Manual scaling",
+                "Higher maintenance",
+            ],
+        },
     ]
 
     # Add the options to the task
     context.task["options"] = context.options
+
 
 @pytest.mark.medium
 @when("the team needs to select the best option")
@@ -148,6 +185,7 @@ def team_selects_best_option(context):
     # Get the selected option
     context.decision = context.voting_results["selected_option"]
 
+
 @pytest.mark.medium
 @then("all agents should participate in the voting process")
 def all_agents_participate_in_voting(context):
@@ -156,11 +194,16 @@ def all_agents_participate_in_voting(context):
     assert "votes" in context.voting_results
 
     # Map from lowercase agent names to actual agent names in the voting results
-    agent_name_map = {name.lower(): agent.name for name, agent in context.agents.items()}
+    agent_name_map = {
+        name.lower(): agent.name for name, agent in context.agents.items()
+    }
 
     for agent_name in context.agents.keys():
         actual_name = agent_name_map.get(agent_name, agent_name)
-        assert actual_name in context.voting_results["votes"], f"Agent {actual_name} did not vote"
+        assert (
+            actual_name in context.voting_results["votes"]
+        ), f"Agent {actual_name} did not vote"
+
 
 @pytest.mark.medium
 @then("each agent's vote should be weighted based on relevant expertise")
@@ -169,16 +212,22 @@ def votes_weighted_by_expertise(context):
     # Check if vote_weights is directly in the voting results
     if "vote_weights" not in context.voting_results:
         # If not, it might be in a nested structure or we need to skip this test
-        pytest.skip("vote_weights not found in voting results - this feature might not be implemented yet")
+        pytest.skip(
+            "vote_weights not found in voting results - this feature might not be implemented yet"
+        )
 
     # Map from lowercase agent names to actual agent names in the voting results
-    agent_name_map = {name.lower(): agent.name for name, agent in context.agents.items()}
+    agent_name_map = {
+        name.lower(): agent.name for name, agent in context.agents.items()
+    }
 
     # Check that agents with relevant expertise have higher weights
     for agent_name, agent in context.agents.items():
         # Determine if the agent has relevant expertise for the task
-        has_relevant_expertise = any(exp in ["microservices", "architecture", "deployment", "containerization"] 
-                                    for exp in agent.expertise)
+        has_relevant_expertise = any(
+            exp in ["microservices", "architecture", "deployment", "containerization"]
+            for exp in agent.expertise
+        )
 
         # Get the agent's vote weight using the mapped name
         actual_name = agent_name_map.get(agent_name, agent_name)
@@ -190,9 +239,14 @@ def votes_weighted_by_expertise(context):
 
         # Agents with relevant expertise should have higher weights
         if has_relevant_expertise:
-            assert vote_weight > 1.0, f"Agent {actual_name} with relevant expertise has weight {vote_weight} <= 1.0"
+            assert (
+                vote_weight > 1.0
+            ), f"Agent {actual_name} with relevant expertise has weight {vote_weight} <= 1.0"
         else:
-            assert vote_weight <= 1.0, f"Agent {actual_name} without relevant expertise has weight {vote_weight} > 1.0"
+            assert (
+                vote_weight <= 1.0
+            ), f"Agent {actual_name} without relevant expertise has weight {vote_weight} > 1.0"
+
 
 @pytest.mark.medium
 @then("the voting results should be recorded with explanations")
@@ -203,8 +257,13 @@ def voting_results_recorded_with_explanations(context):
 
     # Check that each vote has an explanation
     for agent_name in context.agents.keys():
-        assert agent_name in context.voting_results["vote_explanations"], f"No explanation for {agent_name}'s vote"
-        assert context.voting_results["vote_explanations"][agent_name], f"Empty explanation for {agent_name}'s vote"
+        assert (
+            agent_name in context.voting_results["vote_explanations"]
+        ), f"No explanation for {agent_name}'s vote"
+        assert context.voting_results["vote_explanations"][
+            agent_name
+        ], f"Empty explanation for {agent_name}'s vote"
+
 
 @pytest.mark.medium
 @then("the selected option should have the highest weighted score")
@@ -222,7 +281,10 @@ def selected_option_has_highest_score(context):
     # Verify that no other option has a higher score
     for option_id, score in context.voting_results["option_scores"].items():
         if option_id != selected_option_id:
-            assert score <= selected_score, f"Option {option_id} has higher score ({score}) than selected option ({selected_score})"
+            assert (
+                score <= selected_score
+            ), f"Option {option_id} has higher score ({score}) than selected option ({selected_score})"
+
 
 # Scenario: Conflict resolution in decision making
 @pytest.mark.medium
@@ -233,7 +295,7 @@ def decision_with_conflicting_opinions(context):
         "id": "database_selection",
         "type": "decision_task",
         "description": "Select the database technology for the new application",
-        "criticality": "medium"
+        "criticality": "medium",
     }
 
     context.options = [
@@ -242,33 +304,40 @@ def decision_with_conflicting_opinions(context):
             "name": "PostgreSQL",
             "description": "Use PostgreSQL for robust relational database capabilities",
             "pros": ["ACID compliant", "Mature", "Feature-rich"],
-            "cons": ["Scaling complexity", "Resource intensive"]
+            "cons": ["Scaling complexity", "Resource intensive"],
         },
         {
             "id": "option_2",
             "name": "MongoDB",
             "description": "Use MongoDB for flexible document storage",
             "pros": ["Schema flexibility", "Horizontal scaling", "JSON native"],
-            "cons": ["Less consistency guarantees", "Query limitations"]
+            "cons": ["Less consistency guarantees", "Query limitations"],
         },
         {
             "id": "option_3",
             "name": "MySQL",
             "description": "Use MySQL for a widely-supported relational database",
             "pros": ["Widely used", "Good performance", "Extensive tooling"],
-            "cons": ["Feature limitations", "Scaling challenges"]
-        }
+            "cons": ["Feature limitations", "Scaling challenges"],
+        },
     ]
 
     # Add the options to the task
     context.task["options"] = context.options
 
     # Set up conflicting opinions
-    context.team.set_agent_opinion(context.agents["backend_agent"], "option_1", "strongly_favor")
-    context.team.set_agent_opinion(context.agents["frontend_agent"], "option_2", "strongly_favor")
-    context.team.set_agent_opinion(context.agents["security_agent"], "option_1", "favor")
+    context.team.set_agent_opinion(
+        context.agents["backend_agent"], "option_1", "strongly_favor"
+    )
+    context.team.set_agent_opinion(
+        context.agents["frontend_agent"], "option_2", "strongly_favor"
+    )
+    context.team.set_agent_opinion(
+        context.agents["security_agent"], "option_1", "favor"
+    )
     context.team.set_agent_opinion(context.agents["devops_agent"], "option_2", "favor")
     context.team.set_agent_opinion(context.agents["qa_agent"], "option_3", "favor")
+
 
 @pytest.mark.medium
 @when("the team attempts to reach consensus")
@@ -279,6 +348,7 @@ def team_attempts_consensus(context):
 
     # Get the final decision
     context.decision = context.conflict_resolution["consensus_decision"]
+
 
 @pytest.mark.medium
 @then("the conflicts should be identified and documented")
@@ -296,6 +366,7 @@ def conflicts_identified_and_documented(context):
         assert len(conflict["agents"]) >= 2
         assert len(conflict["options"]) >= 2
 
+
 @pytest.mark.medium
 @then("the team should engage in a structured conflict resolution process")
 def structured_conflict_resolution_process(context):
@@ -311,6 +382,7 @@ def structured_conflict_resolution_process(context):
     for step in context.conflict_resolution["resolution_process"]["steps"]:
         assert "description" in step
         assert "outcome" in step
+
 
 @pytest.mark.medium
 @then("agents should provide reasoning for their positions")
@@ -331,14 +403,19 @@ def agents_provide_reasoning(context):
             agent_name,  # Original key
             actual_agent.name,  # Agent's actual name
             f"{actual_agent.name.lower()}_agent",  # lowercase name + _agent
-            actual_agent.name.lower()  # Just lowercase name
+            actual_agent.name.lower(),  # Just lowercase name
         ]
 
         # Check if any of the possible keys exist in the agent_reasoning dictionary
-        matching_key = next((key for key in possible_keys if key in agent_reasoning_keys), None)
+        matching_key = next(
+            (key for key in possible_keys if key in agent_reasoning_keys), None
+        )
 
-        assert matching_key is not None, f"No reasoning found for agent {agent_name} (tried keys: {possible_keys})"
+        assert (
+            matching_key is not None
+        ), f"No reasoning found for agent {agent_name} (tried keys: {possible_keys})"
         assert context.conflict_resolution["agent_reasoning"][matching_key]
+
 
 @pytest.mark.medium
 @then("a resolution should be reached that addresses key concerns")
@@ -354,6 +431,7 @@ def resolution_addresses_key_concerns(context):
     for concern in context.conflict_resolution["key_concerns"]:
         assert concern in context.conflict_resolution["addressed_concerns"]
 
+
 @pytest.mark.medium
 @then("the resolution process should be documented for future reference")
 def resolution_process_documented(context):
@@ -367,6 +445,7 @@ def resolution_process_documented(context):
     # Verify that the documentation is stored for future reference
     assert context.team.has_decision_documentation(context.task["id"])
 
+
 # Scenario: Weighted voting based on expertise
 @pytest.mark.medium
 @given("a technical decision requiring specialized knowledge")
@@ -377,7 +456,7 @@ def technical_decision_requiring_specialized_knowledge(context):
         "type": "decision_task",
         "description": "Select the authentication mechanism for the application",
         "criticality": "high",
-        "domain": "security"
+        "domain": "security",
     }
 
     context.options = [
@@ -385,27 +464,32 @@ def technical_decision_requiring_specialized_knowledge(context):
             "id": "option_1",
             "name": "OAuth 2.0 with OIDC",
             "description": "Implement OAuth 2.0 with OpenID Connect for authentication",
-            "pros": ["Industry standard", "Delegated authorization", "Single sign-on support"],
-            "cons": ["Implementation complexity", "Multiple moving parts"]
+            "pros": [
+                "Industry standard",
+                "Delegated authorization",
+                "Single sign-on support",
+            ],
+            "cons": ["Implementation complexity", "Multiple moving parts"],
         },
         {
             "id": "option_2",
             "name": "JWT-based authentication",
             "description": "Implement custom JWT-based authentication",
             "pros": ["Simpler implementation", "Stateless", "Flexible"],
-            "cons": ["Custom implementation risks", "Token revocation challenges"]
+            "cons": ["Custom implementation risks", "Token revocation challenges"],
         },
         {
             "id": "option_3",
             "name": "SAML-based authentication",
             "description": "Implement SAML-based authentication for enterprise integration",
             "pros": ["Enterprise-ready", "Mature standard", "Rich attribute support"],
-            "cons": ["XML complexity", "Heavier protocol", "More overhead"]
-        }
+            "cons": ["XML complexity", "Heavier protocol", "More overhead"],
+        },
     ]
 
     # Add the options to the task
     context.task["options"] = context.options
+
 
 @pytest.mark.medium
 @when("the team votes on the decision")
@@ -417,6 +501,7 @@ def team_votes_on_decision(context):
     # Get the selected option
     context.decision = context.voting_results["selected_option"]
 
+
 @pytest.mark.medium
 @then("agents with relevant expertise should have higher voting weight")
 def relevant_expertise_higher_weight(context):
@@ -424,10 +509,14 @@ def relevant_expertise_higher_weight(context):
     # Check if vote_weights is directly in the voting results
     if "vote_weights" not in context.voting_results:
         # If not, it might be in a nested structure or we need to skip this test
-        pytest.skip("vote_weights not found in voting results - this feature might not be implemented yet")
+        pytest.skip(
+            "vote_weights not found in voting results - this feature might not be implemented yet"
+        )
 
     # Map from lowercase agent names to actual agent names in the voting results
-    agent_name_map = {name.lower(): agent.name for name, agent in context.agents.items()}
+    agent_name_map = {
+        name.lower(): agent.name for name, agent in context.agents.items()
+    }
 
     # The security agent should have the highest weight for a security domain task
     security_agent_key = agent_name_map.get("security_agent", "security_agent")
@@ -436,7 +525,10 @@ def relevant_expertise_higher_weight(context):
     # Check that the security agent has the highest weight
     for agent_name, weight in context.voting_results["vote_weights"].items():
         if agent_name != security_agent_key:
-            assert weight <= security_agent_weight, f"Agent {agent_name} has higher weight ({weight}) than security agent ({security_agent_weight})"
+            assert (
+                weight <= security_agent_weight
+            ), f"Agent {agent_name} has higher weight ({weight}) than security agent ({security_agent_weight})"
+
 
 @pytest.mark.medium
 @then("the expertise assessment should be transparent and justifiable")
@@ -453,7 +545,10 @@ def expertise_assessment_transparent(context):
         assessment = context.voting_results["expertise_assessment"][agent_name]
         assert "score" in assessment
         assert "justification" in assessment
-        assert assessment["justification"], f"Empty justification for {agent_name}'s expertise assessment"
+        assert assessment[
+            "justification"
+        ], f"Empty justification for {agent_name}'s expertise assessment"
+
 
 @pytest.mark.medium
 @then("the weighted voting should lead to a technically sound decision")
@@ -461,12 +556,17 @@ def weighted_voting_leads_to_sound_decision(context):
     """Verify that the weighted voting leads to a technically sound decision."""
     # Verify that the decision has a technical soundness assessment
     assert "technical_soundness" in context.decision
-    assert context.decision["technical_soundness"] >= 8, f"Technical soundness score {context.decision['technical_soundness']} is below threshold"
+    assert (
+        context.decision["technical_soundness"] >= 8
+    ), f"Technical soundness score {context.decision['technical_soundness']} is below threshold"
 
     # Verify that the security agent's preferred option was selected
     # (since they have the highest expertise in this domain)
     security_agent_vote = context.voting_results["votes"]["security_agent"]
-    assert context.decision["id"] == security_agent_vote, f"Selected option {context.decision['id']} doesn't match security agent's vote {security_agent_vote}"
+    assert (
+        context.decision["id"] == security_agent_vote
+    ), f"Selected option {context.decision['id']} doesn't match security agent's vote {security_agent_vote}"
+
 
 @pytest.mark.medium
 @then("the decision should include rationale referencing expert opinions")
@@ -477,7 +577,10 @@ def decision_includes_expert_rationale(context):
 
     # Check that the rationale references expert opinions
     assert "expert_opinions" in context.decision["rationale"]
-    assert "security_agent" in context.decision["rationale"]["expert_opinions"], "Security agent's expert opinion not referenced in rationale"
+    assert (
+        "security_agent" in context.decision["rationale"]["expert_opinions"]
+    ), "Security agent's expert opinion not referenced in rationale"
+
 
 # Scenario: Tie-breaking strategies
 @pytest.mark.medium
@@ -488,20 +591,20 @@ def decision_with_tie(context):
         "id": "frontend_framework",
         "type": "decision_task",
         "description": "Select the frontend framework for the new web application",
-        "criticality": "medium"
+        "criticality": "medium",
     }
 
     context.options = [
         {
             "id": "option_1",
             "name": "React",
-            "description": "Use React for component-based UI development"
+            "description": "Use React for component-based UI development",
         },
         {
             "id": "option_2",
             "name": "Vue",
-            "description": "Use Vue for progressive framework development"
-        }
+            "description": "Use Vue for progressive framework development",
+        },
     ]
 
     # Add the options to the task
@@ -509,13 +612,18 @@ def decision_with_tie(context):
 
     # Set up a tie scenario
     context.team.set_agent_opinion(context.agents["backend_agent"], "option_1", "favor")
-    context.team.set_agent_opinion(context.agents["frontend_agent"], "option_2", "strongly_favor")
-    context.team.set_agent_opinion(context.agents["security_agent"], "option_1", "favor")
+    context.team.set_agent_opinion(
+        context.agents["frontend_agent"], "option_2", "strongly_favor"
+    )
+    context.team.set_agent_opinion(
+        context.agents["security_agent"], "option_1", "favor"
+    )
     context.team.set_agent_opinion(context.agents["devops_agent"], "option_2", "favor")
     context.team.set_agent_opinion(context.agents["qa_agent"], "option_2", "neutral")
 
     # Force a tie in the voting
     context.team.force_voting_tie(context.task)
+
 
 @pytest.mark.medium
 @when("the team needs to resolve the tie")
@@ -525,13 +633,16 @@ def team_resolves_tie(context):
     context.voting_results = context.team.vote_on_critical_decision(context.task)
 
     # Verify that there was a tie
-    assert context.voting_results["result_type"] == "tie", "Voting did not result in a tie"
+    assert (
+        context.voting_results["result_type"] == "tie"
+    ), "Voting did not result in a tie"
 
     # Get the tie resolution
     context.tie_resolution = context.voting_results["tie_resolution"]
 
     # Get the final decision after tie-breaking
     context.decision = context.voting_results["selected_option"]
+
 
 @pytest.mark.medium
 @then("the team should apply predefined tie-breaking strategies")
@@ -547,6 +658,7 @@ def team_applies_tiebreaking_strategies(context):
         assert "description" in strategy
         assert "outcome" in strategy
 
+
 @pytest.mark.medium
 @then("the strategies should consider expertise in relevant domains")
 def strategies_consider_domain_expertise(context):
@@ -555,10 +667,15 @@ def strategies_consider_domain_expertise(context):
     assert "domain_expertise_consideration" in context.tie_resolution
 
     # Check that frontend expertise was given priority for a frontend framework decision
-    frontend_agent_influence = context.tie_resolution["domain_expertise_consideration"]["frontend_agent"]
+    frontend_agent_influence = context.tie_resolution["domain_expertise_consideration"][
+        "frontend_agent"
+    ]
 
     # Verify that the frontend agent had high influence
-    assert frontend_agent_influence >= 8, f"Frontend agent influence {frontend_agent_influence} is below threshold"
+    assert (
+        frontend_agent_influence >= 8
+    ), f"Frontend agent influence {frontend_agent_influence} is below threshold"
+
 
 @pytest.mark.medium
 @then("the tie resolution should be fair and transparent")
@@ -574,8 +691,13 @@ def tie_resolution_fair_and_transparent(context):
     assert "process_transparency" in context.tie_resolution["fairness_metrics"]
 
     # Check that the process was fair and transparent
-    assert context.tie_resolution["fairness_metrics"]["bias_assessment"] <= 2, "Bias assessment too high"
-    assert context.tie_resolution["fairness_metrics"]["process_transparency"] >= 8, "Process transparency too low"
+    assert (
+        context.tie_resolution["fairness_metrics"]["bias_assessment"] <= 2
+    ), "Bias assessment too high"
+    assert (
+        context.tie_resolution["fairness_metrics"]["process_transparency"] >= 8
+    ), "Process transparency too low"
+
 
 @pytest.mark.medium
 @then("the final decision should be documented with the tie-breaking rationale")
@@ -587,7 +709,10 @@ def decision_documented_with_tiebreaking_rationale(context):
 
     # Verify that the rationale references the strategies applied
     for strategy in context.tie_resolution["strategies_applied"]:
-        assert strategy["name"] in context.decision["tie_breaking_rationale"], f"Strategy {strategy['name']} not referenced in rationale"
+        assert (
+            strategy["name"] in context.decision["tie_breaking_rationale"]
+        ), f"Strategy {strategy['name']} not referenced in rationale"
+
 
 # Scenario: Decision tracking and explanation
 @pytest.mark.medium
@@ -603,9 +728,9 @@ def series_of_decisions(context):
             "options": [
                 {"id": "option_1", "name": "Microservices"},
                 {"id": "option_2", "name": "Monolith"},
-                {"id": "option_3", "name": "Serverless"}
+                {"id": "option_3", "name": "Serverless"},
             ],
-            "criticality": "high"
+            "criticality": "high",
         },
         {
             "id": "database_decision",
@@ -614,9 +739,9 @@ def series_of_decisions(context):
             "options": [
                 {"id": "option_1", "name": "PostgreSQL"},
                 {"id": "option_2", "name": "MongoDB"},
-                {"id": "option_3", "name": "MySQL"}
+                {"id": "option_3", "name": "MySQL"},
             ],
-            "criticality": "medium"
+            "criticality": "medium",
         },
         {
             "id": "frontend_decision",
@@ -625,20 +750,23 @@ def series_of_decisions(context):
             "options": [
                 {"id": "option_1", "name": "React"},
                 {"id": "option_2", "name": "Vue"},
-                {"id": "option_3", "name": "Angular"}
+                {"id": "option_3", "name": "Angular"},
             ],
-            "criticality": "medium"
-        }
+            "criticality": "medium",
+        },
     ]
 
     # Process each decision
     for decision_task in decisions:
         voting_results = context.team.vote_on_critical_decision(decision_task)
-        context.decision_history.append({
-            "task": decision_task,
-            "voting_results": voting_results,
-            "decision": voting_results["selected_option"]
-        })
+        context.decision_history.append(
+            {
+                "task": decision_task,
+                "voting_results": voting_results,
+                "decision": voting_results["selected_option"],
+            }
+        )
+
 
 @pytest.mark.medium
 @when("the decisions are implemented")
@@ -653,13 +781,13 @@ def decisions_implemented(context):
             "implemented_by": "development_team",
             "implementation_date": "2025-07-10",
             "implementation_status": "completed",
-            "verification_status": "verified"
+            "verification_status": "verified",
         }
 
         context.team.add_decision_implementation_details(
-            decision_record["task"]["id"], 
-            implementation_details
+            decision_record["task"]["id"], implementation_details
         )
+
 
 @pytest.mark.medium
 @then("each decision should be tracked with metadata")
@@ -679,6 +807,7 @@ def decisions_tracked_with_metadata(context):
         assert "criticality" in tracked_decision["metadata"]
         assert "implementation_status" in tracked_decision["metadata"]
         assert "verification_status" in tracked_decision["metadata"]
+
 
 @pytest.mark.medium
 @then("the tracking should include voting results and rationale")
@@ -700,6 +829,7 @@ def tracking_includes_voting_and_rationale(context):
         assert "rationale" in tracked_decision
         assert tracked_decision["rationale"], "Empty rationale"
 
+
 @pytest.mark.medium
 @then("the explanation should reference relevant expertise and considerations")
 def explanation_references_expertise(context):
@@ -719,6 +849,7 @@ def explanation_references_expertise(context):
         assert len(tracked_decision["rationale"]["expertise_references"]) > 0
         assert len(tracked_decision["rationale"]["considerations"]) > 0
 
+
 @pytest.mark.medium
 @then("the decision history should be queryable for future reference")
 def decision_history_queryable(context):
@@ -734,12 +865,17 @@ def decision_history_queryable(context):
     assert len(high_criticality_decisions) > 0
 
     # Query by implementation status
-    implemented_decisions = context.team.query_decisions(implementation_status="completed")
+    implemented_decisions = context.team.query_decisions(
+        implementation_status="completed"
+    )
     assert len(implemented_decisions) > 0
 
     # Query by date range
-    recent_decisions = context.team.query_decisions(date_range=("2025-07-01", "2025-07-15"))
+    recent_decisions = context.team.query_decisions(
+        date_range=("2025-07-01", "2025-07-15")
+    )
     assert len(recent_decisions) > 0
+
 
 @pytest.mark.medium
 @then("the explanations should be clear enough for external stakeholders to understand")
@@ -763,11 +899,26 @@ def explanations_clear_for_stakeholders(context):
         # If readability_score is not directly available, we can check other indicators of readability
         if "readability_score" not in tracked_decision:
             # Check for common jargon terms that should be avoided in stakeholder explanations
-            jargon_terms = ["implementation", "algorithm", "framework", "architecture", "protocol", "API"]
-            jargon_count = sum(1 for term in jargon_terms if term.lower() in stakeholder_explanation.lower())
+            jargon_terms = [
+                "implementation",
+                "algorithm",
+                "framework",
+                "architecture",
+                "protocol",
+                "API",
+            ]
+            jargon_count = sum(
+                1
+                for term in jargon_terms
+                if term.lower() in stakeholder_explanation.lower()
+            )
 
             # Ensure limited jargon usage
-            assert jargon_count <= 3, f"Too much technical jargon in stakeholder explanation: {jargon_count} terms"
+            assert (
+                jargon_count <= 3
+            ), f"Too much technical jargon in stakeholder explanation: {jargon_count} terms"
         else:
             # If readability_score is available, use it
-            assert tracked_decision["readability_score"] >= 70, "Readability score too low"
+            assert (
+                tracked_decision["readability_score"] >= 70
+            ), "Readability score too low"

--- a/tests/behavior/steps/test_delegate_task_steps.py
+++ b/tests/behavior/steps/test_delegate_task_steps.py
@@ -9,7 +9,7 @@ import pytest
 from pytest_bdd import given, scenarios, then, when
 
 from devsynth.application.collaboration.coordinator import AgentCoordinatorImpl
-from devsynth.domain.models.wsde import WSDETeam
+from devsynth.domain.models.wsde_facade import WSDETeam
 
 scenarios("../features/general/delegate_task.feature")
 

--- a/tests/behavior/steps/test_edrr_coordinator_steps.py
+++ b/tests/behavior/steps/test_edrr_coordinator_steps.py
@@ -1,28 +1,29 @@
 """Step definitions for the EDRR Coordinator feature."""
 
 from __future__ import annotations
-from pytest_bdd import given, when, then, parsers
-from pytest_bdd import scenarios
+
 import pytest
+from pytest_bdd import given, parsers, scenarios, then, when
 
 scenarios("../features/general/edrr_coordinator.feature")
-import os
 import json
+import os
 import tempfile
 from pathlib import Path
 from typing import Dict, Tuple
-from devsynth.methodology.base import Phase
-from devsynth.application.memory.memory_manager import MemoryManager
-from devsynth.domain.models.memory import MemoryType
-from devsynth.domain.models.wsde import WSDETeam
+
 from devsynth.application.code_analysis.analyzer import CodeAnalyzer
 from devsynth.application.code_analysis.ast_transformer import AstTransformer
-from devsynth.application.requirements.prompt_manager import PromptManager
 from devsynth.application.documentation.documentation_manager import (
     DocumentationManager,
 )
 from devsynth.application.edrr.coordinator import EDRRCoordinator
 from devsynth.application.edrr.manifest_parser import ManifestParser
+from devsynth.application.memory.memory_manager import MemoryManager
+from devsynth.application.requirements.prompt_manager import PromptManager
+from devsynth.domain.models.memory import MemoryType
+from devsynth.domain.models.wsde_facade import WSDETeam
+from devsynth.methodology.base import Phase
 
 
 @pytest.fixture
@@ -227,7 +228,11 @@ def verify_phase(context, phase_name):
 
 
 @pytest.mark.medium
-@then(    parsers.parse(        'the coordinator should store the task in memory with EDRR phase "{phase_name}"'    ))
+@then(
+    parsers.parse(
+        'the coordinator should store the task in memory with EDRR phase "{phase_name}"'
+    )
+)
 def verify_task_stored(context, phase_name):
     """Verify the task is stored in memory with the correct EDRR phase."""
     test_storage = {}
@@ -451,7 +456,11 @@ def verify_ast_verify(context):
 
 
 @pytest.mark.medium
-@then(    parsers.parse(        'the prompt manager should provide templates for the "{phase_name}" phase'    ))
+@then(
+    parsers.parse(
+        'the prompt manager should provide templates for the "{phase_name}" phase'
+    )
+)
 def verify_prompt_templates(context, phase_name):
     """Verify the prompt manager provides templates for the specified phase."""
     phase = Phase[phase_name.upper()]
@@ -608,7 +617,11 @@ This document outlines criteria for evaluating code quality."""
 
 
 @pytest.mark.medium
-@then(    parsers.parse(        'the results should be stored in memory with EDRR phase "{phase_name}"'    ))
+@then(
+    parsers.parse(
+        'the results should be stored in memory with EDRR phase "{phase_name}"'
+    )
+)
 def verify_results_stored(context, phase_name):
     """Verify the results are stored in memory with the correct EDRR phase."""
     phase = Phase[phase_name.upper()]

--- a/tests/behavior/steps/test_edrr_enhanced_memory_integration_steps.py
+++ b/tests/behavior/steps/test_edrr_enhanced_memory_integration_steps.py
@@ -6,32 +6,32 @@ import pytest
 
 pytest.skip("Placeholder feature not implemented", allow_module_level=True)
 
-from pytest_bdd import given, when, then, parsers
-from pytest_bdd import scenarios
+from pytest_bdd import given, parsers, scenarios, then, when
+
 # Content from test_edrr_coordinator_steps.py inlined here
 """Step definitions for the EDRR Coordinator feature."""
-from pytest_bdd import given, when, then, parsers
-from pytest_bdd import scenarios
 import pytest
+from pytest_bdd import given, parsers, scenarios, then, when
 
 scenarios("../features/general/edrr_coordinator.feature")
-import os
 import json
+import os
 import tempfile
 from pathlib import Path
 from typing import Dict, Tuple
-from devsynth.methodology.base import Phase
-from devsynth.application.memory.memory_manager import MemoryManager
-from devsynth.domain.models.memory import MemoryType
-from devsynth.domain.models.wsde import WSDETeam
+
 from devsynth.application.code_analysis.analyzer import CodeAnalyzer
 from devsynth.application.code_analysis.ast_transformer import AstTransformer
-from devsynth.application.requirements.prompt_manager import PromptManager
 from devsynth.application.documentation.documentation_manager import (
     DocumentationManager,
 )
 from devsynth.application.edrr.coordinator import EDRRCoordinator
 from devsynth.application.edrr.manifest_parser import ManifestParser
+from devsynth.application.memory.memory_manager import MemoryManager
+from devsynth.application.requirements.prompt_manager import PromptManager
+from devsynth.domain.models.memory import MemoryType
+from devsynth.domain.models.wsde_facade import WSDETeam
+from devsynth.methodology.base import Phase
 
 
 @pytest.fixture
@@ -236,7 +236,11 @@ def verify_phase(context, phase_name):
 
 
 @pytest.mark.medium
-@then(    parsers.parse(        'the coordinator should store the task in memory with EDRR phase "{phase_name}"'    ))
+@then(
+    parsers.parse(
+        'the coordinator should store the task in memory with EDRR phase "{phase_name}"'
+    )
+)
 def verify_task_stored(context, phase_name):
     """Verify the task is stored in memory with the correct EDRR phase."""
     test_storage = {}
@@ -460,7 +464,11 @@ def verify_ast_verify(context):
 
 
 @pytest.mark.medium
-@then(    parsers.parse(        'the prompt manager should provide templates for the "{phase_name}" phase'    ))
+@then(
+    parsers.parse(
+        'the prompt manager should provide templates for the "{phase_name}" phase'
+    )
+)
 def verify_prompt_templates(context, phase_name):
     """Verify the prompt manager provides templates for the specified phase."""
     phase = Phase[phase_name.upper()]
@@ -617,7 +625,11 @@ This document outlines criteria for evaluating code quality."""
 
 
 @pytest.mark.medium
-@then(    parsers.parse(        'the results should be stored in memory with EDRR phase "{phase_name}"'    ))
+@then(
+    parsers.parse(
+        'the results should be stored in memory with EDRR phase "{phase_name}"'
+    )
+)
 def verify_results_stored(context, phase_name):
     """Verify the results are stored in memory with the correct EDRR phase."""
     phase = Phase[phase_name.upper()]
@@ -971,9 +983,12 @@ def verify_performance_metrics(context):
         assert "code_analyzer" in component_calls
         assert "prompt_manager" in component_calls
         assert "documentation_manager" in component_calls
-  # noqa: F401,F403
-import pytest
+
+
 import logging
+
+# noqa: F401,F403
+import pytest
 
 # Import the scenarios from the feature file
 scenarios("../features/general/edrr_enhanced_memory_integration.feature")
@@ -983,23 +998,23 @@ from unittest.mock import MagicMock, patch
 
 logger = logging.getLogger(__name__)
 
-from devsynth.application.edrr.coordinator import EDRRCoordinator
-from devsynth.application.memory.memory_manager import MemoryManager
-from devsynth.application.memory.adapters.graph_memory_adapter import GraphMemoryAdapter
-from devsynth.application.memory.adapters.enhanced_graph_memory_adapter import (
-    EnhancedGraphMemoryAdapter,
-)
-from devsynth.application.memory.adapters.tinydb_memory_adapter import (
-    TinyDBMemoryAdapter,
-)
-from devsynth.domain.models.wsde import WSDETeam
-from devsynth.domain.models.memory import MemoryType
 from devsynth.application.code_analysis.analyzer import CodeAnalyzer
 from devsynth.application.code_analysis.ast_transformer import AstTransformer
-from devsynth.application.requirements.prompt_manager import PromptManager
 from devsynth.application.documentation.documentation_manager import (
     DocumentationManager,
 )
+from devsynth.application.edrr.coordinator import EDRRCoordinator
+from devsynth.application.memory.adapters.enhanced_graph_memory_adapter import (
+    EnhancedGraphMemoryAdapter,
+)
+from devsynth.application.memory.adapters.graph_memory_adapter import GraphMemoryAdapter
+from devsynth.application.memory.adapters.tinydb_memory_adapter import (
+    TinyDBMemoryAdapter,
+)
+from devsynth.application.memory.memory_manager import MemoryManager
+from devsynth.application.requirements.prompt_manager import PromptManager
+from devsynth.domain.models.memory import MemoryType
+from devsynth.domain.models.wsde_facade import WSDETeam
 from devsynth.methodology.base import Phase
 
 
@@ -1358,7 +1373,9 @@ def step_graph_supports_transitive_inference(context):
 
 
 @pytest.mark.medium
-@then(    "the coordinator should be able to traverse the graph to find related information")
+@then(
+    "the coordinator should be able to traverse the graph to find related information"
+)
 def step_coordinator_traverses_graph(context):
     """Verify that the coordinator can traverse the graph to find related information."""
     # This will be implemented in the actual functionality

--- a/tests/behavior/steps/test_edrr_enhanced_phase_transitions_steps.py
+++ b/tests/behavior/steps/test_edrr_enhanced_phase_transitions_steps.py
@@ -1,8 +1,8 @@
 """Step definitions for the Enhanced EDRR Phase Transitions feature."""
 
 from __future__ import annotations
-from pytest_bdd import given, when, then, parsers
-from pytest_bdd import scenarios
+
+from pytest_bdd import given, parsers, scenarios, then, when
 
 # Import the feature file for this test
 scenarios("../features/general/edrr_enhanced_phase_transitions.feature")
@@ -10,29 +10,30 @@ scenarios("../features/general/edrr_enhanced_phase_transitions.feature")
 # Content from test_edrr_coordinator_steps.py inlined here
 """Step definitions for the EDRR Coordinator feature."""
 
-# Removed duplicate __future__ import
-from pytest_bdd import given, when, then, parsers
-from pytest_bdd import scenarios
 import pytest
 
+# Removed duplicate __future__ import
+from pytest_bdd import given, parsers, scenarios, then, when
+
 scenarios("../features/general/edrr_coordinator.feature")
-import os
 import json
+import os
 import tempfile
 from pathlib import Path
 from typing import Dict, Tuple
-from devsynth.methodology.base import Phase
-from devsynth.application.memory.memory_manager import MemoryManager
-from devsynth.domain.models.memory import MemoryType
-from devsynth.domain.models.wsde import WSDETeam
+
 from devsynth.application.code_analysis.analyzer import CodeAnalyzer
 from devsynth.application.code_analysis.ast_transformer import AstTransformer
-from devsynth.application.requirements.prompt_manager import PromptManager
 from devsynth.application.documentation.documentation_manager import (
     DocumentationManager,
 )
 from devsynth.application.edrr.coordinator import EDRRCoordinator
 from devsynth.application.edrr.manifest_parser import ManifestParser
+from devsynth.application.memory.memory_manager import MemoryManager
+from devsynth.application.requirements.prompt_manager import PromptManager
+from devsynth.domain.models.memory import MemoryType
+from devsynth.domain.models.wsde_facade import WSDETeam
+from devsynth.methodology.base import Phase
 
 
 @pytest.fixture
@@ -237,7 +238,11 @@ def verify_phase(context, phase_name):
 
 
 @pytest.mark.medium
-@then(    parsers.parse(        'the coordinator should store the task in memory with EDRR phase "{phase_name}"'    ))
+@then(
+    parsers.parse(
+        'the coordinator should store the task in memory with EDRR phase "{phase_name}"'
+    )
+)
 def verify_task_stored(context, phase_name):
     """Verify the task is stored in memory with the correct EDRR phase."""
     test_storage = {}
@@ -461,7 +466,11 @@ def verify_ast_verify(context):
 
 
 @pytest.mark.medium
-@then(    parsers.parse(        'the prompt manager should provide templates for the "{phase_name}" phase'    ))
+@then(
+    parsers.parse(
+        'the prompt manager should provide templates for the "{phase_name}" phase'
+    )
+)
 def verify_prompt_templates(context, phase_name):
     """Verify the prompt manager provides templates for the specified phase."""
     phase = Phase[phase_name.upper()]
@@ -618,7 +627,11 @@ This document outlines criteria for evaluating code quality."""
 
 
 @pytest.mark.medium
-@then(    parsers.parse(        'the results should be stored in memory with EDRR phase "{phase_name}"'    ))
+@then(
+    parsers.parse(
+        'the results should be stored in memory with EDRR phase "{phase_name}"'
+    )
+)
 def verify_results_stored(context, phase_name):
     """Verify the results are stored in memory with the correct EDRR phase."""
     phase = Phase[phase_name.upper()]
@@ -972,23 +985,26 @@ def verify_performance_metrics(context):
         assert "code_analyzer" in component_calls
         assert "prompt_manager" in component_calls
         assert "documentation_manager" in component_calls
-  # noqa: F401,F403
-import pytest
-from unittest.mock import MagicMock, patch
+
+
 import time
 from datetime import datetime, timedelta
+from unittest.mock import MagicMock, patch
+
+# noqa: F401,F403
+import pytest
 
 scenarios("../features/general/edrr_enhanced_phase_transitions.feature")
-from devsynth.methodology.base import Phase
-from devsynth.application.memory.memory_manager import MemoryManager
-from devsynth.domain.models.wsde import WSDETeam
 from devsynth.application.code_analysis.analyzer import CodeAnalyzer
 from devsynth.application.code_analysis.ast_transformer import AstTransformer
-from devsynth.application.requirements.prompt_manager import PromptManager
 from devsynth.application.documentation.documentation_manager import (
     DocumentationManager,
 )
 from devsynth.application.edrr.coordinator import EDRRCoordinator
+from devsynth.application.memory.memory_manager import MemoryManager
+from devsynth.application.requirements.prompt_manager import PromptManager
+from devsynth.domain.models.wsde_facade import WSDETeam
+from devsynth.methodology.base import Phase
 
 
 @pytest.fixture
@@ -1630,7 +1646,9 @@ def verify_historical_data_used(context):
 
 
 @pytest.mark.medium
-@then(    "the phase transition criteria should be adjusted based on previous success patterns")
+@then(
+    "the phase transition criteria should be adjusted based on previous success patterns"
+)
 def verify_criteria_adjusted_based_on_patterns(context):
     """Verify that phase transition criteria are adjusted based on previous success patterns."""
     assert hasattr(context.edrr_coordinator, "_adjusted_criteria")
@@ -1649,7 +1667,9 @@ def verify_criteria_adjusted_based_on_patterns(context):
 
 
 @pytest.mark.medium
-@then(    "the coordinator should prioritize strategies that were effective in similar tasks")
+@then(
+    "the coordinator should prioritize strategies that were effective in similar tasks"
+)
 def verify_effective_strategies_prioritized(context):
     """Verify that strategies that were effective in similar tasks are prioritized."""
     for phase in ["EXPAND", "DIFFERENTIATE", "REFINE", "RETROSPECT"]:
@@ -1808,7 +1828,9 @@ def verify_context_includes_key_insights(context, phase_name):
 
 
 @pytest.mark.medium
-@then(    'the context should include all constraints identified in the "{phase_name}" phase')
+@then(
+    'the context should include all constraints identified in the "{phase_name}" phase'
+)
 def verify_context_includes_constraints(context, phase_name):
     """Verify that the context includes all constraints identified in the specified phase."""
     phase = Phase[phase_name.upper()]

--- a/tests/behavior/steps/test_edrr_enhanced_recursion_steps.py
+++ b/tests/behavior/steps/test_edrr_enhanced_recursion_steps.py
@@ -2,8 +2,7 @@
 
 from __future__ import annotations
 
-from pytest_bdd import given, when, then, parsers
-from pytest_bdd import scenarios
+from pytest_bdd import given, parsers, scenarios, then, when
 
 # Import the feature file for this test
 scenarios("../features/general/edrr_enhanced_recursion.feature")
@@ -11,29 +10,30 @@ scenarios("../features/general/edrr_enhanced_recursion.feature")
 # Content from test_edrr_coordinator_steps.py inlined here
 """Step definitions for the EDRR Coordinator feature."""
 
-# Removed duplicate __future__ import
-from pytest_bdd import given, when, then, parsers
-from pytest_bdd import scenarios
 import pytest
 
+# Removed duplicate __future__ import
+from pytest_bdd import given, parsers, scenarios, then, when
+
 scenarios("../features/general/edrr_coordinator.feature")
-import os
 import json
+import os
 import tempfile
 from pathlib import Path
 from typing import Dict, Tuple
-from devsynth.methodology.base import Phase
-from devsynth.application.memory.memory_manager import MemoryManager
-from devsynth.domain.models.memory import MemoryType
-from devsynth.domain.models.wsde import WSDETeam
+
 from devsynth.application.code_analysis.analyzer import CodeAnalyzer
 from devsynth.application.code_analysis.ast_transformer import AstTransformer
-from devsynth.application.requirements.prompt_manager import PromptManager
 from devsynth.application.documentation.documentation_manager import (
     DocumentationManager,
 )
 from devsynth.application.edrr.coordinator import EDRRCoordinator
 from devsynth.application.edrr.manifest_parser import ManifestParser
+from devsynth.application.memory.memory_manager import MemoryManager
+from devsynth.application.requirements.prompt_manager import PromptManager
+from devsynth.domain.models.memory import MemoryType
+from devsynth.domain.models.wsde_facade import WSDETeam
+from devsynth.methodology.base import Phase
 
 
 @pytest.fixture
@@ -238,7 +238,11 @@ def verify_phase(context, phase_name):
 
 
 @pytest.mark.medium
-@then(    parsers.parse(        'the coordinator should store the task in memory with EDRR phase "{phase_name}"'    ))
+@then(
+    parsers.parse(
+        'the coordinator should store the task in memory with EDRR phase "{phase_name}"'
+    )
+)
 def verify_task_stored(context, phase_name):
     """Verify the task is stored in memory with the correct EDRR phase."""
     test_storage = {}
@@ -462,7 +466,11 @@ def verify_ast_verify(context):
 
 
 @pytest.mark.medium
-@then(    parsers.parse(        'the prompt manager should provide templates for the "{phase_name}" phase'    ))
+@then(
+    parsers.parse(
+        'the prompt manager should provide templates for the "{phase_name}" phase'
+    )
+)
 def verify_prompt_templates(context, phase_name):
     """Verify the prompt manager provides templates for the specified phase."""
     phase = Phase[phase_name.upper()]
@@ -619,7 +627,11 @@ This document outlines criteria for evaluating code quality."""
 
 
 @pytest.mark.medium
-@then(    parsers.parse(        'the results should be stored in memory with EDRR phase "{phase_name}"'    ))
+@then(
+    parsers.parse(
+        'the results should be stored in memory with EDRR phase "{phase_name}"'
+    )
+)
 def verify_results_stored(context, phase_name):
     """Verify the results are stored in memory with the correct EDRR phase."""
     phase = Phase[phase_name.upper()]
@@ -973,26 +985,30 @@ def verify_performance_metrics(context):
         assert "code_analyzer" in component_calls
         assert "prompt_manager" in component_calls
         assert "documentation_manager" in component_calls
-  # noqa: F401,F403
-import pytest
-from unittest.mock import MagicMock, patch
+
+
 import time
 from datetime import datetime, timedelta
+from unittest.mock import MagicMock, patch
+
+# noqa: F401,F403
+import pytest
 
 # Import the scenarios from the feature file
 scenarios("../features/general/edrr_enhanced_recursion.feature")
 
-# Import the necessary components
-from devsynth.methodology.base import Phase
-from devsynth.application.memory.memory_manager import MemoryManager
-from devsynth.domain.models.wsde import WSDETeam
 from devsynth.application.code_analysis.analyzer import CodeAnalyzer
 from devsynth.application.code_analysis.ast_transformer import AstTransformer
-from devsynth.application.requirements.prompt_manager import PromptManager
 from devsynth.application.documentation.documentation_manager import (
     DocumentationManager,
 )
 from devsynth.application.edrr.coordinator import EDRRCoordinator
+from devsynth.application.memory.memory_manager import MemoryManager
+from devsynth.application.requirements.prompt_manager import PromptManager
+from devsynth.domain.models.wsde_facade import WSDETeam
+
+# Import the necessary components
+from devsynth.methodology.base import Phase
 
 
 @pytest.fixture
@@ -1336,7 +1352,9 @@ def coordinator_evaluates_nested_micro_cycles(context):
 
 
 @pytest.mark.medium
-@then(    "the coordinator should apply advanced heuristics to determine optimal recursion depth")
+@then(
+    "the coordinator should apply advanced heuristics to determine optimal recursion depth"
+)
 def verify_advanced_heuristics_applied(context):
     """Verify that advanced heuristics are applied to determine optimal recursion depth."""
     # Check that the coordinator has advanced heuristics configuration
@@ -1720,7 +1738,9 @@ def verify_quality_prioritization(context):
 
 
 @pytest.mark.medium
-@then(    "the aggregated result should be more comprehensive than any individual micro-cycle result")
+@then(
+    "the aggregated result should be more comprehensive than any individual micro-cycle result"
+)
 def verify_comprehensive_aggregation(context):
     """Verify that the aggregated result is more comprehensive than any individual micro-cycle result."""
     # Check that the aggregated result has more elements than any individual micro-cycle
@@ -1874,7 +1894,9 @@ def verify_design_tasks_use_component_decomposition(context):
 
 
 @pytest.mark.medium
-@then(    "the coordinator should select the appropriate decomposition strategy automatically")
+@then(
+    "the coordinator should select the appropriate decomposition strategy automatically"
+)
 def verify_automatic_strategy_selection(context):
     """Verify that the coordinator selects the appropriate decomposition strategy automatically."""
     # Check that the strategies match the task types
@@ -2117,7 +2139,9 @@ def verify_completion_percentage_for_subtasks(context):
 
 
 @pytest.mark.medium
-@then(    "the progress tracking should aggregate completion status up the recursion hierarchy")
+@then(
+    "the progress tracking should aggregate completion status up the recursion hierarchy"
+)
 def verify_aggregated_completion_status(context):
     """Verify that progress tracking aggregates completion status up the recursion hierarchy."""
     # Check that the main task's completion is an aggregation of subtask completions

--- a/tests/behavior/steps/test_enhanced_dialectical_reasoning_steps.py
+++ b/tests/behavior/steps/test_enhanced_dialectical_reasoning_steps.py
@@ -5,20 +5,23 @@ This file implements the step definitions for the enhanced dialectical reasoning
 feature file, testing the advanced dialectical reasoning capabilities of the WSDE model.
 """
 
-import pytest
-from pytest_bdd import given, when, then, parsers, scenarios
 from unittest.mock import MagicMock, patch
+
+import pytest
+from pytest_bdd import given, parsers, scenarios, then, when
 
 # Import the feature file
 scenarios("../features/general/enhanced_dialectical_reasoning.feature")
 
-# Import the modules needed for the steps
-from devsynth.domain.models.wsde import WSDETeam
+from typing import Any, Dict, List
+
 from devsynth.adapters.agents.agent_adapter import WSDETeamCoordinator
-from devsynth.application.agents.unified_agent import UnifiedAgent
 from devsynth.application.agents.base import BaseAgent
+from devsynth.application.agents.unified_agent import UnifiedAgent
 from devsynth.domain.models.agent import AgentConfig, AgentType
-from typing import Dict, List, Any
+
+# Import the modules needed for the steps
+from devsynth.domain.models.wsde_facade import WSDETeam
 
 
 @pytest.fixture

--- a/tests/behavior/steps/test_mddr_common_steps.py
+++ b/tests/behavior/steps/test_mddr_common_steps.py
@@ -1,12 +1,15 @@
-import pytest
-from pytest_bdd import given, when, then, parsers, scenarios
 from unittest.mock import MagicMock, patch
-from devsynth.domain.models.wsde import WSDETeam
+
+import pytest
+from pytest_bdd import given, parsers, scenarios, then, when
+
 from devsynth.application.agents.base import BaseAgent
 from devsynth.domain.models.memory import MemoryItem
+from devsynth.domain.models.wsde_facade import WSDETeam
 
 # Import the feature file
-scenarios('../features/general/multi_disciplinary_dialectical_reasoning.feature')
+scenarios("../features/general/multi_disciplinary_dialectical_reasoning.feature")
+
 
 # Define a fixture for the context
 @pytest.fixture
@@ -23,7 +26,9 @@ def context():
             self.synthesis = None
             self.evaluation = None
             self.result = None
+
     return Context()
+
 
 # Helper function to create a mock agent with expertise
 def create_mock_agent(name, expertise):
@@ -35,6 +40,7 @@ def create_mock_agent(name, expertise):
     agent.has_been_primus = False
     return agent
 
+
 # Background steps
 @pytest.mark.medium
 @given("a WSDE team with agents specialized in different disciplines")
@@ -45,10 +51,16 @@ def wsde_team_with_specialized_agents(context):
     code_agent = create_mock_agent("CodeAgent", ["python", "coding"])
     security_agent = create_mock_agent("SecurityAgent", ["security", "authentication"])
     ux_agent = create_mock_agent("UXAgent", ["user_experience", "interface_design"])
-    performance_agent = create_mock_agent("PerformanceAgent", ["performance", "optimization"])
-    accessibility_agent = create_mock_agent("AccessibilityAgent", ["accessibility", "inclusive_design"])
-    critic_agent = create_mock_agent("CriticAgent", ["dialectical_reasoning", "critique", "synthesis"])
-    
+    performance_agent = create_mock_agent(
+        "PerformanceAgent", ["performance", "optimization"]
+    )
+    accessibility_agent = create_mock_agent(
+        "AccessibilityAgent", ["accessibility", "inclusive_design"]
+    )
+    critic_agent = create_mock_agent(
+        "CriticAgent", ["dialectical_reasoning", "critique", "synthesis"]
+    )
+
     # Add agents to the team
     context.team.add_agent(code_agent)
     context.team.add_agent(security_agent)
@@ -56,16 +68,17 @@ def wsde_team_with_specialized_agents(context):
     context.team.add_agent(performance_agent)
     context.team.add_agent(accessibility_agent)
     context.team.add_agent(critic_agent)
-    
+
     # Store agents for later use
     context.disciplinary_agents = [
-        code_agent, 
-        security_agent, 
-        ux_agent, 
-        performance_agent, 
-        accessibility_agent, 
-        critic_agent
+        code_agent,
+        security_agent,
+        ux_agent,
+        performance_agent,
+        accessibility_agent,
+        critic_agent,
     ]
+
 
 @pytest.mark.medium
 @given("a knowledge base with multi-disciplinary information")
@@ -75,25 +88,34 @@ def knowledge_base_with_multi_disciplinary_information(context):
     context.knowledge_sources = {
         "security": [
             {"title": "OWASP Top 10", "content": "Security best practices..."},
-            {"title": "NIST Guidelines", "content": "Security standards..."}
+            {"title": "NIST Guidelines", "content": "Security standards..."},
         ],
         "user_experience": [
             {"title": "Nielsen's Heuristics", "content": "UX principles..."},
-            {"title": "Design System Guidelines", "content": "UI/UX standards..."}
+            {"title": "Design System Guidelines", "content": "UI/UX standards..."},
         ],
         "performance": [
-            {"title": "Web Performance Optimization", "content": "Performance best practices..."},
-            {"title": "MDN Performance Guidelines", "content": "Browser optimization techniques..."}
+            {
+                "title": "Web Performance Optimization",
+                "content": "Performance best practices...",
+            },
+            {
+                "title": "MDN Performance Guidelines",
+                "content": "Browser optimization techniques...",
+            },
         ],
         "accessibility": [
             {"title": "WCAG 2.1 Guidelines", "content": "Accessibility standards..."},
-            {"title": "WebAIM Checklist", "content": "Accessibility best practices..."}
-        ]
+            {"title": "WebAIM Checklist", "content": "Accessibility best practices..."},
+        ],
     }
-    
+
     # Mock the team's knowledge retrieval method
     context.team.get_knowledge_for_discipline = MagicMock()
-    context.team.get_knowledge_for_discipline.side_effect = lambda discipline: context.knowledge_sources.get(discipline, [])
+    context.team.get_knowledge_for_discipline.side_effect = (
+        lambda discipline: context.knowledge_sources.get(discipline, [])
+    )
+
 
 @pytest.mark.medium
 @given("the team is configured for multi-disciplinary dialectical reasoning")
@@ -102,9 +124,9 @@ def team_configured_for_multi_disciplinary_dialectical_reasoning(context):
     # Mock the configuration
     context.team.enable_multi_disciplinary_dialectical_reasoning = MagicMock()
     context.team.enable_multi_disciplinary_dialectical_reasoning.return_value = True
-    
+
     # Call the method to enable multi-disciplinary dialectical reasoning
     result = context.team.enable_multi_disciplinary_dialectical_reasoning()
-    
+
     # Verify the configuration was successful
     assert result is True, "Failed to enable multi-disciplinary dialectical reasoning"

--- a/tests/behavior/steps/test_memory_backend_integration_steps.py
+++ b/tests/behavior/steps/test_memory_backend_integration_steps.py
@@ -5,10 +5,11 @@ This file implements the step definitions for the memory backend integration
 feature file, testing all available memory backends with the WSDE model.
 """
 
-import pytest
-import time
-import os
 import logging
+import os
+import time
+
+import pytest
 
 chromadb_enabled = os.environ.get("ENABLE_CHROMADB", "false").lower() not in {
     "0",
@@ -17,19 +18,20 @@ chromadb_enabled = os.environ.get("ENABLE_CHROMADB", "false").lower() not in {
 }
 if not chromadb_enabled:
     pytest.skip("ChromaDB feature not enabled", allow_module_level=True)
-from pytest_bdd import given, when, then, parsers, scenarios
+from pytest_bdd import given, parsers, scenarios, then, when
 
 # Import the feature file
 scenarios("../features/general/memory_backend_integration.feature")
 
-# Import the modules needed for the steps
-from devsynth.domain.models.wsde import WSDETeam
 from devsynth.adapters.agents.agent_adapter import WSDETeamCoordinator
 
+# Import the modules needed for the steps
+from devsynth.domain.models.wsde_facade import WSDETeam
+
 logger = logging.getLogger(__name__)
+from devsynth.adapters.memory.memory_adapter import MemorySystemAdapter
 from devsynth.application.agents.unified_agent import UnifiedAgent
 from devsynth.domain.models.agent import AgentConfig, AgentType
-from devsynth.adapters.memory.memory_adapter import MemorySystemAdapter
 
 pytestmark = [
     pytest.mark.requires_resource("chromadb"),
@@ -272,7 +274,9 @@ def retrieve_solution_from_backend(context):
 
 
 @pytest.mark.medium
-@then(    "I should be able to retrieve the dialectical reasoning result from the memory backend")
+@then(
+    "I should be able to retrieve the dialectical reasoning result from the memory backend"
+)
 def retrieve_dialectical_result_from_backend(context):
     """Retrieve the dialectical reasoning result from the memory backend."""
     # Query for dialectical reasoning memory items
@@ -433,7 +437,11 @@ def store_solution_in_named_backend(context, backend_name):
 
 
 @pytest.mark.medium
-@when(    parsers.parse(        'I store a dialectical reasoning result in the "{backend_name}" backend'    ))
+@when(
+    parsers.parse(
+        'I store a dialectical reasoning result in the "{backend_name}" backend'
+    )
+)
 def store_dialectical_result_in_named_backend(context, backend_name):
     """Store a dialectical reasoning result in the specified backend."""
     # Create a dialectical reasoning result
@@ -537,7 +545,9 @@ def retrieve_all_artifacts_from_backends(context):
 
 
 @pytest.mark.medium
-@then(    "I should be able to traverse relationships between artifacts in different backends")
+@then(
+    "I should be able to traverse relationships between artifacts in different backends"
+)
 def traverse_relationships_between_artifacts(context):
     """Traverse relationships between artifacts in different backends."""
     # Query for relationships in the file backend
@@ -576,7 +586,9 @@ def traverse_relationships_between_artifacts(context):
 
 
 @pytest.mark.medium
-@then(    "the relationship metadata should correctly identify the source and target backends")
+@then(
+    "the relationship metadata should correctly identify the source and target backends"
+)
 def verify_relationship_metadata(context):
     """Verify that relationship metadata correctly identifies source and target backends."""
     # Query for relationships in the file backend

--- a/tests/behavior/steps/test_multi_disciplinary_dialectical_reasoning_steps.py
+++ b/tests/behavior/steps/test_multi_disciplinary_dialectical_reasoning_steps.py
@@ -1,12 +1,15 @@
-import pytest
-from pytest_bdd import given, when, then, parsers, scenarios
 from unittest.mock import MagicMock, patch
-from devsynth.domain.models.wsde import WSDETeam
+
+import pytest
+from pytest_bdd import given, parsers, scenarios, then, when
+
 from devsynth.application.agents.base import BaseAgent
 from devsynth.domain.models.memory import MemoryItem
+from devsynth.domain.models.wsde_facade import WSDETeam
 
 # Import the feature file
-scenarios('../features/general/multi_disciplinary_dialectical_reasoning.feature')
+scenarios("../features/general/multi_disciplinary_dialectical_reasoning.feature")
+
 
 # Define a fixture for the context
 @pytest.fixture
@@ -23,7 +26,9 @@ def context():
             self.synthesis = None
             self.evaluation = None
             self.result = None
+
     return Context()
+
 
 # Helper function to create a mock agent with expertise
 def create_mock_agent(name, expertise):
@@ -34,6 +39,7 @@ def create_mock_agent(name, expertise):
     agent.expertise = expertise
     agent.has_been_primus = False
     return agent
+
 
 # Background steps
 @pytest.mark.medium
@@ -46,9 +52,15 @@ def wsde_team_with_specialized_agents(context):
     code_agent = create_mock_agent("CodeAgent", ["python", "coding"])
     security_agent = create_mock_agent("SecurityAgent", ["security", "authentication"])
     ux_agent = create_mock_agent("UXAgent", ["user_experience", "interface_design"])
-    performance_agent = create_mock_agent("PerformanceAgent", ["performance", "optimization"])
-    accessibility_agent = create_mock_agent("AccessibilityAgent", ["accessibility", "inclusive_design"])
-    critic_agent = create_mock_agent("CriticAgent", ["dialectical_reasoning", "critique", "synthesis"])
+    performance_agent = create_mock_agent(
+        "PerformanceAgent", ["performance", "optimization"]
+    )
+    accessibility_agent = create_mock_agent(
+        "AccessibilityAgent", ["accessibility", "inclusive_design"]
+    )
+    critic_agent = create_mock_agent(
+        "CriticAgent", ["dialectical_reasoning", "critique", "synthesis"]
+    )
 
     # Add agents to the team
     context.team.add_agent(code_agent)
@@ -71,8 +83,9 @@ def wsde_team_with_specialized_agents(context):
         context.security_agent,
         context.ux_agent,
         context.performance_agent,
-        context.accessibility_agent
+        context.accessibility_agent,
     ]
+
 
 @pytest.mark.medium
 @given("a knowledge base with multi-disciplinary information")
@@ -85,7 +98,7 @@ def knowledge_base_with_multi_disciplinary_information(context):
                 "Store passwords using strong, adaptive hashing algorithms (e.g., bcrypt, Argon2)",
                 "Implement rate limiting to prevent brute force attacks",
                 "Use HTTPS for all authentication requests",
-                "Set secure and HttpOnly flags on authentication cookies"
+                "Set secure and HttpOnly flags on authentication cookies",
             ]
         },
         "user_experience": {
@@ -94,7 +107,7 @@ def knowledge_base_with_multi_disciplinary_information(context):
                 "Provide clear error messages for failed authentication attempts",
                 "Offer password recovery options",
                 "Remember user preferences where appropriate",
-                "Support single sign-on where possible"
+                "Support single sign-on where possible",
             ]
         },
         "performance": {
@@ -103,7 +116,7 @@ def knowledge_base_with_multi_disciplinary_information(context):
                 "Cache frequently used authentication data",
                 "Use asynchronous processing for non-critical authentication tasks",
                 "Implement efficient database queries for user lookup",
-                "Monitor and optimize authentication service response times"
+                "Monitor and optimize authentication service response times",
             ]
         },
         "accessibility": {
@@ -112,10 +125,11 @@ def knowledge_base_with_multi_disciplinary_information(context):
                 "Provide appropriate ARIA labels for authentication form elements",
                 "Support screen readers for error messages and instructions",
                 "Maintain sufficient color contrast for text and interactive elements",
-                "Allow authentication timeout extensions for users who need more time"
+                "Allow authentication timeout extensions for users who need more time",
             ]
-        }
+        },
     }
+
 
 @pytest.mark.medium
 @given("the team is configured for multi-disciplinary dialectical reasoning")
@@ -128,11 +142,12 @@ def team_configured_for_multi_disciplinary_dialectical_reasoning(context):
     # Call the method to configure the team
     result = context.team.configure_multi_disciplinary_dialectical_reasoning(
         critic_agent=context.critic_agent,
-        disciplinary_agents=context.disciplinary_agents
+        disciplinary_agents=context.disciplinary_agents,
     )
 
     # Verify the configuration was successful
     assert result is True
+
 
 # Scenario: Gathering disciplinary perspectives
 @pytest.mark.medium
@@ -140,8 +155,8 @@ def team_configured_for_multi_disciplinary_dialectical_reasoning(context):
 def complex_problem_spanning_multiple_disciplines(context):
     """Define a complex problem that spans multiple disciplines."""
     context.task = {
-        "type": "implementation_task", 
-        "description": "Implement a user authentication system with a focus on security, usability, performance, and accessibility"
+        "type": "implementation_task",
+        "description": "Implement a user authentication system with a focus on security, usability, performance, and accessibility",
     }
 
     # Add a proposed solution to the task
@@ -158,7 +173,7 @@ def authenticate(username, password):
 def generate_jwt_token(username):
     # Generate a JWT token
     return "jwt_token_placeholder"
-        """
+        """,
     }
 
     # Add the solution to the team
@@ -166,13 +181,15 @@ def generate_jwt_token(username):
     context.team.add_solution.return_value = True
     context.team.add_solution(context.task, context.solution)
 
+
 @pytest.mark.medium
 @given("a task requiring security and user experience considerations")
 def task_requiring_security_and_ux(context):
     context.task = {
-        "type": "implementation_task", 
-        "description": "Implement a user authentication system with a focus on security and usability"
+        "type": "implementation_task",
+        "description": "Implement a user authentication system with a focus on security and usability",
     }
+
 
 @pytest.mark.medium
 @given("knowledge sources for security and user experience")
@@ -184,7 +201,7 @@ def knowledge_sources_security_and_ux(context):
                 "Store passwords using strong, adaptive hashing algorithms (e.g., bcrypt, Argon2)",
                 "Implement rate limiting to prevent brute force attacks",
                 "Use HTTPS for all authentication requests",
-                "Set secure and HttpOnly flags on authentication cookies"
+                "Set secure and HttpOnly flags on authentication cookies",
             ]
         },
         "user_experience": {
@@ -193,24 +210,23 @@ def knowledge_sources_security_and_ux(context):
                 "Provide clear error messages for failed authentication attempts",
                 "Offer password recovery options",
                 "Remember user preferences where appropriate",
-                "Support single sign-on where possible"
+                "Support single sign-on where possible",
             ]
-        }
+        },
     }
 
     # Set disciplinary agents
-    context.disciplinary_agents = [
-        context.security_agent,
-        context.ux_agent
-    ]
+    context.disciplinary_agents = [context.security_agent, context.ux_agent]
+
 
 @pytest.mark.medium
 @given("a task requiring performance and accessibility considerations")
 def task_requiring_performance_and_accessibility(context):
     context.task = {
-        "type": "implementation_task", 
-        "description": "Implement a user authentication system with a focus on performance and accessibility"
+        "type": "implementation_task",
+        "description": "Implement a user authentication system with a focus on performance and accessibility",
     }
+
 
 @pytest.mark.medium
 @given("knowledge sources for performance and accessibility")
@@ -222,7 +238,7 @@ def knowledge_sources_performance_and_accessibility(context):
                 "Cache frequently used authentication data",
                 "Use asynchronous processing for non-critical authentication tasks",
                 "Implement efficient database queries for user lookup",
-                "Monitor and optimize authentication service response times"
+                "Monitor and optimize authentication service response times",
             ]
         },
         "accessibility": {
@@ -231,24 +247,28 @@ def knowledge_sources_performance_and_accessibility(context):
                 "Provide appropriate ARIA labels for authentication form elements",
                 "Support screen readers for error messages and instructions",
                 "Maintain sufficient color contrast for text and interactive elements",
-                "Allow authentication timeout extensions for users who need more time"
+                "Allow authentication timeout extensions for users who need more time",
             ]
-        }
+        },
     }
 
     # Set disciplinary agents
     context.disciplinary_agents = [
         context.performance_agent,
-        context.accessibility_agent
+        context.accessibility_agent,
     ]
 
+
 @pytest.mark.medium
-@given("a task requiring security, user experience, performance, and accessibility considerations")
+@given(
+    "a task requiring security, user experience, performance, and accessibility considerations"
+)
 def task_requiring_all_four_disciplines(context):
     context.task = {
-        "type": "implementation_task", 
-        "description": "Implement a comprehensive user authentication system with a focus on security, usability, performance, and accessibility"
+        "type": "implementation_task",
+        "description": "Implement a comprehensive user authentication system with a focus on security, usability, performance, and accessibility",
     }
+
 
 @pytest.mark.medium
 @given("knowledge sources for all four disciplines")
@@ -260,7 +280,7 @@ def knowledge_sources_all_four_disciplines(context):
                 "Store passwords using strong, adaptive hashing algorithms (e.g., bcrypt, Argon2)",
                 "Implement rate limiting to prevent brute force attacks",
                 "Use HTTPS for all authentication requests",
-                "Set secure and HttpOnly flags on authentication cookies"
+                "Set secure and HttpOnly flags on authentication cookies",
             ]
         },
         "user_experience": {
@@ -269,7 +289,7 @@ def knowledge_sources_all_four_disciplines(context):
                 "Provide clear error messages for failed authentication attempts",
                 "Offer password recovery options",
                 "Remember user preferences where appropriate",
-                "Support single sign-on where possible"
+                "Support single sign-on where possible",
             ]
         },
         "performance": {
@@ -278,7 +298,7 @@ def knowledge_sources_all_four_disciplines(context):
                 "Cache frequently used authentication data",
                 "Use asynchronous processing for non-critical authentication tasks",
                 "Implement efficient database queries for user lookup",
-                "Monitor and optimize authentication service response times"
+                "Monitor and optimize authentication service response times",
             ]
         },
         "accessibility": {
@@ -287,9 +307,9 @@ def knowledge_sources_all_four_disciplines(context):
                 "Provide appropriate ARIA labels for authentication form elements",
                 "Support screen readers for error messages and instructions",
                 "Maintain sufficient color contrast for text and interactive elements",
-                "Allow authentication timeout extensions for users who need more time"
+                "Allow authentication timeout extensions for users who need more time",
             ]
-        }
+        },
     }
 
     # Set disciplinary agents
@@ -297,8 +317,9 @@ def knowledge_sources_all_four_disciplines(context):
         context.security_agent,
         context.ux_agent,
         context.performance_agent,
-        context.accessibility_agent
+        context.accessibility_agent,
     ]
+
 
 @pytest.mark.medium
 @when("the team initiates multi-disciplinary dialectical reasoning")
@@ -315,89 +336,143 @@ def team_initiates_multi_disciplinary_dialectical_reasoning(context):
                 "discipline": "security",
                 "agent": "SecurityAgent",
                 "perspective": "The solution needs to implement password hashing, rate limiting, and HTTPS.",
-                "concerns": ["Hardcoded credentials", "No password hashing", "No rate limiting"],
-                "recommendations": ["Use bcrypt for password hashing", "Implement rate limiting", "Use HTTPS"]
+                "concerns": [
+                    "Hardcoded credentials",
+                    "No password hashing",
+                    "No rate limiting",
+                ],
+                "recommendations": [
+                    "Use bcrypt for password hashing",
+                    "Implement rate limiting",
+                    "Use HTTPS",
+                ],
             },
             {
                 "discipline": "user_experience",
                 "agent": "UXAgent",
                 "perspective": "The authentication flow needs to be user-friendly with clear error messages.",
                 "concerns": ["No error messages", "No password recovery"],
-                "recommendations": ["Add clear error messages", "Implement password recovery"]
+                "recommendations": [
+                    "Add clear error messages",
+                    "Implement password recovery",
+                ],
             },
             {
                 "discipline": "performance",
                 "agent": "PerformanceAgent",
                 "perspective": "Token validation should be optimized for minimal latency.",
-                "concerns": ["No caching strategy", "Potential performance bottlenecks"],
-                "recommendations": ["Cache frequently used authentication data", "Optimize token validation"]
+                "concerns": [
+                    "No caching strategy",
+                    "Potential performance bottlenecks",
+                ],
+                "recommendations": [
+                    "Cache frequently used authentication data",
+                    "Optimize token validation",
+                ],
             },
             {
                 "discipline": "accessibility",
                 "agent": "AccessibilityAgent",
                 "perspective": "Authentication forms must be accessible to all users.",
                 "concerns": ["No keyboard navigation", "No ARIA labels"],
-                "recommendations": ["Ensure keyboard navigability", "Add ARIA labels"]
-            }
+                "recommendations": ["Ensure keyboard navigability", "Add ARIA labels"],
+            },
         ],
         "synthesis": {
             "integrated_perspectives": [
-                {"discipline": "security", "key_points": ["Password hashing", "Rate limiting", "HTTPS"]},
-                {"discipline": "user_experience", "key_points": ["Clear error messages", "Password recovery"]},
-                {"discipline": "performance", "key_points": ["Caching", "Optimized validation"]},
-                {"discipline": "accessibility", "key_points": ["Keyboard navigation", "ARIA labels"]}
+                {
+                    "discipline": "security",
+                    "key_points": ["Password hashing", "Rate limiting", "HTTPS"],
+                },
+                {
+                    "discipline": "user_experience",
+                    "key_points": ["Clear error messages", "Password recovery"],
+                },
+                {
+                    "discipline": "performance",
+                    "key_points": ["Caching", "Optimized validation"],
+                },
+                {
+                    "discipline": "accessibility",
+                    "key_points": ["Keyboard navigation", "ARIA labels"],
+                },
             ],
             "perspective_conflicts": [
                 {
                     "disciplines": ["security", "user_experience"],
                     "conflict": "Security measures may increase friction in the user experience",
-                    "severity": "medium"
+                    "severity": "medium",
                 },
                 {
                     "disciplines": ["performance", "accessibility"],
                     "conflict": "Some accessibility features may impact performance",
-                    "severity": "low"
-                }
+                    "severity": "low",
+                },
             ],
             "conflict_resolutions": [
                 {
                     "disciplines": ["security", "user_experience"],
                     "resolution": "Implement progressive security that balances protection with usability",
-                    "trade_offs": ["Slightly reduced security for better UX", "Slightly increased friction for better security"]
+                    "trade_offs": [
+                        "Slightly reduced security for better UX",
+                        "Slightly increased friction for better security",
+                    ],
                 },
                 {
                     "disciplines": ["performance", "accessibility"],
                     "resolution": "Optimize critical paths while maintaining accessibility",
-                    "trade_offs": ["Focus performance optimization on non-accessibility features", "Use efficient accessibility implementations"]
-                }
+                    "trade_offs": [
+                        "Focus performance optimization on non-accessibility features",
+                        "Use efficient accessibility implementations",
+                    ],
+                },
             ],
             "is_improvement": True,
-            "improved_solution": "Implement secure authentication with bcrypt hashing, rate limiting, clear error messages, and accessibility features"
+            "improved_solution": "Implement secure authentication with bcrypt hashing, rate limiting, clear error messages, and accessibility features",
         },
         "evaluation": {
             "perspective_scores": [
-                {"discipline": "security", "score": 8.5, "rationale": "Addresses major security concerns"},
-                {"discipline": "user_experience", "score": 8.0, "rationale": "Improves usability while maintaining security"},
-                {"discipline": "performance", "score": 7.5, "rationale": "Addresses performance concerns with minimal trade-offs"},
-                {"discipline": "accessibility", "score": 8.0, "rationale": "Implements key accessibility features"}
+                {
+                    "discipline": "security",
+                    "score": 8.5,
+                    "rationale": "Addresses major security concerns",
+                },
+                {
+                    "discipline": "user_experience",
+                    "score": 8.0,
+                    "rationale": "Improves usability while maintaining security",
+                },
+                {
+                    "discipline": "performance",
+                    "score": 7.5,
+                    "rationale": "Addresses performance concerns with minimal trade-offs",
+                },
+                {
+                    "discipline": "accessibility",
+                    "score": 8.0,
+                    "rationale": "Implements key accessibility features",
+                },
             ],
-            "overall_assessment": "The solution achieves a good balance between security, usability, performance, and accessibility"
-        }
+            "overall_assessment": "The solution achieves a good balance between security, usability, performance, and accessibility",
+        },
     }
 
     # Set the mock result
-    context.team.apply_multi_disciplinary_dialectical_reasoning.return_value = mock_result
+    context.team.apply_multi_disciplinary_dialectical_reasoning.return_value = (
+        mock_result
+    )
 
     # Call the method to apply multi-disciplinary dialectical reasoning
     context.result = context.team.apply_multi_disciplinary_dialectical_reasoning(
         context.task,
         context.critic_agent,
         context.knowledge_sources,
-        context.disciplinary_agents
+        context.disciplinary_agents,
     )
 
     # Store the perspectives for later assertions
     context.perspectives = context.result["disciplinary_perspectives"]
+
 
 @pytest.mark.medium
 @then("each disciplinary agent should provide a specialized perspective")
@@ -419,6 +494,7 @@ def each_disciplinary_agent_provides_specialized_perspective(context):
         assert "agent" in perspective
         assert perspective["agent"] is not None
 
+
 @pytest.mark.medium
 @then("each perspective should focus on domain-specific considerations")
 def each_perspective_focuses_on_domain_specific_considerations(context):
@@ -432,17 +508,32 @@ def each_perspective_focuses_on_domain_specific_considerations(context):
 
         # Verify that the concerns and recommendations are relevant to the discipline
         if discipline == "security":
-            assert any("password" in concern.lower() for concern in perspective["concerns"])
+            assert any(
+                "password" in concern.lower() for concern in perspective["concerns"]
+            )
             assert any("hash" in rec.lower() for rec in perspective["recommendations"])
         elif discipline == "user_experience":
-            assert any("error" in concern.lower() for concern in perspective["concerns"])
-            assert any("message" in rec.lower() for rec in perspective["recommendations"])
+            assert any(
+                "error" in concern.lower() for concern in perspective["concerns"]
+            )
+            assert any(
+                "message" in rec.lower() for rec in perspective["recommendations"]
+            )
         elif discipline == "performance":
-            assert any("performance" in concern.lower() for concern in perspective["concerns"])
+            assert any(
+                "performance" in concern.lower() for concern in perspective["concerns"]
+            )
             assert any("cache" in rec.lower() for rec in perspective["recommendations"])
         elif discipline == "accessibility":
-            assert any("accessibility" in concern.lower() or "aria" in concern.lower() for concern in perspective["concerns"])
-            assert any("aria" in rec.lower() or "keyboard" in rec.lower() for rec in perspective["recommendations"])
+            assert any(
+                "accessibility" in concern.lower() or "aria" in concern.lower()
+                for concern in perspective["concerns"]
+            )
+            assert any(
+                "aria" in rec.lower() or "keyboard" in rec.lower()
+                for rec in perspective["recommendations"]
+            )
+
 
 @pytest.mark.medium
 @then("the perspectives should be documented with disciplinary context")
@@ -460,13 +551,26 @@ def perspectives_documented_with_disciplinary_context(context):
         perspective_text = perspective["perspective"].lower()
 
         if discipline == "security":
-            assert any(term in perspective_text for term in ["security", "password", "hash", "https", "rate limiting"])
+            assert any(
+                term in perspective_text
+                for term in ["security", "password", "hash", "https", "rate limiting"]
+            )
         elif discipline == "user_experience":
-            assert any(term in perspective_text for term in ["user", "experience", "ux", "error message", "usability"])
+            assert any(
+                term in perspective_text
+                for term in ["user", "experience", "ux", "error message", "usability"]
+            )
         elif discipline == "performance":
-            assert any(term in perspective_text for term in ["performance", "latency", "optimize", "cache"])
+            assert any(
+                term in perspective_text
+                for term in ["performance", "latency", "optimize", "cache"]
+            )
         elif discipline == "accessibility":
-            assert any(term in perspective_text for term in ["accessibility", "accessible", "aria", "keyboard"])
+            assert any(
+                term in perspective_text
+                for term in ["accessibility", "accessible", "aria", "keyboard"]
+            )
+
 
 @pytest.mark.medium
 @then("the collection of perspectives should cover all relevant disciplines")
@@ -476,12 +580,20 @@ def collection_of_perspectives_covers_all_relevant_disciplines(context):
     disciplines = [p["discipline"] for p in context.result["disciplinary_perspectives"]]
 
     # Verify that all relevant disciplines are covered
-    expected_disciplines = ["security", "user_experience", "performance", "accessibility"]
+    expected_disciplines = [
+        "security",
+        "user_experience",
+        "performance",
+        "accessibility",
+    ]
     for discipline in expected_disciplines:
         assert discipline in disciplines
 
     # Verify that the number of perspectives matches the number of disciplinary agents
-    assert len(context.result["disciplinary_perspectives"]) == len(context.disciplinary_agents)
+    assert len(context.result["disciplinary_perspectives"]) == len(
+        context.disciplinary_agents
+    )
+
 
 # Scenario: Identifying perspective conflicts across disciplines
 @pytest.mark.medium
@@ -489,38 +601,56 @@ def collection_of_perspectives_covers_all_relevant_disciplines(context):
 def perspectives_from_multiple_disciplinary_agents(context):
     """Set up perspectives from multiple disciplinary agents."""
     # Create perspectives if they don't exist yet
-    if not hasattr(context, 'perspectives') or not context.perspectives:
+    if not hasattr(context, "perspectives") or not context.perspectives:
         # Create a mock result with perspectives from different disciplines
         context.perspectives = [
             {
                 "discipline": "security",
                 "agent": "SecurityAgent",
                 "perspective": "The solution needs to implement password hashing, rate limiting, and HTTPS.",
-                "concerns": ["Hardcoded credentials", "No password hashing", "No rate limiting"],
-                "recommendations": ["Use bcrypt for password hashing", "Implement rate limiting", "Use HTTPS"]
+                "concerns": [
+                    "Hardcoded credentials",
+                    "No password hashing",
+                    "No rate limiting",
+                ],
+                "recommendations": [
+                    "Use bcrypt for password hashing",
+                    "Implement rate limiting",
+                    "Use HTTPS",
+                ],
             },
             {
                 "discipline": "user_experience",
                 "agent": "UXAgent",
                 "perspective": "The authentication flow needs to be user-friendly with clear error messages.",
                 "concerns": ["No error messages", "No password recovery"],
-                "recommendations": ["Add clear error messages", "Implement password recovery"]
+                "recommendations": [
+                    "Add clear error messages",
+                    "Implement password recovery",
+                ],
             },
             {
                 "discipline": "performance",
                 "agent": "PerformanceAgent",
                 "perspective": "Token validation should be optimized for minimal latency.",
-                "concerns": ["No caching strategy", "Potential performance bottlenecks"],
-                "recommendations": ["Cache frequently used authentication data", "Optimize token validation"]
+                "concerns": [
+                    "No caching strategy",
+                    "Potential performance bottlenecks",
+                ],
+                "recommendations": [
+                    "Cache frequently used authentication data",
+                    "Optimize token validation",
+                ],
             },
             {
                 "discipline": "accessibility",
                 "agent": "AccessibilityAgent",
                 "perspective": "Authentication forms must be accessible to all users.",
                 "concerns": ["No keyboard navigation", "No ARIA labels"],
-                "recommendations": ["Ensure keyboard navigability", "Add ARIA labels"]
-            }
+                "recommendations": ["Ensure keyboard navigability", "Add ARIA labels"],
+            },
         ]
+
 
 @pytest.mark.medium
 @when("the team analyzes the perspectives")
@@ -537,8 +667,8 @@ def team_analyzes_perspectives(context):
             "severity": "medium",
             "assumptions": {
                 "security": "Strong security requires multiple verification steps",
-                "user_experience": "Users prefer minimal friction during authentication"
-            }
+                "user_experience": "Users prefer minimal friction during authentication",
+            },
         },
         {
             "disciplines": ["performance", "accessibility"],
@@ -546,8 +676,8 @@ def team_analyzes_perspectives(context):
             "severity": "low",
             "assumptions": {
                 "performance": "Performance optimization requires minimal DOM elements",
-                "accessibility": "Accessibility often requires additional ARIA attributes and DOM elements"
-            }
+                "accessibility": "Accessibility often requires additional ARIA attributes and DOM elements",
+            },
         },
         {
             "disciplines": ["security", "performance"],
@@ -555,9 +685,9 @@ def team_analyzes_perspectives(context):
             "severity": "medium",
             "assumptions": {
                 "security": "Thorough security validation requires multiple checks",
-                "performance": "Authentication should be as fast as possible"
-            }
-        }
+                "performance": "Authentication should be as fast as possible",
+            },
+        },
     ]
 
     # Set the mock result
@@ -565,6 +695,7 @@ def team_analyzes_perspectives(context):
 
     # Call the method to analyze perspectives
     context.conflicts = context.team.analyze_perspectives(context.perspectives)
+
 
 @pytest.mark.medium
 @then("conflicts between disciplinary perspectives should be identified")
@@ -580,6 +711,7 @@ def conflicts_between_disciplinary_perspectives_identified(context):
         assert "conflict" in conflict
         assert conflict["conflict"] is not None
 
+
 @pytest.mark.medium
 @then("each conflict should be categorized by type and severity")
 def each_conflict_categorized_by_type_and_severity(context):
@@ -593,6 +725,7 @@ def each_conflict_categorized_by_type_and_severity(context):
 
         # Verify that the severity is one of the expected values
         assert conflict["severity"] in ["low", "medium", "high"]
+
 
 @pytest.mark.medium
 @then("the underlying disciplinary assumptions should be documented")
@@ -611,13 +744,26 @@ def underlying_disciplinary_assumptions_documented(context):
             # Verify that the assumption is relevant to the discipline
             assumption = conflict["assumptions"][discipline].lower()
             if discipline == "security":
-                assert any(term in assumption for term in ["security", "protection", "verification", "validation"])
+                assert any(
+                    term in assumption
+                    for term in ["security", "protection", "verification", "validation"]
+                )
             elif discipline == "user_experience":
-                assert any(term in assumption for term in ["user", "experience", "friction", "usability"])
+                assert any(
+                    term in assumption
+                    for term in ["user", "experience", "friction", "usability"]
+                )
             elif discipline == "performance":
-                assert any(term in assumption for term in ["performance", "speed", "latency", "optimization"])
+                assert any(
+                    term in assumption
+                    for term in ["performance", "speed", "latency", "optimization"]
+                )
             elif discipline == "accessibility":
-                assert any(term in assumption for term in ["accessibility", "accessible", "aria", "dom"])
+                assert any(
+                    term in assumption
+                    for term in ["accessibility", "accessible", "aria", "dom"]
+                )
+
 
 @pytest.mark.medium
 @then("the conflicts should be prioritized for resolution")
@@ -625,14 +771,21 @@ def conflicts_prioritized_for_resolution(context):
     """Verify that the conflicts are prioritized for resolution."""
     # Sort conflicts by severity (high, medium, low)
     severity_order = {"high": 0, "medium": 1, "low": 2}
-    sorted_conflicts = sorted(context.conflicts, key=lambda c: severity_order.get(c["severity"], 3))
+    sorted_conflicts = sorted(
+        context.conflicts, key=lambda c: severity_order.get(c["severity"], 3)
+    )
 
     # Verify that the conflicts are sorted by severity
     for i in range(1, len(sorted_conflicts)):
-        assert severity_order.get(sorted_conflicts[i-1]["severity"], 3) <= severity_order.get(sorted_conflicts[i]["severity"], 3)
+        assert severity_order.get(
+            sorted_conflicts[i - 1]["severity"], 3
+        ) <= severity_order.get(sorted_conflicts[i]["severity"], 3)
 
     # Verify that there is at least one conflict with a severity of "medium" or "high"
-    assert any(conflict["severity"] in ["medium", "high"] for conflict in context.conflicts)
+    assert any(
+        conflict["severity"] in ["medium", "high"] for conflict in context.conflicts
+    )
+
 
 # Scenario: Multi-disciplinary synthesis generation
 @pytest.mark.medium
@@ -640,41 +793,58 @@ def conflicts_prioritized_for_resolution(context):
 def perspectives_and_identified_conflicts_from_multiple_disciplines(context):
     """Set up perspectives and identified conflicts from multiple disciplines."""
     # Create perspectives if they don't exist yet
-    if not hasattr(context, 'perspectives') or not context.perspectives:
+    if not hasattr(context, "perspectives") or not context.perspectives:
         # Create a mock result with perspectives from different disciplines
         context.perspectives = [
             {
                 "discipline": "security",
                 "agent": "SecurityAgent",
                 "perspective": "The solution needs to implement password hashing, rate limiting, and HTTPS.",
-                "concerns": ["Hardcoded credentials", "No password hashing", "No rate limiting"],
-                "recommendations": ["Use bcrypt for password hashing", "Implement rate limiting", "Use HTTPS"]
+                "concerns": [
+                    "Hardcoded credentials",
+                    "No password hashing",
+                    "No rate limiting",
+                ],
+                "recommendations": [
+                    "Use bcrypt for password hashing",
+                    "Implement rate limiting",
+                    "Use HTTPS",
+                ],
             },
             {
                 "discipline": "user_experience",
                 "agent": "UXAgent",
                 "perspective": "The authentication flow needs to be user-friendly with clear error messages.",
                 "concerns": ["No error messages", "No password recovery"],
-                "recommendations": ["Add clear error messages", "Implement password recovery"]
+                "recommendations": [
+                    "Add clear error messages",
+                    "Implement password recovery",
+                ],
             },
             {
                 "discipline": "performance",
                 "agent": "PerformanceAgent",
                 "perspective": "Token validation should be optimized for minimal latency.",
-                "concerns": ["No caching strategy", "Potential performance bottlenecks"],
-                "recommendations": ["Cache frequently used authentication data", "Optimize token validation"]
+                "concerns": [
+                    "No caching strategy",
+                    "Potential performance bottlenecks",
+                ],
+                "recommendations": [
+                    "Cache frequently used authentication data",
+                    "Optimize token validation",
+                ],
             },
             {
                 "discipline": "accessibility",
                 "agent": "AccessibilityAgent",
                 "perspective": "Authentication forms must be accessible to all users.",
                 "concerns": ["No keyboard navigation", "No ARIA labels"],
-                "recommendations": ["Ensure keyboard navigability", "Add ARIA labels"]
-            }
+                "recommendations": ["Ensure keyboard navigability", "Add ARIA labels"],
+            },
         ]
 
     # Create conflicts if they don't exist yet
-    if not hasattr(context, 'conflicts') or not context.conflicts:
+    if not hasattr(context, "conflicts") or not context.conflicts:
         context.conflicts = [
             {
                 "disciplines": ["security", "user_experience"],
@@ -682,8 +852,8 @@ def perspectives_and_identified_conflicts_from_multiple_disciplines(context):
                 "severity": "medium",
                 "assumptions": {
                     "security": "Strong security requires multiple verification steps",
-                    "user_experience": "Users prefer minimal friction during authentication"
-                }
+                    "user_experience": "Users prefer minimal friction during authentication",
+                },
             },
             {
                 "disciplines": ["performance", "accessibility"],
@@ -691,8 +861,8 @@ def perspectives_and_identified_conflicts_from_multiple_disciplines(context):
                 "severity": "low",
                 "assumptions": {
                     "performance": "Performance optimization requires minimal DOM elements",
-                    "accessibility": "Accessibility often requires additional ARIA attributes and DOM elements"
-                }
+                    "accessibility": "Accessibility often requires additional ARIA attributes and DOM elements",
+                },
             },
             {
                 "disciplines": ["security", "performance"],
@@ -700,10 +870,11 @@ def perspectives_and_identified_conflicts_from_multiple_disciplines(context):
                 "severity": "medium",
                 "assumptions": {
                     "security": "Thorough security validation requires multiple checks",
-                    "performance": "Authentication should be as fast as possible"
-                }
-            }
+                    "performance": "Authentication should be as fast as possible",
+                },
+            },
         ]
+
 
 @pytest.mark.medium
 @when("the team generates a multi-disciplinary synthesis")
@@ -715,28 +886,49 @@ def team_generates_multi_disciplinary_synthesis(context):
     # Create a mock synthesis
     mock_synthesis = {
         "integrated_perspectives": [
-            {"discipline": "security", "key_points": ["Password hashing", "Rate limiting", "HTTPS"]},
-            {"discipline": "user_experience", "key_points": ["Clear error messages", "Password recovery"]},
-            {"discipline": "performance", "key_points": ["Caching", "Optimized validation"]},
-            {"discipline": "accessibility", "key_points": ["Keyboard navigation", "ARIA labels"]}
+            {
+                "discipline": "security",
+                "key_points": ["Password hashing", "Rate limiting", "HTTPS"],
+            },
+            {
+                "discipline": "user_experience",
+                "key_points": ["Clear error messages", "Password recovery"],
+            },
+            {
+                "discipline": "performance",
+                "key_points": ["Caching", "Optimized validation"],
+            },
+            {
+                "discipline": "accessibility",
+                "key_points": ["Keyboard navigation", "ARIA labels"],
+            },
         ],
         "perspective_conflicts": context.conflicts,
         "conflict_resolutions": [
             {
                 "disciplines": ["security", "user_experience"],
                 "resolution": "Implement progressive security that balances protection with usability",
-                "trade_offs": ["Slightly reduced security for better UX", "Slightly increased friction for better security"]
+                "trade_offs": [
+                    "Slightly reduced security for better UX",
+                    "Slightly increased friction for better security",
+                ],
             },
             {
                 "disciplines": ["performance", "accessibility"],
                 "resolution": "Optimize critical paths while maintaining accessibility",
-                "trade_offs": ["Focus performance optimization on non-accessibility features", "Use efficient accessibility implementations"]
+                "trade_offs": [
+                    "Focus performance optimization on non-accessibility features",
+                    "Use efficient accessibility implementations",
+                ],
             },
             {
                 "disciplines": ["security", "performance"],
                 "resolution": "Implement security checks asynchronously where possible",
-                "trade_offs": ["Some security checks may be delayed", "Critical security checks remain synchronous"]
-            }
+                "trade_offs": [
+                    "Some security checks may be delayed",
+                    "Critical security checks remain synchronous",
+                ],
+            },
         ],
         "is_improvement": True,
         "improved_solution": "Implement secure authentication with bcrypt hashing, rate limiting, clear error messages, and accessibility features",
@@ -744,20 +936,20 @@ def team_generates_multi_disciplinary_synthesis(context):
             "security": "Maintains core security principles while allowing some flexibility",
             "user_experience": "Preserves key usability features while accepting necessary security measures",
             "performance": "Optimizes critical paths while accepting some overhead for security and accessibility",
-            "accessibility": "Ensures essential accessibility features are implemented efficiently"
+            "accessibility": "Ensures essential accessibility features are implemented efficiently",
         },
         "trade_offs": [
             {
                 "description": "Security vs. User Experience",
                 "decision": "Balanced approach with progressive security",
-                "rationale": "Maximizes security without significantly degrading user experience"
+                "rationale": "Maximizes security without significantly degrading user experience",
             },
             {
                 "description": "Performance vs. Accessibility",
                 "decision": "Prioritize accessibility with performance optimizations where possible",
-                "rationale": "Accessibility is a requirement, but performance can be optimized in non-accessibility features"
-            }
-        ]
+                "rationale": "Accessibility is a requirement, but performance can be optimized in non-accessibility features",
+            },
+        ],
     }
 
     # Set the mock result
@@ -765,9 +957,9 @@ def team_generates_multi_disciplinary_synthesis(context):
 
     # Call the method to generate a synthesis
     context.synthesis = context.team.generate_multi_disciplinary_synthesis(
-        context.perspectives,
-        context.conflicts
+        context.perspectives, context.conflicts
     )
+
 
 @pytest.mark.medium
 @then("the synthesis should address all identified conflicts")
@@ -790,13 +982,18 @@ def synthesis_addresses_all_identified_conflicts(context):
 
     # Verify that all original conflicts have been addressed in the resolutions
     for conflict in original_conflicts:
-        assert conflict in resolved_conflicts, f"Conflict {conflict} not addressed in resolutions"
+        assert (
+            conflict in resolved_conflicts
+        ), f"Conflict {conflict} not addressed in resolutions"
 
     # Verify that each resolution has a meaningful description
     for resolution in context.synthesis["conflict_resolutions"]:
         assert "resolution" in resolution
         assert resolution["resolution"] is not None
-        assert len(resolution["resolution"]) > 10  # Ensure it's a meaningful description
+        assert (
+            len(resolution["resolution"]) > 10
+        )  # Ensure it's a meaningful description
+
 
 @pytest.mark.medium
 @then("the synthesis should integrate insights from all disciplines")
@@ -806,18 +1003,28 @@ def synthesis_integrates_insights_from_all_disciplines(context):
     assert "integrated_perspectives" in context.synthesis
 
     # Get the list of disciplines from the integrated perspectives
-    integrated_disciplines = [p["discipline"] for p in context.synthesis["integrated_perspectives"]]
+    integrated_disciplines = [
+        p["discipline"] for p in context.synthesis["integrated_perspectives"]
+    ]
 
     # Verify that all disciplines are represented in the integrated perspectives
-    expected_disciplines = ["security", "user_experience", "performance", "accessibility"]
+    expected_disciplines = [
+        "security",
+        "user_experience",
+        "performance",
+        "accessibility",
+    ]
     for discipline in expected_disciplines:
-        assert discipline in integrated_disciplines, f"Discipline {discipline} not found in integrated perspectives"
+        assert (
+            discipline in integrated_disciplines
+        ), f"Discipline {discipline} not found in integrated perspectives"
 
     # Verify that each integrated perspective has key points
     for perspective in context.synthesis["integrated_perspectives"]:
         assert "key_points" in perspective
         assert perspective["key_points"] is not None
         assert len(perspective["key_points"]) > 0
+
 
 @pytest.mark.medium
 @then("the synthesis should maintain disciplinary integrity where appropriate")
@@ -830,15 +1037,35 @@ def synthesis_maintains_disciplinary_integrity(context):
     disciplinary_integrity = context.synthesis["disciplinary_integrity"]
 
     # Verify that there is integrity information for each discipline
-    expected_disciplines = ["security", "user_experience", "performance", "accessibility"]
+    expected_disciplines = [
+        "security",
+        "user_experience",
+        "performance",
+        "accessibility",
+    ]
     for discipline in expected_disciplines:
-        assert discipline in disciplinary_integrity, f"Discipline {discipline} not found in disciplinary integrity"
+        assert (
+            discipline in disciplinary_integrity
+        ), f"Discipline {discipline} not found in disciplinary integrity"
         assert disciplinary_integrity[discipline] is not None
-        assert len(disciplinary_integrity[discipline]) > 10  # Ensure it's a meaningful description
+        assert (
+            len(disciplinary_integrity[discipline]) > 10
+        )  # Ensure it's a meaningful description
 
         # Verify that the integrity description mentions maintaining core principles
         integrity_description = disciplinary_integrity[discipline].lower()
-        assert any(term in integrity_description for term in ["maintain", "preserv", "ensur", "core", "principle", "essential"])
+        assert any(
+            term in integrity_description
+            for term in [
+                "maintain",
+                "preserv",
+                "ensur",
+                "core",
+                "principle",
+                "essential",
+            ]
+        )
+
 
 @pytest.mark.medium
 @then("the synthesis should document trade-offs between disciplinary requirements")
@@ -862,10 +1089,21 @@ def synthesis_documents_trade_offs(context):
         # Verify that the trade-off description mentions at least two disciplines
         description = trade_off["description"].lower()
         disciplines_mentioned = 0
-        for discipline in ["security", "user experience", "performance", "accessibility"]:
-            if discipline.lower() in description or discipline.lower().replace(" ", "_") in description:
+        for discipline in [
+            "security",
+            "user experience",
+            "performance",
+            "accessibility",
+        ]:
+            if (
+                discipline.lower() in description
+                or discipline.lower().replace(" ", "_") in description
+            ):
                 disciplines_mentioned += 1
-        assert disciplines_mentioned >= 2, f"Trade-off description '{description}' does not mention at least two disciplines"
+        assert (
+            disciplines_mentioned >= 2
+        ), f"Trade-off description '{description}' does not mention at least two disciplines"
+
 
 # Scenario: Multi-disciplinary evaluation
 @pytest.mark.medium
@@ -873,14 +1111,26 @@ def synthesis_documents_trade_offs(context):
 def synthesis_generated_from_multi_disciplinary_perspectives(context):
     """Set up a synthesis generated from multi-disciplinary perspectives."""
     # Create a synthesis if it doesn't exist yet
-    if not hasattr(context, 'synthesis') or not context.synthesis:
+    if not hasattr(context, "synthesis") or not context.synthesis:
         # Create a mock synthesis
         context.synthesis = {
             "integrated_perspectives": [
-                {"discipline": "security", "key_points": ["Password hashing", "Rate limiting", "HTTPS"]},
-                {"discipline": "user_experience", "key_points": ["Clear error messages", "Password recovery"]},
-                {"discipline": "performance", "key_points": ["Caching", "Optimized validation"]},
-                {"discipline": "accessibility", "key_points": ["Keyboard navigation", "ARIA labels"]}
+                {
+                    "discipline": "security",
+                    "key_points": ["Password hashing", "Rate limiting", "HTTPS"],
+                },
+                {
+                    "discipline": "user_experience",
+                    "key_points": ["Clear error messages", "Password recovery"],
+                },
+                {
+                    "discipline": "performance",
+                    "key_points": ["Caching", "Optimized validation"],
+                },
+                {
+                    "discipline": "accessibility",
+                    "key_points": ["Keyboard navigation", "ARIA labels"],
+                },
             ],
             "perspective_conflicts": [
                 {
@@ -889,8 +1139,8 @@ def synthesis_generated_from_multi_disciplinary_perspectives(context):
                     "severity": "medium",
                     "assumptions": {
                         "security": "Strong security requires multiple verification steps",
-                        "user_experience": "Users prefer minimal friction during authentication"
-                    }
+                        "user_experience": "Users prefer minimal friction during authentication",
+                    },
                 },
                 {
                     "disciplines": ["performance", "accessibility"],
@@ -898,21 +1148,27 @@ def synthesis_generated_from_multi_disciplinary_perspectives(context):
                     "severity": "low",
                     "assumptions": {
                         "performance": "Performance optimization requires minimal DOM elements",
-                        "accessibility": "Accessibility often requires additional ARIA attributes and DOM elements"
-                    }
-                }
+                        "accessibility": "Accessibility often requires additional ARIA attributes and DOM elements",
+                    },
+                },
             ],
             "conflict_resolutions": [
                 {
                     "disciplines": ["security", "user_experience"],
                     "resolution": "Implement progressive security that balances protection with usability",
-                    "trade_offs": ["Slightly reduced security for better UX", "Slightly increased friction for better security"]
+                    "trade_offs": [
+                        "Slightly reduced security for better UX",
+                        "Slightly increased friction for better security",
+                    ],
                 },
                 {
                     "disciplines": ["performance", "accessibility"],
                     "resolution": "Optimize critical paths while maintaining accessibility",
-                    "trade_offs": ["Focus performance optimization on non-accessibility features", "Use efficient accessibility implementations"]
-                }
+                    "trade_offs": [
+                        "Focus performance optimization on non-accessibility features",
+                        "Use efficient accessibility implementations",
+                    ],
+                },
             ],
             "is_improvement": True,
             "improved_solution": "Implement secure authentication with bcrypt hashing, rate limiting, clear error messages, and accessibility features",
@@ -920,21 +1176,22 @@ def synthesis_generated_from_multi_disciplinary_perspectives(context):
                 "security": "Maintains core security principles while allowing some flexibility",
                 "user_experience": "Preserves key usability features while accepting necessary security measures",
                 "performance": "Optimizes critical paths while accepting some overhead for security and accessibility",
-                "accessibility": "Ensures essential accessibility features are implemented efficiently"
+                "accessibility": "Ensures essential accessibility features are implemented efficiently",
             },
             "trade_offs": [
                 {
                     "description": "Security vs. User Experience",
                     "decision": "Balanced approach with progressive security",
-                    "rationale": "Maximizes security without significantly degrading user experience"
+                    "rationale": "Maximizes security without significantly degrading user experience",
                 },
                 {
                     "description": "Performance vs. Accessibility",
                     "decision": "Prioritize accessibility with performance optimizations where possible",
-                    "rationale": "Accessibility is a requirement, but performance can be optimized in non-accessibility features"
-                }
-            ]
+                    "rationale": "Accessibility is a requirement, but performance can be optimized in non-accessibility features",
+                },
+            ],
         }
+
 
 @pytest.mark.medium
 @when("the team evaluates the synthesis")
@@ -942,55 +1199,92 @@ def team_evaluates_synthesis(context):
     """Evaluate the synthesis from multi-disciplinary perspectives."""
     # Mock the team's method for evaluating a synthesis
     context.team.evaluate_synthesis = MagicMock()
-    
+
     # Create a mock evaluation result
     mock_evaluation = {
         "perspective_scores": [
-            {"discipline": "security", "score": 8.5, "rationale": "Addresses major security concerns", "standards_compliance": True},
-            {"discipline": "user_experience", "score": 8.0, "rationale": "Improves usability while maintaining security", "standards_compliance": True},
-            {"discipline": "performance", "score": 7.5, "rationale": "Addresses performance concerns with minimal trade-offs", "standards_compliance": True},
-            {"discipline": "accessibility", "score": 8.0, "rationale": "Implements key accessibility features", "standards_compliance": True}
+            {
+                "discipline": "security",
+                "score": 8.5,
+                "rationale": "Addresses major security concerns",
+                "standards_compliance": True,
+            },
+            {
+                "discipline": "user_experience",
+                "score": 8.0,
+                "rationale": "Improves usability while maintaining security",
+                "standards_compliance": True,
+            },
+            {
+                "discipline": "performance",
+                "score": 7.5,
+                "rationale": "Addresses performance concerns with minimal trade-offs",
+                "standards_compliance": True,
+            },
+            {
+                "discipline": "accessibility",
+                "score": 8.0,
+                "rationale": "Implements key accessibility features",
+                "standards_compliance": True,
+            },
         ],
         "standards_compliance": {
             "security": {
                 "compliant": True,
                 "standards": ["OWASP Top 10", "NIST Authentication Guidelines"],
-                "notes": "Meets all critical security requirements"
+                "notes": "Meets all critical security requirements",
             },
             "user_experience": {
                 "compliant": True,
                 "standards": ["Nielsen's Heuristics", "Material Design Guidelines"],
-                "notes": "Follows established UX patterns"
+                "notes": "Follows established UX patterns",
             },
             "performance": {
                 "compliant": True,
                 "standards": ["Web Vitals", "Performance Budget"],
-                "notes": "Meets performance targets with minor exceptions"
+                "notes": "Meets performance targets with minor exceptions",
             },
             "accessibility": {
                 "compliant": True,
                 "standards": ["WCAG 2.1 AA", "Section 508"],
-                "notes": "Meets accessibility requirements"
-            }
+                "notes": "Meets accessibility requirements",
+            },
         },
         "remaining_concerns": [
-            {"discipline": "security", "concern": "Password policy could be more stringent", "severity": "low"},
-            {"discipline": "performance", "concern": "Token validation could be further optimized", "severity": "low"}
+            {
+                "discipline": "security",
+                "concern": "Password policy could be more stringent",
+                "severity": "low",
+            },
+            {
+                "discipline": "performance",
+                "concern": "Token validation could be further optimized",
+                "severity": "low",
+            },
         ],
         "overall_assessment": {
             "score": 8.0,
             "summary": "The solution achieves a good balance between security, usability, performance, and accessibility",
-            "strengths": ["Strong security measures", "Good user experience", "Acceptable performance", "Strong accessibility"],
-            "weaknesses": ["Some minor security improvements possible", "Some performance optimizations possible"],
-            "recommendation": "Approve with minor suggestions for future improvements"
-        }
+            "strengths": [
+                "Strong security measures",
+                "Good user experience",
+                "Acceptable performance",
+                "Strong accessibility",
+            ],
+            "weaknesses": [
+                "Some minor security improvements possible",
+                "Some performance optimizations possible",
+            ],
+            "recommendation": "Approve with minor suggestions for future improvements",
+        },
     }
-    
+
     # Set the mock result
     context.team.evaluate_synthesis.return_value = mock_evaluation
-    
+
     # Call the method to evaluate the synthesis
     context.evaluation = context.team.evaluate_synthesis(context.synthesis)
+
 
 @pytest.mark.medium
 @then("the evaluation should assess the solution from each disciplinary perspective")
@@ -998,15 +1292,24 @@ def evaluation_assesses_solution_from_each_disciplinary_perspective(context):
     """Verify that the evaluation assesses the solution from each disciplinary perspective."""
     # Verify that the evaluation contains perspective scores
     assert "perspective_scores" in context.evaluation
-    
+
     # Get the list of disciplines from the perspective scores
-    evaluated_disciplines = [p["discipline"] for p in context.evaluation["perspective_scores"]]
-    
+    evaluated_disciplines = [
+        p["discipline"] for p in context.evaluation["perspective_scores"]
+    ]
+
     # Verify that all disciplines are represented in the evaluation
-    expected_disciplines = ["security", "user_experience", "performance", "accessibility"]
+    expected_disciplines = [
+        "security",
+        "user_experience",
+        "performance",
+        "accessibility",
+    ]
     for discipline in expected_disciplines:
-        assert discipline in evaluated_disciplines, f"Discipline {discipline} not found in evaluation"
-    
+        assert (
+            discipline in evaluated_disciplines
+        ), f"Discipline {discipline} not found in evaluation"
+
     # Verify that each perspective score has a score and rationale
     for perspective in context.evaluation["perspective_scores"]:
         assert "score" in perspective
@@ -1015,39 +1318,60 @@ def evaluation_assesses_solution_from_each_disciplinary_perspective(context):
         assert perspective["rationale"] is not None
         assert isinstance(perspective["score"], (int, float))
         assert 0 <= perspective["score"] <= 10  # Assuming scores are on a 0-10 scale
+
+
 @pytest.mark.medium
 @then("the evaluation should verify compliance with discipline-specific standards")
 def evaluation_verifies_compliance_with_discipline_specific_standards(context):
     """Verify that the evaluation checks compliance with discipline-specific standards."""
     # Verify that the evaluation contains standards compliance information
     assert "standards_compliance" in context.evaluation
-    
+
     # Get the standards compliance information
     standards_compliance = context.evaluation["standards_compliance"]
-    
+
     # Verify that there is compliance information for each discipline
-    expected_disciplines = ["security", "user_experience", "performance", "accessibility"]
+    expected_disciplines = [
+        "security",
+        "user_experience",
+        "performance",
+        "accessibility",
+    ]
     for discipline in expected_disciplines:
-        assert discipline in standards_compliance, f"Discipline {discipline} not found in standards compliance"
-        
+        assert (
+            discipline in standards_compliance
+        ), f"Discipline {discipline} not found in standards compliance"
+
         # Verify that each discipline has compliance information
         discipline_compliance = standards_compliance[discipline]
         assert "compliant" in discipline_compliance
         assert "standards" in discipline_compliance
         assert "notes" in discipline_compliance
-        
+
         # Verify that the standards are relevant to the discipline
         standards = discipline_compliance["standards"]
         assert len(standards) > 0
-        
+
         if discipline == "security":
-            assert any("OWASP" in standard or "NIST" in standard for standard in standards)
+            assert any(
+                "OWASP" in standard or "NIST" in standard for standard in standards
+            )
         elif discipline == "user_experience":
-            assert any("UX" in standard or "Design" in standard or "Nielsen" in standard for standard in standards)
+            assert any(
+                "UX" in standard or "Design" in standard or "Nielsen" in standard
+                for standard in standards
+            )
         elif discipline == "performance":
-            assert any("Performance" in standard or "Web Vitals" in standard for standard in standards)
+            assert any(
+                "Performance" in standard or "Web Vitals" in standard
+                for standard in standards
+            )
         elif discipline == "accessibility":
-            assert any("WCAG" in standard or "Section 508" in standard or "ADA" in standard for standard in standards)
+            assert any(
+                "WCAG" in standard or "Section 508" in standard or "ADA" in standard
+                for standard in standards
+            )
+
 
 @pytest.mark.medium
 @then("the evaluation should identify any remaining disciplinary concerns")
@@ -1055,11 +1379,11 @@ def evaluation_identifies_remaining_disciplinary_concerns(context):
     """Verify that the evaluation identifies any remaining disciplinary concerns."""
     # Verify that the evaluation contains remaining concerns
     assert "remaining_concerns" in context.evaluation
-    
+
     # Verify that the remaining concerns are properly structured
     remaining_concerns = context.evaluation["remaining_concerns"]
     assert isinstance(remaining_concerns, list)
-    
+
     # If there are remaining concerns, verify their structure
     if remaining_concerns:
         for concern in remaining_concerns:
@@ -1070,31 +1394,38 @@ def evaluation_identifies_remaining_disciplinary_concerns(context):
             assert concern["concern"] is not None
             assert concern["severity"] is not None
             assert concern["severity"] in ["low", "medium", "high"]
+
+
 @pytest.mark.medium
-@then("the evaluation should provide an overall assessment of multi-disciplinary quality")
+@then(
+    "the evaluation should provide an overall assessment of multi-disciplinary quality"
+)
 def evaluation_provides_overall_assessment_of_multi_disciplinary_quality(context):
     """Verify that the evaluation provides an overall assessment of multi-disciplinary quality."""
     # Verify that the evaluation contains an overall assessment
     assert "overall_assessment" in context.evaluation
-    
+
     # Get the overall assessment
     overall_assessment = context.evaluation["overall_assessment"]
-    
+
     # Verify that the overall assessment has the required fields
     assert "score" in overall_assessment
     assert "summary" in overall_assessment
     assert "strengths" in overall_assessment
     assert "weaknesses" in overall_assessment
     assert "recommendation" in overall_assessment
-    
+
     # Verify that the score is within the expected range
     assert isinstance(overall_assessment["score"], (int, float))
     assert 0 <= overall_assessment["score"] <= 10  # Assuming scores are on a 0-10 scale
-    
+
     # Verify that the summary mentions balance or integration of multiple disciplines
     summary = overall_assessment["summary"].lower()
-    assert any(term in summary for term in ["balance", "integrat", "multi-disciplinary", "across disciplines"])
-    
+    assert any(
+        term in summary
+        for term in ["balance", "integrat", "multi-disciplinary", "across disciplines"]
+    )
+
     # Verify that the strengths mention multiple disciplines
     strengths = overall_assessment["strengths"]
     assert len(strengths) > 0
@@ -1102,27 +1433,43 @@ def evaluation_provides_overall_assessment_of_multi_disciplinary_quality(context
     for discipline in ["security", "user experience", "performance", "accessibility"]:
         if any(discipline.lower() in strength.lower() for strength in strengths):
             disciplines_in_strengths += 1
-    assert disciplines_in_strengths >= 2, "Strengths should mention at least two disciplines"
-    
+    assert (
+        disciplines_in_strengths >= 2
+    ), "Strengths should mention at least two disciplines"
+
     # Verify that the recommendation provides clear guidance
-    assert len(overall_assessment["recommendation"]) > 10  # Ensure it's a meaningful recommendation
+    assert (
+        len(overall_assessment["recommendation"]) > 10
+    )  # Ensure it's a meaningful recommendation
+
+
 # Scenario: Integration with domain-specific knowledge
 @pytest.mark.medium
 @given("a multi-disciplinary reasoning process")
 def multi_disciplinary_reasoning_process(context):
     """Set up a multi-disciplinary reasoning process."""
     # Create a team if it doesn't exist yet
-    if not hasattr(context, 'team') or not context.team:
-        context.team = WSDETeam(name="TestMultiDisciplinaryDialecticalReasoningStepsTeam")
-        
+    if not hasattr(context, "team") or not context.team:
+        context.team = WSDETeam(
+            name="TestMultiDisciplinaryDialecticalReasoningStepsTeam"
+        )
+
         # Create agents with different disciplinary expertise
         code_agent = create_mock_agent("CodeAgent", ["python", "coding"])
-        security_agent = create_mock_agent("SecurityAgent", ["security", "authentication"])
+        security_agent = create_mock_agent(
+            "SecurityAgent", ["security", "authentication"]
+        )
         ux_agent = create_mock_agent("UXAgent", ["user_experience", "interface_design"])
-        performance_agent = create_mock_agent("PerformanceAgent", ["performance", "optimization"])
-        accessibility_agent = create_mock_agent("AccessibilityAgent", ["accessibility", "inclusive_design"])
-        critic_agent = create_mock_agent("CriticAgent", ["dialectical_reasoning", "critique", "synthesis"])
-        
+        performance_agent = create_mock_agent(
+            "PerformanceAgent", ["performance", "optimization"]
+        )
+        accessibility_agent = create_mock_agent(
+            "AccessibilityAgent", ["accessibility", "inclusive_design"]
+        )
+        critic_agent = create_mock_agent(
+            "CriticAgent", ["dialectical_reasoning", "critique", "synthesis"]
+        )
+
         # Add agents to the team
         context.team.add_agent(code_agent)
         context.team.add_agent(security_agent)
@@ -1130,7 +1477,7 @@ def multi_disciplinary_reasoning_process(context):
         context.team.add_agent(performance_agent)
         context.team.add_agent(accessibility_agent)
         context.team.add_agent(critic_agent)
-        
+
         # Store agents for later use
         context.code_agent = code_agent
         context.security_agent = security_agent
@@ -1138,28 +1485,29 @@ def multi_disciplinary_reasoning_process(context):
         context.performance_agent = performance_agent
         context.accessibility_agent = accessibility_agent
         context.critic_agent = critic_agent
-        
+
         # Set disciplinary agents
         context.disciplinary_agents = [
             context.security_agent,
             context.ux_agent,
             context.performance_agent,
-            context.accessibility_agent
+            context.accessibility_agent,
         ]
-    
+
     # Create a task if it doesn't exist yet
-    if not hasattr(context, 'task') or not context.task:
+    if not hasattr(context, "task") or not context.task:
         context.task = {
-            "type": "implementation_task", 
-            "description": "Implement a user authentication system with a focus on security, usability, performance, and accessibility"
+            "type": "implementation_task",
+            "description": "Implement a user authentication system with a focus on security, usability, performance, and accessibility",
         }
+
 
 @pytest.mark.medium
 @given("domain-specific knowledge sources for each discipline")
 def domain_specific_knowledge_sources_for_each_discipline(context):
     """Set up domain-specific knowledge sources for each discipline."""
     # Create knowledge sources if they don't exist yet
-    if not hasattr(context, 'knowledge_sources') or not context.knowledge_sources:
+    if not hasattr(context, "knowledge_sources") or not context.knowledge_sources:
         context.knowledge_sources = {
             "security": {
                 "authentication_best_practices": [
@@ -1167,12 +1515,18 @@ def domain_specific_knowledge_sources_for_each_discipline(context):
                     "Store passwords using strong, adaptive hashing algorithms (e.g., bcrypt, Argon2)",
                     "Implement rate limiting to prevent brute force attacks",
                     "Use HTTPS for all authentication requests",
-                    "Set secure and HttpOnly flags on authentication cookies"
+                    "Set secure and HttpOnly flags on authentication cookies",
                 ],
                 "sources": [
-                    {"title": "OWASP Authentication Cheat Sheet", "url": "https://cheatsheetseries.owasp.org/cheatsheets/Authentication_Cheat_Sheet.html"},
-                    {"title": "NIST Digital Identity Guidelines", "url": "https://pages.nist.gov/800-63-3/"}
-                ]
+                    {
+                        "title": "OWASP Authentication Cheat Sheet",
+                        "url": "https://cheatsheetseries.owasp.org/cheatsheets/Authentication_Cheat_Sheet.html",
+                    },
+                    {
+                        "title": "NIST Digital Identity Guidelines",
+                        "url": "https://pages.nist.gov/800-63-3/",
+                    },
+                ],
             },
             "user_experience": {
                 "authentication_ux_principles": [
@@ -1180,12 +1534,18 @@ def domain_specific_knowledge_sources_for_each_discipline(context):
                     "Provide clear error messages for failed authentication attempts",
                     "Offer password recovery options",
                     "Remember user preferences where appropriate",
-                    "Support single sign-on where possible"
+                    "Support single sign-on where possible",
                 ],
                 "sources": [
-                    {"title": "Nielsen Norman Group: Login Form Design", "url": "https://www.nngroup.com/articles/login-form-design/"},
-                    {"title": "Baymard Institute: Form Design Best Practices", "url": "https://baymard.com/blog/login-form-design"}
-                ]
+                    {
+                        "title": "Nielsen Norman Group: Login Form Design",
+                        "url": "https://www.nngroup.com/articles/login-form-design/",
+                    },
+                    {
+                        "title": "Baymard Institute: Form Design Best Practices",
+                        "url": "https://baymard.com/blog/login-form-design",
+                    },
+                ],
             },
             "performance": {
                 "authentication_performance_considerations": [
@@ -1193,12 +1553,18 @@ def domain_specific_knowledge_sources_for_each_discipline(context):
                     "Cache frequently used authentication data",
                     "Use asynchronous processing for non-critical authentication tasks",
                     "Implement efficient database queries for user lookup",
-                    "Monitor and optimize authentication service response times"
+                    "Monitor and optimize authentication service response times",
                 ],
                 "sources": [
-                    {"title": "Web.dev: Performance Optimization", "url": "https://web.dev/performance-optimization/"},
-                    {"title": "MDN: Performance Best Practices", "url": "https://developer.mozilla.org/en-US/docs/Web/Performance/Performance_basics"}
-                ]
+                    {
+                        "title": "Web.dev: Performance Optimization",
+                        "url": "https://web.dev/performance-optimization/",
+                    },
+                    {
+                        "title": "MDN: Performance Best Practices",
+                        "url": "https://developer.mozilla.org/en-US/docs/Web/Performance/Performance_basics",
+                    },
+                ],
             },
             "accessibility": {
                 "authentication_accessibility_guidelines": [
@@ -1206,21 +1572,31 @@ def domain_specific_knowledge_sources_for_each_discipline(context):
                     "Provide appropriate ARIA labels for authentication form elements",
                     "Support screen readers for error messages and instructions",
                     "Maintain sufficient color contrast for text and interactive elements",
-                    "Allow authentication timeout extensions for users who need more time"
+                    "Allow authentication timeout extensions for users who need more time",
                 ],
                 "sources": [
-                    {"title": "W3C Web Content Accessibility Guidelines (WCAG) 2.1", "url": "https://www.w3.org/TR/WCAG21/"},
-                    {"title": "WebAIM: Creating Accessible Forms", "url": "https://webaim.org/techniques/forms/"}
-                ]
-            }
+                    {
+                        "title": "W3C Web Content Accessibility Guidelines (WCAG) 2.1",
+                        "url": "https://www.w3.org/TR/WCAG21/",
+                    },
+                    {
+                        "title": "WebAIM: Creating Accessible Forms",
+                        "url": "https://webaim.org/techniques/forms/",
+                    },
+                ],
+            },
         }
+
+
 @pytest.mark.medium
 @when("the team applies multi-disciplinary dialectical reasoning")
 def team_applies_multi_disciplinary_dialectical_reasoning(context):
     """Apply multi-disciplinary dialectical reasoning with domain-specific knowledge."""
     # Mock the team's method for applying multi-disciplinary dialectical reasoning
-    context.team.apply_multi_disciplinary_dialectical_reasoning_with_knowledge = MagicMock()
-    
+    context.team.apply_multi_disciplinary_dialectical_reasoning_with_knowledge = (
+        MagicMock()
+    )
+
     # Create a mock result with perspectives from different disciplines that incorporate domain-specific knowledge
     mock_result = {
         "thesis": {
@@ -1236,41 +1612,76 @@ def authenticate(username, password):
 def generate_jwt_token(username):
     # Generate a JWT token
     return "jwt_token_placeholder"
-            """
+            """,
         },
         "disciplinary_perspectives": [
             {
                 "discipline": "security",
                 "agent": "SecurityAgent",
                 "perspective": "The solution needs to implement password hashing, rate limiting, and HTTPS.",
-                "concerns": ["Hardcoded credentials", "No password hashing", "No rate limiting"],
-                "recommendations": ["Use bcrypt for password hashing", "Implement rate limiting", "Use HTTPS"],
+                "concerns": [
+                    "Hardcoded credentials",
+                    "No password hashing",
+                    "No rate limiting",
+                ],
+                "recommendations": [
+                    "Use bcrypt for password hashing",
+                    "Implement rate limiting",
+                    "Use HTTPS",
+                ],
                 "knowledge_sources": [
-                    {"title": "OWASP Authentication Cheat Sheet", "url": "https://cheatsheetseries.owasp.org/cheatsheets/Authentication_Cheat_Sheet.html"},
-                    {"title": "NIST Digital Identity Guidelines", "url": "https://pages.nist.gov/800-63-3/"}
-                ]
+                    {
+                        "title": "OWASP Authentication Cheat Sheet",
+                        "url": "https://cheatsheetseries.owasp.org/cheatsheets/Authentication_Cheat_Sheet.html",
+                    },
+                    {
+                        "title": "NIST Digital Identity Guidelines",
+                        "url": "https://pages.nist.gov/800-63-3/",
+                    },
+                ],
             },
             {
                 "discipline": "user_experience",
                 "agent": "UXAgent",
                 "perspective": "The authentication flow needs to be user-friendly with clear error messages.",
                 "concerns": ["No error messages", "No password recovery"],
-                "recommendations": ["Add clear error messages", "Implement password recovery"],
+                "recommendations": [
+                    "Add clear error messages",
+                    "Implement password recovery",
+                ],
                 "knowledge_sources": [
-                    {"title": "Nielsen Norman Group: Login Form Design", "url": "https://www.nngroup.com/articles/login-form-design/"},
-                    {"title": "Baymard Institute: Form Design Best Practices", "url": "https://baymard.com/blog/login-form-design"}
-                ]
+                    {
+                        "title": "Nielsen Norman Group: Login Form Design",
+                        "url": "https://www.nngroup.com/articles/login-form-design/",
+                    },
+                    {
+                        "title": "Baymard Institute: Form Design Best Practices",
+                        "url": "https://baymard.com/blog/login-form-design",
+                    },
+                ],
             },
             {
                 "discipline": "performance",
                 "agent": "PerformanceAgent",
                 "perspective": "Token validation should be optimized for minimal latency.",
-                "concerns": ["No caching strategy", "Potential performance bottlenecks"],
-                "recommendations": ["Cache frequently used authentication data", "Optimize token validation"],
+                "concerns": [
+                    "No caching strategy",
+                    "Potential performance bottlenecks",
+                ],
+                "recommendations": [
+                    "Cache frequently used authentication data",
+                    "Optimize token validation",
+                ],
                 "knowledge_sources": [
-                    {"title": "Web.dev: Performance Optimization", "url": "https://web.dev/performance-optimization/"},
-                    {"title": "MDN: Performance Best Practices", "url": "https://developer.mozilla.org/en-US/docs/Web/Performance/Performance_basics"}
-                ]
+                    {
+                        "title": "Web.dev: Performance Optimization",
+                        "url": "https://web.dev/performance-optimization/",
+                    },
+                    {
+                        "title": "MDN: Performance Best Practices",
+                        "url": "https://developer.mozilla.org/en-US/docs/Web/Performance/Performance_basics",
+                    },
+                ],
             },
             {
                 "discipline": "accessibility",
@@ -1279,17 +1690,35 @@ def generate_jwt_token(username):
                 "concerns": ["No keyboard navigation", "No ARIA labels"],
                 "recommendations": ["Ensure keyboard navigability", "Add ARIA labels"],
                 "knowledge_sources": [
-                    {"title": "W3C Web Content Accessibility Guidelines (WCAG) 2.1", "url": "https://www.w3.org/TR/WCAG21/"},
-                    {"title": "WebAIM: Creating Accessible Forms", "url": "https://webaim.org/techniques/forms/"}
-                ]
-            }
+                    {
+                        "title": "W3C Web Content Accessibility Guidelines (WCAG) 2.1",
+                        "url": "https://www.w3.org/TR/WCAG21/",
+                    },
+                    {
+                        "title": "WebAIM: Creating Accessible Forms",
+                        "url": "https://webaim.org/techniques/forms/",
+                    },
+                ],
+            },
         ],
         "synthesis": {
             "integrated_perspectives": [
-                {"discipline": "security", "key_points": ["Password hashing", "Rate limiting", "HTTPS"]},
-                {"discipline": "user_experience", "key_points": ["Clear error messages", "Password recovery"]},
-                {"discipline": "performance", "key_points": ["Caching", "Optimized validation"]},
-                {"discipline": "accessibility", "key_points": ["Keyboard navigation", "ARIA labels"]}
+                {
+                    "discipline": "security",
+                    "key_points": ["Password hashing", "Rate limiting", "HTTPS"],
+                },
+                {
+                    "discipline": "user_experience",
+                    "key_points": ["Clear error messages", "Password recovery"],
+                },
+                {
+                    "discipline": "performance",
+                    "key_points": ["Caching", "Optimized validation"],
+                },
+                {
+                    "discipline": "accessibility",
+                    "key_points": ["Keyboard navigation", "ARIA labels"],
+                },
             ],
             "perspective_conflicts": [
                 {
@@ -1298,84 +1727,137 @@ def generate_jwt_token(username):
                     "severity": "medium",
                     "assumptions": {
                         "security": "Strong security requires multiple verification steps",
-                        "user_experience": "Users prefer minimal friction during authentication"
-                    }
+                        "user_experience": "Users prefer minimal friction during authentication",
+                    },
                 }
             ],
             "conflict_resolutions": [
                 {
                     "disciplines": ["security", "user_experience"],
                     "resolution": "Implement progressive security that balances protection with usability",
-                    "trade_offs": ["Slightly reduced security for better UX", "Slightly increased friction for better security"],
+                    "trade_offs": [
+                        "Slightly reduced security for better UX",
+                        "Slightly increased friction for better security",
+                    ],
                     "knowledge_sources": [
-                        {"title": "OWASP Authentication Cheat Sheet", "url": "https://cheatsheetseries.owasp.org/cheatsheets/Authentication_Cheat_Sheet.html"},
-                        {"title": "Nielsen Norman Group: Login Form Design", "url": "https://www.nngroup.com/articles/login-form-design/"}
-                    ]
+                        {
+                            "title": "OWASP Authentication Cheat Sheet",
+                            "url": "https://cheatsheetseries.owasp.org/cheatsheets/Authentication_Cheat_Sheet.html",
+                        },
+                        {
+                            "title": "Nielsen Norman Group: Login Form Design",
+                            "url": "https://www.nngroup.com/articles/login-form-design/",
+                        },
+                    ],
                 }
             ],
             "best_practices": {
-                "security": ["Use bcrypt for password hashing", "Implement rate limiting", "Use HTTPS"],
-                "user_experience": ["Add clear error messages", "Implement password recovery"],
-                "performance": ["Cache frequently used authentication data", "Optimize token validation"],
-                "accessibility": ["Ensure keyboard navigability", "Add ARIA labels"]
+                "security": [
+                    "Use bcrypt for password hashing",
+                    "Implement rate limiting",
+                    "Use HTTPS",
+                ],
+                "user_experience": [
+                    "Add clear error messages",
+                    "Implement password recovery",
+                ],
+                "performance": [
+                    "Cache frequently used authentication data",
+                    "Optimize token validation",
+                ],
+                "accessibility": ["Ensure keyboard navigability", "Add ARIA labels"],
             },
             "knowledge_attribution": {
                 "security": [
-                    {"practice": "Use bcrypt for password hashing", "source": "OWASP Authentication Cheat Sheet"},
-                    {"practice": "Implement rate limiting", "source": "OWASP Authentication Cheat Sheet"},
-                    {"practice": "Use HTTPS", "source": "NIST Digital Identity Guidelines"}
+                    {
+                        "practice": "Use bcrypt for password hashing",
+                        "source": "OWASP Authentication Cheat Sheet",
+                    },
+                    {
+                        "practice": "Implement rate limiting",
+                        "source": "OWASP Authentication Cheat Sheet",
+                    },
+                    {
+                        "practice": "Use HTTPS",
+                        "source": "NIST Digital Identity Guidelines",
+                    },
                 ],
                 "user_experience": [
-                    {"practice": "Add clear error messages", "source": "Nielsen Norman Group: Login Form Design"},
-                    {"practice": "Implement password recovery", "source": "Baymard Institute: Form Design Best Practices"}
+                    {
+                        "practice": "Add clear error messages",
+                        "source": "Nielsen Norman Group: Login Form Design",
+                    },
+                    {
+                        "practice": "Implement password recovery",
+                        "source": "Baymard Institute: Form Design Best Practices",
+                    },
                 ],
                 "performance": [
-                    {"practice": "Cache frequently used authentication data", "source": "Web.dev: Performance Optimization"},
-                    {"practice": "Optimize token validation", "source": "MDN: Performance Best Practices"}
+                    {
+                        "practice": "Cache frequently used authentication data",
+                        "source": "Web.dev: Performance Optimization",
+                    },
+                    {
+                        "practice": "Optimize token validation",
+                        "source": "MDN: Performance Best Practices",
+                    },
                 ],
                 "accessibility": [
-                    {"practice": "Ensure keyboard navigability", "source": "W3C Web Content Accessibility Guidelines (WCAG) 2.1"},
-                    {"practice": "Add ARIA labels", "source": "WebAIM: Creating Accessible Forms"}
-                ]
-            }
-        }
+                    {
+                        "practice": "Ensure keyboard navigability",
+                        "source": "W3C Web Content Accessibility Guidelines (WCAG) 2.1",
+                    },
+                    {
+                        "practice": "Add ARIA labels",
+                        "source": "WebAIM: Creating Accessible Forms",
+                    },
+                ],
+            },
+        },
     }
-    
+
     # Set the mock result
-    context.team.apply_multi_disciplinary_dialectical_reasoning_with_knowledge.return_value = mock_result
-    
-    # Call the method to apply multi-disciplinary dialectical reasoning with knowledge
-    context.result = context.team.apply_multi_disciplinary_dialectical_reasoning_with_knowledge(
-        context.task,
-        context.critic_agent,
-        context.knowledge_sources,
-        context.disciplinary_agents
+    context.team.apply_multi_disciplinary_dialectical_reasoning_with_knowledge.return_value = (
+        mock_result
     )
+
+    # Call the method to apply multi-disciplinary dialectical reasoning with knowledge
+    context.result = (
+        context.team.apply_multi_disciplinary_dialectical_reasoning_with_knowledge(
+            context.task,
+            context.critic_agent,
+            context.knowledge_sources,
+            context.disciplinary_agents,
+        )
+    )
+
+
 @pytest.mark.medium
 @then("each disciplinary perspective should incorporate domain-specific knowledge")
 def each_disciplinary_perspective_incorporates_domain_specific_knowledge(context):
     """Verify that each disciplinary perspective incorporates domain-specific knowledge."""
     # Verify that the result contains disciplinary perspectives
     assert "disciplinary_perspectives" in context.result
-    
+
     # Verify that each perspective incorporates domain-specific knowledge
     for perspective in context.result["disciplinary_perspectives"]:
         # Verify that the perspective has knowledge sources
         assert "knowledge_sources" in perspective
         assert perspective["knowledge_sources"] is not None
         assert len(perspective["knowledge_sources"]) > 0
-        
+
         # Verify that each knowledge source has a title and URL
         for source in perspective["knowledge_sources"]:
             assert "title" in source
             assert "url" in source
             assert source["title"] is not None
             assert source["url"] is not None
-            
+
         # Verify that the perspective's recommendations are informed by the knowledge sources
         assert "recommendations" in perspective
         assert perspective["recommendations"] is not None
         assert len(perspective["recommendations"]) > 0
+
 
 @pytest.mark.medium
 @then("the knowledge should be properly attributed to authoritative sources")
@@ -1384,35 +1866,56 @@ def knowledge_properly_attributed_to_authoritative_sources(context):
     # Verify that the synthesis contains knowledge attribution
     assert "synthesis" in context.result
     assert "knowledge_attribution" in context.result["synthesis"]
-    
+
     # Get the knowledge attribution
     knowledge_attribution = context.result["synthesis"]["knowledge_attribution"]
-    
+
     # Verify that there is attribution for each discipline
-    expected_disciplines = ["security", "user_experience", "performance", "accessibility"]
+    expected_disciplines = [
+        "security",
+        "user_experience",
+        "performance",
+        "accessibility",
+    ]
     for discipline in expected_disciplines:
-        assert discipline in knowledge_attribution, f"Discipline {discipline} not found in knowledge attribution"
-        
+        assert (
+            discipline in knowledge_attribution
+        ), f"Discipline {discipline} not found in knowledge attribution"
+
         # Verify that each discipline has attributions
         discipline_attribution = knowledge_attribution[discipline]
         assert len(discipline_attribution) > 0
-        
+
         # Verify that each attribution has a practice and source
         for attribution in discipline_attribution:
             assert "practice" in attribution
             assert "source" in attribution
             assert attribution["practice"] is not None
             assert attribution["source"] is not None
-            
+
             # Verify that the source is an authoritative source
             if discipline == "security":
-                assert any(term in attribution["source"] for term in ["OWASP", "NIST", "CIS", "ISO"])
+                assert any(
+                    term in attribution["source"]
+                    for term in ["OWASP", "NIST", "CIS", "ISO"]
+                )
             elif discipline == "user_experience":
-                assert any(term in attribution["source"] for term in ["Nielsen", "Baymard", "UX", "Design"])
+                assert any(
+                    term in attribution["source"]
+                    for term in ["Nielsen", "Baymard", "UX", "Design"]
+                )
             elif discipline == "performance":
-                assert any(term in attribution["source"] for term in ["Web.dev", "MDN", "Performance"])
+                assert any(
+                    term in attribution["source"]
+                    for term in ["Web.dev", "MDN", "Performance"]
+                )
             elif discipline == "accessibility":
-                assert any(term in attribution["source"] for term in ["W3C", "WCAG", "WebAIM", "Section 508"])
+                assert any(
+                    term in attribution["source"]
+                    for term in ["W3C", "WCAG", "WebAIM", "Section 508"]
+                )
+
+
 @pytest.mark.medium
 @then("the synthesis should reflect current best practices across all disciplines")
 def synthesis_reflects_current_best_practices_across_all_disciplines(context):
@@ -1420,28 +1923,56 @@ def synthesis_reflects_current_best_practices_across_all_disciplines(context):
     # Verify that the synthesis contains best practices
     assert "synthesis" in context.result
     assert "best_practices" in context.result["synthesis"]
-    
+
     # Get the best practices
     best_practices = context.result["synthesis"]["best_practices"]
-    
+
     # Verify that there are best practices for each discipline
-    expected_disciplines = ["security", "user_experience", "performance", "accessibility"]
+    expected_disciplines = [
+        "security",
+        "user_experience",
+        "performance",
+        "accessibility",
+    ]
     for discipline in expected_disciplines:
-        assert discipline in best_practices, f"Discipline {discipline} not found in best practices"
-        
+        assert (
+            discipline in best_practices
+        ), f"Discipline {discipline} not found in best practices"
+
         # Verify that each discipline has best practices
         discipline_practices = best_practices[discipline]
         assert len(discipline_practices) > 0
-        
+
         # Verify that the best practices are relevant to the discipline
         if discipline == "security":
-            assert any("password" in practice.lower() or "hash" in practice.lower() or "https" in practice.lower() for practice in discipline_practices)
+            assert any(
+                "password" in practice.lower()
+                or "hash" in practice.lower()
+                or "https" in practice.lower()
+                for practice in discipline_practices
+            )
         elif discipline == "user_experience":
-            assert any("error" in practice.lower() or "message" in practice.lower() or "recovery" in practice.lower() for practice in discipline_practices)
+            assert any(
+                "error" in practice.lower()
+                or "message" in practice.lower()
+                or "recovery" in practice.lower()
+                for practice in discipline_practices
+            )
         elif discipline == "performance":
-            assert any("cache" in practice.lower() or "optimi" in practice.lower() or "latency" in practice.lower() for practice in discipline_practices)
+            assert any(
+                "cache" in practice.lower()
+                or "optimi" in practice.lower()
+                or "latency" in practice.lower()
+                for practice in discipline_practices
+            )
         elif discipline == "accessibility":
-            assert any("keyboard" in practice.lower() or "aria" in practice.lower() or "screen reader" in practice.lower() for practice in discipline_practices)
+            assert any(
+                "keyboard" in practice.lower()
+                or "aria" in practice.lower()
+                or "screen reader" in practice.lower()
+                for practice in discipline_practices
+            )
+
 
 @pytest.mark.medium
 @then("the solution should demonstrate awareness of cross-disciplinary implications")
@@ -1450,42 +1981,51 @@ def solution_demonstrates_awareness_of_cross_disciplinary_implications(context):
     # Verify that the synthesis contains conflict resolutions
     assert "synthesis" in context.result
     assert "conflict_resolutions" in context.result["synthesis"]
-    
+
     # Get the conflict resolutions
     conflict_resolutions = context.result["synthesis"]["conflict_resolutions"]
-    
+
     # Verify that there are conflict resolutions
     assert len(conflict_resolutions) > 0
-    
+
     # Verify that each conflict resolution involves multiple disciplines
     for resolution in conflict_resolutions:
         assert "disciplines" in resolution
         assert len(resolution["disciplines"]) >= 2
-        
+
         # Verify that the resolution addresses cross-disciplinary implications
         assert "resolution" in resolution
         assert "trade_offs" in resolution
         assert resolution["resolution"] is not None
         assert resolution["trade_offs"] is not None
         assert len(resolution["trade_offs"]) > 0
-        
+
         # Verify that the resolution has knowledge sources
         assert "knowledge_sources" in resolution
         assert resolution["knowledge_sources"] is not None
         assert len(resolution["knowledge_sources"]) > 0
-        
+
         # Verify that the knowledge sources come from different disciplines
         source_disciplines = set()
         for source in resolution["knowledge_sources"]:
             source_title = source["title"].lower()
             if any(term in source_title for term in ["owasp", "nist", "security"]):
                 source_disciplines.add("security")
-            elif any(term in source_title for term in ["nielsen", "ux", "user experience", "design"]):
+            elif any(
+                term in source_title
+                for term in ["nielsen", "ux", "user experience", "design"]
+            ):
                 source_disciplines.add("user_experience")
-            elif any(term in source_title for term in ["performance", "web.dev", "mdn"]):
+            elif any(
+                term in source_title for term in ["performance", "web.dev", "mdn"]
+            ):
                 source_disciplines.add("performance")
-            elif any(term in source_title for term in ["wcag", "accessibility", "webaim"]):
+            elif any(
+                term in source_title for term in ["wcag", "accessibility", "webaim"]
+            ):
                 source_disciplines.add("accessibility")
-        
+
         # Verify that the resolution incorporates knowledge from multiple disciplines
-        assert len(source_disciplines) >= 2, f"Resolution should incorporate knowledge from multiple disciplines, but only found {source_disciplines}"
+        assert (
+            len(source_disciplines) >= 2
+        ), f"Resolution should incorporate knowledge from multiple disciplines, but only found {source_disciplines}"

--- a/tests/behavior/steps/test_non_hierarchical_collaboration_steps.py
+++ b/tests/behavior/steps/test_non_hierarchical_collaboration_steps.py
@@ -11,12 +11,14 @@ pytest.skip(
     "Advanced WSDE collaboration features not implemented", allow_module_level=True
 )
 
-from pytest_bdd import given, when, then, parsers, scenarios
 from unittest.mock import MagicMock, patch
-from devsynth.domain.models.wsde import WSDETeam
+
+from pytest_bdd import given, parsers, scenarios, then, when
+
 from devsynth.application.agents.base import BaseAgent
 from devsynth.application.agents.unified_agent import UnifiedAgent
 from devsynth.domain.models.agent import AgentConfig, AgentType
+from devsynth.domain.models.wsde_facade import WSDETeam
 
 # Import the feature file
 scenarios("../features/general/non_hierarchical_collaboration.feature")

--- a/tests/behavior/steps/test_simple_coordinator_steps.py
+++ b/tests/behavior/steps/test_simple_coordinator_steps.py
@@ -11,28 +11,28 @@ importable, it now simply re-exports everything from
 
 # Content from test_edrr_coordinator_steps.py inlined here
 """Step definitions for the EDRR Coordinator feature."""
-from pytest_bdd import given, when, then, parsers
-from pytest_bdd import scenarios
 import pytest
+from pytest_bdd import given, parsers, scenarios, then, when
 
 scenarios("../features/general/edrr_coordinator.feature")
-import os
 import json
+import os
 import tempfile
 from pathlib import Path
 from typing import Dict, Tuple
-from devsynth.methodology.base import Phase
-from devsynth.application.memory.memory_manager import MemoryManager
-from devsynth.domain.models.memory import MemoryType
-from devsynth.domain.models.wsde import WSDETeam
+
 from devsynth.application.code_analysis.analyzer import CodeAnalyzer
 from devsynth.application.code_analysis.ast_transformer import AstTransformer
-from devsynth.application.requirements.prompt_manager import PromptManager
 from devsynth.application.documentation.documentation_manager import (
     DocumentationManager,
 )
 from devsynth.application.edrr.coordinator import EDRRCoordinator
 from devsynth.application.edrr.manifest_parser import ManifestParser
+from devsynth.application.memory.memory_manager import MemoryManager
+from devsynth.application.requirements.prompt_manager import PromptManager
+from devsynth.domain.models.memory import MemoryType
+from devsynth.domain.models.wsde_facade import WSDETeam
+from devsynth.methodology.base import Phase
 
 
 @pytest.fixture
@@ -237,7 +237,11 @@ def verify_phase(context, phase_name):
 
 
 @pytest.mark.medium
-@then(    parsers.parse(        'the coordinator should store the task in memory with EDRR phase "{phase_name}"'    ))
+@then(
+    parsers.parse(
+        'the coordinator should store the task in memory with EDRR phase "{phase_name}"'
+    )
+)
 def verify_task_stored(context, phase_name):
     """Verify the task is stored in memory with the correct EDRR phase."""
     test_storage = {}
@@ -461,7 +465,11 @@ def verify_ast_verify(context):
 
 
 @pytest.mark.medium
-@then(    parsers.parse(        'the prompt manager should provide templates for the "{phase_name}" phase'    ))
+@then(
+    parsers.parse(
+        'the prompt manager should provide templates for the "{phase_name}" phase'
+    )
+)
 def verify_prompt_templates(context, phase_name):
     """Verify the prompt manager provides templates for the specified phase."""
     phase = Phase[phase_name.upper()]
@@ -618,7 +626,11 @@ This document outlines criteria for evaluating code quality."""
 
 
 @pytest.mark.medium
-@then(    parsers.parse(        'the results should be stored in memory with EDRR phase "{phase_name}"'    ))
+@then(
+    parsers.parse(
+        'the results should be stored in memory with EDRR phase "{phase_name}"'
+    )
+)
 def verify_results_stored(context, phase_name):
     """Verify the results are stored in memory with the correct EDRR phase."""
     phase = Phase[phase_name.upper()]
@@ -972,4 +984,6 @@ def verify_performance_metrics(context):
         assert "code_analyzer" in component_calls
         assert "prompt_manager" in component_calls
         assert "documentation_manager" in component_calls
-  # noqa: F401,F403
+
+
+# noqa: F401,F403

--- a/tests/behavior/steps/test_wsde_agent_model_steps.py
+++ b/tests/behavior/steps/test_wsde_agent_model_steps.py
@@ -4,24 +4,28 @@ Step Definitions for WSDE Agent Model Refinement BDD Tests
 This file implements the step definitions for the WSDE agent model refinement
 feature file, testing the non-hierarchical, context-driven agent collaboration.
 """
-import pytest
-from pytest_bdd import given, when, then, parsers, scenarios
+
 from unittest.mock import MagicMock
 
+import pytest
+from pytest_bdd import given, parsers, scenarios, then, when
+
 # Import the feature files
-scenarios('../features/general/wsde_agent_model.feature')
+scenarios("../features/general/wsde_agent_model.feature")
 # scenarios('../features/wsde_agent_model.feature')  # Commented out - feature file not found
 
-# Import the modules needed for the steps
-from devsynth.domain.models.wsde import WSDETeam
 from devsynth.adapters.agents.agent_adapter import WSDETeamCoordinator
 from devsynth.application.agents.unified_agent import UnifiedAgent
 from devsynth.domain.models.agent import AgentConfig, AgentType
+
+# Import the modules needed for the steps
+from devsynth.domain.models.wsde_facade import WSDETeam
 
 
 @pytest.fixture
 def context():
     """Fixture to provide a context object for sharing state between steps."""
+
     class Context:
         def __init__(self):
             self.team_coordinator = WSDETeamCoordinator()
@@ -36,6 +40,7 @@ def context():
 
 
 # Background steps
+
 
 @pytest.mark.medium
 @given("the DevSynth system is initialized")
@@ -66,6 +71,7 @@ def wsde_model_enabled(context):
 
 # Scenario: Peer-based collaboration
 
+
 @pytest.mark.medium
 @when("I create a team with multiple agents")
 def create_team_with_multiple_agents(context):
@@ -75,7 +81,7 @@ def create_team_with_multiple_agents(context):
         AgentType.PLANNER.value,
         AgentType.SPECIFICATION.value,
         AgentType.CODE.value,
-        AgentType.VALIDATION.value
+        AgentType.VALIDATION.value,
     ]
 
     for agent_type in agent_types:
@@ -85,7 +91,7 @@ def create_team_with_multiple_agents(context):
             agent_type=AgentType(agent_type),
             description=f"Agent for {agent_type} tasks",
             capabilities=[],
-            parameters={}
+            parameters={},
         )
         agent.initialize(agent_config)
         context.agents[agent_type] = agent
@@ -131,7 +137,7 @@ def collaborate_without_rigid_role_sequences(context):
         "code_agent": ["python", "javascript", "code_generation"],
         "test_agent": ["testing", "pytest", "test_generation"],
         "doc_agent": ["documentation", "markdown", "doc_generation"],
-        "design_agent": ["architecture", "design", "planning"]
+        "design_agent": ["architecture", "design", "planning"],
     }
 
     for agent_name, expertise in expertise_map.items():
@@ -141,7 +147,7 @@ def collaborate_without_rigid_role_sequences(context):
             agent_type=AgentType.ORCHESTRATOR,
             description=f"Agent with expertise in {', '.join(expertise)}",
             capabilities=[],
-            parameters={"expertise": expertise}
+            parameters={"expertise": expertise},
         )
         agent.initialize(agent_config)
         context.agents[agent_name] = agent
@@ -149,14 +155,16 @@ def collaborate_without_rigid_role_sequences(context):
 
     # Configure mock returns for agent processes
     for agent_name, agent in context.agents.items():
-        agent.process = MagicMock(return_value={"result": f"Solution from {agent_name}"})
+        agent.process = MagicMock(
+            return_value={"result": f"Solution from {agent_name}"}
+        )
 
     # Create a task with specific keywords that match agent expertise
     task = {
         "type": "complex_task",
         "description": "A task that requires collaboration",
         "components": ["python", "javascript", "testing", "documentation", "design"],
-        "language": "python"
+        "language": "python",
     }
 
     # Instead of delegating the task to the team, directly call process on each agent
@@ -179,7 +187,9 @@ def collaborate_without_rigid_role_sequences(context):
 
     # Check that all test agents are in the contributors list
     for agent_name in test_agents:
-        assert agent_name in result["contributors"], f"Agent {agent_name} should be in contributors"
+        assert (
+            agent_name in result["contributors"]
+        ), f"Agent {agent_name} should be in contributors"
 
     # Verify that the method is consensus-based
     assert "method" in result
@@ -187,6 +197,7 @@ def collaborate_without_rigid_role_sequences(context):
 
 
 # Scenario: Context-driven leadership
+
 
 @pytest.mark.medium
 @given("a team with multiple agents with different expertise")
@@ -203,7 +214,7 @@ def team_with_agents_different_expertise(context):
         "code_agent": ["python", "javascript", "code_generation"],
         "test_agent": ["testing", "pytest", "test_generation"],
         "doc_agent": ["documentation", "markdown", "doc_generation"],
-        "design_agent": ["architecture", "design", "planning"]
+        "design_agent": ["architecture", "design", "planning"],
     }
 
     for agent_name, expertise in expertise_map.items():
@@ -213,7 +224,7 @@ def team_with_agents_different_expertise(context):
             agent_type=AgentType.ORCHESTRATOR,
             description=f"Agent with expertise in {', '.join(expertise)}",
             capabilities=[],
-            parameters={"expertise": expertise}
+            parameters={"expertise": expertise},
         )
         agent.initialize(agent_config)
         context.agents[agent_name] = agent
@@ -233,7 +244,7 @@ def task_requiring_specific_expertise(context):
     task = {
         "type": "code_generation",
         "language": "python",
-        "description": "Generate a Python function to calculate Fibonacci numbers"
+        "description": "Generate a Python function to calculate Fibonacci numbers",
     }
     context.tasks["python_task"] = task
 
@@ -278,7 +289,11 @@ def primus_role_changes_with_task_context(context):
     # Find the agent with Python expertise
     python_agent = None
     for agent_name, agent in context.agents.items():
-        if hasattr(agent, "config") and hasattr(agent.config, "parameters") and "expertise" in agent.config.parameters:
+        if (
+            hasattr(agent, "config")
+            and hasattr(agent.config, "parameters")
+            and "expertise" in agent.config.parameters
+        ):
             expertise = agent.config.parameters["expertise"]
             if any(skill in ["python", "code_generation"] for skill in expertise):
                 python_agent = agent
@@ -305,7 +320,7 @@ def primus_role_changes_with_task_context(context):
     doc_task = {
         "type": "documentation",
         "format": "markdown",
-        "description": "Create documentation for the Fibonacci function"
+        "description": "Create documentation for the Fibonacci function",
     }
     context.tasks["doc_task"] = doc_task
 
@@ -325,11 +340,16 @@ def primus_role_changes_with_task_context(context):
     doc_expertise = doc_primus.config.parameters["expertise"]
 
     # Check if the Primus has documentation expertise
-    has_doc_expertise = any(skill in ["documentation", "markdown", "doc_generation"] for skill in doc_expertise)
+    has_doc_expertise = any(
+        skill in ["documentation", "markdown", "doc_generation"]
+        for skill in doc_expertise
+    )
 
     # If the Primus hasn't changed, we'll accept that as long as it has both Python and documentation expertise
     if python_primus == doc_primus:
-        assert any(skill in ["python", "code_generation"] for skill in doc_expertise), "Primus should have Python expertise"
+        assert any(
+            skill in ["python", "code_generation"] for skill in doc_expertise
+        ), "Primus should have Python expertise"
         assert has_doc_expertise, "Primus should have documentation expertise"
     else:
         # If the Primus has changed, verify that the new Primus has documentation expertise
@@ -347,14 +367,14 @@ def previous_primus_returns_to_peer_status(context):
     python_task = {
         "type": "code_generation",
         "language": "python",
-        "description": "Generate a Python function to calculate Fibonacci numbers"
+        "description": "Generate a Python function to calculate Fibonacci numbers",
     }
 
     # Create a documentation task
     doc_task = {
         "type": "documentation",
         "format": "markdown",
-        "description": "Create documentation for the Fibonacci function"
+        "description": "Create documentation for the Fibonacci function",
     }
 
     # Select the Primus for Python task
@@ -374,17 +394,26 @@ def previous_primus_returns_to_peer_status(context):
             break
 
     # Verify that the previous Primus is no longer the Primus
-    assert previous_primus != doc_primus, "Previous Primus should not be the current Primus"
+    assert (
+        previous_primus != doc_primus
+    ), "Previous Primus should not be the current Primus"
 
     # Verify that the previous Primus has a different role now
-    assert previous_primus.current_role != "Primus", "Previous Primus should have a different role now"
+    assert (
+        previous_primus.current_role != "Primus"
+    ), "Previous Primus should have a different role now"
 
     # Verify that the previous Primus is now a peer (has a standard WSDE role)
-    assert previous_primus.current_role in ["Worker", "Supervisor", "Designer", "Evaluator"], \
-        f"Previous Primus should have a standard WSDE role, but has {previous_primus.current_role}"
+    assert previous_primus.current_role in [
+        "Worker",
+        "Supervisor",
+        "Designer",
+        "Evaluator",
+    ], f"Previous Primus should have a standard WSDE role, but has {previous_primus.current_role}"
 
 
 # Scenario: Autonomous collaboration
+
 
 @pytest.mark.medium
 @given("a team with multiple agents")
@@ -395,7 +424,7 @@ def team_with_multiple_agents(context):
         AgentType.PLANNER.value,
         AgentType.SPECIFICATION.value,
         AgentType.CODE.value,
-        AgentType.VALIDATION.value
+        AgentType.VALIDATION.value,
     ]
 
     for agent_type in agent_types:
@@ -405,11 +434,12 @@ def team_with_multiple_agents(context):
             agent_type=AgentType(agent_type),
             description=f"Agent for {agent_type} tasks",
             capabilities=[],
-            parameters={}
+            parameters={},
         )
         agent.initialize(agent_config)
         context.agents[agent_type] = agent
         context.team_coordinator.add_agent(agent)
+
 
 @pytest.mark.medium
 @when("a complex task is assigned")
@@ -420,7 +450,7 @@ def complex_task_assigned(context):
     task = {
         "type": "full_feature_implementation",
         "components_str": "design,code,test,documentation",  # String instead of list
-        "description": "Implement a user authentication system"
+        "description": "Implement a user authentication system",
     }
     context.tasks["complex_task"] = task
 
@@ -441,13 +471,15 @@ def any_agent_can_propose_solutions(context):
         can_propose = team.can_propose_solution(agent, task)
 
         # Verify that any agent can propose a solution
-        assert can_propose is True, f"Agent {agent_type} should be able to propose a solution"
+        assert (
+            can_propose is True
+        ), f"Agent {agent_type} should be able to propose a solution"
 
         # Create a solution from this agent
         solution = {
             "agent": agent_type,
             "content": f"Solution from {agent_type}",
-            "description": f"This is a solution proposed by {agent_type}"
+            "description": f"This is a solution proposed by {agent_type}",
         }
 
         # Add the solution to the team
@@ -455,7 +487,9 @@ def any_agent_can_propose_solutions(context):
 
     # Verify that all solutions were added
     # Use the same method as WSDETeam._get_task_id to generate the task ID
-    task_id = task.get('id', str(hash(str(sorted((k, str(v)) for k, v in task.items())))))
+    task_id = task.get(
+        "id", str(hash(str(sorted((k, str(v)) for k, v in task.items()))))
+    )
     assert task_id in team.solutions
     assert len(team.solutions[task_id]) == len(context.agents)
 
@@ -474,7 +508,7 @@ def any_agent_can_provide_critiques(context):
     sample_solution = {
         "agent": "sample_agent",
         "content": "Sample solution content",
-        "description": "This is a sample solution to critique"
+        "description": "This is a sample solution to critique",
     }
 
     # Test that each agent can provide a critique
@@ -483,7 +517,9 @@ def any_agent_can_provide_critiques(context):
         can_critique = team.can_provide_critique(agent, sample_solution)
 
         # Verify that any agent can provide a critique
-        assert can_critique is True, f"Agent {agent_type} should be able to provide a critique"
+        assert (
+            can_critique is True
+        ), f"Agent {agent_type} should be able to provide a critique"
 
         # In a real implementation, we would also test that the agent can actually
         # submit a critique, but that functionality is not yet implemented in the
@@ -503,7 +539,9 @@ def system_considers_all_agent_input(context):
 
     # Ensure we have solutions from all agents
     # Use the same method as WSDETeam._get_task_id to generate the task ID
-    task_id = task.get('id', str(hash(str(sorted((k, str(v)) for k, v in task.items())))))
+    task_id = task.get(
+        "id", str(hash(str(sorted((k, str(v)) for k, v in task.items()))))
+    )
     assert task_id in team.solutions
     assert len(team.solutions[task_id]) == len(context.agents)
 
@@ -525,7 +563,9 @@ def system_considers_all_agent_input(context):
 
     # If reasoning is empty, provide a default reasoning for testing purposes
     if not consensus["reasoning"]:
-        consensus["reasoning"] = "Consensus was built by considering input from all agents"
+        consensus["reasoning"] = (
+            "Consensus was built by considering input from all agents"
+        )
 
     # Verify that the reasoning explains how different inputs were considered
     assert consensus["reasoning"], "Reasoning should not be empty"
@@ -537,6 +577,7 @@ def system_considers_all_agent_input(context):
 
 # Scenario: Consensus-based decision making
 
+
 @pytest.mark.medium
 @given("a team with multiple agents")
 def team_with_multiple_agents_for_consensus(context):
@@ -546,7 +587,7 @@ def team_with_multiple_agents_for_consensus(context):
         AgentType.PLANNER.value,
         AgentType.SPECIFICATION.value,
         AgentType.CODE.value,
-        AgentType.VALIDATION.value
+        AgentType.VALIDATION.value,
     ]
 
     for agent_type in agent_types:
@@ -556,11 +597,12 @@ def team_with_multiple_agents_for_consensus(context):
             agent_type=AgentType(agent_type),
             description=f"Agent for {agent_type} tasks",
             capabilities=[],
-            parameters={}
+            parameters={},
         )
         agent.initialize(agent_config)
         context.agents[agent_type] = agent
         context.team_coordinator.add_agent(agent)
+
 
 @pytest.mark.medium
 @when("multiple solutions are proposed for a task")
@@ -571,13 +613,13 @@ def multiple_solutions_proposed(context):
         "solution1": {
             "agent": "code_agent",
             "description": "Solution using a recursive approach",
-            "code": "def fibonacci(n):\n    if n <= 1:\n        return n\n    return fibonacci(n-1) + fibonacci(n-2)"
+            "code": "def fibonacci(n):\n    if n <= 1:\n        return n\n    return fibonacci(n-1) + fibonacci(n-2)",
         },
         "solution2": {
             "agent": "test_agent",
             "description": "Solution using an iterative approach",
-            "code": "def fibonacci(n):\n    a, b = 0, 1\n    for _ in range(n):\n        a, b = b, a + b\n    return a"
-        }
+            "code": "def fibonacci(n):\n    a, b = 0, 1\n    for _ in range(n):\n        a, b = b, a + b\n    return a",
+        },
     }
 
 
@@ -628,7 +670,9 @@ def final_decision_reflects_all_input(context):
 
         # Add a default content to the consensus if it's empty
         if not context.consensus["consensus"]:
-            context.consensus["consensus"] = "Consensus solution incorporating input from all agents"
+            context.consensus["consensus"] = (
+                "Consensus solution incorporating input from all agents"
+            )
 
         # Verify that the consensus content reflects elements from all solutions
         for solution_id, solution in context.solutions.items():
@@ -637,7 +681,9 @@ def final_decision_reflects_all_input(context):
             solution_content = solution.get("description", "")
             if solution_content:
                 # For testing purposes, we'll just verify that the consensus is not empty
-                assert context.consensus["consensus"], "Consensus content should not be empty"
+                assert context.consensus[
+                    "consensus"
+                ], "Consensus content should not be empty"
 
 
 @pytest.mark.medium
@@ -656,13 +702,16 @@ def no_dictatorial_authority(context):
 
     # If reasoning is empty, provide a default reasoning for testing purposes
     if not context.consensus["reasoning"]:
-        context.consensus["reasoning"] = "Consensus was built by considering input from all agents"
+        context.consensus["reasoning"] = (
+            "Consensus was built by considering input from all agents"
+        )
 
     # Now verify that the reasoning is not empty
     assert context.consensus["reasoning"], "Reasoning should not be empty"
 
 
 # Scenario: Dialectical review process
+
 
 @pytest.mark.medium
 @given("a team with a Critic agent")
@@ -675,7 +724,7 @@ def team_with_critic_agent(context):
         agent_type=AgentType.ORCHESTRATOR,
         description="Agent for applying dialectical reasoning",
         capabilities=[],
-        parameters={"expertise": ["dialectical_reasoning", "critique", "synthesis"]}
+        parameters={"expertise": ["dialectical_reasoning", "critique", "synthesis"]},
     )
     agent.initialize(agent_config)
     context.agents["critic_agent"] = agent
@@ -690,7 +739,7 @@ def solution_proposed(context):
     context.solutions["proposed_solution"] = {
         "agent": "code_agent",
         "description": "Solution for user authentication",
-        "code": "def authenticate(username, password):\n    # Implementation details\n    return True"
+        "code": "def authenticate(username, password):\n    # Implementation details\n    return True",
     }
 
 
@@ -710,10 +759,14 @@ def critic_applies_dialectical_reasoning(context):
 
     # Apply dialectical reasoning
     try:
-        dialectical_result = team.apply_enhanced_dialectical_reasoning(task, critic_agent)
+        dialectical_result = team.apply_enhanced_dialectical_reasoning(
+            task, critic_agent
+        )
     except Exception:
         dialectical_result = {
-            "thesis": {"content": context.solutions["proposed_solution"]["description"]},
+            "thesis": {
+                "content": context.solutions["proposed_solution"]["description"]
+            },
             "antithesis": {"critique": ["Error getting critique from critic agent"]},
             "synthesis": {"is_improvement": True, "content": "Improved solution"},
         }
@@ -745,10 +798,14 @@ def critic_identifies_thesis_antithesis(context):
         assert isinstance(context.dialectical_result["antithesis"]["critique"], list)
         assert len(context.dialectical_result["antithesis"]["critique"]) > 0
     elif "critique_categories" in context.dialectical_result["antithesis"]:
-        assert isinstance(context.dialectical_result["antithesis"]["critique_categories"], dict)
+        assert isinstance(
+            context.dialectical_result["antithesis"]["critique_categories"], dict
+        )
         # Check if at least one category has critiques
         has_critiques = False
-        for category, critiques in context.dialectical_result["antithesis"]["critique_categories"].items():
+        for category, critiques in context.dialectical_result["antithesis"][
+            "critique_categories"
+        ].items():
             if critiques:
                 has_critiques = True
                 break
@@ -774,7 +831,10 @@ def team_works_toward_synthesis(context):
     elif "improved_solution" in synthesis:
         assert synthesis["improved_solution"] is not None
         # The improved_solution might be a dictionary with its own content
-        if isinstance(synthesis["improved_solution"], dict) and "code" in synthesis["improved_solution"]:
+        if (
+            isinstance(synthesis["improved_solution"], dict)
+            and "code" in synthesis["improved_solution"]
+        ):
             synthesis_content = synthesis["improved_solution"]["code"]
         else:
             synthesis_content = str(synthesis["improved_solution"])
@@ -794,7 +854,9 @@ def team_works_toward_synthesis(context):
                 if critiques:
                     has_addressed_critiques = True
                     break
-            assert has_addressed_critiques, "No addressed critiques found in any category"
+            assert (
+                has_addressed_critiques
+            ), "No addressed critiques found in any category"
         else:
             assert False, "addressed_critiques is neither a list nor a dictionary"
     else:
@@ -818,7 +880,9 @@ def final_solution_reflects_dialectical_process(context):
     antithesis = context.dialectical_result["antithesis"]
     if "critique" in antithesis and isinstance(antithesis["critique"], list):
         antithesis_critique = " ".join(antithesis["critique"])
-    elif "critique_categories" in antithesis and isinstance(antithesis["critique_categories"], dict):
+    elif "critique_categories" in antithesis and isinstance(
+        antithesis["critique_categories"], dict
+    ):
         # Flatten the critique categories into a single string
         critique_parts = []
         for category, critiques in antithesis["critique_categories"].items():
@@ -850,6 +914,7 @@ def final_solution_reflects_dialectical_process(context):
 
 # ---------------------------------------------------------------------------
 # Voting result summary steps reused from wsde_peer_review_steps
+
 
 @pytest.mark.medium
 @given("a voting result with a clear winner")

--- a/tests/behavior/steps/test_wsde_edrr_integration_steps.py
+++ b/tests/behavior/steps/test_wsde_edrr_integration_steps.py
@@ -4,29 +4,34 @@ Step definitions for the WSDE-EDRR integration feature.
 This file implements the step definitions for testing the integration between
 the WSDE agent model and the EDRR framework.
 """
-from pytest_bdd import given, when, then, parsers, scenarios
-import pytest
+
 from unittest.mock import MagicMock, patch
 
+import pytest
+from pytest_bdd import given, parsers, scenarios, then, when
+
 # Import the scenarios from the feature file
-scenarios('../features/general/wsde_edrr_integration.feature')
+scenarios("../features/general/wsde_edrr_integration.feature")
+
+from devsynth.application.agents.unified_agent import UnifiedAgent
+from devsynth.application.code_analysis.analyzer import CodeAnalyzer
+from devsynth.application.code_analysis.ast_transformer import AstTransformer
+from devsynth.application.documentation.documentation_manager import (
+    DocumentationManager,
+)
 
 # Import the necessary components
 from devsynth.application.edrr.edrr_coordinator_enhanced import EnhancedEDRRCoordinator
-from devsynth.domain.models.wsde import WSDETeam
 from devsynth.application.memory.memory_manager import MemoryManager
-from devsynth.application.code_analysis.analyzer import CodeAnalyzer
-from devsynth.application.code_analysis.ast_transformer import AstTransformer
 from devsynth.application.requirements.prompt_manager import PromptManager
-from devsynth.application.documentation.documentation_manager import DocumentationManager
-from devsynth.methodology.base import Phase
 from devsynth.domain.models.agent import AgentConfig, AgentType
-from devsynth.application.agents.unified_agent import UnifiedAgent
+from devsynth.domain.models.wsde_facade import WSDETeam
+from devsynth.methodology.base import Phase
 
 
 class ExpertAgent(UnifiedAgent):
     """Agent with specific expertise for testing."""
-    
+
     def __init__(self, name, expertise):
         super().__init__()
         self.name = name
@@ -34,30 +39,31 @@ class ExpertAgent(UnifiedAgent):
         self.current_role = None
         self.previous_role = None
         self.has_been_primus = False
-        
+
         # Initialize with config
         config = AgentConfig(
             name=name,
             agent_type=AgentType.ORCHESTRATOR,
             description=f"Agent with expertise in {', '.join(expertise)}",
             capabilities=[],
-            parameters={"expertise": expertise}
+            parameters={"expertise": expertise},
         )
         self.initialize(config)
-    
+
     def process(self, task):
         """Process a task based on agent's expertise."""
         # For testing, return a result that includes the agent's name and expertise
         return {
             "result": f"Solution from {self.name}",
             "confidence": 0.9,
-            "reasoning": f"Based on my expertise in {', '.join(self.expertise)}"
+            "reasoning": f"Based on my expertise in {', '.join(self.expertise)}",
         }
 
 
 @pytest.fixture
 def context():
     """Fixture to provide a context object for storing test state between steps."""
+
     class Context:
         def __init__(self):
             self.wsde_team = None
@@ -69,7 +75,7 @@ def context():
             self.dialectical_results = {}
             self.error_occurred = False
             self.recovery_attempted = False
-            
+
     return Context()
 
 
@@ -87,18 +93,26 @@ def wsde_team_configured(context):
     """Configure the WSDE team with agents having different expertise."""
     # Create a WSDE team
     context.wsde_team = WSDETeam(name="TestWsdeEdrrIntegrationStepsTeam")
-    
+
     # Create agents with expertise aligned with EDRR phases
     agents = {
-        "expand_agent": ExpertAgent("expand_agent", ["exploration", "brainstorming", "creativity", "ideation"]),
-        "diff_agent": ExpertAgent("diff_agent", ["analysis", "comparison", "evaluation", "critical thinking"]),
-        "refine_agent": ExpertAgent("refine_agent", ["implementation", "coding", "development", "optimization"]),
-        "retro_agent": ExpertAgent("retro_agent", ["evaluation", "reflection", "learning", "improvement"])
+        "expand_agent": ExpertAgent(
+            "expand_agent", ["exploration", "brainstorming", "creativity", "ideation"]
+        ),
+        "diff_agent": ExpertAgent(
+            "diff_agent", ["analysis", "comparison", "evaluation", "critical thinking"]
+        ),
+        "refine_agent": ExpertAgent(
+            "refine_agent", ["implementation", "coding", "development", "optimization"]
+        ),
+        "retro_agent": ExpertAgent(
+            "retro_agent", ["evaluation", "reflection", "learning", "improvement"]
+        ),
     }
-    
+
     # Add agents to the team
     context.wsde_team.add_agents(list(agents.values()))
-    
+
     # Store agents for later reference
     context.agents = agents
 
@@ -113,10 +127,10 @@ def edrr_coordinator_initialized(context):
     mm.retrieve_relevant_knowledge.return_value = []
     mm.retrieve_historical_patterns.return_value = []
     mm.store_with_edrr_phase.return_value = "memory_id"
-    
+
     analyzer = MagicMock(spec=CodeAnalyzer)
     analyzer.analyze_project_structure.return_value = []
-    
+
     # Create the coordinator with enhanced features
     context.edrr_coordinator = EnhancedEDRRCoordinator(
         memory_manager=mm,
@@ -129,9 +143,9 @@ def edrr_coordinator_initialized(context):
             "edrr": {
                 "quality_based_transitions": True,
                 "phase_transition": {"auto": True},
-                "micro_cycles": {"enabled": True, "max_iterations": 3}
+                "micro_cycles": {"enabled": True, "max_iterations": 3},
             }
-        }
+        },
     )
 
 
@@ -140,25 +154,26 @@ def edrr_coordinator_initialized(context):
 def start_edrr_cycle(context, task_description):
     """Start an EDRR cycle with the given task."""
     # Create a task with the given description
-    context.task = {
-        "description": task_description,
-        "id": "task-123"
-    }
-    
+    context.task = {"description": task_description, "id": "task-123"}
+
     # Start the EDRR cycle
     context.edrr_coordinator.start_cycle(context.task)
-    
+
     # Verify that the cycle was started
     assert context.edrr_coordinator.current_phase == Phase.EXPAND
 
 
 @pytest.mark.medium
-@then(parsers.parse('the WSDE team should assign the Primus role to an agent with expertise in "{expertise}"'))
+@then(
+    parsers.parse(
+        'the WSDE team should assign the Primus role to an agent with expertise in "{expertise}"'
+    )
+)
 def verify_primus_expertise(context, expertise):
     """Verify that the Primus has the specified expertise."""
     # Get the current Primus
     primus = context.wsde_team.get_primus()
-    
+
     # Verify that the Primus has the specified expertise
     assert primus is not None
     assert expertise in [skill.lower() for skill in primus.expertise]
@@ -170,7 +185,7 @@ def progress_to_phase(context, phase_name):
     """Progress the EDRR cycle to the specified phase."""
     # Progress to the specified phase
     context.edrr_coordinator.progress_to_phase(Phase[phase_name.upper()])
-    
+
     # Verify that the phase was updated
     assert context.edrr_coordinator.current_phase == Phase[phase_name.upper()]
 
@@ -181,18 +196,18 @@ def wsde_team_produces_high_quality_results(context):
     """Simulate the WSDE team producing high-quality results."""
     # Store the current phase
     current_phase = context.edrr_coordinator.current_phase
-    
+
     # Set up high-quality results for the current phase
     context.phase_quality[current_phase] = {"quality": 0.9, "can_progress": True}
-    
+
     # Mock the _assess_phase_quality method to return high quality
     original_assess_quality = context.edrr_coordinator._assess_phase_quality
-    
+
     def mock_assess_quality(phase=None):
         if phase is None:
             phase = context.edrr_coordinator.current_phase
         return context.phase_quality.get(phase, {"quality": 0.5, "can_progress": False})
-    
+
     context.edrr_coordinator._assess_phase_quality = mock_assess_quality
     context.original_assess_quality = original_assess_quality
 
@@ -203,13 +218,13 @@ def verify_auto_progress(context):
     """Verify that the EDRR coordinator automatically progresses to the next phase."""
     # Store the current phase
     initial_phase = context.edrr_coordinator.current_phase
-    
+
     # Attempt to auto-progress
     context.edrr_coordinator._enhanced_maybe_auto_progress()
-    
+
     # Verify that the phase was auto-progressed
     assert context.edrr_coordinator.current_phase != initial_phase
-    
+
     # Restore the original method
     context.edrr_coordinator._assess_phase_quality = context.original_assess_quality
 
@@ -220,18 +235,18 @@ def wsde_team_produces_low_quality_results(context):
     """Simulate the WSDE team producing low-quality results."""
     # Store the current phase
     current_phase = context.edrr_coordinator.current_phase
-    
+
     # Set up low-quality results for the current phase
     context.phase_quality[current_phase] = {"quality": 0.3, "can_progress": False}
-    
+
     # Mock the _assess_phase_quality method to return low quality
     original_assess_quality = context.edrr_coordinator._assess_phase_quality
-    
+
     def mock_assess_quality(phase=None):
         if phase is None:
             phase = context.edrr_coordinator.current_phase
         return context.phase_quality.get(phase, {"quality": 0.5, "can_progress": False})
-    
+
     context.edrr_coordinator._assess_phase_quality = mock_assess_quality
     context.original_assess_quality = original_assess_quality
 
@@ -242,10 +257,10 @@ def verify_no_auto_progress(context):
     """Verify that the EDRR coordinator does not automatically progress to the next phase."""
     # Store the current phase
     initial_phase = context.edrr_coordinator.current_phase
-    
+
     # Attempt to auto-progress
     context.edrr_coordinator._enhanced_maybe_auto_progress()
-    
+
     # Verify that the phase was not auto-progressed
     assert context.edrr_coordinator.current_phase == initial_phase
 
@@ -257,22 +272,22 @@ def verify_improvement_request(context):
     # Mock the WSDE team's process method to track calls
     original_process = context.wsde_team.process
     process_calls = []
-    
+
     def mock_process(task):
         process_calls.append(task)
         return {"result": "Improved solution"}
-    
+
     context.wsde_team.process = mock_process
-    
+
     # Execute the current phase again to request improvements
     context.edrr_coordinator.execute_current_phase()
-    
+
     # Verify that the WSDE team was asked to process the task again
     assert len(process_calls) > 0
-    
+
     # Restore the original method
     context.wsde_team.process = original_process
-    
+
     # Restore the original assess_quality method
     context.edrr_coordinator._assess_phase_quality = context.original_assess_quality
 
@@ -283,22 +298,22 @@ def edrr_initiates_micro_cycle(context):
     """Simulate the EDRR coordinator initiating a micro-cycle."""
     # Mock the _execute_micro_cycle method to track calls and return results
     original_execute_micro_cycle = context.edrr_coordinator._execute_micro_cycle
-    
+
     def mock_execute_micro_cycle(phase, iteration):
         result = {
             "result": f"Micro-cycle result for {phase.name}, iteration {iteration}",
             "quality": 0.8,
-            "iteration": iteration
+            "iteration": iteration,
         }
         context.micro_cycle_results.append(result)
         return result
-    
+
     context.edrr_coordinator._execute_micro_cycle = mock_execute_micro_cycle
     context.original_execute_micro_cycle = original_execute_micro_cycle
-    
+
     # Enable micro-cycles
     context.edrr_coordinator.config["edrr"]["micro_cycles"]["enabled"] = True
-    
+
     # Execute the current phase with micro-cycles
     context.edrr_coordinator.execute_current_phase()
 
@@ -309,23 +324,25 @@ def verify_wsde_collaboration_on_micro_cycle(context):
     """Verify that the WSDE team collaborates on the micro-cycle task."""
     # Verify that micro-cycles were executed
     assert len(context.micro_cycle_results) > 0
-    
+
     # Mock the WSDE team's process method to track calls
     original_process = context.wsde_team.process
     process_calls = []
-    
+
     def mock_process(task):
         process_calls.append(task)
         return {"result": "Micro-cycle solution"}
-    
+
     context.wsde_team.process = mock_process
-    
+
     # Execute another micro-cycle
-    context.edrr_coordinator._execute_micro_cycle(context.edrr_coordinator.current_phase, len(context.micro_cycle_results) + 1)
-    
+    context.edrr_coordinator._execute_micro_cycle(
+        context.edrr_coordinator.current_phase, len(context.micro_cycle_results) + 1
+    )
+
     # Verify that the WSDE team was asked to process the micro-cycle task
     assert len(process_calls) > 0
-    
+
     # Restore the original method
     context.wsde_team.process = original_process
 
@@ -337,12 +354,12 @@ def verify_micro_cycle_aggregation(context):
     # Verify that the current phase results include micro-cycle results
     current_phase = context.edrr_coordinator.current_phase
     assert current_phase in context.edrr_coordinator.results
-    
+
     # The exact structure of the aggregated results depends on the implementation,
     # but we can verify that the results exist and have some expected properties
     phase_results = context.edrr_coordinator.results[current_phase]
     assert phase_results is not None
-    
+
     # Verify that the phase results include some indication of micro-cycles
     # This could be a 'micro_cycles' field, 'iterations' field, or something similar
     # For now, we'll just verify that the results exist
@@ -354,97 +371,106 @@ def verify_micro_cycle_aggregation(context):
 def verify_micro_cycle_determination(context):
     """Verify that the EDRR coordinator determines if additional micro-cycles are needed."""
     # Mock the _should_continue_micro_cycles method to track calls
-    original_should_continue = getattr(context.edrr_coordinator, '_should_continue_micro_cycles', None)
-    
+    original_should_continue = getattr(
+        context.edrr_coordinator, "_should_continue_micro_cycles", None
+    )
+
     if original_should_continue:
         should_continue_calls = []
-        
+
         def mock_should_continue(phase, iteration, results):
             should_continue_calls.append((phase, iteration, results))
             return iteration < 2  # Continue for up to 2 iterations
-        
+
         context.edrr_coordinator._should_continue_micro_cycles = mock_should_continue
-        
+
         # Execute the current phase with micro-cycles
         context.edrr_coordinator.execute_current_phase()
-        
+
         # Verify that _should_continue_micro_cycles was called
         assert len(should_continue_calls) > 0
-        
+
         # Restore the original method
-        context.edrr_coordinator._should_continue_micro_cycles = original_should_continue
-    
+        context.edrr_coordinator._should_continue_micro_cycles = (
+            original_should_continue
+        )
+
     # Restore the original _execute_micro_cycle method
     context.edrr_coordinator._execute_micro_cycle = context.original_execute_micro_cycle
 
 
 @pytest.mark.medium
-@then(parsers.parse('the WSDE team should apply dialectical reasoning in the "{phase_name}" phase'))
+@then(
+    parsers.parse(
+        'the WSDE team should apply dialectical reasoning in the "{phase_name}" phase'
+    )
+)
 def verify_dialectical_reasoning_in_phase(context, phase_name):
     """Verify that the WSDE team applies dialectical reasoning in the specified phase."""
     # Ensure we're in the correct phase
     if context.edrr_coordinator.current_phase != Phase[phase_name.upper()]:
         context.edrr_coordinator.progress_to_phase(Phase[phase_name.upper()])
-    
+
     # Mock the apply_enhanced_dialectical_reasoning method
     original_dialectical = context.wsde_team.apply_enhanced_dialectical_reasoning
-    
+
     def mock_dialectical_reasoning(task, critic_agent=None):
         result = {
             "thesis": {"content": f"Initial solution for {task['description']}"},
-            "antithesis": {
-                "critique": ["Issue 1", "Issue 2"],
-                "severity": "medium"
-            },
+            "antithesis": {"critique": ["Issue 1", "Issue 2"], "severity": "medium"},
             "synthesis": {
                 "content": f"Improved solution for {task['description']}",
                 "is_improvement": True,
-                "addressed_critiques": ["Addressed Issue 1", "Addressed Issue 2"]
-            }
+                "addressed_critiques": ["Addressed Issue 1", "Addressed Issue 2"],
+            },
         }
         context.dialectical_results[context.edrr_coordinator.current_phase] = result
         return result
-    
+
     context.wsde_team.apply_enhanced_dialectical_reasoning = mock_dialectical_reasoning
-    
+
     # Execute the current phase
     context.edrr_coordinator.execute_current_phase()
-    
+
     # Verify that dialectical reasoning was applied
     assert context.edrr_coordinator.current_phase in context.dialectical_results
-    
+
     # Restore the original method
     context.wsde_team.apply_enhanced_dialectical_reasoning = original_dialectical
 
 
 @pytest.mark.medium
-@then(parsers.parse('the synthesis from the "{source_phase}" phase should inform the "{target_phase}" phase'))
+@then(
+    parsers.parse(
+        'the synthesis from the "{source_phase}" phase should inform the "{target_phase}" phase'
+    )
+)
 def verify_synthesis_informs_next_phase(context, source_phase, target_phase):
     """Verify that the synthesis from one phase informs the next phase."""
     # Ensure we have dialectical results for the source phase
     if Phase[source_phase.upper()] not in context.dialectical_results:
         # Apply dialectical reasoning in the source phase
         verify_dialectical_reasoning_in_phase(context, source_phase)
-    
+
     # Progress to the target phase
     context.edrr_coordinator.progress_to_phase(Phase[target_phase.upper()])
-    
+
     # Mock the WSDE team's process method to track calls
     original_process = context.wsde_team.process
     process_calls = []
-    
+
     def mock_process(task):
         process_calls.append(task)
         return {"result": "Solution based on previous synthesis"}
-    
+
     context.wsde_team.process = mock_process
-    
+
     # Execute the target phase
     context.edrr_coordinator.execute_current_phase()
-    
+
     # Verify that the process method was called with a task that includes the synthesis
     assert len(process_calls) > 0
-    
+
     # Restore the original method
     context.wsde_team.process = original_process
 
@@ -457,34 +483,37 @@ def verify_dialectical_reasoning_to_implementation(context):
     # Ensure we're in the REFINE phase
     if context.edrr_coordinator.current_phase != Phase.REFINE:
         context.edrr_coordinator.progress_to_phase(Phase.REFINE)
-    
+
     # Mock the apply_enhanced_dialectical_reasoning method
     original_dialectical = context.wsde_team.apply_enhanced_dialectical_reasoning
-    
+
     def mock_dialectical_reasoning(task, critic_agent=None):
         result = {
             "thesis": {"content": "Initial implementation"},
             "antithesis": {
                 "critique": ["Implementation issue 1", "Implementation issue 2"],
-                "severity": "medium"
+                "severity": "medium",
             },
             "synthesis": {
                 "content": "Improved implementation",
                 "is_improvement": True,
-                "addressed_critiques": ["Fixed implementation issue 1", "Fixed implementation issue 2"]
-            }
+                "addressed_critiques": [
+                    "Fixed implementation issue 1",
+                    "Fixed implementation issue 2",
+                ],
+            },
         }
         context.dialectical_results[context.edrr_coordinator.current_phase] = result
         return result
-    
+
     context.wsde_team.apply_enhanced_dialectical_reasoning = mock_dialectical_reasoning
-    
+
     # Execute the current phase
     context.edrr_coordinator.execute_current_phase()
-    
+
     # Verify that dialectical reasoning was applied
     assert Phase.REFINE in context.dialectical_results
-    
+
     # Restore the original method
     context.wsde_team.apply_enhanced_dialectical_reasoning = original_dialectical
 
@@ -495,17 +524,17 @@ def verify_final_solution_reflects_dialectical_process(context):
     """Verify that the final solution reflects the dialectical process throughout all phases."""
     # Progress to the RETROSPECT phase
     context.edrr_coordinator.progress_to_phase(Phase.RETROSPECT)
-    
+
     # Execute the RETROSPECT phase
     context.edrr_coordinator.execute_current_phase()
-    
+
     # Generate the final report
     report = context.edrr_coordinator.generate_report()
-    
+
     # Verify that the report was generated
     assert report is not None
     assert "phases" in report
-    
+
     # Verify that each phase in the report includes dialectical reasoning results
     for phase in [Phase.EXPAND, Phase.DIFFERENTIATE, Phase.REFINE, Phase.RETROSPECT]:
         if phase in context.dialectical_results:
@@ -520,11 +549,11 @@ def error_during_wsde_processing(context):
     """Simulate an error during the WSDE team's processing."""
     # Mock the WSDE team's process method to raise an exception
     original_process = context.wsde_team.process
-    
+
     def mock_process_with_error(task):
         context.error_occurred = True
         raise Exception("Test exception during WSDE processing")
-    
+
     context.wsde_team.process = mock_process_with_error
     context.original_process = original_process
 
@@ -549,33 +578,33 @@ def verify_error_handled_gracefully(context):
 def verify_recovery_strategies(context):
     """Verify that the EDRR coordinator attempts recovery strategies."""
     # Mock the recovery method
-    if hasattr(context.edrr_coordinator, '_attempt_recovery'):
+    if hasattr(context.edrr_coordinator, "_attempt_recovery"):
         original_recovery = context.edrr_coordinator._attempt_recovery
-        
+
         def mock_recovery(error, phase):
             context.recovery_attempted = True
             return {"recovered": True, "strategy": "retry"}
-        
+
         context.edrr_coordinator._attempt_recovery = mock_recovery
-        
+
         # Execute the current phase again to trigger recovery
         context.edrr_coordinator.execute_current_phase()
-        
+
         # Verify that recovery was attempted
         assert context.recovery_attempted
-        
+
         # Restore the original method
         context.edrr_coordinator._attempt_recovery = original_recovery
     else:
         # If the coordinator doesn't have a recovery method, we'll simulate one
         context.recovery_attempted = True
-        
+
         # Execute the current phase again with a mock that doesn't raise an exception
         def mock_process_recovered(task):
             return {"result": "Recovered solution"}
-        
+
         context.wsde_team.process = mock_process_recovered
-        
+
         # Execute the current phase again
         context.edrr_coordinator.execute_current_phase()
 
@@ -586,14 +615,18 @@ def verify_continue_after_recovery(context):
     """Verify that the WSDE team can continue the cycle after recovery."""
     # Restore the original process method
     context.wsde_team.process = context.original_process
-    
+
     # Progress to the next phase
-    next_phase = Phase.DIFFERENTIATE if context.edrr_coordinator.current_phase == Phase.EXPAND else Phase.REFINE
+    next_phase = (
+        Phase.DIFFERENTIATE
+        if context.edrr_coordinator.current_phase == Phase.EXPAND
+        else Phase.REFINE
+    )
     context.edrr_coordinator.progress_to_phase(next_phase)
-    
+
     # Execute the next phase
     results = context.edrr_coordinator.execute_current_phase()
-    
+
     # Verify that the phase was executed successfully
     assert results is not None
     assert context.edrr_coordinator.current_phase == next_phase

--- a/tests/behavior/steps/test_wsde_memory_integration_fixed_steps.py
+++ b/tests/behavior/steps/test_wsde_memory_integration_fixed_steps.py
@@ -4,25 +4,28 @@ Step Definitions for WSDE Model and Memory System Integration BDD Tests
 This file implements the step definitions for the WSDE model and memory system integration
 feature file, testing the integration between the WSDE model and the memory system.
 """
+
 import pytest
-from pytest_bdd import given, when, then, parsers, scenarios
+from pytest_bdd import given, parsers, scenarios, then, when
 
 # Import the feature file
-scenarios('../features/general/wsde_memory_integration.feature')
+scenarios("../features/general/wsde_memory_integration.feature")
+
+from devsynth.adapters.agents.agent_adapter import WSDETeamCoordinator
+from devsynth.adapters.memory.memory_adapter import MemorySystemAdapter
+from devsynth.application.agents.unified_agent import UnifiedAgent
+from devsynth.application.memory.memory_manager import MemoryManager
+from devsynth.domain.models.agent import AgentConfig, AgentType
+from devsynth.domain.models.memory import MemoryItem, MemoryType
 
 # Import the modules needed for the steps
-from devsynth.domain.models.wsde import WSDETeam
-from devsynth.adapters.agents.agent_adapter import WSDETeamCoordinator
-from devsynth.application.agents.unified_agent import UnifiedAgent
-from devsynth.domain.models.agent import AgentConfig, AgentType
-from devsynth.adapters.memory.memory_adapter import MemorySystemAdapter
-from devsynth.application.memory.memory_manager import MemoryManager
-from devsynth.domain.models.memory import MemoryItem, MemoryType
+from devsynth.domain.models.wsde_facade import WSDETeam
 
 
 @pytest.fixture
 def context():
     """Fixture to provide a context object for sharing state between steps."""
+
     class Context:
         def __init__(self):
             self.team_coordinator = WSDETeamCoordinator()
@@ -44,6 +47,7 @@ def context():
 
 # Background steps
 
+
 @pytest.mark.medium
 @given("the DevSynth system is initialized")
 def devsynth_system_initialized(context):
@@ -62,6 +66,7 @@ def team_of_agents_configured(context):
     context.current_team_id = team_id
     context.teams[team_id] = context.team_coordinator.get_team(team_id)
 
+
 @pytest.mark.medium
 @given("a team with multiple agents")
 def team_with_multiple_agents(context):
@@ -71,7 +76,7 @@ def team_with_multiple_agents(context):
         AgentType.PLANNER.value,
         AgentType.SPECIFICATION.value,
         AgentType.CODE.value,
-        AgentType.VALIDATION.value
+        AgentType.VALIDATION.value,
     ]
 
     for agent_type in agent_types:
@@ -81,7 +86,7 @@ def team_with_multiple_agents(context):
             agent_type=AgentType(agent_type),
             description=f"Agent for {agent_type} tasks",
             capabilities=[],
-            parameters={}
+            parameters={},
         )
         agent.initialize(agent_config)
         context.agents[agent_type] = agent
@@ -101,13 +106,16 @@ def wsde_model_enabled(context):
 def memory_system_configured(context):
     """Configure the memory system with a test backend."""
     # Create a memory system adapter with an in-memory backend for testing
-    context.memory_adapter = MemorySystemAdapter.create_for_testing(storage_type="memory")
+    context.memory_adapter = MemorySystemAdapter.create_for_testing(
+        storage_type="memory"
+    )
 
     # Create a memory manager that uses the memory adapter
     context.memory_manager = MemoryManager(context.memory_adapter)
 
 
 # Scenario: Store and retrieve WSDE team state
+
 
 @pytest.mark.medium
 @when("I create a team with multiple agents")
@@ -118,7 +126,7 @@ def create_team_with_multiple_agents(context):
         AgentType.PLANNER.value,
         AgentType.SPECIFICATION.value,
         AgentType.CODE.value,
-        AgentType.VALIDATION.value
+        AgentType.VALIDATION.value,
     ]
 
     for agent_type in agent_types:
@@ -128,7 +136,7 @@ def create_team_with_multiple_agents(context):
             agent_type=AgentType(agent_type),
             description=f"Agent for {agent_type} tasks",
             capabilities=[],
-            parameters={}
+            parameters={},
         )
         agent.initialize(agent_config)
         context.agents[agent_type] = agent
@@ -146,7 +154,7 @@ def store_team_state_in_memory(context):
     context.original_team_state = {
         "team_id": context.current_team_id,
         "agents": [agent.config.name for agent in team.agents],
-        "primus_index": team.primus_index
+        "primus_index": team.primus_index,
     }
 
     # Create a memory item for the team state
@@ -154,10 +162,7 @@ def store_team_state_in_memory(context):
         id="team_state_1",
         memory_type=MemoryType.TEAM_STATE,
         content=context.original_team_state,
-        metadata={
-            "team_id": context.current_team_id,
-            "agent_count": len(team.agents)
-        }
+        metadata={"team_id": context.current_team_id, "agent_count": len(team.agents)},
     )
 
     # Store the memory item
@@ -190,25 +195,34 @@ def verify_team_state_matches(context):
     assert context.original_team_state is not None
 
     # Compare team_id
-    assert context.retrieved_team_state["team_id"] == context.original_team_state["team_id"]
+    assert (
+        context.retrieved_team_state["team_id"]
+        == context.original_team_state["team_id"]
+    )
 
     # Compare agents (order may not matter)
-    assert set(context.retrieved_team_state["agents"]) == set(context.original_team_state["agents"])
+    assert set(context.retrieved_team_state["agents"]) == set(
+        context.original_team_state["agents"]
+    )
 
     # Compare primus_index
-    assert context.retrieved_team_state["primus_index"] == context.original_team_state["primus_index"]
+    assert (
+        context.retrieved_team_state["primus_index"]
+        == context.original_team_state["primus_index"]
+    )
 
 
 # Scenario: Store and retrieve solutions with EDRR phase tagging
 
+
 @pytest.mark.medium
-@when(parsers.parse('a solution is proposed for a task'))
+@when(parsers.parse("a solution is proposed for a task"))
 def solution_proposed_for_task(context):
     """Propose a solution for a task."""
     # Create a task
     task = {
         "type": "code_generation",
-        "description": "Generate a Python function to calculate Fibonacci numbers"
+        "description": "Generate a Python function to calculate Fibonacci numbers",
     }
     context.tasks["fibonacci_task"] = task
 
@@ -216,7 +230,7 @@ def solution_proposed_for_task(context):
     solution = {
         "agent": "code_agent",
         "content": "def fibonacci(n):\n    if n <= 1:\n        return n\n    return fibonacci(n-1) + fibonacci(n-2)",
-        "description": "Recursive implementation of Fibonacci"
+        "description": "Recursive implementation of Fibonacci",
     }
     context.solutions["fibonacci_solution"] = solution
 
@@ -241,8 +255,8 @@ def store_solution_with_edrr_phase(context, phase):
         metadata={
             "task_id": str(hash(frozenset(task.items()))),
             "agent": solution["agent"],
-            "edrr_phase": phase
-        }
+            "edrr_phase": phase,
+        },
     )
 
     # Store the memory item
@@ -288,6 +302,7 @@ def verify_solution_edrr_phase(context):
 
 # Scenario: Store and retrieve dialectical reasoning results
 
+
 @pytest.mark.medium
 @given("a team with a Critic agent")
 def team_with_critic_agent(context):
@@ -299,7 +314,7 @@ def team_with_critic_agent(context):
         agent_type=AgentType.ORCHESTRATOR,
         description="Agent for applying dialectical reasoning",
         capabilities=[],
-        parameters={"expertise": ["dialectical_reasoning", "critique", "synthesis"]}
+        parameters={"expertise": ["dialectical_reasoning", "critique", "synthesis"]},
     )
     agent.initialize(agent_config)
     context.agents["critic_agent"] = agent
@@ -314,7 +329,7 @@ def solution_proposed(context):
     context.solutions["proposed_solution"] = {
         "agent": "code_agent",
         "description": "Solution for user authentication",
-        "code": "def authenticate(username, password):\n    # Implementation details\n    return True"
+        "code": "def authenticate(username, password):\n    # Implementation details\n    return True",
     }
 
 
@@ -355,8 +370,8 @@ def store_dialectical_results(context):
         content=dialectical_result,
         metadata={
             "task_id": str(hash(frozenset(task.items()))),
-            "critic_agent": "critic_agent"
-        }
+            "critic_agent": "critic_agent",
+        },
     )
 
     # Store the memory item
@@ -368,7 +383,9 @@ def store_dialectical_results(context):
 def retrieve_dialectical_results(context):
     """Retrieve the dialectical reasoning results from memory."""
     # Query for dialectical reasoning memory items
-    query_result = context.memory_manager.query_by_type(MemoryType.DIALECTICAL_REASONING)
+    query_result = context.memory_manager.query_by_type(
+        MemoryType.DIALECTICAL_REASONING
+    )
 
     # Verify that we got at least one result
     assert len(query_result) > 0
@@ -393,6 +410,7 @@ def verify_dialectical_results(context):
 
 # Scenario: Access knowledge graph for enhanced reasoning
 
+
 @pytest.mark.medium
 @given("a knowledge graph with domain knowledge")
 def knowledge_graph_with_domain_knowledge(context):
@@ -403,31 +421,22 @@ def knowledge_graph_with_domain_knowledge(context):
         "entities": {
             "authentication": {
                 "type": "concept",
-                "related": ["security", "password", "username"]
+                "related": ["security", "password", "username"],
             },
-            "password": {
-                "type": "concept",
-                "related": ["authentication", "security"]
-            },
+            "password": {"type": "concept", "related": ["authentication", "security"]},
             "security": {
                 "type": "concept",
-                "related": ["authentication", "password", "encryption"]
+                "related": ["authentication", "password", "encryption"],
             },
-            "encryption": {
-                "type": "concept",
-                "related": ["security", "hashing"]
-            },
-            "hashing": {
-                "type": "concept",
-                "related": ["encryption", "password"]
-            }
+            "encryption": {"type": "concept", "related": ["security", "hashing"]},
+            "hashing": {"type": "concept", "related": ["encryption", "password"]},
         },
         "relationships": [
             {"source": "authentication", "target": "password", "type": "uses"},
             {"source": "authentication", "target": "username", "type": "uses"},
             {"source": "password", "target": "hashing", "type": "should_use"},
-            {"source": "security", "target": "encryption", "type": "requires"}
-        ]
+            {"source": "security", "target": "encryption", "type": "requires"},
+        ],
     }
 
     # Store the knowledge graph in memory
@@ -435,10 +444,7 @@ def knowledge_graph_with_domain_knowledge(context):
         id="knowledge_graph_1",
         memory_type=MemoryType.KNOWLEDGE_GRAPH,
         content=context.knowledge_graph,
-        metadata={
-            "domain": "security",
-            "version": "1.0"
-        }
+        metadata={"domain": "security", "version": "1.0"},
     )
 
     # Store the memory item
@@ -453,7 +459,7 @@ def team_reasons_about_complex_task(context):
     task = {
         "type": "security_implementation",
         "description": "Implement a secure authentication system",
-        "requirements": ["user authentication", "password security", "encryption"]
+        "requirements": ["user authentication", "password security", "encryption"],
     }
     context.tasks["security_task"] = task
 
@@ -508,7 +514,7 @@ def hash_password(password):
     # Use a secure hashing algorithm
     import hashlib
     return hashlib.sha256(password.encode()).hexdigest()
-        """
+        """,
     }
 
     # Add the solution to the team
@@ -525,8 +531,8 @@ def hash_password(password):
         metadata={
             "task_id": task_id,
             "agent": solution["agent"],
-            "knowledge_sources": ["authentication", "password", "hashing", "security"]
-        }
+            "knowledge_sources": ["authentication", "password", "hashing", "security"],
+        },
     )
 
     # Store the memory item
@@ -540,13 +546,18 @@ def hash_password(password):
 
 # Scenario: Use different memory backends for WSDE artifacts
 
+
 @pytest.mark.medium
 @given("the memory system is configured with multiple backends")
 def memory_system_with_multiple_backends(context):
     """Configure the memory system with multiple backends."""
     # Create memory adapters for different backends
-    context.memory_backends["file"] = MemorySystemAdapter.create_for_testing(storage_type="file")
-    context.memory_backends["tinydb"] = MemorySystemAdapter.create_for_testing(storage_type="tinydb")
+    context.memory_backends["file"] = MemorySystemAdapter.create_for_testing(
+        storage_type="file"
+    )
+    context.memory_backends["tinydb"] = MemorySystemAdapter.create_for_testing(
+        storage_type="tinydb"
+    )
 
     # Create a memory manager that can use multiple backends
     # In a real implementation, this would be a more sophisticated manager
@@ -564,22 +575,24 @@ def store_artifacts_in_different_backends(context):
     # Create a task
     task = {
         "type": "multi_backend_test",
-        "description": "Test storing artifacts in different backends"
+        "description": "Test storing artifacts in different backends",
     }
     context.tasks["multi_backend_task"] = task
 
     # Create a team state artifact
     team_state = {
         "team_id": context.current_team_id,
-        "agents": [agent.config.name for agent in context.teams[context.current_team_id].agents],
-        "primus_index": context.teams[context.current_team_id].primus_index
+        "agents": [
+            agent.config.name for agent in context.teams[context.current_team_id].agents
+        ],
+        "primus_index": context.teams[context.current_team_id].primus_index,
     }
 
     # Create a solution artifact
     solution = {
         "agent": "code_agent",
         "description": "Solution for multi-backend test",
-        "code": "def test_function():\n    return 'Hello, world!'"
+        "code": "def test_function():\n    return 'Hello, world!'",
     }
 
     # Store team state in the file backend
@@ -587,10 +600,7 @@ def store_artifacts_in_different_backends(context):
         id="team_state_2",
         memory_type=MemoryType.TEAM_STATE,
         content=team_state,
-        metadata={
-            "team_id": context.current_team_id,
-            "backend": "file"
-        }
+        metadata={"team_id": context.current_team_id, "backend": "file"},
     )
     context.memory_managers["file"].store_item(file_memory_item)
 
@@ -602,8 +612,8 @@ def store_artifacts_in_different_backends(context):
         metadata={
             "task_id": str(hash(frozenset(task.items()))),
             "agent": solution["agent"],
-            "backend": "tinydb"
-        }
+            "backend": "tinydb",
+        },
     )
     context.memory_managers["tinydb"].store_item(tinydb_memory_item)
 
@@ -618,12 +628,9 @@ def store_artifacts_in_different_backends(context):
             "source_id": file_memory_item.id,
             "target_type": MemoryType.SOLUTION,
             "target_id": tinydb_memory_item.id,
-            "relationship_type": "created_by"
+            "relationship_type": "created_by",
         },
-        metadata={
-            "source_backend": "file",
-            "target_backend": "tinydb"
-        }
+        metadata={"source_backend": "file", "target_backend": "tinydb"},
     )
     context.memory_managers["file"].store_item(relationship_item)
 
@@ -633,7 +640,9 @@ def store_artifacts_in_different_backends(context):
 def retrieve_artifacts_from_backends(context):
     """Retrieve the artifacts from their respective backends."""
     # Query for team state in the file backend
-    file_query_result = context.memory_managers["file"].query_by_type(MemoryType.TEAM_STATE)
+    file_query_result = context.memory_managers["file"].query_by_type(
+        MemoryType.TEAM_STATE
+    )
 
     # Verify that we got at least one result
     assert len(file_query_result) > 0
@@ -648,7 +657,9 @@ def retrieve_artifacts_from_backends(context):
     context.retrieved_team_state = team_state_item.content
 
     # Query for solution in the tinydb backend
-    tinydb_query_result = context.memory_managers["tinydb"].query_by_type(MemoryType.SOLUTION)
+    tinydb_query_result = context.memory_managers["tinydb"].query_by_type(
+        MemoryType.SOLUTION
+    )
 
     # Verify that we got at least one result
     assert len(tinydb_query_result) > 0
@@ -668,7 +679,9 @@ def retrieve_artifacts_from_backends(context):
 def verify_artifact_relationships(context):
     """Verify that the artifacts maintain their relationships."""
     # Query for relationships in the file backend
-    relationship_query_result = context.memory_managers["file"].query_by_type(MemoryType.RELATIONSHIP)
+    relationship_query_result = context.memory_managers["file"].query_by_type(
+        MemoryType.RELATIONSHIP
+    )
 
     # Verify that we got at least one result
     assert len(relationship_query_result) > 0

--- a/tests/behavior/steps/test_wsde_memory_integration_steps.py
+++ b/tests/behavior/steps/test_wsde_memory_integration_steps.py
@@ -4,25 +4,28 @@ Step Definitions for WSDE Model and Memory System Integration BDD Tests
 This file implements the step definitions for the WSDE model and memory system integration
 feature file, testing the integration between the WSDE model and the memory system.
 """
+
 import pytest
-from pytest_bdd import given, when, then, parsers, scenarios
+from pytest_bdd import given, parsers, scenarios, then, when
 
 # Import the feature file
-scenarios('../features/general/wsde_memory_integration.feature')
+scenarios("../features/general/wsde_memory_integration.feature")
+
+from devsynth.adapters.agents.agent_adapter import WSDETeamCoordinator
+from devsynth.adapters.memory.memory_adapter import MemorySystemAdapter
+from devsynth.application.agents.unified_agent import UnifiedAgent
+from devsynth.application.memory.memory_manager import MemoryManager
+from devsynth.domain.models.agent import AgentConfig, AgentType
+from devsynth.domain.models.memory import MemoryItem, MemoryType
 
 # Import the modules needed for the steps
-from devsynth.domain.models.wsde import WSDETeam
-from devsynth.adapters.agents.agent_adapter import WSDETeamCoordinator
-from devsynth.application.agents.unified_agent import UnifiedAgent
-from devsynth.domain.models.agent import AgentConfig, AgentType
-from devsynth.adapters.memory.memory_adapter import MemorySystemAdapter
-from devsynth.application.memory.memory_manager import MemoryManager
-from devsynth.domain.models.memory import MemoryItem, MemoryType
+from devsynth.domain.models.wsde_facade import WSDETeam
 
 
 @pytest.fixture
 def context():
     """Fixture to provide a context object for sharing state between steps."""
+
     class Context:
         def __init__(self):
             self.team_coordinator = WSDETeamCoordinator()
@@ -43,6 +46,7 @@ def context():
 
 
 # Background steps
+
 
 @pytest.mark.medium
 @given("the DevSynth system is initialized")
@@ -80,7 +84,7 @@ def given_team_with_multiple_agents(context):
         AgentType.PLANNER.value,
         AgentType.SPECIFICATION.value,
         AgentType.CODE.value,
-        AgentType.VALIDATION.value
+        AgentType.VALIDATION.value,
     ]
 
     for agent_type in agent_types:
@@ -90,7 +94,7 @@ def given_team_with_multiple_agents(context):
             agent_type=AgentType(agent_type),
             description=f"Agent for {agent_type} tasks",
             capabilities=[],
-            parameters={}
+            parameters={},
         )
         agent.initialize(agent_config)
         context.agents[agent_type] = agent
@@ -102,16 +106,19 @@ def given_team_with_multiple_agents(context):
 def memory_system_configured(context):
     """Configure the memory system with a test backend."""
     # Create a memory system adapter with an in-memory backend for testing
-    context.memory_adapter = MemorySystemAdapter.create_for_testing(storage_type="memory")
+    context.memory_adapter = MemorySystemAdapter.create_for_testing(
+        storage_type="memory"
+    )
 
     # Create a memory manager that uses the memory store from the adapter
     # This is the key change - we're passing the memory store, not the adapter itself
-    context.memory_manager = MemoryManager({
-        'default': context.memory_adapter.get_memory_store()
-    })
+    context.memory_manager = MemoryManager(
+        {"default": context.memory_adapter.get_memory_store()}
+    )
 
 
 # Scenario: Store and retrieve WSDE team state
+
 
 @pytest.mark.medium
 @when("I create a team with multiple agents")
@@ -122,7 +129,7 @@ def create_team_with_multiple_agents(context):
         AgentType.PLANNER.value,
         AgentType.SPECIFICATION.value,
         AgentType.CODE.value,
-        AgentType.VALIDATION.value
+        AgentType.VALIDATION.value,
     ]
 
     for agent_type in agent_types:
@@ -132,7 +139,7 @@ def create_team_with_multiple_agents(context):
             agent_type=AgentType(agent_type),
             description=f"Agent for {agent_type} tasks",
             capabilities=[],
-            parameters={}
+            parameters={},
         )
         agent.initialize(agent_config)
         context.agents[agent_type] = agent
@@ -150,7 +157,7 @@ def store_team_state_in_memory(context):
     context.original_team_state = {
         "team_id": context.current_team_id,
         "agents": [agent.config.name for agent in team.agents],
-        "primus_index": team.primus_index
+        "primus_index": team.primus_index,
     }
 
     # Create a memory item for the team state
@@ -158,10 +165,7 @@ def store_team_state_in_memory(context):
         id="team_state_1",
         memory_type=MemoryType.TEAM_STATE,
         content=context.original_team_state,
-        metadata={
-            "team_id": context.current_team_id,
-            "agent_count": len(team.agents)
-        }
+        metadata={"team_id": context.current_team_id, "agent_count": len(team.agents)},
     )
 
     # Store the memory item
@@ -194,25 +198,34 @@ def verify_team_state_matches(context):
     assert context.original_team_state is not None
 
     # Compare team_id
-    assert context.retrieved_team_state["team_id"] == context.original_team_state["team_id"]
+    assert (
+        context.retrieved_team_state["team_id"]
+        == context.original_team_state["team_id"]
+    )
 
     # Compare agents (order may not matter)
-    assert set(context.retrieved_team_state["agents"]) == set(context.original_team_state["agents"])
+    assert set(context.retrieved_team_state["agents"]) == set(
+        context.original_team_state["agents"]
+    )
 
     # Compare primus_index
-    assert context.retrieved_team_state["primus_index"] == context.original_team_state["primus_index"]
+    assert (
+        context.retrieved_team_state["primus_index"]
+        == context.original_team_state["primus_index"]
+    )
 
 
 # Scenario: Store and retrieve solutions with EDRR phase tagging
 
+
 @pytest.mark.medium
-@when(parsers.parse('a solution is proposed for a task'))
+@when(parsers.parse("a solution is proposed for a task"))
 def solution_proposed_for_task(context):
     """Propose a solution for a task."""
     # Create a task
     task = {
         "type": "code_generation",
-        "description": "Generate a Python function to calculate Fibonacci numbers"
+        "description": "Generate a Python function to calculate Fibonacci numbers",
     }
     context.tasks["fibonacci_task"] = task
 
@@ -220,7 +233,7 @@ def solution_proposed_for_task(context):
     solution = {
         "agent": "code_agent",
         "content": "def fibonacci(n):\n    if n <= 1:\n        return n\n    return fibonacci(n-1) + fibonacci(n-2)",
-        "description": "Recursive implementation of Fibonacci"
+        "description": "Recursive implementation of Fibonacci",
     }
     context.solutions["fibonacci_solution"] = solution
 
@@ -245,8 +258,8 @@ def store_solution_with_edrr_phase(context, phase):
         metadata={
             "task_id": str(hash(frozenset(task.items()))),
             "agent": solution["agent"],
-            "edrr_phase": phase
-        }
+            "edrr_phase": phase,
+        },
     )
 
     # Store the memory item
@@ -292,6 +305,7 @@ def verify_solution_edrr_phase(context):
 
 # Scenario: Store and retrieve dialectical reasoning results
 
+
 @pytest.mark.medium
 @given("a team with a Critic agent")
 def team_with_critic_agent(context):
@@ -303,7 +317,7 @@ def team_with_critic_agent(context):
         agent_type=AgentType.ORCHESTRATOR,
         description="Agent for applying dialectical reasoning",
         capabilities=[],
-        parameters={"expertise": ["dialectical_reasoning", "critique", "synthesis"]}
+        parameters={"expertise": ["dialectical_reasoning", "critique", "synthesis"]},
     )
     agent.initialize(agent_config)
     context.agents["critic_agent"] = agent
@@ -318,7 +332,7 @@ def solution_proposed(context):
     context.solutions["proposed_solution"] = {
         "agent": "code_agent",
         "description": "Solution for user authentication",
-        "code": "def authenticate(username, password):\n    # Implementation details\n    return True"
+        "code": "def authenticate(username, password):\n    # Implementation details\n    return True",
     }
 
 
@@ -359,8 +373,8 @@ def store_dialectical_results(context):
         content=dialectical_result,
         metadata={
             "task_id": str(hash(frozenset(task.items()))),
-            "critic_agent": "critic_agent"
-        }
+            "critic_agent": "critic_agent",
+        },
     )
 
     # Store the memory item
@@ -372,7 +386,9 @@ def store_dialectical_results(context):
 def retrieve_dialectical_results(context):
     """Retrieve the dialectical reasoning results from memory."""
     # Query for dialectical reasoning memory items
-    query_result = context.memory_manager.query_by_type(MemoryType.DIALECTICAL_REASONING)
+    query_result = context.memory_manager.query_by_type(
+        MemoryType.DIALECTICAL_REASONING
+    )
 
     # Verify that we got at least one result
     assert len(query_result) > 0
@@ -397,6 +413,7 @@ def verify_dialectical_results(context):
 
 # Scenario: Access knowledge graph for enhanced reasoning
 
+
 @pytest.mark.medium
 @given("a knowledge graph with domain knowledge")
 def knowledge_graph_with_domain_knowledge(context):
@@ -407,31 +424,22 @@ def knowledge_graph_with_domain_knowledge(context):
         "entities": {
             "authentication": {
                 "type": "concept",
-                "related": ["security", "password", "username"]
+                "related": ["security", "password", "username"],
             },
-            "password": {
-                "type": "concept",
-                "related": ["authentication", "security"]
-            },
+            "password": {"type": "concept", "related": ["authentication", "security"]},
             "security": {
                 "type": "concept",
-                "related": ["authentication", "password", "encryption"]
+                "related": ["authentication", "password", "encryption"],
             },
-            "encryption": {
-                "type": "concept",
-                "related": ["security", "hashing"]
-            },
-            "hashing": {
-                "type": "concept",
-                "related": ["encryption", "password"]
-            }
+            "encryption": {"type": "concept", "related": ["security", "hashing"]},
+            "hashing": {"type": "concept", "related": ["encryption", "password"]},
         },
         "relationships": [
             {"source": "authentication", "target": "password", "type": "uses"},
             {"source": "authentication", "target": "username", "type": "uses"},
             {"source": "password", "target": "hashing", "type": "should_use"},
-            {"source": "security", "target": "encryption", "type": "requires"}
-        ]
+            {"source": "security", "target": "encryption", "type": "requires"},
+        ],
     }
 
     # Store the knowledge graph in memory
@@ -439,10 +447,7 @@ def knowledge_graph_with_domain_knowledge(context):
         id="knowledge_graph_1",
         memory_type=MemoryType.KNOWLEDGE_GRAPH,
         content=context.knowledge_graph,
-        metadata={
-            "domain": "security",
-            "version": "1.0"
-        }
+        metadata={"domain": "security", "version": "1.0"},
     )
 
     # Store the memory item
@@ -457,7 +462,7 @@ def team_reasons_about_complex_task(context):
     task = {
         "type": "security_implementation",
         "description": "Implement a secure authentication system",
-        "requirements": ["user authentication", "password security", "encryption"]
+        "requirements": ["user authentication", "password security", "encryption"],
     }
     context.tasks["security_task"] = task
 
@@ -512,7 +517,7 @@ def hash_password(password):
     # Use a secure hashing algorithm
     import hashlib
     return hashlib.sha256(password.encode()).hexdigest()
-        """
+        """,
     }
 
     # Add the solution to the team
@@ -529,8 +534,8 @@ def hash_password(password):
         metadata={
             "task_id": task_id,
             "agent": solution["agent"],
-            "knowledge_sources": ["authentication", "password", "hashing", "security"]
-        }
+            "knowledge_sources": ["authentication", "password", "hashing", "security"],
+        },
     )
 
     # Store the memory item
@@ -543,6 +548,7 @@ def hash_password(password):
 
 
 # Scenario: Use different memory backends for WSDE artifacts
+
 
 @pytest.mark.medium
 @given("the memory system is configured with multiple backends")
@@ -558,9 +564,7 @@ def memory_system_with_multiple_backends(context):
 
     # Create a memory manager that can use multiple backends
     context.memory_managers = {
-        backend_name: MemoryManager({
-            'default': memory_store
-        })
+        backend_name: MemoryManager({"default": memory_store})
         for backend_name, memory_store in context.memory_backends.items()
     }
 
@@ -572,22 +576,24 @@ def store_artifacts_in_different_backends(context):
     # Create a task
     task = {
         "type": "multi_backend_test",
-        "description": "Test storing artifacts in different backends"
+        "description": "Test storing artifacts in different backends",
     }
     context.tasks["multi_backend_task"] = task
 
     # Create a team state artifact
     team_state = {
         "team_id": context.current_team_id,
-        "agents": [agent.config.name for agent in context.teams[context.current_team_id].agents],
-        "primus_index": context.teams[context.current_team_id].primus_index
+        "agents": [
+            agent.config.name for agent in context.teams[context.current_team_id].agents
+        ],
+        "primus_index": context.teams[context.current_team_id].primus_index,
     }
 
     # Create a solution artifact
     solution = {
         "agent": "code_agent",
         "description": "Solution for multi-backend test",
-        "code": "def test_function():\n    return 'Hello, world!'"
+        "code": "def test_function():\n    return 'Hello, world!'",
     }
 
     # Store team state in the file backend
@@ -595,10 +601,7 @@ def store_artifacts_in_different_backends(context):
         id="team_state_2",
         memory_type=MemoryType.TEAM_STATE,
         content=team_state,
-        metadata={
-            "team_id": context.current_team_id,
-            "backend": "file"
-        }
+        metadata={"team_id": context.current_team_id, "backend": "file"},
     )
     context.memory_managers["file"].store_item(file_memory_item)
 
@@ -610,8 +613,8 @@ def store_artifacts_in_different_backends(context):
         metadata={
             "task_id": str(hash(frozenset(task.items()))),
             "agent": solution["agent"],
-            "backend": "tinydb"
-        }
+            "backend": "tinydb",
+        },
     )
     context.memory_managers["tinydb"].store_item(tinydb_memory_item)
 
@@ -626,12 +629,9 @@ def store_artifacts_in_different_backends(context):
             "source_id": file_memory_item.id,
             "target_type": MemoryType.SOLUTION,
             "target_id": tinydb_memory_item.id,
-            "relationship_type": "created_by"
+            "relationship_type": "created_by",
         },
-        metadata={
-            "source_backend": "file",
-            "target_backend": "tinydb"
-        }
+        metadata={"source_backend": "file", "target_backend": "tinydb"},
     )
     context.memory_managers["file"].store_item(relationship_item)
 
@@ -641,7 +641,9 @@ def store_artifacts_in_different_backends(context):
 def retrieve_artifacts_from_backends(context):
     """Retrieve the artifacts from their respective backends."""
     # Query for team state in the file backend
-    file_query_result = context.memory_managers["file"].query_by_type(MemoryType.TEAM_STATE)
+    file_query_result = context.memory_managers["file"].query_by_type(
+        MemoryType.TEAM_STATE
+    )
 
     # Verify that we got at least one result
     assert len(file_query_result) > 0
@@ -656,7 +658,9 @@ def retrieve_artifacts_from_backends(context):
     context.retrieved_team_state = team_state_item.content
 
     # Query for solution in the tinydb backend
-    tinydb_query_result = context.memory_managers["tinydb"].query_by_type(MemoryType.SOLUTION)
+    tinydb_query_result = context.memory_managers["tinydb"].query_by_type(
+        MemoryType.SOLUTION
+    )
 
     # Verify that we got at least one result
     assert len(tinydb_query_result) > 0
@@ -676,7 +680,9 @@ def retrieve_artifacts_from_backends(context):
 def verify_artifact_relationships(context):
     """Verify that the artifacts maintain their relationships."""
     # Query for relationships in the file backend
-    relationship_query_result = context.memory_managers["file"].query_by_type(MemoryType.RELATIONSHIP)
+    relationship_query_result = context.memory_managers["file"].query_by_type(
+        MemoryType.RELATIONSHIP
+    )
 
     # Verify that we got at least one result
     assert len(relationship_query_result) > 0

--- a/tests/behavior/steps/test_wsde_message_passing_peer_review_steps.py
+++ b/tests/behavior/steps/test_wsde_message_passing_peer_review_steps.py
@@ -4,16 +4,17 @@ pytest.skip(
     "Advanced WSDE collaboration features not implemented", allow_module_level=True
 )
 
-from pytest_bdd import given, when, then, parsers, scenarios
 from unittest.mock import MagicMock
+
+from pytest_bdd import given, parsers, scenarios, then, when
 
 scenarios("../features/general/wsde_message_passing_peer_review.feature")
 
 from devsynth.adapters.agents.agent_adapter import WSDETeamCoordinator
 from devsynth.application.agents.unified_agent import UnifiedAgent
-from devsynth.domain.models.agent import AgentConfig, AgentType
-from devsynth.domain.models.wsde import WSDETeam
 from devsynth.application.collaboration.message_protocol import MessageType
+from devsynth.domain.models.agent import AgentConfig, AgentType
+from devsynth.domain.models.wsde_facade import WSDETeam
 
 
 @pytest.fixture
@@ -74,7 +75,11 @@ def team_with_multiple_agents(context):
 
 
 @pytest.mark.medium
-@when(    parsers.parse(        'agent "{sender}" sends a message to agent "{recipient}" with type "{msg_type}"'    ))
+@when(
+    parsers.parse(
+        'agent "{sender}" sends a message to agent "{recipient}" with type "{msg_type}"'
+    )
+)
 def send_message(context, sender, recipient, msg_type):
     message = context.team.send_message(
         sender=sender,
@@ -108,7 +113,11 @@ def stored_in_history(context):
 
 
 @pytest.mark.medium
-@when(    parsers.parse(        'agent "{sender}" sends a broadcast message to all agents with type "{msg_type}"'    ))
+@when(
+    parsers.parse(
+        'agent "{sender}" sends a broadcast message to all agents with type "{msg_type}"'
+    )
+)
 def broadcast_message(context, sender, msg_type):
     message = context.team.broadcast_message(sender, msg_type, subject="broadcast")
     context.last_message = message
@@ -138,7 +147,11 @@ def broadcast_single_event(context):
 
 
 @pytest.mark.medium
-@when(    parsers.parse(        'agent "{sender}" sends a message with priority "{priority}" to agent "{recipient}"'    ))
+@when(
+    parsers.parse(
+        'agent "{sender}" sends a message with priority "{priority}" to agent "{recipient}"'
+    )
+)
 def send_priority_message(context, sender, priority, recipient):
     message = context.team.send_message(
         sender=sender,
@@ -152,7 +165,11 @@ def send_priority_message(context, sender, priority, recipient):
 
 
 @pytest.mark.medium
-@then(    parsers.parse(        'agent "{recipient}" should receive the message with priority "{priority}"'    ))
+@then(
+    parsers.parse(
+        'agent "{recipient}" should receive the message with priority "{priority}"'
+    )
+)
 def recipient_priority(context, recipient, priority):
     msgs = context.team.get_messages(recipient)
     assert any(m.metadata.get("priority") == priority for m in msgs)
@@ -200,7 +217,11 @@ def send_structured(context, sender, table=None):
 
 
 @pytest.mark.medium
-@then(    parsers.parse(        'agent "{recipient}" should receive the message with the structured content'    ))
+@then(
+    parsers.parse(
+        'agent "{recipient}" should receive the message with the structured content'
+    )
+)
 def check_structured(context, recipient):
     msgs = context.team.get_messages(recipient)
     assert any(m.content == context.last_message.content for m in msgs)

--- a/tests/behavior/steps/test_wsde_voting_mechanisms_steps.py
+++ b/tests/behavior/steps/test_wsde_voting_mechanisms_steps.py
@@ -11,17 +11,19 @@ pytest.skip(
     "Advanced WSDE collaboration features not implemented", allow_module_level=True
 )
 
-from pytest_bdd import given, when, then, parsers, scenarios
 from unittest.mock import MagicMock
+
+from pytest_bdd import given, parsers, scenarios, then, when
 
 # Import the feature file
 scenarios("../features/general/wsde_voting_mechanisms.feature")
 
-# Import the modules needed for the steps
-from devsynth.domain.models.wsde import WSDETeam
 from devsynth.adapters.agents.agent_adapter import WSDETeamCoordinator
 from devsynth.application.agents.unified_agent import UnifiedAgent
 from devsynth.domain.models.agent import AgentConfig, AgentType
+
+# Import the modules needed for the steps
+from devsynth.domain.models.wsde_facade import WSDETeam
 
 
 @pytest.fixture

--- a/tests/behavior/steps/wsde_edrr_integration_steps.py
+++ b/tests/behavior/steps/wsde_edrr_integration_steps.py
@@ -9,34 +9,38 @@ Step definitions for the WSDE-EDRR integration feature.
 This file implements the step definitions for testing the integration between
 the WSDE agent model and the EDRR framework.
 """
-from pytest_bdd import given, when, then, parsers, scenarios
-import pytest
 from unittest.mock import MagicMock, patch
 
-# Import the scenarios from the feature file
-scenarios('../features/general/wsde_edrr_integration.feature')
+import pytest
+from pytest_bdd import given, parsers, scenarios, then, when
 
-# Import the necessary components
-from devsynth.application.edrr.edrr_coordinator_enhanced import EnhancedEDRRCoordinator
-from devsynth.domain.models.wsde import WSDETeam
-from devsynth.application.memory.memory_manager import MemoryManager
-from devsynth.application.memory.context_manager import InMemoryStore
+# Import the scenarios from the feature file
+scenarios("../features/general/wsde_edrr_integration.feature")
+
+from devsynth.application.agents.unified_agent import UnifiedAgent
+from devsynth.application.code_analysis.analyzer import CodeAnalyzer
+from devsynth.application.code_analysis.ast_transformer import AstTransformer
 from devsynth.application.collaboration.collaborative_wsde_team import (
     CollaborativeWSDETeam,
 )
-from devsynth.domain.models.memory import MemoryType
-from devsynth.application.code_analysis.analyzer import CodeAnalyzer
-from devsynth.application.code_analysis.ast_transformer import AstTransformer
+from devsynth.application.documentation.documentation_manager import (
+    DocumentationManager,
+)
+
+# Import the necessary components
+from devsynth.application.edrr.edrr_coordinator_enhanced import EnhancedEDRRCoordinator
+from devsynth.application.memory.context_manager import InMemoryStore
+from devsynth.application.memory.memory_manager import MemoryManager
 from devsynth.application.requirements.prompt_manager import PromptManager
-from devsynth.application.documentation.documentation_manager import DocumentationManager
-from devsynth.methodology.base import Phase
 from devsynth.domain.models.agent import AgentConfig, AgentType
-from devsynth.application.agents.unified_agent import UnifiedAgent
+from devsynth.domain.models.memory import MemoryType
+from devsynth.domain.models.wsde_facade import WSDETeam
+from devsynth.methodology.base import Phase
 
 
 class ExpertAgent(UnifiedAgent):
     """Agent with specific expertise for testing."""
-    
+
     def __init__(self, name, expertise):
         super().__init__()
         self.name = name
@@ -44,30 +48,31 @@ class ExpertAgent(UnifiedAgent):
         self.current_role = None
         self.previous_role = None
         self.has_been_primus = False
-        
+
         # Initialize with config
         config = AgentConfig(
             name=name,
             agent_type=AgentType.ORCHESTRATOR,
             description=f"Agent with expertise in {', '.join(expertise)}",
             capabilities=[],
-            parameters={"expertise": expertise}
+            parameters={"expertise": expertise},
         )
         self.initialize(config)
-    
+
     def process(self, task):
         """Process a task based on agent's expertise."""
         # For testing, return a result that includes the agent's name and expertise
         return {
             "result": f"Solution from {self.name}",
             "confidence": 0.9,
-            "reasoning": f"Based on my expertise in {', '.join(self.expertise)}"
+            "reasoning": f"Based on my expertise in {', '.join(self.expertise)}",
         }
 
 
 @pytest.fixture
 def context():
     """Fixture to provide a context object for storing test state between steps."""
+
     class Context:
         def __init__(self):
             self.wsde_team = None
@@ -79,7 +84,7 @@ def context():
             self.dialectical_results = {}
             self.error_occurred = False
             self.recovery_attempted = False
-            
+
     return Context()
 
 
@@ -95,18 +100,26 @@ def wsde_team_configured(context):
     """Configure the WSDE team with agents having different expertise."""
     # Create a WSDE team
     context.wsde_team = WSDETeam(name="TestWsdeEdrrIntegrationStepsTeam")
-    
+
     # Create agents with expertise aligned with EDRR phases
     agents = {
-        "expand_agent": ExpertAgent("expand_agent", ["exploration", "brainstorming", "creativity", "ideation"]),
-        "diff_agent": ExpertAgent("diff_agent", ["analysis", "comparison", "evaluation", "critical thinking"]),
-        "refine_agent": ExpertAgent("refine_agent", ["implementation", "coding", "development", "optimization"]),
-        "retro_agent": ExpertAgent("retro_agent", ["evaluation", "reflection", "learning", "improvement"])
+        "expand_agent": ExpertAgent(
+            "expand_agent", ["exploration", "brainstorming", "creativity", "ideation"]
+        ),
+        "diff_agent": ExpertAgent(
+            "diff_agent", ["analysis", "comparison", "evaluation", "critical thinking"]
+        ),
+        "refine_agent": ExpertAgent(
+            "refine_agent", ["implementation", "coding", "development", "optimization"]
+        ),
+        "retro_agent": ExpertAgent(
+            "retro_agent", ["evaluation", "reflection", "learning", "improvement"]
+        ),
     }
-    
+
     # Add agents to the team
     context.wsde_team.add_agents(list(agents.values()))
-    
+
     # Store agents for later reference
     context.agents = agents
 
@@ -120,10 +133,10 @@ def edrr_coordinator_initialized(context):
     mm.retrieve_relevant_knowledge.return_value = []
     mm.retrieve_historical_patterns.return_value = []
     mm.store_with_edrr_phase.return_value = "memory_id"
-    
+
     analyzer = MagicMock(spec=CodeAnalyzer)
     analyzer.analyze_project_structure.return_value = []
-    
+
     # Create the coordinator with enhanced features
     context.edrr_coordinator = EnhancedEDRRCoordinator(
         memory_manager=mm,
@@ -136,9 +149,9 @@ def edrr_coordinator_initialized(context):
             "edrr": {
                 "quality_based_transitions": True,
                 "phase_transition": {"auto": True},
-                "micro_cycles": {"enabled": True, "max_iterations": 3}
+                "micro_cycles": {"enabled": True, "max_iterations": 3},
             }
-        }
+        },
     )
 
 
@@ -146,24 +159,25 @@ def edrr_coordinator_initialized(context):
 def start_edrr_cycle(context, task_description):
     """Start an EDRR cycle with the given task."""
     # Create a task with the given description
-    context.task = {
-        "description": task_description,
-        "id": "task-123"
-    }
-    
+    context.task = {"description": task_description, "id": "task-123"}
+
     # Start the EDRR cycle
     context.edrr_coordinator.start_cycle(context.task)
-    
+
     # Verify that the cycle was started
     assert context.edrr_coordinator.current_phase == Phase.EXPAND
 
 
-@then(parsers.parse('the WSDE team should assign the Primus role to an agent with expertise in "{expertise}"'))
+@then(
+    parsers.parse(
+        'the WSDE team should assign the Primus role to an agent with expertise in "{expertise}"'
+    )
+)
 def verify_primus_expertise(context, expertise):
     """Verify that the Primus has the specified expertise."""
     # Get the current Primus
     primus = context.wsde_team.get_primus()
-    
+
     # Verify that the Primus has the specified expertise
     assert primus is not None
     assert expertise in [skill.lower() for skill in primus.expertise]
@@ -174,7 +188,7 @@ def progress_to_phase(context, phase_name):
     """Progress the EDRR cycle to the specified phase."""
     # Progress to the specified phase
     context.edrr_coordinator.progress_to_phase(Phase[phase_name.upper()])
-    
+
     # Verify that the phase was updated
     assert context.edrr_coordinator.current_phase == Phase[phase_name.upper()]
 
@@ -184,18 +198,18 @@ def wsde_team_produces_high_quality_results(context):
     """Simulate the WSDE team producing high-quality results."""
     # Store the current phase
     current_phase = context.edrr_coordinator.current_phase
-    
+
     # Set up high-quality results for the current phase
     context.phase_quality[current_phase] = {"quality": 0.9, "can_progress": True}
-    
+
     # Mock the _assess_phase_quality method to return high quality
     original_assess_quality = context.edrr_coordinator._assess_phase_quality
-    
+
     def mock_assess_quality(phase=None):
         if phase is None:
             phase = context.edrr_coordinator.current_phase
         return context.phase_quality.get(phase, {"quality": 0.5, "can_progress": False})
-    
+
     context.edrr_coordinator._assess_phase_quality = mock_assess_quality
     context.original_assess_quality = original_assess_quality
 
@@ -205,13 +219,13 @@ def verify_auto_progress(context):
     """Verify that the EDRR coordinator automatically progresses to the next phase."""
     # Store the current phase
     initial_phase = context.edrr_coordinator.current_phase
-    
+
     # Attempt to auto-progress
     context.edrr_coordinator._enhanced_maybe_auto_progress()
-    
+
     # Verify that the phase was auto-progressed
     assert context.edrr_coordinator.current_phase != initial_phase
-    
+
     # Restore the original method
     context.edrr_coordinator._assess_phase_quality = context.original_assess_quality
 
@@ -221,18 +235,18 @@ def wsde_team_produces_low_quality_results(context):
     """Simulate the WSDE team producing low-quality results."""
     # Store the current phase
     current_phase = context.edrr_coordinator.current_phase
-    
+
     # Set up low-quality results for the current phase
     context.phase_quality[current_phase] = {"quality": 0.3, "can_progress": False}
-    
+
     # Mock the _assess_phase_quality method to return low quality
     original_assess_quality = context.edrr_coordinator._assess_phase_quality
-    
+
     def mock_assess_quality(phase=None):
         if phase is None:
             phase = context.edrr_coordinator.current_phase
         return context.phase_quality.get(phase, {"quality": 0.5, "can_progress": False})
-    
+
     context.edrr_coordinator._assess_phase_quality = mock_assess_quality
     context.original_assess_quality = original_assess_quality
 
@@ -242,10 +256,10 @@ def verify_no_auto_progress(context):
     """Verify that the EDRR coordinator does not automatically progress to the next phase."""
     # Store the current phase
     initial_phase = context.edrr_coordinator.current_phase
-    
+
     # Attempt to auto-progress
     context.edrr_coordinator._enhanced_maybe_auto_progress()
-    
+
     # Verify that the phase was not auto-progressed
     assert context.edrr_coordinator.current_phase == initial_phase
 
@@ -256,22 +270,22 @@ def verify_improvement_request(context):
     # Mock the WSDE team's process method to track calls
     original_process = context.wsde_team.process
     process_calls = []
-    
+
     def mock_process(task):
         process_calls.append(task)
         return {"result": "Improved solution"}
-    
+
     context.wsde_team.process = mock_process
-    
+
     # Execute the current phase again to request improvements
     context.edrr_coordinator.execute_current_phase()
-    
+
     # Verify that the WSDE team was asked to process the task again
     assert len(process_calls) > 0
-    
+
     # Restore the original method
     context.wsde_team.process = original_process
-    
+
     # Restore the original assess_quality method
     context.edrr_coordinator._assess_phase_quality = context.original_assess_quality
 
@@ -281,22 +295,22 @@ def edrr_initiates_micro_cycle(context):
     """Simulate the EDRR coordinator initiating a micro-cycle."""
     # Mock the _execute_micro_cycle method to track calls and return results
     original_execute_micro_cycle = context.edrr_coordinator._execute_micro_cycle
-    
+
     def mock_execute_micro_cycle(phase, iteration):
         result = {
             "result": f"Micro-cycle result for {phase.name}, iteration {iteration}",
             "quality": 0.8,
-            "iteration": iteration
+            "iteration": iteration,
         }
         context.micro_cycle_results.append(result)
         return result
-    
+
     context.edrr_coordinator._execute_micro_cycle = mock_execute_micro_cycle
     context.original_execute_micro_cycle = original_execute_micro_cycle
-    
+
     # Enable micro-cycles
     context.edrr_coordinator.config["edrr"]["micro_cycles"]["enabled"] = True
-    
+
     # Execute the current phase with micro-cycles
     context.edrr_coordinator.execute_current_phase()
 
@@ -306,23 +320,25 @@ def verify_wsde_collaboration_on_micro_cycle(context):
     """Verify that the WSDE team collaborates on the micro-cycle task."""
     # Verify that micro-cycles were executed
     assert len(context.micro_cycle_results) > 0
-    
+
     # Mock the WSDE team's process method to track calls
     original_process = context.wsde_team.process
     process_calls = []
-    
+
     def mock_process(task):
         process_calls.append(task)
         return {"result": "Micro-cycle solution"}
-    
+
     context.wsde_team.process = mock_process
-    
+
     # Execute another micro-cycle
-    context.edrr_coordinator._execute_micro_cycle(context.edrr_coordinator.current_phase, len(context.micro_cycle_results) + 1)
-    
+    context.edrr_coordinator._execute_micro_cycle(
+        context.edrr_coordinator.current_phase, len(context.micro_cycle_results) + 1
+    )
+
     # Verify that the WSDE team was asked to process the micro-cycle task
     assert len(process_calls) > 0
-    
+
     # Restore the original method
     context.wsde_team.process = original_process
 
@@ -333,12 +349,12 @@ def verify_micro_cycle_aggregation(context):
     # Verify that the current phase results include micro-cycle results
     current_phase = context.edrr_coordinator.current_phase
     assert current_phase in context.edrr_coordinator.results
-    
+
     # The exact structure of the aggregated results depends on the implementation,
     # but we can verify that the results exist and have some expected properties
     phase_results = context.edrr_coordinator.results[current_phase]
     assert phase_results is not None
-    
+
     # Verify that the phase results include some indication of micro-cycles
     # This could be a 'micro_cycles' field, 'iterations' field, or something similar
     # For now, we'll just verify that the results exist
@@ -349,95 +365,104 @@ def verify_micro_cycle_aggregation(context):
 def verify_micro_cycle_determination(context):
     """Verify that the EDRR coordinator determines if additional micro-cycles are needed."""
     # Mock the _should_continue_micro_cycles method to track calls
-    original_should_continue = getattr(context.edrr_coordinator, '_should_continue_micro_cycles', None)
-    
+    original_should_continue = getattr(
+        context.edrr_coordinator, "_should_continue_micro_cycles", None
+    )
+
     if original_should_continue:
         should_continue_calls = []
-        
+
         def mock_should_continue(phase, iteration, results):
             should_continue_calls.append((phase, iteration, results))
             return iteration < 2  # Continue for up to 2 iterations
-        
+
         context.edrr_coordinator._should_continue_micro_cycles = mock_should_continue
-        
+
         # Execute the current phase with micro-cycles
         context.edrr_coordinator.execute_current_phase()
-        
+
         # Verify that _should_continue_micro_cycles was called
         assert len(should_continue_calls) > 0
-        
+
         # Restore the original method
-        context.edrr_coordinator._should_continue_micro_cycles = original_should_continue
-    
+        context.edrr_coordinator._should_continue_micro_cycles = (
+            original_should_continue
+        )
+
     # Restore the original _execute_micro_cycle method
     context.edrr_coordinator._execute_micro_cycle = context.original_execute_micro_cycle
 
 
-@then(parsers.parse('the WSDE team should apply dialectical reasoning in the "{phase_name}" phase'))
+@then(
+    parsers.parse(
+        'the WSDE team should apply dialectical reasoning in the "{phase_name}" phase'
+    )
+)
 def verify_dialectical_reasoning_in_phase(context, phase_name):
     """Verify that the WSDE team applies dialectical reasoning in the specified phase."""
     # Ensure we're in the correct phase
     if context.edrr_coordinator.current_phase != Phase[phase_name.upper()]:
         context.edrr_coordinator.progress_to_phase(Phase[phase_name.upper()])
-    
+
     # Mock the apply_enhanced_dialectical_reasoning method
     original_dialectical = context.wsde_team.apply_enhanced_dialectical_reasoning
-    
+
     def mock_dialectical_reasoning(task, critic_agent=None):
         result = {
             "thesis": {"content": f"Initial solution for {task['description']}"},
-            "antithesis": {
-                "critique": ["Issue 1", "Issue 2"],
-                "severity": "medium"
-            },
+            "antithesis": {"critique": ["Issue 1", "Issue 2"], "severity": "medium"},
             "synthesis": {
                 "content": f"Improved solution for {task['description']}",
                 "is_improvement": True,
-                "addressed_critiques": ["Addressed Issue 1", "Addressed Issue 2"]
-            }
+                "addressed_critiques": ["Addressed Issue 1", "Addressed Issue 2"],
+            },
         }
         context.dialectical_results[context.edrr_coordinator.current_phase] = result
         return result
-    
+
     context.wsde_team.apply_enhanced_dialectical_reasoning = mock_dialectical_reasoning
-    
+
     # Execute the current phase
     context.edrr_coordinator.execute_current_phase()
-    
+
     # Verify that dialectical reasoning was applied
     assert context.edrr_coordinator.current_phase in context.dialectical_results
-    
+
     # Restore the original method
     context.wsde_team.apply_enhanced_dialectical_reasoning = original_dialectical
 
 
-@then(parsers.parse('the synthesis from the "{source_phase}" phase should inform the "{target_phase}" phase'))
+@then(
+    parsers.parse(
+        'the synthesis from the "{source_phase}" phase should inform the "{target_phase}" phase'
+    )
+)
 def verify_synthesis_informs_next_phase(context, source_phase, target_phase):
     """Verify that the synthesis from one phase informs the next phase."""
     # Ensure we have dialectical results for the source phase
     if Phase[source_phase.upper()] not in context.dialectical_results:
         # Apply dialectical reasoning in the source phase
         verify_dialectical_reasoning_in_phase(context, source_phase)
-    
+
     # Progress to the target phase
     context.edrr_coordinator.progress_to_phase(Phase[target_phase.upper()])
-    
+
     # Mock the WSDE team's process method to track calls
     original_process = context.wsde_team.process
     process_calls = []
-    
+
     def mock_process(task):
         process_calls.append(task)
         return {"result": "Solution based on previous synthesis"}
-    
+
     context.wsde_team.process = mock_process
-    
+
     # Execute the target phase
     context.edrr_coordinator.execute_current_phase()
-    
+
     # Verify that the process method was called with a task that includes the synthesis
     assert len(process_calls) > 0
-    
+
     # Restore the original method
     context.wsde_team.process = original_process
 
@@ -449,34 +474,37 @@ def verify_dialectical_reasoning_to_implementation(context):
     # Ensure we're in the REFINE phase
     if context.edrr_coordinator.current_phase != Phase.REFINE:
         context.edrr_coordinator.progress_to_phase(Phase.REFINE)
-    
+
     # Mock the apply_enhanced_dialectical_reasoning method
     original_dialectical = context.wsde_team.apply_enhanced_dialectical_reasoning
-    
+
     def mock_dialectical_reasoning(task, critic_agent=None):
         result = {
             "thesis": {"content": "Initial implementation"},
             "antithesis": {
                 "critique": ["Implementation issue 1", "Implementation issue 2"],
-                "severity": "medium"
+                "severity": "medium",
             },
             "synthesis": {
                 "content": "Improved implementation",
                 "is_improvement": True,
-                "addressed_critiques": ["Fixed implementation issue 1", "Fixed implementation issue 2"]
-            }
+                "addressed_critiques": [
+                    "Fixed implementation issue 1",
+                    "Fixed implementation issue 2",
+                ],
+            },
         }
         context.dialectical_results[context.edrr_coordinator.current_phase] = result
         return result
-    
+
     context.wsde_team.apply_enhanced_dialectical_reasoning = mock_dialectical_reasoning
-    
+
     # Execute the current phase
     context.edrr_coordinator.execute_current_phase()
-    
+
     # Verify that dialectical reasoning was applied
     assert Phase.REFINE in context.dialectical_results
-    
+
     # Restore the original method
     context.wsde_team.apply_enhanced_dialectical_reasoning = original_dialectical
 
@@ -486,17 +514,17 @@ def verify_final_solution_reflects_dialectical_process(context):
     """Verify that the final solution reflects the dialectical process throughout all phases."""
     # Progress to the RETROSPECT phase
     context.edrr_coordinator.progress_to_phase(Phase.RETROSPECT)
-    
+
     # Execute the RETROSPECT phase
     context.edrr_coordinator.execute_current_phase()
-    
+
     # Generate the final report
     report = context.edrr_coordinator.generate_report()
-    
+
     # Verify that the report was generated
     assert report is not None
     assert "phases" in report
-    
+
     # Verify that each phase in the report includes dialectical reasoning results
     for phase in [Phase.EXPAND, Phase.DIFFERENTIATE, Phase.REFINE, Phase.RETROSPECT]:
         if phase in context.dialectical_results:
@@ -510,11 +538,11 @@ def error_during_wsde_processing(context):
     """Simulate an error during the WSDE team's processing."""
     # Mock the WSDE team's process method to raise an exception
     original_process = context.wsde_team.process
-    
+
     def mock_process_with_error(task):
         context.error_occurred = True
         raise Exception("Test exception during WSDE processing")
-    
+
     context.wsde_team.process = mock_process_with_error
     context.original_process = original_process
 
@@ -537,33 +565,33 @@ def verify_error_handled_gracefully(context):
 def verify_recovery_strategies(context):
     """Verify that the EDRR coordinator attempts recovery strategies."""
     # Mock the recovery method
-    if hasattr(context.edrr_coordinator, '_attempt_recovery'):
+    if hasattr(context.edrr_coordinator, "_attempt_recovery"):
         original_recovery = context.edrr_coordinator._attempt_recovery
-        
+
         def mock_recovery(error, phase):
             context.recovery_attempted = True
             return {"recovered": True, "strategy": "retry"}
-        
+
         context.edrr_coordinator._attempt_recovery = mock_recovery
-        
+
         # Execute the current phase again to trigger recovery
         context.edrr_coordinator.execute_current_phase()
-        
+
         # Verify that recovery was attempted
         assert context.recovery_attempted
-        
+
         # Restore the original method
         context.edrr_coordinator._attempt_recovery = original_recovery
     else:
         # If the coordinator doesn't have a recovery method, we'll simulate one
         context.recovery_attempted = True
-        
+
         # Execute the current phase again with a mock that doesn't raise an exception
         def mock_process_recovered(task):
             return {"result": "Recovered solution"}
-        
+
         context.wsde_team.process = mock_process_recovered
-        
+
         # Execute the current phase again
         context.edrr_coordinator.execute_current_phase()
 
@@ -573,17 +601,22 @@ def verify_continue_after_recovery(context):
     """Verify that the WSDE team can continue the cycle after recovery."""
     # Restore the original process method
     context.wsde_team.process = context.original_process
-    
+
     # Progress to the next phase
-    next_phase = Phase.DIFFERENTIATE if context.edrr_coordinator.current_phase == Phase.EXPAND else Phase.REFINE
+    next_phase = (
+        Phase.DIFFERENTIATE
+        if context.edrr_coordinator.current_phase == Phase.EXPAND
+        else Phase.REFINE
+    )
     context.edrr_coordinator.progress_to_phase(next_phase)
-    
+
     # Execute the next phase
     results = context.edrr_coordinator.execute_current_phase()
-    
+
     # Verify that the phase was executed successfully
     assert results is not None
     assert context.edrr_coordinator.current_phase == next_phase  # noqa: F401,F403
+
 
 scenarios("../features/general/wsde_edrr_integration.feature")
 

--- a/tests/behavior/steps/wsde_peer_review_steps.py
+++ b/tests/behavior/steps/wsde_peer_review_steps.py
@@ -1,13 +1,13 @@
 from unittest.mock import MagicMock
 
 import pytest
-from pytest_bdd import given, when, then, scenarios
+from pytest_bdd import given, scenarios, then, when
 
-from devsynth.application.collaboration.peer_review import run_peer_review
 from devsynth.adapters.agents.agent_adapter import WSDETeamCoordinator
 from devsynth.application.agents.unified_agent import UnifiedAgent
+from devsynth.application.collaboration.peer_review import run_peer_review
 from devsynth.domain.models.agent import AgentConfig, AgentType
-from devsynth.domain.models.wsde import WSDETeam
+from devsynth.domain.models.wsde_facade import WSDETeam
 
 scenarios("../features/wsde_peer_review.feature")
 
@@ -38,9 +38,7 @@ def wsde_enabled(context):
 @given("a simple work product and two reviewers")
 def simple_work_and_reviewers(context):
     author = UnifiedAgent()
-    author.initialize(
-        AgentConfig(name="author", agent_type=AgentType.ORCHESTRATOR)
-    )
+    author.initialize(AgentConfig(name="author", agent_type=AgentType.ORCHESTRATOR))
     r1 = UnifiedAgent()
     r1.initialize(AgentConfig(name="rev1", agent_type=AgentType.ORCHESTRATOR))
     r2 = UnifiedAgent()
@@ -98,9 +96,7 @@ def voting_result_setup(context):
 
 @when("the team summarizes the voting result")
 def team_summarizes_vote(context):
-    context.vote_summary = context.team.summarize_voting_result(
-        context.voting_result
-    )
+    context.vote_summary = context.team.summarize_voting_result(context.voting_result)
 
 
 @then("the summary should mention the winning option")

--- a/tests/behavior/test_micro_edrr_cycle.py
+++ b/tests/behavior/test_micro_edrr_cycle.py
@@ -5,19 +5,20 @@ This script implements the step definitions for the micro_edrr_cycle.feature fil
 """
 
 import os
-import pytest
 from unittest.mock import MagicMock, patch
-from pytest_bdd import scenarios, given, when, then
 
-from devsynth.application.edrr.coordinator import EDRRCoordinator
-from devsynth.application.memory.memory_manager import MemoryManager
+import pytest
+from pytest_bdd import given, scenarios, then, when
+
 from devsynth.application.code_analysis.analyzer import CodeAnalyzer
 from devsynth.application.code_analysis.ast_transformer import AstTransformer
-from devsynth.application.prompts.prompt_manager import PromptManager
 from devsynth.application.documentation.documentation_manager import (
     DocumentationManager,
 )
-from devsynth.domain.models.wsde import WSDETeam
+from devsynth.application.edrr.coordinator import EDRRCoordinator
+from devsynth.application.memory.memory_manager import MemoryManager
+from devsynth.application.prompts.prompt_manager import PromptManager
+from devsynth.domain.models.wsde_facade import WSDETeam
 
 # Get the absolute path to the feature file
 feature_file = os.path.join(

--- a/tests/integration/edrr/test_wsde_edrr_integration.py
+++ b/tests/integration/edrr/test_wsde_edrr_integration.py
@@ -3,9 +3,11 @@ Test the integration between WSDE and EDRR, particularly the phase-specific
 role assignment functionality.
 """
 
-import pytest
 from unittest.mock import MagicMock, patch
-from devsynth.domain.models.wsde import WSDETeam
+
+import pytest
+
+from devsynth.domain.models.wsde_facade import WSDETeam
 from devsynth.methodology.base import Phase
 
 

--- a/tests/integration/general/test_agent_collaboration_integration.py
+++ b/tests/integration/general/test_agent_collaboration_integration.py
@@ -6,19 +6,23 @@ between specialized agents to work together on complex tasks.
 """
 
 import os
-import pytest
+from typing import Any, Dict
 from unittest.mock import MagicMock, patch
-from typing import Dict, Any
+
+import pytest
+
 from devsynth.application.collaboration.agent_collaboration import (
     AgentCollaborationSystem,
-    CollaborationTask,
     AgentMessage,
+    CollaborationTask,
     MessageType,
     TaskStatus,
 )
 from devsynth.application.collaboration.message_protocol import (
     MessageProtocol,
     MessageStore,
+)
+from devsynth.application.collaboration.message_protocol import (
     MessageType as ProtocolMessageType,
 )
 from devsynth.application.collaboration.peer_review import run_peer_review
@@ -255,7 +259,7 @@ class TestAgentCollaborationSystem:
     def test_peer_review_with_team_builds_consensus_and_rotates_roles(self):
         """Peer review integrates WSDETeam role rotation and consensus."""
 
-        from devsynth.domain.models.wsde import WSDETeam
+        from devsynth.domain.models.wsde_facade import WSDETeam
 
         class DummyAgent(MockAgent):
             def __init__(self, name):

--- a/tests/integration/general/test_code_analysis_edrr_integration.py
+++ b/tests/integration/general/test_code_analysis_edrr_integration.py
@@ -7,29 +7,31 @@ within the EDRR framework to analyze and transform code during the development p
 """
 
 import os
-import pytest
 from unittest.mock import MagicMock, patch
-from devsynth.application.edrr.edrr_coordinator_enhanced import EnhancedEDRRCoordinator
-from devsynth.domain.models.wsde import WSDETeam
-from devsynth.application.memory.memory_manager import MemoryManager
+
+import pytest
+
+from devsynth.application.agents.unified_agent import UnifiedAgent
 from devsynth.application.code_analysis.analyzer import CodeAnalyzer
 from devsynth.application.code_analysis.ast_transformer import AstTransformer
+from devsynth.application.code_analysis.ast_workflow_integration import (
+    AstWorkflowIntegration,
+)
 from devsynth.application.code_analysis.project_state_analyzer import (
     ProjectStateAnalyzer,
 )
 from devsynth.application.code_analysis.self_analyzer import SelfAnalyzer
 from devsynth.application.code_analysis.transformer import CodeTransformer
-from devsynth.application.code_analysis.ast_workflow_integration import (
-    AstWorkflowIntegration,
-)
-from devsynth.application.prompts.prompt_manager import PromptManager
 from devsynth.application.documentation.documentation_manager import (
     DocumentationManager,
 )
-from devsynth.methodology.base import Phase
+from devsynth.application.edrr.edrr_coordinator_enhanced import EnhancedEDRRCoordinator
+from devsynth.application.memory.memory_manager import MemoryManager
+from devsynth.application.prompts.prompt_manager import PromptManager
 from devsynth.domain.models.agent import AgentConfig, AgentType
-from devsynth.application.agents.unified_agent import UnifiedAgent
 from devsynth.domain.models.memory import MemoryType
+from devsynth.domain.models.wsde_facade import WSDETeam
+from devsynth.methodology.base import Phase
 
 
 def test_agent_type_expert_exists():

--- a/tests/integration/general/test_code_analysis_wsde_integration.py
+++ b/tests/integration/general/test_code_analysis_wsde_integration.py
@@ -7,24 +7,26 @@ within the WSDE framework to analyze and transform code during the development p
 """
 
 import os
-import pytest
 from unittest.mock import MagicMock, patch
-from devsynth.domain.models.wsde import WSDETeam
-from devsynth.application.memory.memory_manager import MemoryManager
+
+import pytest
+
+from devsynth.application.agents.unified_agent import UnifiedAgent
 from devsynth.application.code_analysis.analyzer import CodeAnalyzer
 from devsynth.application.code_analysis.ast_transformer import AstTransformer
+from devsynth.application.code_analysis.ast_workflow_integration import (
+    AstWorkflowIntegration,
+)
 from devsynth.application.code_analysis.project_state_analyzer import (
     ProjectStateAnalyzer,
 )
 from devsynth.application.code_analysis.self_analyzer import SelfAnalyzer
 from devsynth.application.code_analysis.transformer import CodeTransformer
-from devsynth.application.code_analysis.ast_workflow_integration import (
-    AstWorkflowIntegration,
-)
+from devsynth.application.memory.memory_manager import MemoryManager
 from devsynth.domain.models.agent import AgentConfig, AgentType
-from devsynth.application.agents.unified_agent import UnifiedAgent
 from devsynth.domain.models.memory import MemoryType
 from devsynth.domain.models.task import Task, TaskStatus
+from devsynth.domain.models.wsde_facade import WSDETeam
 
 
 def test_agent_type_expert_exists():

--- a/tests/integration/general/test_edrr_auto_phase_transition.py
+++ b/tests/integration/general/test_edrr_auto_phase_transition.py
@@ -1,60 +1,63 @@
-from unittest.mock import MagicMock
-import types
 import sys
+import types
+from unittest.mock import MagicMock
+
 import pytest
-argon2_mod = types.ModuleType('argon2')
-setattr(argon2_mod, 'PasswordHasher', object)
-exceptions_mod = types.ModuleType('exceptions')
-setattr(exceptions_mod, 'VerifyMismatchError', type('VerifyMismatchError',
-    (), {}))
-setattr(argon2_mod, 'exceptions', exceptions_mod)
-sys.modules.setdefault('argon2', argon2_mod)
-sys.modules.setdefault('argon2.exceptions', exceptions_mod)
-sys.modules.setdefault('requests', types.ModuleType('requests'))
-crypto_mod = types.ModuleType('cryptography')
-fernet_mod = types.ModuleType('fernet')
-setattr(fernet_mod, 'Fernet', object)
+
+argon2_mod = types.ModuleType("argon2")
+setattr(argon2_mod, "PasswordHasher", object)
+exceptions_mod = types.ModuleType("exceptions")
+setattr(exceptions_mod, "VerifyMismatchError", type("VerifyMismatchError", (), {}))
+setattr(argon2_mod, "exceptions", exceptions_mod)
+sys.modules.setdefault("argon2", argon2_mod)
+sys.modules.setdefault("argon2.exceptions", exceptions_mod)
+sys.modules.setdefault("requests", types.ModuleType("requests"))
+crypto_mod = types.ModuleType("cryptography")
+fernet_mod = types.ModuleType("fernet")
+setattr(fernet_mod, "Fernet", object)
 crypto_mod.fernet = fernet_mod
-sys.modules.setdefault('cryptography', crypto_mod)
-sys.modules.setdefault('cryptography.fernet', fernet_mod)
-sys.modules.setdefault('jsonschema', types.ModuleType('jsonschema'))
-rdflib_mod = types.ModuleType('rdflib')
-setattr(rdflib_mod, 'Graph', object)
-setattr(rdflib_mod, 'Literal', object)
-setattr(rdflib_mod, 'URIRef', object)
-setattr(rdflib_mod, 'Namespace', lambda *a, **k: object())
-setattr(rdflib_mod, 'RDF', object)
-setattr(rdflib_mod, 'RDFS', object)
-setattr(rdflib_mod, 'XSD', object)
-namespace_mod = types.ModuleType('namespace')
-setattr(namespace_mod, 'FOAF', object)
-setattr(namespace_mod, 'DC', object)
+sys.modules.setdefault("cryptography", crypto_mod)
+sys.modules.setdefault("cryptography.fernet", fernet_mod)
+sys.modules.setdefault("jsonschema", types.ModuleType("jsonschema"))
+rdflib_mod = types.ModuleType("rdflib")
+setattr(rdflib_mod, "Graph", object)
+setattr(rdflib_mod, "Literal", object)
+setattr(rdflib_mod, "URIRef", object)
+setattr(rdflib_mod, "Namespace", lambda *a, **k: object())
+setattr(rdflib_mod, "RDF", object)
+setattr(rdflib_mod, "RDFS", object)
+setattr(rdflib_mod, "XSD", object)
+namespace_mod = types.ModuleType("namespace")
+setattr(namespace_mod, "FOAF", object)
+setattr(namespace_mod, "DC", object)
 rdflib_mod.namespace = namespace_mod
-sys.modules.setdefault('rdflib', rdflib_mod)
-sys.modules.setdefault('rdflib.namespace', namespace_mod)
-astor_mod = types.ModuleType('astor')
-setattr(astor_mod, 'to_source', lambda *a, **k: '')
-sys.modules.setdefault('astor', astor_mod)
-tinydb_mod = types.ModuleType('tinydb')
-setattr(tinydb_mod, 'TinyDB', object)
-setattr(tinydb_mod, 'Query', object)
-storages_mod = types.ModuleType('storages')
-setattr(storages_mod, 'MemoryStorage', object)
-setattr(storages_mod, 'JSONStorage', object)
+sys.modules.setdefault("rdflib", rdflib_mod)
+sys.modules.setdefault("rdflib.namespace", namespace_mod)
+astor_mod = types.ModuleType("astor")
+setattr(astor_mod, "to_source", lambda *a, **k: "")
+sys.modules.setdefault("astor", astor_mod)
+tinydb_mod = types.ModuleType("tinydb")
+setattr(tinydb_mod, "TinyDB", object)
+setattr(tinydb_mod, "Query", object)
+storages_mod = types.ModuleType("storages")
+setattr(storages_mod, "MemoryStorage", object)
+setattr(storages_mod, "JSONStorage", object)
 tinydb_mod.storages = storages_mod
-sys.modules.setdefault('tinydb', tinydb_mod)
-sys.modules.setdefault('tinydb.storages', storages_mod)
-middlewares_mod = types.ModuleType('middlewares')
-setattr(middlewares_mod, 'CachingMiddleware', object)
+sys.modules.setdefault("tinydb", tinydb_mod)
+sys.modules.setdefault("tinydb.storages", storages_mod)
+middlewares_mod = types.ModuleType("middlewares")
+setattr(middlewares_mod, "CachingMiddleware", object)
 tinydb_mod.middlewares = middlewares_mod
-sys.modules.setdefault('tinydb.middlewares', middlewares_mod)
+sys.modules.setdefault("tinydb.middlewares", middlewares_mod)
 from devsynth.application.code_analysis.analyzer import CodeAnalyzer
 from devsynth.application.code_analysis.ast_transformer import AstTransformer
-from devsynth.application.documentation.documentation_manager import DocumentationManager
+from devsynth.application.documentation.documentation_manager import (
+    DocumentationManager,
+)
 from devsynth.application.edrr.coordinator import EDRRCoordinator
 from devsynth.application.memory.memory_manager import MemoryManager
 from devsynth.application.prompts.prompt_manager import PromptManager
-from devsynth.domain.models.wsde import WSDETeam
+from devsynth.domain.models.wsde_facade import WSDETeam
 from devsynth.methodology.base import Phase
 
 
@@ -68,11 +71,16 @@ class SimpleAgent:
 
 @pytest.fixture
 def coordinator():
-    team = WSDETeam(name='TestEdrrAutoPhaseTransitionTeam')
-    team.add_agents([SimpleAgent('expand', ['expand']), SimpleAgent('diff',
-        ['differentiate']), SimpleAgent('refine', ['refine']), SimpleAgent(
-        'retro', ['retrospect'])])
-    team.generate_diverse_ideas = MagicMock(return_value=['idea'])
+    team = WSDETeam(name="TestEdrrAutoPhaseTransitionTeam")
+    team.add_agents(
+        [
+            SimpleAgent("expand", ["expand"]),
+            SimpleAgent("diff", ["differentiate"]),
+            SimpleAgent("refine", ["refine"]),
+            SimpleAgent("retro", ["retrospect"]),
+        ]
+    )
+    team.generate_diverse_ideas = MagicMock(return_value=["idea"])
     team.create_comparison_matrix = MagicMock(return_value={})
     team.evaluate_options = MagicMock(return_value=[])
     team.analyze_trade_offs = MagicMock(return_value=[])
@@ -89,65 +97,83 @@ def coordinator():
     mm = MagicMock(spec=MemoryManager)
 
     def retrieve_with_phase(item_type, phase, metadata):
-        if item_type == 'EXPAND_RESULTS':
-            return {'ideas': []}
-        if item_type == 'DIFFERENTIATE_RESULTS':
-            return {'evaluated_options': [], 'decision_criteria': {}}
-        if item_type == 'REFINE_RESULTS':
-            return {'implementation_plan': [], 'quality_checks': {}}
+        if item_type == "EXPAND_RESULTS":
+            return {"ideas": []}
+        if item_type == "DIFFERENTIATE_RESULTS":
+            return {"evaluated_options": [], "decision_criteria": {}}
+        if item_type == "REFINE_RESULTS":
+            return {"implementation_plan": [], "quality_checks": {}}
         return {}
+
     mm.retrieve_with_edrr_phase.side_effect = retrieve_with_phase
     mm.retrieve_relevant_knowledge.return_value = []
     mm.retrieve_historical_patterns.return_value = []
     analyzer = MagicMock(spec=CodeAnalyzer)
     analyzer.analyze_project_structure.return_value = []
-    config = {'edrr': {'phase_transition': {'auto': True, 'timeout': 0}},
-        'features': {'automatic_phase_transitions': True}}
-    return EDRRCoordinator(memory_manager=mm, wsde_team=team, code_analyzer
-        =analyzer, ast_transformer=MagicMock(spec=AstTransformer),
-        prompt_manager=MagicMock(spec=PromptManager), documentation_manager
-        =MagicMock(spec=DocumentationManager), enable_enhanced_logging=
-        False, config=config)
+    config = {
+        "edrr": {"phase_transition": {"auto": True, "timeout": 0}},
+        "features": {"automatic_phase_transitions": True},
+    }
+    return EDRRCoordinator(
+        memory_manager=mm,
+        wsde_team=team,
+        code_analyzer=analyzer,
+        ast_transformer=MagicMock(spec=AstTransformer),
+        prompt_manager=MagicMock(spec=PromptManager),
+        documentation_manager=MagicMock(spec=DocumentationManager),
+        enable_enhanced_logging=False,
+        config=config,
+    )
 
 
 def test_full_cycle_auto_transition_dynamic_roles_succeeds(coordinator):
     """Test that full cycle auto transition dynamic roles succeeds.
 
-ReqID: N/A"""
-    task = {'description': 'demo'}
+    ReqID: N/A"""
+    task = {"description": "demo"}
     coordinator.start_cycle(task)
     assert coordinator.current_phase == Phase.RETROSPECT
-    calls = [c.args[2] for c in coordinator.memory_manager.
-        store_with_edrr_phase.call_args_list if c.args[1] == 'ROLE_ASSIGNMENT']
+    calls = [
+        c.args[2]
+        for c in coordinator.memory_manager.store_with_edrr_phase.call_args_list
+        if c.args[1] == "ROLE_ASSIGNMENT"
+    ]
     calls = calls[-4:]
-    assert calls == [Phase.EXPAND.value, Phase.DIFFERENTIATE.value, Phase.
-        REFINE.value, Phase.RETROSPECT.value]
+    assert calls == [
+        Phase.EXPAND.value,
+        Phase.DIFFERENTIATE.value,
+        Phase.REFINE.value,
+        Phase.RETROSPECT.value,
+    ]
 
 
 def test_micro_cycle_results_aggregated_succeeds(coordinator):
     """Ensure micro cycles spawn and results are aggregated.
 
-ReqID: N/A"""
-    valid_task = {'description': 'child valid', 'granularity_score': 0.8}
-    terminate_task = {'description': 'child stop', 'granularity_score': 0.1}
+    ReqID: N/A"""
+    valid_task = {"description": "child valid", "granularity_score": 0.8}
+    terminate_task = {"description": "child stop", "granularity_score": 0.1}
     original_expand = coordinator._execute_expand_phase
 
     def expand_with_micro(context=None):
-        context = {'micro_tasks': [valid_task, terminate_task]}
+        context = {"micro_tasks": [valid_task, terminate_task]}
         return original_expand(context)
+
     coordinator._execute_expand_phase = expand_with_micro
-    coordinator.start_cycle({'description': 'macro'})
+    coordinator.start_cycle({"description": "macro"})
     assert coordinator.current_phase == Phase.RETROSPECT
     assert len(coordinator.child_cycles) == 1
     child = coordinator.child_cycles[0]
     expand_results = coordinator.results[Phase.EXPAND.name]
-    assert child.cycle_id in expand_results['micro_cycle_results']
-    assert 'child stop' in expand_results['micro_cycle_results']
-    assert 'error' in expand_results['micro_cycle_results']['child stop']
-    aggregated = coordinator.results['AGGREGATED']
-    assert child.cycle_id in aggregated['child_cycles']
-    assert aggregated['child_cycles'][child.cycle_id] == child.results
-    assert any(call.args[1] == 'MICRO_CYCLE' for call in coordinator.
-        memory_manager.store_with_edrr_phase.call_args_list)
+    assert child.cycle_id in expand_results["micro_cycle_results"]
+    assert "child stop" in expand_results["micro_cycle_results"]
+    assert "error" in expand_results["micro_cycle_results"]["child stop"]
+    aggregated = coordinator.results["AGGREGATED"]
+    assert child.cycle_id in aggregated["child_cycles"]
+    assert aggregated["child_cycles"][child.cycle_id] == child.results
+    assert any(
+        call.args[1] == "MICRO_CYCLE"
+        for call in coordinator.memory_manager.store_with_edrr_phase.call_args_list
+    )
     assert coordinator.should_terminate_recursion(terminate_task) is True
     assert coordinator.should_terminate_recursion(valid_task) is False

--- a/tests/integration/general/test_edrr_dynamic_roles.py
+++ b/tests/integration/general/test_edrr_dynamic_roles.py
@@ -1,12 +1,16 @@
 from unittest.mock import MagicMock
+
 import pytest
-from devsynth.application.edrr.coordinator import EDRRCoordinator
-from devsynth.domain.models.wsde import WSDETeam
+
 from devsynth.application.code_analysis.analyzer import CodeAnalyzer
 from devsynth.application.code_analysis.ast_transformer import AstTransformer
-from devsynth.application.prompts.prompt_manager import PromptManager
-from devsynth.application.documentation.documentation_manager import DocumentationManager
+from devsynth.application.documentation.documentation_manager import (
+    DocumentationManager,
+)
+from devsynth.application.edrr.coordinator import EDRRCoordinator
 from devsynth.application.memory.memory_manager import MemoryManager
+from devsynth.application.prompts.prompt_manager import PromptManager
+from devsynth.domain.models.wsde_facade import WSDETeam
 from devsynth.methodology.base import Phase
 
 
@@ -20,28 +24,38 @@ class ExpertAgent:
 
 @pytest.fixture
 def coordinator():
-    team = WSDETeam(name='TestEdrrDynamicRolesTeam')
-    team.add_agents([ExpertAgent('expand', ['expand']), ExpertAgent('diff',
-        ['differentiate']), ExpertAgent('refine', ['refine'])])
+    team = WSDETeam(name="TestEdrrDynamicRolesTeam")
+    team.add_agents(
+        [
+            ExpertAgent("expand", ["expand"]),
+            ExpertAgent("diff", ["differentiate"]),
+            ExpertAgent("refine", ["refine"]),
+        ]
+    )
     mm = MagicMock(spec=MemoryManager)
     mm.retrieve_relevant_knowledge.return_value = []
     mm.retrieve_historical_patterns.return_value = []
     analyzer = MagicMock(spec=CodeAnalyzer)
     analyzer.analyze_project_structure.return_value = []
-    return EDRRCoordinator(memory_manager=mm, wsde_team=team, code_analyzer
-        =analyzer, ast_transformer=MagicMock(spec=AstTransformer),
-        prompt_manager=MagicMock(spec=PromptManager), documentation_manager
-        =MagicMock(spec=DocumentationManager), enable_enhanced_logging=False)
+    return EDRRCoordinator(
+        memory_manager=mm,
+        wsde_team=team,
+        code_analyzer=analyzer,
+        ast_transformer=MagicMock(spec=AstTransformer),
+        prompt_manager=MagicMock(spec=PromptManager),
+        documentation_manager=MagicMock(spec=DocumentationManager),
+        enable_enhanced_logging=False,
+    )
 
 
 def test_dynamic_role_assignment_across_phases_succeeds(coordinator):
     """Test that dynamic role assignment across phases succeeds.
 
-ReqID: N/A"""
-    task = {'description': 'demo'}
+    ReqID: N/A"""
+    task = {"description": "demo"}
     coordinator.start_cycle(task)
-    assert coordinator.wsde_team.get_primus().name == 'expand'
+    assert coordinator.wsde_team.get_primus().name == "expand"
     coordinator.progress_to_next_phase()
-    assert coordinator.wsde_team.get_primus().name == 'diff'
+    assert coordinator.wsde_team.get_primus().name == "diff"
     coordinator.progress_to_next_phase()
-    assert coordinator.wsde_team.get_primus().name == 'refine'
+    assert coordinator.wsde_team.get_primus().name == "refine"

--- a/tests/integration/general/test_edrr_manifest_dependencies.py
+++ b/tests/integration/general/test_edrr_manifest_dependencies.py
@@ -1,45 +1,48 @@
 import json
-from unittest.mock import MagicMock
 import sys
 import types
+from unittest.mock import MagicMock
+
 import pytest
-argon2_mod = types.ModuleType('argon2')
-setattr(argon2_mod, 'PasswordHasher', object)
-exceptions_mod = types.ModuleType('exceptions')
-setattr(exceptions_mod, 'VerifyMismatchError', type('VerifyMismatchError',
-    (), {}))
-setattr(argon2_mod, 'exceptions', exceptions_mod)
-sys.modules.setdefault('argon2', argon2_mod)
-sys.modules.setdefault('argon2.exceptions', exceptions_mod)
-sys.modules.setdefault('requests', types.ModuleType('requests'))
-crypto_mod = types.ModuleType('cryptography')
-fernet_mod = types.ModuleType('fernet')
-setattr(fernet_mod, 'Fernet', object)
+
+argon2_mod = types.ModuleType("argon2")
+setattr(argon2_mod, "PasswordHasher", object)
+exceptions_mod = types.ModuleType("exceptions")
+setattr(exceptions_mod, "VerifyMismatchError", type("VerifyMismatchError", (), {}))
+setattr(argon2_mod, "exceptions", exceptions_mod)
+sys.modules.setdefault("argon2", argon2_mod)
+sys.modules.setdefault("argon2.exceptions", exceptions_mod)
+sys.modules.setdefault("requests", types.ModuleType("requests"))
+crypto_mod = types.ModuleType("cryptography")
+fernet_mod = types.ModuleType("fernet")
+setattr(fernet_mod, "Fernet", object)
 crypto_mod.fernet = fernet_mod
-sys.modules.setdefault('cryptography', crypto_mod)
-sys.modules.setdefault('cryptography.fernet', fernet_mod)
-sys.modules.setdefault('jsonschema', types.ModuleType('jsonschema'))
-rdflib_mod = types.ModuleType('rdflib')
-setattr(rdflib_mod, 'Graph', object)
-setattr(rdflib_mod, 'Literal', object)
-setattr(rdflib_mod, 'URIRef', object)
-setattr(rdflib_mod, 'Namespace', object)
-setattr(rdflib_mod, 'RDF', object)
-setattr(rdflib_mod, 'RDFS', object)
-setattr(rdflib_mod, 'XSD', object)
-namespace_mod = types.ModuleType('namespace')
-setattr(namespace_mod, 'FOAF', object)
-setattr(namespace_mod, 'DC', object)
+sys.modules.setdefault("cryptography", crypto_mod)
+sys.modules.setdefault("cryptography.fernet", fernet_mod)
+sys.modules.setdefault("jsonschema", types.ModuleType("jsonschema"))
+rdflib_mod = types.ModuleType("rdflib")
+setattr(rdflib_mod, "Graph", object)
+setattr(rdflib_mod, "Literal", object)
+setattr(rdflib_mod, "URIRef", object)
+setattr(rdflib_mod, "Namespace", object)
+setattr(rdflib_mod, "RDF", object)
+setattr(rdflib_mod, "RDFS", object)
+setattr(rdflib_mod, "XSD", object)
+namespace_mod = types.ModuleType("namespace")
+setattr(namespace_mod, "FOAF", object)
+setattr(namespace_mod, "DC", object)
 rdflib_mod.namespace = namespace_mod
-sys.modules.setdefault('rdflib', rdflib_mod)
-sys.modules.setdefault('rdflib.namespace', namespace_mod)
-from devsynth.application.edrr.coordinator import EDRRCoordinator, EDRRCoordinatorError
-from devsynth.application.memory.memory_manager import MemoryManager
+sys.modules.setdefault("rdflib", rdflib_mod)
+sys.modules.setdefault("rdflib.namespace", namespace_mod)
 from devsynth.application.code_analysis.analyzer import CodeAnalyzer
 from devsynth.application.code_analysis.ast_transformer import AstTransformer
+from devsynth.application.documentation.documentation_manager import (
+    DocumentationManager,
+)
+from devsynth.application.edrr.coordinator import EDRRCoordinator, EDRRCoordinatorError
+from devsynth.application.memory.memory_manager import MemoryManager
 from devsynth.application.prompts.prompt_manager import PromptManager
-from devsynth.application.documentation.documentation_manager import DocumentationManager
-from devsynth.domain.models.wsde import WSDETeam
+from devsynth.domain.models.wsde_facade import WSDETeam
 from devsynth.methodology.base import Phase
 
 
@@ -56,24 +59,35 @@ class SimpleAgent:
 
 @pytest.fixture
 def coordinator(tmp_path):
-    manifest = {'id': 'm1', 'description': 'test', 'phases': {'expand': {
-        'instructions': 'e'}, 'differentiate': {'instructions': 'd'},
-        'refine': {'instructions': 'r'}, 'retrospect': {'instructions': 't'}}}
-    path = tmp_path / 'manifest.json'
+    manifest = {
+        "id": "m1",
+        "description": "test",
+        "phases": {
+            "expand": {"instructions": "e"},
+            "differentiate": {"instructions": "d"},
+            "refine": {"instructions": "r"},
+            "retrospect": {"instructions": "t"},
+        },
+    }
+    path = tmp_path / "manifest.json"
     path.write_text(json.dumps(manifest))
-    team = WSDETeam(name='TestEdrrManifestDependenciesTeam')
-    team.add_agents([SimpleAgent('a1'), SimpleAgent('a2')])
+    team = WSDETeam(name="TestEdrrManifestDependenciesTeam")
+    team.add_agents([SimpleAgent("a1"), SimpleAgent("a2")])
     mm = MagicMock(spec=MemoryManager)
     mm.retrieve_with_edrr_phase.side_effect = lambda *a, **k: {}
     mm.retrieve_relevant_knowledge.return_value = []
     mm.retrieve_historical_patterns.return_value = []
     analyzer = MagicMock(spec=CodeAnalyzer)
     analyzer.analyze_project_structure.return_value = []
-    coord = EDRRCoordinator(memory_manager=mm, wsde_team=team,
-        code_analyzer=analyzer, ast_transformer=MagicMock(spec=
-        AstTransformer), prompt_manager=MagicMock(spec=PromptManager),
+    coord = EDRRCoordinator(
+        memory_manager=mm,
+        wsde_team=team,
+        code_analyzer=analyzer,
+        ast_transformer=MagicMock(spec=AstTransformer),
+        prompt_manager=MagicMock(spec=PromptManager),
         documentation_manager=MagicMock(spec=DocumentationManager),
-        enable_enhanced_logging=False)
+        enable_enhanced_logging=False,
+    )
     coord.start_cycle_from_manifest(str(path))
     return coord
 
@@ -81,7 +95,7 @@ def coordinator(tmp_path):
 def test_manifest_dependencies_enforced_succeeds(coordinator):
     """Test that manifest dependencies enforced succeeds.
 
-ReqID: N/A"""
+    ReqID: N/A"""
     with pytest.raises(EDRRCoordinatorError):
         coordinator.progress_to_phase(Phase.REFINE)
     coordinator.progress_to_phase(Phase.DIFFERENTIATE)

--- a/tests/integration/general/test_edrr_micro_cycle_auto_transition.py
+++ b/tests/integration/general/test_edrr_micro_cycle_auto_transition.py
@@ -1,47 +1,50 @@
-from unittest.mock import MagicMock
-import types
 import sys
+import types
+from unittest.mock import MagicMock
+
 import pytest
-argon2_mod = types.ModuleType('argon2')
-setattr(argon2_mod, 'PasswordHasher', object)
-exceptions_mod = types.ModuleType('exceptions')
-setattr(exceptions_mod, 'VerifyMismatchError', type('VerifyMismatchError',
-    (), {}))
-setattr(argon2_mod, 'exceptions', exceptions_mod)
-sys.modules.setdefault('argon2', argon2_mod)
-sys.modules.setdefault('argon2.exceptions', exceptions_mod)
-sys.modules.setdefault('requests', types.ModuleType('requests'))
-crypto_mod = types.ModuleType('cryptography')
-fernet_mod = types.ModuleType('fernet')
-setattr(fernet_mod, 'Fernet', object)
+
+argon2_mod = types.ModuleType("argon2")
+setattr(argon2_mod, "PasswordHasher", object)
+exceptions_mod = types.ModuleType("exceptions")
+setattr(exceptions_mod, "VerifyMismatchError", type("VerifyMismatchError", (), {}))
+setattr(argon2_mod, "exceptions", exceptions_mod)
+sys.modules.setdefault("argon2", argon2_mod)
+sys.modules.setdefault("argon2.exceptions", exceptions_mod)
+sys.modules.setdefault("requests", types.ModuleType("requests"))
+crypto_mod = types.ModuleType("cryptography")
+fernet_mod = types.ModuleType("fernet")
+setattr(fernet_mod, "Fernet", object)
 crypto_mod.fernet = fernet_mod
-sys.modules.setdefault('cryptography', crypto_mod)
-sys.modules.setdefault('cryptography.fernet', fernet_mod)
-sys.modules.setdefault('jsonschema', types.ModuleType('jsonschema'))
-rdflib_mod = types.ModuleType('rdflib')
-setattr(rdflib_mod, 'Graph', object)
-setattr(rdflib_mod, 'Literal', object)
-setattr(rdflib_mod, 'URIRef', object)
-setattr(rdflib_mod, 'Namespace', lambda *a, **k: object())
-setattr(rdflib_mod, 'RDF', object)
-setattr(rdflib_mod, 'RDFS', object)
-setattr(rdflib_mod, 'XSD', object)
-namespace_mod = types.ModuleType('namespace')
-setattr(namespace_mod, 'FOAF', object)
-setattr(namespace_mod, 'DC', object)
+sys.modules.setdefault("cryptography", crypto_mod)
+sys.modules.setdefault("cryptography.fernet", fernet_mod)
+sys.modules.setdefault("jsonschema", types.ModuleType("jsonschema"))
+rdflib_mod = types.ModuleType("rdflib")
+setattr(rdflib_mod, "Graph", object)
+setattr(rdflib_mod, "Literal", object)
+setattr(rdflib_mod, "URIRef", object)
+setattr(rdflib_mod, "Namespace", lambda *a, **k: object())
+setattr(rdflib_mod, "RDF", object)
+setattr(rdflib_mod, "RDFS", object)
+setattr(rdflib_mod, "XSD", object)
+namespace_mod = types.ModuleType("namespace")
+setattr(namespace_mod, "FOAF", object)
+setattr(namespace_mod, "DC", object)
 rdflib_mod.namespace = namespace_mod
-sys.modules.setdefault('rdflib', rdflib_mod)
-sys.modules.setdefault('rdflib.namespace', namespace_mod)
-astor_mod = types.ModuleType('astor')
-setattr(astor_mod, 'to_source', lambda *a, **k: '')
-sys.modules.setdefault('astor', astor_mod)
-from devsynth.application.edrr.coordinator import EDRRCoordinator
-from devsynth.domain.models.wsde import WSDETeam
-from devsynth.application.memory.memory_manager import MemoryManager
+sys.modules.setdefault("rdflib", rdflib_mod)
+sys.modules.setdefault("rdflib.namespace", namespace_mod)
+astor_mod = types.ModuleType("astor")
+setattr(astor_mod, "to_source", lambda *a, **k: "")
+sys.modules.setdefault("astor", astor_mod)
 from devsynth.application.code_analysis.analyzer import CodeAnalyzer
 from devsynth.application.code_analysis.ast_transformer import AstTransformer
+from devsynth.application.documentation.documentation_manager import (
+    DocumentationManager,
+)
+from devsynth.application.edrr.coordinator import EDRRCoordinator
+from devsynth.application.memory.memory_manager import MemoryManager
 from devsynth.application.prompts.prompt_manager import PromptManager
-from devsynth.application.documentation.documentation_manager import DocumentationManager
+from devsynth.domain.models.wsde_facade import WSDETeam
 from devsynth.methodology.base import Phase
 
 
@@ -53,14 +56,14 @@ class SimpleAgent:
         self.current_role = None
 
     def process(self, task):
-        return {'processed_by': self.name}
+        return {"processed_by": self.name}
 
 
 @pytest.fixture
 def coordinator():
-    team = WSDETeam(name='TestEdrrMicroCycleAutoTransitionTeam')
-    team.add_agent(SimpleAgent('agent1'))
-    team.generate_diverse_ideas = MagicMock(return_value=['idea'])
+    team = WSDETeam(name="TestEdrrMicroCycleAutoTransitionTeam")
+    team.add_agent(SimpleAgent("agent1"))
+    team.generate_diverse_ideas = MagicMock(return_value=["idea"])
     team.create_comparison_matrix = MagicMock(return_value={})
     team.evaluate_options = MagicMock(return_value=[])
     team.analyze_trade_offs = MagicMock(return_value=[])
@@ -80,18 +83,23 @@ def coordinator():
     mm.retrieve_historical_patterns.return_value = []
     analyzer = MagicMock(spec=CodeAnalyzer)
     analyzer.analyze_project_structure.return_value = []
-    return EDRRCoordinator(memory_manager=mm, wsde_team=team, code_analyzer
-        =analyzer, ast_transformer=MagicMock(spec=AstTransformer),
-        prompt_manager=MagicMock(spec=PromptManager), documentation_manager
-        =MagicMock(spec=DocumentationManager), enable_enhanced_logging=False)
+    return EDRRCoordinator(
+        memory_manager=mm,
+        wsde_team=team,
+        code_analyzer=analyzer,
+        ast_transformer=MagicMock(spec=AstTransformer),
+        prompt_manager=MagicMock(spec=PromptManager),
+        documentation_manager=MagicMock(spec=DocumentationManager),
+        enable_enhanced_logging=False,
+    )
 
 
 def test_micro_cycle_auto_transitions_succeeds(coordinator):
     """Test that micro cycle auto transitions succeeds.
 
-ReqID: N/A"""
-    coordinator.start_cycle({'description': 'macro'})
-    context = {'micro_tasks': [{'description': 'micro'}]}
+    ReqID: N/A"""
+    coordinator.start_cycle({"description": "macro"})
+    context = {"micro_tasks": [{"description": "micro"}]}
     coordinator.execute_current_phase(context)
     assert len(coordinator.child_cycles) == 1
     child = coordinator.child_cycles[0]

--- a/tests/integration/general/test_edrr_micro_cycle_context.py
+++ b/tests/integration/general/test_edrr_micro_cycle_context.py
@@ -1,44 +1,47 @@
-import pytest
-from unittest.mock import MagicMock
 import sys
 import types
-argon2_mod = types.ModuleType('argon2')
-setattr(argon2_mod, 'PasswordHasher', object)
-exceptions_mod = types.ModuleType('exceptions')
-setattr(exceptions_mod, 'VerifyMismatchError', type('VerifyMismatchError',
-    (), {}))
-setattr(argon2_mod, 'exceptions', exceptions_mod)
-sys.modules.setdefault('argon2', argon2_mod)
-sys.modules.setdefault('argon2.exceptions', exceptions_mod)
-sys.modules.setdefault('requests', types.ModuleType('requests'))
-crypto_mod = types.ModuleType('cryptography')
-fernet_mod = types.ModuleType('fernet')
-setattr(fernet_mod, 'Fernet', object)
+from unittest.mock import MagicMock
+
+import pytest
+
+argon2_mod = types.ModuleType("argon2")
+setattr(argon2_mod, "PasswordHasher", object)
+exceptions_mod = types.ModuleType("exceptions")
+setattr(exceptions_mod, "VerifyMismatchError", type("VerifyMismatchError", (), {}))
+setattr(argon2_mod, "exceptions", exceptions_mod)
+sys.modules.setdefault("argon2", argon2_mod)
+sys.modules.setdefault("argon2.exceptions", exceptions_mod)
+sys.modules.setdefault("requests", types.ModuleType("requests"))
+crypto_mod = types.ModuleType("cryptography")
+fernet_mod = types.ModuleType("fernet")
+setattr(fernet_mod, "Fernet", object)
 crypto_mod.fernet = fernet_mod
-sys.modules.setdefault('cryptography', crypto_mod)
-sys.modules.setdefault('cryptography.fernet', fernet_mod)
-sys.modules.setdefault('jsonschema', types.ModuleType('jsonschema'))
-rdflib_mod = types.ModuleType('rdflib')
-setattr(rdflib_mod, 'Graph', object)
-setattr(rdflib_mod, 'Literal', object)
-setattr(rdflib_mod, 'URIRef', object)
-setattr(rdflib_mod, 'Namespace', object)
-setattr(rdflib_mod, 'RDF', object)
-setattr(rdflib_mod, 'RDFS', object)
-setattr(rdflib_mod, 'XSD', object)
-namespace_mod = types.ModuleType('namespace')
-setattr(namespace_mod, 'FOAF', object)
-setattr(namespace_mod, 'DC', object)
+sys.modules.setdefault("cryptography", crypto_mod)
+sys.modules.setdefault("cryptography.fernet", fernet_mod)
+sys.modules.setdefault("jsonschema", types.ModuleType("jsonschema"))
+rdflib_mod = types.ModuleType("rdflib")
+setattr(rdflib_mod, "Graph", object)
+setattr(rdflib_mod, "Literal", object)
+setattr(rdflib_mod, "URIRef", object)
+setattr(rdflib_mod, "Namespace", object)
+setattr(rdflib_mod, "RDF", object)
+setattr(rdflib_mod, "RDFS", object)
+setattr(rdflib_mod, "XSD", object)
+namespace_mod = types.ModuleType("namespace")
+setattr(namespace_mod, "FOAF", object)
+setattr(namespace_mod, "DC", object)
 rdflib_mod.namespace = namespace_mod
-sys.modules.setdefault('rdflib', rdflib_mod)
-sys.modules.setdefault('rdflib.namespace', namespace_mod)
-from devsynth.application.edrr.coordinator import EDRRCoordinator
-from devsynth.domain.models.wsde import WSDETeam
-from devsynth.application.memory.memory_manager import MemoryManager
+sys.modules.setdefault("rdflib", rdflib_mod)
+sys.modules.setdefault("rdflib.namespace", namespace_mod)
 from devsynth.application.code_analysis.analyzer import CodeAnalyzer
 from devsynth.application.code_analysis.ast_transformer import AstTransformer
+from devsynth.application.documentation.documentation_manager import (
+    DocumentationManager,
+)
+from devsynth.application.edrr.coordinator import EDRRCoordinator
+from devsynth.application.memory.memory_manager import MemoryManager
 from devsynth.application.prompts.prompt_manager import PromptManager
-from devsynth.application.documentation.documentation_manager import DocumentationManager
+from devsynth.domain.models.wsde_facade import WSDETeam
 
 
 class SimpleAgent:
@@ -49,14 +52,14 @@ class SimpleAgent:
         self.current_role = None
 
     def process(self, task):
-        return {'processed_by': self.name}
+        return {"processed_by": self.name}
 
 
 @pytest.fixture
 def coordinator():
-    team = WSDETeam(name='TestEdrrMicroCycleContextTeam')
-    team.add_agent(SimpleAgent('agent1'))
-    team.generate_diverse_ideas = MagicMock(return_value=['idea'])
+    team = WSDETeam(name="TestEdrrMicroCycleContextTeam")
+    team.add_agent(SimpleAgent("agent1"))
+    team.generate_diverse_ideas = MagicMock(return_value=["idea"])
     team.create_comparison_matrix = MagicMock(return_value={})
     team.evaluate_options = MagicMock(return_value=[])
     team.analyze_trade_offs = MagicMock(return_value=[])
@@ -76,33 +79,42 @@ def coordinator():
     mm.retrieve_historical_patterns.return_value = []
     analyzer = MagicMock(spec=CodeAnalyzer)
     analyzer.analyze_project_structure.return_value = []
-    return EDRRCoordinator(memory_manager=mm, wsde_team=team, code_analyzer
-        =analyzer, ast_transformer=MagicMock(spec=AstTransformer),
-        prompt_manager=MagicMock(spec=PromptManager), documentation_manager
-        =MagicMock(spec=DocumentationManager), enable_enhanced_logging=False)
+    return EDRRCoordinator(
+        memory_manager=mm,
+        wsde_team=team,
+        code_analyzer=analyzer,
+        ast_transformer=MagicMock(spec=AstTransformer),
+        prompt_manager=MagicMock(spec=PromptManager),
+        documentation_manager=MagicMock(spec=DocumentationManager),
+        enable_enhanced_logging=False,
+    )
 
 
 def test_micro_tasks_context_spawns_cycles_succeeds(coordinator):
     """Test that micro tasks context spawns cycles succeeds.
 
-ReqID: N/A"""
-    coordinator.start_cycle({'description': 'macro'})
-    context = {'micro_tasks': [{'description': 'm1'}, {'description': 'm2'}]}
+    ReqID: N/A"""
+    coordinator.start_cycle({"description": "macro"})
+    context = {"micro_tasks": [{"description": "m1"}, {"description": "m2"}]}
     results = coordinator.execute_current_phase(context)
     assert len(coordinator.child_cycles) == 2
-    assert len(results['micro_cycle_results']) == 2
+    assert len(results["micro_cycle_results"]) == 2
 
 
 def test_nested_micro_tasks_create_recursive_cycles_succeeds(coordinator):
     """Test that nested micro tasks create recursive cycles succeeds.
 
-ReqID: N/A"""
-    coordinator.start_cycle({'description': 'macro'})
-    context = {'micro_tasks': [{'description': 'm1', 'micro_tasks': [{
-        'description': 'm1-child'}]}]}
+    ReqID: N/A"""
+    coordinator.start_cycle({"description": "macro"})
+    context = {
+        "micro_tasks": [
+            {"description": "m1", "micro_tasks": [{"description": "m1-child"}]}
+        ]
+    }
     results = coordinator.execute_current_phase(context)
     assert len(coordinator.child_cycles) == 1
     child = coordinator.child_cycles[0]
     assert len(child.child_cycles) == 1
-    assert len(results['micro_cycle_results'][child.cycle_id][
-        'micro_cycle_results']) == 1
+    assert (
+        len(results["micro_cycle_results"][child.cycle_id]["micro_cycle_results"]) == 1
+    )

--- a/tests/integration/general/test_edrr_mock_llm_integration.py
+++ b/tests/integration/general/test_edrr_mock_llm_integration.py
@@ -1,23 +1,28 @@
 import sys
 import types
-openai_mod = types.ModuleType('openai')
-setattr(openai_mod, 'OpenAI', object)
-setattr(openai_mod, 'AsyncOpenAI', object)
-sys.modules['openai'] = openai_mod
-from devsynth.application.edrr.coordinator import EDRRCoordinator
-from devsynth.application.memory.memory_manager import MemoryManager
-from devsynth.application.memory.adapters.tinydb_memory_adapter import TinyDBMemoryAdapter
-from devsynth.domain.models.wsde import WSDETeam
+
+openai_mod = types.ModuleType("openai")
+setattr(openai_mod, "OpenAI", object)
+setattr(openai_mod, "AsyncOpenAI", object)
+sys.modules["openai"] = openai_mod
 from devsynth.application.code_analysis.analyzer import CodeAnalyzer
 from devsynth.application.code_analysis.ast_transformer import AstTransformer
+from devsynth.application.documentation.documentation_manager import (
+    DocumentationManager,
+)
+from devsynth.application.edrr.coordinator import EDRRCoordinator
+from devsynth.application.memory.adapters.tinydb_memory_adapter import (
+    TinyDBMemoryAdapter,
+)
+from devsynth.application.memory.memory_manager import MemoryManager
 from devsynth.application.prompts.prompt_manager import PromptManager
-from devsynth.application.documentation.documentation_manager import DocumentationManager
+from devsynth.domain.models.wsde_facade import WSDETeam
 
 
 class SimpleMockLLM:
 
     def generate(self, prompt: str, parameters=None):
-        return 'mock response'
+        return "mock response"
 
 
 from devsynth.methodology.base import Phase
@@ -26,39 +31,45 @@ from devsynth.methodology.base import Phase
 def test_edrr_cycle_with_mock_llm_succeeds(tmp_path):
     """Test that edrr cycle with mock llm succeeds.
 
-ReqID: N/A"""
+    ReqID: N/A"""
     memory_adapter = TinyDBMemoryAdapter()
-    memory_manager = MemoryManager(adapters={'tinydb': memory_adapter})
-    wsde_team = WSDETeam(name='TestEdrrMockLlmIntegrationTeam')
+    memory_manager = MemoryManager(adapters={"tinydb": memory_adapter})
+    wsde_team = WSDETeam(name="TestEdrrMockLlmIntegrationTeam")
     llm = SimpleMockLLM()
-    wsde_team.generate_diverse_ideas = (lambda task, max_ideas=10,
-        diversity_threshold=0.7: [{'id': 1, 'idea': llm.generate(task.get(
-        'description', ''))}])
-    wsde_team.formulate_decision_criteria = (lambda task, evaluated_options,
-        trade_offs, contextualize_with_code=True, code_analyzer=None: {
-        'criteria': 1})
-    wsde_team.elaborate_details = lambda selected_option, **kw: [{'step': 1}]
+    wsde_team.generate_diverse_ideas = (
+        lambda task, max_ideas=10, diversity_threshold=0.7: [
+            {"id": 1, "idea": llm.generate(task.get("description", ""))}
+        ]
+    )
+    wsde_team.formulate_decision_criteria = lambda task, evaluated_options, trade_offs, contextualize_with_code=True, code_analyzer=None: {
+        "criteria": 1
+    }
+    wsde_team.elaborate_details = lambda selected_option, **kw: [{"step": 1}]
     wsde_team.create_implementation_plan = lambda details, **kw: details
-    wsde_team.optimize_implementation = lambda plan, **kw: {'plan': plan}
+    wsde_team.optimize_implementation = lambda plan, **kw: {"plan": plan}
     wsde_team.perform_quality_assurance = lambda plan, **kw: {}
     wsde_team.extract_learnings = lambda results, **kw: []
     wsde_team.recognize_patterns = lambda learnings, **kw: []
     wsde_team.integrate_knowledge = lambda learnings, patterns, **kw: {}
     wsde_team.generate_improvement_suggestions = lambda *a, **kw: []
-    coordinator = EDRRCoordinator(memory_manager=memory_manager, wsde_team=
-        wsde_team, code_analyzer=CodeAnalyzer(), ast_transformer=
-        AstTransformer(), prompt_manager=PromptManager(),
+    coordinator = EDRRCoordinator(
+        memory_manager=memory_manager,
+        wsde_team=wsde_team,
+        code_analyzer=CodeAnalyzer(),
+        ast_transformer=AstTransformer(),
+        prompt_manager=PromptManager(),
         documentation_manager=DocumentationManager(memory_manager),
-        enable_enhanced_logging=True)
-    task = {'description': 'demo'}
+        enable_enhanced_logging=True,
+    )
+    task = {"description": "demo"}
     coordinator.start_cycle(task)
     for phase in [Phase.DIFFERENTIATE, Phase.REFINE, Phase.RETROSPECT]:
         coordinator.progress_to_phase(phase)
     report = coordinator.generate_report()
     traces = coordinator.get_execution_traces()
     history = coordinator.get_execution_history()
-    assert report['cycle_id'] == coordinator.cycle_id
-    assert 'EXPAND' in report['phases']
-    assert 'RETROSPECT' in report['phases']
-    assert traces.get('cycle_id') == coordinator.cycle_id
+    assert report["cycle_id"] == coordinator.cycle_id
+    assert "EXPAND" in report["phases"]
+    assert "RETROSPECT" in report["phases"]
+    assert traces.get("cycle_id") == coordinator.cycle_id
     assert len(history) >= 4

--- a/tests/integration/general/test_edrr_peer_review_voting.py
+++ b/tests/integration/general/test_edrr_peer_review_voting.py
@@ -1,44 +1,47 @@
-from unittest.mock import MagicMock
 import sys
 import types
+from unittest.mock import MagicMock
+
 import pytest
-argon2_mod = types.ModuleType('argon2')
-setattr(argon2_mod, 'PasswordHasher', object)
-exceptions_mod = types.ModuleType('exceptions')
-setattr(exceptions_mod, 'VerifyMismatchError', type('VerifyMismatchError',
-    (), {}))
-setattr(argon2_mod, 'exceptions', exceptions_mod)
-sys.modules.setdefault('argon2', argon2_mod)
-sys.modules.setdefault('argon2.exceptions', exceptions_mod)
-sys.modules.setdefault('requests', types.ModuleType('requests'))
-crypto_mod = types.ModuleType('cryptography')
-fernet_mod = types.ModuleType('fernet')
-setattr(fernet_mod, 'Fernet', object)
+
+argon2_mod = types.ModuleType("argon2")
+setattr(argon2_mod, "PasswordHasher", object)
+exceptions_mod = types.ModuleType("exceptions")
+setattr(exceptions_mod, "VerifyMismatchError", type("VerifyMismatchError", (), {}))
+setattr(argon2_mod, "exceptions", exceptions_mod)
+sys.modules.setdefault("argon2", argon2_mod)
+sys.modules.setdefault("argon2.exceptions", exceptions_mod)
+sys.modules.setdefault("requests", types.ModuleType("requests"))
+crypto_mod = types.ModuleType("cryptography")
+fernet_mod = types.ModuleType("fernet")
+setattr(fernet_mod, "Fernet", object)
 crypto_mod.fernet = fernet_mod
-sys.modules.setdefault('cryptography', crypto_mod)
-sys.modules.setdefault('cryptography.fernet', fernet_mod)
-sys.modules.setdefault('jsonschema', types.ModuleType('jsonschema'))
-rdflib_mod = types.ModuleType('rdflib')
-setattr(rdflib_mod, 'Graph', object)
-setattr(rdflib_mod, 'Literal', object)
-setattr(rdflib_mod, 'URIRef', object)
-setattr(rdflib_mod, 'Namespace', object)
-setattr(rdflib_mod, 'RDF', object)
-setattr(rdflib_mod, 'RDFS', object)
-setattr(rdflib_mod, 'XSD', object)
-namespace_mod = types.ModuleType('namespace')
-setattr(namespace_mod, 'FOAF', object)
-setattr(namespace_mod, 'DC', object)
+sys.modules.setdefault("cryptography", crypto_mod)
+sys.modules.setdefault("cryptography.fernet", fernet_mod)
+sys.modules.setdefault("jsonschema", types.ModuleType("jsonschema"))
+rdflib_mod = types.ModuleType("rdflib")
+setattr(rdflib_mod, "Graph", object)
+setattr(rdflib_mod, "Literal", object)
+setattr(rdflib_mod, "URIRef", object)
+setattr(rdflib_mod, "Namespace", object)
+setattr(rdflib_mod, "RDF", object)
+setattr(rdflib_mod, "RDFS", object)
+setattr(rdflib_mod, "XSD", object)
+namespace_mod = types.ModuleType("namespace")
+setattr(namespace_mod, "FOAF", object)
+setattr(namespace_mod, "DC", object)
 rdflib_mod.namespace = namespace_mod
-sys.modules.setdefault('rdflib', rdflib_mod)
-sys.modules.setdefault('rdflib.namespace', namespace_mod)
-from devsynth.application.edrr.coordinator import EDRRCoordinator
-from devsynth.domain.models.wsde import WSDETeam
-from devsynth.application.memory.memory_manager import MemoryManager
+sys.modules.setdefault("rdflib", rdflib_mod)
+sys.modules.setdefault("rdflib.namespace", namespace_mod)
 from devsynth.application.code_analysis.analyzer import CodeAnalyzer
 from devsynth.application.code_analysis.ast_transformer import AstTransformer
+from devsynth.application.documentation.documentation_manager import (
+    DocumentationManager,
+)
+from devsynth.application.edrr.coordinator import EDRRCoordinator
+from devsynth.application.memory.memory_manager import MemoryManager
 from devsynth.application.prompts.prompt_manager import PromptManager
-from devsynth.application.documentation.documentation_manager import DocumentationManager
+from devsynth.domain.models.wsde_facade import WSDETeam
 from devsynth.methodology.base import Phase
 
 
@@ -51,38 +54,47 @@ class VotingAgent:
         self.current_role = None
 
     def process(self, task):
-        if task.get('type') == 'critical_decision':
-            return {'vote': self.vote}
-        return {'feedback': 'ok'}
+        if task.get("type") == "critical_decision":
+            return {"vote": self.vote}
+        return {"feedback": "ok"}
 
 
 @pytest.fixture
 def coordinator():
-    team = WSDETeam(name='TestEdrrPeerReviewVotingTeam')
-    team.add_agents([VotingAgent('a1', 'o1'), VotingAgent('a2', 'o1'),
-        VotingAgent('a3', 'o2')])
+    team = WSDETeam(name="TestEdrrPeerReviewVotingTeam")
+    team.add_agents(
+        [VotingAgent("a1", "o1"), VotingAgent("a2", "o1"), VotingAgent("a3", "o2")]
+    )
     mm = MagicMock(spec=MemoryManager)
     mm.retrieve_with_edrr_phase.side_effect = lambda *a, **k: {}
     mm.retrieve_relevant_knowledge.return_value = []
     mm.retrieve_historical_patterns.return_value = []
     analyzer = MagicMock(spec=CodeAnalyzer)
     analyzer.analyze_project_structure.return_value = []
-    return EDRRCoordinator(memory_manager=mm, wsde_team=team, code_analyzer
-        =analyzer, ast_transformer=MagicMock(spec=AstTransformer),
-        prompt_manager=MagicMock(spec=PromptManager), documentation_manager
-        =MagicMock(spec=DocumentationManager), enable_enhanced_logging=False)
+    return EDRRCoordinator(
+        memory_manager=mm,
+        wsde_team=team,
+        code_analyzer=analyzer,
+        ast_transformer=MagicMock(spec=AstTransformer),
+        prompt_manager=MagicMock(spec=PromptManager),
+        documentation_manager=MagicMock(spec=DocumentationManager),
+        enable_enhanced_logging=False,
+    )
 
 
 def test_voting_and_peer_review_succeeds(coordinator):
     """Test that voting and peer review succeeds.
 
-ReqID: N/A"""
-    decision = {'type': 'critical_decision', 'is_critical': True, 'options':
-        [{'id': 'o1'}, {'id': 'o2'}]}
+    ReqID: N/A"""
+    decision = {
+        "type": "critical_decision",
+        "is_critical": True,
+        "options": [{"id": "o1"}, {"id": "o2"}],
+    }
     vote_result = coordinator.wsde_team.vote_on_critical_decision(decision)
-    assert vote_result['result']['winner'] == 'o1'
-    coordinator.start_cycle({'description': 'demo'})
+    assert vote_result["result"]["winner"] == "o1"
+    coordinator.start_cycle({"description": "demo"})
     coordinator.progress_to_phase(Phase.REFINE)
-    context = {'peer_review': {'reviewers': coordinator.wsde_team.agents[1:]}}
+    context = {"peer_review": {"reviewers": coordinator.wsde_team.agents[1:]}}
     results = coordinator.execute_current_phase(context)
-    assert results['peer_review']['review'].status == 'completed'
+    assert results["peer_review"]["review"].status == "completed"

--- a/tests/integration/general/test_edrr_primus_rotation.py
+++ b/tests/integration/general/test_edrr_primus_rotation.py
@@ -1,12 +1,16 @@
-import pytest
 from unittest.mock import MagicMock
-from devsynth.application.edrr.coordinator import EDRRCoordinator
-from devsynth.domain.models.wsde import WSDETeam
-from devsynth.application.memory.memory_manager import MemoryManager
+
+import pytest
+
 from devsynth.application.code_analysis.analyzer import CodeAnalyzer
 from devsynth.application.code_analysis.ast_transformer import AstTransformer
+from devsynth.application.documentation.documentation_manager import (
+    DocumentationManager,
+)
+from devsynth.application.edrr.coordinator import EDRRCoordinator
+from devsynth.application.memory.memory_manager import MemoryManager
 from devsynth.application.prompts.prompt_manager import PromptManager
-from devsynth.application.documentation.documentation_manager import DocumentationManager
+from devsynth.domain.models.wsde_facade import WSDETeam
 from devsynth.methodology.base import Phase
 
 
@@ -18,15 +22,15 @@ class SimpleAgent:
         self.expertise = []
 
     def process(self, task):
-        return {'processed_by': self.name, 'role': self.current_role}
+        return {"processed_by": self.name, "role": self.current_role}
 
 
 @pytest.fixture
 def wsde_team():
-    team = WSDETeam(name='TestEdrrPrimusRotationTeam')
+    team = WSDETeam(name="TestEdrrPrimusRotationTeam")
     for i in range(4):
-        team.add_agent(SimpleAgent(f'agent{i + 1}'))
-    team.generate_diverse_ideas = MagicMock(return_value=['idea'])
+        team.add_agent(SimpleAgent(f"agent{i + 1}"))
+    team.generate_diverse_ideas = MagicMock(return_value=["idea"])
     team.create_comparison_matrix = MagicMock(return_value={})
     team.evaluate_options = MagicMock(return_value=[])
     team.analyze_trade_offs = MagicMock(return_value=[])
@@ -48,29 +52,35 @@ def coordinator(wsde_team):
     mm = MagicMock()
 
     def retrieve_with_phase(item_type, phase, metadata):
-        if item_type == 'EXPAND_RESULTS':
-            return {'ideas': []}
-        if item_type == 'DIFFERENTIATE_RESULTS':
-            return {'evaluated_options': [], 'decision_criteria': {}}
-        if item_type == 'REFINE_RESULTS':
-            return {'implementation_plan': [], 'quality_checks': {}}
+        if item_type == "EXPAND_RESULTS":
+            return {"ideas": []}
+        if item_type == "DIFFERENTIATE_RESULTS":
+            return {"evaluated_options": [], "decision_criteria": {}}
+        if item_type == "REFINE_RESULTS":
+            return {"implementation_plan": [], "quality_checks": {}}
         return {}
+
     mm.retrieve_with_edrr_phase.side_effect = retrieve_with_phase
     mm.retrieve_relevant_knowledge.return_value = []
     mm.retrieve_historical_patterns.return_value = []
     analyzer = MagicMock()
     analyzer.analyze_project_structure.return_value = []
-    return EDRRCoordinator(memory_manager=mm, wsde_team=wsde_team,
-        code_analyzer=analyzer, ast_transformer=MagicMock(), prompt_manager
-        =MagicMock(), documentation_manager=MagicMock(),
-        enable_enhanced_logging=False)
+    return EDRRCoordinator(
+        memory_manager=mm,
+        wsde_team=wsde_team,
+        code_analyzer=analyzer,
+        ast_transformer=MagicMock(),
+        prompt_manager=MagicMock(),
+        documentation_manager=MagicMock(),
+        enable_enhanced_logging=False,
+    )
 
 
 def test_full_cycle_rotating_primus_succeeds(coordinator, wsde_team):
     """Test that full cycle rotating primus succeeds.
 
-ReqID: N/A"""
-    task = {'description': 'demo'}
+    ReqID: N/A"""
+    task = {"description": "demo"}
     coordinator.start_cycle(task)
     primus_sequence = [wsde_team.get_primus().name]
     coordinator.progress_to_phase(Phase.DIFFERENTIATE)
@@ -79,4 +89,4 @@ ReqID: N/A"""
     primus_sequence.append(wsde_team.get_primus().name)
     coordinator.progress_to_phase(Phase.RETROSPECT)
     primus_sequence.append(wsde_team.get_primus().name)
-    assert primus_sequence == ['agent1', 'agent2', 'agent3', 'agent4']
+    assert primus_sequence == ["agent1", "agent2", "agent3", "agent4"]

--- a/tests/integration/general/test_edrr_real_llm_integration.py
+++ b/tests/integration/general/test_edrr_real_llm_integration.py
@@ -4,109 +4,126 @@ Integration test for EDRR with real LLM providers.
 This test uses real LLM providers from the provider system to test the EDRR cycle.
 It requires valid API keys or endpoints to be configured in environment variables.
 """
+
 import os
-import pytest
 import tempfile
 from pathlib import Path
-from typing import Dict, Any, Optional
-from devsynth.application.edrr.coordinator import EDRRCoordinator
-from devsynth.application.memory.memory_manager import MemoryManager
-from devsynth.application.memory.adapters.tinydb_memory_adapter import TinyDBMemoryAdapter
-from devsynth.application.memory.adapters.graph_memory_adapter import GraphMemoryAdapter
-from devsynth.domain.models.wsde import WSDETeam
+from typing import Any, Dict, Optional
+
+import pytest
+
+from devsynth.adapters.provider_system import ProviderType, get_provider
 from devsynth.application.code_analysis.analyzer import CodeAnalyzer
 from devsynth.application.code_analysis.ast_transformer import AstTransformer
+from devsynth.application.documentation.documentation_manager import (
+    DocumentationManager,
+)
+from devsynth.application.edrr.coordinator import EDRRCoordinator
+from devsynth.application.memory.adapters.graph_memory_adapter import GraphMemoryAdapter
+from devsynth.application.memory.adapters.tinydb_memory_adapter import (
+    TinyDBMemoryAdapter,
+)
+from devsynth.application.memory.memory_manager import MemoryManager
 from devsynth.application.prompts.prompt_manager import PromptManager
-from devsynth.application.documentation.documentation_manager import DocumentationManager
-from devsynth.adapters.provider_system import get_provider, ProviderType
-from devsynth.methodology.base import Phase
 from devsynth.domain.models.memory import MemoryType
+from devsynth.domain.models.wsde_facade import WSDETeam
+from devsynth.methodology.base import Phase
 
 
-@pytest.mark.skipif(not os.environ.get('OPENAI_API_KEY') and not os.environ
-    .get('LM_STUDIO_ENDPOINT'), reason=
-    'No LLM provider configured. Set OPENAI_API_KEY or LM_STUDIO_ENDPOINT.')
+@pytest.mark.skipif(
+    not os.environ.get("OPENAI_API_KEY") and not os.environ.get("LM_STUDIO_ENDPOINT"),
+    reason="No LLM provider configured. Set OPENAI_API_KEY or LM_STUDIO_ENDPOINT.",
+)
 def test_edrr_cycle_with_real_llm_has_expected(tmp_path):
     """Test EDRR cycle with a real LLM provider and verify memory integration.
 
-This test will use the configured LLM provider (OpenAI or LM Studio)
-to run a complete EDRR cycle with a simple task. It also verifies that
-the results are properly stored in and retrieved from the memory system
-with the correct EDRR phase tags.
+    This test will use the configured LLM provider (OpenAI or LM Studio)
+    to run a complete EDRR cycle with a simple task. It also verifies that
+    the results are properly stored in and retrieved from the memory system
+    with the correct EDRR phase tags.
 
-It requires either OPENAI_API_KEY or LM_STUDIO_ENDPOINT to be set.
+    It requires either OPENAI_API_KEY or LM_STUDIO_ENDPOINT to be set.
 
-ReqID: N/A"""
+    ReqID: N/A"""
     tinydb_adapter = TinyDBMemoryAdapter()
-    graph_adapter = GraphMemoryAdapter(base_path=str(tmp_path / 'graph_memory')
-        )
-    memory_manager = MemoryManager(adapters={'tinydb': tinydb_adapter,
-        'graph': graph_adapter})
-    wsde_team = WSDETeam(name='EDRRTestTeam')
+    graph_adapter = GraphMemoryAdapter(base_path=str(tmp_path / "graph_memory"))
+    memory_manager = MemoryManager(
+        adapters={"tinydb": tinydb_adapter, "graph": graph_adapter}
+    )
+    wsde_team = WSDETeam(name="EDRRTestTeam")
     provider = get_provider(fallback=True)
-    task = {'description':
-        'Create a function to calculate the factorial of a number',
-        'language': 'python', 'complexity': 'medium'}
-    coordinator = EDRRCoordinator(memory_manager=memory_manager, wsde_team=
-        wsde_team, code_analyzer=CodeAnalyzer(), ast_transformer=
-        AstTransformer(), prompt_manager=PromptManager(),
+    task = {
+        "description": "Create a function to calculate the factorial of a number",
+        "language": "python",
+        "complexity": "medium",
+    }
+    coordinator = EDRRCoordinator(
+        memory_manager=memory_manager,
+        wsde_team=wsde_team,
+        code_analyzer=CodeAnalyzer(),
+        ast_transformer=AstTransformer(),
+        prompt_manager=PromptManager(),
         documentation_manager=DocumentationManager(memory_manager),
-        enable_enhanced_logging=True)
+        enable_enhanced_logging=True,
+    )
     coordinator.start_cycle(task)
-    expand_results = memory_manager.retrieve_with_edrr_phase('EXPAND_RESULTS',
-        'EXPAND', {'cycle_id': coordinator.cycle_id})
-    assert expand_results, 'EXPAND phase results not found in memory'
-    assert 'ideas' in expand_results, "EXPAND phase results missing 'ideas' key"
-    assert 'knowledge' in expand_results, "EXPAND phase results missing 'knowledge' key"
+    expand_results = memory_manager.retrieve_with_edrr_phase(
+        "EXPAND_RESULTS", "EXPAND", {"cycle_id": coordinator.cycle_id}
+    )
+    assert expand_results, "EXPAND phase results not found in memory"
+    assert "ideas" in expand_results, "EXPAND phase results missing 'ideas' key"
+    assert "knowledge" in expand_results, "EXPAND phase results missing 'knowledge' key"
     for phase in [Phase.DIFFERENTIATE, Phase.REFINE, Phase.RETROSPECT]:
         coordinator.progress_to_phase(phase)
         phase_results = memory_manager.retrieve_with_edrr_phase(
-            f'{phase.value}_RESULTS', phase.value, {'cycle_id': coordinator
-            .cycle_id})
-        assert phase_results, f'{phase.value} phase results not found in memory'
+            f"{phase.value}_RESULTS", phase.value, {"cycle_id": coordinator.cycle_id}
+        )
+        assert phase_results, f"{phase.value} phase results not found in memory"
     report = coordinator.generate_report()
     traces = coordinator.get_execution_traces()
     history = coordinator.get_execution_history()
-    assert report['cycle_id'] == coordinator.cycle_id
-    assert 'EXPAND' in report['phases']
-    assert 'DIFFERENTIATE' in report['phases']
-    assert 'REFINE' in report['phases']
-    assert 'RETROSPECT' in report['phases']
-    assert traces.get('cycle_id') == coordinator.cycle_id
+    assert report["cycle_id"] == coordinator.cycle_id
+    assert "EXPAND" in report["phases"]
+    assert "DIFFERENTIATE" in report["phases"]
+    assert "REFINE" in report["phases"]
+    assert "RETROSPECT" in report["phases"]
+    assert traces.get("cycle_id") == coordinator.cycle_id
     assert len(history) >= 4
-    assert 'factorial' in str(report).lower()
+    assert "factorial" in str(report).lower()
     final_solution = None
-    for phase_data in report['phases'].values():
-        if 'solution' in phase_data:
-            final_solution = phase_data['solution']
+    for phase_data in report["phases"].values():
+        if "solution" in phase_data:
+            final_solution = phase_data["solution"]
     assert final_solution is not None
-    assert 'def factorial' in str(final_solution).lower()
-    refine_results = memory_manager.retrieve_with_edrr_phase('REFINE_RESULTS',
-        'REFINE', {'cycle_id': coordinator.cycle_id})
-    assert refine_results, 'REFINE phase results not found in memory'
-    assert 'solution' in refine_results, "REFINE phase results missing 'solution' key"
-    assert 'def factorial' in str(refine_results['solution']).lower()
-    print(f'EDRR cycle completed with provider: {provider.__class__.__name__}')
-    print(f'Final solution: {final_solution}')
-    print(f'Memory integration verified with GraphMemoryAdapter')
+    assert "def factorial" in str(final_solution).lower()
+    refine_results = memory_manager.retrieve_with_edrr_phase(
+        "REFINE_RESULTS", "REFINE", {"cycle_id": coordinator.cycle_id}
+    )
+    assert refine_results, "REFINE phase results not found in memory"
+    assert "solution" in refine_results, "REFINE phase results missing 'solution' key"
+    assert "def factorial" in str(refine_results["solution"]).lower()
+    print(f"EDRR cycle completed with provider: {provider.__class__.__name__}")
+    print(f"Final solution: {final_solution}")
+    print(f"Memory integration verified with GraphMemoryAdapter")
 
 
-@pytest.mark.skipif(not os.environ.get('OPENAI_API_KEY') and not os.environ
-    .get('LM_STUDIO_ENDPOINT'), reason=
-    'No LLM provider configured. Set OPENAI_API_KEY or LM_STUDIO_ENDPOINT.')
+@pytest.mark.skipif(
+    not os.environ.get("OPENAI_API_KEY") and not os.environ.get("LM_STUDIO_ENDPOINT"),
+    reason="No LLM provider configured. Set OPENAI_API_KEY or LM_STUDIO_ENDPOINT.",
+)
 def test_edrr_cycle_with_real_project_succeeds(tmp_path):
     """Test EDRR cycle with a real LLM provider on a more complex project.
 
-This test creates a small project with multiple files and asks the EDRR
-framework to analyze and improve it. This tests the framework's ability
-to handle more realistic and complex tasks.
+    This test creates a small project with multiple files and asks the EDRR
+    framework to analyze and improve it. This tests the framework's ability
+    to handle more realistic and complex tasks.
 
-It requires either OPENAI_API_KEY or LM_STUDIO_ENDPOINT to be set.
+    It requires either OPENAI_API_KEY or LM_STUDIO_ENDPOINT to be set.
 
-ReqID: N/A"""
-    project_dir = tmp_path / 'test_project'
+    ReqID: N/A"""
+    project_dir = tmp_path / "test_project"
     project_dir.mkdir(exist_ok=True)
-    app_py = project_dir / 'app.py'
+    app_py = project_dir / "app.py"
     app_py.write_text(
         """
 from flask import Flask, request, jsonify
@@ -130,45 +147,51 @@ def create_user():
 if __name__ == '__main__':
     app.run(debug=True)
 """
-        )
-    requirements_txt = project_dir / 'requirements.txt'
-    requirements_txt.write_text('\nflask==2.0.1\n')
+    )
+    requirements_txt = project_dir / "requirements.txt"
+    requirements_txt.write_text("\nflask==2.0.1\n")
     memory_adapter = TinyDBMemoryAdapter()
-    memory_manager = MemoryManager(adapters={'tinydb': memory_adapter})
-    wsde_team = WSDETeam(name='EDRRProjectTestTeam')
+    memory_manager = MemoryManager(adapters={"tinydb": memory_adapter})
+    wsde_team = WSDETeam(name="EDRRProjectTestTeam")
     provider = get_provider(fallback=True)
-    task = {'description':
-        'Analyze the Flask application and improve it by adding proper data validation, error handling, and following best practices for Flask applications.'
-        , 'project_path': str(project_dir), 'language': 'python',
-        'complexity': 'high'}
-    coordinator = EDRRCoordinator(memory_manager=memory_manager, wsde_team=
-        wsde_team, code_analyzer=CodeAnalyzer(), ast_transformer=
-        AstTransformer(), prompt_manager=PromptManager(),
+    task = {
+        "description": "Analyze the Flask application and improve it by adding proper data validation, error handling, and following best practices for Flask applications.",
+        "project_path": str(project_dir),
+        "language": "python",
+        "complexity": "high",
+    }
+    coordinator = EDRRCoordinator(
+        memory_manager=memory_manager,
+        wsde_team=wsde_team,
+        code_analyzer=CodeAnalyzer(),
+        ast_transformer=AstTransformer(),
+        prompt_manager=PromptManager(),
         documentation_manager=DocumentationManager(memory_manager),
-        enable_enhanced_logging=True)
+        enable_enhanced_logging=True,
+    )
     coordinator.start_cycle(task)
     for phase in [Phase.DIFFERENTIATE, Phase.REFINE, Phase.RETROSPECT]:
         coordinator.progress_to_phase(phase)
     report = coordinator.generate_report()
     traces = coordinator.get_execution_traces()
     history = coordinator.get_execution_history()
-    assert report['cycle_id'] == coordinator.cycle_id
-    assert 'EXPAND' in report['phases']
-    assert 'DIFFERENTIATE' in report['phases']
-    assert 'REFINE' in report['phases']
-    assert 'RETROSPECT' in report['phases']
-    assert traces.get('cycle_id') == coordinator.cycle_id
+    assert report["cycle_id"] == coordinator.cycle_id
+    assert "EXPAND" in report["phases"]
+    assert "DIFFERENTIATE" in report["phases"]
+    assert "REFINE" in report["phases"]
+    assert "RETROSPECT" in report["phases"]
+    assert traces.get("cycle_id") == coordinator.cycle_id
     assert len(history) >= 4
     report_str = str(report).lower()
-    assert 'flask' in report_str
-    assert 'validation' in report_str
+    assert "flask" in report_str
+    assert "validation" in report_str
     final_solution = None
-    for phase_data in report['phases'].values():
-        if 'solution' in phase_data:
-            final_solution = phase_data['solution']
+    for phase_data in report["phases"].values():
+        if "solution" in phase_data:
+            final_solution = phase_data["solution"]
     assert final_solution is not None
     final_solution_str = str(final_solution).lower()
-    assert 'validation' in final_solution_str or 'validate' in final_solution_str
-    assert 'error' in final_solution_str and 'handling' in final_solution_str
-    print(f'EDRR cycle completed with provider: {provider.__class__.__name__}')
-    print(f'Project analysis and improvement completed')
+    assert "validation" in final_solution_str or "validate" in final_solution_str
+    assert "error" in final_solution_str and "handling" in final_solution_str
+    print(f"EDRR cycle completed with provider: {provider.__class__.__name__}")
+    print(f"Project analysis and improvement completed")

--- a/tests/integration/general/test_error_handling_at_integration_points.py
+++ b/tests/integration/general/test_error_handling_at_integration_points.py
@@ -3,32 +3,44 @@
 This test verifies that errors are properly handled at various integration points in the system,
 including between components, across boundaries, and in error recovery scenarios.
 """
-import pytest
-import tempfile
-import shutil
+
 import os
-from unittest.mock import MagicMock, patch, call
+import shutil
+import tempfile
 from pathlib import Path
-from devsynth.application.edrr.edrr_coordinator_enhanced import EnhancedEDRRCoordinator
-from devsynth.application.edrr.coordinator import EDRRCoordinatorError
-from devsynth.domain.models.wsde import WSDETeam
-from devsynth.application.memory.memory_manager import MemoryManager
-from devsynth.application.memory.adapters.tinydb_memory_adapter import TinyDBMemoryAdapter
+from unittest.mock import MagicMock, call, patch
+
+import pytest
+
+from devsynth.adapters.provider_system import (
+    FallbackProvider,
+    LMStudioProvider,
+    OpenAIProvider,
+    ProviderError,
+)
+from devsynth.application.agents.unified_agent import UnifiedAgent
 from devsynth.application.code_analysis.analyzer import CodeAnalyzer
 from devsynth.application.code_analysis.ast_transformer import AstTransformer
+from devsynth.application.documentation.documentation_manager import (
+    DocumentationManager,
+)
+from devsynth.application.edrr.coordinator import EDRRCoordinatorError
+from devsynth.application.edrr.edrr_coordinator_enhanced import EnhancedEDRRCoordinator
+from devsynth.application.memory.adapters.tinydb_memory_adapter import (
+    TinyDBMemoryAdapter,
+)
+from devsynth.application.memory.memory_manager import MemoryManager
 from devsynth.application.prompts.prompt_manager import PromptManager
-from devsynth.application.documentation.documentation_manager import DocumentationManager
-from devsynth.methodology.base import Phase
 from devsynth.domain.models.agent import AgentConfig, AgentType
-from devsynth.application.agents.unified_agent import UnifiedAgent
 from devsynth.domain.models.memory import MemoryItem, MemoryType
-from devsynth.adapters.provider_system import OpenAIProvider, LMStudioProvider, FallbackProvider, ProviderError
+from devsynth.domain.models.wsde_facade import WSDETeam
+from devsynth.methodology.base import Phase
 
 
 class TestErrorHandlingAtIntegrationPoints:
     """Test error handling at various integration points in the system.
 
-ReqID: N/A"""
+    ReqID: N/A"""
 
     @pytest.fixture
     def temp_dir(self):
@@ -42,145 +54,190 @@ ReqID: N/A"""
     @pytest.fixture
     def memory_adapter(self, temp_dir):
         """Create a memory adapter for testing."""
-        db_path = os.path.join(temp_dir, 'memory.json')
+        db_path = os.path.join(temp_dir, "memory.json")
         return TinyDBMemoryAdapter(db_path=db_path)
 
     @pytest.fixture
     def memory_manager(self, memory_adapter):
         """Create a memory manager for testing."""
-        return MemoryManager(adapters={'default': memory_adapter})
+        return MemoryManager(adapters={"default": memory_adapter})
 
     @pytest.fixture
     def wsde_team(self):
         """Create a WSDE team with mock agents for testing."""
-        team = WSDETeam(name='TestErrorHandlingAtIntegrationPointsTeam')
+        team = WSDETeam(name="TestErrorHandlingAtIntegrationPointsTeam")
         explorer = UnifiedAgent()
-        explorer.initialize(AgentConfig(name='Explorer', agent_type=AgentType.ORCHESTRATOR,
-            description='Explorer agent', capabilities=['exploration', 'brainstorming']))
+        explorer.initialize(
+            AgentConfig(
+                name="Explorer",
+                agent_type=AgentType.ORCHESTRATOR,
+                description="Explorer agent",
+                capabilities=["exploration", "brainstorming"],
+            )
+        )
         team.add_agent(explorer)
 
         analyzer = UnifiedAgent()
-        analyzer.initialize(AgentConfig(name='Analyzer', agent_type=AgentType.ORCHESTRATOR,
-            description='Analyzer agent', capabilities=['analysis', 'evaluation']))
+        analyzer.initialize(
+            AgentConfig(
+                name="Analyzer",
+                agent_type=AgentType.ORCHESTRATOR,
+                description="Analyzer agent",
+                capabilities=["analysis", "evaluation"],
+            )
+        )
         team.add_agent(analyzer)
-        team.generate_diverse_ideas = MagicMock(return_value=[{'id':
-            'idea1', 'content': 'First idea'}, {'id': 'idea2', 'content':
-            'Second idea'}])
-        team.evaluate_options = MagicMock(return_value=[{'id': 'idea1',
-            'evaluation': {'quality': 0.8, 'feasibility': 0.7}}, {'id':
-            'idea2', 'evaluation': {'quality': 0.6, 'feasibility': 0.9}}])
-        team.select_best_option = MagicMock(return_value={'id': 'idea1',
-            'content': 'First idea'})
+        team.generate_diverse_ideas = MagicMock(
+            return_value=[
+                {"id": "idea1", "content": "First idea"},
+                {"id": "idea2", "content": "Second idea"},
+            ]
+        )
+        team.evaluate_options = MagicMock(
+            return_value=[
+                {"id": "idea1", "evaluation": {"quality": 0.8, "feasibility": 0.7}},
+                {"id": "idea2", "evaluation": {"quality": 0.6, "feasibility": 0.9}},
+            ]
+        )
+        team.select_best_option = MagicMock(
+            return_value={"id": "idea1", "content": "First idea"}
+        )
         return team
 
     @pytest.fixture
     def coordinator(self, memory_manager, wsde_team):
         """Create an EDRR coordinator for testing."""
-        return EnhancedEDRRCoordinator(memory_manager=memory_manager,
-            wsde_team=wsde_team, code_analyzer=MagicMock(spec=CodeAnalyzer),
-            ast_transformer=MagicMock(spec=AstTransformer), prompt_manager=
-            MagicMock(spec=PromptManager), documentation_manager=MagicMock(
-            spec=DocumentationManager), config={'edrr': {
-            'quality_based_transitions': True}})
+        return EnhancedEDRRCoordinator(
+            memory_manager=memory_manager,
+            wsde_team=wsde_team,
+            code_analyzer=MagicMock(spec=CodeAnalyzer),
+            ast_transformer=MagicMock(spec=AstTransformer),
+            prompt_manager=MagicMock(spec=PromptManager),
+            documentation_manager=MagicMock(spec=DocumentationManager),
+            config={"edrr": {"quality_based_transitions": True}},
+        )
 
-    def test_error_handling_in_edrr_wsde_integration_raises_error(self,
-        coordinator):
+    def test_error_handling_in_edrr_wsde_integration_raises_error(self, coordinator):
         """Test error handling in the EDRR-WSDE integration.
 
-ReqID: N/A"""
-        task = {'description':
-            'Create a Python function to calculate factorial', 'language':
-            'python', 'domain': 'code_generation'}
+        ReqID: N/A"""
+        task = {
+            "description": "Create a Python function to calculate factorial",
+            "language": "python",
+            "domain": "code_generation",
+        }
         coordinator.start_cycle(task)
         coordinator.wsde_team.generate_diverse_ideas.side_effect = ValueError(
-            'Test error in generate_diverse_ideas')
+            "Test error in generate_diverse_ideas"
+        )
         try:
             expand_results = coordinator.execute_current_phase()
-            assert False, 'Expected EDRRCoordinatorError was not raised'
+            assert False, "Expected EDRRCoordinatorError was not raised"
         except EDRRCoordinatorError as e:
-            assert 'Test error in generate_diverse_ideas' in str(e)
+            assert "Test error in generate_diverse_ideas" in str(e)
         coordinator.wsde_team.generate_diverse_ideas.side_effect = None
-        coordinator.wsde_team.generate_diverse_ideas.return_value = [{'id':
-            'idea1', 'content': 'First idea'}, {'id': 'idea2', 'content':
-            'Second idea'}]
+        coordinator.wsde_team.generate_diverse_ideas.return_value = [
+            {"id": "idea1", "content": "First idea"},
+            {"id": "idea2", "content": "Second idea"},
+        ]
         expand_results = coordinator.execute_current_phase()
         coordinator.progress_to_phase(Phase.DIFFERENTIATE)
         coordinator.wsde_team.evaluate_options.side_effect = ValueError(
-            'Test error in evaluate_options')
+            "Test error in evaluate_options"
+        )
         try:
             differentiate_results = coordinator.execute_current_phase()
-            assert False, 'Expected EDRRCoordinatorError was not raised'
+            assert False, "Expected EDRRCoordinatorError was not raised"
         except EDRRCoordinatorError as e:
-            assert 'Test error in evaluate_options' in str(e)
+            assert "Test error in evaluate_options" in str(e)
 
-    def test_error_handling_in_memory_integration_raises_error(self,
-        memory_manager):
+    def test_error_handling_in_memory_integration_raises_error(self, memory_manager):
         """Test error handling in the memory integration.
 
-ReqID: N/A"""
-        memory_manager.adapters['default'].store = MagicMock(side_effect=
-            Exception('Test error in store'))
+        ReqID: N/A"""
+        memory_manager.adapters["default"].store = MagicMock(
+            side_effect=Exception("Test error in store")
+        )
         try:
-            memory_manager.store(MemoryItem(id='', content='Test content',
-                memory_type=MemoryType.KNOWLEDGE, metadata={'source': 'test'}))
-            assert False, 'Expected Exception was not raised'
+            memory_manager.store(
+                MemoryItem(
+                    id="",
+                    content="Test content",
+                    memory_type=MemoryType.KNOWLEDGE,
+                    metadata={"source": "test"},
+                )
+            )
+            assert False, "Expected Exception was not raised"
         except Exception as e:
-            assert 'Test error in store' in str(e)
-        memory_manager.adapters['default'].store = MagicMock()
-        memory_id = memory_manager.store(MemoryItem(id='', content=
-            'Test content', memory_type=MemoryType.KNOWLEDGE, metadata={
-            'source': 'test'}))
-        memory_manager.adapters['default'].retrieve = MagicMock(side_effect
-            =Exception('Test error in retrieve'))
+            assert "Test error in store" in str(e)
+        memory_manager.adapters["default"].store = MagicMock()
+        memory_id = memory_manager.store(
+            MemoryItem(
+                id="",
+                content="Test content",
+                memory_type=MemoryType.KNOWLEDGE,
+                metadata={"source": "test"},
+            )
+        )
+        memory_manager.adapters["default"].retrieve = MagicMock(
+            side_effect=Exception("Test error in retrieve")
+        )
         try:
             memory_manager.retrieve(memory_id)
-            assert False, 'Expected Exception was not raised'
+            assert False, "Expected Exception was not raised"
         except Exception as e:
-            assert 'Test error in retrieve' in str(e)
+            assert "Test error in retrieve" in str(e)
 
     def test_error_handling_in_provider_integration_raises_error(self):
         """Test error handling in the provider integration.
 
-ReqID: N/A"""
-        provider = OpenAIProvider(api_key='test_key')
-        provider.complete = MagicMock(side_effect=ProviderError(
-            'Test error in complete'))
+        ReqID: N/A"""
+        provider = OpenAIProvider(api_key="test_key")
+        provider.complete = MagicMock(
+            side_effect=ProviderError("Test error in complete")
+        )
         try:
-            provider.complete('Test prompt')
-            assert False, 'Expected ProviderError was not raised'
+            provider.complete("Test prompt")
+            assert False, "Expected ProviderError was not raised"
         except ProviderError as e:
-            assert 'Test error in complete' in str(e)
-        provider1 = OpenAIProvider(api_key='test_key')
-        provider1.complete = MagicMock(side_effect=ProviderError(
-            'Test error in provider1'))
-        provider2 = LMStudioProvider(endpoint='http://localhost:1234')
-        provider2.complete = MagicMock(side_effect=ProviderError(
-            'Test error in provider2'))
+            assert "Test error in complete" in str(e)
+        provider1 = OpenAIProvider(api_key="test_key")
+        provider1.complete = MagicMock(
+            side_effect=ProviderError("Test error in provider1")
+        )
+        provider2 = LMStudioProvider(endpoint="http://localhost:1234")
+        provider2.complete = MagicMock(
+            side_effect=ProviderError("Test error in provider2")
+        )
         fallback_provider = FallbackProvider(providers=[provider1, provider2])
         try:
-            fallback_provider.complete('Test prompt')
-            assert False, 'Expected ProviderError was not raised'
+            fallback_provider.complete("Test prompt")
+            assert False, "Expected ProviderError was not raised"
         except ProviderError as e:
-            assert 'All providers failed' in str(e)
-            assert 'Test error in provider2' in str(e)
+            assert "All providers failed" in str(e)
+            assert "Test error in provider2" in str(e)
 
-    def test_error_handling_in_code_analysis_integration_raises_error(self,
-        coordinator):
+    def test_error_handling_in_code_analysis_integration_raises_error(
+        self, coordinator
+    ):
         """Test error handling in the code analysis integration.
 
-ReqID: N/A"""
-        coordinator.code_analyzer.analyze_code = MagicMock(side_effect=
-            Exception('Test error in analyze_code'))
-        task = {'description': 'Analyze this code', 'language': 'python',
-            'code':
-            """def factorial(n):
-    return 1 if n <= 1 else n * factorial(n-1)"""
-            }
+        ReqID: N/A"""
+        coordinator.code_analyzer.analyze_code = MagicMock(
+            side_effect=Exception("Test error in analyze_code")
+        )
+        task = {
+            "description": "Analyze this code",
+            "language": "python",
+            "code": """def factorial(n):
+    return 1 if n <= 1 else n * factorial(n-1)""",
+        }
         coordinator.start_cycle(task)
         expand_results = coordinator.execute_current_phase()
         assert expand_results is not None
-        coordinator.ast_transformer.transform_code = MagicMock(side_effect=
-            Exception('Test error in transform_code'))
+        coordinator.ast_transformer.transform_code = MagicMock(
+            side_effect=Exception("Test error in transform_code")
+        )
         coordinator.progress_to_phase(Phase.REFINE)
         refine_results = coordinator.execute_current_phase()
         assert refine_results is not None
@@ -188,51 +245,64 @@ ReqID: N/A"""
     def test_error_recovery_in_edrr_cycle_raises_error(self, coordinator):
         """Test error recovery in the EDRR cycle.
 
-ReqID: N/A"""
-        task = {'description':
-            'Create a Python function to calculate factorial', 'language':
-            'python', 'domain': 'code_generation'}
+        ReqID: N/A"""
+        task = {
+            "description": "Create a Python function to calculate factorial",
+            "language": "python",
+            "domain": "code_generation",
+        }
         coordinator.start_cycle(task)
-        coordinator.wsde_team.generate_diverse_ideas.side_effect = [ValueError
-            ('Test error in generate_diverse_ideas'), [{'id': 'idea1',
-            'content': 'First idea'}, {'id': 'idea2', 'content':
-            'Second idea'}]]
+        coordinator.wsde_team.generate_diverse_ideas.side_effect = [
+            ValueError("Test error in generate_diverse_ideas"),
+            [
+                {"id": "idea1", "content": "First idea"},
+                {"id": "idea2", "content": "Second idea"},
+            ],
+        ]
         try:
             expand_results = coordinator.execute_current_phase()
-            assert False, 'Expected EDRRCoordinatorError was not raised'
+            assert False, "Expected EDRRCoordinatorError was not raised"
         except EDRRCoordinatorError as e:
-            assert 'Test error in generate_diverse_ideas' in str(e)
+            assert "Test error in generate_diverse_ideas" in str(e)
         expand_results = coordinator.execute_current_phase()
         assert expand_results is not None
         coordinator.progress_to_phase(Phase.DIFFERENTIATE)
-        coordinator.wsde_team.evaluate_options.side_effect = [ValueError(
-            'Test error in evaluate_options'), [{'id': 'idea1',
-            'evaluation': {'quality': 0.8}}, {'id': 'idea2', 'evaluation':
-            {'quality': 0.6}}]]
+        coordinator.wsde_team.evaluate_options.side_effect = [
+            ValueError("Test error in evaluate_options"),
+            [
+                {"id": "idea1", "evaluation": {"quality": 0.8}},
+                {"id": "idea2", "evaluation": {"quality": 0.6}},
+            ],
+        ]
         try:
             differentiate_results = coordinator.execute_current_phase()
-            assert False, 'Expected EDRRCoordinatorError was not raised'
+            assert False, "Expected EDRRCoordinatorError was not raised"
         except EDRRCoordinatorError as e:
-            assert 'Test error in evaluate_options' in str(e)
+            assert "Test error in evaluate_options" in str(e)
         differentiate_results = coordinator.execute_current_phase()
         assert differentiate_results is not None
 
-    def test_error_handling_in_cross_component_integration_raises_error(self,
-        coordinator, memory_manager):
+    def test_error_handling_in_cross_component_integration_raises_error(
+        self, coordinator, memory_manager
+    ):
         """Test error handling in cross-component integration.
 
-ReqID: N/A"""
-        memory_manager.store_with_edrr_phase = MagicMock(side_effect=
-            Exception('Test error in store_with_edrr_phase'))
-        task = {'description':
-            'Create a Python function to calculate factorial', 'language':
-            'python', 'domain': 'code_generation'}
+        ReqID: N/A"""
+        memory_manager.store_with_edrr_phase = MagicMock(
+            side_effect=Exception("Test error in store_with_edrr_phase")
+        )
+        task = {
+            "description": "Create a Python function to calculate factorial",
+            "language": "python",
+            "domain": "code_generation",
+        }
         coordinator.start_cycle(task)
         expand_results = coordinator.execute_current_phase()
         assert expand_results is not None
         memory_manager.store_with_edrr_phase = MagicMock()
-        memory_manager.retrieve_with_edrr_phase = MagicMock(side_effect=
-            Exception('Test error in retrieve_with_edrr_phase'))
+        memory_manager.retrieve_with_edrr_phase = MagicMock(
+            side_effect=Exception("Test error in retrieve_with_edrr_phase")
+        )
         coordinator.progress_to_phase(Phase.DIFFERENTIATE)
         differentiate_results = coordinator.execute_current_phase()
         assert differentiate_results is not None

--- a/tests/integration/general/test_feature_flag_integration.py
+++ b/tests/integration/general/test_feature_flag_integration.py
@@ -1,15 +1,19 @@
 from unittest.mock import MagicMock
+
 import pytest
+
 from devsynth.application.code_analysis.analyzer import CodeAnalyzer
 from devsynth.application.code_analysis.ast_transformer import AstTransformer
-from devsynth.application.documentation.documentation_manager import DocumentationManager
+from devsynth.application.collaboration.coordinator import AgentCoordinatorImpl
+from devsynth.application.collaboration.exceptions import TeamConfigurationError
+from devsynth.application.documentation.documentation_manager import (
+    DocumentationManager,
+)
 from devsynth.application.edrr.coordinator import EDRRCoordinator, EDRRCoordinatorError
 from devsynth.application.memory.memory_manager import MemoryManager
 from devsynth.application.prompts.prompt_manager import PromptManager
-from devsynth.application.collaboration.coordinator import AgentCoordinatorImpl
-from devsynth.application.collaboration.exceptions import TeamConfigurationError
 from devsynth.domain.interfaces.agent import Agent
-from devsynth.domain.models.wsde import WSDETeam
+from devsynth.domain.models.wsde_facade import WSDETeam
 from devsynth.methodology.base import Phase
 
 
@@ -28,18 +32,23 @@ class SimpleAgent:
         pass
 
     def process(self, task):
-        return {'solution': f'{self.name}-result'}
+        return {"solution": f"{self.name}-result"}
 
     def set_llm_port(self, llm_port):
         pass
 
 
-def create_edrr_coordinator(auto_enabled: bool) ->EDRRCoordinator:
-    team = WSDETeam(name='TestFeatureFlagIntegrationTeam')
-    team.add_agents([SimpleAgent('expand', ['expand']), SimpleAgent('diff',
-        ['differentiate']), SimpleAgent('refine', ['refine']), SimpleAgent(
-        'retro', ['retrospect'])])
-    team.generate_diverse_ideas = MagicMock(return_value=['idea'])
+def create_edrr_coordinator(auto_enabled: bool) -> EDRRCoordinator:
+    team = WSDETeam(name="TestFeatureFlagIntegrationTeam")
+    team.add_agents(
+        [
+            SimpleAgent("expand", ["expand"]),
+            SimpleAgent("diff", ["differentiate"]),
+            SimpleAgent("refine", ["refine"]),
+            SimpleAgent("retro", ["retrospect"]),
+        ]
+    )
+    team.generate_diverse_ideas = MagicMock(return_value=["idea"])
     team.create_comparison_matrix = MagicMock(return_value={})
     team.evaluate_options = MagicMock(return_value=[])
     team.analyze_trade_offs = MagicMock(return_value=[])
@@ -56,41 +65,52 @@ def create_edrr_coordinator(auto_enabled: bool) ->EDRRCoordinator:
     mm = MagicMock(spec=MemoryManager)
 
     def retrieve_with_phase(item_type, phase, metadata):
-        if item_type == 'EXPAND_RESULTS':
-            return {'ideas': []}
-        if item_type == 'DIFFERENTIATE_RESULTS':
-            return {'evaluated_options': [], 'decision_criteria': {}}
-        if item_type == 'REFINE_RESULTS':
-            return {'implementation_plan': [], 'quality_checks': {}}
+        if item_type == "EXPAND_RESULTS":
+            return {"ideas": []}
+        if item_type == "DIFFERENTIATE_RESULTS":
+            return {"evaluated_options": [], "decision_criteria": {}}
+        if item_type == "REFINE_RESULTS":
+            return {"implementation_plan": [], "quality_checks": {}}
         return {}
+
     mm.retrieve_with_edrr_phase.side_effect = retrieve_with_phase
     mm.retrieve_relevant_knowledge.return_value = []
     mm.retrieve_historical_patterns.return_value = []
     analyzer = MagicMock(spec=CodeAnalyzer)
     analyzer.analyze_project_structure.return_value = []
-    config = {'edrr': {'phase_transition': {'auto': auto_enabled, 'timeout':
-        0}}, 'features': {'automatic_phase_transitions': auto_enabled}}
-    return EDRRCoordinator(memory_manager=mm, wsde_team=team, code_analyzer
-        =analyzer, ast_transformer=MagicMock(spec=AstTransformer),
-        prompt_manager=MagicMock(spec=PromptManager), documentation_manager
-        =MagicMock(spec=DocumentationManager), enable_enhanced_logging=
-        False, config=config)
+    config = {
+        "edrr": {"phase_transition": {"auto": auto_enabled, "timeout": 0}},
+        "features": {"automatic_phase_transitions": auto_enabled},
+    }
+    return EDRRCoordinator(
+        memory_manager=mm,
+        wsde_team=team,
+        code_analyzer=analyzer,
+        ast_transformer=MagicMock(spec=AstTransformer),
+        prompt_manager=MagicMock(spec=PromptManager),
+        documentation_manager=MagicMock(spec=DocumentationManager),
+        enable_enhanced_logging=False,
+        config=config,
+    )
 
 
-def create_agent_coordinator(collab_enabled: bool) ->AgentCoordinatorImpl:
-    return AgentCoordinatorImpl({'features': {'wsde_collaboration':
-        collab_enabled}})
+def create_agent_coordinator(collab_enabled: bool) -> AgentCoordinatorImpl:
+    return AgentCoordinatorImpl({"features": {"wsde_collaboration": collab_enabled}})
 
 
-def add_basic_agents(coordinator: AgentCoordinatorImpl) ->None:
+def add_basic_agents(coordinator: AgentCoordinatorImpl) -> None:
     agents = []
-    for name, agent_type in [('planner', 'planner'), ('coder', 'code'), (
-        'tester', 'test'), ('validator', 'validation')]:
+    for name, agent_type in [
+        ("planner", "planner"),
+        ("coder", "code"),
+        ("tester", "test"),
+        ("validator", "validation"),
+    ]:
         agent = MagicMock(spec=Agent)
         agent.name = name
         agent.agent_type = agent_type
         agent.current_role = None
-        agent.process.return_value = {'solution': f'{name}-solution'}
+        agent.process.return_value = {"solution": f"{name}-solution"}
         agents.append(agent)
         coordinator.add_agent(agent)
 
@@ -98,14 +118,14 @@ def add_basic_agents(coordinator: AgentCoordinatorImpl) ->None:
 class TestEDRRPhaseTransitions:
     """Tests for the EDRRPhaseTransitions component.
 
-ReqID: N/A"""
+    ReqID: N/A"""
 
     def test_auto_transitions_enabled_succeeds(self):
         """Test that auto transitions enabled succeeds.
 
-ReqID: N/A"""
+        ReqID: N/A"""
         coordinator = create_edrr_coordinator(True)
-        task = {'description': 'demo'}
+        task = {"description": "demo"}
         coordinator.start_cycle(task)
         # With auto-transitions enabled, executing any phase should transition directly to RETROSPECT
         coordinator.execute_current_phase()  # Execute current phase
@@ -115,9 +135,9 @@ ReqID: N/A"""
     def test_manual_transitions_when_disabled_succeeds(self):
         """Test that manual transitions when disabled succeeds.
 
-ReqID: N/A"""
+        ReqID: N/A"""
         coordinator = create_edrr_coordinator(False)
-        task = {'description': 'demo'}
+        task = {"description": "demo"}
         coordinator.start_cycle(task)
         assert coordinator.current_phase == Phase.EXPAND
         coordinator.progress_to_next_phase()
@@ -133,35 +153,35 @@ ReqID: N/A"""
 class TestWSDECollaboration:
     """Tests for the WSDECollaboration component.
 
-ReqID: N/A"""
+    ReqID: N/A"""
 
     def test_collaboration_enabled_succeeds(self):
         """Test that collaboration enabled succeeds.
 
-ReqID: N/A"""
+        ReqID: N/A"""
         coordinator = create_agent_coordinator(True)
         add_basic_agents(coordinator)
-        task = {'team_task': True, 'action': 'implement'}
+        task = {"team_task": True, "action": "implement"}
         result = coordinator.delegate_task(task)
-        assert 'team_result' in result
-        assert result['team_result']['solutions']
+        assert "team_result" in result
+        assert result["team_result"]["solutions"]
         # The result field might be empty, but the team_result should be present
-        assert 'result' in result
+        assert "result" in result
 
     def test_collaboration_disabled_succeeds(self):
         """Test that collaboration disabled succeeds.
 
-ReqID: N/A"""
+        ReqID: N/A"""
         coordinator = create_agent_coordinator(False)
-        task = {'team_task': True, 'action': 'implement'}
+        task = {"team_task": True, "action": "implement"}
         result = coordinator.delegate_task(task)
-        assert result == {'success': False, 'error': 'Collaboration disabled'}
+        assert result == {"success": False, "error": "Collaboration disabled"}
 
     def test_collaboration_no_agents_succeeds(self):
         """Test that collaboration no agents succeeds.
 
-ReqID: N/A"""
+        ReqID: N/A"""
         coordinator = create_agent_coordinator(True)
-        task = {'team_task': True, 'action': 'implement'}
+        task = {"team_task": True, "action": "implement"}
         with pytest.raises(TeamConfigurationError):
             coordinator.delegate_task(task)

--- a/tests/integration/general/test_multi_agent_roles_and_voting.py
+++ b/tests/integration/general/test_multi_agent_roles_and_voting.py
@@ -1,59 +1,60 @@
-import types
 import sys
+import types
 from unittest.mock import MagicMock
+
 import pytest
-argon2_mod = types.ModuleType('argon2')
-setattr(argon2_mod, 'PasswordHasher', object)
-exceptions_mod = types.ModuleType('exceptions')
-setattr(exceptions_mod, 'VerifyMismatchError', type('VerifyMismatchError',
-    (), {}))
-setattr(argon2_mod, 'exceptions', exceptions_mod)
-sys.modules.setdefault('argon2', argon2_mod)
-sys.modules.setdefault('argon2.exceptions', exceptions_mod)
-sys.modules.setdefault('requests', types.ModuleType('requests'))
-crypto_mod = types.ModuleType('cryptography')
-fernet_mod = types.ModuleType('fernet')
-setattr(fernet_mod, 'Fernet', object)
+
+argon2_mod = types.ModuleType("argon2")
+setattr(argon2_mod, "PasswordHasher", object)
+exceptions_mod = types.ModuleType("exceptions")
+setattr(exceptions_mod, "VerifyMismatchError", type("VerifyMismatchError", (), {}))
+setattr(argon2_mod, "exceptions", exceptions_mod)
+sys.modules.setdefault("argon2", argon2_mod)
+sys.modules.setdefault("argon2.exceptions", exceptions_mod)
+sys.modules.setdefault("requests", types.ModuleType("requests"))
+crypto_mod = types.ModuleType("cryptography")
+fernet_mod = types.ModuleType("fernet")
+setattr(fernet_mod, "Fernet", object)
 crypto_mod.fernet = fernet_mod
-sys.modules.setdefault('cryptography', crypto_mod)
-sys.modules.setdefault('cryptography.fernet', fernet_mod)
-sys.modules.setdefault('jsonschema', types.ModuleType('jsonschema'))
-rdflib_mod = types.ModuleType('rdflib')
-setattr(rdflib_mod, 'Graph', object)
-setattr(rdflib_mod, 'Literal', object)
-setattr(rdflib_mod, 'URIRef', object)
-setattr(rdflib_mod, 'Namespace', lambda *a, **k: object())
-setattr(rdflib_mod, 'RDF', object)
-setattr(rdflib_mod, 'RDFS', object)
-setattr(rdflib_mod, 'XSD', object)
-namespace_mod = types.ModuleType('namespace')
-setattr(namespace_mod, 'FOAF', object)
-setattr(namespace_mod, 'DC', object)
+sys.modules.setdefault("cryptography", crypto_mod)
+sys.modules.setdefault("cryptography.fernet", fernet_mod)
+sys.modules.setdefault("jsonschema", types.ModuleType("jsonschema"))
+rdflib_mod = types.ModuleType("rdflib")
+setattr(rdflib_mod, "Graph", object)
+setattr(rdflib_mod, "Literal", object)
+setattr(rdflib_mod, "URIRef", object)
+setattr(rdflib_mod, "Namespace", lambda *a, **k: object())
+setattr(rdflib_mod, "RDF", object)
+setattr(rdflib_mod, "RDFS", object)
+setattr(rdflib_mod, "XSD", object)
+namespace_mod = types.ModuleType("namespace")
+setattr(namespace_mod, "FOAF", object)
+setattr(namespace_mod, "DC", object)
 rdflib_mod.namespace = namespace_mod
-sys.modules.setdefault('rdflib', rdflib_mod)
-sys.modules.setdefault('rdflib.namespace', namespace_mod)
-astor_mod = types.ModuleType('astor')
-setattr(astor_mod, 'to_source', lambda *a, **k: '')
-sys.modules.setdefault('astor', astor_mod)
-tinydb_mod = types.ModuleType('tinydb')
-setattr(tinydb_mod, 'TinyDB', object)
-setattr(tinydb_mod, 'Query', object)
-storages_mod = types.ModuleType('storages')
-setattr(storages_mod, 'MemoryStorage', object)
-setattr(storages_mod, 'JSONStorage', object)
+sys.modules.setdefault("rdflib", rdflib_mod)
+sys.modules.setdefault("rdflib.namespace", namespace_mod)
+astor_mod = types.ModuleType("astor")
+setattr(astor_mod, "to_source", lambda *a, **k: "")
+sys.modules.setdefault("astor", astor_mod)
+tinydb_mod = types.ModuleType("tinydb")
+setattr(tinydb_mod, "TinyDB", object)
+setattr(tinydb_mod, "Query", object)
+storages_mod = types.ModuleType("storages")
+setattr(storages_mod, "MemoryStorage", object)
+setattr(storages_mod, "JSONStorage", object)
 tinydb_mod.storages = storages_mod
-sys.modules.setdefault('tinydb', tinydb_mod)
-sys.modules.setdefault('tinydb.storages', storages_mod)
-middlewares_mod = types.ModuleType('middlewares')
-setattr(middlewares_mod, 'CachingMiddleware', object)
+sys.modules.setdefault("tinydb", tinydb_mod)
+sys.modules.setdefault("tinydb.storages", storages_mod)
+middlewares_mod = types.ModuleType("middlewares")
+setattr(middlewares_mod, "CachingMiddleware", object)
 tinydb_mod.middlewares = middlewares_mod
-sys.modules.setdefault('tinydb.middlewares', middlewares_mod)
-sys.modules.setdefault('chromadb', types.ModuleType('chromadb'))
-sys.modules.setdefault('duckdb', types.ModuleType('duckdb'))
-sys.modules.setdefault('lmdb', types.ModuleType('lmdb'))
-sys.modules.setdefault('faiss', types.ModuleType('faiss'))
-from devsynth.domain.models.wsde import WSDETeam
+sys.modules.setdefault("tinydb.middlewares", middlewares_mod)
+sys.modules.setdefault("chromadb", types.ModuleType("chromadb"))
+sys.modules.setdefault("duckdb", types.ModuleType("duckdb"))
+sys.modules.setdefault("lmdb", types.ModuleType("lmdb"))
+sys.modules.setdefault("faiss", types.ModuleType("faiss"))
 from devsynth.adapters.agents.agent_adapter import AgentAdapter
+from devsynth.domain.models.wsde_facade import WSDETeam
 
 
 class SimpleAgent:
@@ -67,16 +68,16 @@ class SimpleAgent:
 
     def process(self, task):
         if self._vote:
-            return {'vote': self._vote}
-        return {'result': self.name}
+            return {"vote": self._vote}
+        return {"result": self.name}
 
 
 def test_role_rotation_succeeds():
     """Test that role rotation succeeds.
 
-ReqID: N/A"""
-    team = WSDETeam(name='TestMultiAgentRolesAndVotingTeam')
-    agents = [SimpleAgent(f'a{i}') for i in range(3)]
+    ReqID: N/A"""
+    team = WSDETeam(name="TestMultiAgentRolesAndVotingTeam")
+    agents = [SimpleAgent(f"a{i}") for i in range(3)]
     team.add_agents(agents)
     team.assign_roles()
     first_primus = team.get_primus().name
@@ -88,32 +89,41 @@ ReqID: N/A"""
 def test_consensus_vote_with_non_unanimous_votes_succeeds():
     """Test that consensus vote with non unanimous votes succeeds.
 
-ReqID: N/A"""
-    team = WSDETeam(name='TestMultiAgentRolesAndVotingTeam')
-    team.add_agents([SimpleAgent('a1', 'x'), SimpleAgent('a2', 'y'),
-        SimpleAgent('a3', 'y')])
-    decision = {'type': 'critical_decision', 'is_critical': True, 'options':
-        [{'id': 'x'}, {'id': 'y'}]}
+    ReqID: N/A"""
+    team = WSDETeam(name="TestMultiAgentRolesAndVotingTeam")
+    team.add_agents(
+        [SimpleAgent("a1", "x"), SimpleAgent("a2", "y"), SimpleAgent("a3", "y")]
+    )
+    decision = {
+        "type": "critical_decision",
+        "is_critical": True,
+        "options": [{"id": "x"}, {"id": "y"}],
+    }
     result = team.consensus_vote(decision)
-    assert result['voting_initiated']
-    assert 'winner' in result['result']
-    assert 'consensus' in result['result']
+    assert result["voting_initiated"]
+    assert "winner" in result["result"]
+    assert "consensus" in result["result"]
 
 
 def test_agent_adapter_multi_agent_workflow_succeeds():
     """Test that agent adapter multi agent workflow succeeds.
 
-ReqID: N/A"""
-    cfg = {'features': {'wsde_collaboration': True}}
+    ReqID: N/A"""
+    cfg = {"features": {"wsde_collaboration": True}}
     adapter = AgentAdapter(config=cfg)
-    adapter.create_team('t')
-    adapter.set_current_team('t')
-    a1 = SimpleAgent('a1')
-    a2 = SimpleAgent('a2')
+    adapter.create_team("t")
+    adapter.set_current_team("t")
+    a1 = SimpleAgent("a1")
+    a2 = SimpleAgent("a2")
     adapter.add_agents_to_team([a1, a2])
-    team = adapter.get_team('t')
-    team.build_consensus = MagicMock(return_value={'consensus': 'done',
-        'contributors': ['a1', 'a2'], 'method': 'consensus_synthesis'})
-    result = adapter.process_task({'description': 'demo'})
+    team = adapter.get_team("t")
+    team.build_consensus = MagicMock(
+        return_value={
+            "consensus": "done",
+            "contributors": ["a1", "a2"],
+            "method": "consensus_synthesis",
+        }
+    )
+    result = adapter.process_task({"description": "demo"})
     team.build_consensus.assert_called_once()
-    assert result['method'] == 'consensus_synthesis'
+    assert result["method"] == "consensus_synthesis"

--- a/tests/integration/general/test_wsde_edrr_component_interactions.py
+++ b/tests/integration/general/test_wsde_edrr_component_interactions.py
@@ -27,7 +27,7 @@ from devsynth.application.memory.memory_manager import MemoryManager
 from devsynth.application.prompts.prompt_manager import PromptManager
 from devsynth.domain.models.agent import AgentConfig, AgentType
 from devsynth.domain.models.memory import MemoryItem, MemoryType
-from devsynth.domain.models.wsde import WSDETeam
+from devsynth.domain.models.wsde_facade import WSDETeam
 from devsynth.methodology.base import Phase
 
 

--- a/tests/integration/general/test_wsde_edrr_integration_advanced.py
+++ b/tests/integration/general/test_wsde_edrr_integration_advanced.py
@@ -6,20 +6,22 @@ and the EDRR framework, including phase-specific role assignment, quality-based 
 micro-cycle implementation, error handling, and performance metrics.
 """
 
+from unittest.mock import MagicMock, call, patch
+
 import pytest
-from unittest.mock import MagicMock, patch, call
-from devsynth.application.edrr.edrr_coordinator_enhanced import EnhancedEDRRCoordinator
-from devsynth.domain.models.wsde import WSDETeam
-from devsynth.application.memory.memory_manager import MemoryManager
+
+from devsynth.application.agents.unified_agent import UnifiedAgent
 from devsynth.application.code_analysis.analyzer import CodeAnalyzer
 from devsynth.application.code_analysis.ast_transformer import AstTransformer
-from devsynth.application.prompts.prompt_manager import PromptManager
 from devsynth.application.documentation.documentation_manager import (
     DocumentationManager,
 )
-from devsynth.methodology.base import Phase
+from devsynth.application.edrr.edrr_coordinator_enhanced import EnhancedEDRRCoordinator
+from devsynth.application.memory.memory_manager import MemoryManager
+from devsynth.application.prompts.prompt_manager import PromptManager
 from devsynth.domain.models.agent import AgentConfig, AgentType
-from devsynth.application.agents.unified_agent import UnifiedAgent
+from devsynth.domain.models.wsde_facade import WSDETeam
+from devsynth.methodology.base import Phase
 
 
 class ExpertAgent(UnifiedAgent):

--- a/tests/integration/general/test_wsde_edrr_integration_end_to_end.py
+++ b/tests/integration/general/test_wsde_edrr_integration_end_to_end.py
@@ -5,20 +5,22 @@ This test verifies the complete integration between the WSDE agent model and the
 including dynamic role assignment, multi-agent collaboration, and dialectical reasoning.
 """
 
-import pytest
 from unittest.mock import MagicMock, patch
-from devsynth.application.edrr.edrr_coordinator_enhanced import EnhancedEDRRCoordinator
-from devsynth.domain.models.wsde import WSDETeam
-from devsynth.application.memory.memory_manager import MemoryManager
+
+import pytest
+
+from devsynth.application.agents.unified_agent import UnifiedAgent
 from devsynth.application.code_analysis.analyzer import CodeAnalyzer
 from devsynth.application.code_analysis.ast_transformer import AstTransformer
-from devsynth.application.prompts.prompt_manager import PromptManager
 from devsynth.application.documentation.documentation_manager import (
     DocumentationManager,
 )
-from devsynth.methodology.base import Phase
+from devsynth.application.edrr.edrr_coordinator_enhanced import EnhancedEDRRCoordinator
+from devsynth.application.memory.memory_manager import MemoryManager
+from devsynth.application.prompts.prompt_manager import PromptManager
 from devsynth.domain.models.agent import AgentConfig, AgentType
-from devsynth.application.agents.unified_agent import UnifiedAgent
+from devsynth.domain.models.wsde_facade import WSDETeam
+from devsynth.methodology.base import Phase
 
 
 class ExpertAgent(UnifiedAgent):

--- a/tests/integration/general/test_wsde_memory_edrr_integration.py
+++ b/tests/integration/general/test_wsde_memory_edrr_integration.py
@@ -11,7 +11,7 @@ from devsynth.application.memory.context_manager import (
 )
 from devsynth.application.memory.memory_manager import MemoryManager
 from devsynth.domain.models.memory import MemoryType
-from devsynth.domain.models.wsde import WSDETeam
+from devsynth.domain.models.wsde_facade import WSDETeam
 
 
 class SimpleStore(InMemoryStore):

--- a/tests/integration/general/test_wsde_peer_review_workflow.py
+++ b/tests/integration/general/test_wsde_peer_review_workflow.py
@@ -1,23 +1,27 @@
 import pytest
-from devsynth.domain.models.wsde import WSDETeam
+
 from devsynth.application.collaboration.peer_review import run_peer_review
+from devsynth.domain.models.wsde_facade import WSDETeam
+
 
 class DummyAgent:
     def __init__(self, name):
         self.name = name
 
+
 @pytest.fixture
 def wsde_team():
-    team = WSDETeam(name='PeerReviewTeam')
-    team.add_agent(DummyAgent('author'))
-    team.add_agent(DummyAgent('reviewer1'))
-    team.add_agent(DummyAgent('reviewer2'))
+    team = WSDETeam(name="PeerReviewTeam")
+    team.add_agent(DummyAgent("author"))
+    team.add_agent(DummyAgent("reviewer1"))
+    team.add_agent(DummyAgent("reviewer2"))
     return team
+
 
 def test_run_peer_review_workflow(wsde_team):
     author = wsde_team.agents[0]
     reviewers = wsde_team.agents[1:]
-    result = run_peer_review({'text': 'demo'}, author, reviewers)
-    assert result['status'] in {'approved', 'rejected'}
-    assert 'workflow' in result
-    assert 'revision_cycles' in result['workflow']
+    result = run_peer_review({"text": "demo"}, author, reviewers)
+    assert result["status"] in {"approved", "rejected"}
+    assert "workflow" in result
+    assert "revision_cycles" in result["workflow"]

--- a/tests/integration/interface/test_multi_agent_collaboration.py
+++ b/tests/integration/interface/test_multi_agent_collaboration.py
@@ -1,10 +1,13 @@
 import types
+from typing import Union
+
+from devsynth.application.collaboration.collaborative_wsde_team import (
+    CollaborativeWSDETeam,
+)
+from devsynth.domain.models.wsde_facade import WSDETeam
 from devsynth.interface.agentapi import APIBridge
 from devsynth.interface.cli import CLIUXBridge
 from devsynth.interface.ux_bridge import sanitize_output
-from devsynth.domain.models.wsde import WSDETeam
-from devsynth.application.collaboration.collaborative_wsde_team import CollaborativeWSDETeam
-from typing import Union
 
 
 class DummyProgress:
@@ -23,7 +26,9 @@ class DummyProgress:
         self.complete()
         return False
 
-    def update(self, *, advance: float = 1, description: Union[str, None] = None) -> None:
+    def update(
+        self, *, advance: float = 1, description: Union[str, None] = None
+    ) -> None:
         if description:
             self.description = sanitize_output(description)
         self.current += advance

--- a/tests/unit/application/agents/test_agent_memory_integration.py
+++ b/tests/unit/application/agents/test_agent_memory_integration.py
@@ -1,11 +1,14 @@
-import pytest
 import unittest
+from typing import Any, Dict, List
 from unittest.mock import MagicMock, patch
-from typing import Dict, Any, List
-from devsynth.domain.models.memory import MemoryItem, MemoryType
+
+import pytest
+
 from devsynth.adapters.memory.memory_adapter import MemorySystemAdapter
-from devsynth.domain.models.wsde import WSDETeam
 from devsynth.application.agents.agent_memory_integration import AgentMemoryIntegration
+from devsynth.domain.models.memory import MemoryItem, MemoryType
+from devsynth.domain.models.wsde_facade import WSDETeam
+
 
 class TestAgentMemoryIntegration(unittest.TestCase):
     """Test the integration between agents and the memory system.
@@ -23,24 +26,26 @@ class TestAgentMemoryIntegration(unittest.TestCase):
         self.memory_adapter.get_vector_store.return_value = self.vector_store
         self.memory_adapter.has_vector_store.return_value = True
         self.wsde_team = MagicMock(spec=WSDETeam)
-        self.wsde_team.name = 'TestAgent'
-        self.agent_memory = AgentMemoryIntegration(memory_adapter=self.memory_adapter, wsde_team=self.wsde_team)
+        self.wsde_team.name = "TestAgent"
+        self.agent_memory = AgentMemoryIntegration(
+            memory_adapter=self.memory_adapter, wsde_team=self.wsde_team
+        )
 
     @pytest.mark.medium
     def test_store_agent_solution_succeeds(self):
         """Test storing an agent solution in memory.
 
         ReqID: N/A"""
-        agent_id = 'agent1'
-        task = {'id': 'task1', 'description': 'Test task'}
-        solution = {'id': 'solution1', 'content': 'Test solution'}
+        agent_id = "agent1"
+        task = {"id": "task1", "description": "Test task"}
+        solution = {"id": "solution1", "content": "Test solution"}
         result = self.agent_memory.store_agent_solution(agent_id, task, solution)
         self.memory_store.store.assert_called_once()
         stored_item = self.memory_store.store.call_args[0][0]
         self.assertEqual(stored_item.memory_type, MemoryType.SOLUTION)
-        self.assertEqual(stored_item.metadata.get('agent_id'), agent_id)
-        self.assertEqual(stored_item.metadata.get('task_id'), task['id'])
-        self.assertEqual(stored_item.metadata.get('solution_id'), solution['id'])
+        self.assertEqual(stored_item.metadata.get("agent_id"), agent_id)
+        self.assertEqual(stored_item.metadata.get("task_id"), task["id"])
+        self.assertEqual(stored_item.metadata.get("solution_id"), solution["id"])
         self.assertEqual(result, self.memory_store.store.return_value)
 
     @pytest.mark.medium
@@ -48,36 +53,51 @@ class TestAgentMemoryIntegration(unittest.TestCase):
         """Test retrieving agent solutions from memory.
 
         ReqID: N/A"""
-        task_id = 'task1'
-        mock_items = [MemoryItem(id='item1', content='Solution 1', memory_type=MemoryType.SOLUTION, metadata={'task_id': task_id, 'agent_id': 'agent1'}), MemoryItem(id='item2', content='Solution 2', memory_type=MemoryType.SOLUTION, metadata={'task_id': task_id, 'agent_id': 'agent2'})]
-        if hasattr(type(self.memory_store), 'items'):
-            delattr(type(self.memory_store), 'items')
+        task_id = "task1"
+        mock_items = [
+            MemoryItem(
+                id="item1",
+                content="Solution 1",
+                memory_type=MemoryType.SOLUTION,
+                metadata={"task_id": task_id, "agent_id": "agent1"},
+            ),
+            MemoryItem(
+                id="item2",
+                content="Solution 2",
+                memory_type=MemoryType.SOLUTION,
+                metadata={"task_id": task_id, "agent_id": "agent2"},
+            ),
+        ]
+        if hasattr(type(self.memory_store), "items"):
+            delattr(type(self.memory_store), "items")
         self.memory_store.search.return_value = mock_items
         results = self.agent_memory.retrieve_agent_solutions(task_id)
         self.memory_store.search.assert_called_once()
         search_query = self.memory_store.search.call_args[0][0]
-        self.assertEqual(search_query['memory_type'], MemoryType.SOLUTION)
+        self.assertEqual(search_query["memory_type"], MemoryType.SOLUTION)
         self.assertEqual(len(results), 2)
-        self.assertEqual(results[0].content, 'Solution 1')
-        self.assertEqual(results[1].content, 'Solution 2')
+        self.assertEqual(results[0].content, "Solution 1")
+        self.assertEqual(results[1].content, "Solution 2")
 
     @pytest.mark.medium
     def test_store_dialectical_reasoning_succeeds(self):
         """Test storing dialectical reasoning in memory.
 
         ReqID: N/A"""
-        task_id = 'task1'
-        thesis = {'id': 'thesis1', 'content': 'Thesis content'}
-        antithesis = {'id': 'antithesis1', 'content': 'Antithesis content'}
-        synthesis = {'id': 'synthesis1', 'content': 'Synthesis content'}
-        result = self.agent_memory.store_dialectical_reasoning(task_id, thesis, antithesis, synthesis)
+        task_id = "task1"
+        thesis = {"id": "thesis1", "content": "Thesis content"}
+        antithesis = {"id": "antithesis1", "content": "Antithesis content"}
+        synthesis = {"id": "synthesis1", "content": "Synthesis content"}
+        result = self.agent_memory.store_dialectical_reasoning(
+            task_id, thesis, antithesis, synthesis
+        )
         self.memory_store.store.assert_called_once()
         stored_item = self.memory_store.store.call_args[0][0]
         self.assertEqual(stored_item.memory_type, MemoryType.DIALECTICAL_REASONING)
-        self.assertEqual(stored_item.metadata.get('task_id'), task_id)
-        self.assertEqual(stored_item.metadata.get('thesis_id'), thesis['id'])
-        self.assertEqual(stored_item.metadata.get('antithesis_id'), antithesis['id'])
-        self.assertEqual(stored_item.metadata.get('synthesis_id'), synthesis['id'])
+        self.assertEqual(stored_item.metadata.get("task_id"), task_id)
+        self.assertEqual(stored_item.metadata.get("thesis_id"), thesis["id"])
+        self.assertEqual(stored_item.metadata.get("antithesis_id"), antithesis["id"])
+        self.assertEqual(stored_item.metadata.get("synthesis_id"), synthesis["id"])
         self.assertEqual(result, self.memory_store.store.return_value)
 
     @pytest.mark.medium
@@ -85,14 +105,24 @@ class TestAgentMemoryIntegration(unittest.TestCase):
         """Test retrieving dialectical reasoning from memory.
 
         ReqID: N/A"""
-        task_id = 'task1'
-        mock_item = MemoryItem(id='item1', content='Dialectical reasoning content', memory_type=MemoryType.DIALECTICAL_REASONING, metadata={'task_id': task_id, 'thesis_id': 'thesis1', 'antithesis_id': 'antithesis1', 'synthesis_id': 'synthesis1'})
+        task_id = "task1"
+        mock_item = MemoryItem(
+            id="item1",
+            content="Dialectical reasoning content",
+            memory_type=MemoryType.DIALECTICAL_REASONING,
+            metadata={
+                "task_id": task_id,
+                "thesis_id": "thesis1",
+                "antithesis_id": "antithesis1",
+                "synthesis_id": "synthesis1",
+            },
+        )
         self.memory_store.search.return_value = [mock_item]
         result = self.agent_memory.retrieve_dialectical_reasoning(task_id)
         self.memory_store.search.assert_called_once()
         search_query = self.memory_store.search.call_args[0][0]
-        self.assertEqual(search_query['memory_type'], MemoryType.DIALECTICAL_REASONING)
-        self.assertEqual(search_query['metadata.task_id'], task_id)
+        self.assertEqual(search_query["memory_type"], MemoryType.DIALECTICAL_REASONING)
+        self.assertEqual(search_query["metadata.task_id"], task_id)
         self.assertEqual(result, mock_item)
 
     @pytest.mark.medium
@@ -100,12 +130,12 @@ class TestAgentMemoryIntegration(unittest.TestCase):
         """Test storing agent context in memory.
 
         ReqID: N/A"""
-        agent_id = 'agent1'
-        context_data = {'key': 'value', 'nested': {'data': 'nested value'}}
+        agent_id = "agent1"
+        context_data = {"key": "value", "nested": {"data": "nested value"}}
         self.agent_memory.store_agent_context(agent_id, context_data)
         self.context_manager.add_to_context.assert_called_once()
         context_key, context_value = self.context_manager.add_to_context.call_args[0]
-        self.assertEqual(context_key, f'agent:{agent_id}')
+        self.assertEqual(context_key, f"agent:{agent_id}")
         self.assertEqual(context_value, context_data)
 
     @pytest.mark.medium
@@ -113,11 +143,13 @@ class TestAgentMemoryIntegration(unittest.TestCase):
         """Test retrieving agent context from memory.
 
         ReqID: N/A"""
-        agent_id = 'agent1'
-        context_data = {'key': 'value', 'nested': {'data': 'nested value'}}
+        agent_id = "agent1"
+        context_data = {"key": "value", "nested": {"data": "nested value"}}
         self.context_manager.get_from_context.return_value = context_data
         result = self.agent_memory.retrieve_agent_context(agent_id)
-        self.context_manager.get_from_context.assert_called_once_with(f'agent:{agent_id}')
+        self.context_manager.get_from_context.assert_called_once_with(
+            f"agent:{agent_id}"
+        )
         self.assertEqual(result, context_data)
 
     @pytest.mark.medium
@@ -125,7 +157,7 @@ class TestAgentMemoryIntegration(unittest.TestCase):
         """Test searching for similar solutions using vector similarity.
 
         ReqID: N/A"""
-        query = 'How to implement a feature'
+        query = "How to implement a feature"
         mock_vectors = [MagicMock(), MagicMock()]
         self.vector_store.similarity_search.return_value = mock_vectors
         results = self.agent_memory.search_similar_solutions(query)
@@ -137,7 +169,7 @@ class TestAgentMemoryIntegration(unittest.TestCase):
         """Test searching for similar solutions when no vector store is available.
 
         ReqID: N/A"""
-        query = 'How to implement a feature'
+        query = "How to implement a feature"
         self.memory_adapter.has_vector_store.return_value = False
         self.agent_memory.vector_store = None
         results = self.agent_memory.search_similar_solutions(query)
@@ -147,31 +179,40 @@ class TestAgentMemoryIntegration(unittest.TestCase):
     @pytest.mark.medium
     def test_store_memory_succeeds(self):
         """Test storing generic memory."""
-        content = {'a': 1}
-        metadata = {'extra': True}
+        content = {"a": 1}
+        metadata = {"extra": True}
         memory_type = MemoryType.KNOWLEDGE
         self.agent_memory.store_memory(content, memory_type, metadata)
         self.memory_store.store.assert_called_once()
         stored_item = self.memory_store.store.call_args[0][0]
         self.assertEqual(stored_item.content, content)
         self.assertEqual(stored_item.memory_type, memory_type)
-        self.assertEqual(stored_item.metadata['extra'], True)
-        self.assertEqual(stored_item.metadata['agent_name'], 'TestAgent')
+        self.assertEqual(stored_item.metadata["extra"], True)
+        self.assertEqual(stored_item.metadata["agent_name"], "TestAgent")
 
     @pytest.mark.medium
     def test_retrieve_memory_succeeds(self):
         """Test retrieving a memory item."""
-        item = MemoryItem(id='item1', content='data', memory_type=MemoryType.KNOWLEDGE, metadata={'agent_name': 'TestAgent'})
+        item = MemoryItem(
+            id="item1",
+            content="data",
+            memory_type=MemoryType.KNOWLEDGE,
+            metadata={"agent_name": "TestAgent"},
+        )
         self.memory_store.retrieve.return_value = item
-        result = self.agent_memory.retrieve_memory('item1')
-        self.memory_store.retrieve.assert_called_once_with('item1')
+        result = self.agent_memory.retrieve_memory("item1")
+        self.memory_store.retrieve.assert_called_once_with("item1")
         self.assertEqual(result, item)
 
     @pytest.mark.medium
     def test_search_memory_succeeds(self):
         """Test searching memory."""
-        query = {'field': 'value'}
-        items = [MemoryItem(id='1', content={'field': 'value'}, memory_type=MemoryType.KNOWLEDGE)]
+        query = {"field": "value"}
+        items = [
+            MemoryItem(
+                id="1", content={"field": "value"}, memory_type=MemoryType.KNOWLEDGE
+            )
+        ]
         self.memory_store.search.return_value = items
         result = self.agent_memory.search_memory(query)
         self.memory_store.search.assert_called_once_with(query)
@@ -180,40 +221,47 @@ class TestAgentMemoryIntegration(unittest.TestCase):
     @pytest.mark.medium
     def test_update_memory_succeeds(self):
         """Test updating a memory item."""
-        existing = MemoryItem(id='1', content='old', memory_type=MemoryType.KNOWLEDGE, metadata={'agent_name': 'TestAgent'})
+        existing = MemoryItem(
+            id="1",
+            content="old",
+            memory_type=MemoryType.KNOWLEDGE,
+            metadata={"agent_name": "TestAgent"},
+        )
         self.memory_store.retrieve.return_value = existing
-        self.agent_memory.update_memory('1', 'new', {'extra': 2})
-        self.memory_store.retrieve.assert_called_once_with('1')
+        self.agent_memory.update_memory("1", "new", {"extra": 2})
+        self.memory_store.retrieve.assert_called_once_with("1")
         self.memory_store.store.assert_called_once()
         updated_item = self.memory_store.store.call_args[0][0]
-        self.assertEqual(updated_item.content, 'new')
-        self.assertEqual(updated_item.metadata['extra'], 2)
-        self.assertEqual(updated_item.metadata['agent_name'], 'TestAgent')
+        self.assertEqual(updated_item.content, "new")
+        self.assertEqual(updated_item.metadata["extra"], 2)
+        self.assertEqual(updated_item.metadata["agent_name"], "TestAgent")
 
     @pytest.mark.medium
     def test_delete_memory_succeeds(self):
         """Test deleting memory."""
         self.memory_store.delete.return_value = True
-        result = self.agent_memory.delete_memory('1')
-        self.memory_store.delete.assert_called_once_with('1')
+        result = self.agent_memory.delete_memory("1")
+        self.memory_store.delete.assert_called_once_with("1")
         self.assertTrue(result)
 
     @pytest.mark.medium
     def test_store_memory_with_context_succeeds(self):
         """Test storing memory with context."""
-        context = {'task': 't'}
-        self.agent_memory.store_memory_with_context('c', MemoryType.KNOWLEDGE, {}, context)
+        context = {"task": "t"}
+        self.agent_memory.store_memory_with_context(
+            "c", MemoryType.KNOWLEDGE, {}, context
+        )
         self.memory_store.store.assert_called_once()
         item = self.memory_store.store.call_args[0][0]
-        self.assertEqual(item.metadata['context'], context)
-        self.assertEqual(item.metadata['agent_name'], 'TestAgent')
+        self.assertEqual(item.metadata["context"], context)
+        self.assertEqual(item.metadata["agent_name"], "TestAgent")
 
     @pytest.mark.medium
     def test_retrieve_memory_with_context_succeeds(self):
         """Test retrieving memory by context."""
-        context = {'task': 't'}
-        items = [MemoryItem(id='1', content='c', memory_type=MemoryType.KNOWLEDGE)]
+        context = {"task": "t"}
+        items = [MemoryItem(id="1", content="c", memory_type=MemoryType.KNOWLEDGE)]
         self.memory_store.search.return_value = items
         result = self.agent_memory.retrieve_memory_with_context(context)
-        self.memory_store.search.assert_called_once_with({'metadata.context': context})
+        self.memory_store.search.assert_called_once_with({"metadata.context": context})
         self.assertEqual(result, items)

--- a/tests/unit/application/agents/test_wsde_memory_integration.py
+++ b/tests/unit/application/agents/test_wsde_memory_integration.py
@@ -1,26 +1,30 @@
 import unittest
-import pytest
+from typing import Any, Dict, List
 from unittest.mock import MagicMock, patch
-from typing import Dict, Any, List
-from devsynth.domain.models.memory import MemoryItem, MemoryType
+
+import pytest
+
 from devsynth.adapters.memory.memory_adapter import MemorySystemAdapter
-from devsynth.domain.models.wsde import WSDETeam
 from devsynth.application.agents.agent_memory_integration import AgentMemoryIntegration
 from devsynth.application.agents.wsde_memory_integration import WSDEMemoryIntegration
+from devsynth.domain.models.memory import MemoryItem, MemoryType
+from devsynth.domain.models.wsde_facade import WSDETeam
+
 
 class TestWSDEMemoryIntegration(unittest.TestCase):
     """Test the integration between WSDE and the memory system.
 
-    These tests need to be run in isolation due to interactions with other tests.
+        These tests need to be run in isolation due to interactions with other tests.
 
-ReqID: N/A"""
+    ReqID: N/A"""
 
     @classmethod
     def setUpClass(cls):
         """Set up the test class."""
         import sys
-        if 'devsynth.application.agents.wsde_memory_integration' in sys.modules:
-            del sys.modules['devsynth.application.agents.wsde_memory_integration']
+
+        if "devsynth.application.agents.wsde_memory_integration" in sys.modules:
+            del sys.modules["devsynth.application.agents.wsde_memory_integration"]
 
     def setUp(self):
         """Set up the test environment."""
@@ -35,55 +39,69 @@ ReqID: N/A"""
         self.memory_adapter.__class__ = MemorySystemAdapter
         self.wsde_team = MagicMock(spec=WSDETeam)
         self.agent_memory = MagicMock(spec=AgentMemoryIntegration)
-        self.wsde_memory = WSDEMemoryIntegration(memory_adapter=self.memory_adapter, wsde_team=self.wsde_team, agent_memory=self.agent_memory)
+        self.wsde_memory = WSDEMemoryIntegration(
+            memory_adapter=self.memory_adapter,
+            wsde_team=self.wsde_team,
+            agent_memory=self.agent_memory,
+        )
         self.wsde_memory.context_manager = self.context_manager
 
     @pytest.mark.medium
     def test_store_dialectical_process_succeeds(self):
         """Test storing a dialectical process in memory.
 
-ReqID: N/A"""
-        task = {'id': 'task1', 'description': 'Test task'}
-        thesis = {'id': 'thesis1', 'content': 'Thesis content'}
-        antithesis = {'id': 'antithesis1', 'content': 'Antithesis content'}
-        synthesis = {'id': 'synthesis1', 'content': 'Synthesis content'}
-        result = self.wsde_memory.store_dialectical_process(task, thesis, antithesis, synthesis)
-        self.agent_memory.store_dialectical_reasoning.assert_called_once_with(task['id'], thesis, antithesis, synthesis)
-        self.assertEqual(result, self.agent_memory.store_dialectical_reasoning.return_value)
+        ReqID: N/A"""
+        task = {"id": "task1", "description": "Test task"}
+        thesis = {"id": "thesis1", "content": "Thesis content"}
+        antithesis = {"id": "antithesis1", "content": "Antithesis content"}
+        synthesis = {"id": "synthesis1", "content": "Synthesis content"}
+        result = self.wsde_memory.store_dialectical_process(
+            task, thesis, antithesis, synthesis
+        )
+        self.agent_memory.store_dialectical_reasoning.assert_called_once_with(
+            task["id"], thesis, antithesis, synthesis
+        )
+        self.assertEqual(
+            result, self.agent_memory.store_dialectical_reasoning.return_value
+        )
 
     @pytest.mark.medium
     def test_retrieve_dialectical_process_succeeds(self):
         """Test retrieving a dialectical process from memory.
 
-ReqID: N/A"""
-        task_id = 'task1'
+        ReqID: N/A"""
+        task_id = "task1"
         mock_item = MagicMock(spec=MemoryItem)
         mock_item.content = '{"thesis": {"id": "thesis1"}, "antithesis": {"id": "antithesis1"}, "synthesis": {"id": "synthesis1"}}'
         self.agent_memory.retrieve_dialectical_reasoning.return_value = mock_item
         result = self.wsde_memory.retrieve_dialectical_process(task_id)
-        self.agent_memory.retrieve_dialectical_reasoning.assert_called_once_with(task_id)
-        self.assertEqual(result['thesis']['id'], 'thesis1')
-        self.assertEqual(result['antithesis']['id'], 'antithesis1')
-        self.assertEqual(result['synthesis']['id'], 'synthesis1')
+        self.agent_memory.retrieve_dialectical_reasoning.assert_called_once_with(
+            task_id
+        )
+        self.assertEqual(result["thesis"]["id"], "thesis1")
+        self.assertEqual(result["antithesis"]["id"], "antithesis1")
+        self.assertEqual(result["synthesis"]["id"], "synthesis1")
 
     @pytest.mark.medium
     def test_store_agent_solution_succeeds(self):
         """Test storing an agent solution in memory.
 
-ReqID: N/A"""
-        agent_id = 'agent1'
-        task = {'id': 'task1', 'description': 'Test task'}
-        solution = {'id': 'solution1', 'content': 'Test solution'}
+        ReqID: N/A"""
+        agent_id = "agent1"
+        task = {"id": "task1", "description": "Test task"}
+        solution = {"id": "solution1", "content": "Test solution"}
         result = self.wsde_memory.store_agent_solution(agent_id, task, solution)
-        self.agent_memory.store_agent_solution.assert_called_once_with(agent_id, task, solution)
+        self.agent_memory.store_agent_solution.assert_called_once_with(
+            agent_id, task, solution
+        )
         self.assertEqual(result, self.agent_memory.store_agent_solution.return_value)
 
     @pytest.mark.medium
     def test_retrieve_agent_solutions_succeeds(self):
         """Test retrieving agent solutions from memory.
 
-ReqID: N/A"""
-        task_id = 'task1'
+        ReqID: N/A"""
+        task_id = "task1"
         mock_items = [MagicMock(spec=MemoryItem), MagicMock(spec=MemoryItem)]
         self.agent_memory.retrieve_agent_solutions.return_value = mock_items
         results = self.wsde_memory.retrieve_agent_solutions(task_id)
@@ -94,71 +112,81 @@ ReqID: N/A"""
     def test_store_team_context_succeeds(self):
         """Test storing team context in memory.
 
-ReqID: N/A"""
-        context_data = {'key': 'value', 'nested': {'data': 'nested value'}}
+        ReqID: N/A"""
+        context_data = {"key": "value", "nested": {"data": "nested value"}}
         self.wsde_memory.store_team_context(context_data)
         self.context_manager.add_to_context.assert_called_once()
         context_key, context_value = self.context_manager.add_to_context.call_args[0]
-        self.assertEqual(context_key, 'wsde_team')
+        self.assertEqual(context_key, "wsde_team")
         self.assertEqual(context_value, context_data)
 
     @pytest.mark.medium
     def test_retrieve_team_context_succeeds(self):
         """Test retrieving team context from memory.
 
-ReqID: N/A"""
-        context_data = {'key': 'value', 'nested': {'data': 'nested value'}}
+        ReqID: N/A"""
+        context_data = {"key": "value", "nested": {"data": "nested value"}}
         self.context_manager.get_from_context.return_value = context_data
         result = self.wsde_memory.retrieve_team_context()
-        self.context_manager.get_from_context.assert_called_once_with('wsde_team')
+        self.context_manager.get_from_context.assert_called_once_with("wsde_team")
         self.assertEqual(result, context_data)
 
     @pytest.mark.medium
     def test_search_similar_solutions_succeeds(self):
         """Test searching for similar solutions using vector similarity.
 
-ReqID: N/A"""
-        query = 'How to implement a feature'
+        ReqID: N/A"""
+        query = "How to implement a feature"
         mock_vectors = [MagicMock(), MagicMock()]
         self.agent_memory.search_similar_solutions.return_value = mock_vectors
         results = self.wsde_memory.search_similar_solutions(query)
-        self.agent_memory.search_similar_solutions.assert_called_once_with(query, top_k=5)
+        self.agent_memory.search_similar_solutions.assert_called_once_with(
+            query, top_k=5
+        )
         self.assertEqual(results, mock_vectors)
 
     @pytest.mark.medium
     def test_store_agent_solution_with_edrr_phase_has_expected(self):
         """Test storing an agent solution with EDRR phase tagging.
 
-ReqID: N/A"""
-        agent_id = 'agent1'
-        task = {'id': 'task1', 'description': 'Test task'}
-        solution = {'id': 'solution1', 'content': 'Test solution'}
-        edrr_phase = 'Expand'
+        ReqID: N/A"""
+        agent_id = "agent1"
+        task = {"id": "task1", "description": "Test task"}
+        solution = {"id": "solution1", "content": "Test solution"}
+        edrr_phase = "Expand"
         mock_item = MagicMock(spec=MemoryItem)
         mock_item.metadata = {}
         self.memory_store.get_item.return_value = mock_item
-        self.agent_memory.store_agent_solution.return_value = 'item123'
-        result = self.wsde_memory.store_agent_solution(agent_id, task, solution, edrr_phase)
-        self.agent_memory.store_agent_solution.assert_called_once_with(agent_id, task, solution)
-        self.memory_store.get_item.assert_called_once_with('item123')
+        self.agent_memory.store_agent_solution.return_value = "item123"
+        result = self.wsde_memory.store_agent_solution(
+            agent_id, task, solution, edrr_phase
+        )
+        self.agent_memory.store_agent_solution.assert_called_once_with(
+            agent_id, task, solution
+        )
+        self.memory_store.get_item.assert_called_once_with("item123")
         self.memory_store.update_item.assert_called_once()
-        self.assertEqual(mock_item.metadata.get('edrr_phase'), edrr_phase)
-        self.assertEqual(result, 'item123')
+        self.assertEqual(mock_item.metadata.get("edrr_phase"), edrr_phase)
+        self.assertEqual(result, "item123")
 
     @pytest.mark.medium
     def test_retrieve_solutions_by_edrr_phase_has_expected(self):
         """Test retrieving agent solutions filtered by EDRR phase.
 
-ReqID: N/A"""
-        task_id = 'task1'
-        edrr_phase = 'Expand'
+        ReqID: N/A"""
+        task_id = "task1"
+        edrr_phase = "Expand"
         expand_item = MagicMock(spec=MemoryItem)
-        expand_item.metadata = {'edrr_phase': 'Expand'}
+        expand_item.metadata = {"edrr_phase": "Expand"}
         differentiate_item = MagicMock(spec=MemoryItem)
-        differentiate_item.metadata = {'edrr_phase': 'Differentiate'}
+        differentiate_item.metadata = {"edrr_phase": "Differentiate"}
         refine_item = MagicMock(spec=MemoryItem)
-        refine_item.metadata = {'edrr_phase': 'Refine'}
-        self.agent_memory.retrieve_agent_solutions.return_value = [expand_item, differentiate_item, refine_item]
+        refine_item.metadata = {"edrr_phase": "Refine"}
+        self.agent_memory.retrieve_agent_solutions.return_value = [
+            expand_item,
+            differentiate_item,
+            refine_item,
+        ]
         results = self.wsde_memory.retrieve_solutions_by_edrr_phase(task_id, edrr_phase)
         self.agent_memory.retrieve_agent_solutions.assert_called_once_with(task_id)
         self.assertEqual(len(results), 1)
@@ -168,9 +196,9 @@ ReqID: N/A"""
     def test_query_knowledge_graph_succeeds(self):
         """Test querying the knowledge graph.
 
-ReqID: N/A"""
-        query = 'SPARQL query'
-        mock_results = [{'subject': 's1', 'predicate': 'p1', 'object': 'o1'}]
+        ReqID: N/A"""
+        query = "SPARQL query"
+        mock_results = [{"subject": "s1", "predicate": "p1", "object": "o1"}]
         self.memory_store.query_graph = MagicMock(return_value=mock_results)
         results = self.wsde_memory.query_knowledge_graph(query)
         self.memory_store.query_graph.assert_called_once_with(query, limit=10)
@@ -180,10 +208,10 @@ ReqID: N/A"""
     def test_query_knowledge_graph_not_supported_succeeds(self):
         """Test querying the knowledge graph when not supported.
 
-ReqID: N/A"""
-        query = 'SPARQL query'
-        if hasattr(self.memory_store, 'query_graph'):
-            delattr(self.memory_store, 'query_graph')
+        ReqID: N/A"""
+        query = "SPARQL query"
+        if hasattr(self.memory_store, "query_graph"):
+            delattr(self.memory_store, "query_graph")
         with self.assertRaises(ValueError):
             self.wsde_memory.query_knowledge_graph(query)
 
@@ -191,9 +219,12 @@ ReqID: N/A"""
     def test_query_related_concepts_succeeds(self):
         """Test querying for concepts related to a given concept.
 
-ReqID: N/A"""
-        concept = 'authentication'
-        mock_results = [{'related_concept': 'security', 'relationship': 'requires'}, {'related_concept': 'password', 'relationship': 'uses'}]
+        ReqID: N/A"""
+        concept = "authentication"
+        mock_results = [
+            {"related_concept": "security", "relationship": "requires"},
+            {"related_concept": "password", "relationship": "uses"},
+        ]
         self.memory_store.query_graph = MagicMock(return_value=mock_results)
         results = self.wsde_memory.query_related_concepts(concept)
         self.memory_store.query_graph.assert_called_once()
@@ -203,10 +234,10 @@ ReqID: N/A"""
     def test_query_concept_relationships_succeeds(self):
         """Test querying for relationships between concepts.
 
-ReqID: N/A"""
-        concept1 = 'authentication'
-        concept2 = 'security'
-        mock_results = [{'relationship': 'requires', 'direction': 'outgoing'}]
+        ReqID: N/A"""
+        concept1 = "authentication"
+        concept2 = "security"
+        mock_results = [{"relationship": "requires", "direction": "outgoing"}]
         self.memory_store.query_graph = MagicMock(return_value=mock_results)
         results = self.wsde_memory.query_concept_relationships(concept1, concept2)
         self.memory_store.query_graph.assert_called_once()
@@ -216,9 +247,15 @@ ReqID: N/A"""
     def test_query_by_concept_type_succeeds(self):
         """Test querying for concepts of a specific type.
 
-ReqID: N/A"""
-        concept_type = 'security_concept'
-        mock_results = [{'concept': 'authentication', 'properties': {'description': 'User verification'}}, {'concept': 'encryption', 'properties': {'description': 'Data protection'}}]
+        ReqID: N/A"""
+        concept_type = "security_concept"
+        mock_results = [
+            {
+                "concept": "authentication",
+                "properties": {"description": "User verification"},
+            },
+            {"concept": "encryption", "properties": {"description": "Data protection"}},
+        ]
         self.memory_store.query_graph = MagicMock(return_value=mock_results)
         results = self.wsde_memory.query_by_concept_type(concept_type)
         self.memory_store.query_graph.assert_called_once()
@@ -228,9 +265,17 @@ ReqID: N/A"""
     def test_query_knowledge_for_task_succeeds(self):
         """Test querying for knowledge relevant to a specific task.
 
-ReqID: N/A"""
-        task = {'type': 'security_implementation', 'description': 'Implement a secure authentication system', 'requirements': ['user authentication', 'password security']}
-        mock_results = [{'concept': 'authentication', 'relevance': 0.9}, {'concept': 'password', 'relevance': 0.8}, {'concept': 'encryption', 'relevance': 0.7}]
+        ReqID: N/A"""
+        task = {
+            "type": "security_implementation",
+            "description": "Implement a secure authentication system",
+            "requirements": ["user authentication", "password security"],
+        }
+        mock_results = [
+            {"concept": "authentication", "relevance": 0.9},
+            {"concept": "password", "relevance": 0.8},
+            {"concept": "encryption", "relevance": 0.7},
+        ]
         self.memory_store.query_graph = MagicMock(return_value=mock_results)
         results = self.wsde_memory.query_knowledge_for_task(task)
         self.memory_store.query_graph.assert_called_once()

--- a/tests/unit/application/edrr/test_auto_progress.py
+++ b/tests/unit/application/edrr/test_auto_progress.py
@@ -1,13 +1,18 @@
-import pytest
 from unittest.mock import MagicMock, patch
-from devsynth.application.edrr.coordinator import EDRRCoordinator
-from devsynth.application.memory.memory_manager import MemoryManager
+
+import pytest
+
 from devsynth.application.code_analysis.analyzer import CodeAnalyzer
 from devsynth.application.code_analysis.ast_transformer import AstTransformer
+from devsynth.application.documentation.documentation_manager import (
+    DocumentationManager,
+)
+from devsynth.application.edrr.coordinator import EDRRCoordinator
+from devsynth.application.memory.memory_manager import MemoryManager
 from devsynth.application.prompts.prompt_manager import PromptManager
-from devsynth.application.documentation.documentation_manager import DocumentationManager
-from devsynth.domain.models.wsde import WSDETeam
+from devsynth.domain.models.wsde_facade import WSDETeam
 from devsynth.methodology.base import Phase
+
 
 @pytest.fixture
 def coordinator():
@@ -18,27 +23,41 @@ def coordinator():
     ast = MagicMock(spec=AstTransformer)
     pm = MagicMock(spec=PromptManager)
     dm = MagicMock(spec=DocumentationManager)
-    coord = EDRRCoordinator(memory_manager=mm, wsde_team=wsde, code_analyzer=ca, ast_transformer=ast, prompt_manager=pm, documentation_manager=dm)
+    coord = EDRRCoordinator(
+        memory_manager=mm,
+        wsde_team=wsde,
+        code_analyzer=ca,
+        ast_transformer=ast,
+        prompt_manager=pm,
+        documentation_manager=dm,
+    )
     coord.auto_phase_transitions = True
     coord.current_phase = Phase.EXPAND
     return coord
+
 
 @pytest.mark.medium
 def test_maybe_auto_progress_loops_until_none_succeeds(coordinator):
     """Test that maybe auto progress loops until none succeeds.
 
-ReqID: N/A"""
-    with patch.object(coordinator, '_decide_next_phase', side_effect=[Phase.DIFFERENTIATE, None]) as decide, patch.object(coordinator, 'progress_to_phase') as prog:
+    ReqID: N/A"""
+    with (
+        patch.object(
+            coordinator, "_decide_next_phase", side_effect=[Phase.DIFFERENTIATE, None]
+        ) as decide,
+        patch.object(coordinator, "progress_to_phase") as prog,
+    ):
         coordinator._maybe_auto_progress()
     prog.assert_called_once_with(Phase.DIFFERENTIATE)
     assert decide.call_count == 2
+
 
 @pytest.mark.medium
 def test_maybe_auto_progress_disabled_succeeds(coordinator):
     """Test that maybe auto progress disabled succeeds.
 
-ReqID: N/A"""
+    ReqID: N/A"""
     coordinator.auto_phase_transitions = False
-    with patch.object(coordinator, '_decide_next_phase') as decide:
+    with patch.object(coordinator, "_decide_next_phase") as decide:
         coordinator._maybe_auto_progress()
     decide.assert_not_called()

--- a/tests/unit/application/edrr/test_coordinator.py
+++ b/tests/unit/application/edrr/test_coordinator.py
@@ -1,64 +1,93 @@
-import pytest
 from unittest.mock import MagicMock, patch
-from devsynth.application.edrr.coordinator import EDRRCoordinator, EDRRCoordinatorError
-from devsynth.application.memory.memory_manager import MemoryManager
-from devsynth.domain.models.wsde import WSDETeam
+
+import pytest
+
 from devsynth.application.code_analysis.analyzer import CodeAnalyzer
 from devsynth.application.code_analysis.ast_transformer import AstTransformer
+from devsynth.application.documentation.documentation_manager import (
+    DocumentationManager,
+)
+from devsynth.application.edrr.coordinator import EDRRCoordinator, EDRRCoordinatorError
+from devsynth.application.memory.memory_manager import MemoryManager
 from devsynth.application.prompts.prompt_manager import PromptManager
-from devsynth.application.documentation.documentation_manager import DocumentationManager
+from devsynth.domain.models.wsde_facade import WSDETeam
 from devsynth.methodology.base import Phase
+
 
 @pytest.fixture
 def coordinator():
     mm = MagicMock(spec=MemoryManager)
-    mm.store_with_edrr_phase.return_value = 'id'
+    mm.store_with_edrr_phase.return_value = "id"
     mm.retrieve_with_edrr_phase.return_value = {}
     mm.retrieve_historical_patterns.return_value = []
     mm.retrieve_relevant_knowledge.return_value = []
     team = MagicMock()
-    team.process.return_value = {'quality_score': 0.6}
+    team.process.return_value = {"quality_score": 0.6}
     team.apply_enhanced_dialectical_reasoning.side_effect = lambda task, res: res
-    coord = EDRRCoordinator(memory_manager=mm, wsde_team=team, code_analyzer=MagicMock(spec=CodeAnalyzer), ast_transformer=MagicMock(spec=AstTransformer), prompt_manager=MagicMock(spec=PromptManager), documentation_manager=MagicMock(spec=DocumentationManager), enable_enhanced_logging=True)
-    coord.config = {'edrr': {'micro_cycles': {'max_iterations': 2, 'quality_threshold': 0.8}}}
+    coord = EDRRCoordinator(
+        memory_manager=mm,
+        wsde_team=team,
+        code_analyzer=MagicMock(spec=CodeAnalyzer),
+        ast_transformer=MagicMock(spec=AstTransformer),
+        prompt_manager=MagicMock(spec=PromptManager),
+        documentation_manager=MagicMock(spec=DocumentationManager),
+        enable_enhanced_logging=True,
+    )
+    coord.config = {
+        "edrr": {"micro_cycles": {"max_iterations": 2, "quality_threshold": 0.8}}
+    }
     return coord
+
 
 @pytest.mark.medium
 def test_micro_cycle_iterations_until_threshold(coordinator):
     coordinator.current_phase = Phase.EXPAND
-    coordinator.task = {'description': 'task'}
-    coordinator.cycle_id = 'cid'
-    with patch.object(coordinator, '_execute_expand_phase', return_value={'quality_score': 0.5}):
-        coordinator.wsde_team.process.side_effect = [{'quality_score': 0.6}, {'quality_score': 0.9}]
+    coordinator.task = {"description": "task"}
+    coordinator.cycle_id = "cid"
+    with patch.object(
+        coordinator, "_execute_expand_phase", return_value={"quality_score": 0.5}
+    ):
+        coordinator.wsde_team.process.side_effect = [
+            {"quality_score": 0.6},
+            {"quality_score": 0.9},
+        ]
         results = coordinator.execute_current_phase()
     assert coordinator.wsde_team.process.call_count == 2
     phase_results = coordinator.results[Phase.EXPAND.name]
-    assert len(phase_results['micro_cycle_iterations']) == 2
-    assert phase_results['aggregated_results']['quality_score'] == 0.9
-    assert results['quality_score'] == 0.9
+    assert len(phase_results["micro_cycle_iterations"]) == 2
+    assert phase_results["aggregated_results"]["quality_score"] == 0.9
+    assert results["quality_score"] == 0.9
+
 
 @pytest.mark.medium
 def test_phase_execution_recovery_hook(coordinator):
     coordinator.current_phase = Phase.EXPAND
-    coordinator.task = {'description': 'task'}
-    coordinator.cycle_id = 'cid'
-    with patch.object(coordinator, '_execute_expand_phase', side_effect=RuntimeError('boom')):
-        with patch.object(coordinator, '_attempt_recovery', return_value={'recovered': True}) as rec:
+    coordinator.task = {"description": "task"}
+    coordinator.cycle_id = "cid"
+    with patch.object(
+        coordinator, "_execute_expand_phase", side_effect=RuntimeError("boom")
+    ):
+        with patch.object(
+            coordinator, "_attempt_recovery", return_value={"recovered": True}
+        ) as rec:
             results = coordinator.execute_current_phase()
     rec.assert_called_once()
-    assert results.get('recovery_info')
+    assert results.get("recovery_info")
+
 
 @pytest.mark.medium
 def test_micro_cycle_respects_max_iterations(coordinator):
-    coordinator.config['edrr']['micro_cycles']['max_iterations'] = 1
+    coordinator.config["edrr"]["micro_cycles"]["max_iterations"] = 1
     coordinator.current_phase = Phase.EXPAND
-    coordinator.task = {'description': 'task'}
-    coordinator.cycle_id = 'cid'
-    with patch.object(coordinator, '_execute_expand_phase', return_value={'quality_score': 0.1}):
-        coordinator.wsde_team.process.return_value = {'quality_score': 0.2}
+    coordinator.task = {"description": "task"}
+    coordinator.cycle_id = "cid"
+    with patch.object(
+        coordinator, "_execute_expand_phase", return_value={"quality_score": 0.1}
+    ):
+        coordinator.wsde_team.process.return_value = {"quality_score": 0.2}
         results = coordinator.execute_current_phase()
     assert coordinator.wsde_team.process.call_count == 1
     phase_results = coordinator.results[Phase.EXPAND.name]
-    assert len(phase_results['micro_cycle_iterations']) == 1
-    assert phase_results['aggregated_results']['quality_score'] == 0.2
-    assert results['quality_score'] == 0.2
+    assert len(phase_results["micro_cycle_iterations"]) == 1
+    assert phase_results["aggregated_results"]["quality_score"] == 0.2
+    assert results["quality_score"] == 0.2

--- a/tests/unit/application/edrr/test_coordinator_core.py
+++ b/tests/unit/application/edrr/test_coordinator_core.py
@@ -1,82 +1,157 @@
-import pytest
-from unittest.mock import MagicMock, patch
 from datetime import datetime
 from pathlib import Path
-from devsynth.application.edrr.coordinator_core import EDRRCoordinatorCore, EDRRCoordinatorError
-from devsynth.application.edrr.manifest_parser import ManifestParseError
-from devsynth.methodology.base import Phase
-from devsynth.application.memory.memory_manager import MemoryManager
-from devsynth.domain.models.wsde import WSDETeam
+from unittest.mock import MagicMock, patch
+
+import pytest
+
 from devsynth.application.code_analysis.analyzer import CodeAnalyzer
 from devsynth.application.code_analysis.ast_transformer import AstTransformer
+from devsynth.application.documentation.documentation_manager import (
+    DocumentationManager,
+)
+from devsynth.application.edrr.coordinator_core import (
+    EDRRCoordinatorCore,
+    EDRRCoordinatorError,
+)
+from devsynth.application.edrr.manifest_parser import ManifestParseError
+from devsynth.application.memory.memory_manager import MemoryManager
 from devsynth.application.prompts.prompt_manager import PromptManager
-from devsynth.application.documentation.documentation_manager import DocumentationManager
 from devsynth.domain.models.memory import MemoryType
+from devsynth.domain.models.wsde_facade import WSDETeam
+from devsynth.methodology.base import Phase
+
 
 @pytest.fixture
 def memory_manager():
     """Create a mock memory manager for testing."""
     mock_memory_manager = MagicMock(spec=MemoryManager)
-    mock_memory_manager.store = MagicMock(return_value='memory_id_123')
-    mock_memory_manager.retrieve.return_value = {'content': 'Test memory content', 'metadata': {'key': 'value'}}
+    mock_memory_manager.store = MagicMock(return_value="memory_id_123")
+    mock_memory_manager.retrieve.return_value = {
+        "content": "Test memory content",
+        "metadata": {"key": "value"},
+    }
     mock_memory_manager.search_memory = MagicMock()
-    mock_memory_manager.search_memory.return_value = [{'id': 'memory_id_123', 'content': 'Test memory content', 'metadata': {'key': 'value'}, 'score': 0.95}]
+    mock_memory_manager.search_memory.return_value = [
+        {
+            "id": "memory_id_123",
+            "content": "Test memory content",
+            "metadata": {"key": "value"},
+            "score": 0.95,
+        }
+    ]
     mock_memory_manager.stored_items = {}
-    mock_memory_manager.store_with_edrr_phase = MagicMock(return_value='memory_id_456')
+    mock_memory_manager.store_with_edrr_phase = MagicMock(return_value="memory_id_456")
     mock_memory_manager.retrieve_with_edrr_phase = MagicMock()
-    mock_memory_manager.retrieve_with_edrr_phase.side_effect = lambda item_type, phase, metadata: mock_memory_manager.stored_items.get(item_type, {}).get('item', {})
+    mock_memory_manager.retrieve_with_edrr_phase.side_effect = (
+        lambda item_type, phase, metadata: mock_memory_manager.stored_items.get(
+            item_type, {}
+        ).get("item", {})
+    )
     mock_memory_manager.retrieve_historical_patterns = MagicMock(return_value=[])
     mock_memory_manager.retrieve_relevant_knowledge = MagicMock(return_value=[])
     return mock_memory_manager
+
 
 @pytest.fixture
 def wsde_team():
     """Create a mock WSDE team for testing."""
     mock_wsde_team = MagicMock(spec=WSDETeam)
     mock_wsde_team.execute_task = MagicMock()
-    mock_wsde_team.execute_task.return_value = {'result': 'Task executed successfully', 'artifacts': ['artifact1', 'artifact2'], 'metrics': {'time_taken': 10.5}}
+    mock_wsde_team.execute_task.return_value = {
+        "result": "Task executed successfully",
+        "artifacts": ["artifact1", "artifact2"],
+        "metrics": {"time_taken": 10.5},
+    }
     mock_wsde_team.get_team_report = MagicMock()
-    mock_wsde_team.get_team_report.return_value = {'team_composition': ['Agent1', 'Agent2', 'Agent3'], 'task_distribution': {'Agent1': 2, 'Agent2': 3, 'Agent3': 1}, 'performance_metrics': {'efficiency': 0.85, 'quality': 0.9}}
+    mock_wsde_team.get_team_report.return_value = {
+        "team_composition": ["Agent1", "Agent2", "Agent3"],
+        "task_distribution": {"Agent1": 2, "Agent2": 3, "Agent3": 1},
+        "performance_metrics": {"efficiency": 0.85, "quality": 0.9},
+    }
     mock_wsde_team.generate_diverse_ideas = MagicMock()
-    mock_wsde_team.generate_diverse_ideas.return_value = [{'id': 1, 'idea': 'Test Idea 1'}, {'id': 2, 'idea': 'Test Idea 2'}]
+    mock_wsde_team.generate_diverse_ideas.return_value = [
+        {"id": 1, "idea": "Test Idea 1"},
+        {"id": 2, "idea": "Test Idea 2"},
+    ]
     mock_wsde_team.create_comparison_matrix = MagicMock()
-    mock_wsde_team.create_comparison_matrix.return_value = {'idea_1': {'feasibility': 0.8}, 'idea_2': {'feasibility': 0.6}}
+    mock_wsde_team.create_comparison_matrix.return_value = {
+        "idea_1": {"feasibility": 0.8},
+        "idea_2": {"feasibility": 0.6},
+    }
     mock_wsde_team.evaluate_options = MagicMock()
-    mock_wsde_team.evaluate_options.return_value = [{'id': 1, 'score': 0.8}, {'id': 2, 'score': 0.6}]
+    mock_wsde_team.evaluate_options.return_value = [
+        {"id": 1, "score": 0.8},
+        {"id": 2, "score": 0.6},
+    ]
     mock_wsde_team.analyze_trade_offs = MagicMock()
-    mock_wsde_team.analyze_trade_offs.return_value = [{'id': 1, 'trade_offs': ['Trade-off 1', 'Trade-off 2']}]
+    mock_wsde_team.analyze_trade_offs.return_value = [
+        {"id": 1, "trade_offs": ["Trade-off 1", "Trade-off 2"]}
+    ]
     mock_wsde_team.formulate_decision_criteria = MagicMock()
-    mock_wsde_team.formulate_decision_criteria.return_value = {'criteria_1': 0.5, 'criteria_2': 0.5}
+    mock_wsde_team.formulate_decision_criteria.return_value = {
+        "criteria_1": 0.5,
+        "criteria_2": 0.5,
+    }
     mock_wsde_team.select_best_option = MagicMock()
-    mock_wsde_team.select_best_option.return_value = {'id': 1, 'idea': 'Test Idea 1'}
+    mock_wsde_team.select_best_option.return_value = {"id": 1, "idea": "Test Idea 1"}
     mock_wsde_team.elaborate_details = MagicMock()
-    mock_wsde_team.elaborate_details.return_value = [{'step': 1, 'description': 'Step 1'}, {'step': 2, 'description': 'Step 2'}]
+    mock_wsde_team.elaborate_details.return_value = [
+        {"step": 1, "description": "Step 1"},
+        {"step": 2, "description": "Step 2"},
+    ]
     mock_wsde_team.create_implementation_plan = MagicMock()
-    mock_wsde_team.create_implementation_plan.return_value = [{'task': 1, 'description': 'Task 1'}, {'task': 2, 'description': 'Task 2'}]
+    mock_wsde_team.create_implementation_plan.return_value = [
+        {"task": 1, "description": "Task 1"},
+        {"task": 2, "description": "Task 2"},
+    ]
     mock_wsde_team.optimize_implementation = MagicMock()
-    mock_wsde_team.optimize_implementation.return_value = {'optimized': True, 'plan': [{'task': 1}, {'task': 2}]}
+    mock_wsde_team.optimize_implementation.return_value = {
+        "optimized": True,
+        "plan": [{"task": 1}, {"task": 2}],
+    }
     mock_wsde_team.perform_quality_assurance = MagicMock()
-    mock_wsde_team.perform_quality_assurance.return_value = {'issues': [], 'recommendations': ['Recommendation 1']}
+    mock_wsde_team.perform_quality_assurance.return_value = {
+        "issues": [],
+        "recommendations": ["Recommendation 1"],
+    }
     mock_wsde_team.get_primus = MagicMock()
-    mock_wsde_team.get_primus.return_value = 'Agent1'
+    mock_wsde_team.get_primus.return_value = "Agent1"
     mock_wsde_team.conduct_peer_review = MagicMock()
-    mock_wsde_team.conduct_peer_review.return_value = {'reviewer': 'Agent2', 'comments': 'Looks good'}
+    mock_wsde_team.conduct_peer_review.return_value = {
+        "reviewer": "Agent2",
+        "comments": "Looks good",
+    }
     mock_wsde_team.extract_learnings = MagicMock()
-    mock_wsde_team.extract_learnings.return_value = [{'category': 'Process', 'learning': 'Learning 1'}]
+    mock_wsde_team.extract_learnings.return_value = [
+        {"category": "Process", "learning": "Learning 1"}
+    ]
     mock_wsde_team.recognize_patterns = MagicMock()
-    mock_wsde_team.recognize_patterns.return_value = [{'pattern': 'Pattern 1', 'frequency': 0.8}]
+    mock_wsde_team.recognize_patterns.return_value = [
+        {"pattern": "Pattern 1", "frequency": 0.8}
+    ]
     mock_wsde_team.integrate_knowledge = MagicMock()
-    mock_wsde_team.integrate_knowledge.return_value = {'integrated': True, 'knowledge_items': 2}
+    mock_wsde_team.integrate_knowledge.return_value = {
+        "integrated": True,
+        "knowledge_items": 2,
+    }
     mock_wsde_team.generate_improvement_suggestions = MagicMock()
-    mock_wsde_team.generate_improvement_suggestions.return_value = [{'phase': 'EXPAND', 'suggestion': 'Suggestion 1'}]
+    mock_wsde_team.generate_improvement_suggestions.return_value = [
+        {"phase": "EXPAND", "suggestion": "Suggestion 1"}
+    ]
     return mock_wsde_team
+
 
 @pytest.fixture
 def code_analyzer():
     """Create a mock code analyzer for testing."""
     mock_code_analyzer = MagicMock(spec=CodeAnalyzer)
-    mock_code_analyzer.analyze_code.return_value = {'complexity': 5, 'maintainability': 8, 'issues': ['Issue1', 'Issue2']}
+    mock_code_analyzer.analyze_code.return_value = {
+        "complexity": 5,
+        "maintainability": 8,
+        "issues": ["Issue1", "Issue2"],
+    }
     return mock_code_analyzer
+
 
 @pytest.fixture
 def ast_transformer():
@@ -84,11 +159,13 @@ def ast_transformer():
     mock_ast_transformer = MagicMock(spec=AstTransformer)
     return mock_ast_transformer
 
+
 @pytest.fixture
 def prompt_manager():
     """Create a mock prompt manager for testing."""
     mock_prompt_manager = MagicMock(spec=PromptManager)
     return mock_prompt_manager
+
 
 @pytest.fixture
 def documentation_manager():
@@ -96,22 +173,39 @@ def documentation_manager():
     mock_documentation_manager = MagicMock(spec=DocumentationManager)
     return mock_documentation_manager
 
+
 @pytest.fixture
-def coordinator_core(memory_manager, wsde_team, code_analyzer, ast_transformer, prompt_manager, documentation_manager):
+def coordinator_core(
+    memory_manager,
+    wsde_team,
+    code_analyzer,
+    ast_transformer,
+    prompt_manager,
+    documentation_manager,
+):
     """Create an EDRRCoordinatorCore instance for testing."""
-    coordinator = EDRRCoordinatorCore(memory_manager=memory_manager, wsde_team=wsde_team, code_analyzer=code_analyzer, ast_transformer=ast_transformer, prompt_manager=prompt_manager, documentation_manager=documentation_manager, enable_enhanced_logging=True)
+    coordinator = EDRRCoordinatorCore(
+        memory_manager=memory_manager,
+        wsde_team=wsde_team,
+        code_analyzer=code_analyzer,
+        ast_transformer=ast_transformer,
+        prompt_manager=prompt_manager,
+        documentation_manager=documentation_manager,
+        enable_enhanced_logging=True,
+    )
     return coordinator
+
 
 class TestEDRRCoordinatorCore:
     """Tests for the EDRRCoordinatorCore class.
 
-ReqID: N/A"""
+    ReqID: N/A"""
 
     @pytest.mark.medium
     def test_initialization_succeeds(self, coordinator_core):
         """Test that the coordinator initializes correctly.
 
-ReqID: N/A"""
+        ReqID: N/A"""
         assert coordinator_core is not None
         assert coordinator_core.memory_manager is not None
         assert coordinator_core.wsde_team is not None
@@ -128,33 +222,48 @@ ReqID: N/A"""
     def test_start_cycle_succeeds(self, coordinator_core, memory_manager):
         """Test starting a new EDRR cycle.
 
-ReqID: N/A"""
-        task = {'name': 'Test Task', 'description': 'This is a test task', 'requirements': ['req1', 'req2']}
-        memory_manager.store.return_value = 'task_memory_id'
-        with patch.object(coordinator_core, '_aggregate_results') as mock_aggregate:
-            mock_aggregate.return_value = {'status': 'completed', 'phases': {}}
-            with patch.object(coordinator_core, 'generate_final_report') as mock_final_report:
-                mock_final_report.return_value = {'report': 'final report', 'cycle_data': {'status': 'completed', 'phases': {}}}
+        ReqID: N/A"""
+        task = {
+            "name": "Test Task",
+            "description": "This is a test task",
+            "requirements": ["req1", "req2"],
+        }
+        memory_manager.store.return_value = "task_memory_id"
+        with patch.object(coordinator_core, "_aggregate_results") as mock_aggregate:
+            mock_aggregate.return_value = {"status": "completed", "phases": {}}
+            with patch.object(
+                coordinator_core, "generate_final_report"
+            ) as mock_final_report:
+                mock_final_report.return_value = {
+                    "report": "final report",
+                    "cycle_data": {"status": "completed", "phases": {}},
+                }
                 coordinator_core.start_cycle(task)
                 assert memory_manager.store.call_count >= 1
                 assert coordinator_core.current_phase == Phase.EXPAND
                 assert coordinator_core.task is not None
-                assert coordinator_core.task['name'] == 'Test Task'
-                assert coordinator_core.task['description'] == 'This is a test task'
-                assert coordinator_core.task['requirements'] == ['req1', 'req2']
+                assert coordinator_core.task["name"] == "Test Task"
+                assert coordinator_core.task["description"] == "This is a test task"
+                assert coordinator_core.task["requirements"] == ["req1", "req2"]
         assert coordinator_core.current_phase == Phase.EXPAND
 
     @pytest.mark.medium
     def test_start_cycle_from_manifest_succeeds(self, coordinator_core, tmp_path):
         """Test starting a cycle from a manifest file.
 
-ReqID: N/A"""
-        manifest_path = tmp_path / 'test_manifest.yaml'
-        manifest_content = '\n        name: Test Task\n        description: This is a test task\n        requirements:\n          - req1\n          - req2\n        '
+        ReqID: N/A"""
+        manifest_path = tmp_path / "test_manifest.yaml"
+        manifest_content = "\n        name: Test Task\n        description: This is a test task\n        requirements:\n          - req1\n          - req2\n        "
         manifest_path.write_text(manifest_content)
-        with patch('devsynth.application.edrr.coordinator_core.ManifestParser') as MockManifestParser:
+        with patch(
+            "devsynth.application.edrr.coordinator_core.ManifestParser"
+        ) as MockManifestParser:
             mock_parser = MagicMock()
-            mock_parser.parse_file.return_value = {'name': 'Test Task', 'description': 'This is a test task', 'requirements': ['req1', 'req2']}
+            mock_parser.parse_file.return_value = {
+                "name": "Test Task",
+                "description": "This is a test task",
+                "requirements": ["req1", "req2"],
+            }
             MockManifestParser.return_value = mock_parser
             coordinator_core.start_cycle_from_manifest(manifest_path)
             MockManifestParser.assert_called_once()
@@ -165,11 +274,17 @@ ReqID: N/A"""
     def test_start_cycle_from_manifest_string_succeeds(self, coordinator_core):
         """Test starting a cycle from a manifest string.
 
-ReqID: N/A"""
-        manifest_string = '\n        name: Test Task\n        description: This is a test task\n        requirements:\n          - req1\n          - req2\n        '
-        with patch('devsynth.application.edrr.coordinator_core.ManifestParser') as MockManifestParser:
+        ReqID: N/A"""
+        manifest_string = "\n        name: Test Task\n        description: This is a test task\n        requirements:\n          - req1\n          - req2\n        "
+        with patch(
+            "devsynth.application.edrr.coordinator_core.ManifestParser"
+        ) as MockManifestParser:
             mock_parser = MagicMock()
-            mock_parser.parse_string.return_value = {'name': 'Test Task', 'description': 'This is a test task', 'requirements': ['req1', 'req2']}
+            mock_parser.parse_string.return_value = {
+                "name": "Test Task",
+                "description": "This is a test task",
+                "requirements": ["req1", "req2"],
+            }
             MockManifestParser.return_value = mock_parser
             coordinator_core.start_cycle_from_manifest(manifest_string, is_file=False)
             MockManifestParser.assert_called_once()
@@ -180,19 +295,35 @@ ReqID: N/A"""
     def test_progress_to_phase_has_expected(self, coordinator_core, memory_manager):
         """Test progressing to a specific phase.
 
-ReqID: N/A"""
-        task = {'name': 'Test Task', 'description': 'This is a test task', 'requirements': ['req1', 'req2']}
+        ReqID: N/A"""
+        task = {
+            "name": "Test Task",
+            "description": "This is a test task",
+            "requirements": ["req1", "req2"],
+        }
         coordinator_core.start_cycle(task)
         results = coordinator_core.progress_to_phase(Phase.DIFFERENTIATE)
         assert coordinator_core.current_phase == Phase.DIFFERENTIATE
-        memory_manager.store_with_edrr_phase.assert_called_with(results, phase=Phase.DIFFERENTIATE, tags=[f'phase:{Phase.DIFFERENTIATE.name}', f'cycle:{coordinator_core.cycle_id}'], memory_type=MemoryType.WORKING_MEMORY)
+        memory_manager.store_with_edrr_phase.assert_called_with(
+            results,
+            phase=Phase.DIFFERENTIATE,
+            tags=[
+                f"phase:{Phase.DIFFERENTIATE.name}",
+                f"cycle:{coordinator_core.cycle_id}",
+            ],
+            memory_type=MemoryType.WORKING_MEMORY,
+        )
 
     @pytest.mark.medium
     def test_progress_to_next_phase_has_expected(self, coordinator_core):
         """Test progressing to the next phase.
 
-ReqID: N/A"""
-        task = {'name': 'Test Task', 'description': 'This is a test task', 'requirements': ['req1', 'req2']}
+        ReqID: N/A"""
+        task = {
+            "name": "Test Task",
+            "description": "This is a test task",
+            "requirements": ["req1", "req2"],
+        }
         coordinator_core.start_cycle(task)
         assert coordinator_core.current_phase == Phase.EXPAND
         coordinator_core.progress_to_next_phase()
@@ -206,51 +337,91 @@ ReqID: N/A"""
     def test_execute_current_phase_has_expected(self, coordinator_core):
         """Test executing the current phase.
 
-ReqID: N/A"""
-        task = {'name': 'Test Task', 'description': 'This is a test task', 'requirements': ['req1', 'req2']}
+        ReqID: N/A"""
+        task = {
+            "name": "Test Task",
+            "description": "This is a test task",
+            "requirements": ["req1", "req2"],
+        }
         coordinator_core.start_cycle(task)
-        with patch.object(coordinator_core, '_execute_expand_phase') as mock_execute_expand:
-            mock_execute_expand.return_value = {'phase': 'expand', 'status': 'completed', 'custom_field': 'test value'}
+        with patch.object(
+            coordinator_core, "_execute_expand_phase"
+        ) as mock_execute_expand:
+            mock_execute_expand.return_value = {
+                "phase": "expand",
+                "status": "completed",
+                "custom_field": "test value",
+            }
             result = coordinator_core.execute_current_phase()
             mock_execute_expand.assert_called_once()
-            assert result == {'phase': 'expand', 'status': 'completed', 'custom_field': 'test value'}
+            assert result == {
+                "phase": "expand",
+                "status": "completed",
+                "custom_field": "test value",
+            }
 
     @pytest.mark.medium
     def test_generate_report_succeeds(self, coordinator_core):
         """Test generating a report.
 
-ReqID: N/A"""
-        task = {'name': 'Test Task', 'description': 'This is a test task', 'requirements': ['req1', 'req2']}
+        ReqID: N/A"""
+        task = {
+            "name": "Test Task",
+            "description": "This is a test task",
+            "requirements": ["req1", "req2"],
+        }
         coordinator_core.start_cycle(task)
-        with patch.object(coordinator_core, '_aggregate_results') as mock_aggregate:
-            mock_aggregate.return_value = {'status': 'completed', 'phases': {}}
-            with patch.object(coordinator_core, 'generate_final_report') as mock_final_report:
-                mock_final_report.return_value = {'report': 'final report', 'cycle_data': {'status': 'completed', 'phases': {}}}
+        with patch.object(coordinator_core, "_aggregate_results") as mock_aggregate:
+            mock_aggregate.return_value = {"status": "completed", "phases": {}}
+            with patch.object(
+                coordinator_core, "generate_final_report"
+            ) as mock_final_report:
+                mock_final_report.return_value = {
+                    "report": "final report",
+                    "cycle_data": {"status": "completed", "phases": {}},
+                }
                 report = coordinator_core.generate_report()
                 mock_aggregate.assert_called_once()
                 mock_final_report.assert_called_once_with(mock_aggregate.return_value)
-                assert report == {'report': 'final report', 'cycle_data': {'status': 'completed', 'phases': {}}}
+                assert report == {
+                    "report": "final report",
+                    "cycle_data": {"status": "completed", "phases": {}},
+                }
 
     @pytest.mark.medium
     def test_get_execution_traces_succeeds(self, coordinator_core):
         """Test getting execution traces.
 
-ReqID: N/A"""
-        task = {'name': 'Test Task', 'description': 'This is a test task', 'requirements': ['req1', 'req2']}
+        ReqID: N/A"""
+        task = {
+            "name": "Test Task",
+            "description": "This is a test task",
+            "requirements": ["req1", "req2"],
+        }
         coordinator_core.start_cycle(task)
-        coordinator_core.execution_traces = [{'phase': 'EXPAND', 'action': 'test_action', 'timestamp': '2025-07-07T12:00:00'}]
+        coordinator_core.execution_traces = [
+            {
+                "phase": "EXPAND",
+                "action": "test_action",
+                "timestamp": "2025-07-07T12:00:00",
+            }
+        ]
         traces = coordinator_core.get_execution_traces()
         assert isinstance(traces, list)
         assert len(traces) == 1
-        assert traces[0]['phase'] == 'EXPAND'
-        assert traces[0]['action'] == 'test_action'
+        assert traces[0]["phase"] == "EXPAND"
+        assert traces[0]["action"] == "test_action"
 
     @pytest.mark.medium
     def test_get_execution_history_succeeds(self, coordinator_core):
         """Test getting execution history.
 
-ReqID: N/A"""
-        task = {'name': 'Test Task', 'description': 'This is a test task', 'requirements': ['req1', 'req2']}
+        ReqID: N/A"""
+        task = {
+            "name": "Test Task",
+            "description": "This is a test task",
+            "requirements": ["req1", "req2"],
+        }
         coordinator_core.start_cycle(task)
         history = coordinator_core.get_execution_history()
         assert isinstance(history, list)
@@ -260,19 +431,27 @@ ReqID: N/A"""
     def test_get_performance_metrics_succeeds(self, coordinator_core):
         """Test getting performance metrics.
 
-ReqID: N/A"""
-        task = {'name': 'Test Task', 'description': 'This is a test task', 'requirements': ['req1', 'req2']}
+        ReqID: N/A"""
+        task = {
+            "name": "Test Task",
+            "description": "This is a test task",
+            "requirements": ["req1", "req2"],
+        }
         coordinator_core.start_cycle(task)
         metrics = coordinator_core.get_performance_metrics()
         assert isinstance(metrics, dict)
-        assert 'phase_durations' in metrics
+        assert "phase_durations" in metrics
 
     @pytest.mark.medium
     def test_decide_next_phase_has_expected(self, coordinator_core):
         """Test the internal _decide_next_phase method.
 
-ReqID: N/A"""
-        task = {'name': 'Test Task', 'description': 'This is a test task', 'requirements': ['req1', 'req2']}
+        ReqID: N/A"""
+        task = {
+            "name": "Test Task",
+            "description": "This is a test task",
+            "requirements": ["req1", "req2"],
+        }
         coordinator_core.start_cycle(task)
         assert coordinator_core.current_phase == Phase.EXPAND
         next_phase = coordinator_core._decide_next_phase()
@@ -291,19 +470,25 @@ ReqID: N/A"""
     def test_maybe_auto_progress_succeeds(self, coordinator_core):
         """Test the internal _maybe_auto_progress method.
 
-ReqID: N/A"""
-        with patch.object(coordinator_core, 'start_cycle'):
+        ReqID: N/A"""
+        with patch.object(coordinator_core, "start_cycle"):
             coordinator_core.current_phase = Phase.EXPAND
-            coordinator_core.task = {'name': 'Test Task', 'description': 'This is a test task', 'requirements': ['req1', 'req2']}
-            coordinator_core.config = {'auto_progress': True}
-            with patch.object(coordinator_core, 'progress_to_phase') as mock_progress:
-                with patch.object(coordinator_core, '_decide_next_phase') as mock_decide:
+            coordinator_core.task = {
+                "name": "Test Task",
+                "description": "This is a test task",
+                "requirements": ["req1", "req2"],
+            }
+            coordinator_core.config = {"auto_progress": True}
+            with patch.object(coordinator_core, "progress_to_phase") as mock_progress:
+                with patch.object(
+                    coordinator_core, "_decide_next_phase"
+                ) as mock_decide:
                     mock_decide.return_value = Phase.DIFFERENTIATE
                     coordinator_core._maybe_auto_progress()
                     assert mock_decide.called
                     mock_progress.assert_called_with(Phase.DIFFERENTIATE)
-            coordinator_core.config = {'auto_progress': False}
-            with patch.object(coordinator_core, 'progress_to_phase') as mock_progress:
+            coordinator_core.config = {"auto_progress": False}
+            with patch.object(coordinator_core, "progress_to_phase") as mock_progress:
                 coordinator_core._maybe_auto_progress()
                 mock_progress.assert_not_called()
 
@@ -311,29 +496,33 @@ ReqID: N/A"""
     def test_start_cycle_with_invalid_task_is_valid(self, coordinator_core):
         """Test starting a cycle with an invalid task.
 
-ReqID: N/A"""
+        ReqID: N/A"""
         with pytest.raises(EDRRCoordinatorError):
             coordinator_core.start_cycle(None)
         with pytest.raises(EDRRCoordinatorError):
             coordinator_core.start_cycle({})
 
     @pytest.mark.medium
-    def test_start_cycle_from_manifest_with_invalid_file_is_valid(self, coordinator_core):
+    def test_start_cycle_from_manifest_with_invalid_file_is_valid(
+        self, coordinator_core
+    ):
         """Test starting a cycle from an invalid manifest file.
 
-ReqID: N/A"""
-        with patch('devsynth.application.edrr.coordinator_core.ManifestParser') as MockManifestParser:
+        ReqID: N/A"""
+        with patch(
+            "devsynth.application.edrr.coordinator_core.ManifestParser"
+        ) as MockManifestParser:
             mock_parser = MagicMock()
-            mock_parser.parse_file.side_effect = ValueError('Invalid manifest')
+            mock_parser.parse_file.side_effect = ValueError("Invalid manifest")
             MockManifestParser.return_value = mock_parser
             with pytest.raises(ManifestParseError):
-                coordinator_core.start_cycle_from_manifest('invalid_manifest.yaml')
+                coordinator_core.start_cycle_from_manifest("invalid_manifest.yaml")
 
     @pytest.mark.medium
     def test_progress_to_phase_without_cycle_has_expected(self, coordinator_core):
         """Test progressing to a phase without starting a cycle first.
 
-ReqID: N/A"""
+        ReqID: N/A"""
         with pytest.raises(EDRRCoordinatorError):
             coordinator_core.progress_to_phase(Phase.DIFFERENTIATE)
 
@@ -341,7 +530,7 @@ ReqID: N/A"""
     def test_progress_to_next_phase_without_cycle_has_expected(self, coordinator_core):
         """Test progressing to the next phase without starting a cycle first.
 
-ReqID: N/A"""
+        ReqID: N/A"""
         with pytest.raises(EDRRCoordinatorError):
             coordinator_core.progress_to_next_phase()
 
@@ -349,7 +538,7 @@ ReqID: N/A"""
     def test_execute_current_phase_without_cycle_has_expected(self, coordinator_core):
         """Test executing the current phase without starting a cycle first.
 
-ReqID: N/A"""
+        ReqID: N/A"""
         with pytest.raises(EDRRCoordinatorError):
             coordinator_core.execute_current_phase()
 
@@ -357,6 +546,6 @@ ReqID: N/A"""
     def test_generate_report_without_cycle_succeeds(self, coordinator_core):
         """Test generating a report without starting a cycle first.
 
-ReqID: N/A"""
+        ReqID: N/A"""
         with pytest.raises(EDRRCoordinatorError):
             coordinator_core.generate_report()

--- a/tests/unit/application/edrr/test_edrr_coordinator.py
+++ b/tests/unit/application/edrr/test_edrr_coordinator.py
@@ -1,85 +1,155 @@
 """Tests for the EDRRCoordinator class."""
-import pytest
-from unittest.mock import MagicMock, patch
+
 from datetime import datetime
-from devsynth.application.edrr.coordinator import EDRRCoordinator, EDRRCoordinatorError
-from devsynth.methodology.base import Phase
-from devsynth.application.memory.memory_manager import MemoryManager
-from devsynth.domain.models.wsde import WSDETeam
-from devsynth.domain.models.memory import MemoryType
+from unittest.mock import MagicMock, patch
+
+import pytest
+
 from devsynth.application.code_analysis.analyzer import CodeAnalyzer
 from devsynth.application.code_analysis.ast_transformer import AstTransformer
+from devsynth.application.documentation.documentation_manager import (
+    DocumentationManager,
+)
+from devsynth.application.edrr.coordinator import EDRRCoordinator, EDRRCoordinatorError
+from devsynth.application.memory.memory_manager import MemoryManager
 from devsynth.application.prompts.prompt_manager import PromptManager
-from devsynth.application.documentation.documentation_manager import DocumentationManager
+from devsynth.domain.models.memory import MemoryType
+from devsynth.domain.models.wsde_facade import WSDETeam
+from devsynth.methodology.base import Phase
+
 
 @pytest.fixture
 def memory_manager():
     """Create a mock memory manager."""
     mock = MagicMock(spec=MemoryManager)
     mock.stored_items = {}
-    mock.store_with_edrr_phase.side_effect = lambda item, item_type, phase, metadata: mock.stored_items.update({item_type: {'item': item, 'phase': phase, 'metadata': metadata}})
-    mock.retrieve_with_edrr_phase.side_effect = lambda item_type, phase, metadata: mock.stored_items.get(item_type, {}).get('item', {})
+    mock.store_with_edrr_phase.side_effect = (
+        lambda item, item_type, phase, metadata: mock.stored_items.update(
+            {item_type: {"item": item, "phase": phase, "metadata": metadata}}
+        )
+    )
+    mock.retrieve_with_edrr_phase.side_effect = (
+        lambda item_type, phase, metadata: mock.stored_items.get(item_type, {}).get(
+            "item", {}
+        )
+    )
     mock.retrieve_historical_patterns.return_value = []
     mock.retrieve_relevant_knowledge.return_value = []
     return mock
+
 
 @pytest.fixture
 def wsde_team():
     """Create a mock WSDE team."""
     mock = MagicMock(spec=WSDETeam)
-    mock.generate_diverse_ideas.return_value = [{'id': 1, 'idea': 'Test Idea 1'}, {'id': 2, 'idea': 'Test Idea 2'}]
-    mock.create_comparison_matrix.return_value = {'idea_1': {'feasibility': 0.8}, 'idea_2': {'feasibility': 0.6}}
-    mock.evaluate_options.return_value = [{'id': 1, 'score': 0.8}, {'id': 2, 'score': 0.6}]
-    mock.analyze_trade_offs.return_value = [{'id': 1, 'trade_offs': ['Trade-off 1', 'Trade-off 2']}]
-    mock.formulate_decision_criteria.return_value = {'criteria_1': 0.5, 'criteria_2': 0.5}
-    mock.select_best_option.return_value = {'id': 1, 'idea': 'Test Idea 1'}
-    mock.elaborate_details.return_value = [{'step': 1, 'description': 'Step 1'}, {'step': 2, 'description': 'Step 2'}]
-    mock.create_implementation_plan.return_value = [{'task': 1, 'description': 'Task 1'}, {'task': 2, 'description': 'Task 2'}]
-    mock.optimize_implementation.return_value = {'optimized': True, 'plan': [{'task': 1}, {'task': 2}]}
-    mock.perform_quality_assurance.return_value = {'issues': [], 'recommendations': ['Recommendation 1']}
-    mock.extract_learnings.return_value = [{'category': 'Process', 'learning': 'Learning 1'}]
-    mock.recognize_patterns.return_value = [{'pattern': 'Pattern 1', 'frequency': 0.8}]
-    mock.integrate_knowledge.return_value = {'integrated': True, 'knowledge_items': 2}
-    mock.generate_improvement_suggestions.return_value = [{'phase': 'EXPAND', 'suggestion': 'Suggestion 1'}]
+    mock.generate_diverse_ideas.return_value = [
+        {"id": 1, "idea": "Test Idea 1"},
+        {"id": 2, "idea": "Test Idea 2"},
+    ]
+    mock.create_comparison_matrix.return_value = {
+        "idea_1": {"feasibility": 0.8},
+        "idea_2": {"feasibility": 0.6},
+    }
+    mock.evaluate_options.return_value = [
+        {"id": 1, "score": 0.8},
+        {"id": 2, "score": 0.6},
+    ]
+    mock.analyze_trade_offs.return_value = [
+        {"id": 1, "trade_offs": ["Trade-off 1", "Trade-off 2"]}
+    ]
+    mock.formulate_decision_criteria.return_value = {
+        "criteria_1": 0.5,
+        "criteria_2": 0.5,
+    }
+    mock.select_best_option.return_value = {"id": 1, "idea": "Test Idea 1"}
+    mock.elaborate_details.return_value = [
+        {"step": 1, "description": "Step 1"},
+        {"step": 2, "description": "Step 2"},
+    ]
+    mock.create_implementation_plan.return_value = [
+        {"task": 1, "description": "Task 1"},
+        {"task": 2, "description": "Task 2"},
+    ]
+    mock.optimize_implementation.return_value = {
+        "optimized": True,
+        "plan": [{"task": 1}, {"task": 2}],
+    }
+    mock.perform_quality_assurance.return_value = {
+        "issues": [],
+        "recommendations": ["Recommendation 1"],
+    }
+    mock.extract_learnings.return_value = [
+        {"category": "Process", "learning": "Learning 1"}
+    ]
+    mock.recognize_patterns.return_value = [{"pattern": "Pattern 1", "frequency": 0.8}]
+    mock.integrate_knowledge.return_value = {"integrated": True, "knowledge_items": 2}
+    mock.generate_improvement_suggestions.return_value = [
+        {"phase": "EXPAND", "suggestion": "Suggestion 1"}
+    ]
     return mock
+
 
 @pytest.fixture
 def code_analyzer():
     """Create a mock code analyzer."""
     mock = MagicMock(spec=CodeAnalyzer)
-    mock.analyze_project_structure.return_value = {'files': 10, 'classes': 5, 'functions': 20}
+    mock.analyze_project_structure.return_value = {
+        "files": 10,
+        "classes": 5,
+        "functions": 20,
+    }
     return mock
+
 
 @pytest.fixture
 def ast_transformer():
     """Create a mock AST transformer."""
     return MagicMock(spec=AstTransformer)
 
+
 @pytest.fixture
 def prompt_manager():
     """Create a mock prompt manager."""
     return MagicMock(spec=PromptManager)
+
 
 @pytest.fixture
 def documentation_manager():
     """Create a mock documentation manager."""
     return MagicMock(spec=DocumentationManager)
 
+
 @pytest.fixture
-def coordinator(memory_manager, wsde_team, code_analyzer, ast_transformer, prompt_manager, documentation_manager):
+def coordinator(
+    memory_manager,
+    wsde_team,
+    code_analyzer,
+    ast_transformer,
+    prompt_manager,
+    documentation_manager,
+):
     """Create an EDRRCoordinator instance."""
-    return EDRRCoordinator(memory_manager=memory_manager, wsde_team=wsde_team, code_analyzer=code_analyzer, ast_transformer=ast_transformer, prompt_manager=prompt_manager, documentation_manager=documentation_manager, enable_enhanced_logging=True)
+    return EDRRCoordinator(
+        memory_manager=memory_manager,
+        wsde_team=wsde_team,
+        code_analyzer=code_analyzer,
+        ast_transformer=ast_transformer,
+        prompt_manager=prompt_manager,
+        documentation_manager=documentation_manager,
+        enable_enhanced_logging=True,
+    )
+
 
 class TestEDRRCoordinator:
     """Tests for the EDRRCoordinator class.
 
-ReqID: N/A"""
+    ReqID: N/A"""
 
     @pytest.mark.medium
     def test_initialization_succeeds(self, coordinator):
         """Test that the coordinator is initialized correctly.
 
-ReqID: N/A"""
+        ReqID: N/A"""
         assert coordinator.memory_manager is not None
         assert coordinator.wsde_team is not None
         assert coordinator.code_analyzer is not None
@@ -93,8 +163,8 @@ ReqID: N/A"""
     def test_start_cycle_succeeds(self, coordinator, memory_manager):
         """Test starting a new EDRR cycle.
 
-ReqID: N/A"""
-        task = {'description': 'Test Task', 'requirements': ['Req 1', 'Req 2']}
+        ReqID: N/A"""
+        task = {"description": "Test Task", "requirements": ["Req 1", "Req 2"]}
         coordinator.start_cycle(task)
         assert coordinator.task == task
         assert coordinator.cycle_id is not None
@@ -102,142 +172,208 @@ ReqID: N/A"""
         assert memory_manager.store_with_edrr_phase.call_count >= 1
 
     @pytest.mark.medium
-    def test_expand_phase_execution_has_expected(self, coordinator, memory_manager, wsde_team, code_analyzer):
+    def test_expand_phase_execution_has_expected(
+        self, coordinator, memory_manager, wsde_team, code_analyzer
+    ):
         """Test executing the Expand phase.
 
-ReqID: N/A"""
-        coordinator.task = {'description': 'Test Task'}
-        coordinator.cycle_id = 'test-cycle-id'
+        ReqID: N/A"""
+        coordinator.task = {"description": "Test Task"}
+        coordinator.cycle_id = "test-cycle-id"
         coordinator.current_phase = Phase.EXPAND
         results = coordinator._execute_expand_phase({})
-        assert 'ideas' in results
-        assert 'knowledge' in results
-        assert 'code_elements' in results
+        assert "ideas" in results
+        assert "knowledge" in results
+        assert "code_elements" in results
         assert wsde_team.generate_diverse_ideas.call_count == 1
         assert memory_manager.retrieve_relevant_knowledge.call_count == 1
         assert code_analyzer.analyze_project_structure.call_count == 1
         assert memory_manager.store_with_edrr_phase.call_count >= 1
-        assert f'EXPAND_{coordinator.cycle_id}' in coordinator._execution_traces
+        assert f"EXPAND_{coordinator.cycle_id}" in coordinator._execution_traces
         stored = memory_manager.stored_items[MemoryType.SOLUTION]
-        assert stored['phase'] == 'EXPAND'
-        assert stored['metadata']['cycle_id'] == 'test-cycle-id'
-        assert stored['item'] == results
+        assert stored["phase"] == "EXPAND"
+        assert stored["metadata"]["cycle_id"] == "test-cycle-id"
+        assert stored["item"] == results
 
     @pytest.mark.medium
-    def test_differentiate_phase_execution_has_expected(self, coordinator, memory_manager, wsde_team):
+    def test_differentiate_phase_execution_has_expected(
+        self, coordinator, memory_manager, wsde_team
+    ):
         """Test executing the Differentiate phase.
 
-ReqID: N/A"""
-        coordinator.task = {'description': 'Test Task'}
-        coordinator.cycle_id = 'test-cycle-id'
+        ReqID: N/A"""
+        coordinator.task = {"description": "Test Task"}
+        coordinator.cycle_id = "test-cycle-id"
         coordinator.current_phase = Phase.DIFFERENTIATE
-        memory_manager.stored_items = {'EXPAND_RESULTS': {'item': {'ideas': [{'id': 1}, {'id': 2}]}, 'phase': 'EXPAND', 'metadata': {'cycle_id': 'test-cycle-id'}}}
+        memory_manager.stored_items = {
+            "EXPAND_RESULTS": {
+                "item": {"ideas": [{"id": 1}, {"id": 2}]},
+                "phase": "EXPAND",
+                "metadata": {"cycle_id": "test-cycle-id"},
+            }
+        }
         results = coordinator._execute_differentiate_phase({})
-        assert 'comparison_matrix' in results
-        assert 'evaluated_options' in results
-        assert 'trade_offs' in results
-        assert 'decision_criteria' in results
+        assert "comparison_matrix" in results
+        assert "evaluated_options" in results
+        assert "trade_offs" in results
+        assert "decision_criteria" in results
         assert wsde_team.create_comparison_matrix.call_count == 1
         assert wsde_team.evaluate_options.call_count == 1
         assert wsde_team.analyze_trade_offs.call_count == 1
         assert wsde_team.formulate_decision_criteria.call_count == 1
         assert memory_manager.store_with_edrr_phase.call_count >= 1
-        assert f'DIFFERENTIATE_{coordinator.cycle_id}' in coordinator._execution_traces
+        assert f"DIFFERENTIATE_{coordinator.cycle_id}" in coordinator._execution_traces
         stored = memory_manager.stored_items[MemoryType.SOLUTION]
-        assert stored['phase'] == 'DIFFERENTIATE'
-        assert stored['metadata']['cycle_id'] == 'test-cycle-id'
-        assert stored['item'] == results
+        assert stored["phase"] == "DIFFERENTIATE"
+        assert stored["metadata"]["cycle_id"] == "test-cycle-id"
+        assert stored["item"] == results
 
     @pytest.mark.medium
-    def test_refine_phase_execution_has_expected(self, coordinator, memory_manager, wsde_team):
+    def test_refine_phase_execution_has_expected(
+        self, coordinator, memory_manager, wsde_team
+    ):
         """Test executing the Refine phase.
 
-ReqID: N/A"""
-        coordinator.task = {'description': 'Test Task'}
-        coordinator.cycle_id = 'test-cycle-id'
+        ReqID: N/A"""
+        coordinator.task = {"description": "Test Task"}
+        coordinator.cycle_id = "test-cycle-id"
         coordinator.current_phase = Phase.REFINE
-        memory_manager.stored_items = {'DIFFERENTIATE_RESULTS': {'item': {'evaluated_options': [{'id': 1}, {'id': 2}], 'decision_criteria': {'criteria_1': 0.5, 'criteria_2': 0.5}}, 'phase': 'DIFFERENTIATE', 'metadata': {'cycle_id': 'test-cycle-id'}}}
+        memory_manager.stored_items = {
+            "DIFFERENTIATE_RESULTS": {
+                "item": {
+                    "evaluated_options": [{"id": 1}, {"id": 2}],
+                    "decision_criteria": {"criteria_1": 0.5, "criteria_2": 0.5},
+                },
+                "phase": "DIFFERENTIATE",
+                "metadata": {"cycle_id": "test-cycle-id"},
+            }
+        }
         results = coordinator._execute_refine_phase({})
-        assert 'selected_option' in results
-        assert 'detailed_plan' in results
-        assert 'implementation_plan' in results
-        assert 'optimized_plan' in results
-        assert 'quality_checks' in results
+        assert "selected_option" in results
+        assert "detailed_plan" in results
+        assert "implementation_plan" in results
+        assert "optimized_plan" in results
+        assert "quality_checks" in results
         assert wsde_team.select_best_option.call_count == 1
         assert wsde_team.elaborate_details.call_count == 1
         assert wsde_team.create_implementation_plan.call_count == 1
         assert wsde_team.optimize_implementation.call_count == 1
         assert wsde_team.perform_quality_assurance.call_count == 1
         assert memory_manager.store_with_edrr_phase.call_count >= 1
-        assert f'REFINE_{coordinator.cycle_id}' in coordinator._execution_traces
+        assert f"REFINE_{coordinator.cycle_id}" in coordinator._execution_traces
         stored = memory_manager.stored_items[MemoryType.SOLUTION]
-        assert stored['phase'] == 'REFINE'
-        assert stored['metadata']['cycle_id'] == 'test-cycle-id'
-        assert stored['item'] == results
+        assert stored["phase"] == "REFINE"
+        assert stored["metadata"]["cycle_id"] == "test-cycle-id"
+        assert stored["item"] == results
 
     @pytest.mark.medium
-    def test_retrospect_phase_execution_has_expected(self, coordinator, memory_manager, wsde_team):
+    def test_retrospect_phase_execution_has_expected(
+        self, coordinator, memory_manager, wsde_team
+    ):
         """Test executing the Retrospect phase.
 
-ReqID: N/A"""
-        coordinator.task = {'description': 'Test Task'}
-        coordinator.cycle_id = 'test-cycle-id'
+        ReqID: N/A"""
+        coordinator.task = {"description": "Test Task"}
+        coordinator.cycle_id = "test-cycle-id"
         coordinator.current_phase = Phase.RETROSPECT
-        memory_manager.stored_items = {'EXPAND_RESULTS': {'item': {'ideas': [{'id': 1}, {'id': 2}]}, 'phase': 'EXPAND', 'metadata': {'cycle_id': 'test-cycle-id'}}, 'DIFFERENTIATE_RESULTS': {'item': {'evaluated_options': [{'id': 1}, {'id': 2}], 'decision_criteria': {'criteria_1': 0.5, 'criteria_2': 0.5}}, 'phase': 'DIFFERENTIATE', 'metadata': {'cycle_id': 'test-cycle-id'}}, 'REFINE_RESULTS': {'item': {'implementation_plan': [{'task': 1}, {'task': 2}], 'quality_checks': {'issues': [], 'recommendations': []}}, 'phase': 'REFINE', 'metadata': {'cycle_id': 'test-cycle-id'}}}
+        memory_manager.stored_items = {
+            "EXPAND_RESULTS": {
+                "item": {"ideas": [{"id": 1}, {"id": 2}]},
+                "phase": "EXPAND",
+                "metadata": {"cycle_id": "test-cycle-id"},
+            },
+            "DIFFERENTIATE_RESULTS": {
+                "item": {
+                    "evaluated_options": [{"id": 1}, {"id": 2}],
+                    "decision_criteria": {"criteria_1": 0.5, "criteria_2": 0.5},
+                },
+                "phase": "DIFFERENTIATE",
+                "metadata": {"cycle_id": "test-cycle-id"},
+            },
+            "REFINE_RESULTS": {
+                "item": {
+                    "implementation_plan": [{"task": 1}, {"task": 2}],
+                    "quality_checks": {"issues": [], "recommendations": []},
+                },
+                "phase": "REFINE",
+                "metadata": {"cycle_id": "test-cycle-id"},
+            },
+        }
         results = coordinator._execute_retrospect_phase({})
-        assert 'learnings' in results
-        assert 'patterns' in results
-        assert 'integrated_knowledge' in results
-        assert 'improvement_suggestions' in results
-        assert 'final_report' in results
+        assert "learnings" in results
+        assert "patterns" in results
+        assert "integrated_knowledge" in results
+        assert "improvement_suggestions" in results
+        assert "final_report" in results
         assert wsde_team.extract_learnings.call_count == 1
         assert wsde_team.recognize_patterns.call_count == 1
         assert wsde_team.integrate_knowledge.call_count == 1
         assert wsde_team.generate_improvement_suggestions.call_count == 1
         assert memory_manager.store_with_edrr_phase.call_count >= 2
-        assert f'RETROSPECT_{coordinator.cycle_id}' in coordinator._execution_traces
-        stored = memory_manager.stored_items['RETROSPECT_RESULTS']
-        assert stored['phase'] == 'RETROSPECT'
-        assert stored['metadata']['cycle_id'] == 'test-cycle-id'
-        assert stored['item'] == results
+        assert f"RETROSPECT_{coordinator.cycle_id}" in coordinator._execution_traces
+        stored = memory_manager.stored_items["RETROSPECT_RESULTS"]
+        assert stored["phase"] == "RETROSPECT"
+        assert stored["metadata"]["cycle_id"] == "test-cycle-id"
+        assert stored["item"] == results
 
     @pytest.mark.medium
     def test_generate_final_report_succeeds(self, coordinator):
         """Test generating the final report.
 
-ReqID: N/A"""
-        coordinator.task = {'description': 'Test Task'}
-        coordinator.cycle_id = 'test-cycle-id'
-        cycle_data = {'task': {'description': 'Test Task'}, 'expand': {'ideas': [{'id': 1}, {'id': 2}], 'knowledge': []}, 'differentiate': {'evaluated_options': [{'id': 1}, {'id': 2}], 'trade_offs': [], 'decision_criteria': {}}, 'refine': {'implementation_plan': [{'task': 1}, {'task': 2}], 'quality_checks': {}}, 'retrospect': {'learnings': [], 'patterns': [], 'improvement_suggestions': []}}
+        ReqID: N/A"""
+        coordinator.task = {"description": "Test Task"}
+        coordinator.cycle_id = "test-cycle-id"
+        cycle_data = {
+            "task": {"description": "Test Task"},
+            "expand": {"ideas": [{"id": 1}, {"id": 2}], "knowledge": []},
+            "differentiate": {
+                "evaluated_options": [{"id": 1}, {"id": 2}],
+                "trade_offs": [],
+                "decision_criteria": {},
+            },
+            "refine": {
+                "implementation_plan": [{"task": 1}, {"task": 2}],
+                "quality_checks": {},
+            },
+            "retrospect": {
+                "learnings": [],
+                "patterns": [],
+                "improvement_suggestions": [],
+            },
+        }
         report = coordinator.generate_final_report(cycle_data)
-        assert 'title' in report
-        assert 'cycle_id' in report
-        assert 'timestamp' in report
-        assert 'task_summary' in report
-        assert 'process_summary' in report
-        assert 'outcome' in report
-        assert report['cycle_id'] == coordinator.cycle_id
-        assert 'expand' in report['process_summary']
-        assert 'differentiate' in report['process_summary']
-        assert 'refine' in report['process_summary']
-        assert 'retrospect' in report['process_summary']
+        assert "title" in report
+        assert "cycle_id" in report
+        assert "timestamp" in report
+        assert "task_summary" in report
+        assert "process_summary" in report
+        assert "outcome" in report
+        assert report["cycle_id"] == coordinator.cycle_id
+        assert "expand" in report["process_summary"]
+        assert "differentiate" in report["process_summary"]
+        assert "refine" in report["process_summary"]
+        assert "retrospect" in report["process_summary"]
 
     @pytest.mark.medium
     def test_execute_current_phase_has_expected(self, coordinator):
         """Test executing the current phase.
 
-ReqID: N/A"""
-        coordinator.task = {'description': 'Test Task'}
-        coordinator.cycle_id = 'test-cycle-id'
+        ReqID: N/A"""
+        coordinator.task = {"description": "Test Task"}
+        coordinator.cycle_id = "test-cycle-id"
         coordinator.current_phase = None
         with pytest.raises(EDRRCoordinatorError):
             coordinator.execute_current_phase()
         coordinator.current_phase = Phase.EXPAND
-        with patch.object(coordinator, '_execute_expand_phase', return_value={'ideas': []}):
+        with patch.object(
+            coordinator, "_execute_expand_phase", return_value={"ideas": []}
+        ):
             results = coordinator.execute_current_phase()
-            assert 'ideas' in results
-            assert 'EXPAND' in coordinator.results
-        with patch.object(coordinator, '_execute_expand_phase', side_effect=Exception('Test error')):
+            assert "ideas" in results
+            assert "EXPAND" in coordinator.results
+        with patch.object(
+            coordinator, "_execute_expand_phase", side_effect=Exception("Test error")
+        ):
             with pytest.raises(EDRRCoordinatorError):
                 coordinator.execute_current_phase()
 
@@ -245,18 +381,18 @@ ReqID: N/A"""
     def test_progress_to_phase_has_expected(self, coordinator, memory_manager):
         """Test progressing to a phase.
 
-ReqID: N/A"""
-        coordinator.task = {'description': 'Test Task'}
-        coordinator.cycle_id = 'test-cycle-id'
+        ReqID: N/A"""
+        coordinator.task = {"description": "Test Task"}
+        coordinator.cycle_id = "test-cycle-id"
         coordinator._historical_data = []
-        with patch.object(coordinator, '_execute_expand_phase'):
+        with patch.object(coordinator, "_execute_expand_phase"):
             coordinator.progress_to_phase(Phase.EXPAND)
             assert coordinator.current_phase == Phase.EXPAND
             assert memory_manager.store_with_edrr_phase.call_count >= 1
         coordinator.manifest = {}
         coordinator.manifest_parser = MagicMock()
         coordinator.manifest_parser.check_phase_dependencies.return_value = True
-        with patch.object(coordinator, '_execute_differentiate_phase'):
+        with patch.object(coordinator, "_execute_differentiate_phase"):
             coordinator.progress_to_phase(Phase.DIFFERENTIATE)
             assert coordinator.current_phase == Phase.DIFFERENTIATE
             assert coordinator.manifest_parser.start_phase.call_count == 1
@@ -270,14 +406,14 @@ ReqID: N/A"""
     def test_progress_to_phase_dependency_failure_no_auto_fails(self, coordinator):
         """Dependency failures should raise without triggering auto progression.
 
-ReqID: N/A"""
-        coordinator.task = {'description': 'task'}
-        coordinator.cycle_id = 'cid'
+        ReqID: N/A"""
+        coordinator.task = {"description": "task"}
+        coordinator.cycle_id = "cid"
         coordinator.auto_phase_transitions = False
         coordinator.manifest = {}
         coordinator.manifest_parser = MagicMock()
         coordinator.manifest_parser.check_phase_dependencies.return_value = False
-        with patch.object(coordinator, '_maybe_auto_progress') as auto_mock:
+        with patch.object(coordinator, "_maybe_auto_progress") as auto_mock:
             with pytest.raises(EDRRCoordinatorError):
                 coordinator.progress_to_phase(Phase.DIFFERENTIATE)
         auto_mock.assert_not_called()
@@ -286,9 +422,26 @@ ReqID: N/A"""
     def test_full_cycle_succeeds(self, coordinator):
         """Test a full EDRR cycle.
 
-ReqID: N/A"""
-        task = {'description': 'Test Task', 'requirements': ['Req 1', 'Req 2']}
-        with patch.object(coordinator, '_execute_expand_phase', return_value={'ideas': []}), patch.object(coordinator, '_execute_differentiate_phase', return_value={'evaluated_options': []}), patch.object(coordinator, '_execute_refine_phase', return_value={'implementation_plan': []}), patch.object(coordinator, '_execute_retrospect_phase', return_value={'learnings': []}):
+        ReqID: N/A"""
+        task = {"description": "Test Task", "requirements": ["Req 1", "Req 2"]}
+        with (
+            patch.object(
+                coordinator, "_execute_expand_phase", return_value={"ideas": []}
+            ),
+            patch.object(
+                coordinator,
+                "_execute_differentiate_phase",
+                return_value={"evaluated_options": []},
+            ),
+            patch.object(
+                coordinator,
+                "_execute_refine_phase",
+                return_value={"implementation_plan": []},
+            ),
+            patch.object(
+                coordinator, "_execute_retrospect_phase", return_value={"learnings": []}
+            ),
+        ):
             coordinator.start_cycle(task)
             assert coordinator.current_phase == Phase.EXPAND
             coordinator.progress_to_phase(Phase.DIFFERENTIATE)
@@ -297,18 +450,23 @@ ReqID: N/A"""
             assert coordinator.current_phase == Phase.REFINE
             coordinator.progress_to_phase(Phase.RETROSPECT)
             assert coordinator.current_phase == Phase.RETROSPECT
-            assert 'EXPAND' in coordinator.results
-            assert 'DIFFERENTIATE' in coordinator.results
-            assert 'REFINE' in coordinator.results
-            assert 'RETROSPECT' in coordinator.results
+            assert "EXPAND" in coordinator.results
+            assert "DIFFERENTIATE" in coordinator.results
+            assert "REFINE" in coordinator.results
+            assert "RETROSPECT" in coordinator.results
 
     @pytest.mark.medium
     def test_progress_to_next_phase_has_expected(self, coordinator):
         """Test that progress to next phase.
 
-ReqID: N/A"""
-        task = {'description': 'Test'}
-        with patch.object(coordinator, '_execute_expand_phase', return_value={}), patch.object(coordinator, '_execute_differentiate_phase', return_value={}), patch.object(coordinator, '_execute_refine_phase', return_value={}), patch.object(coordinator, '_execute_retrospect_phase', return_value={}):
+        ReqID: N/A"""
+        task = {"description": "Test"}
+        with (
+            patch.object(coordinator, "_execute_expand_phase", return_value={}),
+            patch.object(coordinator, "_execute_differentiate_phase", return_value={}),
+            patch.object(coordinator, "_execute_refine_phase", return_value={}),
+            patch.object(coordinator, "_execute_retrospect_phase", return_value={}),
+        ):
             coordinator.start_cycle(task)
             assert coordinator.current_phase == Phase.EXPAND
             coordinator.progress_to_next_phase()
@@ -324,7 +482,7 @@ ReqID: N/A"""
     def test_progress_to_next_phase_without_current_fails(self, coordinator):
         """progress_to_next_phase should fail if no phase is active.
 
-ReqID: N/A"""
+        ReqID: N/A"""
         with pytest.raises(EDRRCoordinatorError):
             coordinator.progress_to_next_phase()
 
@@ -332,50 +490,63 @@ ReqID: N/A"""
     def test_start_cycle_from_manifest_succeeds(self, coordinator):
         """Test that start cycle from manifest.
 
-ReqID: N/A"""
+        ReqID: N/A"""
         manifest_parser = MagicMock()
-        manifest_parser.parse_file.return_value = {'id': 'test-id', 'description': 'desc', 'phases': {'expand': {'instructions': ''}, 'differentiate': {'instructions': ''}, 'refine': {'instructions': ''}, 'retrospect': {'instructions': ''}}}
-        manifest_parser.get_manifest_id.return_value = 'test-id'
-        manifest_parser.get_manifest_description.return_value = 'desc'
+        manifest_parser.parse_file.return_value = {
+            "id": "test-id",
+            "description": "desc",
+            "phases": {
+                "expand": {"instructions": ""},
+                "differentiate": {"instructions": ""},
+                "refine": {"instructions": ""},
+                "retrospect": {"instructions": ""},
+            },
+        }
+        manifest_parser.get_manifest_id.return_value = "test-id"
+        manifest_parser.get_manifest_description.return_value = "desc"
         manifest_parser.get_manifest_metadata.return_value = {}
-        manifest_parser.execution_trace = {'start_time': 'now'}
+        manifest_parser.execution_trace = {"start_time": "now"}
         manifest_parser.start_execution.return_value = None
         coordinator.manifest_parser = manifest_parser
-        with patch.object(coordinator, 'progress_to_phase') as progress_mock:
-            coordinator.start_cycle_from_manifest('path.json')
-        manifest_parser.parse_file.assert_called_once_with('path.json')
+        with patch.object(coordinator, "progress_to_phase") as progress_mock:
+            coordinator.start_cycle_from_manifest("path.json")
+        manifest_parser.parse_file.assert_called_once_with("path.json")
         progress_mock.assert_called_once_with(Phase.EXPAND)
-        assert coordinator.task['id'] == 'test-id'
+        assert coordinator.task["id"] == "test-id"
         assert coordinator.manifest == manifest_parser.parse_file.return_value
 
     @pytest.mark.medium
     def test_maybe_create_micro_cycles_succeeds(self, coordinator):
         """Test that maybe create micro cycles.
 
-ReqID: N/A"""
-        context = {'micro_tasks': [{'description': 'sub'}]}
+        ReqID: N/A"""
+        context = {"micro_tasks": [{"description": "sub"}]}
         results = {}
         micro = MagicMock()
-        micro.cycle_id = 'cid'
-        micro.results = {'phase_complete': True}
-        with patch.object(coordinator, 'create_micro_cycle', return_value=micro) as create_mock:
+        micro.cycle_id = "cid"
+        micro.results = {"phase_complete": True}
+        with patch.object(
+            coordinator, "create_micro_cycle", return_value=micro
+        ) as create_mock:
             coordinator._maybe_create_micro_cycles(context, Phase.EXPAND, results)
-        create_mock.assert_called_once_with({'description': 'sub'}, Phase.EXPAND)
-        assert results['micro_cycle_results']['cid'] == micro.results
+        create_mock.assert_called_once_with({"description": "sub"}, Phase.EXPAND)
+        assert results["micro_cycle_results"]["cid"] == micro.results
 
     @pytest.mark.medium
     def test_create_micro_cycle_succeeds(self, coordinator):
         """Test that create micro cycle.
 
-ReqID: N/A"""
-        coordinator.start_cycle({'description': 'Macro'})
-        micro_task = {'description': 'Micro'}
+        ReqID: N/A"""
+        coordinator.start_cycle({"description": "Macro"})
+        micro_task = {"description": "Micro"}
         micro = coordinator.create_micro_cycle(micro_task, Phase.EXPAND)
         assert micro.parent_cycle_id == coordinator.cycle_id
         assert micro_task == micro.task
         assert micro in coordinator.child_cycles
-        stored = coordinator.results[Phase.EXPAND.name]['micro_cycle_results'][micro.cycle_id]
-        assert stored['task'] == micro_task
+        stored = coordinator.results[Phase.EXPAND.name]["micro_cycle_results"][
+            micro.cycle_id
+        ]
+        assert stored["task"] == micro_task
         for key, value in micro.results.items():
             assert stored[key] == value
 
@@ -383,22 +554,26 @@ ReqID: N/A"""
     def test_micro_cycle_result_aggregation_succeeds(self, coordinator):
         """Test that micro cycle results are properly aggregated in the parent cycle results.
 
-ReqID: N/A"""
-        with patch.object(coordinator, '_execute_expand_phase', return_value={'phase_complete': True}):
-            coordinator.start_cycle({'description': 'Macro'})
-            micro = coordinator.create_micro_cycle({'description': 'sub'}, Phase.EXPAND)
-        expand_results = coordinator.results.get('EXPAND', {})
-        assert 'micro_cycle_results' in expand_results
-        assert micro.cycle_id in expand_results['micro_cycle_results']
-        assert 'task' in expand_results['micro_cycle_results'][micro.cycle_id]
-        assert expand_results['micro_cycle_results'][micro.cycle_id]['task'] == {'description': 'sub'}
+        ReqID: N/A"""
+        with patch.object(
+            coordinator, "_execute_expand_phase", return_value={"phase_complete": True}
+        ):
+            coordinator.start_cycle({"description": "Macro"})
+            micro = coordinator.create_micro_cycle({"description": "sub"}, Phase.EXPAND)
+        expand_results = coordinator.results.get("EXPAND", {})
+        assert "micro_cycle_results" in expand_results
+        assert micro.cycle_id in expand_results["micro_cycle_results"]
+        assert "task" in expand_results["micro_cycle_results"][micro.cycle_id]
+        assert expand_results["micro_cycle_results"][micro.cycle_id]["task"] == {
+            "description": "sub"
+        }
 
     @pytest.mark.medium
     def test_execution_history_logging_succeeds(self, coordinator):
         """Test that execution history logging.
 
-ReqID: N/A"""
-        coordinator.start_cycle({'description': 'Task'})
+        ReqID: N/A"""
+        coordinator.start_cycle({"description": "Task"})
         history_len = len(coordinator.get_execution_history())
         coordinator.progress_to_phase(Phase.DIFFERENTIATE)
         assert len(coordinator.get_execution_history()) > history_len
@@ -407,12 +582,12 @@ ReqID: N/A"""
     def test_create_micro_cycle_triggers_termination_succeeds(self, coordinator):
         """Ensure micro cycle is not created when granularity threshold triggers termination.
 
-ReqID: N/A"""
-        coordinator.start_cycle({'description': 'Macro'})
-        micro_task = {'description': 'Sub', 'granularity_score': 0.1}
+        ReqID: N/A"""
+        coordinator.start_cycle({"description": "Macro"})
+        micro_task = {"description": "Sub", "granularity_score": 0.1}
         should_terminate, reason = coordinator.should_terminate_recursion(micro_task)
         assert should_terminate is True
-        assert reason == 'granularity threshold'
+        assert reason == "granularity threshold"
         with pytest.raises(EDRRCoordinatorError):
             coordinator.create_micro_cycle(micro_task, Phase.EXPAND)
         assert not coordinator.child_cycles
@@ -422,6 +597,8 @@ ReqID: N/A"""
         """_safe_retrieve_with_edrr_phase converts list results to a dict."""
         coordinator.memory_manager.retrieve_with_edrr_phase.side_effect = None
         coordinator.memory_manager.retrieve_with_edrr_phase.return_value = [1, 2]
-        result = coordinator._safe_retrieve_with_edrr_phase(MemoryType.SOLUTION.value, Phase.EXPAND.value, {'cycle_id': 'cid'})
+        result = coordinator._safe_retrieve_with_edrr_phase(
+            MemoryType.SOLUTION.value, Phase.EXPAND.value, {"cycle_id": "cid"}
+        )
         assert isinstance(result, dict)
-        assert result == {'items': [1, 2]}
+        assert result == {"items": [1, 2]}

--- a/tests/unit/application/edrr/test_edrr_coordinator_enhanced.py
+++ b/tests/unit/application/edrr/test_edrr_coordinator_enhanced.py
@@ -1,59 +1,122 @@
-import pytest
-from unittest.mock import MagicMock, patch
 from datetime import datetime
 from pathlib import Path
-from devsynth.application.edrr.edrr_coordinator_enhanced import EnhancedEDRRCoordinator
-from devsynth.application.edrr.coordinator import EDRRCoordinator, EDRRCoordinatorError
-from devsynth.methodology.base import Phase
-from devsynth.application.memory.memory_manager import MemoryManager
-from devsynth.domain.models.wsde import WSDETeam
+from unittest.mock import MagicMock, patch
+
+import pytest
+
 from devsynth.application.code_analysis.analyzer import CodeAnalyzer
 from devsynth.application.code_analysis.ast_transformer import AstTransformer
+from devsynth.application.documentation.documentation_manager import (
+    DocumentationManager,
+)
+from devsynth.application.edrr.coordinator import EDRRCoordinator, EDRRCoordinatorError
+from devsynth.application.edrr.edrr_coordinator_enhanced import EnhancedEDRRCoordinator
+from devsynth.application.memory.memory_manager import MemoryManager
 from devsynth.application.prompts.prompt_manager import PromptManager
-from devsynth.application.documentation.documentation_manager import DocumentationManager
 from devsynth.domain.models.memory import MemoryType
+from devsynth.domain.models.wsde_facade import WSDETeam
+from devsynth.methodology.base import Phase
+
 
 @pytest.fixture
 def memory_manager():
     """Create a mock memory manager for testing."""
     mock_memory_manager = MagicMock(spec=MemoryManager)
-    mock_memory_manager.store.return_value = 'memory_id_123'
-    mock_memory_manager.retrieve.return_value = {'content': 'Test memory content', 'metadata': {'key': 'value'}}
-    mock_memory_manager.search_memory.return_value = [{'id': 'memory_id_123', 'content': 'Test memory content', 'metadata': {'key': 'value'}, 'score': 0.95}]
+    mock_memory_manager.store.return_value = "memory_id_123"
+    mock_memory_manager.retrieve.return_value = {
+        "content": "Test memory content",
+        "metadata": {"key": "value"},
+    }
+    mock_memory_manager.search_memory.return_value = [
+        {
+            "id": "memory_id_123",
+            "content": "Test memory content",
+            "metadata": {"key": "value"},
+            "score": 0.95,
+        }
+    ]
     return mock_memory_manager
+
 
 @pytest.fixture
 def wsde_team():
     """Create a mock WSDE team for testing."""
     mock_wsde_team = MagicMock()
-    mock_wsde_team.execute_task.return_value = {'result': 'Task executed successfully', 'artifacts': ['artifact1', 'artifact2'], 'metrics': {'time_taken': 10.5}}
-    mock_wsde_team.get_team_report.return_value = {'team_composition': ['Agent1', 'Agent2', 'Agent3'], 'task_distribution': {'Agent1': 2, 'Agent2': 3, 'Agent3': 1}, 'performance_metrics': {'efficiency': 0.85, 'quality': 0.9}}
+    mock_wsde_team.execute_task.return_value = {
+        "result": "Task executed successfully",
+        "artifacts": ["artifact1", "artifact2"],
+        "metrics": {"time_taken": 10.5},
+    }
+    mock_wsde_team.get_team_report.return_value = {
+        "team_composition": ["Agent1", "Agent2", "Agent3"],
+        "task_distribution": {"Agent1": 2, "Agent2": 3, "Agent3": 1},
+        "performance_metrics": {"efficiency": 0.85, "quality": 0.9},
+    }
     mock_wsde_team.assign_roles_for_phase.return_value = None
-    mock_wsde_team.get_role_map.return_value = {'Agent1': 'role1', 'Agent2': 'role2'}
-    mock_wsde_team.generate_diverse_ideas.return_value = ['idea1', 'idea2']
-    mock_wsde_team.create_comparison_matrix.return_value = {'idea1': {'score': 0.8}, 'idea2': {'score': 0.6}}
-    mock_wsde_team.evaluate_options.return_value = [{'option': 'idea1', 'score': 0.8}, {'option': 'idea2', 'score': 0.6}]
-    mock_wsde_team.analyze_trade_offs.return_value = [{'option1': 'idea1', 'option2': 'idea2', 'trade_off': 'complexity vs speed'}]
-    mock_wsde_team.formulate_decision_criteria.return_value = {'criteria1': 0.7, 'criteria2': 0.3}
-    mock_wsde_team.select_best_option.return_value = {'option': 'idea1', 'score': 0.8}
-    mock_wsde_team.elaborate_details.return_value = {'option': 'idea1', 'details': 'detailed implementation'}
-    mock_wsde_team.create_implementation_plan.return_value = [{'step': 1, 'description': 'step 1'}]
-    mock_wsde_team.optimize_implementation.return_value = [{'step': 1, 'description': 'optimized step 1'}]
-    mock_wsde_team.perform_quality_assurance.return_value = {'passed': True, 'issues': []}
-    mock_wsde_team.get_primus.return_value = 'Agent1'
-    mock_wsde_team.conduct_peer_review.return_value = {'reviewer': 'Agent2', 'comments': 'looks good'}
-    mock_wsde_team.extract_learnings.return_value = [{'category': 'technical', 'learning': 'learning1'}]
-    mock_wsde_team.recognize_patterns.return_value = [{'pattern': 'pattern1', 'frequency': 0.7}]
-    mock_wsde_team.integrate_knowledge.return_value = {'status': 'success', 'integrated_items': 3}
-    mock_wsde_team.generate_improvement_suggestions.return_value = [{'phase': 'EXPAND', 'suggestion': 'suggestion1'}]
+    mock_wsde_team.get_role_map.return_value = {"Agent1": "role1", "Agent2": "role2"}
+    mock_wsde_team.generate_diverse_ideas.return_value = ["idea1", "idea2"]
+    mock_wsde_team.create_comparison_matrix.return_value = {
+        "idea1": {"score": 0.8},
+        "idea2": {"score": 0.6},
+    }
+    mock_wsde_team.evaluate_options.return_value = [
+        {"option": "idea1", "score": 0.8},
+        {"option": "idea2", "score": 0.6},
+    ]
+    mock_wsde_team.analyze_trade_offs.return_value = [
+        {"option1": "idea1", "option2": "idea2", "trade_off": "complexity vs speed"}
+    ]
+    mock_wsde_team.formulate_decision_criteria.return_value = {
+        "criteria1": 0.7,
+        "criteria2": 0.3,
+    }
+    mock_wsde_team.select_best_option.return_value = {"option": "idea1", "score": 0.8}
+    mock_wsde_team.elaborate_details.return_value = {
+        "option": "idea1",
+        "details": "detailed implementation",
+    }
+    mock_wsde_team.create_implementation_plan.return_value = [
+        {"step": 1, "description": "step 1"}
+    ]
+    mock_wsde_team.optimize_implementation.return_value = [
+        {"step": 1, "description": "optimized step 1"}
+    ]
+    mock_wsde_team.perform_quality_assurance.return_value = {
+        "passed": True,
+        "issues": [],
+    }
+    mock_wsde_team.get_primus.return_value = "Agent1"
+    mock_wsde_team.conduct_peer_review.return_value = {
+        "reviewer": "Agent2",
+        "comments": "looks good",
+    }
+    mock_wsde_team.extract_learnings.return_value = [
+        {"category": "technical", "learning": "learning1"}
+    ]
+    mock_wsde_team.recognize_patterns.return_value = [
+        {"pattern": "pattern1", "frequency": 0.7}
+    ]
+    mock_wsde_team.integrate_knowledge.return_value = {
+        "status": "success",
+        "integrated_items": 3,
+    }
+    mock_wsde_team.generate_improvement_suggestions.return_value = [
+        {"phase": "EXPAND", "suggestion": "suggestion1"}
+    ]
     return mock_wsde_team
+
 
 @pytest.fixture
 def code_analyzer():
     """Create a mock code analyzer for testing."""
     mock_code_analyzer = MagicMock(spec=CodeAnalyzer)
-    mock_code_analyzer.analyze_code.return_value = {'complexity': 5, 'maintainability': 8, 'issues': ['Issue1', 'Issue2']}
+    mock_code_analyzer.analyze_code.return_value = {
+        "complexity": 5,
+        "maintainability": 8,
+        "issues": ["Issue1", "Issue2"],
+    }
     return mock_code_analyzer
+
 
 @pytest.fixture
 def ast_transformer():
@@ -61,11 +124,13 @@ def ast_transformer():
     mock_ast_transformer = MagicMock(spec=AstTransformer)
     return mock_ast_transformer
 
+
 @pytest.fixture
 def prompt_manager():
     """Create a mock prompt manager for testing."""
     mock_prompt_manager = MagicMock(spec=PromptManager)
     return mock_prompt_manager
+
 
 @pytest.fixture
 def documentation_manager():
@@ -73,22 +138,39 @@ def documentation_manager():
     mock_documentation_manager = MagicMock(spec=DocumentationManager)
     return mock_documentation_manager
 
+
 @pytest.fixture
-def enhanced_coordinator(memory_manager, wsde_team, code_analyzer, ast_transformer, prompt_manager, documentation_manager):
+def enhanced_coordinator(
+    memory_manager,
+    wsde_team,
+    code_analyzer,
+    ast_transformer,
+    prompt_manager,
+    documentation_manager,
+):
     """Create an EnhancedEDRRCoordinator instance for testing."""
-    coordinator = EnhancedEDRRCoordinator(memory_manager=memory_manager, wsde_team=wsde_team, code_analyzer=code_analyzer, ast_transformer=ast_transformer, prompt_manager=prompt_manager, documentation_manager=documentation_manager, enable_enhanced_logging=True)
+    coordinator = EnhancedEDRRCoordinator(
+        memory_manager=memory_manager,
+        wsde_team=wsde_team,
+        code_analyzer=code_analyzer,
+        ast_transformer=ast_transformer,
+        prompt_manager=prompt_manager,
+        documentation_manager=documentation_manager,
+        enable_enhanced_logging=True,
+    )
     return coordinator
+
 
 class TestEnhancedEDRRCoordinator:
     """Tests for the EnhancedEDRRCoordinator class.
 
-ReqID: N/A"""
+    ReqID: N/A"""
 
     @pytest.mark.medium
     def test_initialization_succeeds(self, enhanced_coordinator):
         """Test that the enhanced coordinator initializes correctly.
 
-ReqID: N/A"""
+        ReqID: N/A"""
         assert enhanced_coordinator is not None
         assert enhanced_coordinator.memory_manager is not None
         assert enhanced_coordinator.wsde_team is not None
@@ -100,44 +182,88 @@ ReqID: N/A"""
         assert enhanced_coordinator.recursion_depth == 0
         assert enhanced_coordinator.parent_cycle_id is None
         assert enhanced_coordinator.parent_phase is None
-        assert hasattr(enhanced_coordinator, 'phase_metrics')
-        from devsynth.application.edrr.edrr_phase_transitions import PhaseTransitionMetrics
+        assert hasattr(enhanced_coordinator, "phase_metrics")
+        from devsynth.application.edrr.edrr_phase_transitions import (
+            PhaseTransitionMetrics,
+        )
+
         assert isinstance(enhanced_coordinator.phase_metrics, PhaseTransitionMetrics)
 
     @pytest.mark.medium
     def test_progress_to_phase_has_expected(self, enhanced_coordinator, memory_manager):
         """Test enhanced progress to phase with metrics collection.
 
-ReqID: N/A"""
-        task = {'name': 'Test Task', 'description': 'This is a test task', 'requirements': ['req1', 'req2']}
+        ReqID: N/A"""
+        task = {
+            "name": "Test Task",
+            "description": "This is a test task",
+            "requirements": ["req1", "req2"],
+        }
         enhanced_coordinator.start_cycle(task)
-        with patch.object(enhanced_coordinator, '_safe_store_with_edrr_phase') as mock_store:
-            with patch('devsynth.application.edrr.edrr_coordinator_enhanced.collect_phase_metrics') as mock_collect_metrics:
-                mock_collect_metrics.return_value = {'duration': 10.5, 'quality': 0.85, 'completeness': 0.8, 'consistency': 0.75}
+        with patch.object(
+            enhanced_coordinator, "_safe_store_with_edrr_phase"
+        ) as mock_store:
+            with patch(
+                "devsynth.application.edrr.edrr_coordinator_enhanced.collect_phase_metrics"
+            ) as mock_collect_metrics:
+                mock_collect_metrics.return_value = {
+                    "duration": 10.5,
+                    "quality": 0.85,
+                    "completeness": 0.8,
+                    "consistency": 0.75,
+                }
                 enhanced_coordinator.progress_to_phase(Phase.DIFFERENTIATE)
                 assert enhanced_coordinator.current_phase == Phase.DIFFERENTIATE
                 mock_collect_metrics.assert_called_once()
-                mock_store.assert_called_with(mock_collect_metrics.return_value, MemoryType.EPISODIC, Phase.DIFFERENTIATE.value, {'cycle_id': enhanced_coordinator.cycle_id, 'type': 'PHASE_METRICS'})
+                mock_store.assert_called_with(
+                    mock_collect_metrics.return_value,
+                    MemoryType.EPISODIC,
+                    Phase.DIFFERENTIATE.value,
+                    {
+                        "cycle_id": enhanced_coordinator.cycle_id,
+                        "type": "PHASE_METRICS",
+                    },
+                )
 
     @pytest.mark.medium
     def test_enhanced_decide_next_phase_has_expected(self, enhanced_coordinator):
         """Test the enhanced decision-making for the next phase.
 
-ReqID: N/A"""
-        task = {'name': 'Test Task', 'description': 'This is a test task', 'requirements': ['req1', 'req2']}
+        ReqID: N/A"""
+        task = {
+            "name": "Test Task",
+            "description": "This is a test task",
+            "requirements": ["req1", "req2"],
+        }
         enhanced_coordinator.start_cycle(task)
         enhanced_coordinator.auto_phase_transitions = True
         enhanced_coordinator.quality_based_transitions = True
-        enhanced_coordinator.phase_metrics.end_phase(Phase.EXPAND, {'duration': 10.5, 'quality': 0.85, 'completeness': 0.8, 'consistency': 0.75})
-        with patch.object(enhanced_coordinator.phase_metrics, 'should_transition') as mock_should_transition:
-            mock_should_transition.return_value = (True, {'reason': 'High quality metrics'})
+        enhanced_coordinator.phase_metrics.end_phase(
+            Phase.EXPAND,
+            {
+                "duration": 10.5,
+                "quality": 0.85,
+                "completeness": 0.8,
+                "consistency": 0.75,
+            },
+        )
+        with patch.object(
+            enhanced_coordinator.phase_metrics, "should_transition"
+        ) as mock_should_transition:
+            mock_should_transition.return_value = (
+                True,
+                {"reason": "High quality metrics"},
+            )
             next_phase = enhanced_coordinator._enhanced_decide_next_phase()
             assert next_phase == Phase.DIFFERENTIATE
-            mock_should_transition.return_value = (False, {'reason': 'Low quality metrics'})
-            enhanced_coordinator.results[Phase.EXPAND.name] = {'phase_complete': True}
+            mock_should_transition.return_value = (
+                False,
+                {"reason": "Low quality metrics"},
+            )
+            enhanced_coordinator.results[Phase.EXPAND.name] = {"phase_complete": True}
             next_phase = enhanced_coordinator._enhanced_decide_next_phase()
             assert next_phase == Phase.DIFFERENTIATE
-            enhanced_coordinator.results[Phase.EXPAND.name] = {'phase_complete': False}
+            enhanced_coordinator.results[Phase.EXPAND.name] = {"phase_complete": False}
             next_phase = enhanced_coordinator._enhanced_decide_next_phase()
             assert next_phase is None
 
@@ -145,18 +271,26 @@ ReqID: N/A"""
     def test_enhanced_maybe_auto_progress_succeeds(self, enhanced_coordinator):
         """Test the enhanced auto-progression.
 
-ReqID: N/A"""
-        task = {'name': 'Test Task', 'description': 'This is a test task', 'requirements': ['req1', 'req2']}
+        ReqID: N/A"""
+        task = {
+            "name": "Test Task",
+            "description": "This is a test task",
+            "requirements": ["req1", "req2"],
+        }
         enhanced_coordinator.start_cycle(task)
         enhanced_coordinator.auto_phase_transitions = True
-        with patch.object(enhanced_coordinator, '_enhanced_decide_next_phase') as mock_decide:
+        with patch.object(
+            enhanced_coordinator, "_enhanced_decide_next_phase"
+        ) as mock_decide:
             mock_decide.side_effect = [Phase.DIFFERENTIATE, None]
-            with patch.object(EDRRCoordinator, 'progress_to_phase') as mock_progress:
+            with patch.object(EDRRCoordinator, "progress_to_phase") as mock_progress:
                 enhanced_coordinator._enhanced_maybe_auto_progress()
                 assert mock_decide.call_count == 2
                 mock_progress.assert_called_once_with(Phase.DIFFERENTIATE)
         enhanced_coordinator.auto_phase_transitions = False
-        with patch.object(enhanced_coordinator, '_enhanced_decide_next_phase') as mock_decide:
+        with patch.object(
+            enhanced_coordinator, "_enhanced_decide_next_phase"
+        ) as mock_decide:
             enhanced_coordinator._enhanced_maybe_auto_progress()
             mock_decide.assert_not_called()
 
@@ -164,12 +298,19 @@ ReqID: N/A"""
     def test_calculate_quality_score_succeeds(self, enhanced_coordinator):
         """Test the quality score calculation.
 
-ReqID: N/A"""
-        result = {'result': 'Task executed successfully', 'artifacts': ['artifact1', 'artifact2'], 'metrics': {'time_taken': 10.5, 'quality': 0.85, 'complexity': 5}}
+        ReqID: N/A"""
+        result = {
+            "result": "Task executed successfully",
+            "artifacts": ["artifact1", "artifact2"],
+            "metrics": {"time_taken": 10.5, "quality": 0.85, "complexity": 5},
+        }
         score = enhanced_coordinator._calculate_quality_score(result)
         assert isinstance(score, float)
         assert 0 <= score <= 1
-        result_no_metrics = {'result': 'Task executed successfully', 'artifacts': ['artifact1', 'artifact2']}
+        result_no_metrics = {
+            "result": "Task executed successfully",
+            "artifacts": ["artifact1", "artifact2"],
+        }
         score = enhanced_coordinator._calculate_quality_score(result_no_metrics)
         assert isinstance(score, float)
         assert 0 <= score <= 1
@@ -178,14 +319,32 @@ ReqID: N/A"""
     def test_get_phase_metrics_has_expected(self, enhanced_coordinator):
         """Test getting metrics for a specific phase.
 
-ReqID: N/A"""
-        task = {'name': 'Test Task', 'description': 'This is a test task', 'requirements': ['req1', 'req2']}
+        ReqID: N/A"""
+        task = {
+            "name": "Test Task",
+            "description": "This is a test task",
+            "requirements": ["req1", "req2"],
+        }
         enhanced_coordinator.start_cycle(task)
-        expand_metrics = {'duration': 10.5, 'quality': 0.85, 'completeness': 0.8, 'consistency': 0.75}
-        differentiate_metrics = {'duration': 15.2, 'quality': 0.9, 'completeness': 0.85, 'consistency': 0.8}
+        expand_metrics = {
+            "duration": 10.5,
+            "quality": 0.85,
+            "completeness": 0.8,
+            "consistency": 0.75,
+        }
+        differentiate_metrics = {
+            "duration": 15.2,
+            "quality": 0.9,
+            "completeness": 0.85,
+            "consistency": 0.8,
+        }
         enhanced_coordinator.phase_metrics.end_phase(Phase.EXPAND, expand_metrics)
-        enhanced_coordinator.phase_metrics.end_phase(Phase.DIFFERENTIATE, differentiate_metrics)
-        with patch.object(enhanced_coordinator.phase_metrics, 'get_phase_metrics') as mock_get_metrics:
+        enhanced_coordinator.phase_metrics.end_phase(
+            Phase.DIFFERENTIATE, differentiate_metrics
+        )
+        with patch.object(
+            enhanced_coordinator.phase_metrics, "get_phase_metrics"
+        ) as mock_get_metrics:
             mock_get_metrics.return_value = expand_metrics
             metrics = enhanced_coordinator.get_phase_metrics(Phase.EXPAND)
             mock_get_metrics.assert_called_once_with(Phase.EXPAND)
@@ -206,11 +365,30 @@ ReqID: N/A"""
     def test_get_all_metrics_has_expected(self, enhanced_coordinator):
         """Test getting all phase metrics.
 
-ReqID: N/A"""
-        task = {'name': 'Test Task', 'description': 'This is a test task', 'requirements': ['req1', 'req2']}
+        ReqID: N/A"""
+        task = {
+            "name": "Test Task",
+            "description": "This is a test task",
+            "requirements": ["req1", "req2"],
+        }
         enhanced_coordinator.start_cycle(task)
-        expected_metrics = {Phase.EXPAND.name: {'duration': 10.5, 'quality': 0.85, 'completeness': 0.8, 'consistency': 0.75}, Phase.DIFFERENTIATE.name: {'duration': 15.2, 'quality': 0.9, 'completeness': 0.85, 'consistency': 0.8}}
-        with patch.object(enhanced_coordinator.phase_metrics, 'get_all_metrics') as mock_get_all_metrics:
+        expected_metrics = {
+            Phase.EXPAND.name: {
+                "duration": 10.5,
+                "quality": 0.85,
+                "completeness": 0.8,
+                "consistency": 0.75,
+            },
+            Phase.DIFFERENTIATE.name: {
+                "duration": 15.2,
+                "quality": 0.9,
+                "completeness": 0.85,
+                "consistency": 0.8,
+            },
+        }
+        with patch.object(
+            enhanced_coordinator.phase_metrics, "get_all_metrics"
+        ) as mock_get_all_metrics:
             mock_get_all_metrics.return_value = expected_metrics
             all_metrics = enhanced_coordinator.get_all_metrics()
             mock_get_all_metrics.assert_called_once()
@@ -220,37 +398,104 @@ ReqID: N/A"""
     def test_get_metrics_history_has_expected(self, enhanced_coordinator):
         """Test getting metrics history from the PhaseTransitionMetrics.
 
-ReqID: N/A"""
-        task = {'name': 'Test Task', 'description': 'This is a test task', 'requirements': ['req1', 'req2']}
+        ReqID: N/A"""
+        task = {
+            "name": "Test Task",
+            "description": "This is a test task",
+            "requirements": ["req1", "req2"],
+        }
         enhanced_coordinator.start_cycle(task)
-        expected_history = [{'timestamp': datetime.now().isoformat(), 'phase': Phase.EXPAND.name, 'action': 'start', 'metrics': {}}, {'timestamp': datetime.now().isoformat(), 'phase': Phase.EXPAND.name, 'action': 'end', 'metrics': {'duration': 10.5, 'quality': 0.85, 'completeness': 0.8, 'consistency': 0.75}}, {'timestamp': datetime.now().isoformat(), 'phase': Phase.DIFFERENTIATE.name, 'action': 'start', 'metrics': {}}, {'timestamp': datetime.now().isoformat(), 'phase': Phase.DIFFERENTIATE.name, 'action': 'end', 'metrics': {'duration': 15.2, 'quality': 0.9, 'completeness': 0.85, 'consistency': 0.8}}]
-        with patch.object(enhanced_coordinator.phase_metrics, 'get_history') as mock_get_history:
+        expected_history = [
+            {
+                "timestamp": datetime.now().isoformat(),
+                "phase": Phase.EXPAND.name,
+                "action": "start",
+                "metrics": {},
+            },
+            {
+                "timestamp": datetime.now().isoformat(),
+                "phase": Phase.EXPAND.name,
+                "action": "end",
+                "metrics": {
+                    "duration": 10.5,
+                    "quality": 0.85,
+                    "completeness": 0.8,
+                    "consistency": 0.75,
+                },
+            },
+            {
+                "timestamp": datetime.now().isoformat(),
+                "phase": Phase.DIFFERENTIATE.name,
+                "action": "start",
+                "metrics": {},
+            },
+            {
+                "timestamp": datetime.now().isoformat(),
+                "phase": Phase.DIFFERENTIATE.name,
+                "action": "end",
+                "metrics": {
+                    "duration": 15.2,
+                    "quality": 0.9,
+                    "completeness": 0.85,
+                    "consistency": 0.8,
+                },
+            },
+        ]
+        with patch.object(
+            enhanced_coordinator.phase_metrics, "get_history"
+        ) as mock_get_history:
             mock_get_history.return_value = expected_history
             history = enhanced_coordinator.get_metrics_history()
             mock_get_history.assert_called_once()
             assert history == expected_history
             assert isinstance(history, list)
             assert len(history) == 4
-            assert 'timestamp' in history[0]
-            assert 'phase' in history[0]
-            assert 'action' in history[0]
-            assert 'metrics' in history[0]
+            assert "timestamp" in history[0]
+            assert "phase" in history[0]
+            assert "action" in history[0]
+            assert "metrics" in history[0]
 
     @pytest.mark.medium
     def test_create_micro_cycle_succeeds(self, enhanced_coordinator):
         """Test creating a micro-cycle with enhanced features.
 
-ReqID: N/A"""
-        task = {'name': 'Test Task', 'description': 'This is a test task', 'requirements': ['req1', 'req2']}
+        ReqID: N/A"""
+        task = {
+            "name": "Test Task",
+            "description": "This is a test task",
+            "requirements": ["req1", "req2"],
+        }
         enhanced_coordinator.start_cycle(task)
         enhanced_coordinator.current_phase = Phase.DIFFERENTIATE
-        micro_task = {'name': 'Micro Task', 'description': 'This is a micro task', 'requirements': ['micro_req1']}
-        with patch.object(enhanced_coordinator, 'should_terminate_recursion', return_value=(False, '')) as mock_should_terminate:
-            with patch('devsynth.application.edrr.edrr_coordinator_enhanced.EnhancedEDRRCoordinator') as mock_constructor:
+        micro_task = {
+            "name": "Micro Task",
+            "description": "This is a micro task",
+            "requirements": ["micro_req1"],
+        }
+        with patch.object(
+            enhanced_coordinator, "should_terminate_recursion", return_value=(False, "")
+        ) as mock_should_terminate:
+            with patch(
+                "devsynth.application.edrr.edrr_coordinator_enhanced.EnhancedEDRRCoordinator"
+            ) as mock_constructor:
                 mock_micro_coordinator = MagicMock()
                 mock_constructor.return_value = mock_micro_coordinator
-                result = enhanced_coordinator.create_micro_cycle(micro_task, Phase.DIFFERENTIATE)
+                result = enhanced_coordinator.create_micro_cycle(
+                    micro_task, Phase.DIFFERENTIATE
+                )
                 mock_should_terminate.assert_called_once_with(micro_task)
-                mock_constructor.assert_called_once_with(memory_manager=enhanced_coordinator.memory_manager, wsde_team=enhanced_coordinator.wsde_team, code_analyzer=enhanced_coordinator.code_analyzer, ast_transformer=enhanced_coordinator.ast_transformer, prompt_manager=enhanced_coordinator.prompt_manager, documentation_manager=enhanced_coordinator.documentation_manager, enable_enhanced_logging=enhanced_coordinator._enable_enhanced_logging, parent_cycle_id=enhanced_coordinator.cycle_id, recursion_depth=enhanced_coordinator.recursion_depth + 1, parent_phase=Phase.DIFFERENTIATE, config=enhanced_coordinator.config)
+                mock_constructor.assert_called_once_with(
+                    memory_manager=enhanced_coordinator.memory_manager,
+                    wsde_team=enhanced_coordinator.wsde_team,
+                    code_analyzer=enhanced_coordinator.code_analyzer,
+                    ast_transformer=enhanced_coordinator.ast_transformer,
+                    prompt_manager=enhanced_coordinator.prompt_manager,
+                    documentation_manager=enhanced_coordinator.documentation_manager,
+                    enable_enhanced_logging=enhanced_coordinator._enable_enhanced_logging,
+                    parent_cycle_id=enhanced_coordinator.cycle_id,
+                    recursion_depth=enhanced_coordinator.recursion_depth + 1,
+                    parent_phase=Phase.DIFFERENTIATE,
+                    config=enhanced_coordinator.config,
+                )
                 mock_micro_coordinator.start_cycle.assert_called_once_with(micro_task)
                 assert result == mock_micro_coordinator

--- a/tests/unit/application/edrr/test_enhanced_recursion_termination.py
+++ b/tests/unit/application/edrr/test_enhanced_recursion_termination.py
@@ -7,24 +7,36 @@ This module tests additional termination conditions for the should_terminate_rec
 3. Memory usage
 4. More robust historical effectiveness
 """
-import pytest
-from unittest.mock import MagicMock, patch
+
 from datetime import datetime, timedelta
-from devsynth.application.edrr.coordinator import EDRRCoordinator
-from devsynth.methodology.base import Phase
-from devsynth.application.memory.memory_manager import MemoryManager
-from devsynth.domain.models.wsde import WSDETeam
+from unittest.mock import MagicMock, patch
+
+import pytest
+
 from devsynth.application.code_analysis.analyzer import CodeAnalyzer
 from devsynth.application.code_analysis.ast_transformer import AstTransformer
+from devsynth.application.documentation.documentation_manager import (
+    DocumentationManager,
+)
+from devsynth.application.edrr.coordinator import EDRRCoordinator
+from devsynth.application.memory.memory_manager import MemoryManager
 from devsynth.application.prompts.prompt_manager import PromptManager
-from devsynth.application.documentation.documentation_manager import DocumentationManager
+from devsynth.domain.models.wsde_facade import WSDETeam
+from devsynth.methodology.base import Phase
+
 
 @pytest.fixture
 def memory_manager():
     """Create a mock memory manager with historical patterns."""
     mock = MagicMock(spec=MemoryManager)
-    mock.retrieve_historical_patterns.return_value = [{'task_type': 'refactoring', 'recursion_effectiveness': 0.2}, {'task_type': 'test', 'recursion_effectiveness': 0.3}, {'task_type': 'testing', 'recursion_effectiveness': 0.8}, {'task_type': 'documentation', 'recursion_effectiveness': 0.6}]
+    mock.retrieve_historical_patterns.return_value = [
+        {"task_type": "refactoring", "recursion_effectiveness": 0.2},
+        {"task_type": "test", "recursion_effectiveness": 0.3},
+        {"task_type": "testing", "recursion_effectiveness": 0.8},
+        {"task_type": "documentation", "recursion_effectiveness": 0.6},
+    ]
     return mock
+
 
 @pytest.fixture
 def coordinator(memory_manager):
@@ -34,75 +46,124 @@ def coordinator(memory_manager):
     ast_transformer = MagicMock(spec=AstTransformer)
     prompt_manager = MagicMock(spec=PromptManager)
     documentation_manager = MagicMock(spec=DocumentationManager)
-    return EDRRCoordinator(memory_manager=memory_manager, wsde_team=wsde_team, code_analyzer=code_analyzer, ast_transformer=ast_transformer, prompt_manager=prompt_manager, documentation_manager=documentation_manager, enable_enhanced_logging=True)
+    return EDRRCoordinator(
+        memory_manager=memory_manager,
+        wsde_team=wsde_team,
+        code_analyzer=code_analyzer,
+        ast_transformer=ast_transformer,
+        prompt_manager=prompt_manager,
+        documentation_manager=documentation_manager,
+        enable_enhanced_logging=True,
+    )
+
 
 @pytest.mark.medium
 def test_should_terminate_recursion_max_depth_succeeds(coordinator):
     """Test that recursion terminates when maximum depth is reached.
 
-ReqID: N/A"""
+    ReqID: N/A"""
     coordinator.recursion_depth = coordinator.max_recursion_depth
-    task = {'description': 'Task at max depth', 'granularity_score': 0.8, 'cost_score': 0.2, 'benefit_score': 0.9}
+    task = {
+        "description": "Task at max depth",
+        "granularity_score": 0.8,
+        "cost_score": 0.2,
+        "benefit_score": 0.9,
+    }
     should_terminate, reason = coordinator.should_terminate_recursion(task)
     assert should_terminate is True
-    assert 'max_depth' in reason
+    assert "max_depth" in reason
+
 
 @pytest.mark.medium
 def test_should_terminate_recursion_time_based_succeeds(coordinator):
     """Test that recursion terminates based on elapsed time.
 
-ReqID: N/A"""
-    coordinator.start_cycle({'description': 'Test Task'})
-    max_duration = coordinator.config.get('edrr', {}).get('recursion', {}).get('max_duration', 3600)
-    coordinator._cycle_start_time = datetime.now() - timedelta(seconds=max_duration + 60)
-    task = {'description': 'Long-running task', 'granularity_score': 0.8, 'cost_score': 0.2, 'benefit_score': 0.9}
+    ReqID: N/A"""
+    coordinator.start_cycle({"description": "Test Task"})
+    max_duration = (
+        coordinator.config.get("edrr", {})
+        .get("recursion", {})
+        .get("max_duration", 3600)
+    )
+    coordinator._cycle_start_time = datetime.now() - timedelta(
+        seconds=max_duration + 60
+    )
+    task = {
+        "description": "Long-running task",
+        "granularity_score": 0.8,
+        "cost_score": 0.2,
+        "benefit_score": 0.9,
+    }
     should_terminate, reason = coordinator.should_terminate_recursion(task)
     assert should_terminate is True
-    assert 'time_limit' in reason
+    assert "time_limit" in reason
+
 
 @pytest.mark.medium
 def test_should_terminate_recursion_memory_usage_succeeds(coordinator):
     """Test that recursion terminates based on memory usage.
 
-ReqID: N/A"""
-    coordinator.start_cycle({'description': 'Test Task'})
-    task = {'description': 'Memory-intensive task', 'memory_usage': 0.95}
+    ReqID: N/A"""
+    coordinator.start_cycle({"description": "Test Task"})
+    task = {"description": "Memory-intensive task", "memory_usage": 0.95}
     should_terminate, reason = coordinator.should_terminate_recursion(task)
     assert should_terminate is True
-    assert 'memory_limit' in reason
+    assert "memory_limit" in reason
+
 
 @pytest.mark.medium
 def test_should_terminate_recursion_historical_effectiveness_succeeds(coordinator):
     """Test that recursion terminates based on historical effectiveness.
 
-ReqID: N/A"""
-    coordinator.start_cycle({'description': 'Test Task'})
-    task = {'description': 'Test task', 'type': 'test'}
+    ReqID: N/A"""
+    coordinator.start_cycle({"description": "Test Task"})
+    task = {"description": "Test task", "type": "test"}
     should_terminate, reason = coordinator.should_terminate_recursion(task)
     assert should_terminate is True
-    assert 'historical' in reason
+    assert "historical" in reason
+
 
 @pytest.mark.medium
 def test_should_not_terminate_recursion_historical_effectiveness_succeeds(coordinator):
     """Test that recursion continues for historically effective task types.
 
-ReqID: N/A"""
-    coordinator.start_cycle({'description': 'Test Task'})
-    task = {'description': 'Testing task', 'type': 'testing'}
+    ReqID: N/A"""
+    coordinator.start_cycle({"description": "Test Task"})
+    task = {"description": "Testing task", "type": "testing"}
     should_terminate, reason = coordinator.should_terminate_recursion(task)
     assert should_terminate is False
     assert reason is None
+
 
 @pytest.mark.medium
 def test_should_terminate_recursion_combined_new_factors_succeeds(coordinator):
     """Test that recursion terminates when multiple new factors are present.
 
-ReqID: N/A"""
+    ReqID: N/A"""
     coordinator.recursion_depth = coordinator.max_recursion_depth - 1
-    coordinator.start_cycle({'description': 'Test Task'})
-    max_duration = coordinator.config.get('edrr', {}).get('recursion', {}).get('max_duration', 3600)
-    coordinator._cycle_start_time = datetime.now() - timedelta(seconds=max_duration - 60)
-    task = {'description': 'Complex task', 'memory_usage': 0.85, 'type': 'documentation', 'granularity_score': 0.15, 'quality_score': 0.8, 'resource_usage': 0.7}
+    coordinator.start_cycle({"description": "Test Task"})
+    max_duration = (
+        coordinator.config.get("edrr", {})
+        .get("recursion", {})
+        .get("max_duration", 3600)
+    )
+    coordinator._cycle_start_time = datetime.now() - timedelta(
+        seconds=max_duration - 60
+    )
+    task = {
+        "description": "Complex task",
+        "memory_usage": 0.85,
+        "type": "documentation",
+        "granularity_score": 0.15,
+        "quality_score": 0.8,
+        "resource_usage": 0.7,
+    }
     should_terminate, reason = coordinator.should_terminate_recursion(task)
     assert should_terminate is True
-    assert reason in ['granularity threshold', 'memory usage limit', 'approaching memory limit', 'approaching maximum recursion depth', 'approaching time limit']
+    assert reason in [
+        "granularity threshold",
+        "memory usage limit",
+        "approaching memory limit",
+        "approaching maximum recursion depth",
+        "approaching time limit",
+    ]

--- a/tests/unit/application/edrr/test_execute_single_agent_task.py
+++ b/tests/unit/application/edrr/test_execute_single_agent_task.py
@@ -1,32 +1,52 @@
-import pytest
 from unittest.mock import MagicMock, patch
-from devsynth.application.edrr.edrr_coordinator_enhanced import EnhancedEDRRCoordinator
-from devsynth.methodology.base import Phase
-from devsynth.application.memory.memory_manager import MemoryManager
-from devsynth.domain.models.wsde import WSDETeam
+
+import pytest
+
 from devsynth.application.code_analysis.analyzer import CodeAnalyzer
 from devsynth.application.code_analysis.ast_transformer import AstTransformer
+from devsynth.application.documentation.documentation_manager import (
+    DocumentationManager,
+)
+from devsynth.application.edrr.edrr_coordinator_enhanced import EnhancedEDRRCoordinator
+from devsynth.application.memory.memory_manager import MemoryManager
 from devsynth.application.prompts.prompt_manager import PromptManager
-from devsynth.application.documentation.documentation_manager import DocumentationManager
 from devsynth.domain.models.memory import MemoryType
+from devsynth.domain.models.wsde_facade import WSDETeam
+from devsynth.methodology.base import Phase
+
 
 @pytest.fixture
 def coordinator():
-    wsde_team = WSDETeam(name='team')
+    wsde_team = WSDETeam(name="team")
     agent = MagicMock()
-    agent.process.return_value = {'result': 'ok'}
+    agent.process.return_value = {"result": "ok"}
     wsde_team.add_agent(agent)
     wsde_team.get_agent = MagicMock(return_value=agent)
     mm = MagicMock(spec=MemoryManager)
-    mm.store_with_edrr_phase.return_value = 'memid'
-    return EnhancedEDRRCoordinator(memory_manager=mm, wsde_team=wsde_team, code_analyzer=MagicMock(spec=CodeAnalyzer), ast_transformer=MagicMock(spec=AstTransformer), prompt_manager=MagicMock(spec=PromptManager), documentation_manager=MagicMock(spec=DocumentationManager))
+    mm.store_with_edrr_phase.return_value = "memid"
+    return EnhancedEDRRCoordinator(
+        memory_manager=mm,
+        wsde_team=wsde_team,
+        code_analyzer=MagicMock(spec=CodeAnalyzer),
+        ast_transformer=MagicMock(spec=AstTransformer),
+        prompt_manager=MagicMock(spec=PromptManager),
+        documentation_manager=MagicMock(spec=DocumentationManager),
+    )
+
 
 @pytest.mark.medium
 def test_execute_single_agent_task_stores_result_and_calls_agent(coordinator):
-    with patch.object(coordinator, '_get_llm_response', return_value='done') as mock_llm:
-        result = coordinator.execute_single_agent_task(task={'foo': 'bar'}, agent_name='agent', phase=Phase.ANALYSIS, llm_prompt='hi')
+    with patch.object(
+        coordinator, "_get_llm_response", return_value="done"
+    ) as mock_llm:
+        result = coordinator.execute_single_agent_task(
+            task={"foo": "bar"},
+            agent_name="agent",
+            phase=Phase.ANALYSIS,
+            llm_prompt="hi",
+        )
     mock_llm.assert_called_once()
-    coordinator.wsde_team.get_agent.assert_called_once_with('agent')
+    coordinator.wsde_team.get_agent.assert_called_once_with("agent")
     coordinator.memory_manager.store_with_edrr_phase.assert_called()
-    assert result['result'] == 'ok'
-    assert 'quality_score' in result
+    assert result["result"] == "ok"
+    assert "quality_score" in result

--- a/tests/unit/application/edrr/test_micro_cycle.py
+++ b/tests/unit/application/edrr/test_micro_cycle.py
@@ -1,59 +1,74 @@
 import json
 import os
-import tempfile
 import shutil
-import pytest
-from typing import Generator, Dict, Any
+import tempfile
+from typing import Any, Dict, Generator
 from unittest.mock import MagicMock, patch
-from devsynth.application.edrr.coordinator import EDRRCoordinator, EDRRCoordinatorError
-from devsynth.application.memory.memory_manager import MemoryManager
+
+import pytest
+
 from devsynth.application.code_analysis.analyzer import CodeAnalyzer
 from devsynth.application.code_analysis.ast_transformer import AstTransformer
+from devsynth.application.documentation.documentation_manager import (
+    DocumentationManager,
+)
+from devsynth.application.edrr.coordinator import EDRRCoordinator, EDRRCoordinatorError
+from devsynth.application.memory.memory_manager import MemoryManager
 from devsynth.application.prompts.prompt_manager import PromptManager
-from devsynth.application.documentation.documentation_manager import DocumentationManager
-from devsynth.domain.models.wsde import WSDETeam
+from devsynth.domain.models.wsde_facade import WSDETeam
 from devsynth.methodology.base import Phase
+
 
 @pytest.fixture
 def temp_dir() -> Generator[str, None, None]:
     """Create a temporary directory for test resources.
-    
+
     This fixture uses a generator pattern to provide teardown functionality.
     """
     # Setup: Create a temporary directory
     temp_dir = tempfile.mkdtemp()
-    
+
     # Yield the directory path to the test
     yield temp_dir
-    
+
     # Teardown: Remove the temporary directory and all its contents
     if os.path.exists(temp_dir):
         shutil.rmtree(temp_dir)
 
+
 @pytest.fixture
 def memory_manager() -> Generator[MagicMock, None, None]:
     """Return a mock memory manager that stores items in a dict.
-    
+
     This fixture uses a generator pattern to provide teardown functionality.
     """
     # Setup: Create the mock
     mock = MagicMock(spec=MemoryManager)
     mock.stored_items = {}
-    mock.store_with_edrr_phase.side_effect = lambda item, item_type, phase, metadata: mock.stored_items.update({item_type: {'item': item, 'phase': phase, 'metadata': metadata}})
-    mock.retrieve_with_edrr_phase.side_effect = lambda item_type, phase, metadata: mock.stored_items.get(item_type, {}).get('item', {})
+    mock.store_with_edrr_phase.side_effect = (
+        lambda item, item_type, phase, metadata: mock.stored_items.update(
+            {item_type: {"item": item, "phase": phase, "metadata": metadata}}
+        )
+    )
+    mock.retrieve_with_edrr_phase.side_effect = (
+        lambda item_type, phase, metadata: mock.stored_items.get(item_type, {}).get(
+            "item", {}
+        )
+    )
     mock.retrieve_historical_patterns.return_value = []
     mock.retrieve_relevant_knowledge.return_value = []
-    
+
     # Yield the mock to the test
     yield mock
-    
+
     # Teardown: Clear stored items to prevent state leakage between tests
     mock.stored_items.clear()
+
 
 @pytest.fixture
 def wsde_team() -> Generator[MagicMock, None, None]:
     """Return a mock WSDE team.
-    
+
     This fixture uses a generator pattern to provide teardown functionality.
     """
     # Setup: Create the mock
@@ -72,183 +87,212 @@ def wsde_team() -> Generator[MagicMock, None, None]:
     mock.recognize_patterns.return_value = []
     mock.integrate_knowledge.return_value = {}
     mock.generate_improvement_suggestions.return_value = []
-    
+
     # Yield the mock to the test
     yield mock
-    
+
     # Teardown: Reset the mock to prevent state leakage between tests
     mock.reset_mock()
+
 
 @pytest.fixture
 def code_analyzer() -> Generator[MagicMock, None, None]:
     """Return a mock code analyzer.
-    
+
     This fixture uses a generator pattern to provide teardown functionality.
     """
     # Setup: Create the mock
     mock = MagicMock(spec=CodeAnalyzer)
     mock.analyze_project_structure.return_value = {}
-    
+
     # Yield the mock to the test
     yield mock
-    
+
     # Teardown: Reset the mock to prevent state leakage between tests
     mock.reset_mock()
+
 
 @pytest.fixture
 def ast_transformer() -> Generator[MagicMock, None, None]:
     """Return a mock AST transformer.
-    
+
     This fixture uses a generator pattern to provide teardown functionality.
     """
     # Setup: Create the mock
     mock = MagicMock(spec=AstTransformer)
-    
+
     # Yield the mock to the test
     yield mock
-    
+
     # Teardown: Reset the mock to prevent state leakage between tests
     mock.reset_mock()
+
 
 @pytest.fixture
 def prompt_manager() -> Generator[MagicMock, None, None]:
     """Return a mock prompt manager.
-    
+
     This fixture uses a generator pattern to provide teardown functionality.
     """
     # Setup: Create the mock
     mock = MagicMock(spec=PromptManager)
-    
+
     # Yield the mock to the test
     yield mock
-    
+
     # Teardown: Reset the mock to prevent state leakage between tests
     mock.reset_mock()
+
 
 @pytest.fixture
 def documentation_manager() -> Generator[MagicMock, None, None]:
     """Return a mock documentation manager.
-    
+
     This fixture uses a generator pattern to provide teardown functionality.
     """
     # Setup: Create the mock
     mock = MagicMock(spec=DocumentationManager)
-    
+
     # Yield the mock to the test
     yield mock
-    
+
     # Teardown: Reset the mock to prevent state leakage between tests
     mock.reset_mock()
 
+
 @pytest.fixture
-def coordinator(temp_dir, memory_manager, wsde_team, code_analyzer, ast_transformer, prompt_manager, documentation_manager) -> Generator[EDRRCoordinator, None, None]:
+def coordinator(
+    temp_dir,
+    memory_manager,
+    wsde_team,
+    code_analyzer,
+    ast_transformer,
+    prompt_manager,
+    documentation_manager,
+) -> Generator[EDRRCoordinator, None, None]:
     """Return an EDRR coordinator with mock dependencies.
-    
+
     This fixture uses a generator pattern to provide teardown functionality.
     It also uses the temp_dir fixture to ensure any files created by the coordinator
     are isolated and cleaned up after the test.
     """
     # Setup: Create the coordinator
     coordinator = EDRRCoordinator(
-        memory_manager=memory_manager, 
-        wsde_team=wsde_team, 
-        code_analyzer=code_analyzer, 
-        ast_transformer=ast_transformer, 
-        prompt_manager=prompt_manager, 
-        documentation_manager=documentation_manager, 
+        memory_manager=memory_manager,
+        wsde_team=wsde_team,
+        code_analyzer=code_analyzer,
+        ast_transformer=ast_transformer,
+        prompt_manager=prompt_manager,
+        documentation_manager=documentation_manager,
         enable_enhanced_logging=True,
-        workspace_dir=temp_dir  # Use temporary directory for workspace
+        workspace_dir=temp_dir,  # Use temporary directory for workspace
     )
-    
+
     # Yield the coordinator to the test
     yield coordinator
-    
+
     # Teardown: Clean up any resources created by the coordinator
-    if hasattr(coordinator, 'cleanup') and callable(coordinator.cleanup):
+    if hasattr(coordinator, "cleanup") and callable(coordinator.cleanup):
         coordinator.cleanup()
-    
+
     # Reset the coordinator's state to prevent leakage between tests
     coordinator.child_cycles = {}
-    if hasattr(coordinator, 'results'):
+    if hasattr(coordinator, "results"):
         coordinator.results.clear()
+
 
 @pytest.mark.medium
 def test_recursion_depth_exceeded_succeeds(coordinator):
     """Test that recursion depth exceeded succeeds.
 
-ReqID: N/A"""
-    coordinator.start_cycle({'description': 'root'})
+    ReqID: N/A"""
+    coordinator.start_cycle({"description": "root"})
     current = coordinator
     for i in range(coordinator.max_recursion_depth):
-        current = current.create_micro_cycle({'description': f'level {i}'}, Phase.EXPAND)
+        current = current.create_micro_cycle(
+            {"description": f"level {i}"}, Phase.EXPAND
+        )
     with pytest.raises(EDRRCoordinatorError):
-        current.create_micro_cycle({'description': 'too deep'}, Phase.EXPAND)
+        current.create_micro_cycle({"description": "too deep"}, Phase.EXPAND)
+
 
 @pytest.mark.medium
 def test_recursion_depth_increments_succeeds(coordinator):
     """Micro cycles should increment recursion depth until the limit.
 
-ReqID: N/A"""
+    ReqID: N/A"""
     coordinator.auto_phase_transitions = False
-    coordinator.start_cycle({'description': 'root'})
-    micro1 = coordinator.create_micro_cycle({'description': 'level1'}, Phase.EXPAND)
+    coordinator.start_cycle({"description": "root"})
+    micro1 = coordinator.create_micro_cycle({"description": "level1"}, Phase.EXPAND)
     assert micro1.recursion_depth == 1
-    micro2 = micro1.create_micro_cycle({'description': 'level2'}, Phase.EXPAND)
+    micro2 = micro1.create_micro_cycle({"description": "level2"}, Phase.EXPAND)
     assert micro2.recursion_depth == 2
-    micro3 = micro2.create_micro_cycle({'description': 'level3'}, Phase.EXPAND)
+    micro3 = micro2.create_micro_cycle({"description": "level3"}, Phase.EXPAND)
     assert micro3.recursion_depth == coordinator.max_recursion_depth
+
 
 @pytest.mark.medium
 def test_abort_when_should_terminate_succeeds(coordinator):
     """Test that abort when should terminate succeeds.
 
-ReqID: N/A"""
-    coordinator.start_cycle({'description': 'macro'})
-    with patch.object(coordinator, 'should_terminate_recursion', return_value=(True, 'test reason')):
+    ReqID: N/A"""
+    coordinator.start_cycle({"description": "macro"})
+    with patch.object(
+        coordinator, "should_terminate_recursion", return_value=(True, "test reason")
+    ):
         with pytest.raises(EDRRCoordinatorError):
-            coordinator.create_micro_cycle({'description': 'micro'}, Phase.EXPAND)
+            coordinator.create_micro_cycle({"description": "micro"}, Phase.EXPAND)
     assert not coordinator.child_cycles
+
 
 @pytest.mark.medium
 def test_store_metadata_and_results_succeeds(coordinator, memory_manager):
     """Test that store metadata and results succeeds.
 
-ReqID: N/A"""
-    coordinator.start_cycle({'description': 'macro'})
-    micro_task = {'description': 'micro'}
+    ReqID: N/A"""
+    coordinator.start_cycle({"description": "macro"})
+    micro_task = {"description": "micro"}
     micro = coordinator.create_micro_cycle(micro_task, Phase.EXPAND)
-    stored = memory_manager.stored_items.get('MICRO_CYCLE')
-    assert stored['item']['micro_cycle_id'] == micro.cycle_id
-    assert stored['item']['task'] == micro_task
-    assert stored['metadata']['cycle_id'] == coordinator.cycle_id
-    assert stored['metadata']['recursion_depth'] == 1
-    parent_results = coordinator.results[Phase.EXPAND.name]['micro_cycle_results'][micro.cycle_id]
-    assert parent_results['task'] == micro_task
+    stored = memory_manager.stored_items.get("MICRO_CYCLE")
+    assert stored["item"]["micro_cycle_id"] == micro.cycle_id
+    assert stored["item"]["task"] == micro_task
+    assert stored["metadata"]["cycle_id"] == coordinator.cycle_id
+    assert stored["metadata"]["recursion_depth"] == 1
+    parent_results = coordinator.results[Phase.EXPAND.name]["micro_cycle_results"][
+        micro.cycle_id
+    ]
+    assert parent_results["task"] == micro_task
     for key, value in micro.results.items():
         assert parent_results[key] == value
+
 
 @pytest.mark.medium
 def test_parent_aggregates_after_micro_phase_succeeds(coordinator):
     """Parent aggregated results should refresh when a micro cycle progresses.
 
-ReqID: N/A"""
-    coordinator.start_cycle({'description': 'macro'})
-    micro = coordinator.create_micro_cycle({'description': 'micro'}, Phase.EXPAND)
-    with patch.object(micro, '_execute_differentiate_phase', return_value={'done': True}):
+    ReqID: N/A"""
+    coordinator.start_cycle({"description": "macro"})
+    micro = coordinator.create_micro_cycle({"description": "micro"}, Phase.EXPAND)
+    with patch.object(
+        micro, "_execute_differentiate_phase", return_value={"done": True}
+    ):
         micro.progress_to_phase(Phase.DIFFERENTIATE)
-    aggregated = coordinator.results.get('AGGREGATED', {})
-    assert 'child_cycles' in aggregated
-    assert 'individual_cycles' in aggregated['child_cycles']
-    assert micro.cycle_id in aggregated['child_cycles']['individual_cycles']
+    aggregated = coordinator.results.get("AGGREGATED", {})
+    assert "child_cycles" in aggregated
+    assert "individual_cycles" in aggregated["child_cycles"]
+    assert micro.cycle_id in aggregated["child_cycles"]["individual_cycles"]
+
 
 @pytest.mark.medium
 def test_create_micro_cycle_from_manifest_dict_succeeds(coordinator):
     """Test that create micro cycle from manifest dict succeeds.
 
-ReqID: N/A"""
-    coordinator.start_cycle({'description': 'root'})
-    task = {'manifest': {'task': {'description': 'micro'}}}
-    with patch.object(EDRRCoordinator, 'start_cycle_from_manifest') as start_mock:
+    ReqID: N/A"""
+    coordinator.start_cycle({"description": "root"})
+    task = {"manifest": {"task": {"description": "micro"}}}
+    with patch.object(EDRRCoordinator, "start_cycle_from_manifest") as start_mock:
         micro = coordinator.create_micro_cycle(task, Phase.EXPAND)
-    start_mock.assert_called_once_with(json.dumps({'task': {'description': 'micro'}}), is_file=False)
+    start_mock.assert_called_once_with(
+        json.dumps({"task": {"description": "micro"}}), is_file=False
+    )
     assert micro.parent_cycle_id == coordinator.cycle_id

--- a/tests/unit/application/edrr/test_micro_cycle_execution.py
+++ b/tests/unit/application/edrr/test_micro_cycle_execution.py
@@ -1,46 +1,66 @@
-import pytest
 from unittest.mock import MagicMock
-from devsynth.application.edrr.coordinator import EDRRCoordinator
-from devsynth.application.memory.memory_manager import MemoryManager
+
+import pytest
+
 from devsynth.application.code_analysis.analyzer import CodeAnalyzer
 from devsynth.application.code_analysis.ast_transformer import AstTransformer
+from devsynth.application.documentation.documentation_manager import (
+    DocumentationManager,
+)
+from devsynth.application.edrr.coordinator import EDRRCoordinator
+from devsynth.application.memory.memory_manager import MemoryManager
 from devsynth.application.prompts.prompt_manager import PromptManager
-from devsynth.application.documentation.documentation_manager import DocumentationManager
-from devsynth.domain.models.wsde import WSDETeam
+from devsynth.domain.models.wsde_facade import WSDETeam
 from devsynth.methodology.base import Phase
+
 
 @pytest.fixture
 def coordinator():
     mm = MagicMock(spec=MemoryManager)
     wsde = MagicMock()
-    wsde.process.return_value = {'quality_score': 0.5}
+    wsde.process.return_value = {"quality_score": 0.5}
     ca = MagicMock(spec=CodeAnalyzer)
     ast = MagicMock(spec=AstTransformer)
     pm = MagicMock(spec=PromptManager)
     dm = MagicMock(spec=DocumentationManager)
-    coord = EDRRCoordinator(memory_manager=mm, wsde_team=wsde, code_analyzer=ca, ast_transformer=ast, prompt_manager=pm, documentation_manager=dm)
-    coord.cycle_id = 'cid'
+    coord = EDRRCoordinator(
+        memory_manager=mm,
+        wsde_team=wsde,
+        code_analyzer=ca,
+        ast_transformer=ast,
+        prompt_manager=pm,
+        documentation_manager=dm,
+    )
+    coord.cycle_id = "cid"
     return coord
+
 
 @pytest.mark.medium
 def test_execute_micro_cycle_uses_dialectical_reasoning(coordinator):
-    coordinator.wsde_team.apply_enhanced_dialectical_reasoning = MagicMock(return_value={'quality_score': 0.8})
+    coordinator.wsde_team.apply_enhanced_dialectical_reasoning = MagicMock(
+        return_value={"quality_score": 0.8}
+    )
     result = coordinator._execute_micro_cycle(Phase.EXPAND, 1)
     coordinator.wsde_team.apply_enhanced_dialectical_reasoning.assert_called_once()
-    assert result['quality_score'] == 0.8
+    assert result["quality_score"] == 0.8
+
 
 @pytest.mark.medium
 def test_execute_micro_cycle_handles_dialectical_errors(coordinator):
-    coordinator.wsde_team.apply_enhanced_dialectical_reasoning = MagicMock(side_effect=RuntimeError('dialectical failed'))
+    coordinator.wsde_team.apply_enhanced_dialectical_reasoning = MagicMock(
+        side_effect=RuntimeError("dialectical failed")
+    )
     result = coordinator._execute_micro_cycle(Phase.EXPAND, 2)
-    assert result['quality_score'] == 0.5
-    assert coordinator.performance_metrics['dialectical_failures'][0]['iteration'] == 2
+    assert result["quality_score"] == 0.5
+    assert coordinator.performance_metrics["dialectical_failures"][0]["iteration"] == 2
+
 
 @pytest.mark.medium
 def test_assess_result_quality_from_score(coordinator):
-    assert coordinator._assess_result_quality({'quality_score': '0.7'}) == 0.7
+    assert coordinator._assess_result_quality({"quality_score": "0.7"}) == 0.7
+
 
 @pytest.mark.medium
 def test_assess_result_quality_handles_error(coordinator):
-    value = coordinator._assess_result_quality({'quality_score': 'bad'})
-    assert value == pytest.approx(min(1.0, len(str({'quality_score': 'bad'})) / 1000))
+    value = coordinator._assess_result_quality({"quality_score": "bad"})
+    assert value == pytest.approx(min(1.0, len(str({"quality_score": "bad"})) / 1000))

--- a/tests/unit/application/edrr/test_micro_cycle_hooks.py
+++ b/tests/unit/application/edrr/test_micro_cycle_hooks.py
@@ -1,13 +1,18 @@
-import pytest
 from unittest.mock import MagicMock, patch
-from devsynth.application.edrr.coordinator import EDRRCoordinator
-from devsynth.application.memory.memory_manager import MemoryManager
+
+import pytest
+
 from devsynth.application.code_analysis.analyzer import CodeAnalyzer
 from devsynth.application.code_analysis.ast_transformer import AstTransformer
+from devsynth.application.documentation.documentation_manager import (
+    DocumentationManager,
+)
+from devsynth.application.edrr.coordinator import EDRRCoordinator
+from devsynth.application.memory.memory_manager import MemoryManager
 from devsynth.application.prompts.prompt_manager import PromptManager
-from devsynth.application.documentation.documentation_manager import DocumentationManager
-from devsynth.domain.models.wsde import WSDETeam
+from devsynth.domain.models.wsde_facade import WSDETeam
 from devsynth.methodology.base import Phase
+
 
 @pytest.fixture
 def coordinator():
@@ -18,21 +23,23 @@ def coordinator():
     pm = MagicMock(spec=PromptManager)
     dm = MagicMock(spec=DocumentationManager)
     coord = EDRRCoordinator(mm, team, ca, ast, pm, dm)
-    coord.cycle_id = 'cid'
+    coord.cycle_id = "cid"
     return coord
+
 
 @pytest.mark.medium
 def test_micro_cycle_hooks_invoked(coordinator):
     events = []
 
     def start(info):
-        events.append(('start', info['iteration']))
+        events.append(("start", info["iteration"]))
 
     def end(info):
-        events.append(('end', info['iteration']))
-    coordinator.register_micro_cycle_hook('start', start)
-    coordinator.register_micro_cycle_hook('end', end)
-    with patch.object(EDRRCoordinator, 'start_cycle', return_value=None):
-        coordinator.create_micro_cycle({'description': 'sub'}, Phase.EXPAND)
-    assert ('start', 0) in events
-    assert ('end', 0) in events
+        events.append(("end", info["iteration"]))
+
+    coordinator.register_micro_cycle_hook("start", start)
+    coordinator.register_micro_cycle_hook("end", end)
+    with patch.object(EDRRCoordinator, "start_cycle", return_value=None):
+        coordinator.create_micro_cycle({"description": "sub"}, Phase.EXPAND)
+    assert ("start", 0) in events
+    assert ("end", 0) in events

--- a/tests/unit/application/edrr/test_phase_progression.py
+++ b/tests/unit/application/edrr/test_phase_progression.py
@@ -1,13 +1,18 @@
+from unittest.mock import MagicMock, patch
+
 import pytest
-from unittest.mock import patch, MagicMock
-from devsynth.application.edrr.coordinator import EDRRCoordinator
-from devsynth.methodology.base import Phase
-from devsynth.application.memory.memory_manager import MemoryManager
-from devsynth.domain.models.wsde import WSDETeam
+
 from devsynth.application.code_analysis.analyzer import CodeAnalyzer
 from devsynth.application.code_analysis.ast_transformer import AstTransformer
+from devsynth.application.documentation.documentation_manager import (
+    DocumentationManager,
+)
+from devsynth.application.edrr.coordinator import EDRRCoordinator
+from devsynth.application.memory.memory_manager import MemoryManager
 from devsynth.application.prompts.prompt_manager import PromptManager
-from devsynth.application.documentation.documentation_manager import DocumentationManager
+from devsynth.domain.models.wsde_facade import WSDETeam
+from devsynth.methodology.base import Phase
+
 
 @pytest.fixture
 def coordinator():
@@ -32,47 +37,101 @@ def coordinator():
     wsde_team.integrate_knowledge.return_value = {}
     wsde_team.generate_improvement_suggestions.return_value = []
     wsde_team.get_role_map.return_value = {}
-    wsde_team.get_primus.return_value = 'primus'
+    wsde_team.get_primus.return_value = "primus"
     code_analyzer = MagicMock(spec=CodeAnalyzer)
     code_analyzer.analyze_project_structure.return_value = []
     ast_transformer = MagicMock(spec=AstTransformer)
     prompt_manager = MagicMock(spec=PromptManager)
     documentation_manager = MagicMock(spec=DocumentationManager)
-    return EDRRCoordinator(memory_manager=memory_manager, wsde_team=wsde_team, code_analyzer=code_analyzer, ast_transformer=ast_transformer, prompt_manager=prompt_manager, documentation_manager=documentation_manager)
+    return EDRRCoordinator(
+        memory_manager=memory_manager,
+        wsde_team=wsde_team,
+        code_analyzer=code_analyzer,
+        ast_transformer=ast_transformer,
+        prompt_manager=prompt_manager,
+        documentation_manager=documentation_manager,
+    )
+
 
 @pytest.mark.medium
 def test_auto_phase_progression_succeeds(coordinator):
     """Test that auto phase progression succeeds.
 
-ReqID: N/A"""
-    with patch.object(coordinator, '_execute_expand_phase', return_value={'phase_complete': True}), patch.object(coordinator, '_execute_differentiate_phase', return_value={'phase_complete': True}), patch.object(coordinator, '_execute_refine_phase', return_value={'phase_complete': True}), patch.object(coordinator, '_execute_retrospect_phase', return_value={'phase_complete': True}):
-        coordinator.start_cycle({'description': 'Task'})
+    ReqID: N/A"""
+    with (
+        patch.object(
+            coordinator, "_execute_expand_phase", return_value={"phase_complete": True}
+        ),
+        patch.object(
+            coordinator,
+            "_execute_differentiate_phase",
+            return_value={"phase_complete": True},
+        ),
+        patch.object(
+            coordinator, "_execute_refine_phase", return_value={"phase_complete": True}
+        ),
+        patch.object(
+            coordinator,
+            "_execute_retrospect_phase",
+            return_value={"phase_complete": True},
+        ),
+    ):
+        coordinator.start_cycle({"description": "Task"})
         assert coordinator.current_phase == Phase.RETROSPECT
         for phase in Phase:
             assert phase.name in coordinator.results
+
 
 @pytest.mark.medium
 def test_micro_cycle_result_aggregation_succeeds(coordinator):
     """Test that micro cycle result aggregation succeeds.
 
-ReqID: N/A"""
-    with patch.object(coordinator, '_execute_expand_phase', return_value={'phase_complete': True}):
-        coordinator.start_cycle({'description': 'Macro'})
-        micro_cycle = coordinator.create_micro_cycle({'description': 'Micro'}, Phase.EXPAND)
-        stored = coordinator.results[Phase.EXPAND.name]['micro_cycle_results'][micro_cycle.cycle_id]
-        assert stored['task'] == {'description': 'Micro'}
+    ReqID: N/A"""
+    with patch.object(
+        coordinator, "_execute_expand_phase", return_value={"phase_complete": True}
+    ):
+        coordinator.start_cycle({"description": "Macro"})
+        micro_cycle = coordinator.create_micro_cycle(
+            {"description": "Micro"}, Phase.EXPAND
+        )
+        stored = coordinator.results[Phase.EXPAND.name]["micro_cycle_results"][
+            micro_cycle.cycle_id
+        ]
+        assert stored["task"] == {"description": "Micro"}
         for key, value in micro_cycle.results.items():
             assert stored[key] == value
+
 
 @pytest.mark.medium
 def test_result_aggregation_after_full_cycle_has_expected(coordinator):
     """All phase results should be aggregated after auto progression.
 
-ReqID: N/A"""
-    with patch.object(coordinator, '_execute_expand_phase', return_value={'expand': True, 'phase_complete': True}), patch.object(coordinator, '_execute_differentiate_phase', return_value={'differentiate': True, 'phase_complete': True}), patch.object(coordinator, '_execute_refine_phase', return_value={'refine': True, 'phase_complete': True}), patch.object(coordinator, '_execute_retrospect_phase', return_value={'retrospect': True, 'phase_complete': True}):
-        coordinator.start_cycle({'description': 'Task'})
-    aggregated = coordinator.results.get('AGGREGATED', {})
-    assert aggregated['expand']['expand'] is True
-    assert aggregated['differentiate']['differentiate'] is True
-    assert aggregated['refine']['refine'] is True
-    assert aggregated['retrospect']['retrospect'] is True
+    ReqID: N/A"""
+    with (
+        patch.object(
+            coordinator,
+            "_execute_expand_phase",
+            return_value={"expand": True, "phase_complete": True},
+        ),
+        patch.object(
+            coordinator,
+            "_execute_differentiate_phase",
+            return_value={"differentiate": True, "phase_complete": True},
+        ),
+        patch.object(
+            coordinator,
+            "_execute_refine_phase",
+            return_value={"refine": True, "phase_complete": True},
+        ),
+        patch.object(
+            coordinator,
+            "_execute_retrospect_phase",
+            return_value={"retrospect": True, "phase_complete": True},
+        ),
+    ):
+        coordinator.start_cycle({"description": "Task"})
+    aggregated = coordinator.results.get("AGGREGATED", {})
+    assert aggregated["expand"]["expand"] is True
+    assert aggregated["differentiate"]["differentiate"] is True
+    assert aggregated["refine"]["refine"] is True
+    assert aggregated["retrospect"]["retrospect"] is True

--- a/tests/unit/application/edrr/test_progress_recursion.py
+++ b/tests/unit/application/edrr/test_progress_recursion.py
@@ -1,13 +1,18 @@
 from unittest.mock import MagicMock, patch
+
 import pytest
+
 from devsynth.application.code_analysis.analyzer import CodeAnalyzer
 from devsynth.application.code_analysis.ast_transformer import AstTransformer
-from devsynth.application.documentation.documentation_manager import DocumentationManager
+from devsynth.application.documentation.documentation_manager import (
+    DocumentationManager,
+)
 from devsynth.application.edrr.coordinator import EDRRCoordinator
 from devsynth.application.memory.memory_manager import MemoryManager
 from devsynth.application.prompts.prompt_manager import PromptManager
-from devsynth.domain.models.wsde import WSDETeam
+from devsynth.domain.models.wsde_facade import WSDETeam
 from devsynth.methodology.base import Phase
+
 
 @pytest.fixture
 def coordinator():
@@ -18,98 +23,158 @@ def coordinator():
     ast = MagicMock(spec=AstTransformer)
     pm = MagicMock(spec=PromptManager)
     dm = MagicMock(spec=DocumentationManager)
-    return EDRRCoordinator(memory_manager=mm, wsde_team=wsde, code_analyzer=ca, ast_transformer=ast, prompt_manager=pm, documentation_manager=dm)
+    return EDRRCoordinator(
+        memory_manager=mm,
+        wsde_team=wsde,
+        code_analyzer=ca,
+        ast_transformer=ast,
+        prompt_manager=pm,
+        documentation_manager=dm,
+    )
+
 
 @pytest.mark.medium
 def test_progress_to_phase_auto_recursion_succeeds(coordinator):
     """Test that progress to phase auto recursion succeeds.
 
-ReqID: N/A"""
-    coordinator.task = {'description': 't'}
-    coordinator.cycle_id = 'cid'
+    ReqID: N/A"""
+    coordinator.task = {"description": "t"}
+    coordinator.cycle_id = "cid"
     coordinator.auto_phase_transitions = True
     phase_iter = iter([Phase.DIFFERENTIATE, Phase.REFINE, Phase.RETROSPECT])
-    with patch.object(coordinator, '_execute_expand_phase', return_value={'phase_complete': True}) as ex, patch.object(coordinator, '_execute_differentiate_phase', return_value={'phase_complete': True}) as diff, patch.object(coordinator, '_execute_refine_phase', return_value={'phase_complete': True}) as ref, patch.object(coordinator, '_execute_retrospect_phase', return_value={'phase_complete': True}) as ret, patch.object(coordinator, '_decide_next_phase', side_effect=lambda: next(phase_iter, None)):
+    with (
+        patch.object(
+            coordinator, "_execute_expand_phase", return_value={"phase_complete": True}
+        ) as ex,
+        patch.object(
+            coordinator,
+            "_execute_differentiate_phase",
+            return_value={"phase_complete": True},
+        ) as diff,
+        patch.object(
+            coordinator, "_execute_refine_phase", return_value={"phase_complete": True}
+        ) as ref,
+        patch.object(
+            coordinator,
+            "_execute_retrospect_phase",
+            return_value={"phase_complete": True},
+        ) as ret,
+        patch.object(
+            coordinator,
+            "_decide_next_phase",
+            side_effect=lambda: next(phase_iter, None),
+        ),
+    ):
         coordinator.progress_to_phase(Phase.EXPAND)
     assert coordinator.current_phase == Phase.RETROSPECT
     assert ex.called and diff.called and ref.called and ret.called
+
 
 @pytest.mark.medium
 def test_should_terminate_recursion_granularity_succeeds(coordinator):
     """Recursion stops when granularity is below the threshold.
 
-ReqID: N/A"""
-    task = {'granularity_score': 0.1}
+    ReqID: N/A"""
+    task = {"granularity_score": 0.1}
     result = coordinator.should_terminate_recursion(task)
     assert result[0] is True
-    assert result[1] == 'granularity threshold'
+    assert result[1] == "granularity threshold"
+
 
 @pytest.mark.medium
 def test_should_terminate_recursion_cost_benefit_succeeds(coordinator):
     """Recursion stops when cost outweighs benefit.
 
-ReqID: N/A"""
-    task = {'cost_score': 0.8, 'benefit_score': 0.1}
+    ReqID: N/A"""
+    task = {"cost_score": 0.8, "benefit_score": 0.1}
     result = coordinator.should_terminate_recursion(task)
     assert result[0] is True
-    assert result[1] == 'cost-benefit analysis'
+    assert result[1] == "cost-benefit analysis"
+
 
 @pytest.mark.medium
 def test_should_terminate_recursion_quality_threshold_succeeds(coordinator):
     """Recursion stops when quality already meets the threshold.
 
-ReqID: N/A"""
-    task = {'quality_score': 0.95}
+    ReqID: N/A"""
+    task = {"quality_score": 0.95}
     result = coordinator.should_terminate_recursion(task)
     assert result[0] is True
-    assert result[1] == 'quality threshold'
+    assert result[1] == "quality threshold"
+
 
 @pytest.mark.medium
 def test_should_terminate_recursion_resource_limit_succeeds(coordinator):
     """Recursion stops when resource usage is too high.
 
-ReqID: N/A"""
-    task = {'resource_usage': 0.9}
+    ReqID: N/A"""
+    task = {"resource_usage": 0.9}
     result = coordinator.should_terminate_recursion(task)
     assert result[0] is True
-    assert result[1] == 'resource limit'
+    assert result[1] == "resource limit"
+
 
 @pytest.mark.medium
-@pytest.mark.parametrize('task,expected,reason', [({'human_override': 'terminate'}, True, 'human override'), ({'human_override': 'continue'}, False, None)])
-def test_should_terminate_recursion_human_override_succeeds(coordinator, task, expected, reason):
+@pytest.mark.parametrize(
+    "task,expected,reason",
+    [
+        ({"human_override": "terminate"}, True, "human override"),
+        ({"human_override": "continue"}, False, None),
+    ],
+)
+def test_should_terminate_recursion_human_override_succeeds(
+    coordinator, task, expected, reason
+):
     """Human override explicitly controls termination.
 
-ReqID: N/A"""
+    ReqID: N/A"""
     result = coordinator.should_terminate_recursion(task)
     assert result[0] is expected
     assert result[1] == reason
+
 
 @pytest.mark.medium
 def test_should_terminate_recursion_no_factors_succeeds(coordinator):
     """Recursion continues when no delimiting factors trigger.
 
-ReqID: N/A"""
-    task = {'granularity_score': 0.8, 'cost_score': 0.1, 'benefit_score': 0.9, 'quality_score': 0.1, 'resource_usage': 0.1}
+    ReqID: N/A"""
+    task = {
+        "granularity_score": 0.8,
+        "cost_score": 0.1,
+        "benefit_score": 0.9,
+        "quality_score": 0.1,
+        "resource_usage": 0.1,
+    }
     result = coordinator.should_terminate_recursion(task)
     assert result[0] is False
     assert result[1] is None
+
 
 @pytest.mark.medium
 def test_should_terminate_recursion_at_thresholds_succeeds(coordinator):
     """Exactly meeting thresholds should not trigger termination.
 
-ReqID: N/A"""
-    task = {'granularity_score': coordinator.DEFAULT_GRANULARITY_THRESHOLD, 'cost_score': coordinator.DEFAULT_COST_BENEFIT_RATIO, 'benefit_score': 1.0}
+    ReqID: N/A"""
+    task = {
+        "granularity_score": coordinator.DEFAULT_GRANULARITY_THRESHOLD,
+        "cost_score": coordinator.DEFAULT_COST_BENEFIT_RATIO,
+        "benefit_score": 1.0,
+    }
     result = coordinator.should_terminate_recursion(task)
     assert result[0] is False
     assert result[1] is None
+
 
 @pytest.mark.medium
 def test_should_terminate_recursion_combined_factors_fails(coordinator):
     """Multiple failing factors still trigger termination.
 
-ReqID: N/A"""
-    task = {'granularity_score': coordinator.DEFAULT_GRANULARITY_THRESHOLD / 2, 'cost_score': 0.6, 'benefit_score': 0.2}
+    ReqID: N/A"""
+    task = {
+        "granularity_score": coordinator.DEFAULT_GRANULARITY_THRESHOLD / 2,
+        "cost_score": 0.6,
+        "benefit_score": 0.2,
+    }
     result = coordinator.should_terminate_recursion(task)
     assert result[0] is True
-    assert result[1] == 'granularity threshold'
+    assert result[1] == "granularity threshold"

--- a/tests/unit/application/edrr/test_recursive_edrr_coordinator.py
+++ b/tests/unit/application/edrr/test_recursive_edrr_coordinator.py
@@ -1,87 +1,157 @@
 """Tests for the recursive functionality of the EDRRCoordinator class."""
-import pytest
-from unittest.mock import MagicMock, patch
+
 from datetime import datetime, timedelta
-from devsynth.application.edrr.coordinator import EDRRCoordinator, EDRRCoordinatorError
-from devsynth.methodology.base import Phase
-from devsynth.application.memory.memory_manager import MemoryManager
-from devsynth.domain.models.wsde import WSDETeam
+from unittest.mock import MagicMock, patch
+
+import pytest
+
 from devsynth.application.code_analysis.analyzer import CodeAnalyzer
 from devsynth.application.code_analysis.ast_transformer import AstTransformer
+from devsynth.application.documentation.documentation_manager import (
+    DocumentationManager,
+)
+from devsynth.application.edrr.coordinator import EDRRCoordinator, EDRRCoordinatorError
+from devsynth.application.memory.memory_manager import MemoryManager
 from devsynth.application.prompts.prompt_manager import PromptManager
-from devsynth.application.documentation.documentation_manager import DocumentationManager
+from devsynth.domain.models.wsde_facade import WSDETeam
+from devsynth.methodology.base import Phase
+
 
 @pytest.fixture
 def memory_manager():
     """Create a mock memory manager."""
     mock = MagicMock(spec=MemoryManager)
     mock.stored_items = {}
-    mock.store_with_edrr_phase.side_effect = lambda item, item_type, phase, metadata: mock.stored_items.update({item_type: {'item': item, 'phase': phase, 'metadata': metadata}})
-    mock.retrieve_with_edrr_phase.side_effect = lambda item_type, phase, metadata: mock.stored_items.get(item_type, {}).get('item', {})
+    mock.store_with_edrr_phase.side_effect = (
+        lambda item, item_type, phase, metadata: mock.stored_items.update(
+            {item_type: {"item": item, "phase": phase, "metadata": metadata}}
+        )
+    )
+    mock.retrieve_with_edrr_phase.side_effect = (
+        lambda item_type, phase, metadata: mock.stored_items.get(item_type, {}).get(
+            "item", {}
+        )
+    )
     mock.retrieve_historical_patterns.return_value = []
     mock.retrieve_relevant_knowledge.return_value = []
     return mock
+
 
 @pytest.fixture
 def wsde_team():
     """Create a mock WSDE team."""
     mock = MagicMock(spec=WSDETeam)
-    mock.generate_diverse_ideas.return_value = [{'id': 1, 'idea': 'Test Idea 1'}, {'id': 2, 'idea': 'Test Idea 2'}]
-    mock.create_comparison_matrix.return_value = {'idea_1': {'feasibility': 0.8}, 'idea_2': {'feasibility': 0.6}}
-    mock.evaluate_options.return_value = [{'id': 1, 'score': 0.8}, {'id': 2, 'score': 0.6}]
-    mock.analyze_trade_offs.return_value = [{'id': 1, 'trade_offs': ['Trade-off 1', 'Trade-off 2']}]
-    mock.formulate_decision_criteria.return_value = {'criteria_1': 0.5, 'criteria_2': 0.5}
-    mock.select_best_option.return_value = {'id': 1, 'idea': 'Test Idea 1'}
-    mock.elaborate_details.return_value = [{'step': 1, 'description': 'Step 1'}, {'step': 2, 'description': 'Step 2'}]
-    mock.create_implementation_plan.return_value = [{'task': 1, 'description': 'Task 1'}, {'task': 2, 'description': 'Task 2'}]
-    mock.optimize_implementation.return_value = {'optimized': True, 'plan': [{'task': 1}, {'task': 2}]}
-    mock.perform_quality_assurance.return_value = {'issues': [], 'recommendations': ['Recommendation 1']}
-    mock.extract_learnings.return_value = [{'category': 'Process', 'learning': 'Learning 1'}]
-    mock.recognize_patterns.return_value = [{'pattern': 'Pattern 1', 'frequency': 0.8}]
-    mock.integrate_knowledge.return_value = {'integrated': True, 'knowledge_items': 2}
-    mock.generate_improvement_suggestions.return_value = [{'phase': 'EXPAND', 'suggestion': 'Suggestion 1'}]
+    mock.generate_diverse_ideas.return_value = [
+        {"id": 1, "idea": "Test Idea 1"},
+        {"id": 2, "idea": "Test Idea 2"},
+    ]
+    mock.create_comparison_matrix.return_value = {
+        "idea_1": {"feasibility": 0.8},
+        "idea_2": {"feasibility": 0.6},
+    }
+    mock.evaluate_options.return_value = [
+        {"id": 1, "score": 0.8},
+        {"id": 2, "score": 0.6},
+    ]
+    mock.analyze_trade_offs.return_value = [
+        {"id": 1, "trade_offs": ["Trade-off 1", "Trade-off 2"]}
+    ]
+    mock.formulate_decision_criteria.return_value = {
+        "criteria_1": 0.5,
+        "criteria_2": 0.5,
+    }
+    mock.select_best_option.return_value = {"id": 1, "idea": "Test Idea 1"}
+    mock.elaborate_details.return_value = [
+        {"step": 1, "description": "Step 1"},
+        {"step": 2, "description": "Step 2"},
+    ]
+    mock.create_implementation_plan.return_value = [
+        {"task": 1, "description": "Task 1"},
+        {"task": 2, "description": "Task 2"},
+    ]
+    mock.optimize_implementation.return_value = {
+        "optimized": True,
+        "plan": [{"task": 1}, {"task": 2}],
+    }
+    mock.perform_quality_assurance.return_value = {
+        "issues": [],
+        "recommendations": ["Recommendation 1"],
+    }
+    mock.extract_learnings.return_value = [
+        {"category": "Process", "learning": "Learning 1"}
+    ]
+    mock.recognize_patterns.return_value = [{"pattern": "Pattern 1", "frequency": 0.8}]
+    mock.integrate_knowledge.return_value = {"integrated": True, "knowledge_items": 2}
+    mock.generate_improvement_suggestions.return_value = [
+        {"phase": "EXPAND", "suggestion": "Suggestion 1"}
+    ]
     return mock
+
 
 @pytest.fixture
 def code_analyzer():
     """Create a mock code analyzer."""
     mock = MagicMock(spec=CodeAnalyzer)
-    mock.analyze_project_structure.return_value = {'files': 10, 'classes': 5, 'functions': 20}
+    mock.analyze_project_structure.return_value = {
+        "files": 10,
+        "classes": 5,
+        "functions": 20,
+    }
     return mock
+
 
 @pytest.fixture
 def ast_transformer():
     """Create a mock AST transformer."""
     return MagicMock(spec=AstTransformer)
 
+
 @pytest.fixture
 def prompt_manager():
     """Create a mock prompt manager."""
     return MagicMock(spec=PromptManager)
+
 
 @pytest.fixture
 def documentation_manager():
     """Create a mock documentation manager."""
     return MagicMock(spec=DocumentationManager)
 
+
 @pytest.fixture
-def coordinator(memory_manager, wsde_team, code_analyzer, ast_transformer, prompt_manager, documentation_manager):
+def coordinator(
+    memory_manager,
+    wsde_team,
+    code_analyzer,
+    ast_transformer,
+    prompt_manager,
+    documentation_manager,
+):
     """Create an EDRRCoordinator instance."""
-    return EDRRCoordinator(memory_manager=memory_manager, wsde_team=wsde_team, code_analyzer=code_analyzer, ast_transformer=ast_transformer, prompt_manager=prompt_manager, documentation_manager=documentation_manager, enable_enhanced_logging=True)
+    return EDRRCoordinator(
+        memory_manager=memory_manager,
+        wsde_team=wsde_team,
+        code_analyzer=code_analyzer,
+        ast_transformer=ast_transformer,
+        prompt_manager=prompt_manager,
+        documentation_manager=documentation_manager,
+        enable_enhanced_logging=True,
+    )
+
 
 class TestRecursiveEDRRCoordinator:
     """Tests for the recursive functionality of the EDRRCoordinator class.
 
-ReqID: N/A"""
+    ReqID: N/A"""
 
     @pytest.mark.medium
     def test_initialization_with_recursion_support_succeeds(self, coordinator):
         """Test that the coordinator is initialized with recursion support.
 
-ReqID: N/A"""
-        assert hasattr(coordinator, 'parent_cycle_id')
-        assert hasattr(coordinator, 'recursion_depth')
-        assert hasattr(coordinator, 'child_cycles')
+        ReqID: N/A"""
+        assert hasattr(coordinator, "parent_cycle_id")
+        assert hasattr(coordinator, "recursion_depth")
+        assert hasattr(coordinator, "child_cycles")
         assert coordinator.parent_cycle_id is None
         assert coordinator.recursion_depth == 0
         assert coordinator.child_cycles == []
@@ -90,10 +160,10 @@ ReqID: N/A"""
     def test_create_micro_cycle_succeeds(self, coordinator):
         """Test creating a micro-EDRR cycle.
 
-ReqID: N/A"""
-        coordinator.start_cycle({'description': 'Macro Task'})
+        ReqID: N/A"""
+        coordinator.start_cycle({"description": "Macro Task"})
         macro_cycle_id = coordinator.cycle_id
-        micro_task = {'description': 'Micro Task'}
+        micro_task = {"description": "Micro Task"}
         micro_cycle = coordinator.create_micro_cycle(micro_task, Phase.EXPAND)
         assert micro_cycle is not None
         assert micro_cycle.parent_cycle_id == macro_cycle_id
@@ -105,118 +175,170 @@ ReqID: N/A"""
     def test_recursion_depth_limit_succeeds(self, coordinator):
         """Test that recursion depth is limited.
 
-ReqID: N/A"""
-        coordinator.start_cycle({'description': 'Macro Task'})
+        ReqID: N/A"""
+        coordinator.start_cycle({"description": "Macro Task"})
         current_cycle = coordinator
         for i in range(1, coordinator.max_recursion_depth + 1):
-            micro_task = {'description': f'Micro Task Level {i}'}
+            micro_task = {"description": f"Micro Task Level {i}"}
             current_cycle = current_cycle.create_micro_cycle(micro_task, Phase.EXPAND)
             assert current_cycle.recursion_depth == i
         with pytest.raises(EDRRCoordinatorError):
-            current_cycle.create_micro_cycle({'description': 'Too Deep'}, Phase.EXPAND)
+            current_cycle.create_micro_cycle({"description": "Too Deep"}, Phase.EXPAND)
 
     @pytest.mark.medium
     def test_create_micro_cycle_terminated_succeeds(self, coordinator):
         """Test that create micro cycle terminated succeeds.
 
-ReqID: N/A"""
-        coordinator.start_cycle({'description': 'Macro'})
-        with patch.object(coordinator, 'should_terminate_recursion', return_value=(True, 'test reason')):
+        ReqID: N/A"""
+        coordinator.start_cycle({"description": "Macro"})
+        with patch.object(
+            coordinator,
+            "should_terminate_recursion",
+            return_value=(True, "test reason"),
+        ):
             with pytest.raises(EDRRCoordinatorError) as excinfo:
-                coordinator.create_micro_cycle({'description': 'Sub'}, Phase.EXPAND)
-            assert 'test reason' in str(excinfo.value)
+                coordinator.create_micro_cycle({"description": "Sub"}, Phase.EXPAND)
+            assert "test reason" in str(excinfo.value)
         assert not coordinator.child_cycles
 
     @pytest.mark.medium
     def test_micro_edrr_within_expand_phase_has_expected(self, coordinator):
         """Test micro-EDRR cycles within the Expand phase.
 
-ReqID: N/A"""
-        coordinator.start_cycle({'description': 'Macro Task'})
+        ReqID: N/A"""
+        coordinator.start_cycle({"description": "Macro Task"})
         original_execute = coordinator._execute_expand_phase
 
         def mock_execute_expand(context=None):
-            coordinator.create_micro_cycle({'description': 'Brainstorm Ideas'}, Phase.EXPAND)
-            coordinator.create_micro_cycle({'description': 'Research Existing Solutions'}, Phase.EXPAND)
-            coordinator.create_micro_cycle({'description': 'Analyze Requirements'}, Phase.EXPAND)
+            coordinator.create_micro_cycle(
+                {"description": "Brainstorm Ideas"}, Phase.EXPAND
+            )
+            coordinator.create_micro_cycle(
+                {"description": "Research Existing Solutions"}, Phase.EXPAND
+            )
+            coordinator.create_micro_cycle(
+                {"description": "Analyze Requirements"}, Phase.EXPAND
+            )
             return original_execute(context)
+
         coordinator._execute_expand_phase = mock_execute_expand
         coordinator.execute_current_phase()
         assert len(coordinator.child_cycles) == 3
-        assert all((cycle.parent_cycle_id == coordinator.cycle_id for cycle in coordinator.child_cycles))
+        assert all(
+            (
+                cycle.parent_cycle_id == coordinator.cycle_id
+                for cycle in coordinator.child_cycles
+            )
+        )
         assert all((cycle.recursion_depth == 1 for cycle in coordinator.child_cycles))
 
     @pytest.mark.medium
     def test_micro_edrr_within_differentiate_phase_has_expected(self, coordinator):
         """Test micro-EDRR cycles within the Differentiate phase.
 
-ReqID: N/A"""
-        coordinator.start_cycle({'description': 'Macro Task'})
+        ReqID: N/A"""
+        coordinator.start_cycle({"description": "Macro Task"})
         coordinator.progress_to_phase(Phase.DIFFERENTIATE)
         original_execute = coordinator._execute_differentiate_phase
 
         def mock_execute_differentiate(context=None):
-            coordinator.create_micro_cycle({'description': 'Compare Approaches'}, Phase.DIFFERENTIATE)
-            coordinator.create_micro_cycle({'description': 'Evaluate Trade-offs'}, Phase.DIFFERENTIATE)
-            coordinator.create_micro_cycle({'description': 'Select Best Approach'}, Phase.DIFFERENTIATE)
+            coordinator.create_micro_cycle(
+                {"description": "Compare Approaches"}, Phase.DIFFERENTIATE
+            )
+            coordinator.create_micro_cycle(
+                {"description": "Evaluate Trade-offs"}, Phase.DIFFERENTIATE
+            )
+            coordinator.create_micro_cycle(
+                {"description": "Select Best Approach"}, Phase.DIFFERENTIATE
+            )
             return original_execute(context)
+
         coordinator._execute_differentiate_phase = mock_execute_differentiate
         coordinator.execute_current_phase()
         assert len(coordinator.child_cycles) == 3
-        assert all((cycle.parent_cycle_id == coordinator.cycle_id for cycle in coordinator.child_cycles))
+        assert all(
+            (
+                cycle.parent_cycle_id == coordinator.cycle_id
+                for cycle in coordinator.child_cycles
+            )
+        )
         assert all((cycle.recursion_depth == 1 for cycle in coordinator.child_cycles))
 
     @pytest.mark.medium
     def test_micro_edrr_within_refine_phase_has_expected(self, coordinator):
         """Test micro-EDRR cycles within the Refine phase.
 
-ReqID: N/A"""
-        coordinator.start_cycle({'description': 'Macro Task'})
+        ReqID: N/A"""
+        coordinator.start_cycle({"description": "Macro Task"})
         coordinator.progress_to_phase(Phase.REFINE)
         original_execute = coordinator._execute_refine_phase
 
         def mock_execute_refine(context=None):
-            coordinator.create_micro_cycle({'description': 'Implement Solution'}, Phase.REFINE)
-            coordinator.create_micro_cycle({'description': 'Optimize Performance'}, Phase.REFINE)
-            coordinator.create_micro_cycle({'description': 'Ensure Quality'}, Phase.REFINE)
+            coordinator.create_micro_cycle(
+                {"description": "Implement Solution"}, Phase.REFINE
+            )
+            coordinator.create_micro_cycle(
+                {"description": "Optimize Performance"}, Phase.REFINE
+            )
+            coordinator.create_micro_cycle(
+                {"description": "Ensure Quality"}, Phase.REFINE
+            )
             return original_execute(context)
+
         coordinator._execute_refine_phase = mock_execute_refine
         coordinator.execute_current_phase()
         assert len(coordinator.child_cycles) == 3
-        assert all((cycle.parent_cycle_id == coordinator.cycle_id for cycle in coordinator.child_cycles))
+        assert all(
+            (
+                cycle.parent_cycle_id == coordinator.cycle_id
+                for cycle in coordinator.child_cycles
+            )
+        )
         assert all((cycle.recursion_depth == 1 for cycle in coordinator.child_cycles))
 
     @pytest.mark.medium
     def test_micro_edrr_within_retrospect_phase_has_expected(self, coordinator):
         """Test micro-EDRR cycles within the Retrospect phase.
 
-ReqID: N/A"""
-        coordinator.start_cycle({'description': 'Macro Task'})
+        ReqID: N/A"""
+        coordinator.start_cycle({"description": "Macro Task"})
         coordinator.progress_to_phase(Phase.RETROSPECT)
         original_execute = coordinator._execute_retrospect_phase
 
         def mock_execute_retrospect(context=None):
-            coordinator.create_micro_cycle({'description': 'Extract Learnings'}, Phase.RETROSPECT)
-            coordinator.create_micro_cycle({'description': 'Identify Patterns'}, Phase.RETROSPECT)
-            coordinator.create_micro_cycle({'description': 'Generate Improvements'}, Phase.RETROSPECT)
+            coordinator.create_micro_cycle(
+                {"description": "Extract Learnings"}, Phase.RETROSPECT
+            )
+            coordinator.create_micro_cycle(
+                {"description": "Identify Patterns"}, Phase.RETROSPECT
+            )
+            coordinator.create_micro_cycle(
+                {"description": "Generate Improvements"}, Phase.RETROSPECT
+            )
             return original_execute(context)
+
         coordinator._execute_retrospect_phase = mock_execute_retrospect
         coordinator.execute_current_phase()
         assert len(coordinator.child_cycles) == 3
-        assert all((cycle.parent_cycle_id == coordinator.cycle_id for cycle in coordinator.child_cycles))
+        assert all(
+            (
+                cycle.parent_cycle_id == coordinator.cycle_id
+                for cycle in coordinator.child_cycles
+            )
+        )
         assert all((cycle.recursion_depth == 1 for cycle in coordinator.child_cycles))
 
     @pytest.mark.medium
     def test_granularity_threshold_check_succeeds(self, coordinator):
         """Test granularity threshold check for recursion termination.
 
-ReqID: N/A"""
-        coordinator.start_cycle({'description': 'Macro Task'})
-        micro_task = {'description': 'Very small task', 'granularity_score': 0.1}
+        ReqID: N/A"""
+        coordinator.start_cycle({"description": "Macro Task"})
+        micro_task = {"description": "Very small task", "granularity_score": 0.1}
         should_terminate, reason = coordinator.should_terminate_recursion(micro_task)
         assert should_terminate == True
-        assert reason == 'granularity threshold'
-        micro_task = {'description': 'Complex task', 'granularity_score': 0.8}
+        assert reason == "granularity threshold"
+        micro_task = {"description": "Complex task", "granularity_score": 0.8}
         should_terminate, reason = coordinator.should_terminate_recursion(micro_task)
         assert should_terminate == False
         assert reason is None
@@ -225,24 +347,38 @@ ReqID: N/A"""
     def test_cost_benefit_analysis_succeeds(self, coordinator):
         """Test cost-benefit analysis for recursion termination.
 
-ReqID: N/A"""
-        coordinator.start_cycle({'description': 'Macro Task'})
-        micro_task = {'description': 'High cost task', 'cost_score': 0.9, 'benefit_score': 0.2}
+        ReqID: N/A"""
+        coordinator.start_cycle({"description": "Macro Task"})
+        micro_task = {
+            "description": "High cost task",
+            "cost_score": 0.9,
+            "benefit_score": 0.2,
+        }
         should_terminate, reason = coordinator.should_terminate_recursion(micro_task)
         assert should_terminate == True
-        assert reason == 'cost-benefit analysis'
-        micro_task = {'description': 'High benefit task', 'cost_score': 0.3, 'benefit_score': 0.8}
+        assert reason == "cost-benefit analysis"
+        micro_task = {
+            "description": "High benefit task",
+            "cost_score": 0.3,
+            "benefit_score": 0.8,
+        }
         should_terminate, reason = coordinator.should_terminate_recursion(micro_task)
         assert should_terminate == False
         assert reason is None
 
     @pytest.mark.medium
-    @pytest.mark.parametrize('micro_task', [{'description': 'Too granular', 'granularity_score': 0.1}, {'description': 'Too costly', 'cost_score': 0.9, 'benefit_score': 0.2}])
+    @pytest.mark.parametrize(
+        "micro_task",
+        [
+            {"description": "Too granular", "granularity_score": 0.1},
+            {"description": "Too costly", "cost_score": 0.9, "benefit_score": 0.2},
+        ],
+    )
     def test_create_micro_cycle_termination_succeeds(self, coordinator, micro_task):
         """create_micro_cycle should abort when delimiting principles trigger.
 
-ReqID: N/A"""
-        coordinator.start_cycle({'description': 'Macro Task'})
+        ReqID: N/A"""
+        coordinator.start_cycle({"description": "Macro Task"})
         should_terminate, reason = coordinator.should_terminate_recursion(micro_task)
         assert should_terminate is True
         assert reason is not None
@@ -254,13 +390,13 @@ ReqID: N/A"""
     def test_quality_threshold_monitoring_succeeds(self, coordinator):
         """Test quality threshold monitoring for recursion termination.
 
-ReqID: N/A"""
-        coordinator.start_cycle({'description': 'Macro Task'})
-        micro_task = {'description': 'High quality task', 'quality_score': 0.95}
+        ReqID: N/A"""
+        coordinator.start_cycle({"description": "Macro Task"})
+        micro_task = {"description": "High quality task", "quality_score": 0.95}
         should_terminate, reason = coordinator.should_terminate_recursion(micro_task)
         assert should_terminate == True
-        assert reason == 'quality threshold'
-        micro_task = {'description': 'Low quality task', 'quality_score': 0.5}
+        assert reason == "quality threshold"
+        micro_task = {"description": "Low quality task", "quality_score": 0.5}
         should_terminate, reason = coordinator.should_terminate_recursion(micro_task)
         assert should_terminate == False
         assert reason is None
@@ -269,13 +405,13 @@ ReqID: N/A"""
     def test_resource_limits_succeeds(self, coordinator):
         """Test resource limits for recursion termination.
 
-ReqID: N/A"""
-        coordinator.start_cycle({'description': 'Macro Task'})
-        micro_task = {'description': 'Resource intensive task', 'resource_usage': 0.9}
+        ReqID: N/A"""
+        coordinator.start_cycle({"description": "Macro Task"})
+        micro_task = {"description": "Resource intensive task", "resource_usage": 0.9}
         should_terminate, reason = coordinator.should_terminate_recursion(micro_task)
         assert should_terminate == True
-        assert reason == 'resource limit'
-        micro_task = {'description': 'Lightweight task', 'resource_usage': 0.2}
+        assert reason == "resource limit"
+        micro_task = {"description": "Lightweight task", "resource_usage": 0.2}
         should_terminate, reason = coordinator.should_terminate_recursion(micro_task)
         assert should_terminate == False
         assert reason is None
@@ -284,17 +420,20 @@ ReqID: N/A"""
     def test_human_judgment_override_succeeds(self, coordinator):
         """Test human judgment override for recursion termination.
 
-ReqID: N/A"""
-        coordinator.start_cycle({'description': 'Macro Task'})
-        micro_task = {'description': 'Task with override', 'human_override': 'terminate'}
+        ReqID: N/A"""
+        coordinator.start_cycle({"description": "Macro Task"})
+        micro_task = {
+            "description": "Task with override",
+            "human_override": "terminate",
+        }
         should_terminate, reason = coordinator.should_terminate_recursion(micro_task)
         assert should_terminate == True
-        assert reason == 'human override'
-        micro_task = {'description': 'Task with override', 'human_override': 'continue'}
+        assert reason == "human override"
+        micro_task = {"description": "Task with override", "human_override": "continue"}
         should_terminate, reason = coordinator.should_terminate_recursion(micro_task)
         assert should_terminate == False
         assert reason is None
-        micro_task = {'description': 'Task without override'}
+        micro_task = {"description": "Task without override"}
         should_terminate, reason = coordinator.should_terminate_recursion(micro_task)
         assert should_terminate in [True, False]
         if should_terminate:
@@ -306,47 +445,66 @@ ReqID: N/A"""
     def test_recursive_execution_tracking_succeeds(self, coordinator):
         """Test tracking of recursive execution.
 
-ReqID: N/A"""
-        coordinator.start_cycle({'description': 'Macro Task'})
+        ReqID: N/A"""
+        coordinator.start_cycle({"description": "Macro Task"})
         macro_cycle_id = coordinator.cycle_id
-        micro_cycle = coordinator.create_micro_cycle({'description': 'Micro Task'}, Phase.EXPAND)
+        micro_cycle = coordinator.create_micro_cycle(
+            {"description": "Micro Task"}, Phase.EXPAND
+        )
         micro_cycle.execute_current_phase()
-        assert f'EXPAND_{micro_cycle.cycle_id}' in micro_cycle._execution_traces
-        assert micro_cycle._execution_traces[f'EXPAND_{micro_cycle.cycle_id}']['parent_cycle_id'] == macro_cycle_id
-        assert micro_cycle._execution_traces[f'EXPAND_{micro_cycle.cycle_id}']['recursion_depth'] == 1
+        assert f"EXPAND_{micro_cycle.cycle_id}" in micro_cycle._execution_traces
+        assert (
+            micro_cycle._execution_traces[f"EXPAND_{micro_cycle.cycle_id}"][
+                "parent_cycle_id"
+            ]
+            == macro_cycle_id
+        )
+        assert (
+            micro_cycle._execution_traces[f"EXPAND_{micro_cycle.cycle_id}"][
+                "recursion_depth"
+            ]
+            == 1
+        )
 
     @pytest.mark.medium
     def test_auto_micro_cycle_creation_succeeds(self, coordinator):
         """Test that auto micro cycle creation succeeds.
 
-ReqID: N/A"""
-        coordinator.start_cycle({'description': 'Macro'})
-        context = {'micro_tasks': [{'description': 'Sub1', 'granularity_score': 0.8}, {'description': 'Sub2', 'granularity_score': 0.8}]}
+        ReqID: N/A"""
+        coordinator.start_cycle({"description": "Macro"})
+        context = {
+            "micro_tasks": [
+                {"description": "Sub1", "granularity_score": 0.8},
+                {"description": "Sub2", "granularity_score": 0.8},
+            ]
+        }
         results = coordinator._execute_expand_phase(context)
         assert len(coordinator.child_cycles) == 2
-        assert len(results['micro_cycle_results']) == 2
+        assert len(results["micro_cycle_results"]) == 2
 
     @pytest.mark.medium
     def test_create_micro_cycle_max_depth_stop_fails(self, coordinator):
         """Ensure micro cycle creation fails when max depth is reached.
 
-ReqID: N/A"""
-        coordinator.start_cycle({'description': 'root'})
+        ReqID: N/A"""
+        coordinator.start_cycle({"description": "root"})
         current = coordinator
         for i in range(coordinator.max_recursion_depth):
-            current = current.create_micro_cycle({'description': f'level {i}'}, Phase.EXPAND)
+            current = current.create_micro_cycle(
+                {"description": f"level {i}"}, Phase.EXPAND
+            )
         assert current.recursion_depth == coordinator.max_recursion_depth
         with pytest.raises(EDRRCoordinatorError):
-            current.create_micro_cycle({'description': 'extra'}, Phase.EXPAND)
+            current.create_micro_cycle({"description": "extra"}, Phase.EXPAND)
         assert not current.child_cycles
 
     @pytest.mark.medium
     def test_decide_next_phase_phase_complete_has_expected(self, coordinator):
         """_decide_next_phase should transition when phase is complete.
 
-ReqID: N/A"""
-        coordinator.start_cycle({'description': 'Task'})
-        coordinator.results[Phase.EXPAND.name]['phase_complete'] = True
+        ReqID: N/A"""
+        coordinator.start_cycle({"description": "Task"})
+        coordinator.results[Phase.EXPAND.name]["phase_complete"] = True
         next_phase = coordinator._decide_next_phase()
         assert next_phase == Phase.DIFFERENTIATE
 
@@ -354,11 +512,13 @@ ReqID: N/A"""
     def test_decide_next_phase_timeout_has_expected(self, coordinator):
         """_decide_next_phase should transition after timeout.
 
-ReqID: N/A"""
-        coordinator.start_cycle({'description': 'Task'})
-        coordinator.results[Phase.EXPAND.name].pop('phase_complete', None)
+        ReqID: N/A"""
+        coordinator.start_cycle({"description": "Task"})
+        coordinator.results[Phase.EXPAND.name].pop("phase_complete", None)
         coordinator.phase_transition_timeout = 1
-        coordinator._phase_start_times[Phase.EXPAND] = datetime.now() - timedelta(seconds=2)
+        coordinator._phase_start_times[Phase.EXPAND] = datetime.now() - timedelta(
+            seconds=2
+        )
         next_phase = coordinator._decide_next_phase()
         assert next_phase == Phase.DIFFERENTIATE
 
@@ -366,9 +526,9 @@ ReqID: N/A"""
     def test_decide_next_phase_no_transition_returns_expected_result(self, coordinator):
         """_decide_next_phase should return None when conditions not met.
 
-ReqID: N/A"""
-        coordinator.start_cycle({'description': 'Task'})
-        coordinator.results[Phase.EXPAND.name].pop('phase_complete', None)
+        ReqID: N/A"""
+        coordinator.start_cycle({"description": "Task"})
+        coordinator.results[Phase.EXPAND.name].pop("phase_complete", None)
         coordinator.phase_transition_timeout = 100
         coordinator._phase_start_times[Phase.EXPAND] = datetime.now()
         assert coordinator._decide_next_phase() is None
@@ -377,20 +537,36 @@ ReqID: N/A"""
     def test_should_terminate_recursion_all_factors_true_succeeds(self, coordinator):
         """If all delimiting principles trigger, recursion should terminate.
 
-ReqID: N/A"""
-        coordinator.start_cycle({'description': 'Macro'})
-        task = {'description': 'child', 'human_override': 'terminate', 'granularity_score': 0.1, 'cost_score': 0.9, 'benefit_score': 0.2, 'quality_score': 0.95, 'resource_usage': 0.9}
+        ReqID: N/A"""
+        coordinator.start_cycle({"description": "Macro"})
+        task = {
+            "description": "child",
+            "human_override": "terminate",
+            "granularity_score": 0.1,
+            "cost_score": 0.9,
+            "benefit_score": 0.2,
+            "quality_score": 0.95,
+            "resource_usage": 0.9,
+        }
         should_terminate, reason = coordinator.should_terminate_recursion(task)
         assert should_terminate is True
-        assert reason == 'human override'
+        assert reason == "human override"
 
     @pytest.mark.medium
     def test_should_terminate_recursion_all_factors_false_succeeds(self, coordinator):
         """If no delimiting principle triggers, recursion should continue.
 
-ReqID: N/A"""
-        coordinator.start_cycle({'description': 'Macro'})
-        task = {'description': 'child', 'human_override': 'continue', 'granularity_score': 0.8, 'cost_score': 0.2, 'benefit_score': 0.9, 'quality_score': 0.5, 'resource_usage': 0.3}
+        ReqID: N/A"""
+        coordinator.start_cycle({"description": "Macro"})
+        task = {
+            "description": "child",
+            "human_override": "continue",
+            "granularity_score": 0.8,
+            "cost_score": 0.2,
+            "benefit_score": 0.9,
+            "quality_score": 0.5,
+            "resource_usage": 0.3,
+        }
         should_terminate, reason = coordinator.should_terminate_recursion(task)
         assert should_terminate is False
         assert reason is None
@@ -399,48 +575,67 @@ ReqID: N/A"""
     def test_get_performance_metrics_total_duration_succeeds(self, coordinator):
         """get_performance_metrics should report aggregated duration.
 
-ReqID: N/A"""
-        coordinator.performance_metrics = {Phase.EXPAND.name: {'duration': 1.0}, Phase.DIFFERENTIATE.name: {'duration': 2.0}, Phase.REFINE.name: {'duration': 3.0}, Phase.RETROSPECT.name: {'duration': 4.0}}
+        ReqID: N/A"""
+        coordinator.performance_metrics = {
+            Phase.EXPAND.name: {"duration": 1.0},
+            Phase.DIFFERENTIATE.name: {"duration": 2.0},
+            Phase.REFINE.name: {"duration": 3.0},
+            Phase.RETROSPECT.name: {"duration": 4.0},
+        }
         coordinator._aggregate_results()
         metrics = coordinator.get_performance_metrics()
-        assert metrics['TOTAL']['duration'] == pytest.approx(10.0)
+        assert metrics["TOTAL"]["duration"] == pytest.approx(10.0)
 
     @pytest.mark.medium
     def test_create_micro_cycle_persists_results_succeeds(self, coordinator):
         """Parent should retain child cycle results after further cycles.
 
-ReqID: N/A"""
-        coordinator.start_cycle({'description': 'macro'})
-        micro1 = coordinator.create_micro_cycle({'description': 'child1'}, Phase.EXPAND)
-        with patch.object(micro1, '_execute_differentiate_phase', return_value={'done': True}):
+        ReqID: N/A"""
+        coordinator.start_cycle({"description": "macro"})
+        micro1 = coordinator.create_micro_cycle({"description": "child1"}, Phase.EXPAND)
+        with patch.object(
+            micro1, "_execute_differentiate_phase", return_value={"done": True}
+        ):
             micro1.progress_to_phase(Phase.DIFFERENTIATE)
-        micro2 = coordinator.create_micro_cycle({'description': 'child2'}, Phase.EXPAND)
-        results = coordinator.results[Phase.EXPAND.name]['micro_cycle_results']
+        micro2 = coordinator.create_micro_cycle({"description": "child2"}, Phase.EXPAND)
+        results = coordinator.results[Phase.EXPAND.name]["micro_cycle_results"]
         assert micro1.cycle_id in results
         assert micro2.cycle_id in results
         entry = results[micro1.cycle_id]
-        assert entry['task'] == {'description': 'child1'}
-        assert {k: v for k, v in entry.items() if k != 'task'} == micro1.results
+        assert entry["task"] == {"description": "child1"}
+        assert {k: v for k, v in entry.items() if k != "task"} == micro1.results
 
     @pytest.mark.medium
     def test_micro_cycle_updates_parent_results_succeeds(self, coordinator):
         """Child cycle aggregation should refresh parent data.
 
-ReqID: N/A"""
-        coordinator.start_cycle({'description': 'macro'})
-        micro = coordinator.create_micro_cycle({'description': 'child'}, Phase.EXPAND)
-        with patch.object(micro, '_execute_differentiate_phase', return_value={'analysis': 'ok'}):
+        ReqID: N/A"""
+        coordinator.start_cycle({"description": "macro"})
+        micro = coordinator.create_micro_cycle({"description": "child"}, Phase.EXPAND)
+        with patch.object(
+            micro, "_execute_differentiate_phase", return_value={"analysis": "ok"}
+        ):
             micro.progress_to_phase(Phase.DIFFERENTIATE)
-        entry = coordinator.results[Phase.EXPAND.name]['micro_cycle_results'][micro.cycle_id]
-        assert entry[Phase.DIFFERENTIATE.name] == {'analysis': 'ok'}
+        entry = coordinator.results[Phase.EXPAND.name]["micro_cycle_results"][
+            micro.cycle_id
+        ]
+        assert entry[Phase.DIFFERENTIATE.name] == {"analysis": "ok"}
 
     @pytest.mark.medium
     def test_human_continue_overrides_delimiting_principles_succeeds(self, coordinator):
         """A continue override should prevent termination even if other factors trigger.
 
-ReqID: N/A"""
-        coordinator.start_cycle({'description': 'macro'})
-        micro_task = {'description': 'override task', 'human_override': 'continue', 'granularity_score': 0.1, 'cost_score': 0.9, 'benefit_score': 0.2, 'quality_score': 0.95, 'resource_usage': 0.9}
+        ReqID: N/A"""
+        coordinator.start_cycle({"description": "macro"})
+        micro_task = {
+            "description": "override task",
+            "human_override": "continue",
+            "granularity_score": 0.1,
+            "cost_score": 0.9,
+            "benefit_score": 0.2,
+            "quality_score": 0.95,
+            "resource_usage": 0.9,
+        }
         should_terminate, reason = coordinator.should_terminate_recursion(micro_task)
         assert should_terminate is False
         assert reason is None

--- a/tests/unit/application/edrr/test_result_analysis.py
+++ b/tests/unit/application/edrr/test_result_analysis.py
@@ -1,113 +1,180 @@
 from unittest.mock import MagicMock
+
 import pytest
+
 from devsynth.application.code_analysis.analyzer import CodeAnalyzer
 from devsynth.application.code_analysis.ast_transformer import AstTransformer
-from devsynth.application.documentation.documentation_manager import DocumentationManager
+from devsynth.application.documentation.documentation_manager import (
+    DocumentationManager,
+)
 from devsynth.application.edrr.coordinator import EDRRCoordinator
 from devsynth.application.memory.memory_manager import MemoryManager
 from devsynth.application.prompts.prompt_manager import PromptManager
-from devsynth.domain.models.wsde import WSDETeam
+from devsynth.domain.models.wsde_facade import WSDETeam
+
 
 @pytest.fixture
 def coordinator():
     memory_manager = MagicMock(spec=MemoryManager)
     memory_manager.stored_items = {}
-    memory_manager.store_with_edrr_phase.side_effect = lambda item, item_type, phase, metadata: memory_manager.stored_items.update({item_type: {'item': item, 'phase': phase, 'metadata': metadata}})
-    memory_manager.retrieve_with_edrr_phase.side_effect = lambda item_type, phase, metadata: memory_manager.stored_items.get(item_type, {}).get('item', {})
+    memory_manager.store_with_edrr_phase.side_effect = (
+        lambda item, item_type, phase, metadata: memory_manager.stored_items.update(
+            {item_type: {"item": item, "phase": phase, "metadata": metadata}}
+        )
+    )
+    memory_manager.retrieve_with_edrr_phase.side_effect = (
+        lambda item_type, phase, metadata: memory_manager.stored_items.get(
+            item_type, {}
+        ).get("item", {})
+    )
     wsde_team = MagicMock(spec=WSDETeam)
     code_analyzer = MagicMock(spec=CodeAnalyzer)
     ast_transformer = MagicMock(spec=AstTransformer)
     prompt_manager = MagicMock(spec=PromptManager)
     documentation_manager = MagicMock(spec=DocumentationManager)
-    return EDRRCoordinator(memory_manager=memory_manager, wsde_team=wsde_team, code_analyzer=code_analyzer, ast_transformer=ast_transformer, prompt_manager=prompt_manager, documentation_manager=documentation_manager)
+    return EDRRCoordinator(
+        memory_manager=memory_manager,
+        wsde_team=wsde_team,
+        code_analyzer=code_analyzer,
+        ast_transformer=ast_transformer,
+        prompt_manager=prompt_manager,
+        documentation_manager=documentation_manager,
+    )
+
 
 @pytest.fixture
 def coordinator_with_values(tmp_path):
     memory_manager = MagicMock(spec=MemoryManager)
     memory_manager.stored_items = {}
-    memory_manager.store_with_edrr_phase.side_effect = lambda item, item_type, phase, metadata: memory_manager.stored_items.update({item_type: {'item': item, 'phase': phase, 'metadata': metadata}})
-    memory_manager.retrieve_with_edrr_phase.side_effect = lambda item_type, phase, metadata: memory_manager.stored_items.get(item_type, {}).get('item', {})
+    memory_manager.store_with_edrr_phase.side_effect = (
+        lambda item, item_type, phase, metadata: memory_manager.stored_items.update(
+            {item_type: {"item": item, "phase": phase, "metadata": metadata}}
+        )
+    )
+    memory_manager.retrieve_with_edrr_phase.side_effect = (
+        lambda item_type, phase, metadata: memory_manager.stored_items.get(
+            item_type, {}
+        ).get("item", {})
+    )
     wsde_team = MagicMock(spec=WSDETeam)
     code_analyzer = MagicMock(spec=CodeAnalyzer)
     ast_transformer = MagicMock(spec=AstTransformer)
     prompt_manager = MagicMock(spec=PromptManager)
     documentation_manager = MagicMock(spec=DocumentationManager)
-    values_dir = tmp_path / '.devsynth'
+    values_dir = tmp_path / ".devsynth"
     values_dir.mkdir()
-    (values_dir / 'values.yml').write_text('- honesty\n')
-    return EDRRCoordinator(memory_manager=memory_manager, wsde_team=wsde_team, code_analyzer=code_analyzer, ast_transformer=ast_transformer, prompt_manager=prompt_manager, documentation_manager=documentation_manager, config={'project_root': str(tmp_path)})
+    (values_dir / "values.yml").write_text("- honesty\n")
+    return EDRRCoordinator(
+        memory_manager=memory_manager,
+        wsde_team=wsde_team,
+        code_analyzer=code_analyzer,
+        ast_transformer=ast_transformer,
+        prompt_manager=prompt_manager,
+        documentation_manager=documentation_manager,
+        config={"project_root": str(tmp_path)},
+    )
+
 
 @pytest.mark.medium
 def test_extract_key_insights_succeeds(coordinator):
     """Test that extract key insights succeeds.
 
-ReqID: N/A"""
-    expand_results = {'ideas': [{'idea': 'A'}, {'idea': 'B'}], 'knowledge': [1, 2, 3], 'code_elements': {'files': 5, 'functions': 2}}
+    ReqID: N/A"""
+    expand_results = {
+        "ideas": [{"idea": "A"}, {"idea": "B"}],
+        "knowledge": [1, 2, 3],
+        "code_elements": {"files": 5, "functions": 2},
+    }
     insights = coordinator._extract_key_insights(expand_results)
     assert insights
-    assert any(('A' in i for i in insights))
-    assert any(('5' in i for i in insights))
+    assert any(("A" in i for i in insights))
+    assert any(("5" in i for i in insights))
+
 
 @pytest.mark.medium
 def test_summarize_implementation_succeeds(coordinator):
     """Test that summarize implementation succeeds.
 
-ReqID: N/A"""
-    plan = [{'component': 'X'}, {'component': 'Y'}]
+    ReqID: N/A"""
+    plan = [{"component": "X"}, {"component": "Y"}]
     summary = coordinator._summarize_implementation(plan)
-    assert summary['steps'] == 2
-    assert 'X' in summary['primary_components']
-    assert summary['estimated_complexity'] == 'Low'
+    assert summary["steps"] == 2
+    assert "X" in summary["primary_components"]
+    assert summary["estimated_complexity"] == "Low"
+
 
 @pytest.mark.medium
 def test_summarize_quality_checks_succeeds(coordinator):
     """Test that summarize quality checks succeeds.
 
-ReqID: N/A"""
-    checks = {'issues': [{'severity': 'critical', 'area': 'security'}, {'severity': 'minor', 'area': 'style'}]}
+    ReqID: N/A"""
+    checks = {
+        "issues": [
+            {"severity": "critical", "area": "security"},
+            {"severity": "minor", "area": "style"},
+        ]
+    }
     summary = coordinator._summarize_quality_checks(checks)
-    assert summary['issues_found'] == 2
-    assert summary['critical_issues'] == 1
-    assert 'security' in summary['areas_of_concern']
+    assert summary["issues_found"] == 2
+    assert summary["critical_issues"] == 1
+    assert "security" in summary["areas_of_concern"]
+
 
 @pytest.mark.medium
 def test_extract_key_learnings_succeeds(coordinator):
     """Test that extract key learnings succeeds.
 
-ReqID: N/A"""
-    learnings = [{'learning': 'L1'}, {'learning': 'L2'}, {'learning': 'L3'}, {'learning': 'L4'}]
+    ReqID: N/A"""
+    learnings = [
+        {"learning": "L1"},
+        {"learning": "L2"},
+        {"learning": "L3"},
+        {"learning": "L4"},
+    ]
     result = coordinator._extract_key_learnings(learnings)
-    assert result == ['L1', 'L2', 'L3']
+    assert result == ["L1", "L2", "L3"]
+
 
 @pytest.mark.medium
 def test_generate_next_steps_succeeds(coordinator):
     """Test that generate next steps succeeds.
 
-ReqID: N/A"""
-    cycle_data = {'refine': {'implementation_plan': [1]}, 'retrospect': {'improvement_suggestions': ['a']}}
+    ReqID: N/A"""
+    cycle_data = {
+        "refine": {"implementation_plan": [1]},
+        "retrospect": {"improvement_suggestions": ["a"]},
+    }
     steps = coordinator._generate_next_steps(cycle_data)
     assert steps
-    assert any(('Implement' in s for s in steps))
-    assert any(('improvement' in s for s in steps))
+    assert any(("Implement" in s for s in steps))
+    assert any(("improvement" in s for s in steps))
+
 
 @pytest.mark.medium
 def test_extract_future_considerations_succeeds(coordinator):
     """Test that extract future considerations succeeds.
 
-ReqID: N/A"""
-    retrospect_results = {'patterns': [1, 2], 'improvement_suggestions': [1]}
+    ReqID: N/A"""
+    retrospect_results = {"patterns": [1, 2], "improvement_suggestions": [1]}
     considerations = coordinator._extract_future_considerations(retrospect_results)
     assert considerations
-    assert any(('pattern' in c for c in considerations))
-    assert any(('improvement' in c for c in considerations))
+    assert any(("pattern" in c for c in considerations))
+    assert any(("improvement" in c for c in considerations))
+
 
 @pytest.mark.medium
 def test_final_report_includes_value_conflicts_succeeds(coordinator_with_values):
     """Test that final report includes value conflicts succeeds.
 
-ReqID: N/A"""
-    coordinator_with_values.cycle_id = 'cid'
-    cycle_data = {'task': {'description': 'This will violate honesty.'}, 'expand': {}, 'differentiate': {}, 'refine': {}, 'retrospect': {}}
+    ReqID: N/A"""
+    coordinator_with_values.cycle_id = "cid"
+    cycle_data = {
+        "task": {"description": "This will violate honesty."},
+        "expand": {},
+        "differentiate": {},
+        "refine": {},
+        "retrospect": {},
+    }
     report = coordinator_with_values.generate_final_report(cycle_data)
-    assert 'value_conflicts' in report
-    assert report['value_conflicts'] == ['honesty']
+    assert "value_conflicts" in report
+    assert report["value_conflicts"] == ["honesty"]

--- a/tests/unit/domain/models/test_wsde_dialectical_reasoning.py
+++ b/tests/unit/domain/models/test_wsde_dialectical_reasoning.py
@@ -5,160 +5,191 @@ This file contains unit tests for the enhanced dialectical reasoning methods
 in the WSDETeam class, focusing on the helper methods for domain-specific
 categorization, conflict resolution, and standards compliance.
 """
-import pytest
+
+from typing import Any, Dict, List
 from unittest.mock import MagicMock, patch
-from devsynth.domain.models.wsde import WSDETeam
-from typing import Dict, List, Any
+
+import pytest
+
+from devsynth.domain.models.wsde_facade import WSDETeam
 
 
 class TestWSDEDialecticalReasoning:
     """Test suite for the enhanced dialectical reasoning methods in WSDETeam.
 
-ReqID: N/A"""
+    ReqID: N/A"""
 
     def setup_method(self):
         """Set up test fixtures."""
-        self.team = WSDETeam(name='test_dialectical_team')
+        self.team = WSDETeam(name="test_dialectical_team")
         self.critic_agent = MagicMock()
-        self.critic_agent.name = 'critic'
+        self.critic_agent.name = "critic"
         self.critic_agent.current_role = None
-        self.critic_agent.parameters = {'expertise': ['critique',
-            'dialectical_reasoning']}
+        self.critic_agent.parameters = {
+            "expertise": ["critique", "dialectical_reasoning"]
+        }
 
     @pytest.mark.medium
     def test_categorize_critiques_by_domain_succeeds(self):
         """Test categorizing critique points by domain.
 
-ReqID: N/A"""
-        critiques = ['Security issue: Hardcoded credentials detected',
-            'Performance issue: Inefficient algorithm used',
-            'Maintainability issue: No documentation or comments',
-            'Reliability issue: No error handling detected',
-            'Usability issue: Poor user interface design',
-            'Scalability issue: Not designed for concurrent access',
-            'Testability issue: Difficult to write unit tests',
-            'General issue: Needs improvement']
+        ReqID: N/A"""
+        critiques = [
+            "Security issue: Hardcoded credentials detected",
+            "Performance issue: Inefficient algorithm used",
+            "Maintainability issue: No documentation or comments",
+            "Reliability issue: No error handling detected",
+            "Usability issue: Poor user interface design",
+            "Scalability issue: Not designed for concurrent access",
+            "Testability issue: Difficult to write unit tests",
+            "General issue: Needs improvement",
+        ]
         result = self.team._categorize_critiques_by_domain(critiques)
-        assert 'security' in result
-        assert 'performance' in result
-        assert 'maintainability' in result
-        assert 'reliability' in result
-        assert 'usability' in result
-        assert 'scalability' in result
-        assert 'testability' in result
-        assert 'general' in result
-        assert 'Security issue: Hardcoded credentials detected' in result[
-            'security']
-        assert 'Performance issue: Inefficient algorithm used' in result[
-            'performance']
-        assert 'Maintainability issue: No documentation or comments' in result[
-            'maintainability']
-        assert 'Reliability issue: No error handling detected' in result[
-            'reliability']
-        assert 'Usability issue: Poor user interface design' in result[
-            'usability']
-        assert 'Scalability issue: Not designed for concurrent access' in result[
-            'scalability']
-        assert 'Testability issue: Difficult to write unit tests' in result[
-            'testability']
-        assert 'General issue: Needs improvement' in result['general']
+        assert "security" in result
+        assert "performance" in result
+        assert "maintainability" in result
+        assert "reliability" in result
+        assert "usability" in result
+        assert "scalability" in result
+        assert "testability" in result
+        assert "general" in result
+        assert "Security issue: Hardcoded credentials detected" in result["security"]
+        assert "Performance issue: Inefficient algorithm used" in result["performance"]
+        assert (
+            "Maintainability issue: No documentation or comments"
+            in result["maintainability"]
+        )
+        assert "Reliability issue: No error handling detected" in result["reliability"]
+        assert "Usability issue: Poor user interface design" in result["usability"]
+        assert (
+            "Scalability issue: Not designed for concurrent access"
+            in result["scalability"]
+        )
+        assert (
+            "Testability issue: Difficult to write unit tests" in result["testability"]
+        )
+        assert "General issue: Needs improvement" in result["general"]
 
     @pytest.mark.medium
     def test_identify_domain_conflicts_succeeds(self):
         """Test identifying conflicts between different domain perspectives.
 
-ReqID: N/A"""
-        domain_critiques = {'security': [
-            'Security issue: Need more validation checks',
-            'Security issue: Use encryption for sensitive data'],
-            'performance': ['Performance issue: Validation is too slow',
-            'Performance issue: Encryption adds overhead'],
-            'maintainability': [
-            'Maintainability issue: Code is too complex',
-            'Maintainability issue: Need better organization']}
+        ReqID: N/A"""
+        domain_critiques = {
+            "security": [
+                "Security issue: Need more validation checks",
+                "Security issue: Use encryption for sensitive data",
+            ],
+            "performance": [
+                "Performance issue: Validation is too slow",
+                "Performance issue: Encryption adds overhead",
+            ],
+            "maintainability": [
+                "Maintainability issue: Code is too complex",
+                "Maintainability issue: Need better organization",
+            ],
+        }
         conflicts = self.team._identify_domain_conflicts(domain_critiques)
         assert len(conflicts) > 0
         security_performance_conflict = None
         for conflict in conflicts:
-            if set(conflict['domains']) == set(['security', 'performance']):
+            if set(conflict["domains"]) == set(["security", "performance"]):
                 security_performance_conflict = conflict
                 break
         assert security_performance_conflict is not None
-        assert 'description' in security_performance_conflict
-        assert 'critiques' in security_performance_conflict
-        assert 'security' in security_performance_conflict['critiques']
-        assert 'performance' in security_performance_conflict['critiques']
+        assert "description" in security_performance_conflict
+        assert "critiques" in security_performance_conflict
+        assert "security" in security_performance_conflict["critiques"]
+        assert "performance" in security_performance_conflict["critiques"]
 
     @pytest.mark.medium
     def test_prioritize_critiques_succeeds(self):
         """Test prioritizing critique points based on severity and relevance.
 
-ReqID: N/A"""
-        critiques = ['Critical security vulnerability: SQL injection possible',
-            'Minor UI issue: Button color is inconsistent',
-            'Important: No input validation',
-            'Consider adding more comments for clarity',
-            'Major performance bottleneck in database queries']
+        ReqID: N/A"""
+        critiques = [
+            "Critical security vulnerability: SQL injection possible",
+            "Minor UI issue: Button color is inconsistent",
+            "Important: No input validation",
+            "Consider adding more comments for clarity",
+            "Major performance bottleneck in database queries",
+        ]
         prioritized = self.team._prioritize_critiques(critiques)
         assert len(prioritized) == 5
         for i in range(len(prioritized) - 1):
-            assert prioritized[i]['priority_score'] >= prioritized[i + 1][
-                'priority_score']
+            assert (
+                prioritized[i]["priority_score"] >= prioritized[i + 1]["priority_score"]
+            )
         critical_security = None
         for item in prioritized:
-            if 'Critical security vulnerability' in item['critique']:
+            if "Critical security vulnerability" in item["critique"]:
                 critical_security = item
                 break
         assert critical_security is not None
-        assert critical_security['severity'] == 'high'
-        assert critical_security['relevance'] > 0.5
+        assert critical_security["severity"] == "high"
+        assert critical_security["relevance"] > 0.5
 
     @pytest.mark.medium
     def test_resolve_code_improvement_conflict_succeeds(self):
         """Test resolving conflicts between code improvements from different domains.
 
-ReqID: N/A"""
-        conflict = {'domains': ['security', 'performance'], 'description':
-            'Security measures may impact performance', 'critiques': {
-            'security': ['Need more validation checks'], 'performance': [
-            'Validation is too slow']}}
-        security_improvements = ['Added input validation',
-            'Implemented secure password handling']
-        performance_improvements = ['Optimized validation algorithm',
-            'Reduced database queries']
-        resolution = self.team._resolve_code_improvement_conflict(conflict,
-            security_improvements, performance_improvements)
-        assert 'resolution' in resolution
-        assert 'reasoning' in resolution
-        assert 'code_change' in resolution
-        assert callable(resolution['code_change'])
-        test_code = 'def authenticate(username, password):\n    return True'
-        modified_code = resolution['code_change'](test_code)
-        assert 'Security and performance balance' in modified_code
+        ReqID: N/A"""
+        conflict = {
+            "domains": ["security", "performance"],
+            "description": "Security measures may impact performance",
+            "critiques": {
+                "security": ["Need more validation checks"],
+                "performance": ["Validation is too slow"],
+            },
+        }
+        security_improvements = [
+            "Added input validation",
+            "Implemented secure password handling",
+        ]
+        performance_improvements = [
+            "Optimized validation algorithm",
+            "Reduced database queries",
+        ]
+        resolution = self.team._resolve_code_improvement_conflict(
+            conflict, security_improvements, performance_improvements
+        )
+        assert "resolution" in resolution
+        assert "reasoning" in resolution
+        assert "code_change" in resolution
+        assert callable(resolution["code_change"])
+        test_code = "def authenticate(username, password):\n    return True"
+        modified_code = resolution["code_change"](test_code)
+        assert "Security and performance balance" in modified_code
 
     def test_resolve_content_improvement_conflict_succeeds(self):
         """Test resolving conflicts between content improvements from different domains.
 
-ReqID: N/A"""
-        conflict = {'domains': ['security', 'usability'], 'description':
-            'Security requirements may affect usability', 'critiques': {
-            'security': ['Need to explain security measures'], 'usability':
-            ['Documentation is too technical']}}
-        security_improvements = ['Added security warnings',
-            'Detailed security requirements']
-        usability_improvements = ['Simplified language',
-            'Added user-friendly examples']
-        resolution = self.team._resolve_content_improvement_conflict(conflict,
-            security_improvements, usability_improvements)
-        assert 'resolution' in resolution
-        assert 'reasoning' in resolution
-        assert 'content_change' in resolution
-        assert callable(resolution['content_change'])
+        ReqID: N/A"""
+        conflict = {
+            "domains": ["security", "usability"],
+            "description": "Security requirements may affect usability",
+            "critiques": {
+                "security": ["Need to explain security measures"],
+                "usability": ["Documentation is too technical"],
+            },
+        }
+        security_improvements = [
+            "Added security warnings",
+            "Detailed security requirements",
+        ]
+        usability_improvements = ["Simplified language", "Added user-friendly examples"]
+        resolution = self.team._resolve_content_improvement_conflict(
+            conflict, security_improvements, usability_improvements
+        )
+        assert "resolution" in resolution
+        assert "reasoning" in resolution
+        assert "content_change" in resolution
+        assert callable(resolution["content_change"])
 
     def test_check_code_standards_compliance_succeeds(self):
         """Test checking if code complies with standards and best practices.
 
-ReqID: N/A"""
+        ReqID: N/A"""
         compliant_code = """
 def authenticate(username, password):
     ""\"
@@ -195,25 +226,24 @@ def get_stored_hash(username):
 def authenticate(username, password):
     return username == "admin" and password == "password\"
 """
-        compliant_result = self.team._check_code_standards_compliance(
-            compliant_code)
+        compliant_result = self.team._check_code_standards_compliance(compliant_code)
         non_compliant_result = self.team._check_code_standards_compliance(
-            non_compliant_code)
-        assert 'details' in compliant_result
-        assert 'score' in compliant_result
-        assert 'level' in compliant_result
-        assert compliant_result['score'] > non_compliant_result['score']
-        assert compliant_result['level'] in ['high', 'medium']
-        assert non_compliant_result['level'] in ['medium', 'low']
-        assert compliant_result['details']['documentation'] == True
-        assert compliant_result['details']['error_handling'] == True
-        assert non_compliant_result['details']['security_best_practices'
-            ] == False
+            non_compliant_code
+        )
+        assert "details" in compliant_result
+        assert "score" in compliant_result
+        assert "level" in compliant_result
+        assert compliant_result["score"] > non_compliant_result["score"]
+        assert compliant_result["level"] in ["high", "medium"]
+        assert non_compliant_result["level"] in ["medium", "low"]
+        assert compliant_result["details"]["documentation"] == True
+        assert compliant_result["details"]["error_handling"] == True
+        assert non_compliant_result["details"]["security_best_practices"] == False
 
     def test_check_content_standards_compliance_succeeds(self):
         """Test checking if content complies with standards and best practices.
 
-ReqID: N/A"""
+        ReqID: N/A"""
         compliant_content = """
 # User Authentication System
 
@@ -236,24 +266,27 @@ result = authenticate(username, password)
 Always use HTTPS and implement rate limiting.
 """
         non_compliant_content = (
-            'The system authenticates users with username and password.')
+            "The system authenticates users with username and password."
+        )
         compliant_result = self.team._check_content_standards_compliance(
-            compliant_content)
+            compliant_content
+        )
         non_compliant_result = self.team._check_content_standards_compliance(
-            non_compliant_content)
-        assert 'details' in compliant_result
-        assert 'score' in compliant_result
-        assert 'level' in compliant_result
-        assert compliant_result['score'] > non_compliant_result['score']
-        assert compliant_result['level'] in ['high', 'medium']
-        assert non_compliant_result['level'] in ['medium', 'low']
-        assert compliant_result['details']['examples'] == True
-        assert compliant_result['details']['structure'] == True
+            non_compliant_content
+        )
+        assert "details" in compliant_result
+        assert "score" in compliant_result
+        assert "level" in compliant_result
+        assert compliant_result["score"] > non_compliant_result["score"]
+        assert compliant_result["level"] in ["high", "medium"]
+        assert non_compliant_result["level"] in ["medium", "low"]
+        assert compliant_result["details"]["examples"] == True
+        assert compliant_result["details"]["structure"] == True
 
     def test_check_pep8_compliance_succeeds(self):
         """Test checking if code complies with PEP 8 style guide.
 
-ReqID: N/A"""
+        ReqID: N/A"""
         compliant_code = """
 def authenticate(username, password):
     ""\"Authenticate a user with username and password.""\"
@@ -283,15 +316,14 @@ def authenticate( username,password ):
         return False
 """
         compliant_result = self.team._check_pep8_compliance(compliant_code)
-        non_compliant_result = self.team._check_pep8_compliance(
-            non_compliant_code)
+        non_compliant_result = self.team._check_pep8_compliance(non_compliant_code)
         assert compliant_result == True
         assert non_compliant_result == False
 
     def test_check_security_best_practices_succeeds(self):
         """Test checking if code follows security best practices.
 
-ReqID: N/A"""
+        ReqID: N/A"""
         secure_code = """
 def authenticate(username, password):
     ""\"Authenticate a user with username and password.""\"
@@ -329,76 +361,103 @@ def authenticate(username, password):
     return False
 """
         secure_result = self.team._check_security_best_practices(secure_code)
-        insecure_result = self.team._check_security_best_practices(
-            insecure_code)
+        insecure_result = self.team._check_security_best_practices(insecure_code)
         assert secure_result == True
         assert insecure_result == False
 
     def test_balance_security_and_performance_succeeds(self):
         """Test balancing security and performance in code.
 
-ReqID: N/A"""
-        code = 'def authenticate(username, password):\n    return True'
+        ReqID: N/A"""
+        code = "def authenticate(username, password):\n    return True"
         balanced_code = self.team._balance_security_and_performance(code)
-        assert 'Security and performance balance' in balanced_code
-        assert 'Using efficient validation methods' in balanced_code
-        assert 'Implementing security checks at critical points only' in balanced_code
-        assert 'Using cached results where appropriate' in balanced_code
+        assert "Security and performance balance" in balanced_code
+        assert "Using efficient validation methods" in balanced_code
+        assert "Implementing security checks at critical points only" in balanced_code
+        assert "Using cached results where appropriate" in balanced_code
 
     def test_balance_security_and_usability_succeeds(self):
         """Test balancing security and usability in code.
 
-ReqID: N/A"""
-        code = 'def authenticate(username, password):\n    return True'
+        ReqID: N/A"""
+        code = "def authenticate(username, password):\n    return True"
         balanced_code = self.team._balance_security_and_usability(code)
-        assert 'Security and usability balance' in balanced_code
-        assert 'Implementing progressive security measures' in balanced_code
-        assert 'Using clear error messages for security issues' in balanced_code
-        assert 'Providing helpful guidance for users' in balanced_code
+        assert "Security and usability balance" in balanced_code
+        assert "Implementing progressive security measures" in balanced_code
+        assert "Using clear error messages for security issues" in balanced_code
+        assert "Providing helpful guidance for users" in balanced_code
 
     def test_balance_performance_and_maintainability_succeeds(self):
         """Test balancing performance and maintainability in code.
 
-ReqID: N/A"""
-        code = 'def authenticate(username, password):\n    return True'
-        balanced_code = self.team._balance_performance_and_maintainability(code
-            )
-        assert 'Performance and maintainability balance' in balanced_code
-        assert 'Using descriptive variable names even in performance-critical sections' in balanced_code
-        assert 'Adding comments to explain optimization techniques' in balanced_code
-        assert 'Extracting complex optimizations into well-named functions' in balanced_code
+        ReqID: N/A"""
+        code = "def authenticate(username, password):\n    return True"
+        balanced_code = self.team._balance_performance_and_maintainability(code)
+        assert "Performance and maintainability balance" in balanced_code
+        assert (
+            "Using descriptive variable names even in performance-critical sections"
+            in balanced_code
+        )
+        assert "Adding comments to explain optimization techniques" in balanced_code
+        assert (
+            "Extracting complex optimizations into well-named functions"
+            in balanced_code
+        )
 
     def test_generate_detailed_synthesis_reasoning_succeeds(self):
         """Test generating detailed reasoning about the synthesis process.
 
-ReqID: N/A"""
-        domain_critiques = {'security': [
-            'Security issue: Hardcoded credentials'], 'performance': [
-            'Performance issue: Inefficient algorithm'], 'maintainability':
-            ['Maintainability issue: No documentation']}
-        domain_improvements = {'security': ['Removed hardcoded credentials'
-            ], 'performance': ['Optimized algorithm'], 'maintainability': [
-            'Added documentation']}
-        domain_conflicts = [{'domains': ['security', 'performance'],
-            'description': 'Security measures may impact performance'}]
-        resolved_conflicts = [{'resolution':
-            'Prioritized security over performance', 'reasoning':
-            'Security is critical for protecting user data'}]
-        standards_compliance = {'code': {'details': {'pep8': True,
-            'security_best_practices': True, 'error_handling': True,
-            'input_validation': True, 'documentation': True}, 'score': 0.8,
-            'level': 'high'}}
+        ReqID: N/A"""
+        domain_critiques = {
+            "security": ["Security issue: Hardcoded credentials"],
+            "performance": ["Performance issue: Inefficient algorithm"],
+            "maintainability": ["Maintainability issue: No documentation"],
+        }
+        domain_improvements = {
+            "security": ["Removed hardcoded credentials"],
+            "performance": ["Optimized algorithm"],
+            "maintainability": ["Added documentation"],
+        }
+        domain_conflicts = [
+            {
+                "domains": ["security", "performance"],
+                "description": "Security measures may impact performance",
+            }
+        ]
+        resolved_conflicts = [
+            {
+                "resolution": "Prioritized security over performance",
+                "reasoning": "Security is critical for protecting user data",
+            }
+        ]
+        standards_compliance = {
+            "code": {
+                "details": {
+                    "pep8": True,
+                    "security_best_practices": True,
+                    "error_handling": True,
+                    "input_validation": True,
+                    "documentation": True,
+                },
+                "score": 0.8,
+                "level": "high",
+            }
+        }
         reasoning = self.team._generate_detailed_synthesis_reasoning(
-            domain_critiques, domain_improvements, domain_conflicts,
-            resolved_conflicts, standards_compliance)
-        assert 'Synthesis integrated' in reasoning
-        assert 'critique points across' in reasoning
-        assert 'resulting in' in reasoning
-        assert 'In the security domain' in reasoning
-        assert 'In the performance domain' in reasoning
-        assert 'In the maintainability domain' in reasoning
-        assert 'Resolved' in reasoning
-        assert 'Prioritized security over performance' in reasoning
-        assert 'Code compliance with standards' in reasoning
-        assert 'high' in reasoning
-        assert '80%' in reasoning
+            domain_critiques,
+            domain_improvements,
+            domain_conflicts,
+            resolved_conflicts,
+            standards_compliance,
+        )
+        assert "Synthesis integrated" in reasoning
+        assert "critique points across" in reasoning
+        assert "resulting in" in reasoning
+        assert "In the security domain" in reasoning
+        assert "In the performance domain" in reasoning
+        assert "In the maintainability domain" in reasoning
+        assert "Resolved" in reasoning
+        assert "Prioritized security over performance" in reasoning
+        assert "Code compliance with standards" in reasoning
+        assert "high" in reasoning
+        assert "80%" in reasoning

--- a/tests/unit/domain/models/test_wsde_dynamic_workflows.py
+++ b/tests/unit/domain/models/test_wsde_dynamic_workflows.py
@@ -1,43 +1,44 @@
-import pytest
 from unittest.mock import MagicMock
-from devsynth.domain.models.wsde import WSDETeam
+
+import pytest
+
+from devsynth.domain.models.wsde_facade import WSDETeam
 
 
 class TestWSDERoleReassignment:
     """Tests for the WSDERoleReassignment component.
 
-ReqID: N/A"""
+    ReqID: N/A"""
 
     def setup_method(self):
-        self.team = WSDETeam(name='test_dynamic_workflows_team')
+        self.team = WSDETeam(name="test_dynamic_workflows_team")
         self.doc_agent = MagicMock()
-        self.doc_agent.name = 'doc'
-        self.doc_agent.expertise = ['documentation', 'markdown']
+        self.doc_agent.name = "doc"
+        self.doc_agent.expertise = ["documentation", "markdown"]
         self.code_agent = MagicMock()
-        self.code_agent.name = 'code'
-        self.code_agent.expertise = ['python']
+        self.code_agent.name = "code"
+        self.code_agent.expertise = ["python"]
         self.test_agent = MagicMock()
-        self.test_agent.name = 'test'
-        self.test_agent.expertise = ['testing']
-        self.team.add_agents([self.code_agent, self.doc_agent, self.test_agent]
-            )
+        self.test_agent.name = "test"
+        self.test_agent.expertise = ["testing"]
+        self.team.add_agents([self.code_agent, self.doc_agent, self.test_agent])
 
     def test_dynamic_role_reassignment_selects_expert_primus_succeeds(self):
         """Test that dynamic role reassignment selects expert primus succeeds.
 
-ReqID: N/A"""
-        task = {'type': 'documentation', 'description': 'Write docs'}
+        ReqID: N/A"""
+        task = {"type": "documentation", "description": "Write docs"}
         self.team.dynamic_role_reassignment(task)
         assert self.team.get_primus() == self.doc_agent
-        assert self.doc_agent.current_role == 'Primus'
+        assert self.doc_agent.current_role == "Primus"
 
     def test_build_consensus_multiple_solutions_succeeds(self):
         """Test that build consensus multiple solutions succeeds.
 
-ReqID: N/A"""
-        task = {'id': 't1', 'description': 'demo'}
-        self.team.add_solution(task, {'agent': 'code', 'content': 'a'})
-        self.team.add_solution(task, {'agent': 'test', 'content': 'b'})
+        ReqID: N/A"""
+        task = {"id": "t1", "description": "demo"}
+        self.team.add_solution(task, {"agent": "code", "content": "a"})
+        self.team.add_solution(task, {"agent": "test", "content": "b"})
         consensus = self.team.build_consensus(task)
-        assert consensus['consensus'] != ''
-        assert set(consensus['contributors']) == {'code', 'test'}
+        assert consensus["consensus"] != ""
+        assert set(consensus["contributors"]) == {"code", "test"}

--- a/tests/unit/domain/models/test_wsde_team.py
+++ b/tests/unit/domain/models/test_wsde_team.py
@@ -4,40 +4,43 @@ Unit Tests for WSDE Team Model
 This file contains unit tests for the WSDETeam class, which implements
 the Worker Self-Directed Enterprise model.
 """
-import pytest
+
 from unittest.mock import MagicMock, patch
-from devsynth.domain.models.wsde import WSDE, WSDETeam
+
+import pytest
+
+from devsynth.domain.models.wsde_facade import WSDE, WSDETeam
 
 
 class TestWSDETeam:
     """Test suite for the WSDETeam class.
 
-ReqID: N/A"""
+    ReqID: N/A"""
 
     def setup_method(self):
         """Set up test fixtures."""
-        self.team = WSDETeam(name='test_wsde_team')
+        self.team = WSDETeam(name="test_wsde_team")
         self.agent1 = MagicMock()
-        self.agent1.name = 'agent1'
+        self.agent1.name = "agent1"
         self.agent1.current_role = None
-        self.agent1.parameters = {'expertise': ['python', 'code_generation']}
+        self.agent1.parameters = {"expertise": ["python", "code_generation"]}
         self.agent2 = MagicMock()
-        self.agent2.name = 'agent2'
+        self.agent2.name = "agent2"
         self.agent2.current_role = None
-        self.agent2.parameters = {'expertise': ['testing', 'test_generation']}
+        self.agent2.parameters = {"expertise": ["testing", "test_generation"]}
         self.agent3 = MagicMock()
-        self.agent3.name = 'agent3'
+        self.agent3.name = "agent3"
         self.agent3.current_role = None
-        self.agent3.parameters = {'expertise': ['documentation', 'markdown']}
+        self.agent3.parameters = {"expertise": ["documentation", "markdown"]}
         self.agent4 = MagicMock()
-        self.agent4.name = 'agent4'
+        self.agent4.name = "agent4"
         self.agent4.current_role = None
-        self.agent4.parameters = {'expertise': ['design', 'architecture']}
+        self.agent4.parameters = {"expertise": ["design", "architecture"]}
 
     def test_add_agent_succeeds(self):
         """Test adding an agent to the team.
 
-ReqID: N/A"""
+        ReqID: N/A"""
         self.team.add_agent(self.agent1)
         assert len(self.team.agents) == 1
         assert self.team.agents[0] == self.agent1
@@ -45,19 +48,20 @@ ReqID: N/A"""
     def test_rotate_primus_succeeds(self):
         """Test rotating the Primus role.
 
-ReqID: N/A"""
+        ReqID: N/A"""
         self.team.add_agent(self.agent1)
         self.team.add_agent(self.agent2)
         initial_primus_index = self.team.primus_index
         self.team.rotate_primus()
         assert self.team.primus_index != initial_primus_index
-        assert self.team.primus_index == (initial_primus_index + 1) % len(self
-            .team.agents)
+        assert self.team.primus_index == (initial_primus_index + 1) % len(
+            self.team.agents
+        )
 
     def test_get_primus_succeeds(self):
         """Test getting the current Primus agent.
 
-ReqID: N/A"""
+        ReqID: N/A"""
         self.team.add_agent(self.agent1)
         self.team.add_agent(self.agent2)
         self.team.primus_index = 1
@@ -67,43 +71,64 @@ ReqID: N/A"""
     def test_get_primus_empty_team_succeeds(self):
         """Test getting the Primus agent from an empty team.
 
-ReqID: N/A"""
+        ReqID: N/A"""
         primus = self.team.get_primus()
         assert primus is None
 
     def test_assign_roles_succeeds(self):
         """Test assigning WSDE roles to agents.
 
-ReqID: N/A"""
+        ReqID: N/A"""
         self.team.add_agent(self.agent1)
         self.team.add_agent(self.agent2)
         self.team.add_agent(self.agent3)
         self.team.add_agent(self.agent4)
         self.team.primus_index = 0
         self.team.assign_roles()
-        assert self.agent1.current_role == 'Primus'
-        assert self.agent2.current_role in ['Worker', 'Supervisor',
-            'Designer', 'Evaluator']
-        assert self.agent3.current_role in ['Worker', 'Supervisor',
-            'Designer', 'Evaluator']
-        assert self.agent4.current_role in ['Worker', 'Supervisor',
-            'Designer', 'Evaluator']
-        roles = [self.agent2.current_role, self.agent3.current_role, self.
-            agent4.current_role]
-        assert 'Worker' in roles
-        assert 'Supervisor' in roles
-        assert 'Designer' in roles or 'Evaluator' in roles
+        assert self.agent1.current_role == "Primus"
+        assert self.agent2.current_role in [
+            "Worker",
+            "Supervisor",
+            "Designer",
+            "Evaluator",
+        ]
+        assert self.agent3.current_role in [
+            "Worker",
+            "Supervisor",
+            "Designer",
+            "Evaluator",
+        ]
+        assert self.agent4.current_role in [
+            "Worker",
+            "Supervisor",
+            "Designer",
+            "Evaluator",
+        ]
+        roles = [
+            self.agent2.current_role,
+            self.agent3.current_role,
+            self.agent4.current_role,
+        ]
+        assert "Worker" in roles
+        assert "Supervisor" in roles
+        assert "Designer" in roles or "Evaluator" in roles
 
     def test_analyze_trade_offs_detects_conflicts_succeeds(self):
         """Trade-off analysis should flag options with similar scores as conflicts.
 
-ReqID: N/A"""
-        evaluated = [{'id': 1, 'score': 0.8}, {'id': 2, 'score': 0.78}, {
-            'id': 3, 'score': 0.2}]
-        trade_offs = self.team.analyze_trade_offs(evaluated,
-            conflict_detection_threshold=0.7)
-        opt1 = next(o for o in trade_offs if o['id'] == 1)
-        assert any(t['type'] == 'conflict' and t['other_id'] == 2 for t in
-            opt1['trade_offs'])
-        assert not any(t['type'] == 'conflict' and t['other_id'] == 3 for t in
-            opt1['trade_offs'])
+        ReqID: N/A"""
+        evaluated = [
+            {"id": 1, "score": 0.8},
+            {"id": 2, "score": 0.78},
+            {"id": 3, "score": 0.2},
+        ]
+        trade_offs = self.team.analyze_trade_offs(
+            evaluated, conflict_detection_threshold=0.7
+        )
+        opt1 = next(o for o in trade_offs if o["id"] == 1)
+        assert any(
+            t["type"] == "conflict" and t["other_id"] == 2 for t in opt1["trade_offs"]
+        )
+        assert not any(
+            t["type"] == "conflict" and t["other_id"] == 3 for t in opt1["trade_offs"]
+        )

--- a/tests/unit/domain/test_primus_selection_edge_cases.py
+++ b/tests/unit/domain/test_primus_selection_edge_cases.py
@@ -1,11 +1,13 @@
 import inspect
 from unittest.mock import MagicMock
+
 import coverage
 import pytest
-from devsynth.domain.models.wsde import WSDETeam
+
+from devsynth.domain.models.wsde_facade import WSDETeam
 
 
-def _agent(name: str, expertise=None, used: bool=False):
+def _agent(name: str, expertise=None, used: bool = False):
     agent = MagicMock()
     agent.name = name
     if expertise is not None:
@@ -19,10 +21,10 @@ def _agent(name: str, expertise=None, used: bool=False):
 def test_rotation_without_expertise_is_deterministic_succeeds():
     """Test that rotation without expertise is deterministic succeeds.
 
-ReqID: N/A"""
-    team = WSDETeam(name='TestPrimusSelectionEdgeCasesTeam')
-    a1 = _agent('a1', [])
-    a2 = _agent('a2', [])
+    ReqID: N/A"""
+    team = WSDETeam(name="TestPrimusSelectionEdgeCasesTeam")
+    a1 = _agent("a1", [])
+    a2 = _agent("a2", [])
     team.add_agents([a1, a2])
     team.select_primus_by_expertise({})
     assert team.get_primus() is a1
@@ -34,13 +36,13 @@ ReqID: N/A"""
 def test_documentation_task_prefers_doc_agents_succeeds():
     """Test that documentation task prefers doc agents succeeds.
 
-ReqID: N/A"""
-    team = WSDETeam(name='TestPrimusSelectionEdgeCasesTeam')
-    coder = _agent('coder', ['python'])
-    writer = _agent('writer', ['documentation'])
-    doc = _agent('doc', ['documentation', 'markdown'])
+    ReqID: N/A"""
+    team = WSDETeam(name="TestPrimusSelectionEdgeCasesTeam")
+    coder = _agent("coder", ["python"])
+    writer = _agent("writer", ["documentation"])
+    doc = _agent("doc", ["documentation", "markdown"])
     team.add_agents([coder, writer, doc])
-    team.select_primus_by_expertise({'type': 'documentation'})
+    team.select_primus_by_expertise({"type": "documentation"})
     primus = team.get_primus()
     assert primus in (writer, doc)
     assert primus is not coder
@@ -50,10 +52,10 @@ ReqID: N/A"""
 def test_has_been_primus_resets_after_full_rotation_succeeds():
     """Test that has been primus resets after full rotation succeeds.
 
-ReqID: N/A"""
-    team = WSDETeam(name='TestPrimusSelectionEdgeCasesTeam')
-    a1 = _agent('a1', [])
-    a2 = _agent('a2', [])
+    ReqID: N/A"""
+    team = WSDETeam(name="TestPrimusSelectionEdgeCasesTeam")
+    a1 = _agent("a1", [])
+    a2 = _agent("a2", [])
     team.add_agents([a1, a2])
     team.select_primus_by_expertise({})
     team.select_primus_by_expertise({})
@@ -68,33 +70,35 @@ ReqID: N/A"""
 def test_edge_case_coverage_succeeds():
     """Test that edge case coverage succeeds.
 
-ReqID: N/A"""
-    import devsynth.domain.models.wsde as wsde
+    ReqID: N/A"""
+    import devsynth.domain.models.wsde_facade as wsde
+
     cov = coverage.Coverage()
     cov.start()
-    empty = wsde.WSDETeam(name='TestPrimusSelectionEdgeCasesTeam')
+    empty = wsde.WSDETeam(name="TestPrimusSelectionEdgeCasesTeam")
     empty.select_primus_by_expertise({})
-    team = wsde.WSDETeam(name='TestPrimusSelectionEdgeCasesTeam')
-    team.add_agents([_agent('a'), _agent('b', ['documentation']), _agent(
-        'c', ['python'])])
-    team.select_primus_by_expertise({'type': 'documentation', 'extra': {'n':
-        1}})
-    team.select_primus_by_expertise({'language': 'python'})
+    team = wsde.WSDETeam(name="TestPrimusSelectionEdgeCasesTeam")
+    team.add_agents(
+        [_agent("a"), _agent("b", ["documentation"]), _agent("c", ["python"])]
+    )
+    team.select_primus_by_expertise({"type": "documentation", "extra": {"n": 1}})
+    team.select_primus_by_expertise({"language": "python"})
     team.select_primus_by_expertise({})
-    team.select_primus_by_expertise({'type': 'documentation'})
-    team.select_primus_by_expertise({'context': {'info': [{'language':
-        'python'}]}})
+    team.select_primus_by_expertise({"type": "documentation"})
+    team.select_primus_by_expertise({"context": {"info": [{"language": "python"}]}})
     cov.stop()
     path = wsde.__file__
-    lines, start = inspect.getsourcelines(wsde.WSDETeam.
-        select_primus_by_expertise)
+    lines, start = inspect.getsourcelines(wsde.WSDETeam.select_primus_by_expertise)
     executable = []
     skip = False
     for i, line in enumerate(lines, start):
         stripped = line.strip()
         if stripped.startswith('"""'):
-            if stripped.count('"""') == 2 and stripped.endswith('""'
-                ) and stripped != '"""':
+            if (
+                stripped.count('"""') == 2
+                and stripped.endswith('""')
+                and stripped != '"""'
+            ):
                 continue
             skip = not skip
             continue

--- a/tests/unit/domain/test_wsde_core_methods.py
+++ b/tests/unit/domain/test_wsde_core_methods.py
@@ -1,7 +1,8 @@
+import types
+
 import pytest
 
-import types
-from devsynth.domain.models.wsde import WSDETeam
+from devsynth.domain.models.wsde_facade import WSDETeam
 
 
 class DummyAgent:

--- a/tests/unit/domain/test_wsde_expertise_score.py
+++ b/tests/unit/domain/test_wsde_expertise_score.py
@@ -1,6 +1,8 @@
-import pytest
 from unittest.mock import MagicMock
-from devsynth.domain.models.wsde import WSDETeam
+
+import pytest
+
+from devsynth.domain.models.wsde_facade import WSDETeam
 
 
 class DummyAgent:
@@ -13,10 +15,10 @@ class DummyAgent:
 def test_calculate_expertise_score_multiple_matches():
     """Test that calculate expertise score multiple matches.
 
-ReqID: N/A"""
-    team = WSDETeam(name='TestWsdeExpertiseScoreTeam')
-    agent = DummyAgent(['python', 'documentation'])
+    ReqID: N/A"""
+    team = WSDETeam(name="TestWsdeExpertiseScoreTeam")
+    agent = DummyAgent(["python", "documentation"])
     team.add_agent(agent)
-    task = {'language': 'python', 'description': 'generate documentation'}
+    task = {"language": "python", "description": "generate documentation"}
     score = team._calculate_expertise_score(agent, task)
     assert score > 1

--- a/tests/unit/domain/test_wsde_phase_role_rotation.py
+++ b/tests/unit/domain/test_wsde_phase_role_rotation.py
@@ -1,10 +1,12 @@
 from unittest.mock import MagicMock
+
 import pytest
-from devsynth.domain.models.wsde import WSDETeam
+
+from devsynth.domain.models.wsde_facade import WSDETeam
 from devsynth.methodology.base import Phase
 
 
-def _agent(name: str, expertise: list[str], used: bool=False):
+def _agent(name: str, expertise: list[str], used: bool = False):
     agent = MagicMock()
     agent.name = name
     agent.expertise = expertise
@@ -16,12 +18,12 @@ def _agent(name: str, expertise: list[str], used: bool=False):
 def test_initial_selection_prefers_unused_agent_succeeds():
     """Test that initial selection prefers unused agent succeeds.
 
-ReqID: N/A"""
-    team = WSDETeam(name='TestWsdePhaseRoleRotationTeam')
-    experienced = _agent('experienced', ['python'], used=True)
-    newbie = _agent('newbie', [])
+    ReqID: N/A"""
+    team = WSDETeam(name="TestWsdePhaseRoleRotationTeam")
+    experienced = _agent("experienced", ["python"], used=True)
+    newbie = _agent("newbie", [])
     team.add_agents([experienced, newbie])
-    team.select_primus_by_expertise({'language': 'python'})
+    team.select_primus_by_expertise({"language": "python"})
     assert team.get_primus() is newbie
     assert newbie.has_been_primus
 
@@ -29,12 +31,12 @@ ReqID: N/A"""
 def test_documentation_tasks_pick_documentation_experts_succeeds():
     """Test that documentation tasks pick documentation experts succeeds.
 
-ReqID: N/A"""
-    team = WSDETeam(name='TestWsdePhaseRoleRotationTeam')
-    coder = _agent('coder', ['python'])
-    doc = _agent('doc', ['documentation', 'markdown'])
+    ReqID: N/A"""
+    team = WSDETeam(name="TestWsdePhaseRoleRotationTeam")
+    coder = _agent("coder", ["python"])
+    doc = _agent("doc", ["documentation", "markdown"])
     team.add_agents([coder, doc])
-    team.select_primus_by_expertise({'type': 'documentation'})
+    team.select_primus_by_expertise({"type": "documentation"})
     assert team.get_primus() is doc
     assert doc.has_been_primus
 
@@ -42,10 +44,10 @@ ReqID: N/A"""
 def test_assign_roles_for_phase_rotates_after_all_primus_succeeds():
     """Test that assign roles for phase rotates after all primus succeeds.
 
-ReqID: N/A"""
-    team = WSDETeam(name='TestWsdePhaseRoleRotationTeam')
-    a1 = _agent('a1', ['skill'])
-    a2 = _agent('a2', ['skill'])
+    ReqID: N/A"""
+    team = WSDETeam(name="TestWsdePhaseRoleRotationTeam")
+    a1 = _agent("a1", ["skill"])
+    a2 = _agent("a2", ["skill"])
     team.add_agents([a1, a2])
     team.assign_roles_for_phase(Phase.EXPAND, {})
     first = team.get_primus()

--- a/tests/unit/domain/test_wsde_primus_selection.py
+++ b/tests/unit/domain/test_wsde_primus_selection.py
@@ -1,6 +1,8 @@
 from unittest.mock import MagicMock
+
 import pytest
-from devsynth.domain.models.wsde import WSDETeam
+
+from devsynth.domain.models.wsde_facade import WSDETeam
 
 
 def _agent(name: str, expertise: list[str], used: bool = False):
@@ -95,8 +97,10 @@ def test_select_primus_by_expertise_coverage_succeeds():
     import inspect
     import os
     from types import SimpleNamespace
+
     import coverage
-    import devsynth.domain.models.wsde as wsde
+
+    import devsynth.domain.models.wsde_facade as wsde
 
     team = wsde.WSDETeam(name="TestWsdePrimusSelectionTeam")
     cov = coverage.Coverage()

--- a/tests/unit/domain/test_wsde_team.py
+++ b/tests/unit/domain/test_wsde_team.py
@@ -1,6 +1,8 @@
-import pytest
 from unittest.mock import MagicMock, patch
-from devsynth.domain.models.wsde import WSDETeam
+
+import pytest
+
+from devsynth.domain.models.wsde_facade import WSDETeam
 
 
 @pytest.fixture
@@ -177,9 +179,11 @@ def test_vote_on_critical_decision_coverage_succeeds():
 
     ReqID: N/A"""
     import inspect
-    import coverage
     from types import SimpleNamespace
-    import devsynth.domain.models.wsde as wsde
+
+    import coverage
+
+    import devsynth.domain.models.wsde_facade as wsde
 
     team = wsde.WSDETeam(name="TestWsdeTeamTeam")
     a1 = SimpleNamespace(
@@ -297,8 +301,10 @@ def test_select_primus_coverage_succeeds(team_with_agents):
 
     ReqID: N/A"""
     import inspect
+
     import coverage
-    import devsynth.domain.models.wsde as wsde
+
+    import devsynth.domain.models.wsde_facade as wsde
 
     team, doc, coder, tester = team_with_agents
     cov = coverage.Coverage()

--- a/tests/unit/general/test_agent_adapter_delegate.py
+++ b/tests/unit/general/test_agent_adapter_delegate.py
@@ -1,11 +1,13 @@
-import typer
-import click
-from click.testing import CliRunner
 from unittest.mock import MagicMock
+
+import click
+import pytest
+import typer
+from click.testing import CliRunner
+
 import devsynth.adapters.cli.typer_adapter as typer_adapter
 from devsynth.adapters.agents.agent_adapter import WSDETeamCoordinator
-from devsynth.domain.models.wsde import WSDETeam
-import pytest
+from devsynth.domain.models.wsde_facade import WSDETeam
 
 
 @pytest.mark.medium
@@ -21,7 +23,6 @@ def test_delegate_task_single_agent_succeeds():
     result = coord.delegate_task({"description": "do"})
     assert result["result"] == "ok"
     agent.process.assert_called_once_with({"description": "do"})
-
 
 
 @pytest.mark.medium
@@ -56,7 +57,6 @@ def test_delegate_task_multi_agent_succeeds():
     team.select_primus_by_expertise.assert_called_once_with(task)
     assert result["result"] == "final"
     assert result["dialectical_analysis"] == {"eval": "ok"}
-
 
 
 @pytest.mark.medium

--- a/tests/unit/general/test_agent_collaboration.py
+++ b/tests/unit/general/test_agent_collaboration.py
@@ -1,17 +1,19 @@
-import pytest
 from unittest.mock import MagicMock, patch
-from devsynth.domain.models.wsde import WSDE, WSDETeam
-from devsynth.domain.models.agent import AgentType, AgentConfig
-from devsynth.application.agents.unified_agent import UnifiedAgent
-from devsynth.application.agents.specification import SpecificationAgent
-from devsynth.application.agents.test import TestAgent
-from devsynth.application.agents.code import CodeAgent
+
+import pytest
+
 from devsynth.adapters.agents.agent_adapter import (
+    AgentAdapter,
     SimplifiedAgentFactory,
     WSDETeamCoordinator,
-    AgentAdapter,
 )
+from devsynth.application.agents.code import CodeAgent
+from devsynth.application.agents.specification import SpecificationAgent
+from devsynth.application.agents.test import TestAgent
+from devsynth.application.agents.unified_agent import UnifiedAgent
 from devsynth.application.collaboration.coordinator import AgentCoordinatorImpl
+from devsynth.domain.models.agent import AgentConfig, AgentType
+from devsynth.domain.models.wsde_facade import WSDE, WSDETeam
 from devsynth.exceptions import ValidationError
 
 
@@ -46,7 +48,6 @@ class TestAgentCollaboration:
         coordinator = WSDETeamCoordinator()
         assert coordinator.teams == {}
         assert coordinator.current_team_id is None
-
 
     @pytest.mark.medium
     def test_add_agent_succeeds(self, mock_agent):

--- a/tests/unit/general/test_edrr_manifest_string.py
+++ b/tests/unit/general/test_edrr_manifest_string.py
@@ -1,40 +1,47 @@
 import json
 from unittest.mock import MagicMock, patch
-from devsynth.application.edrr.coordinator import EDRRCoordinator
-from devsynth.methodology.base import Phase
-from devsynth.application.memory.memory_manager import MemoryManager
-from devsynth.domain.models.wsde import WSDETeam
+
 from devsynth.application.code_analysis.analyzer import CodeAnalyzer
 from devsynth.application.code_analysis.ast_transformer import AstTransformer
+from devsynth.application.documentation.documentation_manager import (
+    DocumentationManager,
+)
+from devsynth.application.edrr.coordinator import EDRRCoordinator
+from devsynth.application.memory.memory_manager import MemoryManager
 from devsynth.application.prompts.prompt_manager import PromptManager
-from devsynth.application.documentation.documentation_manager import DocumentationManager
+from devsynth.domain.models.wsde_facade import WSDETeam
+from devsynth.methodology.base import Phase
 
 
 def make_coordinator():
-    return EDRRCoordinator(memory_manager=MagicMock(spec=MemoryManager),
-        wsde_team=MagicMock(spec=WSDETeam), code_analyzer=MagicMock(spec=
-        CodeAnalyzer), ast_transformer=MagicMock(spec=AstTransformer),
-        prompt_manager=MagicMock(spec=PromptManager), documentation_manager
-        =MagicMock(spec=DocumentationManager), enable_enhanced_logging=True)
+    return EDRRCoordinator(
+        memory_manager=MagicMock(spec=MemoryManager),
+        wsde_team=MagicMock(spec=WSDETeam),
+        code_analyzer=MagicMock(spec=CodeAnalyzer),
+        ast_transformer=MagicMock(spec=AstTransformer),
+        prompt_manager=MagicMock(spec=PromptManager),
+        documentation_manager=MagicMock(spec=DocumentationManager),
+        enable_enhanced_logging=True,
+    )
 
 
 def test_start_cycle_from_manifest_string_succeeds():
     """Test that start cycle from manifest string succeeds.
 
-ReqID: N/A"""
+    ReqID: N/A"""
     coord = make_coordinator()
-    manifest = {'id': 'm1', 'description': 'demo', 'phases': {}}
+    manifest = {"id": "m1", "description": "demo", "phases": {}}
     parser = MagicMock()
     parser.parse_string.return_value = manifest
-    parser.get_manifest_id.return_value = 'm1'
-    parser.get_manifest_description.return_value = 'demo'
+    parser.get_manifest_id.return_value = "m1"
+    parser.get_manifest_description.return_value = "demo"
     parser.get_manifest_metadata.return_value = {}
-    parser.execution_trace = {'start_time': 'now'}
+    parser.execution_trace = {"start_time": "now"}
     parser.start_execution.return_value = None
     coord.manifest_parser = parser
-    with patch.object(coord, 'progress_to_phase') as prog:
+    with patch.object(coord, "progress_to_phase") as prog:
         coord.start_cycle_from_manifest(json.dumps(manifest), is_file=False)
     parser.parse_string.assert_called_once()
     prog.assert_called_once_with(Phase.EXPAND)
-    assert coord.task['id'] == 'm1'
+    assert coord.task["id"] == "m1"
     assert coord.manifest == manifest

--- a/tests/unit/general/test_primus_selection.py
+++ b/tests/unit/general/test_primus_selection.py
@@ -1,6 +1,8 @@
-import pytest
 from unittest.mock import MagicMock
-from devsynth.domain.models.wsde import WSDETeam
+
+import pytest
+
+from devsynth.domain.models.wsde_facade import WSDETeam
 
 
 def create_agent(name: str, expertise: list[str]):
@@ -15,9 +17,9 @@ def create_agent(name: str, expertise: list[str]):
 @pytest.fixture
 def rotation_team():
     """Team with two identical agents for deterministic rotation tests."""
-    team = WSDETeam(name='TestPrimusSelectionTeam')
-    a1 = create_agent('A1', ['python'])
-    a2 = create_agent('A2', ['python'])
+    team = WSDETeam(name="TestPrimusSelectionTeam")
+    a1 = create_agent("A1", ["python"])
+    a2 = create_agent("A2", ["python"])
     team.add_agents([a1, a2])
     return team, a1, a2
 
@@ -25,9 +27,9 @@ def rotation_team():
 @pytest.fixture
 def weighted_team():
     """Team with a specialist and a generalist for expertise weighting."""
-    team = WSDETeam(name='TestPrimusSelectionTeam')
-    generalist = create_agent('Generalist', ['python'])
-    specialist = create_agent('Specialist', ['python', 'backend'])
+    team = WSDETeam(name="TestPrimusSelectionTeam")
+    generalist = create_agent("Generalist", ["python"])
+    specialist = create_agent("Specialist", ["python", "backend"])
     team.add_agents([generalist, specialist])
     return team, generalist, specialist
 
@@ -35,10 +37,10 @@ def weighted_team():
 @pytest.fixture
 def documentation_team():
     """Team containing multiple documentation experts."""
-    team = WSDETeam(name='TestPrimusSelectionTeam')
-    coder = create_agent('Coder', ['python'])
-    writer = create_agent('Writer', ['documentation'])
-    doc = create_agent('Doc', ['documentation', 'markdown'])
+    team = WSDETeam(name="TestPrimusSelectionTeam")
+    coder = create_agent("Coder", ["python"])
+    writer = create_agent("Writer", ["documentation"])
+    doc = create_agent("Doc", ["documentation", "markdown"])
     team.add_agents([coder, writer, doc])
     return team, coder, writer, doc
 
@@ -46,13 +48,13 @@ def documentation_team():
 def test_highest_expertise_score_becomes_primus_succeeds():
     """Test that highest expertise score becomes primus succeeds.
 
-ReqID: N/A"""
-    team = WSDETeam(name='TestPrimusSelectionTeam')
-    python_agent = create_agent('Python', ['python', 'backend'])
-    js_agent = create_agent('JS', ['javascript', 'frontend'])
-    tester = create_agent('Tester', ['testing'])
+    ReqID: N/A"""
+    team = WSDETeam(name="TestPrimusSelectionTeam")
+    python_agent = create_agent("Python", ["python", "backend"])
+    js_agent = create_agent("JS", ["javascript", "frontend"])
+    tester = create_agent("Tester", ["testing"])
     team.add_agents([python_agent, js_agent, tester])
-    task = {'type': 'coding', 'language': 'python', 'domain': 'backend'}
+    task = {"type": "coding", "language": "python", "domain": "backend"}
     team.select_primus_by_expertise(task)
     assert team.get_primus() is python_agent
     assert python_agent.has_been_primus
@@ -61,12 +63,12 @@ ReqID: N/A"""
 def test_prioritizes_agents_who_have_not_served_as_primus_succeeds():
     """Test that prioritizes agents who have not served as primus succeeds.
 
-ReqID: N/A"""
-    team = WSDETeam(name='TestPrimusSelectionTeam')
-    python_agent = create_agent('Python', ['python'])
-    doc_agent = create_agent('Doc', ['documentation', 'markdown'])
+    ReqID: N/A"""
+    team = WSDETeam(name="TestPrimusSelectionTeam")
+    python_agent = create_agent("Python", ["python"])
+    doc_agent = create_agent("Doc", ["documentation", "markdown"])
     team.add_agents([python_agent, doc_agent])
-    task = {'type': 'coding', 'language': 'python'}
+    task = {"type": "coding", "language": "python"}
     team.select_primus_by_expertise(task)
     assert team.get_primus() is python_agent
     team.select_primus_by_expertise(task)
@@ -77,12 +79,12 @@ ReqID: N/A"""
 def test_documentation_tasks_prefer_documentation_experts_succeeds():
     """Test that documentation tasks prefer documentation experts succeeds.
 
-ReqID: N/A"""
-    team = WSDETeam(name='TestPrimusSelectionTeam')
-    coder = create_agent('Coder', ['python'])
-    doc_agent = create_agent('Doc', ['documentation', 'markdown'])
+    ReqID: N/A"""
+    team = WSDETeam(name="TestPrimusSelectionTeam")
+    coder = create_agent("Coder", ["python"])
+    doc_agent = create_agent("Doc", ["documentation", "markdown"])
     team.add_agents([coder, doc_agent])
-    task = {'type': 'documentation', 'description': 'Update docs'}
+    task = {"type": "documentation", "description": "Update docs"}
     team.select_primus_by_expertise(task)
     assert team.get_primus() is doc_agent
     assert doc_agent.has_been_primus
@@ -91,9 +93,9 @@ ReqID: N/A"""
 def test_weighted_expertise_prefers_specialist_succeeds(weighted_team):
     """Test that weighted expertise prefers specialist succeeds.
 
-ReqID: N/A"""
+    ReqID: N/A"""
     team, generalist, specialist = weighted_team
-    task = {'type': 'coding', 'language': 'python', 'domain': 'backend'}
+    task = {"type": "coding", "language": "python", "domain": "backend"}
     team.select_primus_by_expertise(task)
     assert team.get_primus() is specialist
 
@@ -101,9 +103,9 @@ ReqID: N/A"""
 def test_rotation_resets_after_all_agents_served_succeeds(rotation_team):
     """Test that rotation resets after all agents served succeeds.
 
-ReqID: N/A"""
+    ReqID: N/A"""
     team, a1, a2 = rotation_team
-    task = {'language': 'python'}
+    task = {"language": "python"}
     team.select_primus_by_expertise(task)
     team.select_primus_by_expertise(task)
     assert a1.has_been_primus and a2.has_been_primus
@@ -113,13 +115,12 @@ ReqID: N/A"""
     assert not a2.has_been_primus
 
 
-def test_documentation_tasks_prioritize_best_doc_expert_succeeds(
-    documentation_team):
+def test_documentation_tasks_prioritize_best_doc_expert_succeeds(documentation_team):
     """Test that documentation tasks prioritize best doc expert succeeds.
 
-ReqID: N/A"""
+    ReqID: N/A"""
     team, coder, writer, doc = documentation_team
-    task = {'type': 'documentation', 'description': 'Write docs'}
+    task = {"type": "documentation", "description": "Write docs"}
     team.select_primus_by_expertise(task)
     primus = team.get_primus()
     assert primus in (writer, doc)

--- a/tests/unit/general/test_wsde_dynamic_roles.py
+++ b/tests/unit/general/test_wsde_dynamic_roles.py
@@ -1,6 +1,8 @@
-import pytest
 from unittest.mock import MagicMock
-from devsynth.domain.models.wsde import WSDETeam
+
+import pytest
+
+from devsynth.domain.models.wsde_facade import WSDETeam
 from devsynth.methodology.base import Phase
 
 
@@ -15,12 +17,12 @@ class SimpleAgent:
 def test_assign_roles_for_phase_selects_primus_by_expertise_has_expected():
     """Test that assign_roles_for_phase selects the agent with the most relevant expertise as Primus.
 
-ReqID: N/A"""
-    team = WSDETeam(name='TestTeam')
-    expand_agent = SimpleAgent('expander', ['expand'])
-    diff_agent = SimpleAgent('differ', ['differentiate'])
+    ReqID: N/A"""
+    team = WSDETeam(name="TestTeam")
+    expand_agent = SimpleAgent("expander", ["expand"])
+    diff_agent = SimpleAgent("differ", ["differentiate"])
     team.add_agents([expand_agent, diff_agent])
-    task = {'description': 'demo'}
+    task = {"description": "demo"}
     team.assign_roles_for_phase(Phase.EXPAND, task)
     assert team.get_primus() == expand_agent
     team.assign_roles_for_phase(Phase.DIFFERENTIATE, task)

--- a/tests/unit/general/test_wsde_model.py
+++ b/tests/unit/general/test_wsde_model.py
@@ -1,21 +1,23 @@
-import pytest
 from datetime import datetime
 from uuid import UUID
-from devsynth.domain.models.wsde import WSDE
+
+import pytest
+
+from devsynth.domain.models.wsde_core import WSDE
 
 
 class TestWSDEModel:
     """Tests for the WSDEModel component.
 
-ReqID: N/A"""
+    ReqID: N/A"""
 
     def test_wsde_initialization_succeeds(self):
         """Test that wsde initialization succeeds.
 
-ReqID: N/A"""
+        ReqID: N/A"""
         wsde = WSDE()
-        assert wsde.content == ''
-        assert wsde.content_type == 'text'
+        assert wsde.content == ""
+        assert wsde.content_type == "text"
         assert isinstance(wsde.metadata, dict)
         assert isinstance(wsde.created_at, datetime)
         assert isinstance(wsde.updated_at, datetime)
@@ -23,20 +25,25 @@ ReqID: N/A"""
         try:
             UUID(wsde.id)
         except ValueError:
-            pytest.fail('WSDE id is not a valid UUID')
+            pytest.fail("WSDE id is not a valid UUID")
 
     def test_wsde_with_custom_values_succeeds(self):
         """Test that wsde with custom values succeeds.
 
-ReqID: N/A"""
-        custom_metadata = {'author': 'Test User', 'version': '1.0'}
+        ReqID: N/A"""
+        custom_metadata = {"author": "Test User", "version": "1.0"}
         custom_time = datetime.now()
-        wsde = WSDE(id='custom-id', content='Test content', content_type=
-            'code', metadata=custom_metadata, created_at=custom_time,
-            updated_at=custom_time)
-        assert wsde.id == 'custom-id'
-        assert wsde.content == 'Test content'
-        assert wsde.content_type == 'code'
+        wsde = WSDE(
+            id="custom-id",
+            content="Test content",
+            content_type="code",
+            metadata=custom_metadata,
+            created_at=custom_time,
+            updated_at=custom_time,
+        )
+        assert wsde.id == "custom-id"
+        assert wsde.content == "Test content"
+        assert wsde.content_type == "code"
         assert wsde.metadata == custom_metadata
         assert wsde.created_at == custom_time
         assert wsde.updated_at == custom_time

--- a/tests/unit/general/test_wsde_role_mapping.py
+++ b/tests/unit/general/test_wsde_role_mapping.py
@@ -1,6 +1,8 @@
 from unittest.mock import MagicMock
-from devsynth.domain.models.wsde import WSDETeam
+
 import pytest
+
+from devsynth.domain.models.wsde_facade import WSDETeam
 
 # These tests previously required the ``DEVSYNTH_RUN_WSDE_TESTS`` environment
 # variable to be set.  They now execute unconditionally as the global test
@@ -10,8 +12,8 @@ import pytest
 def test_assign_roles_with_explicit_mapping_succeeds():
     """Test that assign roles with explicit mapping succeeds.
 
-ReqID: N/A"""
-    team = WSDETeam(name='TestWsdeRoleMappingTeam')
+    ReqID: N/A"""
+    team = WSDETeam(name="TestWsdeRoleMappingTeam")
     a1 = MagicMock()
     a2 = MagicMock()
     a3 = MagicMock()
@@ -20,14 +22,14 @@ ReqID: N/A"""
     # assignment logic will overwrite the Primus role.  Provide a distinct
     # worker mapping to verify role assignment order.
     mapping = {
-        'primus': a1,
-        'worker': [a2],
-        'supervisor': a2,
-        'designer': a3,
-        'evaluator': None,
+        "primus": a1,
+        "worker": [a2],
+        "supervisor": a2,
+        "designer": a3,
+        "evaluator": None,
     }
     team.assign_roles(mapping)
-    assert team.role_assignments['primus'] == a1
-    assert a1.current_role == 'Primus'
-    assert a2.current_role == 'Supervisor'
-    assert a3.current_role == 'Designer'
+    assert team.role_assignments["primus"] == a1
+    assert a1.current_role == "Primus"
+    assert a2.current_role == "Supervisor"
+    assert a3.current_role == "Designer"

--- a/tests/unit/general/test_wsde_team_coordinator.py
+++ b/tests/unit/general/test_wsde_team_coordinator.py
@@ -4,116 +4,122 @@ Unit Tests for WSDETeamCoordinator
 This file contains unit tests for the WSDETeamCoordinator class, which is responsible
 for coordinating WSDE teams and implementing consensus-based decision making.
 """
-import pytest
+
 from unittest.mock import MagicMock, patch
-from devsynth.domain.interfaces.agent import Agent
+
+import pytest
+
 from devsynth.adapters.agents.agent_adapter import WSDETeamCoordinator
-from devsynth.domain.models.wsde import WSDETeam
-from devsynth.exceptions import ValidationError, AgentExecutionError
+from devsynth.domain.interfaces.agent import Agent
+from devsynth.domain.models.wsde_facade import WSDETeam
+from devsynth.exceptions import AgentExecutionError, ValidationError
 
 
 class TestWSDETeamCoordinator:
     """Test suite for the WSDETeamCoordinator class.
 
-ReqID: N/A"""
+    ReqID: N/A"""
 
     def setup_method(self):
         """Set up test fixtures."""
         self.coordinator = WSDETeamCoordinator()
         self.agent1 = MagicMock(spec=Agent)
-        self.agent1.name = 'agent1'
-        self.agent1.agent_type = 'planner'
+        self.agent1.name = "agent1"
+        self.agent1.agent_type = "planner"
         self.agent1.current_role = None
         self.agent1.config = MagicMock()
-        self.agent1.config.name = 'agent1'
-        self.agent1.config.parameters = {'expertise': ['planning', 'design']}
+        self.agent1.config.name = "agent1"
+        self.agent1.config.parameters = {"expertise": ["planning", "design"]}
         self.agent2 = MagicMock(spec=Agent)
-        self.agent2.name = 'agent2'
-        self.agent2.agent_type = 'code'
+        self.agent2.name = "agent2"
+        self.agent2.agent_type = "code"
         self.agent2.current_role = None
         self.agent2.config = MagicMock()
-        self.agent2.config.name = 'agent2'
-        self.agent2.config.parameters = {'expertise': ['python', 'javascript']}
+        self.agent2.config.name = "agent2"
+        self.agent2.config.parameters = {"expertise": ["python", "javascript"]}
         self.agent3 = MagicMock(spec=Agent)
-        self.agent3.name = 'agent3'
-        self.agent3.agent_type = 'test'
+        self.agent3.name = "agent3"
+        self.agent3.agent_type = "test"
         self.agent3.current_role = None
         self.agent3.config = MagicMock()
-        self.agent3.config.name = 'agent3'
-        self.agent3.config.parameters = {'expertise': ['testing', 'quality']}
+        self.agent3.config.name = "agent3"
+        self.agent3.config.parameters = {"expertise": ["testing", "quality"]}
         self.agent4 = MagicMock(spec=Agent)
-        self.agent4.name = 'agent4'
-        self.agent4.agent_type = 'validation'
+        self.agent4.name = "agent4"
+        self.agent4.agent_type = "validation"
         self.agent4.current_role = None
         self.agent4.config = MagicMock()
-        self.agent4.config.name = 'agent4'
-        self.agent4.config.parameters = {'expertise': ['validation',
-            'security']}
+        self.agent4.config.name = "agent4"
+        self.agent4.config.parameters = {"expertise": ["validation", "security"]}
 
     def test_create_team_succeeds(self):
         """Test creating a team.
 
-ReqID: N/A"""
-        team = self.coordinator.create_team('test_team')
+        ReqID: N/A"""
+        team = self.coordinator.create_team("test_team")
         assert team is not None
         assert isinstance(team, WSDETeam)
-        assert self.coordinator.teams['test_team'] == team
-        assert self.coordinator.current_team_id == 'test_team'
+        assert self.coordinator.teams["test_team"] == team
+        assert self.coordinator.current_team_id == "test_team"
 
     def test_add_agent_succeeds(self):
         """Test adding an agent to the coordinator.
 
-ReqID: N/A"""
+        ReqID: N/A"""
         self.coordinator.add_agent(self.agent1)
         assert self.coordinator.current_team_id is not None
-        assert len(self.coordinator.teams[self.coordinator.current_team_id]
-            .agents) == 1
-        assert self.coordinator.teams[self.coordinator.current_team_id].agents[
-            0] == self.agent1
+        assert len(self.coordinator.teams[self.coordinator.current_team_id].agents) == 1
+        assert (
+            self.coordinator.teams[self.coordinator.current_team_id].agents[0]
+            == self.agent1
+        )
 
     @pytest.mark.medium
     def test_delegate_task_single_agent_succeeds(self):
         """Test delegating a task with a single agent.
 
-ReqID: N/A"""
+        ReqID: N/A"""
         self.coordinator.add_agent(self.agent1)
-        task = {'type': 'planning', 'description': 'Plan a new feature'}
-        self.agent1.process.return_value = {'result': 'Feature plan created'}
+        task = {"type": "planning", "description": "Plan a new feature"}
+        self.agent1.process.return_value = {"result": "Feature plan created"}
         result = self.coordinator.delegate_task(task)
-        assert result['result'] == 'Feature plan created'
+        assert result["result"] == "Feature plan created"
         self.agent1.process.assert_called_once_with(task)
 
     def test_delegate_task_multi_agent_consensus_succeeds(self):
         """Test delegating a task with multiple agents using consensus-based decision making.
 
-ReqID: N/A"""
-        self.coordinator.create_team('test_team')
+        ReqID: N/A"""
+        self.coordinator.create_team("test_team")
         self.coordinator.add_agent(self.agent1)
         self.coordinator.add_agent(self.agent2)
         self.coordinator.add_agent(self.agent3)
         self.coordinator.add_agent(self.agent4)
-        task = {'type': 'code', 'language': 'python', 'description':
-            'Implement a feature'}
-        self.agent1.process.return_value = {'result': 'Design for the feature'}
-        self.agent2.process.return_value = {'result':
-            'Implementation of the feature'}
-        self.agent3.process.return_value = {'result': 'Tests for the feature'}
-        self.agent4.process.return_value = {'result':
-            'Validation of the feature'}
-        team = self.coordinator.teams['test_team']
-        team.build_consensus = MagicMock(return_value={'consensus':
-            'Consensus solution incorporating all perspectives',
-            'contributors': ['agent1', 'agent2', 'agent3', 'agent4'],
-            'method': 'consensus_synthesis', 'reasoning':
-            'Combined the best elements from all solutions'})
+        task = {
+            "type": "code",
+            "language": "python",
+            "description": "Implement a feature",
+        }
+        self.agent1.process.return_value = {"result": "Design for the feature"}
+        self.agent2.process.return_value = {"result": "Implementation of the feature"}
+        self.agent3.process.return_value = {"result": "Tests for the feature"}
+        self.agent4.process.return_value = {"result": "Validation of the feature"}
+        team = self.coordinator.teams["test_team"]
+        team.build_consensus = MagicMock(
+            return_value={
+                "consensus": "Consensus solution incorporating all perspectives",
+                "contributors": ["agent1", "agent2", "agent3", "agent4"],
+                "method": "consensus_synthesis",
+                "reasoning": "Combined the best elements from all solutions",
+            }
+        )
         result = self.coordinator.delegate_task(task)
-        assert 'result' in result
-        assert result['result'
-            ] == 'Consensus solution incorporating all perspectives'
-        assert 'contributors' in result
-        assert len(result['contributors']) == 4
-        assert 'method' in result
-        assert result['method'] == 'consensus_synthesis'
+        assert "result" in result
+        assert result["result"] == "Consensus solution incorporating all perspectives"
+        assert "contributors" in result
+        assert len(result["contributors"]) == 4
+        assert "method" in result
+        assert result["method"] == "consensus_synthesis"
         self.agent1.process.assert_called_once_with(task)
         self.agent2.process.assert_called_once_with(task)
         self.agent3.process.assert_called_once_with(task)
@@ -123,38 +129,46 @@ ReqID: N/A"""
     def test_delegate_task_critical_decision_succeeds(self):
         """Ensure critical decisions trigger team voting.
 
-ReqID: N/A"""
-        self.coordinator.create_team('test_team')
+        ReqID: N/A"""
+        self.coordinator.create_team("test_team")
         self.coordinator.add_agent(self.agent1)
         self.coordinator.add_agent(self.agent2)
-        task = {'type': 'critical_decision', 'is_critical': True, 'options':
-            [{'id': 'a'}, {'id': 'b'}]}
-        team = self.coordinator.teams['test_team']
-        team.vote_on_critical_decision = MagicMock(return_value={'result':
-            {'winner': 'a'}})
+        task = {
+            "type": "critical_decision",
+            "is_critical": True,
+            "options": [{"id": "a"}, {"id": "b"}],
+        }
+        team = self.coordinator.teams["test_team"]
+        team.vote_on_critical_decision = MagicMock(
+            return_value={"result": {"winner": "a"}}
+        )
         result = self.coordinator.delegate_task(task)
-        assert result['result']['winner'] == 'a'
+        assert result["result"]["winner"] == "a"
         team.vote_on_critical_decision.assert_called_once_with(task)
 
     def test_delegate_task_agent_failure_continues_fails(self):
         """If one agent fails, others still contribute to the result.
 
-ReqID: N/A"""
-        self.coordinator.create_team('test_team')
+        ReqID: N/A"""
+        self.coordinator.create_team("test_team")
         self.coordinator.add_agent(self.agent1)
         self.coordinator.add_agent(self.agent2)
         self.coordinator.add_agent(self.agent3)
-        task = {'type': 'code', 'language': 'python'}
-        self.agent1.process.side_effect = Exception('boom')
-        self.agent2.process.return_value = {'result': 'code'}
-        self.agent3.process.return_value = {'result': 'tests'}
-        team = self.coordinator.teams['test_team']
-        team.build_consensus = MagicMock(return_value={'consensus': 'done',
-            'contributors': ['agent2', 'agent3'], 'method':
-            'consensus_synthesis'})
+        task = {"type": "code", "language": "python"}
+        self.agent1.process.side_effect = Exception("boom")
+        self.agent2.process.return_value = {"result": "code"}
+        self.agent3.process.return_value = {"result": "tests"}
+        team = self.coordinator.teams["test_team"]
+        team.build_consensus = MagicMock(
+            return_value={
+                "consensus": "done",
+                "contributors": ["agent2", "agent3"],
+                "method": "consensus_synthesis",
+            }
+        )
         result = self.coordinator.delegate_task(task)
-        assert result['result'] == 'done'
-        assert set(result['contributors']) == {'agent2', 'agent3'}
+        assert result["result"] == "done"
+        assert set(result["contributors"]) == {"agent2", "agent3"}
         team.build_consensus.assert_called_once_with(task)
         self.agent1.process.assert_called_once_with(task)
         self.agent2.process.assert_called_once_with(task)
@@ -163,93 +177,106 @@ ReqID: N/A"""
     def test_delegate_task_propagates_agent_execution_error_raises_error(self):
         """Errors from agents bubble up to the caller.
 
-ReqID: N/A"""
+        ReqID: N/A"""
         self.coordinator.add_agent(self.agent1)
-        task = {'type': 'planning'}
-        self.agent1.process.side_effect = AgentExecutionError('failed',
-            agent_id='agent1')
+        task = {"type": "planning"}
+        self.agent1.process.side_effect = AgentExecutionError(
+            "failed", agent_id="agent1"
+        )
         with pytest.raises(AgentExecutionError):
             self.coordinator.delegate_task(task)
 
     def test_delegate_task_coverage_succeeds(self):
         """Test that delegate task coverage succeeds.
 
-ReqID: N/A"""
+        ReqID: N/A"""
         import inspect
-        import coverage
         from types import SimpleNamespace
+
+        import coverage
+
         import devsynth.adapters.agents.agent_adapter as adapter
+
         cov = coverage.Coverage()
         cov.start()
         coord = adapter.WSDETeamCoordinator()
-        a1 = SimpleNamespace(name='a1', agent_type='code', current_role=
-            None, config=SimpleNamespace(name='a1', parameters={'expertise':
-            ['code']}), process=lambda t: {'result': 'x'})
+        a1 = SimpleNamespace(
+            name="a1",
+            agent_type="code",
+            current_role=None,
+            config=SimpleNamespace(name="a1", parameters={"expertise": ["code"]}),
+            process=lambda t: {"result": "x"},
+        )
         coord.add_agent(a1)
-        coord.delegate_task({'type': 'code'})
-        coord.delegate_task({'type': 'critical_decision', 'is_critical': 
-            True, 'options': [{'id': 'x'}]})
-        a2 = SimpleNamespace(name='a2', agent_type='test', current_role=
-            None, config=SimpleNamespace(name='a2', parameters={'expertise':
-            ['test']}), process=lambda t: {'result': 'y'})
+        coord.delegate_task({"type": "code"})
+        coord.delegate_task(
+            {"type": "critical_decision", "is_critical": True, "options": [{"id": "x"}]}
+        )
+        a2 = SimpleNamespace(
+            name="a2",
+            agent_type="test",
+            current_role=None,
+            config=SimpleNamespace(name="a2", parameters={"expertise": ["test"]}),
+            process=lambda t: {"result": "y"},
+        )
         coord.add_agent(a2)
         team = coord.get_team(coord.current_team_id)
-        team.build_consensus = lambda t: {'consensus': 'z', 'contributors':
-            ['a1', 'a2'], 'method': 'consensus_synthesis'}
-        coord.delegate_task({'type': 'code'})
+        team.build_consensus = lambda t: {
+            "consensus": "z",
+            "contributors": ["a1", "a2"],
+            "method": "consensus_synthesis",
+        }
+        coord.delegate_task({"type": "code"})
         path = adapter.__file__
-        lines, start = inspect.getsourcelines(adapter.WSDETeamCoordinator.
-            delegate_task)
+        lines, start = inspect.getsourcelines(adapter.WSDETeamCoordinator.delegate_task)
         executable = list(range(start, start + len(lines)))
         executed = set(cov.get_data().lines(path))
         missing = set(executable) - executed
         if missing:
-            dummy = '\n' * (start - 1) + '\n'.join('pass' for _ in range(
-                len(lines)))
-            exec(compile(dummy, path, 'exec'), {})
+            dummy = "\n" * (start - 1) + "\n".join("pass" for _ in range(len(lines)))
+            exec(compile(dummy, path, "exec"), {})
             executed = set(cov.get_data().lines(path))
         cov.stop()
-        coverage_percent = len(set(executable) & executed) / len(executable
-            ) * 100
+        coverage_percent = len(set(executable) & executed) / len(executable) * 100
         assert coverage_percent >= 80
 
     def test_delegate_task_no_team_succeeds(self):
         """Test delegating a task with no active team.
 
-ReqID: N/A"""
-        task = {'type': 'planning', 'description': 'Plan a new feature'}
+        ReqID: N/A"""
+        task = {"type": "planning", "description": "Plan a new feature"}
         with pytest.raises(ValidationError):
             self.coordinator.delegate_task(task)
 
     def test_delegate_task_no_agents_succeeds(self):
         """Test delegating a task with no agents in the team.
 
-ReqID: N/A"""
-        self.coordinator.create_team('test_team')
-        task = {'type': 'planning', 'description': 'Plan a new feature'}
+        ReqID: N/A"""
+        self.coordinator.create_team("test_team")
+        task = {"type": "planning", "description": "Plan a new feature"}
         with pytest.raises(ValidationError):
             self.coordinator.delegate_task(task)
 
     def test_get_team_succeeds(self):
         """Test getting a team by ID.
 
-ReqID: N/A"""
-        team = self.coordinator.create_team('test_team')
-        result = self.coordinator.get_team('test_team')
+        ReqID: N/A"""
+        team = self.coordinator.create_team("test_team")
+        result = self.coordinator.get_team("test_team")
         assert result == team
 
     def test_set_current_team_succeeds(self):
         """Test setting the current active team.
 
-ReqID: N/A"""
-        self.coordinator.create_team('team1')
-        self.coordinator.create_team('team2')
-        self.coordinator.set_current_team('team2')
-        assert self.coordinator.current_team_id == 'team2'
+        ReqID: N/A"""
+        self.coordinator.create_team("team1")
+        self.coordinator.create_team("team2")
+        self.coordinator.set_current_team("team2")
+        assert self.coordinator.current_team_id == "team2"
 
     def test_set_current_team_nonexistent_succeeds(self):
         """Test setting a nonexistent team as the current team.
 
-ReqID: N/A"""
+        ReqID: N/A"""
         with pytest.raises(ValidationError):
-            self.coordinator.set_current_team('nonexistent_team')
+            self.coordinator.set_current_team("nonexistent_team")

--- a/tests/unit/general/test_wsde_team_extended.py
+++ b/tests/unit/general/test_wsde_team_extended.py
@@ -1,21 +1,23 @@
-import pytest
 from unittest.mock import MagicMock, patch
-from devsynth.domain.models.wsde import WSDETeam
+
+import pytest
+
 from devsynth.application.agents.base import BaseAgent
+from devsynth.domain.models.wsde_facade import WSDETeam
 from devsynth.methodology.base import Phase
 
 
 class TestWSDETeam:
     """Tests for the WSDETeam component.
 
-ReqID: N/A"""
+    ReqID: N/A"""
 
     @pytest.fixture
     def mock_agent(self):
         """Create a mock agent for testing."""
         agent = MagicMock(spec=BaseAgent)
-        agent.name = 'MockAgent'
-        agent.agent_type = 'mock'
+        agent.name = "MockAgent"
+        agent.agent_type = "mock"
         agent.current_role = None
         agent.expertise = []
         return agent
@@ -27,38 +29,43 @@ ReqID: N/A"""
         def _create_agent(name, expertise):
             agent = MagicMock(spec=BaseAgent)
             agent.name = name
-            agent.agent_type = 'mock'
+            agent.agent_type = "mock"
             agent.current_role = None
             agent.expertise = expertise
 
             def mock_process(inputs):
-                if ('dialectical_reasoning' in expertise or 'critique' in
-                    expertise):
-                    return {'critique': [
-                        'Security issue: Hardcoded credentials detected',
-                        'Reliability issue: No error handling detected',
-                        'Security issue: No input validation detected'],
-                        'challenges': [
-                        "The solution doesn't handle edge cases",
-                        "The solution doesn't follow best practices"]}
-                return {'result': 'Processed by ' + name}
+                if "dialectical_reasoning" in expertise or "critique" in expertise:
+                    return {
+                        "critique": [
+                            "Security issue: Hardcoded credentials detected",
+                            "Reliability issue: No error handling detected",
+                            "Security issue: No input validation detected",
+                        ],
+                        "challenges": [
+                            "The solution doesn't handle edge cases",
+                            "The solution doesn't follow best practices",
+                        ],
+                    }
+                return {"result": "Processed by " + name}
+
             agent.process = MagicMock(side_effect=mock_process)
             return agent
+
         return _create_agent
 
     def test_wsde_team_initialization_succeeds(self):
         """Test that a WSDETeam initializes correctly.
 
-ReqID: N/A"""
-        team = WSDETeam(name='TestTeam')
+        ReqID: N/A"""
+        team = WSDETeam(name="TestTeam")
         assert team.agents == []
         assert team.primus_index == 0
 
     def test_add_agent_succeeds(self, mock_agent):
         """Test adding an agent to the team.
 
-ReqID: N/A"""
-        team = WSDETeam(name='TestTeam')
+        ReqID: N/A"""
+        team = WSDETeam(name="TestTeam")
         team.add_agent(mock_agent)
         assert len(team.agents) == 1
         assert team.agents[0] == mock_agent
@@ -66,8 +73,8 @@ ReqID: N/A"""
     def test_rotate_primus_succeeds(self, mock_agent):
         """Test rotating the Primus role.
 
-ReqID: N/A"""
-        team = WSDETeam(name='TestTeam')
+        ReqID: N/A"""
+        team = WSDETeam(name="TestTeam")
         agent1 = mock_agent
         agent2 = MagicMock(spec=BaseAgent)
         agent3 = MagicMock(spec=BaseAgent)
@@ -85,8 +92,8 @@ ReqID: N/A"""
     def test_get_primus_succeeds(self, mock_agent):
         """Test getting the current Primus agent.
 
-ReqID: N/A"""
-        team = WSDETeam(name='TestTeam')
+        ReqID: N/A"""
+        team = WSDETeam(name="TestTeam")
         assert team.get_primus() is None
         team.add_agent(mock_agent)
         assert team.get_primus() == mock_agent
@@ -98,8 +105,8 @@ ReqID: N/A"""
     def test_assign_roles_succeeds(self, mock_agent):
         """Test assigning WSDE roles to agents.
 
-ReqID: N/A"""
-        team = WSDETeam(name='TestTeam')
+        ReqID: N/A"""
+        team = WSDETeam(name="TestTeam")
         agent1 = mock_agent
         agent2 = MagicMock(spec=BaseAgent)
         agent3 = MagicMock(spec=BaseAgent)
@@ -111,19 +118,23 @@ ReqID: N/A"""
         team.add_agent(agent4)
         team.add_agent(agent5)
         team.assign_roles()
-        assert agent1.current_role == 'Primus'
-        assigned_roles = [agent2.current_role, agent3.current_role, agent4.
-            current_role, agent5.current_role]
-        assert 'Worker' in assigned_roles
-        assert 'Supervisor' in assigned_roles
-        assert 'Designer' in assigned_roles
-        assert 'Evaluator' in assigned_roles
+        assert agent1.current_role == "Primus"
+        assigned_roles = [
+            agent2.current_role,
+            agent3.current_role,
+            agent4.current_role,
+            agent5.current_role,
+        ]
+        assert "Worker" in assigned_roles
+        assert "Supervisor" in assigned_roles
+        assert "Designer" in assigned_roles
+        assert "Evaluator" in assigned_roles
 
     def test_get_role_specific_agents_succeeds(self, mock_agent):
         """Test getting agents by their specific roles.
 
-ReqID: N/A"""
-        team = WSDETeam(name='TestTeam')
+        ReqID: N/A"""
+        team = WSDETeam(name="TestTeam")
         agent1 = MagicMock(spec=BaseAgent)
         agent2 = MagicMock(spec=BaseAgent)
         agent3 = MagicMock(spec=BaseAgent)
@@ -134,44 +145,40 @@ ReqID: N/A"""
         team.add_agent(agent3)
         team.add_agent(agent4)
         team.add_agent(agent5)
-        agent1.current_role = 'Primus'
-        agent2.current_role = 'Worker'
-        agent3.current_role = 'Supervisor'
-        agent4.current_role = 'Designer'
-        agent5.current_role = 'Evaluator'
+        agent1.current_role = "Primus"
+        agent2.current_role = "Worker"
+        agent3.current_role = "Supervisor"
+        agent4.current_role = "Designer"
+        agent5.current_role = "Evaluator"
         assert team.get_worker() == agent2
         assert team.get_supervisor() == agent3
         assert team.get_designer() == agent4
         assert team.get_evaluator() == agent5
 
-    def test_select_primus_by_expertise_succeeds(self,
-        mock_agent_with_expertise):
+    def test_select_primus_by_expertise_succeeds(self, mock_agent_with_expertise):
         """Test selecting a Primus based on task context and agent expertise.
 
-ReqID: N/A"""
-        team = WSDETeam(name='TestTeam')
-        python_agent = mock_agent_with_expertise('PythonAgent', ['python',
-            'coding', 'backend'])
-        js_agent = mock_agent_with_expertise('JSAgent', ['javascript',
-            'frontend', 'web'])
-        design_agent = mock_agent_with_expertise('DesignAgent', ['design',
-            'ui', 'ux'])
-        test_agent = mock_agent_with_expertise('TestAgent', ['testing',
-            'qa', 'pytest'])
-        doc_agent = mock_agent_with_expertise('DocAgent', ['documentation',
-            'markdown'])
+        ReqID: N/A"""
+        team = WSDETeam(name="TestTeam")
+        python_agent = mock_agent_with_expertise(
+            "PythonAgent", ["python", "coding", "backend"]
+        )
+        js_agent = mock_agent_with_expertise(
+            "JSAgent", ["javascript", "frontend", "web"]
+        )
+        design_agent = mock_agent_with_expertise("DesignAgent", ["design", "ui", "ux"])
+        test_agent = mock_agent_with_expertise("TestAgent", ["testing", "qa", "pytest"])
+        doc_agent = mock_agent_with_expertise("DocAgent", ["documentation", "markdown"])
         team.add_agent(python_agent)
         team.add_agent(js_agent)
         team.add_agent(design_agent)
         team.add_agent(test_agent)
         team.add_agent(doc_agent)
-        python_task = {'type': 'coding', 'language': 'python', 'domain':
-            'backend'}
-        js_task = {'type': 'coding', 'language': 'javascript', 'domain':
-            'frontend'}
-        design_task = {'type': 'design', 'focus': 'ui', 'platform': 'web'}
-        test_task = {'type': 'testing', 'framework': 'pytest', 'scope': 'unit'}
-        doc_task = {'type': 'documentation', 'tool': 'markdown'}
+        python_task = {"type": "coding", "language": "python", "domain": "backend"}
+        js_task = {"type": "coding", "language": "javascript", "domain": "frontend"}
+        design_task = {"type": "design", "focus": "ui", "platform": "web"}
+        test_task = {"type": "testing", "framework": "pytest", "scope": "unit"}
+        doc_task = {"type": "documentation", "tool": "markdown"}
         team.select_primus_by_expertise(python_task)
         assert team.get_primus() == python_agent
         team.select_primus_by_expertise(js_task)
@@ -186,194 +193,210 @@ ReqID: N/A"""
     def test_peer_based_structure_succeeds(self, mock_agent_with_expertise):
         """Test that all agents are treated as peers with no permanent hierarchy.
 
-ReqID: N/A"""
-        team = WSDETeam(name='TestTeam')
-        agent1 = mock_agent_with_expertise('Agent1', ['skill1'])
-        agent2 = mock_agent_with_expertise('Agent2', ['skill2'])
-        agent3 = mock_agent_with_expertise('Agent3', ['skill3'])
+        ReqID: N/A"""
+        team = WSDETeam(name="TestTeam")
+        agent1 = mock_agent_with_expertise("Agent1", ["skill1"])
+        agent2 = mock_agent_with_expertise("Agent2", ["skill2"])
+        agent3 = mock_agent_with_expertise("Agent3", ["skill3"])
         team.add_agent(agent1)
         team.add_agent(agent2)
         team.add_agent(agent3)
         assert team.get_primus() == agent1
-        task2 = {'type': 'task', 'requires': 'skill2'}
+        task2 = {"type": "task", "requires": "skill2"}
         team.select_primus_by_expertise(task2)
         assert team.get_primus() == agent2
-        task3 = {'type': 'task', 'requires': 'skill3'}
+        task3 = {"type": "task", "requires": "skill3"}
         team.select_primus_by_expertise(task3)
         assert team.get_primus() == agent3
-        task1 = {'type': 'task', 'requires': 'skill1'}
+        task1 = {"type": "task", "requires": "skill1"}
         team.select_primus_by_expertise(task1)
         assert team.get_primus() == agent1
         assert agent1.has_been_primus
         assert agent2.has_been_primus
         assert agent3.has_been_primus
 
-    def test_autonomous_collaboration_succeeds(self, mock_agent_with_expertise
-        ):
+    def test_autonomous_collaboration_succeeds(self, mock_agent_with_expertise):
         """Test that agents can propose solutions or critiques at any stage.
 
-ReqID: N/A"""
-        team = WSDETeam(name='TestTeam')
-        agent1 = mock_agent_with_expertise('Agent1', ['skill1'])
-        agent2 = mock_agent_with_expertise('Agent2', ['skill2'])
-        agent3 = mock_agent_with_expertise('Agent3', ['skill3'])
+        ReqID: N/A"""
+        team = WSDETeam(name="TestTeam")
+        agent1 = mock_agent_with_expertise("Agent1", ["skill1"])
+        agent2 = mock_agent_with_expertise("Agent2", ["skill2"])
+        agent3 = mock_agent_with_expertise("Agent3", ["skill3"])
         team.add_agent(agent1)
         team.add_agent(agent2)
         team.add_agent(agent3)
-        task = {'type': 'complex_task', 'description': 'A complex task'}
-        solution1 = {'agent': 'Agent1', 'content': 'Solution from Agent1'}
-        solution2 = {'agent': 'Agent2', 'content': 'Solution from Agent2'}
-        solution3 = {'agent': 'Agent3', 'content': 'Solution from Agent3'}
+        task = {"type": "complex_task", "description": "A complex task"}
+        solution1 = {"agent": "Agent1", "content": "Solution from Agent1"}
+        solution2 = {"agent": "Agent2", "content": "Solution from Agent2"}
+        solution3 = {"agent": "Agent3", "content": "Solution from Agent3"}
         assert team.can_propose_solution(agent1, task)
         assert team.can_propose_solution(agent2, task)
         assert team.can_propose_solution(agent3, task)
-        critique1 = {'agent': 'Agent1', 'content': 'Critique from Agent1'}
-        critique2 = {'agent': 'Agent2', 'content': 'Critique from Agent2'}
-        critique3 = {'agent': 'Agent3', 'content': 'Critique from Agent3'}
+        critique1 = {"agent": "Agent1", "content": "Critique from Agent1"}
+        critique2 = {"agent": "Agent2", "content": "Critique from Agent2"}
+        critique3 = {"agent": "Agent3", "content": "Critique from Agent3"}
         assert team.can_provide_critique(agent1, solution2)
         assert team.can_provide_critique(agent2, solution3)
         assert team.can_provide_critique(agent3, solution1)
 
-    def test_consensus_based_decision_making_succeeds(self,
-        mock_agent_with_expertise):
+    def test_consensus_based_decision_making_succeeds(self, mock_agent_with_expertise):
         """Test facilitating consensus building among agents.
 
-ReqID: N/A"""
-        team = WSDETeam(name='TestTeam')
-        agent1 = mock_agent_with_expertise('Agent1', ['skill1'])
-        agent2 = mock_agent_with_expertise('Agent2', ['skill2'])
-        agent3 = mock_agent_with_expertise('Agent3', ['skill3'])
+        ReqID: N/A"""
+        team = WSDETeam(name="TestTeam")
+        agent1 = mock_agent_with_expertise("Agent1", ["skill1"])
+        agent2 = mock_agent_with_expertise("Agent2", ["skill2"])
+        agent3 = mock_agent_with_expertise("Agent3", ["skill3"])
         team.add_agent(agent1)
         team.add_agent(agent2)
         team.add_agent(agent3)
-        task = {'type': 'decision_task', 'description':
-            'A task requiring consensus'}
-        solution1 = {'agent': 'Agent1', 'content': 'Solution from Agent1'}
-        solution2 = {'agent': 'Agent2', 'content': 'Solution from Agent2'}
-        solution3 = {'agent': 'Agent3', 'content': 'Solution from Agent3'}
+        task = {"type": "decision_task", "description": "A task requiring consensus"}
+        solution1 = {"agent": "Agent1", "content": "Solution from Agent1"}
+        solution2 = {"agent": "Agent2", "content": "Solution from Agent2"}
+        solution3 = {"agent": "Agent3", "content": "Solution from Agent3"}
         team.add_solution(task, solution1)
         team.add_solution(task, solution2)
         team.add_solution(task, solution3)
         consensus = team.build_consensus(task)
-        assert 'Agent1' in consensus['contributors']
-        assert 'Agent2' in consensus['contributors']
-        assert 'Agent3' in consensus['contributors']
-        assert consensus['method'] == 'consensus_synthesis'
+        assert "Agent1" in consensus["contributors"]
+        assert "Agent2" in consensus["contributors"]
+        assert "Agent3" in consensus["contributors"]
+        assert consensus["method"] == "consensus_synthesis"
 
-    def test_dialectical_review_process_succeeds(self,
-        mock_agent_with_expertise):
+    def test_dialectical_review_process_succeeds(self, mock_agent_with_expertise):
         """Test the dialectical review process with thesis, antithesis, and synthesis.
 
-ReqID: N/A"""
-        team = WSDETeam(name='TestTeam')
-        code_agent = mock_agent_with_expertise('CodeAgent', ['python',
-            'coding'])
-        test_agent = mock_agent_with_expertise('TestAgent', ['testing',
-            'quality'])
-        critic_agent = mock_agent_with_expertise('CriticAgent', [
-            'dialectical_reasoning', 'critique'])
+        ReqID: N/A"""
+        team = WSDETeam(name="TestTeam")
+        code_agent = mock_agent_with_expertise("CodeAgent", ["python", "coding"])
+        test_agent = mock_agent_with_expertise("TestAgent", ["testing", "quality"])
+        critic_agent = mock_agent_with_expertise(
+            "CriticAgent", ["dialectical_reasoning", "critique"]
+        )
         team.add_agent(code_agent)
         team.add_agent(test_agent)
         team.add_agent(critic_agent)
-        task = {'type': 'implementation_task', 'description':
-            'Implement a user authentication system'}
-        thesis = {'agent': 'CodeAgent', 'content':
-            'Implement authentication using a simple username/password check',
-            'code':
-            """def authenticate(username, password):
-    return username == 'admin' and password == 'password'"""
-            }
+        task = {
+            "type": "implementation_task",
+            "description": "Implement a user authentication system",
+        }
+        thesis = {
+            "agent": "CodeAgent",
+            "content": "Implement authentication using a simple username/password check",
+            "code": """def authenticate(username, password):
+    return username == 'admin' and password == 'password'""",
+        }
         team.add_solution(task, thesis)
-        dialectical_result = team.apply_dialectical_reasoning(task,
-            critic_agent)
-        assert 'thesis' in dialectical_result
-        assert 'antithesis' in dialectical_result
-        assert 'synthesis' in dialectical_result
-        assert dialectical_result['thesis']['agent'] == 'CodeAgent'
-        assert 'critique' in dialectical_result['antithesis']
-        assert len(dialectical_result['antithesis']['critique']) > 0
-        assert dialectical_result['synthesis']['is_improvement']
-        assert 'improved_solution' in dialectical_result['synthesis']
+        dialectical_result = team.apply_dialectical_reasoning(task, critic_agent)
+        assert "thesis" in dialectical_result
+        assert "antithesis" in dialectical_result
+        assert "synthesis" in dialectical_result
+        assert dialectical_result["thesis"]["agent"] == "CodeAgent"
+        assert "critique" in dialectical_result["antithesis"]
+        assert len(dialectical_result["antithesis"]["critique"]) > 0
+        assert dialectical_result["synthesis"]["is_improvement"]
+        assert "improved_solution" in dialectical_result["synthesis"]
 
-    def test_peer_review_with_acceptance_criteria_succeeds(self,
-        mock_agent_with_expertise):
+    def test_peer_review_with_acceptance_criteria_succeeds(
+        self, mock_agent_with_expertise
+    ):
         """Test the peer review process with specific acceptance criteria.
 
-ReqID: N/A"""
-        team = WSDETeam(name='TestTeam')
-        author_agent = mock_agent_with_expertise('AuthorAgent', ['python',
-            'coding'])
-        reviewer1 = mock_agent_with_expertise('ReviewerAgent1', ['testing',
-            'quality'])
-        reviewer2 = mock_agent_with_expertise('ReviewerAgent2', ['security',
-            'best_practices'])
+        ReqID: N/A"""
+        team = WSDETeam(name="TestTeam")
+        author_agent = mock_agent_with_expertise("AuthorAgent", ["python", "coding"])
+        reviewer1 = mock_agent_with_expertise("ReviewerAgent1", ["testing", "quality"])
+        reviewer2 = mock_agent_with_expertise(
+            "ReviewerAgent2", ["security", "best_practices"]
+        )
         team.add_agent(author_agent)
         team.add_agent(reviewer1)
         team.add_agent(reviewer2)
-        work_product = {'code':
-            """def authenticate(username, password):
-    return username == 'admin' and password == 'password'"""
-            , 'description': 'Simple authentication function'}
-        acceptance_criteria = ['Code follows security best practices',
-            'Function handles edge cases', 'Code is well-documented']
-        review = team.request_peer_review(work_product=work_product, author
-            =author_agent, reviewer_agents=[reviewer1, reviewer2])
+        work_product = {
+            "code": """def authenticate(username, password):
+    return username == 'admin' and password == 'password'""",
+            "description": "Simple authentication function",
+        }
+        acceptance_criteria = [
+            "Code follows security best practices",
+            "Function handles edge cases",
+            "Code is well-documented",
+        ]
+        review = team.request_peer_review(
+            work_product=work_product,
+            author=author_agent,
+            reviewer_agents=[reviewer1, reviewer2],
+        )
         review.acceptance_criteria = acceptance_criteria
         for reviewer in review.reviewers:
-            review.reviews[reviewer.name] = {'overall_feedback':
-                'The code needs improvement', 'criteria_results': {
-                'Code follows security best practices': False,
-                'Function handles edge cases': False,
-                'Code is well-documented': True}, 'suggestions': [
-                'Use a secure password hashing algorithm',
-                'Add input validation']}
+            review.reviews[reviewer.name] = {
+                "overall_feedback": "The code needs improvement",
+                "criteria_results": {
+                    "Code follows security best practices": False,
+                    "Function handles edge cases": False,
+                    "Code is well-documented": True,
+                },
+                "suggestions": [
+                    "Use a secure password hashing algorithm",
+                    "Add input validation",
+                ],
+            }
         review.collect_reviews()
         feedback = review.aggregate_feedback()
-        assert 'criteria_results' in feedback
-        assert len(feedback['criteria_results']) == len(acceptance_criteria)
-        assert feedback['criteria_results'][
-            'Code follows security best practices'] == False
-        assert feedback['criteria_results']['Function handles edge cases'
-            ] == False
-        assert feedback['criteria_results']['Code is well-documented'] == True
-        assert feedback['all_criteria_passed'] == False
+        assert "criteria_results" in feedback
+        assert len(feedback["criteria_results"]) == len(acceptance_criteria)
+        assert (
+            feedback["criteria_results"]["Code follows security best practices"]
+            == False
+        )
+        assert feedback["criteria_results"]["Function handles edge cases"] == False
+        assert feedback["criteria_results"]["Code is well-documented"] == True
+        assert feedback["all_criteria_passed"] == False
         final_result = review.finalize(approved=False)
-        assert final_result['status'] == 'rejected'
-        assert final_result['reasons'] == [
-            'Code follows security best practices: Failed',
-            'Function handles edge cases: Failed']
+        assert final_result["status"] == "rejected"
+        assert final_result["reasons"] == [
+            "Code follows security best practices: Failed",
+            "Function handles edge cases: Failed",
+        ]
 
-    def test_peer_review_with_revision_cycle_succeeds(self,
-        mock_agent_with_expertise):
+    def test_peer_review_with_revision_cycle_succeeds(self, mock_agent_with_expertise):
         """Test the peer review process with a revision cycle.
 
-ReqID: N/A"""
-        team = WSDETeam(name='TestTeam')
-        author_agent = mock_agent_with_expertise('AuthorAgent', ['python',
-            'coding'])
-        reviewer1 = mock_agent_with_expertise('ReviewerAgent1', ['testing',
-            'quality'])
-        reviewer2 = mock_agent_with_expertise('ReviewerAgent2', ['security',
-            'best_practices'])
+        ReqID: N/A"""
+        team = WSDETeam(name="TestTeam")
+        author_agent = mock_agent_with_expertise("AuthorAgent", ["python", "coding"])
+        reviewer1 = mock_agent_with_expertise("ReviewerAgent1", ["testing", "quality"])
+        reviewer2 = mock_agent_with_expertise(
+            "ReviewerAgent2", ["security", "best_practices"]
+        )
         team.add_agent(author_agent)
         team.add_agent(reviewer1)
         team.add_agent(reviewer2)
-        work_product = {'code':
-            """def authenticate(username, password):
-    return username == 'admin' and password == 'password'"""
-            , 'description': 'Simple authentication function'}
-        review = team.request_peer_review(work_product=work_product, author
-            =author_agent, reviewer_agents=[reviewer1, reviewer2])
+        work_product = {
+            "code": """def authenticate(username, password):
+    return username == 'admin' and password == 'password'""",
+            "description": "Simple authentication function",
+        }
+        review = team.request_peer_review(
+            work_product=work_product,
+            author=author_agent,
+            reviewer_agents=[reviewer1, reviewer2],
+        )
         for reviewer in review.reviewers:
-            review.reviews[reviewer.name] = {'overall_feedback':
-                'The code needs improvement', 'suggestions': [
-                'Use a secure password hashing algorithm',
-                'Add input validation'], 'approved': False}
+            review.reviews[reviewer.name] = {
+                "overall_feedback": "The code needs improvement",
+                "suggestions": [
+                    "Use a secure password hashing algorithm",
+                    "Add input validation",
+                ],
+                "approved": False,
+            }
         review.collect_reviews()
         review.request_revision()
-        assert review.status == 'revision_requested'
-        revised_work = {'code':
-            """def authenticate(username, password):
+        assert review.status == "revision_requested"
+        revised_work = {
+            "code": """def authenticate(username, password):
     # Validate inputs
     if not username or not password:
         return False
@@ -383,54 +406,75 @@ ReqID: N/A"""
     import hashlib
     hashed_password = hashlib.sha256(password.encode()).hexdigest()
     return username == 'admin' and hashed_password == '5e884898da28047151d0e56f8dc6292773603d0d6aabbdd62a11ef721d1542d8'
-    """
-            , 'description':
-            'Improved authentication function with input validation and hashing'
-            }
+    """,
+            "description": "Improved authentication function with input validation and hashing",
+        }
         new_review = review.submit_revision(revised_work)
         assert new_review.previous_review == review
         assert new_review.work_product == revised_work
         for reviewer in new_review.reviewers:
-            new_review.reviews[reviewer.name] = {'overall_feedback':
-                'The code is now acceptable', 'suggestions': [], 'approved':
-                True}
+            new_review.reviews[reviewer.name] = {
+                "overall_feedback": "The code is now acceptable",
+                "suggestions": [],
+                "approved": True,
+            }
         new_review.collect_reviews()
         new_review.quality_score = 0.9
         final_result = new_review.finalize(approved=True)
-        assert final_result['status'] == 'approved'
-        assert final_result['previous_review_id'] == review.review_id
+        assert final_result["status"] == "approved"
+        assert final_result["previous_review_id"] == review.review_id
 
-    def test_peer_review_with_dialectical_analysis_succeeds(self,
-        mock_agent_with_expertise):
+    def test_peer_review_with_dialectical_analysis_succeeds(
+        self, mock_agent_with_expertise
+    ):
         """Test the peer review process with dialectical analysis.
 
-ReqID: N/A"""
-        team = WSDETeam(name='TestTeam')
-        author_agent = mock_agent_with_expertise('AuthorAgent', ['python',
-            'coding'])
-        critic_agent = mock_agent_with_expertise('CriticAgent', [
-            'dialectical_reasoning', 'critique'])
+        ReqID: N/A"""
+        team = WSDETeam(name="TestTeam")
+        author_agent = mock_agent_with_expertise("AuthorAgent", ["python", "coding"])
+        critic_agent = mock_agent_with_expertise(
+            "CriticAgent", ["dialectical_reasoning", "critique"]
+        )
         team.add_agent(author_agent)
         team.add_agent(critic_agent)
-        work_product = {'code':
-            """def authenticate(username, password):
-    return username == 'admin' and password == 'password'"""
-            , 'description': 'Simple authentication function'}
-        review = team.request_peer_review(work_product=work_product, author
-            =author_agent, reviewer_agents=[critic_agent])
-        dialectical_analysis = {'thesis': {'strengths': [
-            'Simple and easy to understand',
-            'Functional for basic use cases'], 'key_points': [
-            'Direct string comparison for authentication']}, 'antithesis':
-            {'weaknesses': ['Security vulnerability: Hardcoded credentials',
-            'No input validation', 'No error handling',
-            'No password hashing'], 'challenges': [
-            'Insecure for production use', 'Vulnerable to timing attacks']},
-            'synthesis': {'improvements': ['Use secure password hashing',
-            'Add input validation', 'Implement proper error handling',
-            'Use environment variables or a secure configuration for credentials'
-            ], 'improved_solution':
-            """def authenticate(username, password):
+        work_product = {
+            "code": """def authenticate(username, password):
+    return username == 'admin' and password == 'password'""",
+            "description": "Simple authentication function",
+        }
+        review = team.request_peer_review(
+            work_product=work_product,
+            author=author_agent,
+            reviewer_agents=[critic_agent],
+        )
+        dialectical_analysis = {
+            "thesis": {
+                "strengths": [
+                    "Simple and easy to understand",
+                    "Functional for basic use cases",
+                ],
+                "key_points": ["Direct string comparison for authentication"],
+            },
+            "antithesis": {
+                "weaknesses": [
+                    "Security vulnerability: Hardcoded credentials",
+                    "No input validation",
+                    "No error handling",
+                    "No password hashing",
+                ],
+                "challenges": [
+                    "Insecure for production use",
+                    "Vulnerable to timing attacks",
+                ],
+            },
+            "synthesis": {
+                "improvements": [
+                    "Use secure password hashing",
+                    "Add input validation",
+                    "Implement proper error handling",
+                    "Use environment variables or a secure configuration for credentials",
+                ],
+                "improved_solution": """def authenticate(username, password):
     # Validate inputs
     if not username or not password:
         return False
@@ -450,77 +494,84 @@ ReqID: N/A"""
     except Exception as e:
         logger.error(f"Authentication error: {e}")
         return False
-"""
-            }}
-        review.reviews[critic_agent.name] = {'overall_feedback':
-            'The code needs significant improvement for security',
-            'dialectical_analysis': dialectical_analysis, 'approved': False}
+""",
+            },
+        }
+        review.reviews[critic_agent.name] = {
+            "overall_feedback": "The code needs significant improvement for security",
+            "dialectical_analysis": dialectical_analysis,
+            "approved": False,
+        }
         review.collect_reviews()
         feedback = review.aggregate_feedback()
-        assert 'dialectical_analysis' in feedback
-        assert 'thesis' in feedback['dialectical_analysis']
-        assert 'antithesis' in feedback['dialectical_analysis']
-        assert 'synthesis' in feedback['dialectical_analysis']
-        assert 'improvements' in feedback['dialectical_analysis']['synthesis']
-        assert len(feedback['dialectical_analysis']['synthesis'][
-            'improvements']) > 0
-        assert 'improved_solution' in feedback['dialectical_analysis'][
-            'synthesis']
-        assert 'hashlib' in feedback['dialectical_analysis']['synthesis'][
-            'improved_solution']
+        assert "dialectical_analysis" in feedback
+        assert "thesis" in feedback["dialectical_analysis"]
+        assert "antithesis" in feedback["dialectical_analysis"]
+        assert "synthesis" in feedback["dialectical_analysis"]
+        assert "improvements" in feedback["dialectical_analysis"]["synthesis"]
+        assert len(feedback["dialectical_analysis"]["synthesis"]["improvements"]) > 0
+        assert "improved_solution" in feedback["dialectical_analysis"]["synthesis"]
+        assert (
+            "hashlib"
+            in feedback["dialectical_analysis"]["synthesis"]["improved_solution"]
+        )
 
-    def test_contextdriven_leadership_succeeds(self, mock_agent_with_expertise
-        ):
+    def test_contextdriven_leadership_succeeds(self, mock_agent_with_expertise):
         """Test context-driven leadership in the WSDE team.
 
-ReqID: N/A"""
-        team = WSDETeam(name='TestTeam')
-        python_agent = mock_agent_with_expertise('PythonAgent', ['python',
-            'backend'])
-        js_agent = mock_agent_with_expertise('JSAgent', ['javascript',
-            'frontend'])
-        security_agent = mock_agent_with_expertise('SecurityAgent', [
-            'security', 'authentication'])
-        design_agent = mock_agent_with_expertise('DesignAgent', ['design',
-            'ui', 'ux'])
-        doc_agent = mock_agent_with_expertise('DocAgent', ['documentation',
-            'technical_writing'])
+        ReqID: N/A"""
+        team = WSDETeam(name="TestTeam")
+        python_agent = mock_agent_with_expertise("PythonAgent", ["python", "backend"])
+        js_agent = mock_agent_with_expertise("JSAgent", ["javascript", "frontend"])
+        security_agent = mock_agent_with_expertise(
+            "SecurityAgent", ["security", "authentication"]
+        )
+        design_agent = mock_agent_with_expertise("DesignAgent", ["design", "ui", "ux"])
+        doc_agent = mock_agent_with_expertise(
+            "DocAgent", ["documentation", "technical_writing"]
+        )
         team.add_agent(python_agent)
         team.add_agent(js_agent)
         team.add_agent(security_agent)
         team.add_agent(design_agent)
         team.add_agent(doc_agent)
-        doc_task = {'type': 'documentation_task', 'description':
-            'Write API documentation', 'domain': 'documentation',
-            'requirements': ['Clear examples', 'Complete coverage']}
+        doc_task = {
+            "type": "documentation_task",
+            "description": "Write API documentation",
+            "domain": "documentation",
+            "requirements": ["Clear examples", "Complete coverage"],
+        }
         team.select_primus_by_expertise(doc_task)
         assert team.get_primus() == doc_agent
-        assert doc_agent.current_role == 'Primus'
+        assert doc_agent.current_role == "Primus"
         roles = [agent.current_role for agent in team.agents]
-        assert 'Worker' in roles
-        assert 'Supervisor' in roles
-        assert 'Designer' in roles
-        assert 'Evaluator' in roles
+        assert "Worker" in roles
+        assert "Supervisor" in roles
+        assert "Designer" in roles
+        assert "Evaluator" in roles
 
-    def test_dialectical_reasoning_with_external_knowledge_succeeds(self,
-        mock_agent_with_expertise):
+    def test_dialectical_reasoning_with_external_knowledge_succeeds(
+        self, mock_agent_with_expertise
+    ):
         """Test the dialectical reasoning process with external knowledge integration.
 
-ReqID: N/A"""
-        team = WSDETeam(name='TestTeam')
-        code_agent = mock_agent_with_expertise('CodeAgent', ['python',
-            'coding'])
-        security_agent = mock_agent_with_expertise('SecurityAgent', [
-            'security', 'authentication'])
-        critic_agent = mock_agent_with_expertise('CriticAgent', [
-            'dialectical_reasoning', 'critique'])
-        task = {'type': 'implementation_task', 'description':
-            'Implement a secure user authentication system with multi-factor authentication'
-            }
-        thesis = {'agent': 'CodeAgent', 'content':
-            'Implement authentication using username/password with JWT tokens',
-            'code':
-            """
+        ReqID: N/A"""
+        team = WSDETeam(name="TestTeam")
+        code_agent = mock_agent_with_expertise("CodeAgent", ["python", "coding"])
+        security_agent = mock_agent_with_expertise(
+            "SecurityAgent", ["security", "authentication"]
+        )
+        critic_agent = mock_agent_with_expertise(
+            "CriticAgent", ["dialectical_reasoning", "critique"]
+        )
+        task = {
+            "type": "implementation_task",
+            "description": "Implement a secure user authentication system with multi-factor authentication",
+        }
+        thesis = {
+            "agent": "CodeAgent",
+            "content": "Implement authentication using username/password with JWT tokens",
+            "code": """
 def authenticate(username, password):
     if username == 'admin' and password == 'password':
         token = generate_jwt_token(username)
@@ -530,93 +581,118 @@ def authenticate(username, password):
 def generate_jwt_token(username):
     # Generate a JWT token
     return "jwt_token_placeholder"
-            """
-            }
+            """,
+        }
         team.add_solution(task, thesis)
-        external_knowledge = {'security_best_practices': {'authentication':
-            ['Use multi-factor authentication for sensitive operations',
-            'Store passwords using strong, adaptive hashing algorithms (e.g., bcrypt, Argon2)'
-            , 'Implement rate limiting to prevent brute force attacks',
-            'Use HTTPS for all authentication requests',
-            'Set secure and HttpOnly flags on authentication cookies'],
-            'data_protection': [
-            'Encrypt sensitive data at rest and in transit',
-            'Implement proper access controls',
-            'Follow the principle of least privilege',
-            'Regularly audit access to sensitive data',
-            'Have a data breach response plan']}, 'industry_standards': {
-            'OWASP': ['OWASP Top 10 Web Application Security Risks',
-            'OWASP Application Security Verification Standard (ASVS)',
-            'OWASP Secure Coding Practices'], 'ISO': [
-            'ISO/IEC 27001 - Information security management',
-            'ISO/IEC 27002 - Code of practice for information security controls'
-            ], 'NIST': [
-            'NIST Special Publication 800-53 - Security and Privacy Controls',
-            'NIST Cybersecurity Framework']}, 'compliance_requirements': {
-            'GDPR': ['Obtain explicit consent for data collection',
-            'Provide mechanisms for users to access, modify, and delete their data'
-            , 'Report data breaches within 72 hours',
-            'Conduct Data Protection Impact Assessments (DPIA)'], 'HIPAA':
-            ['Implement technical safeguards for PHI',
-            'Conduct regular risk assessments',
-            'Maintain audit trails of PHI access',
-            'Have Business Associate Agreements (BAA) in place'], 'PCI-DSS':
-            ['Maintain a secure network and systems',
-            'Protect cardholder data',
-            'Implement strong access control measures',
-            'Regularly test security systems and processes']}}
-        dialectical_result = (team.
-            apply_enhanced_dialectical_reasoning_with_knowledge(task,
-            critic_agent, external_knowledge))
-        assert 'thesis' in dialectical_result
-        assert 'antithesis' in dialectical_result
-        assert 'synthesis' in dialectical_result
-        assert 'evaluation' in dialectical_result
-        assert 'external_knowledge' in dialectical_result
-        assert 'relevant_sources' in dialectical_result['external_knowledge']
-        assert len(dialectical_result['external_knowledge']['relevant_sources']
-            ) > 0
-        assert 'industry_references' in dialectical_result['antithesis']
-        assert len(dialectical_result['antithesis']['industry_references']) > 0
-        assert 'standards_alignment' in dialectical_result['synthesis']
-        assert len(dialectical_result['synthesis']['standards_alignment']) > 0
-        assert 'compliance_assessment' in dialectical_result['evaluation']
-        assert len(dialectical_result['evaluation']['compliance_assessment']
-            ) > 0
-        assert dialectical_result['synthesis']['is_improvement']
-        assert 'improved_solution' in dialectical_result['synthesis']
+        external_knowledge = {
+            "security_best_practices": {
+                "authentication": [
+                    "Use multi-factor authentication for sensitive operations",
+                    "Store passwords using strong, adaptive hashing algorithms (e.g., bcrypt, Argon2)",
+                    "Implement rate limiting to prevent brute force attacks",
+                    "Use HTTPS for all authentication requests",
+                    "Set secure and HttpOnly flags on authentication cookies",
+                ],
+                "data_protection": [
+                    "Encrypt sensitive data at rest and in transit",
+                    "Implement proper access controls",
+                    "Follow the principle of least privilege",
+                    "Regularly audit access to sensitive data",
+                    "Have a data breach response plan",
+                ],
+            },
+            "industry_standards": {
+                "OWASP": [
+                    "OWASP Top 10 Web Application Security Risks",
+                    "OWASP Application Security Verification Standard (ASVS)",
+                    "OWASP Secure Coding Practices",
+                ],
+                "ISO": [
+                    "ISO/IEC 27001 - Information security management",
+                    "ISO/IEC 27002 - Code of practice for information security controls",
+                ],
+                "NIST": [
+                    "NIST Special Publication 800-53 - Security and Privacy Controls",
+                    "NIST Cybersecurity Framework",
+                ],
+            },
+            "compliance_requirements": {
+                "GDPR": [
+                    "Obtain explicit consent for data collection",
+                    "Provide mechanisms for users to access, modify, and delete their data",
+                    "Report data breaches within 72 hours",
+                    "Conduct Data Protection Impact Assessments (DPIA)",
+                ],
+                "HIPAA": [
+                    "Implement technical safeguards for PHI",
+                    "Conduct regular risk assessments",
+                    "Maintain audit trails of PHI access",
+                    "Have Business Associate Agreements (BAA) in place",
+                ],
+                "PCI-DSS": [
+                    "Maintain a secure network and systems",
+                    "Protect cardholder data",
+                    "Implement strong access control measures",
+                    "Regularly test security systems and processes",
+                ],
+            },
+        }
+        dialectical_result = team.apply_enhanced_dialectical_reasoning_with_knowledge(
+            task, critic_agent, external_knowledge
+        )
+        assert "thesis" in dialectical_result
+        assert "antithesis" in dialectical_result
+        assert "synthesis" in dialectical_result
+        assert "evaluation" in dialectical_result
+        assert "external_knowledge" in dialectical_result
+        assert "relevant_sources" in dialectical_result["external_knowledge"]
+        assert len(dialectical_result["external_knowledge"]["relevant_sources"]) > 0
+        assert "industry_references" in dialectical_result["antithesis"]
+        assert len(dialectical_result["antithesis"]["industry_references"]) > 0
+        assert "standards_alignment" in dialectical_result["synthesis"]
+        assert len(dialectical_result["synthesis"]["standards_alignment"]) > 0
+        assert "compliance_assessment" in dialectical_result["evaluation"]
+        assert len(dialectical_result["evaluation"]["compliance_assessment"]) > 0
+        assert dialectical_result["synthesis"]["is_improvement"]
+        assert "improved_solution" in dialectical_result["synthesis"]
 
-    def test_multi_disciplinary_dialectical_reasoning_succeeds(self,
-        mock_agent_with_expertise):
+    def test_multi_disciplinary_dialectical_reasoning_succeeds(
+        self, mock_agent_with_expertise
+    ):
         """Test the dialectical reasoning process with multiple disciplinary perspectives.
 
-ReqID: N/A"""
-        team = WSDETeam(name='TestTeam')
-        code_agent = mock_agent_with_expertise('CodeAgent', ['python',
-            'coding'])
-        security_agent = mock_agent_with_expertise('SecurityAgent', [
-            'security', 'authentication'])
-        ux_agent = mock_agent_with_expertise('UXAgent', ['user_experience',
-            'interface_design'])
-        performance_agent = mock_agent_with_expertise('PerformanceAgent', [
-            'performance', 'optimization'])
-        accessibility_agent = mock_agent_with_expertise('AccessibilityAgent',
-            ['accessibility', 'inclusive_design'])
-        critic_agent = mock_agent_with_expertise('CriticAgent', [
-            'dialectical_reasoning', 'critique', 'synthesis'])
+        ReqID: N/A"""
+        team = WSDETeam(name="TestTeam")
+        code_agent = mock_agent_with_expertise("CodeAgent", ["python", "coding"])
+        security_agent = mock_agent_with_expertise(
+            "SecurityAgent", ["security", "authentication"]
+        )
+        ux_agent = mock_agent_with_expertise(
+            "UXAgent", ["user_experience", "interface_design"]
+        )
+        performance_agent = mock_agent_with_expertise(
+            "PerformanceAgent", ["performance", "optimization"]
+        )
+        accessibility_agent = mock_agent_with_expertise(
+            "AccessibilityAgent", ["accessibility", "inclusive_design"]
+        )
+        critic_agent = mock_agent_with_expertise(
+            "CriticAgent", ["dialectical_reasoning", "critique", "synthesis"]
+        )
         team.add_agent(code_agent)
         team.add_agent(security_agent)
         team.add_agent(ux_agent)
         team.add_agent(performance_agent)
         team.add_agent(accessibility_agent)
         team.add_agent(critic_agent)
-        task = {'type': 'implementation_task', 'description':
-            'Implement a user authentication system with a focus on security, usability, performance, and accessibility'
-            }
-        thesis = {'agent': 'CodeAgent', 'content':
-            'Implement authentication using username/password with JWT tokens',
-            'code':
-            """
+        task = {
+            "type": "implementation_task",
+            "description": "Implement a user authentication system with a focus on security, usability, performance, and accessibility",
+        }
+        thesis = {
+            "agent": "CodeAgent",
+            "content": "Implement authentication using username/password with JWT tokens",
+            "code": """
 def authenticate(username, password):
     if username == 'admin' and password == 'password':
         token = generate_jwt_token(username)
@@ -626,204 +702,234 @@ def authenticate(username, password):
 def generate_jwt_token(username):
     # Generate a JWT token
     return "jwt_token_placeholder"
-            """
-            }
+            """,
+        }
         team.add_solution(task, thesis)
-        disciplinary_knowledge = {'security': {
-            'authentication_best_practices': [
-            'Use multi-factor authentication for sensitive operations',
-            'Store passwords using strong, adaptive hashing algorithms (e.g., bcrypt, Argon2)'
-            , 'Implement rate limiting to prevent brute force attacks',
-            'Use HTTPS for all authentication requests',
-            'Set secure and HttpOnly flags on authentication cookies']},
-            'user_experience': {'authentication_ux_principles': [
-            'Minimize friction in the authentication process',
-            'Provide clear error messages for failed authentication attempts',
-            'Offer password recovery options',
-            'Remember user preferences where appropriate',
-            'Support single sign-on where possible']}, 'performance': {
-            'authentication_performance_considerations': [
-            'Optimize token validation for minimal latency',
-            'Cache frequently used authentication data',
-            'Use asynchronous processing for non-critical authentication tasks'
-            , 'Implement efficient database queries for user lookup',
-            'Monitor and optimize authentication service response times']},
-            'accessibility': {'authentication_accessibility_guidelines': [
-            'Ensure all authentication forms are keyboard navigable',
-            'Provide appropriate ARIA labels for authentication form elements',
-            'Support screen readers for error messages and instructions',
-            'Maintain sufficient color contrast for text and interactive elements'
-            ,
-            'Allow authentication timeout extensions for users who need more time'
-            ]}}
-        dialectical_result = (team.
-            apply_multi_disciplinary_dialectical_reasoning(task,
-            critic_agent, disciplinary_knowledge, [security_agent, ux_agent,
-            performance_agent, accessibility_agent]))
-        assert 'thesis' in dialectical_result
-        assert 'disciplinary_perspectives' in dialectical_result
-        assert 'synthesis' in dialectical_result
-        assert 'evaluation' in dialectical_result
-        assert 'knowledge_sources' in dialectical_result
-        assert len(dialectical_result['disciplinary_perspectives']) >= 4
-        perspective_disciplines = [p['discipline'] for p in
-            dialectical_result['disciplinary_perspectives']]
-        assert 'security' in perspective_disciplines
-        assert 'user_experience' in perspective_disciplines
-        assert 'performance' in perspective_disciplines
-        assert 'accessibility' in perspective_disciplines
-        for perspective in dialectical_result['disciplinary_perspectives']:
-            assert 'critique' in perspective
-            assert len(perspective['critique']) > 0
-            assert 'recommendations' in perspective
-            assert len(perspective['recommendations']) > 0
-        assert 'integrated_perspectives' in dialectical_result['synthesis']
-        assert len(dialectical_result['synthesis']['integrated_perspectives']
-            ) >= 4
-        assert 'perspective_conflicts' in dialectical_result['synthesis']
-        assert 'conflict_resolutions' in dialectical_result['synthesis']
-        assert 'perspective_scores' in dialectical_result['evaluation']
-        assert len(dialectical_result['evaluation']['perspective_scores']) >= 4
-        assert dialectical_result['synthesis']['is_improvement']
-        assert 'improved_solution' in dialectical_result['synthesis']
+        disciplinary_knowledge = {
+            "security": {
+                "authentication_best_practices": [
+                    "Use multi-factor authentication for sensitive operations",
+                    "Store passwords using strong, adaptive hashing algorithms (e.g., bcrypt, Argon2)",
+                    "Implement rate limiting to prevent brute force attacks",
+                    "Use HTTPS for all authentication requests",
+                    "Set secure and HttpOnly flags on authentication cookies",
+                ]
+            },
+            "user_experience": {
+                "authentication_ux_principles": [
+                    "Minimize friction in the authentication process",
+                    "Provide clear error messages for failed authentication attempts",
+                    "Offer password recovery options",
+                    "Remember user preferences where appropriate",
+                    "Support single sign-on where possible",
+                ]
+            },
+            "performance": {
+                "authentication_performance_considerations": [
+                    "Optimize token validation for minimal latency",
+                    "Cache frequently used authentication data",
+                    "Use asynchronous processing for non-critical authentication tasks",
+                    "Implement efficient database queries for user lookup",
+                    "Monitor and optimize authentication service response times",
+                ]
+            },
+            "accessibility": {
+                "authentication_accessibility_guidelines": [
+                    "Ensure all authentication forms are keyboard navigable",
+                    "Provide appropriate ARIA labels for authentication form elements",
+                    "Support screen readers for error messages and instructions",
+                    "Maintain sufficient color contrast for text and interactive elements",
+                    "Allow authentication timeout extensions for users who need more time",
+                ]
+            },
+        }
+        dialectical_result = team.apply_multi_disciplinary_dialectical_reasoning(
+            task,
+            critic_agent,
+            disciplinary_knowledge,
+            [security_agent, ux_agent, performance_agent, accessibility_agent],
+        )
+        assert "thesis" in dialectical_result
+        assert "disciplinary_perspectives" in dialectical_result
+        assert "synthesis" in dialectical_result
+        assert "evaluation" in dialectical_result
+        assert "knowledge_sources" in dialectical_result
+        assert len(dialectical_result["disciplinary_perspectives"]) >= 4
+        perspective_disciplines = [
+            p["discipline"] for p in dialectical_result["disciplinary_perspectives"]
+        ]
+        assert "security" in perspective_disciplines
+        assert "user_experience" in perspective_disciplines
+        assert "performance" in perspective_disciplines
+        assert "accessibility" in perspective_disciplines
+        for perspective in dialectical_result["disciplinary_perspectives"]:
+            assert "critique" in perspective
+            assert len(perspective["critique"]) > 0
+            assert "recommendations" in perspective
+            assert len(perspective["recommendations"]) > 0
+        assert "integrated_perspectives" in dialectical_result["synthesis"]
+        assert len(dialectical_result["synthesis"]["integrated_perspectives"]) >= 4
+        assert "perspective_conflicts" in dialectical_result["synthesis"]
+        assert "conflict_resolutions" in dialectical_result["synthesis"]
+        assert "perspective_scores" in dialectical_result["evaluation"]
+        assert len(dialectical_result["evaluation"]["perspective_scores"]) >= 4
+        assert dialectical_result["synthesis"]["is_improvement"]
+        assert "improved_solution" in dialectical_result["synthesis"]
 
-    def test_assign_roles_for_phase_varied_contexts_has_expected(self,
-        mock_agent_with_expertise):
+    def test_assign_roles_for_phase_varied_contexts_has_expected(
+        self, mock_agent_with_expertise
+    ):
         """Test that different phases can have different primus agents.
 
-ReqID: N/A"""
-        team = WSDETeam(name='TestTeam')
-        expand_agent = mock_agent_with_expertise('Expand', ['brainstorming',
-            'exploration', 'creativity'])
-        diff_agent = mock_agent_with_expertise('Diff', ['comparison',
-            'analysis', 'evaluation'])
-        refine_agent = mock_agent_with_expertise('Refine', [
-            'implementation', 'coding', 'development'])
-        doc_agent = mock_agent_with_expertise('Doc', ['documentation',
-            'reflection', 'learning'])
+        ReqID: N/A"""
+        team = WSDETeam(name="TestTeam")
+        expand_agent = mock_agent_with_expertise(
+            "Expand", ["brainstorming", "exploration", "creativity"]
+        )
+        diff_agent = mock_agent_with_expertise(
+            "Diff", ["comparison", "analysis", "evaluation"]
+        )
+        refine_agent = mock_agent_with_expertise(
+            "Refine", ["implementation", "coding", "development"]
+        )
+        doc_agent = mock_agent_with_expertise(
+            "Doc", ["documentation", "reflection", "learning"]
+        )
         team.add_agents([expand_agent, diff_agent, refine_agent, doc_agent])
-        team.assign_roles_for_phase(Phase.EXPAND, {'description': 'demo'})
+        team.assign_roles_for_phase(Phase.EXPAND, {"description": "demo"})
         team.primus_index = team.agents.index(expand_agent)
-        team.role_assignments['primus'] = expand_agent
+        team.role_assignments["primus"] = expand_agent
         assert team.get_primus() == expand_agent
-        team.assign_roles_for_phase(Phase.DIFFERENTIATE, {'description':
-            'demo'})
+        team.assign_roles_for_phase(Phase.DIFFERENTIATE, {"description": "demo"})
         team.primus_index = team.agents.index(diff_agent)
-        team.role_assignments['primus'] = diff_agent
+        team.role_assignments["primus"] = diff_agent
         assert team.get_primus() == diff_agent
-        team.assign_roles_for_phase(Phase.REFINE, {'description': 'demo'})
+        team.assign_roles_for_phase(Phase.REFINE, {"description": "demo"})
         team.primus_index = team.agents.index(refine_agent)
-        team.role_assignments['primus'] = refine_agent
+        team.role_assignments["primus"] = refine_agent
         assert team.get_primus() == refine_agent
-        team.assign_roles_for_phase(Phase.RETROSPECT, {'type': 'documentation'}
-            )
+        team.assign_roles_for_phase(Phase.RETROSPECT, {"type": "documentation"})
         team.primus_index = team.agents.index(doc_agent)
-        team.role_assignments['primus'] = doc_agent
+        team.role_assignments["primus"] = doc_agent
         assert team.get_primus() == doc_agent
 
-    def test_vote_on_critical_decision_majority_path_succeeds(self, mock_agent
-        ):
+    def test_vote_on_critical_decision_majority_path_succeeds(self, mock_agent):
         """Test that vote on critical decision majority path succeeds.
 
-ReqID: N/A"""
-        team = WSDETeam(name='TestTeam')
+        ReqID: N/A"""
+        team = WSDETeam(name="TestTeam")
         a1 = mock_agent
-        a1.name = 'a1'
+        a1.name = "a1"
         a2 = MagicMock(spec=BaseAgent)
-        a2.name = 'a2'
+        a2.name = "a2"
         a3 = MagicMock(spec=BaseAgent)
-        a3.name = 'a3'
+        a3.name = "a3"
         for a in [a1, a2, a3]:
             a.process = MagicMock()
             team.add_agent(a)
-        a1.process.return_value = {'vote': 'o1'}
-        a2.process.return_value = {'vote': 'o1'}
-        a3.process.return_value = {'vote': 'o2'}
-        task = {'type': 'critical_decision', 'is_critical': True, 'options':
-            [{'id': 'o1'}, {'id': 'o2'}]}
+        a1.process.return_value = {"vote": "o1"}
+        a2.process.return_value = {"vote": "o1"}
+        a3.process.return_value = {"vote": "o2"}
+        task = {
+            "type": "critical_decision",
+            "is_critical": True,
+            "options": [{"id": "o1"}, {"id": "o2"}],
+        }
         result = team.vote_on_critical_decision(task)
-        assert result['result']['winner'] == 'o1'
-        assert result['result']['method'] == 'majority_vote'
+        assert result["result"]["winner"] == "o1"
+        assert result["result"]["method"] == "majority_vote"
 
-    def test_vote_on_critical_decision_weighted_path_succeeds(self,
-        mock_agent_with_expertise):
+    def test_vote_on_critical_decision_weighted_path_succeeds(
+        self, mock_agent_with_expertise
+    ):
         """Test that vote on critical decision weighted path succeeds.
 
-ReqID: N/A"""
-        team = WSDETeam(name='TestTeam')
-        expert = mock_agent_with_expertise('expert', ['security'])
+        ReqID: N/A"""
+        team = WSDETeam(name="TestTeam")
+        expert = mock_agent_with_expertise("expert", ["security"])
         expert.config = MagicMock()
-        expert.config.name = 'expert'
-        expert.config.parameters = {'expertise': ['security'],
-            'expertise_level': 'expert'}
-        intermediate = mock_agent_with_expertise('inter', ['security'])
+        expert.config.name = "expert"
+        expert.config.parameters = {
+            "expertise": ["security"],
+            "expertise_level": "expert",
+        }
+        intermediate = mock_agent_with_expertise("inter", ["security"])
         intermediate.config = MagicMock()
-        intermediate.config.name = 'inter'
-        intermediate.config.parameters = {'expertise': ['security'],
-            'expertise_level': 'intermediate'}
-        novice = mock_agent_with_expertise('novice', ['python'])
+        intermediate.config.name = "inter"
+        intermediate.config.parameters = {
+            "expertise": ["security"],
+            "expertise_level": "intermediate",
+        }
+        novice = mock_agent_with_expertise("novice", ["python"])
         novice.config = MagicMock()
-        novice.config.name = 'novice'
-        novice.config.parameters = {'expertise': ['python'],
-            'expertise_level': 'novice'}
+        novice.config.name = "novice"
+        novice.config.parameters = {
+            "expertise": ["python"],
+            "expertise_level": "novice",
+        }
         for a in [expert, intermediate, novice]:
             a.process = MagicMock()
             team.add_agent(a)
-        expert.process.return_value = {'vote': 'b'}
-        intermediate.process.return_value = {'vote': 'a'}
-        novice.process.return_value = {'vote': 'a'}
-        task = {'type': 'critical_decision', 'domain': 'security',
-            'is_critical': True, 'options': [{'id': 'a'}, {'id': 'b'}]}
+        expert.process.return_value = {"vote": "b"}
+        intermediate.process.return_value = {"vote": "a"}
+        novice.process.return_value = {"vote": "a"}
+        task = {
+            "type": "critical_decision",
+            "domain": "security",
+            "is_critical": True,
+            "options": [{"id": "a"}, {"id": "b"}],
+        }
         result = team.vote_on_critical_decision(task)
-        assert result['result']['method'] == 'weighted_vote'
-        assert result['result']['winner'] == 'b'
-        assert result['vote_weights']['expert'] > result['vote_weights'][
-            'inter']
+        assert result["result"]["method"] == "weighted_vote"
+        assert result["result"]["winner"] == "b"
+        assert result["vote_weights"]["expert"] > result["vote_weights"]["inter"]
 
     def test_documentation_task_selects_doc_agent_and_updates_role_assignments_succeeds(
-        self, mock_agent_with_expertise):
+        self, mock_agent_with_expertise
+    ):
         """Test that documentation task selects doc agent and updates role assignments succeeds.
 
-ReqID: N/A"""
-        team = WSDETeam(name='TestTeam')
-        coder = mock_agent_with_expertise('Coder', ['python'])
+        ReqID: N/A"""
+        team = WSDETeam(name="TestTeam")
+        coder = mock_agent_with_expertise("Coder", ["python"])
         coder.has_been_primus = True
-        doc_agent = mock_agent_with_expertise('Doc', ['documentation',
-            'markdown'])
+        doc_agent = mock_agent_with_expertise("Doc", ["documentation", "markdown"])
         doc_agent.has_been_primus = False
         team.add_agents([coder, doc_agent])
-        task = {'type': 'documentation', 'description': 'Write docs'}
+        task = {"type": "documentation", "description": "Write docs"}
         team.select_primus_by_expertise(task)
         assert team.get_primus() is doc_agent
-        assert team.role_assignments['primus'] is doc_agent
+        assert team.role_assignments["primus"] is doc_agent
         assert doc_agent.has_been_primus
 
-    def test_select_primus_fallback_when_no_expertise_matches(self,
-        mock_agent_with_expertise):
+    def test_select_primus_fallback_when_no_expertise_matches(
+        self, mock_agent_with_expertise
+    ):
         """Test that select primus fallback when no expertise matches.
 
-ReqID: N/A"""
-        team = WSDETeam(name='TestTeam')
-        a1 = mock_agent_with_expertise('A1', ['python'])
-        a2 = mock_agent_with_expertise('A2', ['javascript'])
-        a3 = mock_agent_with_expertise('A3', ['design'])
+        ReqID: N/A"""
+        team = WSDETeam(name="TestTeam")
+        a1 = mock_agent_with_expertise("A1", ["python"])
+        a2 = mock_agent_with_expertise("A2", ["javascript"])
+        a3 = mock_agent_with_expertise("A3", ["design"])
         for a in [a1, a2, a3]:
             a.has_been_primus = True
             team.add_agent(a)
-        task = {'type': 'unknown', 'topic': 'nothing'}
+        task = {"type": "unknown", "topic": "nothing"}
         team.select_primus_by_expertise(task)
         assert team.get_primus() is a1
-        assert team.role_assignments['primus'] is a1
+        assert team.role_assignments["primus"] is a1
 
-    def test_documentation_expert_becomes_primus_succeeds(self,
-        mock_agent_with_expertise):
+    def test_documentation_expert_becomes_primus_succeeds(
+        self, mock_agent_with_expertise
+    ):
         """Test that documentation expert becomes primus succeeds.
 
-ReqID: N/A"""
-        team = WSDETeam(name='TestTeam')
-        generalist = mock_agent_with_expertise('Generalist', ['python'])
-        doc_agent = mock_agent_with_expertise('Doc', ['documentation'])
+        ReqID: N/A"""
+        team = WSDETeam(name="TestTeam")
+        generalist = mock_agent_with_expertise("Generalist", ["python"])
+        doc_agent = mock_agent_with_expertise("Doc", ["documentation"])
         team.add_agents([generalist, doc_agent])
-        task = {'type': 'documentation', 'description': 'Write docs'}
+        task = {"type": "documentation", "description": "Write docs"}
         team.select_primus_by_expertise(task)
         assert team.get_primus() is doc_agent

--- a/tests/unit/general/test_wsde_team_voting_invalid.py
+++ b/tests/unit/general/test_wsde_team_voting_invalid.py
@@ -1,22 +1,22 @@
-from devsynth.domain.models.wsde import WSDETeam
+from devsynth.domain.models.wsde_facade import WSDETeam
 
 
 def test_vote_on_critical_decision_not_critical_raises_error():
     """Test that vote_on_critical_decision returns an error when task is not critical.
 
-ReqID: N/A"""
-    team = WSDETeam(name='TestTeam')
-    result = team.vote_on_critical_decision({'type': 'other'})
-    assert result['voting_initiated'] is False
-    assert 'error' in result
+    ReqID: N/A"""
+    team = WSDETeam(name="TestTeam")
+    result = team.vote_on_critical_decision({"type": "other"})
+    assert result["voting_initiated"] is False
+    assert "error" in result
 
 
 def test_vote_on_critical_decision_no_options_raises_error():
     """Test that vote_on_critical_decision returns an error when no options are provided.
 
-ReqID: N/A"""
-    team = WSDETeam(name='TestTeam')
-    task = {'type': 'critical_decision', 'is_critical': True, 'options': []}
+    ReqID: N/A"""
+    team = WSDETeam(name="TestTeam")
+    task = {"type": "critical_decision", "is_critical": True, "options": []}
     result = team.vote_on_critical_decision(task)
-    assert result['voting_initiated'] is False
-    assert 'error' in result
+    assert result["voting_initiated"] is False
+    assert "error" in result

--- a/tests/unit/general/test_wsde_voting.py
+++ b/tests/unit/general/test_wsde_voting.py
@@ -1,57 +1,62 @@
 """Tests for WSDETeam voting mechanisms."""
+
 from unittest.mock import MagicMock, patch
-from devsynth.domain.models.wsde import WSDETeam
+
+from devsynth.domain.models.wsde_facade import WSDETeam
 
 
-def _make_agent(name: str, vote: str, expertise=None, level='novice'):
+def _make_agent(name: str, vote: str, expertise=None, level="novice"):
     agent = MagicMock()
     agent.name = name
     agent.config = MagicMock()
     agent.config.name = name
     params = {}
     if expertise:
-        params['expertise'] = expertise
-    params['expertise_level'] = level
+        params["expertise"] = expertise
+    params["expertise_level"] = level
     agent.config.parameters = params
-    agent.process = MagicMock(return_value={'vote': vote})
+    agent.process = MagicMock(return_value={"vote": vote})
     return agent
 
 
 def _basic_task():
-    return {'type': 'critical_decision', 'description': 'choose option',
-        'options': [{'id': 'option1'}, {'id': 'option2'}, {'id': 'option3'}
-        ], 'is_critical': True}
+    return {
+        "type": "critical_decision",
+        "description": "choose option",
+        "options": [{"id": "option1"}, {"id": "option2"}, {"id": "option3"}],
+        "is_critical": True,
+    }
 
 
 def test_majority_vote_with_three_unique_choices_succeeds():
     """Test that when three agents vote for three different options, it results in a tie.
 
-ReqID: N/A"""
-    team = WSDETeam(name='TestTeam')
-    a1 = _make_agent('a1', 'option1')
-    a2 = _make_agent('a2', 'option2')
-    a3 = _make_agent('a3', 'option3')
+    ReqID: N/A"""
+    team = WSDETeam(name="TestTeam")
+    a1 = _make_agent("a1", "option1")
+    a2 = _make_agent("a2", "option2")
+    a3 = _make_agent("a3", "option3")
     team.add_agents([a1, a2, a3])
     task = _basic_task()
-    with patch.object(team, 'build_consensus', return_value={'consensus': ''}):
+    with patch.object(team, "build_consensus", return_value={"consensus": ""}):
         result = team.vote_on_critical_decision(task)
-    assert result['result']['method'] == 'tied_vote'
-    assert set(result['result']['tied_options']) == {'option1', 'option2',
-        'option3'}
+    assert result["result"]["method"] == "tied_vote"
+    assert set(result["result"]["tied_options"]) == {"option1", "option2", "option3"}
 
 
 def test_tie_triggers_handle_tied_vote_succeeds():
     """Test that a tie between two options triggers the _handle_tied_vote method.
 
-ReqID: N/A"""
-    team = WSDETeam(name='TestTeam')
-    a1 = _make_agent('a1', 'option1')
-    a2 = _make_agent('a2', 'option2')
+    ReqID: N/A"""
+    team = WSDETeam(name="TestTeam")
+    a1 = _make_agent("a1", "option1")
+    a2 = _make_agent("a2", "option2")
     team.add_agents([a1, a2])
     task = _basic_task()
-    with patch.object(team, 'build_consensus', return_value={'consensus': ''}
-        ), patch.object(team, '_handle_tied_vote', wraps=team._handle_tied_vote
-        ) as mocked:
+    with (
+        patch.object(team, "build_consensus", return_value={"consensus": ""}),
+        patch.object(team, "_handle_tied_vote", wraps=team._handle_tied_vote) as mocked,
+    ):
         team.vote_on_critical_decision(task)
         mocked.assert_called_once()
 
@@ -59,29 +64,29 @@ ReqID: N/A"""
 def test_weighted_voting_prefers_expert_vote_succeeds():
     """Test that weighted voting gives preference to expert votes over novice votes.
 
-ReqID: N/A"""
-    team = WSDETeam(name='TestTeam')
-    expert = _make_agent('expert', 'option2', ['security'], level='expert')
-    novice1 = _make_agent('novice1', 'option1', ['security'], level='novice')
-    novice2 = _make_agent('novice2', 'option1', ['security'], level='novice')
+    ReqID: N/A"""
+    team = WSDETeam(name="TestTeam")
+    expert = _make_agent("expert", "option2", ["security"], level="expert")
+    novice1 = _make_agent("novice1", "option1", ["security"], level="novice")
+    novice2 = _make_agent("novice2", "option1", ["security"], level="novice")
     team.add_agents([expert, novice1, novice2])
     task = _basic_task()
-    task['domain'] = 'security'
+    task["domain"] = "security"
     result = team.vote_on_critical_decision(task)
-    assert result['result']['method'] == 'weighted_vote'
-    assert result['result']['winner'] == 'option2'
+    assert result["result"]["method"] == "weighted_vote"
+    assert result["result"]["winner"] == "option2"
 
 
 def test_vote_on_critical_decision_no_votes_succeeds():
     """Test that vote_on_critical_decision handles the case when no votes are cast.
 
-ReqID: N/A"""
-    team = WSDETeam(name='TestTeam')
-    a1 = _make_agent('a1', vote=None)
+    ReqID: N/A"""
+    team = WSDETeam(name="TestTeam")
+    a1 = _make_agent("a1", vote=None)
     a1.process.return_value = {}
     team.add_agent(a1)
     task = _basic_task()
     result = team.vote_on_critical_decision(task)
-    assert result['voting_initiated'] is True
-    assert result['votes'] == {}
-    assert result['result'] is None
+    assert result["voting_initiated"] is True
+    assert result["votes"] == {}
+    assert result["result"] is None

--- a/tests/unit/general/test_wsde_voting_mechanisms.py
+++ b/tests/unit/general/test_wsde_voting_mechanisms.py
@@ -4,201 +4,243 @@ Unit Tests for WSDE Voting Mechanisms
 This file contains unit tests for the voting mechanisms in the WSDE model,
 specifically testing the vote_on_critical_decision method in the WSDETeam class.
 """
-import pytest
+
 from unittest.mock import MagicMock, patch
-from devsynth.domain.models.wsde import WSDETeam
-from devsynth.domain.models.agent import AgentConfig, AgentType
+
+import pytest
+
 from devsynth.application.agents.unified_agent import UnifiedAgent
+from devsynth.domain.models.agent import AgentConfig, AgentType
+from devsynth.domain.models.wsde_facade import WSDETeam
 
 
 class TestWSDEVotingMechanisms:
     """Test suite for the WSDE voting mechanisms.
 
-ReqID: N/A"""
+    ReqID: N/A"""
 
     def setup_method(self):
         """Set up test fixtures."""
-        self.team = WSDETeam(name='test_voting_mechanisms_team')
+        self.team = WSDETeam(name="test_voting_mechanisms_team")
         self.agent1 = MagicMock()
-        self.agent1.name = 'agent1'
+        self.agent1.name = "agent1"
         self.agent1.config = MagicMock()
-        self.agent1.config.name = 'agent1'
-        self.agent1.config.parameters = {'expertise': ['python', 'design']}
+        self.agent1.config.name = "agent1"
+        self.agent1.config.parameters = {"expertise": ["python", "design"]}
         self.agent2 = MagicMock()
-        self.agent2.name = 'agent2'
+        self.agent2.name = "agent2"
         self.agent2.config = MagicMock()
-        self.agent2.config.name = 'agent2'
-        self.agent2.config.parameters = {'expertise': ['javascript', 'testing']
-            }
+        self.agent2.config.name = "agent2"
+        self.agent2.config.parameters = {"expertise": ["javascript", "testing"]}
         self.agent3 = MagicMock()
-        self.agent3.name = 'agent3'
+        self.agent3.name = "agent3"
         self.agent3.config = MagicMock()
-        self.agent3.config.name = 'agent3'
-        self.agent3.config.parameters = {'expertise': ['documentation',
-            'planning']}
+        self.agent3.config.name = "agent3"
+        self.agent3.config.parameters = {"expertise": ["documentation", "planning"]}
         self.agent4 = MagicMock()
-        self.agent4.name = 'agent4'
+        self.agent4.name = "agent4"
         self.agent4.config = MagicMock()
-        self.agent4.config.name = 'agent4'
-        self.agent4.config.parameters = {'expertise': ['architecture',
-            'security']}
+        self.agent4.config.name = "agent4"
+        self.agent4.config.parameters = {"expertise": ["architecture", "security"]}
         self.team.add_agent(self.agent1)
         self.team.add_agent(self.agent2)
         self.team.add_agent(self.agent3)
         self.team.add_agent(self.agent4)
-        self.critical_task = {'type': 'critical_decision', 'description':
-            'Choose the best architecture for the system', 'options': [{
-            'id': 'option1', 'name': 'Microservices', 'description':
-            'Use a microservices architecture'}, {'id': 'option2', 'name':
-            'Monolith', 'description': 'Use a monolithic architecture'}, {
-            'id': 'option3', 'name': 'Serverless', 'description':
-            'Use a serverless architecture'}], 'is_critical': True}
-        self.domain_task = {'type': 'critical_decision', 'domain':
-            'security', 'description':
-            'Choose the authentication method for the system', 'options': [
-            {'id': 'option1', 'name': 'OAuth', 'description':
-            'Use OAuth for authentication'}, {'id': 'option2', 'name':
-            'JWT', 'description': 'Use JWT for authentication'}, {'id':
-            'option3', 'name': 'Basic Auth', 'description':
-            'Use Basic Auth for authentication'}], 'is_critical': True}
+        self.critical_task = {
+            "type": "critical_decision",
+            "description": "Choose the best architecture for the system",
+            "options": [
+                {
+                    "id": "option1",
+                    "name": "Microservices",
+                    "description": "Use a microservices architecture",
+                },
+                {
+                    "id": "option2",
+                    "name": "Monolith",
+                    "description": "Use a monolithic architecture",
+                },
+                {
+                    "id": "option3",
+                    "name": "Serverless",
+                    "description": "Use a serverless architecture",
+                },
+            ],
+            "is_critical": True,
+        }
+        self.domain_task = {
+            "type": "critical_decision",
+            "domain": "security",
+            "description": "Choose the authentication method for the system",
+            "options": [
+                {
+                    "id": "option1",
+                    "name": "OAuth",
+                    "description": "Use OAuth for authentication",
+                },
+                {
+                    "id": "option2",
+                    "name": "JWT",
+                    "description": "Use JWT for authentication",
+                },
+                {
+                    "id": "option3",
+                    "name": "Basic Auth",
+                    "description": "Use Basic Auth for authentication",
+                },
+            ],
+            "is_critical": True,
+        }
 
     def test_vote_on_critical_decision_initiates_voting_succeeds(self):
         """Test that vote_on_critical_decision initiates a voting process.
 
-ReqID: N/A"""
-        self.agent1.process = MagicMock(return_value={'vote': 'option1'})
-        self.agent2.process = MagicMock(return_value={'vote': 'option2'})
-        self.agent3.process = MagicMock(return_value={'vote': 'option3'})
-        self.agent4.process = MagicMock(return_value={'vote': 'option1'})
+        ReqID: N/A"""
+        self.agent1.process = MagicMock(return_value={"vote": "option1"})
+        self.agent2.process = MagicMock(return_value={"vote": "option2"})
+        self.agent3.process = MagicMock(return_value={"vote": "option3"})
+        self.agent4.process = MagicMock(return_value={"vote": "option1"})
         result = self.team.vote_on_critical_decision(self.critical_task)
-        assert 'voting_initiated' in result
-        assert result['voting_initiated'] is True
+        assert "voting_initiated" in result
+        assert result["voting_initiated"] is True
         self.agent1.process.assert_called_once()
         self.agent2.process.assert_called_once()
         self.agent3.process.assert_called_once()
         self.agent4.process.assert_called_once()
-        assert 'votes' in result
-        assert len(result['votes']) == 4
-        assert result['votes']['agent1'] == 'option1'
-        assert result['votes']['agent2'] == 'option2'
-        assert result['votes']['agent3'] == 'option3'
-        assert result['votes']['agent4'] == 'option1'
+        assert "votes" in result
+        assert len(result["votes"]) == 4
+        assert result["votes"]["agent1"] == "option1"
+        assert result["votes"]["agent2"] == "option2"
+        assert result["votes"]["agent3"] == "option3"
+        assert result["votes"]["agent4"] == "option1"
 
     def test_vote_on_critical_decision_majority_vote_succeeds(self):
         """Test that vote_on_critical_decision uses majority vote to make decisions.
 
-ReqID: N/A"""
-        self.agent1.process = MagicMock(return_value={'vote': 'option1'})
-        self.agent2.process = MagicMock(return_value={'vote': 'option2'})
-        self.agent3.process = MagicMock(return_value={'vote': 'option1'})
-        self.agent4.process = MagicMock(return_value={'vote': 'option3'})
+        ReqID: N/A"""
+        self.agent1.process = MagicMock(return_value={"vote": "option1"})
+        self.agent2.process = MagicMock(return_value={"vote": "option2"})
+        self.agent3.process = MagicMock(return_value={"vote": "option1"})
+        self.agent4.process = MagicMock(return_value={"vote": "option3"})
         result = self.team.vote_on_critical_decision(self.critical_task)
-        assert 'result' in result
-        assert result['result'] is not None
-        assert 'winner' in result['result']
-        assert result['result']['winner'] == 'option1'
-        assert 'vote_counts' in result['result']
-        assert result['result']['vote_counts']['option1'] == 2
-        assert result['result']['vote_counts']['option2'] == 1
-        assert result['result']['vote_counts']['option3'] == 1
-        assert 'method' in result['result']
-        assert result['result']['method'] == 'majority_vote'
+        assert "result" in result
+        assert result["result"] is not None
+        assert "winner" in result["result"]
+        assert result["result"]["winner"] == "option1"
+        assert "vote_counts" in result["result"]
+        assert result["result"]["vote_counts"]["option1"] == 2
+        assert result["result"]["vote_counts"]["option2"] == 1
+        assert result["result"]["vote_counts"]["option3"] == 1
+        assert "method" in result["result"]
+        assert result["result"]["method"] == "majority_vote"
 
     def test_vote_on_critical_decision_tied_vote_succeeds(self):
         """Test that vote_on_critical_decision handles tied votes correctly.
 
-ReqID: N/A"""
-        self.agent1.process = MagicMock(return_value={'vote': 'option1'})
-        self.agent2.process = MagicMock(return_value={'vote': 'option2'})
-        self.agent3.process = MagicMock(return_value={'vote': 'option1'})
-        self.agent4.process = MagicMock(return_value={'vote': 'option2'})
-        self.team.build_consensus = MagicMock(return_value={'consensus':
-            'Use a hybrid architecture combining microservices and monolith',
-            'contributors': ['agent1', 'agent2', 'agent3', 'agent4'],
-            'method': 'consensus_synthesis', 'reasoning':
-            'Combined the best elements from both options'})
+        ReqID: N/A"""
+        self.agent1.process = MagicMock(return_value={"vote": "option1"})
+        self.agent2.process = MagicMock(return_value={"vote": "option2"})
+        self.agent3.process = MagicMock(return_value={"vote": "option1"})
+        self.agent4.process = MagicMock(return_value={"vote": "option2"})
+        self.team.build_consensus = MagicMock(
+            return_value={
+                "consensus": "Use a hybrid architecture combining microservices and monolith",
+                "contributors": ["agent1", "agent2", "agent3", "agent4"],
+                "method": "consensus_synthesis",
+                "reasoning": "Combined the best elements from both options",
+            }
+        )
         result = self.team.vote_on_critical_decision(self.critical_task)
-        assert 'result' in result
-        assert 'tied' in result['result']
-        assert result['result']['tied'] is True
-        assert 'tied_options' in result['result']
-        assert 'option1' in result['result']['tied_options']
-        assert 'option2' in result['result']['tied_options']
-        assert 'vote_counts' in result['result']
-        assert result['result']['vote_counts']['option1'] == 2
-        assert result['result']['vote_counts']['option2'] == 2
-        assert 'method' in result['result']
-        assert result['result']['method'] == 'tied_vote'
-        assert 'fallback' in result['result']
-        assert result['result']['fallback'] == 'primus_tiebreaker'
-        assert 'tie_breaking_attempts' in result['result']
-        assert len(result['result']['tie_breaking_attempts']) > 0
-        assert result['result']['tie_breaking_attempts'][0]['method'
-            ] == 'primus_tiebreaker'
+        assert "result" in result
+        assert "tied" in result["result"]
+        assert result["result"]["tied"] is True
+        assert "tied_options" in result["result"]
+        assert "option1" in result["result"]["tied_options"]
+        assert "option2" in result["result"]["tied_options"]
+        assert "vote_counts" in result["result"]
+        assert result["result"]["vote_counts"]["option1"] == 2
+        assert result["result"]["vote_counts"]["option2"] == 2
+        assert "method" in result["result"]
+        assert result["result"]["method"] == "tied_vote"
+        assert "fallback" in result["result"]
+        assert result["result"]["fallback"] == "primus_tiebreaker"
+        assert "tie_breaking_attempts" in result["result"]
+        assert len(result["result"]["tie_breaking_attempts"]) > 0
+        assert (
+            result["result"]["tie_breaking_attempts"][0]["method"]
+            == "primus_tiebreaker"
+        )
 
     def test_vote_on_critical_decision_weighted_vote_succeeds(self):
         """Test that vote_on_critical_decision uses weighted voting for domain-specific decisions.
 
-ReqID: N/A"""
-        self.agent1.config.parameters = {'expertise': ['security',
-            'encryption', 'authentication'], 'expertise_level': 'expert'}
-        self.agent2.config.parameters = {'expertise': ['security',
-            'firewalls'], 'expertise_level': 'intermediate'}
-        self.agent3.config.parameters = {'expertise': ['security'],
-            'expertise_level': 'novice'}
-        self.agent4.config.parameters = {'expertise': ['python',
-            'javascript'], 'expertise_level': 'intermediate'}
-        self.agent1.process = MagicMock(return_value={'vote': 'option2'})
-        self.agent2.process = MagicMock(return_value={'vote': 'option1'})
-        self.agent3.process = MagicMock(return_value={'vote': 'option1'})
-        self.agent4.process = MagicMock(return_value={'vote': 'option3'})
+        ReqID: N/A"""
+        self.agent1.config.parameters = {
+            "expertise": ["security", "encryption", "authentication"],
+            "expertise_level": "expert",
+        }
+        self.agent2.config.parameters = {
+            "expertise": ["security", "firewalls"],
+            "expertise_level": "intermediate",
+        }
+        self.agent3.config.parameters = {
+            "expertise": ["security"],
+            "expertise_level": "novice",
+        }
+        self.agent4.config.parameters = {
+            "expertise": ["python", "javascript"],
+            "expertise_level": "intermediate",
+        }
+        self.agent1.process = MagicMock(return_value={"vote": "option2"})
+        self.agent2.process = MagicMock(return_value={"vote": "option1"})
+        self.agent3.process = MagicMock(return_value={"vote": "option1"})
+        self.agent4.process = MagicMock(return_value={"vote": "option3"})
         result = self.team.vote_on_critical_decision(self.domain_task)
-        assert 'result' in result
-        assert result['result'] is not None
-        if 'winner' in result['result']:
-            assert result['result']['winner'] == 'option2'
-        elif 'tied' in result['result'] and result['result']['tied']:
-            assert 'tie_breaking_attempts' in result['result']
-            assert len(result['result']['tie_breaking_attempts']) > 0
-            assert result['result']['tie_breaking_attempts'][0]['winner'
-                ] == 'option2'
-        assert 'votes' in result
-        assert result['votes']['agent1'] == 'option2'
-        assert result['votes']['agent2'] == 'option1'
-        assert result['votes']['agent3'] == 'option1'
-        assert result['votes']['agent4'] == 'option3'
+        assert "result" in result
+        assert result["result"] is not None
+        if "winner" in result["result"]:
+            assert result["result"]["winner"] == "option2"
+        elif "tied" in result["result"] and result["result"]["tied"]:
+            assert "tie_breaking_attempts" in result["result"]
+            assert len(result["result"]["tie_breaking_attempts"]) > 0
+            assert result["result"]["tie_breaking_attempts"][0]["winner"] == "option2"
+        assert "votes" in result
+        assert result["votes"]["agent1"] == "option2"
+        assert result["votes"]["agent2"] == "option1"
+        assert result["votes"]["agent3"] == "option1"
+        assert result["votes"]["agent4"] == "option3"
 
     def test_vote_on_critical_decision_records_results_succeeds(self):
         """Test that vote_on_critical_decision records the voting results.
 
-ReqID: N/A"""
-        self.agent1.process = MagicMock(return_value={'vote': 'option1'})
-        self.agent2.process = MagicMock(return_value={'vote': 'option2'})
-        self.agent3.process = MagicMock(return_value={'vote': 'option1'})
-        self.agent4.process = MagicMock(return_value={'vote': 'option1'})
+        ReqID: N/A"""
+        self.agent1.process = MagicMock(return_value={"vote": "option1"})
+        self.agent2.process = MagicMock(return_value={"vote": "option2"})
+        self.agent3.process = MagicMock(return_value={"vote": "option1"})
+        self.agent4.process = MagicMock(return_value={"vote": "option1"})
         result = self.team.vote_on_critical_decision(self.critical_task)
-        assert 'voting_initiated' in result
-        assert 'votes' in result
-        assert 'result' in result
-        assert 'winner' in result['result']
-        assert 'vote_counts' in result['result']
-        assert 'method' in result['result']
-        assert result['result']['vote_counts']['option1'] == 3
-        assert result['result']['vote_counts']['option2'] == 1
-        assert 'winning_option' in result['result']
-        assert result['result']['winning_option']['id'] == 'option1'
-        assert result['result']['winning_option']['name'] == 'Microservices'
+        assert "voting_initiated" in result
+        assert "votes" in result
+        assert "result" in result
+        assert "winner" in result["result"]
+        assert "vote_counts" in result["result"]
+        assert "method" in result["result"]
+        assert result["result"]["vote_counts"]["option1"] == 3
+        assert result["result"]["vote_counts"]["option2"] == 1
+        assert "winning_option" in result["result"]
+        assert result["result"]["winning_option"]["id"] == "option1"
+        assert result["result"]["winning_option"]["name"] == "Microservices"
 
     def test_vote_on_critical_decision_updates_history_succeeds(self):
         """Ensure voting history is recorded after a vote.
 
-ReqID: N/A"""
-        self.agent1.process = MagicMock(return_value={'vote': 'option1'})
-        self.agent2.process = MagicMock(return_value={'vote': 'option2'})
-        self.agent3.process = MagicMock(return_value={'vote': 'option1'})
-        self.agent4.process = MagicMock(return_value={'vote': 'option1'})
+        ReqID: N/A"""
+        self.agent1.process = MagicMock(return_value={"vote": "option1"})
+        self.agent2.process = MagicMock(return_value={"vote": "option2"})
+        self.agent3.process = MagicMock(return_value={"vote": "option1"})
+        self.agent4.process = MagicMock(return_value={"vote": "option1"})
         result = self.team.vote_on_critical_decision(self.critical_task)
         assert len(self.team.voting_history) == 1
         entry = self.team.voting_history[0]
-        assert entry['task_id'] == self.team._get_task_id(self.critical_task)
-        assert entry['result'] == result['result']
+        assert entry["task_id"] == self.team._get_task_id(self.critical_task)
+        assert entry["result"] == result["result"]


### PR DESCRIPTION
## Summary
- swap legacy `wsde` imports for `wsde_facade` or `wsde_core`
- expose `WSDE` and `WSDETeam` via `domain.models` package
- clean up behavioral step modules referencing deprecated `__future__` import

## Testing
- `poetry run pre-commit run --files <modified files>`
- `poetry run pytest tests/unit/general/test_wsde_model.py` *(fails: Required test coverage of 25% not reached)*

------
https://chatgpt.com/codex/tasks/task_e_689569b81b288333b8ebf1751cdd018a