### PR TITLE
feat: add circuit breaker hooks to memory retry

### DIFF
--- a/tests/unit/application/memory/test_retry.py
+++ b/tests/unit/application/memory/test_retry.py
@@ -1,10 +1,24 @@
 """
 Unit tests for the retry mechanism with exponential backoff.
 """
-import pytest
+
 import time
-from unittest.mock import MagicMock, patch, call
-from devsynth.application.memory.retry import RetryError, retry_with_backoff, retry_operation, RetryConfig, DEFAULT_RETRY_CONFIG, QUICK_RETRY_CONFIG, PERSISTENT_RETRY_CONFIG, NETWORK_RETRY_CONFIG, with_retry
+from unittest.mock import MagicMock, call, patch
+
+import pytest
+
+from devsynth.application.memory.retry import (
+    DEFAULT_RETRY_CONFIG,
+    NETWORK_RETRY_CONFIG,
+    PERSISTENT_RETRY_CONFIG,
+    QUICK_RETRY_CONFIG,
+    RetryConfig,
+    RetryError,
+    retry_operation,
+    retry_with_backoff,
+    with_retry,
+)
+
 
 @pytest.mark.medium
 class TestRetryWithBackoff:
@@ -16,37 +30,52 @@ class TestRetryWithBackoff:
 
         @pytest.mark.medium
         @retry_with_backoff(max_retries=3)
-        def test_func(self, arg1, arg2=None):
-            return f'{arg1}-{arg2}'
-        result = test_func('value1', arg2='value2')
-        assert result == 'value1-value2'
+        def test_func(arg1, arg2=None):
+            return f"{arg1}-{arg2}"
+
+        result = test_func("value1", arg2="value2")
+        assert result == "value1-value2"
 
     @pytest.mark.medium
     def test_retry_on_failure(self):
         """Test that the decorator retries when the function fails."""
         mock_func = MagicMock()
-        mock_func.side_effect = [ValueError('first failure'), ValueError('second failure'), 'success']
-        decorated_func = retry_with_backoff(max_retries=3, initial_backoff=0.01, backoff_multiplier=1.0)(mock_func)
+        mock_func.side_effect = [
+            ValueError("first failure"),
+            ValueError("second failure"),
+            "success",
+        ]
+        decorated_func = retry_with_backoff(
+            max_retries=3, initial_backoff=0.01, backoff_multiplier=1.0
+        )(mock_func)
         result = decorated_func()
-        assert result == 'success'
+        assert result == "success"
         assert mock_func.call_count == 3
 
     @pytest.mark.medium
     def test_max_retries_exceeded(self):
         """Test that the decorator raises RetryError when max retries is exceeded."""
-        mock_func = MagicMock(side_effect=ValueError('test error'))
-        decorated_func = retry_with_backoff(max_retries=2, initial_backoff=0.01, backoff_multiplier=1.0)(mock_func)
+        mock_func = MagicMock(side_effect=ValueError("test error"))
+        decorated_func = retry_with_backoff(
+            max_retries=2, initial_backoff=0.01, backoff_multiplier=1.0
+        )(mock_func)
         with pytest.raises(RetryError) as excinfo:
             decorated_func()
-        assert 'All 2 retry attempts failed' in str(excinfo.value)
+        assert "All 2 retry attempts failed" in str(excinfo.value)
         assert mock_func.call_count == 3
 
     @pytest.mark.medium
     def test_exceptions_to_retry(self):
         """Test that the decorator only retries specified exceptions."""
         mock_func = MagicMock()
-        mock_func.side_effect = [ValueError('retry this'), TypeError("don't retry this"), 'success']
-        decorated_func = retry_with_backoff(max_retries=3, initial_backoff=0.01, exceptions_to_retry=[ValueError])(mock_func)
+        mock_func.side_effect = [
+            ValueError("retry this"),
+            TypeError("don't retry this"),
+            "success",
+        ]
+        decorated_func = retry_with_backoff(
+            max_retries=3, initial_backoff=0.01, exceptions_to_retry=[ValueError]
+        )(mock_func)
         with pytest.raises(TypeError, match="don't retry this"):
             decorated_func()
         assert mock_func.call_count == 2
@@ -54,9 +83,11 @@ class TestRetryWithBackoff:
     @pytest.mark.medium
     def test_backoff_calculation(self):
         """Test that the backoff time increases exponentially."""
-        with patch('time.sleep') as mock_sleep:
-            mock_func = MagicMock(side_effect=ValueError('test error'))
-            decorated_func = retry_with_backoff(max_retries=3, initial_backoff=1.0, backoff_multiplier=2.0, jitter=False)(mock_func)
+        with patch("time.sleep") as mock_sleep:
+            mock_func = MagicMock(side_effect=ValueError("test error"))
+            decorated_func = retry_with_backoff(
+                max_retries=3, initial_backoff=1.0, backoff_multiplier=2.0, jitter=False
+            )(mock_func)
             with pytest.raises(RetryError):
                 decorated_func()
             assert mock_sleep.call_count == 3
@@ -67,15 +98,22 @@ class TestRetryWithBackoff:
     @pytest.mark.medium
     def test_max_backoff(self):
         """Test that the backoff time is capped at max_backoff."""
-        with patch('time.sleep') as mock_sleep:
-            mock_func = MagicMock(side_effect=ValueError('test error'))
-            decorated_func = retry_with_backoff(max_retries=3, initial_backoff=2.0, backoff_multiplier=3.0, max_backoff=5.0, jitter=False)(mock_func)
+        with patch("time.sleep") as mock_sleep:
+            mock_func = MagicMock(side_effect=ValueError("test error"))
+            decorated_func = retry_with_backoff(
+                max_retries=3,
+                initial_backoff=2.0,
+                backoff_multiplier=3.0,
+                max_backoff=5.0,
+                jitter=False,
+            )(mock_func)
             with pytest.raises(RetryError):
                 decorated_func()
             assert mock_sleep.call_count == 3
             assert mock_sleep.call_args_list[0][0][0] == 2.0
             assert mock_sleep.call_args_list[1][0][0] == 5.0
             assert mock_sleep.call_args_list[2][0][0] == 5.0
+
 
 @pytest.mark.medium
 class TestRetryOperation:
@@ -86,28 +124,44 @@ class TestRetryOperation:
         """Test that retry_operation returns the result when the function succeeds."""
 
         @pytest.mark.medium
-        def test_func(self, arg1, arg2=None):
-            return f'{arg1}-{arg2}'
-        result = retry_operation(test_func, max_retries=3, initial_backoff=0.01, arg1='value1', arg2='value2')
-        assert result == 'value1-value2'
+        def test_func(arg1, arg2=None):
+            return f"{arg1}-{arg2}"
+
+        result = retry_operation(
+            test_func,
+            max_retries=3,
+            initial_backoff=0.01,
+            arg1="value1",
+            arg2="value2",
+        )
+        assert result == "value1-value2"
 
     @pytest.mark.medium
     def test_retry_on_failure(self):
         """Test that retry_operation retries when the function fails."""
         mock_func = MagicMock()
-        mock_func.side_effect = [ValueError('first failure'), ValueError('second failure'), 'success']
-        result = retry_operation(mock_func, max_retries=3, initial_backoff=0.01, backoff_multiplier=1.0)
-        assert result == 'success'
+        mock_func.side_effect = [
+            ValueError("first failure"),
+            ValueError("second failure"),
+            "success",
+        ]
+        result = retry_operation(
+            mock_func, max_retries=3, initial_backoff=0.01, backoff_multiplier=1.0
+        )
+        assert result == "success"
         assert mock_func.call_count == 3
 
     @pytest.mark.medium
     def test_max_retries_exceeded(self):
         """Test that retry_operation raises RetryError when max retries is exceeded."""
-        mock_func = MagicMock(side_effect=ValueError('test error'))
+        mock_func = MagicMock(side_effect=ValueError("test error"))
         with pytest.raises(RetryError) as excinfo:
-            retry_operation(mock_func, max_retries=2, initial_backoff=0.01, backoff_multiplier=1.0)
-        assert 'All 2 retry attempts failed' in str(excinfo.value)
+            retry_operation(
+                mock_func, max_retries=2, initial_backoff=0.01, backoff_multiplier=1.0
+            )
+        assert "All 2 retry attempts failed" in str(excinfo.value)
         assert mock_func.call_count == 3
+
 
 @pytest.mark.medium
 class TestRetryConfig:
@@ -116,7 +170,14 @@ class TestRetryConfig:
     @pytest.mark.medium
     def test_retry_config_initialization(self):
         """Test that RetryConfig initializes with expected values."""
-        config = RetryConfig(max_retries=5, initial_backoff=2.0, backoff_multiplier=3.0, max_backoff=30.0, jitter=False, exceptions_to_retry=[ValueError, TypeError])
+        config = RetryConfig(
+            max_retries=5,
+            initial_backoff=2.0,
+            backoff_multiplier=3.0,
+            max_backoff=30.0,
+            jitter=False,
+            exceptions_to_retry=[ValueError, TypeError],
+        )
         assert config.max_retries == 5
         assert config.initial_backoff == 2.0
         assert config.backoff_multiplier == 3.0
@@ -166,6 +227,7 @@ class TestRetryConfig:
         assert TimeoutError in NETWORK_RETRY_CONFIG.exceptions_to_retry
         assert OSError in NETWORK_RETRY_CONFIG.exceptions_to_retry
 
+
 @pytest.mark.medium
 class TestWithRetry:
     """Tests for the with_retry decorator."""
@@ -173,24 +235,59 @@ class TestWithRetry:
     @pytest.mark.medium
     def test_with_retry_default_config(self):
         """Test that with_retry uses DEFAULT_RETRY_CONFIG by default."""
-        with patch('devsynth.application.memory.retry.retry_with_backoff') as mock_retry:
+        with patch(
+            "devsynth.application.memory.retry.retry_with_backoff"
+        ) as mock_retry:
             mock_retry.return_value = lambda f: f
 
             @pytest.mark.medium
             @with_retry()
             def test_func(self):
-                return 'success'
-            mock_retry.assert_called_once_with(max_retries=DEFAULT_RETRY_CONFIG.max_retries, initial_backoff=DEFAULT_RETRY_CONFIG.initial_backoff, backoff_multiplier=DEFAULT_RETRY_CONFIG.backoff_multiplier, max_backoff=DEFAULT_RETRY_CONFIG.max_backoff, jitter=DEFAULT_RETRY_CONFIG.jitter, exceptions_to_retry=DEFAULT_RETRY_CONFIG.exceptions_to_retry)
+                return "success"
+
+            mock_retry.assert_called_once_with(
+                max_retries=DEFAULT_RETRY_CONFIG.max_retries,
+                initial_backoff=DEFAULT_RETRY_CONFIG.initial_backoff,
+                backoff_multiplier=DEFAULT_RETRY_CONFIG.backoff_multiplier,
+                max_backoff=DEFAULT_RETRY_CONFIG.max_backoff,
+                jitter=DEFAULT_RETRY_CONFIG.jitter,
+                exceptions_to_retry=DEFAULT_RETRY_CONFIG.exceptions_to_retry,
+                condition_callbacks=DEFAULT_RETRY_CONFIG.condition_callbacks,
+                circuit_breaker_name=DEFAULT_RETRY_CONFIG.circuit_breaker_name,
+                circuit_breaker_failure_threshold=DEFAULT_RETRY_CONFIG.circuit_breaker_failure_threshold,
+                circuit_breaker_reset_timeout=DEFAULT_RETRY_CONFIG.circuit_breaker_reset_timeout,
+            )
 
     @pytest.mark.medium
     def test_with_retry_custom_config(self):
         """Test that with_retry uses the provided RetryConfig."""
-        custom_config = RetryConfig(max_retries=7, initial_backoff=0.5, backoff_multiplier=1.5, max_backoff=10.0, jitter=False, exceptions_to_retry=[ValueError])
-        with patch('devsynth.application.memory.retry.retry_with_backoff') as mock_retry:
+        custom_config = RetryConfig(
+            max_retries=7,
+            initial_backoff=0.5,
+            backoff_multiplier=1.5,
+            max_backoff=10.0,
+            jitter=False,
+            exceptions_to_retry=[ValueError],
+        )
+        with patch(
+            "devsynth.application.memory.retry.retry_with_backoff"
+        ) as mock_retry:
             mock_retry.return_value = lambda f: f
 
             @pytest.mark.medium
             @with_retry(custom_config)
             def test_func(self):
-                return 'success'
-            mock_retry.assert_called_once_with(max_retries=custom_config.max_retries, initial_backoff=custom_config.initial_backoff, backoff_multiplier=custom_config.backoff_multiplier, max_backoff=custom_config.max_backoff, jitter=custom_config.jitter, exceptions_to_retry=custom_config.exceptions_to_retry)
+                return "success"
+
+            mock_retry.assert_called_once_with(
+                max_retries=custom_config.max_retries,
+                initial_backoff=custom_config.initial_backoff,
+                backoff_multiplier=custom_config.backoff_multiplier,
+                max_backoff=custom_config.max_backoff,
+                jitter=custom_config.jitter,
+                exceptions_to_retry=custom_config.exceptions_to_retry,
+                condition_callbacks=custom_config.condition_callbacks,
+                circuit_breaker_name=custom_config.circuit_breaker_name,
+                circuit_breaker_failure_threshold=custom_config.circuit_breaker_failure_threshold,
+                circuit_breaker_reset_timeout=custom_config.circuit_breaker_reset_timeout,
+            )

--- a/tests/unit/application/memory/test_retry_logic.py
+++ b/tests/unit/application/memory/test_retry_logic.py
@@ -1,0 +1,69 @@
+"""Regression tests for retry logic with circuit breaker and condition hooks."""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from devsynth.application.memory.circuit_breaker import CircuitBreakerOpenError
+from devsynth.application.memory.retry import (
+    reset_memory_retry_metrics,
+    retry_error_counter,
+    retry_event_counter,
+    retry_with_backoff,
+)
+
+
+@pytest.mark.medium
+class TestRetryLogic:
+    """Tests for retry integration features."""
+
+    def setup_method(self) -> None:
+        """Reset metrics before each test."""
+        reset_memory_retry_metrics()
+
+    @pytest.mark.medium
+    def test_condition_callback_aborts_retry(self) -> None:
+        """Ensure condition callbacks can abort further retries."""
+
+        mock_func = MagicMock(side_effect=ValueError("fail"))
+
+        def condition_cb(exc: Exception, count: int) -> bool:
+            return False
+
+        decorated = retry_with_backoff(
+            max_retries=3,
+            initial_backoff=0.01,
+            backoff_multiplier=1.0,
+            jitter=False,
+            condition_callbacks=[condition_cb],
+        )(mock_func)
+
+        with pytest.raises(ValueError):
+            decorated()
+
+        assert mock_func.call_count == 1
+        assert retry_event_counter.labels(status="abort")._value.get() == 1
+        assert retry_error_counter.labels(error_type="ValueError")._value.get() == 1
+
+    @pytest.mark.medium
+    def test_circuit_breaker_stops_retries(self) -> None:
+        """Verify circuit breaker prevents retries once open."""
+
+        mock_func = MagicMock(side_effect=ValueError("boom"))
+        decorated = retry_with_backoff(
+            max_retries=5,
+            initial_backoff=0.01,
+            backoff_multiplier=1.0,
+            jitter=False,
+            circuit_breaker_name="retry_test_cb",
+            circuit_breaker_failure_threshold=2,
+            circuit_breaker_reset_timeout=1.0,
+        )(mock_func)
+
+        with pytest.raises(CircuitBreakerOpenError):
+            decorated()
+
+        assert mock_func.call_count == 2
+        assert retry_event_counter.labels(status="attempt")._value.get() == 2
+        assert retry_error_counter.labels(error_type="ValueError")._value.get() == 2
+        assert retry_event_counter.labels(status="abort")._value.get() == 1


### PR DESCRIPTION
## Summary
- integrate circuit breaker support and condition callbacks into retry decorator
- emit Prometheus metrics for retry attempts, aborts, and failures
- add regression tests for circuit breaker and condition callbacks

## Testing
- `poetry run pytest tests/unit/application/memory/test_retry_logic.py tests/unit/application/memory/test_retry.py -q --no-cov`


------
https://chatgpt.com/codex/tasks/task_e_68962598f5548333861ee87566c2489a