### PR TITLE
refactor: replace dict options with list

### DIFF
--- a/src/devsynth/adapters/cli/typer_adapter.py
+++ b/src/devsynth/adapters/cli/typer_adapter.py
@@ -63,7 +63,7 @@ def _patch_typer_types() -> None:
         if annotation in {UXBridge, typer.models.Context, Any}:
             return click.STRING
         origin = getattr(annotation, "__origin__", None)
-        if origin in {UXBridge, typer.models.Context, dict, Any} or annotation is dict:
+        if origin in {UXBridge, typer.models.Context, Any}:
             return click.STRING
         try:
             return orig(annotation=annotation, parameter_info=parameter_info)

--- a/src/devsynth/application/cli/commands/run_tests_cmd.py
+++ b/src/devsynth/application/cli/commands/run_tests_cmd.py
@@ -4,12 +4,12 @@ Wraps :func:`devsynth.testing.run_tests` to provide a `devsynth run-tests`
 command. This command mirrors the options exposed by the underlying helper.
 
 Example:
-    `devsynth run-tests --target unit-tests --fast`
+    `devsynth run-tests --target unit-tests --speed fast`
 """
 
 from __future__ import annotations
 
-from typing import Any, Optional
+from typing import Any, List, Optional
 
 import typer
 
@@ -28,9 +28,11 @@ def run_tests_cmd(
         "--target",
         help="Test target to run",
     ),
-    fast: bool = typer.Option(False, "--fast", help="Run only fast tests"),
-    medium: bool = typer.Option(False, "--medium", help="Run only medium tests"),
-    slow: bool = typer.Option(False, "--slow", help="Run only slow tests"),
+    speeds: List[str] = typer.Option(
+        [],
+        "--speed",
+        help="Speed categories to run (can be used multiple times)",
+    ),
     report: bool = typer.Option(False, "--report", help="Generate HTML report"),
     verbose: bool = typer.Option(False, "--verbose", help="Show verbose output"),
     no_parallel: bool = typer.Option(
@@ -49,15 +51,7 @@ def run_tests_cmd(
 
     ux_bridge = bridge if isinstance(bridge, UXBridge) else globals()["bridge"]
 
-    speed_categories = []
-    if fast:
-        speed_categories.append("fast")
-    if medium:
-        speed_categories.append("medium")
-    if slow:
-        speed_categories.append("slow")
-    if not speed_categories:
-        speed_categories = None
+    speed_categories = speeds or None
 
     success, _ = run_tests(
         target,

--- a/tests/unit/application/cli/commands/test_run_tests_cmd.py
+++ b/tests/unit/application/cli/commands/test_run_tests_cmd.py
@@ -22,10 +22,7 @@ def patch_typer_types(monkeypatch):
         if annotation in {module.UXBridge, typer.models.Context, typing.Any}:
             return click.STRING
         origin = getattr(annotation, "__origin__", None)
-        if (
-            origin in {module.UXBridge, typer.models.Context, dict, typing.Any}
-            or annotation is dict
-        ):
+        if origin in {module.UXBridge, typer.models.Context, typing.Any}:
             return click.STRING
         try:
             return orig(annotation=annotation, parameter_info=parameter_info)
@@ -46,7 +43,7 @@ def test_run_tests_cmd_invokes_runner() -> None:
     """run_tests_cmd should call the underlying ``run_tests`` helper."""
 
     with patch.object(module, "run_tests", return_value=(True, "ok")) as mock_run:
-        module.run_tests_cmd(target="unit-tests", fast=True, bridge=DummyBridge())
+        module.run_tests_cmd(target="unit-tests", speeds=["fast"], bridge=DummyBridge())
         mock_run.assert_called_once()
 
 
@@ -70,7 +67,7 @@ def test_run_tests_cli_full_invocation() -> None:
         app = build_app()
         result = runner.invoke(
             app,
-            ["run-tests", "--target", "unit-tests", "--fast", "--verbose"],
+            ["run-tests", "--target", "unit-tests", "--speed", "fast", "--verbose"],
         )
 
         assert result.exit_code == 0


### PR DESCRIPTION
## Summary
- replace run-tests dict options with repeated `--speed` flags
- drop dict handling from Typer adapter type patch
- adjust tests for new `--speed` interface

## Testing
- `SKIP=devsynth-align poetry run pre-commit run --files src/devsynth/application/cli/commands/run_tests_cmd.py src/devsynth/adapters/cli/typer_adapter.py tests/unit/application/cli/commands/test_run_tests_cmd.py`
- `poetry run pytest tests/unit/application/cli/commands/test_run_tests_cmd.py --cov-fail-under=0 -n 0`


------
https://chatgpt.com/codex/tasks/task_e_689580e5ca248333b9c9ce85ab4f065d