### PR TITLE
docs: update WSDE references

### DIFF
--- a/docs/architecture/wsde_agent_model.md
+++ b/docs/architecture/wsde_agent_model.md
@@ -326,8 +326,9 @@ final = team.build_consensus(task)
 print(final["consensus"])
 ```
 
-The methods used in this example are implemented in
-`src/devsynth/domain/models/wsde.py` and tested in
+The methods used in this example are implemented across
+`src/devsynth/domain/models/wsde_core.py` and
+`src/devsynth/domain/models/wsde_facade.py` and tested in
 `tests/unit/domain/test_wsde_phase_role_rotation.py` and
 `tests/integration/general/test_collaborative_decision_making.py`.
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -53,7 +53,9 @@ The following patterns are used for test file placement:
 
 1. **Unit Tests**: `tests/unit/<module_path>/test_<module_name>.py`
    - Unit tests follow the same directory structure as the source code
-   - Example: `src/devsynth/domain/models/wsde.py` → `tests/unit/domain/models/test_wsde.py`
+   - Examples:
+     - `src/devsynth/domain/models/wsde_core.py` → `tests/unit/domain/models/test_wsde_core.py`
+     - `src/devsynth/domain/models/wsde_facade.py` → `tests/unit/domain/models/test_wsde_facade.py`
 
 2. **Integration Tests**: `tests/integration/<feature_area>/test_<feature_name>.py`
    - Integration tests are grouped by feature area


### PR DESCRIPTION
## Summary
- replace WSDE doc references with wsde_core and wsde_facade modules
- update tests README to demonstrate new module naming

## Testing
- `SKIP=fix-code-blocks poetry run pre-commit run --files docs/architecture/wsde_agent_model.md tests/README.md`


------
https://chatgpt.com/codex/tasks/task_e_6895746b9d808333a35e9f3e695661d7