### PR TITLE
feat: map sprint planning and retrospectives

### DIFF
--- a/docs/technical_reference/sprint_edrr_integration.md
+++ b/docs/technical_reference/sprint_edrr_integration.md
@@ -112,6 +112,14 @@ The Retrospect phase naturally aligns with sprint retrospectives:
 - Develop metrics for measuring improvement over time
 - Automate evaluation of retrospective data in the EDRR review process
 
+### 2.5 Automated Planning and Retrospective Mapping
+
+DevSynth's `SprintAdapter` now automatically converts requirement
+analysis outputs from the Expand phase into a structured sprint plan and
+summarizes Retrospect phase results for sprint metrics. These mappings are
+implemented in `devsynth.application.edrr.sprint_planning` and
+`devsynth.application.edrr.sprint_retrospective`.
+
 
 ## 3. Time-Boxing EDRR Cycles
 

--- a/src/devsynth/application/edrr/sprint_planning.py
+++ b/src/devsynth/application/edrr/sprint_planning.py
@@ -1,0 +1,29 @@
+"""Sprint planning adapter for EDRR integration.
+
+This module provides helpers that translate requirement analysis results
+from the Expand phase into a structured sprint plan. The sprint adapter
+uses this mapping to align upcoming work with documented requirements.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict
+
+
+def map_requirements_to_plan(requirement_results: Dict[str, Any]) -> Dict[str, Any]:
+    """Return sprint planning information derived from requirement analysis.
+
+    Args:
+        requirement_results: Results produced by the Expand phase's
+            requirements analysis step.
+
+    Returns:
+        Dictionary containing planned scope, objectives and success criteria
+        for the next sprint.
+    """
+
+    return {
+        "planned_scope": requirement_results.get("recommended_scope", []),
+        "objectives": requirement_results.get("objectives", []),
+        "success_criteria": requirement_results.get("success_criteria", []),
+    }

--- a/src/devsynth/application/edrr/sprint_retrospective.py
+++ b/src/devsynth/application/edrr/sprint_retrospective.py
@@ -1,0 +1,35 @@
+"""Sprint retrospective adapter for EDRR integration.
+
+Utilities in this module convert raw retrospective results from the
+Retrospect phase into summaries suitable for sprint metrics.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict
+
+
+def map_retrospective_to_summary(
+    retrospective: Dict[str, Any], sprint: int
+) -> Dict[str, Any]:
+    """Return summarized retrospective information.
+
+    Args:
+        retrospective: Results produced by the Retrospect phase.
+        sprint: Current sprint number.
+
+    Returns:
+        Summary dictionary containing positives, improvements and action
+        items. If no retrospective data is provided an empty dict is
+        returned.
+    """
+
+    if not retrospective:
+        return {}
+
+    return {
+        "positives": retrospective.get("positives", []),
+        "improvements": retrospective.get("improvements", []),
+        "action_items": retrospective.get("action_items", []),
+        "sprint": sprint,
+    }

--- a/tests/integration/general/test_sprint_edrr_integration.py
+++ b/tests/integration/general/test_sprint_edrr_integration.py
@@ -23,6 +23,7 @@ def test_requirements_analysis_updates_sprint_plan():
     adapter.after_cycle(results)
 
     assert adapter.sprint_plan["planned_scope"] == ["feature"]
+    assert adapter.sprint_plan["objectives"] == ["obj"]
     assert adapter.metrics["planned_scope"][0] == ["feature"]
     assert adapter.metrics["actual_scope"][0] == ["feature"]
 
@@ -43,6 +44,10 @@ def test_retrospective_evaluation_logged():
     adapter.after_cycle(results)
 
     assert adapter.metrics["retrospective_reviews"][0]["action_items"] == ["fix"]
+    assert (
+        adapter.metrics["retrospective_reviews"][0]["sprint"]
+        == adapter.current_sprint_number
+    )
     assert adapter.metrics["quality_metrics"][adapter.current_sprint_number] == {
         "quality": "high"
     }


### PR DESCRIPTION
## Summary
- add sprint planning mapper to translate requirement analysis into a sprint plan
- capture retrospective summaries for sprint metrics
- document and test Sprint-EDRR planning and retrospective workflow

## Testing
- `poetry run pre-commit run --files src/devsynth/application/edrr/sprint_planning.py src/devsynth/application/edrr/sprint_retrospective.py src/devsynth/methodology/sprint.py tests/integration/general/test_sprint_edrr_integration.py docs/technical_reference/sprint_edrr_integration.md`
- `poetry run pytest --no-cov tests/integration/general/test_sprint_edrr_integration.py tests/unit/methodology/test_sprint_adapter.py tests/unit/methodology/test_sprint_hooks.py`

------
https://chatgpt.com/codex/tasks/task_e_68961a8cfd8c8333b7caeec703fdf0a7