### PR TITLE
Add NotImplementedError to interfaces and add tests

### DIFF
--- a/src/devsynth/application/promises/implementation.py
+++ b/src/devsynth/application/promises/implementation.py
@@ -2,23 +2,25 @@
 Concrete implementation of the Promise system.
 Provides a Promise class that implements the PromiseInterface.
 """
+
+import logging
+import uuid
 from enum import Enum, auto
 from typing import Any, Callable, Dict, Generic, List, Optional, TypeVar, Union
-import uuid
-import logging
 
-from devsynth.exceptions import DevSynthError
 from devsynth.application.promises.interface import PromiseInterface
+from devsynth.exceptions import DevSynthError
 
 # Setup logger
 logger = logging.getLogger(__name__)
 
-T = TypeVar('T')
-S = TypeVar('S')
+T = TypeVar("T")
+S = TypeVar("S")
 
 
 class PromiseState(Enum):
     """Enum representing the possible states of a Promise."""
+
     PENDING = auto()
     FULFILLED = auto()
     REJECTED = auto()
@@ -26,12 +28,16 @@ class PromiseState(Enum):
 
 class PromiseError(DevSynthError):
     """Base class for Promise-related errors."""
-    pass
+
+    def __init__(self, message: str | None = None) -> None:
+        super().__init__(message or "Promise error")
 
 
 class PromiseStateError(PromiseError):
     """Error raised when an invalid state transition is attempted."""
-    pass
+
+    def __init__(self, message: str | None = None) -> None:
+        super().__init__(message or "Invalid promise state")
 
 
 class Promise(PromiseInterface[T], Generic[T]):
@@ -68,9 +74,9 @@ class Promise(PromiseInterface[T], Generic[T]):
             "created_at": None,  # Will be set by calling code
             "resolved_at": None,
             "rejected_at": None,
-            "source": None,      # Component that created this promise
+            "source": None,  # Component that created this promise
             "capability": None,  # Capability this promise represents
-            "tags": [],          # User-defined tags for filtering and grouping
+            "tags": [],  # User-defined tags for filtering and grouping
         }
 
         logger.debug(f"Promise {self._id} created in PENDING state")
@@ -112,7 +118,9 @@ class Promise(PromiseInterface[T], Generic[T]):
             PromiseStateError: If the promise is not in the fulfilled state.
         """
         if self._state != PromiseState.FULFILLED:
-            raise PromiseStateError(f"Cannot get value of promise in state {self._state}")
+            raise PromiseStateError(
+                f"Cannot get value of promise in state {self._state}"
+            )
         return self._value
 
     @property
@@ -127,7 +135,9 @@ class Promise(PromiseInterface[T], Generic[T]):
             PromiseStateError: If the promise is not in the rejected state.
         """
         if self._state != PromiseState.REJECTED:
-            raise PromiseStateError(f"Cannot get reason of promise in state {self._state}")
+            raise PromiseStateError(
+                f"Cannot get reason of promise in state {self._state}"
+            )
         return self._reason
 
     @property
@@ -171,7 +181,7 @@ class Promise(PromiseInterface[T], Generic[T]):
             self._children_ids.append(child_id)
             logger.debug(f"Added child promise {child_id} to parent {self._id}")
 
-    def set_metadata(self, key: str, value: Any) -> 'Promise[T]':
+    def set_metadata(self, key: str, value: Any) -> "Promise[T]":
         """
         Set a metadata value for DevSynth analysis.
 
@@ -197,7 +207,11 @@ class Promise(PromiseInterface[T], Generic[T]):
         """
         return self._metadata.get(key)
 
-    def then(self, on_fulfilled: Callable[[T], S], on_rejected: Optional[Callable[[Exception], S]] = None) -> 'Promise[S]':
+    def then(
+        self,
+        on_fulfilled: Callable[[T], S],
+        on_rejected: Optional[Callable[[Exception], S]] = None,
+    ) -> "Promise[S]":
         """
         Attaches callbacks for the resolution and/or rejection of the Promise.
 
@@ -249,7 +263,7 @@ class Promise(PromiseInterface[T], Generic[T]):
         logger.debug(f"Promise {self._id} chained to new promise {result_promise.id}")
         return result_promise
 
-    def catch(self, on_rejected: Callable[[Exception], S]) -> 'Promise[S]':
+    def catch(self, on_rejected: Callable[[Exception], S]) -> "Promise[S]":
         """
         Attaches a callback for only the rejection of the Promise.
 
@@ -328,7 +342,7 @@ class Promise(PromiseInterface[T], Generic[T]):
         self._on_rejected = []
 
     @staticmethod
-    def resolve_value(value: T) -> 'Promise[T]':
+    def resolve_value(value: T) -> "Promise[T]":
         """
         Creates a Promise that is resolved with a given value.
 
@@ -343,7 +357,7 @@ class Promise(PromiseInterface[T], Generic[T]):
         return promise
 
     @staticmethod
-    def reject_with(reason: Exception) -> 'Promise[Any]':
+    def reject_with(reason: Exception) -> "Promise[Any]":
         """
         Creates a Promise that is rejected with a given reason.
 
@@ -358,7 +372,7 @@ class Promise(PromiseInterface[T], Generic[T]):
         return promise
 
     @staticmethod
-    def all(promises: List['Promise[Any]']) -> 'Promise[List[Any]]':
+    def all(promises: List["Promise[Any]"]) -> "Promise[List[Any]]":
         """
         Returns a promise that resolves when all of the promises in the iterable argument
         have resolved, or rejects with the reason of the first passed promise that rejects.
@@ -396,7 +410,7 @@ class Promise(PromiseInterface[T], Generic[T]):
         return result_promise
 
     @staticmethod
-    def race(promises: List['Promise[T]']) -> 'Promise[T]':
+    def race(promises: List["Promise[T]"]) -> "Promise[T]":
         """
         Returns a promise that resolves or rejects as soon as one of the promises in
         the iterable resolves or rejects, with the value or reason from that promise.

--- a/src/devsynth/application/promises/interface.py
+++ b/src/devsynth/application/promises/interface.py
@@ -4,17 +4,19 @@ DevSynth Promise System API Specification.
 This module defines the core interface for the Promise System, which provides
 a capability declaration, verification, and authorization framework for agents.
 """
-from abc import ABC, abstractmethod
-from typing import Dict, List, Optional, Set, Any, Union, Generic, TypeVar, Callable
-from enum import Enum
-from dataclasses import dataclass
-import uuid
+
 import logging
+import uuid
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from enum import Enum
+from typing import Any, Callable, Dict, Generic, List, Optional, Set, TypeVar, Union
 
 from devsynth.exceptions import PromiseStateError
 
-T = TypeVar('T')
-S = TypeVar('S')
+T = TypeVar("T")
+S = TypeVar("S")
+
 
 class PromiseInterface(Generic[T], ABC):
     """
@@ -26,31 +28,31 @@ class PromiseInterface(Generic[T], ABC):
     @abstractmethod
     def id(self) -> str:
         """Get the unique identifier of this promise."""
-        pass
+        raise NotImplementedError
 
     @property
     @abstractmethod
-    def state(self) -> 'PromiseState':
+    def state(self) -> "PromiseState":
         """Get the current state of this promise."""
-        pass
+        raise NotImplementedError
 
     @property
     @abstractmethod
     def is_pending(self) -> bool:
         """Check if the promise is in the pending state."""
-        pass
+        raise NotImplementedError
 
     @property
     @abstractmethod
     def is_fulfilled(self) -> bool:
         """Check if the promise is in the fulfilled state."""
-        pass
+        raise NotImplementedError
 
     @property
     @abstractmethod
     def is_rejected(self) -> bool:
         """Check if the promise is in the rejected state."""
-        pass
+        raise NotImplementedError
 
     @property
     @abstractmethod
@@ -64,7 +66,7 @@ class PromiseInterface(Generic[T], ABC):
         Raises:
             PromiseStateError: If the promise is not in the fulfilled state.
         """
-        pass
+        raise NotImplementedError
 
     @property
     @abstractmethod
@@ -78,10 +80,10 @@ class PromiseInterface(Generic[T], ABC):
         Raises:
             PromiseStateError: If the promise is not in the rejected state.
         """
-        pass
+        raise NotImplementedError
 
     @abstractmethod
-    def set_metadata(self, key: str, value: Any) -> 'PromiseInterface[T]':
+    def set_metadata(self, key: str, value: Any) -> "PromiseInterface[T]":
         """
         Set a metadata value for DevSynth analysis.
 
@@ -92,7 +94,7 @@ class PromiseInterface(Generic[T], ABC):
         Returns:
             Self, for chaining
         """
-        pass
+        raise NotImplementedError
 
     @abstractmethod
     def get_metadata(self, key: str) -> Any:
@@ -105,10 +107,14 @@ class PromiseInterface(Generic[T], ABC):
         Returns:
             The associated value, or None if the key does not exist
         """
-        pass
+        raise NotImplementedError
 
     @abstractmethod
-    def then(self, on_fulfilled: Callable[[T], S], on_rejected: Optional[Callable[[Exception], S]] = None) -> 'PromiseInterface[S]':
+    def then(
+        self,
+        on_fulfilled: Callable[[T], S],
+        on_rejected: Optional[Callable[[Exception], S]] = None,
+    ) -> "PromiseInterface[S]":
         """
         Attaches callbacks for the resolution and/or rejection of the Promise.
 
@@ -119,10 +125,10 @@ class PromiseInterface(Generic[T], ABC):
         Returns:
             A new Promise resolving with the return value of the called callback.
         """
-        pass
+        raise NotImplementedError
 
     @abstractmethod
-    def catch(self, on_rejected: Callable[[Exception], S]) -> 'PromiseInterface[S]':
+    def catch(self, on_rejected: Callable[[Exception], S]) -> "PromiseInterface[S]":
         """
         Attaches a callback for only the rejection of the Promise.
 
@@ -132,7 +138,7 @@ class PromiseInterface(Generic[T], ABC):
         Returns:
             A new Promise resolving with the return value of the on_rejected callback.
         """
-        pass
+        raise NotImplementedError
 
     @abstractmethod
     def resolve(self, value: T) -> None:
@@ -146,7 +152,7 @@ class PromiseInterface(Generic[T], ABC):
         Raises:
             PromiseStateError: If the promise is already fulfilled or rejected
         """
-        pass
+        raise NotImplementedError
 
     @abstractmethod
     def reject(self, reason: Exception) -> None:
@@ -160,15 +166,16 @@ class PromiseInterface(Generic[T], ABC):
         Raises:
             PromiseStateError: If the promise is already fulfilled or rejected
         """
-        pass
+        raise NotImplementedError
 
 
 class PromiseState(Enum):
     """Represents the possible states of a Promise."""
-    PENDING = "pending"       # Promise is created but not yet fulfilled
-    FULFILLED = "fulfilled"   # Promise has been successfully fulfilled
-    REJECTED = "rejected"     # Promise has failed to be fulfilled
-    CANCELLED = "cancelled"   # Promise has been cancelled before fulfillment
+
+    PENDING = "pending"  # Promise is created but not yet fulfilled
+    FULFILLED = "fulfilled"  # Promise has been successfully fulfilled
+    REJECTED = "rejected"  # Promise has failed to be fulfilled
+    CANCELLED = "cancelled"  # Promise has been cancelled before fulfillment
 
 
 class BasicPromise(PromiseInterface[T], Generic[T]):
@@ -315,8 +322,10 @@ class BasicPromise(PromiseInterface[T], Generic[T]):
         self._on_fulfilled.clear()
         self._on_rejected.clear()
 
+
 class PromiseType(Enum):
     """Types of promises that can be made in the system."""
+
     FILE_READ = "file_read"
     FILE_WRITE = "file_write"
     CODE_ANALYSIS = "code_analysis"
@@ -332,11 +341,12 @@ class PromiseType(Enum):
 @dataclass
 class PromiseMetadata:
     """Metadata associated with a Promise."""
+
     created_at: float  # Unix timestamp
-    owner_id: str      # ID of the agent that created the promise
-    context_id: str    # Context or task ID this promise belongs to
-    tags: List[str]    # User-defined tags for filtering and organization
-    trace_id: str      # For distributed tracing
+    owner_id: str  # ID of the agent that created the promise
+    context_id: str  # Context or task ID this promise belongs to
+    tags: List[str]  # User-defined tags for filtering and organization
+    trace_id: str  # For distributed tracing
     priority: int = 1  # Priority level (higher is more important)
 
 
@@ -346,15 +356,16 @@ class Promise:
     Represents a Promise in the system - a declaration of intent to perform
     a capability with specific parameters and constraints.
     """
-    id: str                           # Unique identifier
-    type: PromiseType                 # Type of capability
-    parameters: Dict[str, Any]        # Parameters for this promise
-    state: PromiseState               # Current state
-    metadata: PromiseMetadata         # Associated metadata
-    result: Optional[Any] = None      # Result when fulfilled
-    error: Optional[str] = None       # Error message if rejected
-    parent_id: Optional[str] = None   # Parent promise if this is a sub-promise
-    children_ids: List[str] = None    # Child promises if this has sub-promises
+
+    id: str  # Unique identifier
+    type: PromiseType  # Type of capability
+    parameters: Dict[str, Any]  # Parameters for this promise
+    state: PromiseState  # Current state
+    metadata: PromiseMetadata  # Associated metadata
+    result: Optional[Any] = None  # Result when fulfilled
+    error: Optional[str] = None  # Error message if rejected
+    parent_id: Optional[str] = None  # Parent promise if this is a sub-promise
+    children_ids: List[str] = None  # Child promises if this has sub-promises
 
     def __post_init__(self):
         if self.children_ids is None:
@@ -376,7 +387,7 @@ class IPromiseManager(ABC):
         context_id: str,
         tags: Optional[List[str]] = None,
         parent_id: Optional[str] = None,
-        priority: int = 1
+        priority: int = 1,
     ) -> Promise:
         """
         Create a new promise with the given parameters.
@@ -393,7 +404,7 @@ class IPromiseManager(ABC):
         Returns:
             A newly created Promise in PENDING state
         """
-        pass
+        raise NotImplementedError
 
     @abstractmethod
     def fulfill_promise(self, promise_id: str, result: Any) -> Promise:
@@ -407,7 +418,7 @@ class IPromiseManager(ABC):
         Returns:
             The updated Promise in FULFILLED state
         """
-        pass
+        raise NotImplementedError
 
     @abstractmethod
     def reject_promise(self, promise_id: str, error: str) -> Promise:
@@ -421,7 +432,7 @@ class IPromiseManager(ABC):
         Returns:
             The updated Promise in REJECTED state
         """
-        pass
+        raise NotImplementedError
 
     @abstractmethod
     def cancel_promise(self, promise_id: str, reason: str) -> Promise:
@@ -435,7 +446,7 @@ class IPromiseManager(ABC):
         Returns:
             The updated Promise in CANCELLED state
         """
-        pass
+        raise NotImplementedError
 
     @abstractmethod
     def get_promise(self, promise_id: str) -> Promise:
@@ -448,7 +459,7 @@ class IPromiseManager(ABC):
         Returns:
             The Promise object
         """
-        pass
+        raise NotImplementedError
 
     @abstractmethod
     def list_promises(
@@ -458,7 +469,7 @@ class IPromiseManager(ABC):
         state: Optional[PromiseState] = None,
         type: Optional[PromiseType] = None,
         tags: Optional[List[str]] = None,
-        parent_id: Optional[str] = None
+        parent_id: Optional[str] = None,
     ) -> List[Promise]:
         """
         List promises matching the given filters.
@@ -474,7 +485,7 @@ class IPromiseManager(ABC):
         Returns:
             List of matching Promises
         """
-        pass
+        raise NotImplementedError
 
     @abstractmethod
     def create_child_promise(
@@ -484,7 +495,7 @@ class IPromiseManager(ABC):
         parameters: Dict[str, Any],
         owner_id: str,
         tags: Optional[List[str]] = None,
-        priority: int = 1
+        priority: int = 1,
     ) -> Promise:
         """
         Create a child promise linked to a parent promise.
@@ -500,7 +511,7 @@ class IPromiseManager(ABC):
         Returns:
             A newly created Promise linked to its parent
         """
-        pass
+        raise NotImplementedError
 
     @abstractmethod
     def validate_promise_chain(self, root_promise_id: str) -> bool:
@@ -513,7 +524,7 @@ class IPromiseManager(ABC):
         Returns:
             True if the chain is valid, False otherwise
         """
-        pass
+        raise NotImplementedError
 
     @abstractmethod
     def get_promise_chain(self, promise_id: str) -> List[Promise]:
@@ -526,7 +537,7 @@ class IPromiseManager(ABC):
         Returns:
             List of all related Promises in the chain
         """
-        pass
+        raise NotImplementedError
 
 
 class IPromiseAuthority(ABC):
@@ -537,10 +548,7 @@ class IPromiseAuthority(ABC):
 
     @abstractmethod
     def can_create(
-        self,
-        agent_id: str,
-        promise_type: PromiseType,
-        parameters: Dict[str, Any]
+        self, agent_id: str, promise_type: PromiseType, parameters: Dict[str, Any]
     ) -> bool:
         """
         Check if an agent is authorized to create a promise of the given type.
@@ -553,7 +561,7 @@ class IPromiseAuthority(ABC):
         Returns:
             True if authorized, False otherwise
         """
-        pass
+        raise NotImplementedError
 
     @abstractmethod
     def can_fulfill(self, agent_id: str, promise_id: str) -> bool:
@@ -567,7 +575,7 @@ class IPromiseAuthority(ABC):
         Returns:
             True if authorized, False otherwise
         """
-        pass
+        raise NotImplementedError
 
     @abstractmethod
     def can_reject(self, agent_id: str, promise_id: str) -> bool:
@@ -581,7 +589,7 @@ class IPromiseAuthority(ABC):
         Returns:
             True if authorized, False otherwise
         """
-        pass
+        raise NotImplementedError
 
     @abstractmethod
     def can_cancel(self, agent_id: str, promise_id: str) -> bool:
@@ -595,15 +603,10 @@ class IPromiseAuthority(ABC):
         Returns:
             True if authorized, False otherwise
         """
-        pass
+        raise NotImplementedError
 
     @abstractmethod
-    def can_delegate(
-        self,
-        agent_id: str,
-        promise_id: str,
-        delegate_to: str
-    ) -> bool:
+    def can_delegate(self, agent_id: str, promise_id: str, delegate_to: str) -> bool:
         """
         Check if an agent is authorized to delegate a promise to another agent.
 
@@ -615,14 +618,11 @@ class IPromiseAuthority(ABC):
         Returns:
             True if authorized, False otherwise
         """
-        pass
+        raise NotImplementedError
 
     @abstractmethod
     def register_capability(
-        self,
-        agent_id: str,
-        promise_type: PromiseType,
-        constraints: Dict[str, Any]
+        self, agent_id: str, promise_type: PromiseType, constraints: Dict[str, Any]
     ) -> bool:
         """
         Register an agent as capable of handling promises of a specific type.
@@ -635,7 +635,7 @@ class IPromiseAuthority(ABC):
         Returns:
             True if registration successful, False otherwise
         """
-        pass
+        raise NotImplementedError
 
     @abstractmethod
     def list_agent_capabilities(self, agent_id: str) -> Dict[PromiseType, Dict]:
@@ -648,4 +648,4 @@ class IPromiseAuthority(ABC):
         Returns:
             Dictionary mapping capability types to their constraints
         """
-        pass
+        raise NotImplementedError

--- a/src/devsynth/domain/interfaces/cli.py
+++ b/src/devsynth/domain/interfaces/cli.py
@@ -1,6 +1,5 @@
-
 from abc import ABC, abstractmethod
-from typing import Optional, Dict, Any
+from typing import Any, Dict, Optional
 
 # Create a logger for this module
 from devsynth.logging_setup import DevSynthLogger
@@ -8,35 +7,38 @@ from devsynth.logging_setup import DevSynthLogger
 logger = DevSynthLogger(__name__)
 from devsynth.exceptions import DevSynthError
 
+
 class CLIInterface(ABC):
     """Interface for CLI operations."""
-    
+
     @abstractmethod
     def initialize_project(self, path: str) -> None:
         """Initialize a new project at the specified path."""
-        pass
-    
+        raise NotImplementedError
+
     @abstractmethod
     def generate_spec(self, requirements_file: str) -> None:
         """Generate specifications from requirements."""
-        pass
-    
+        raise NotImplementedError
+
     @abstractmethod
     def generate_tests(self, spec_file: str) -> None:
         """Generate tests from specifications."""
-        pass
-    
+        raise NotImplementedError
+
     @abstractmethod
     def generate_code(self) -> None:
         """Generate code from tests."""
-        pass
-    
+        raise NotImplementedError
+
     @abstractmethod
     def run(self, target: Optional[str] = None) -> None:
         """Execute the generated code or a specific target."""
-        pass
-    
+        raise NotImplementedError
+
     @abstractmethod
-    def configure(self, key: Optional[str] = None, value: Optional[str] = None) -> Dict[str, Any]:
+    def configure(
+        self, key: Optional[str] = None, value: Optional[str] = None
+    ) -> Dict[str, Any]:
         """View or set configuration options."""
-        pass
+        raise NotImplementedError

--- a/src/devsynth/domain/interfaces/code_analysis.py
+++ b/src/devsynth/domain/interfaces/code_analysis.py
@@ -3,7 +3,7 @@ Domain interfaces for code analysis.
 """
 
 from abc import ABC, abstractmethod
-from typing import List, Dict, Any, Optional, Union
+from typing import Any, Dict, List, Optional, Union
 
 
 class FileAnalysisResult(ABC):
@@ -17,7 +17,7 @@ class FileAnalysisResult(ABC):
             A list of dictionaries containing import information.
             Each dictionary should have at least 'name' and 'path' keys.
         """
-        pass
+        raise NotImplementedError
 
     @abstractmethod
     def get_classes(self) -> List[Dict[str, Any]]:
@@ -27,7 +27,7 @@ class FileAnalysisResult(ABC):
             A list of dictionaries containing class information.
             Each dictionary should have at least 'name', 'methods', and 'attributes' keys.
         """
-        pass
+        raise NotImplementedError
 
     @abstractmethod
     def get_functions(self) -> List[Dict[str, Any]]:
@@ -37,7 +37,7 @@ class FileAnalysisResult(ABC):
             A list of dictionaries containing function information.
             Each dictionary should have at least 'name', 'params', and 'return_type' keys.
         """
-        pass
+        raise NotImplementedError
 
     @abstractmethod
     def get_variables(self) -> List[Dict[str, Any]]:
@@ -47,7 +47,7 @@ class FileAnalysisResult(ABC):
             A list of dictionaries containing variable information.
             Each dictionary should have at least 'name' and 'type' keys.
         """
-        pass
+        raise NotImplementedError
 
     @abstractmethod
     def get_docstring(self) -> str:
@@ -56,7 +56,7 @@ class FileAnalysisResult(ABC):
         Returns:
             The docstring as a string, or an empty string if no docstring is found.
         """
-        pass
+        raise NotImplementedError
 
     @abstractmethod
     def get_metrics(self) -> Dict[str, Any]:
@@ -65,7 +65,7 @@ class FileAnalysisResult(ABC):
         Returns:
             A dictionary of metrics, such as lines of code, complexity, etc.
         """
-        pass
+        raise NotImplementedError
 
 
 class CodeAnalysisResult(ABC):
@@ -81,7 +81,7 @@ class CodeAnalysisResult(ABC):
         Returns:
             The FileAnalysisResult for the file, or None if the file was not analyzed.
         """
-        pass
+        raise NotImplementedError
 
     @abstractmethod
     def get_symbol_references(self, symbol_name: str) -> List[Dict[str, Any]]:
@@ -94,7 +94,7 @@ class CodeAnalysisResult(ABC):
             A list of dictionaries containing reference information.
             Each dictionary should have at least 'file', 'line', and 'column' keys.
         """
-        pass
+        raise NotImplementedError
 
     @abstractmethod
     def get_dependencies(self, module_name: str) -> List[str]:
@@ -106,7 +106,7 @@ class CodeAnalysisResult(ABC):
         Returns:
             A list of module names that the specified module depends on.
         """
-        pass
+        raise NotImplementedError
 
     @abstractmethod
     def get_metrics(self) -> Dict[str, Any]:
@@ -115,7 +115,7 @@ class CodeAnalysisResult(ABC):
         Returns:
             A dictionary of metrics, such as total lines of code, number of files, etc.
         """
-        pass
+        raise NotImplementedError
 
 
 class TransformationResult(ABC):
@@ -128,7 +128,7 @@ class TransformationResult(ABC):
         Returns:
             The original code as a string.
         """
-        pass
+        raise NotImplementedError
 
     @abstractmethod
     def get_transformed_code(self) -> str:
@@ -137,7 +137,7 @@ class TransformationResult(ABC):
         Returns:
             The transformed code as a string.
         """
-        pass
+        raise NotImplementedError
 
     @abstractmethod
     def get_changes(self) -> List[Dict[str, Any]]:
@@ -147,7 +147,7 @@ class TransformationResult(ABC):
             A list of dictionaries containing change information.
             Each dictionary should have at least a 'description' key.
         """
-        pass
+        raise NotImplementedError
 
 
 class CodeTransformationProvider(ABC):
@@ -166,7 +166,7 @@ class CodeTransformationProvider(ABC):
         Returns:
             A TransformationResult containing the transformed code and changes made.
         """
-        pass
+        raise NotImplementedError
 
     @abstractmethod
     def transform_file(
@@ -181,7 +181,7 @@ class CodeTransformationProvider(ABC):
         Returns:
             A TransformationResult containing the transformed code and changes made.
         """
-        pass
+        raise NotImplementedError
 
     @abstractmethod
     def transform_directory(
@@ -197,7 +197,7 @@ class CodeTransformationProvider(ABC):
         Returns:
             A dictionary mapping file paths to TransformationResult objects.
         """
-        pass
+        raise NotImplementedError
 
 
 class CodeAnalysisProvider(ABC):
@@ -213,7 +213,7 @@ class CodeAnalysisProvider(ABC):
         Returns:
             A FileAnalysisResult containing the analysis of the file.
         """
-        pass
+        raise NotImplementedError
 
     @abstractmethod
     def analyze_directory(
@@ -228,7 +228,7 @@ class CodeAnalysisProvider(ABC):
         Returns:
             A CodeAnalysisResult containing the analysis of the directory.
         """
-        pass
+        raise NotImplementedError
 
     @abstractmethod
     def analyze_code(
@@ -243,7 +243,7 @@ class CodeAnalysisProvider(ABC):
         Returns:
             A FileAnalysisResult containing the analysis of the code.
         """
-        pass
+        raise NotImplementedError
 
 
 class SimpleFileAnalysis(FileAnalysisResult):

--- a/src/devsynth/domain/interfaces/onnx.py
+++ b/src/devsynth/domain/interfaces/onnx.py
@@ -1,5 +1,5 @@
 from abc import ABC, abstractmethod
-from typing import Any, Iterable, Dict
+from typing import Any, Dict, Iterable
 
 from devsynth.logging_setup import DevSynthLogger
 
@@ -12,7 +12,9 @@ class OnnxRuntime(ABC):
     @abstractmethod
     def load_model(self, model_path: str) -> None:
         """Load an ONNX model from the given path."""
+        raise NotImplementedError
 
     @abstractmethod
     def run(self, inputs: Dict[str, Any]) -> Iterable[Any]:
         """Run inference on the loaded model."""
+        raise NotImplementedError

--- a/tests/unit/application/promises/test_interface_not_implemented.py
+++ b/tests/unit/application/promises/test_interface_not_implemented.py
@@ -1,0 +1,59 @@
+from typing import Any
+
+import pytest
+
+from devsynth.application.promises.interface import PromiseInterface
+
+
+class DummyPromise(PromiseInterface[int]):
+    @property
+    def id(self) -> str:  # pragma: no cover - intentional
+        return super().id
+
+    @property
+    def state(self):  # pragma: no cover - intentional
+        return super().state
+
+    @property
+    def is_pending(self) -> bool:  # pragma: no cover - intentional
+        return super().is_pending
+
+    @property
+    def is_fulfilled(self) -> bool:  # pragma: no cover - intentional
+        return super().is_fulfilled
+
+    @property
+    def is_rejected(self) -> bool:  # pragma: no cover - intentional
+        return super().is_rejected
+
+    @property
+    def value(self) -> int:  # pragma: no cover - intentional
+        return super().value
+
+    @property
+    def reason(self) -> Exception:  # pragma: no cover - intentional
+        return super().reason
+
+    def set_metadata(self, key: str, value: Any):  # pragma: no cover - intentional
+        return super().set_metadata(key, value)
+
+    def get_metadata(self, key: str):  # pragma: no cover - intentional
+        return super().get_metadata(key)
+
+    def then(self, on_fulfilled, on_rejected=None):  # pragma: no cover - intentional
+        return super().then(on_fulfilled, on_rejected)
+
+    def catch(self, on_rejected):  # pragma: no cover - intentional
+        return super().catch(on_rejected)
+
+    def resolve(self, value: int) -> None:  # pragma: no cover - intentional
+        super().resolve(value)
+
+    def reject(self, reason: Exception) -> None:  # pragma: no cover - intentional
+        super().reject(reason)
+
+
+def test_promise_interface_id_not_implemented() -> None:
+    promise = DummyPromise()
+    with pytest.raises(NotImplementedError):
+        _ = promise.id

--- a/tests/unit/domain/interfaces/test_interfaces.py
+++ b/tests/unit/domain/interfaces/test_interfaces.py
@@ -1,0 +1,77 @@
+from typing import Any, Dict
+
+import pytest
+
+from devsynth.domain.interfaces.cli import CLIInterface
+from devsynth.domain.interfaces.code_analysis import FileAnalysisResult
+from devsynth.domain.interfaces.onnx import OnnxRuntime
+
+
+class DummyCLI(CLIInterface):
+    def initialize_project(self, path: str) -> None:  # pragma: no cover - intentional
+        super().initialize_project(path)
+
+    def generate_spec(
+        self, requirements_file: str
+    ) -> None:  # pragma: no cover - intentional
+        super().generate_spec(requirements_file)
+
+    def generate_tests(self, spec_file: str) -> None:  # pragma: no cover - intentional
+        super().generate_tests(spec_file)
+
+    def generate_code(self) -> None:  # pragma: no cover - intentional
+        super().generate_code()
+
+    def run(self, target: str | None = None) -> None:  # pragma: no cover - intentional
+        super().run(target)
+
+    def configure(
+        self, key: str | None = None, value: str | None = None
+    ) -> Dict[str, Any]:  # pragma: no cover - intentional
+        return super().configure(key, value)
+
+
+def test_cli_interface_raises_not_implemented() -> None:
+    cli = DummyCLI()
+    with pytest.raises(NotImplementedError):
+        cli.initialize_project("/tmp")
+
+
+class DummyFileAnalysis(FileAnalysisResult):
+    def get_imports(self):  # pragma: no cover - intentional
+        return super().get_imports()
+
+    def get_classes(self):  # pragma: no cover - intentional
+        return super().get_classes()
+
+    def get_functions(self):  # pragma: no cover - intentional
+        return super().get_functions()
+
+    def get_variables(self):  # pragma: no cover - intentional
+        return super().get_variables()
+
+    def get_docstring(self):  # pragma: no cover - intentional
+        return super().get_docstring()
+
+    def get_metrics(self):  # pragma: no cover - intentional
+        return super().get_metrics()
+
+
+def test_file_analysis_result_raises_not_implemented() -> None:
+    analysis = DummyFileAnalysis()
+    with pytest.raises(NotImplementedError):
+        analysis.get_imports()
+
+
+class DummyOnnx(OnnxRuntime):
+    def load_model(self, model_path: str) -> None:  # pragma: no cover - intentional
+        super().load_model(model_path)
+
+    def run(self, inputs: Dict[str, Any]):  # pragma: no cover - intentional
+        return super().run(inputs)
+
+
+def test_onnx_runtime_raises_not_implemented() -> None:
+    runtime = DummyOnnx()
+    with pytest.raises(NotImplementedError):
+        runtime.load_model("model.onnx")


### PR DESCRIPTION
## Summary
- replace pass statements in domain and promise interfaces with `NotImplementedError`
- add constructors for promise-related error classes
- test interface stubs to ensure NotImplementedError is raised

## Testing
- `poetry run pre-commit run --files src/devsynth/domain/interfaces/cli.py src/devsynth/domain/interfaces/code_analysis.py src/devsynth/domain/interfaces/onnx.py src/devsynth/application/promises/agent.py src/devsynth/application/promises/broker.py src/devsynth/application/promises/implementation.py src/devsynth/application/promises/interface.py tests/unit/domain/interfaces/__init__.py tests/unit/domain/interfaces/test_interfaces.py tests/unit/application/promises/test_interface_not_implemented.py`
- `poetry run pytest --no-cov tests/unit/domain/interfaces tests/unit/application/promises`


------
https://chatgpt.com/codex/tasks/task_e_68961aece6008333b2e0cd8d072ca5b3