### PR TITLE
feat: improve init wizard and progress handling

### DIFF
--- a/docs/getting_started/basic_usage.md
+++ b/docs/getting_started/basic_usage.md
@@ -41,7 +41,7 @@ DevSynth can generate shell completion scripts to speed up command entry:
 devsynth completion --install
 ```
 
-Run the above command to install completion for your current shell or omit `--install` to print the script path.
+Run the above command to install completion for your current shell or pass `--shell zsh` to target a specific shell. Omit `--install` to print the script instead of saving it.
 
 ## Initialize a Project
 
@@ -59,6 +59,8 @@ cd my-project
 ```
 
 This command creates a new project directory with the necessary structure for DevSynth to work with. When executed inside an existing project, it now launches an interactive wizard that reads any `pyproject.toml` or `project.yaml` it finds.
+
+Both the CLI and WebUI display a progress bar for each step and provide clearer warnings if initialization is aborted.
 
 ## Define Requirements
 

--- a/src/devsynth/interface/webui_setup.py
+++ b/src/devsynth/interface/webui_setup.py
@@ -1,17 +1,19 @@
 """WebUI wrapper for the interactive setup wizard."""
+
 from __future__ import annotations
 
 from typing import Optional
 
 from devsynth.application.cli.setup_wizard import SetupWizard
 from devsynth.interface.ux_bridge import UXBridge
+from devsynth.interface.webui_bridge import WebUIBridge
 
 
 class WebUISetupWizard:
     """Expose the CLI :class:`SetupWizard` through a WebUI bridge."""
 
     def __init__(self, bridge: Optional[UXBridge] = None) -> None:
-        self.bridge = bridge or UXBridge()
+        self.bridge = bridge or WebUIBridge()
 
     def run(self) -> None:
         """Launch the guided setup wizard."""

--- a/tests/integration/general/test_webui_setup.py
+++ b/tests/integration/general/test_webui_setup.py
@@ -1,8 +1,9 @@
 import importlib
 import sys
-from types import ModuleType
 from pathlib import Path
+from types import ModuleType
 from unittest.mock import MagicMock
+
 import pytest
 
 
@@ -142,7 +143,7 @@ def test_offline_toggle_saves_config_succeeds(monkeypatch, tmp_path):
     import devsynth.interface.webui as webui
 
     importlib.reload(webui)
-    from devsynth.config import ProjectUnifiedConfig, ConfigModel
+    from devsynth.config import ConfigModel, ProjectUnifiedConfig
 
     cfg = ProjectUnifiedConfig(
         ConfigModel(project_root=str(tmp_path)), tmp_path / "project.yaml", False
@@ -158,3 +159,16 @@ def test_offline_toggle_saves_config_succeeds(monkeypatch, tmp_path):
     )
     webui.WebUI().config_page()
     assert saved.get("offline") is True
+
+
+@pytest.mark.medium
+def test_webui_bridge_error_display_succeeds(monkeypatch):
+    """WebUIBridge displays errors via st.error."""
+    st = _setup_streamlit(monkeypatch)
+    from devsynth.interface import webui_bridge
+
+    # Ensure WebUIBridge uses our stubbed streamlit module
+    monkeypatch.setattr(webui_bridge, "st", st)
+    bridge = webui_bridge.WebUIBridge()
+    bridge.display_result("Failure", message_type="error")
+    assert st.error.called

--- a/tests/unit/application/cli/test_completion_cmd.py
+++ b/tests/unit/application/cli/test_completion_cmd.py
@@ -1,0 +1,24 @@
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from devsynth.adapters.cli import typer_adapter
+
+
+@pytest.mark.medium
+def test_completion_cmd_outputs_script(monkeypatch):
+    """completion_cmd outputs a completion script when not installing."""
+    bridge = MagicMock()
+    typer_adapter.completion_cmd(shell="bash", bridge=bridge)
+    bridge.show_completion.assert_called_once()
+
+
+@pytest.mark.medium
+def test_completion_cmd_installs_script(tmp_path):
+    """completion_cmd writes script to path when install=True."""
+    bridge = MagicMock()
+    target = tmp_path / "comp.sh"
+    typer_adapter.completion_cmd(shell="bash", install=True, path=target, bridge=bridge)
+    assert target.exists()
+    bridge.show_completion.assert_called_once_with(str(target))


### PR DESCRIPTION
## Summary
- streamline `devsynth init` with progress tracking and clearer messaging
- add CLI shell completion command and streamlit-based WebUI messaging
- document shell completion and progress improvements

## Testing
- `poetry run pre-commit run --files docs/getting_started/basic_usage.md src/devsynth/adapters/cli/typer_adapter.py src/devsynth/application/cli/setup_wizard.py src/devsynth/interface/webui_bridge.py src/devsynth/interface/webui_setup.py tests/integration/general/test_webui_setup.py tests/unit/application/cli/test_completion_cmd.py`
- `poetry run pytest --no-cov tests/unit/application/cli/test_completion_cmd.py tests/unit/application/cli/test_init_cmd.py tests/unit/application/cli/test_setup_wizard.py tests/integration/general/test_webui_setup.py`

------
https://chatgpt.com/codex/tasks/task_e_689614aba2688333b47fefcaa8590e26