### PR TITLE
Add deployment bootstrapping and image publish scripts

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,6 +3,7 @@ version: '3.8'
 services:
   # Main DevSynth application
   devsynth:
+    image: ghcr.io/devsynth/devsynth:${DEVSYNTH_IMAGE_TAG:-latest}
     build:
       context: .
       target: development

--- a/docs/deployment/runbooks/rollback.md
+++ b/docs/deployment/runbooks/rollback.md
@@ -15,3 +15,7 @@ If a deployment needs to be rolled back, use the following steps:
    ```bash
    scripts/deployment/health_check.sh
    ```
+4. (Optional) Republish the previous image tag as `latest` if the rollback is permanent:
+   ```bash
+   scripts/deployment/publish_image.sh <previous_tag>
+   ```

--- a/scripts/deployment/bootstrap.sh
+++ b/scripts/deployment/bootstrap.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Build images and start the DevSynth stack.
+# Usage: bootstrap.sh [environment]
+#   environment: development (default), staging, production, testing
+
+ENVIRONMENT=${1:-development}
+
+# Build images for the current compose configuration
+
+docker compose build
+
+# Start the stack for the requested environment
+"$(dirname "$0")/start_stack.sh" "$ENVIRONMENT"
+
+# Perform a simple service health check
+"$(dirname "$0")/health_check.sh"

--- a/scripts/deployment/health_check.sh
+++ b/scripts/deployment/health_check.sh
@@ -3,8 +3,12 @@ set -euo pipefail
 
 # Check the health of DevSynth services.
 # Verifies API and monitoring endpoints respond successfully.
+# Usage: health_check.sh [api_url] [grafana_url]
 
-curl -fsS http://localhost:8000/health > /dev/null
-curl -fsS http://localhost:3000/api/health > /dev/null
+API_URL=${1:-http://localhost:8000/health}
+GRAFANA_URL=${2:-http://localhost:3000/api/health}
+
+curl -fsS "$API_URL" > /dev/null
+curl -fsS "$GRAFANA_URL" > /dev/null
 
 echo "All services are healthy"

--- a/scripts/deployment/publish_image.sh
+++ b/scripts/deployment/publish_image.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Build and publish the DevSynth image to a registry.
+# Usage: publish_image.sh [tag]
+#   tag: image tag to publish (default: latest)
+
+TAG=${1:-latest}
+export DEVSYNTH_IMAGE_TAG="$TAG"
+
+# Build the image with the specified tag
+
+docker compose build devsynth
+
+# Push the image to the configured registry
+
+docker compose push devsynth

--- a/tests/integration/general/test_deployment_automation.py
+++ b/tests/integration/general/test_deployment_automation.py
@@ -1,7 +1,7 @@
 """Tests for deployment automation scripts.
 
-This suite verifies that deployment scripts exist and basic rollback
-instructions are documented.
+This suite verifies that deployment scripts exist, images can be published,
+and rollback instructions are documented.
 """
 
 from pathlib import Path
@@ -11,11 +11,11 @@ SCRIPTS_DIR = ROOT / "scripts/deployment"
 RUNBOOKS_DIR = ROOT / "docs/deployment/runbooks"
 
 
-def test_bootstrap_env_script_exists_and_contains_docker():
-    script = SCRIPTS_DIR / "bootstrap_env.sh"
+def test_bootstrap_script_exists_and_builds_images():
+    script = SCRIPTS_DIR / "bootstrap.sh"
     assert script.exists()
     content = script.read_text()
-    assert "docker compose" in content
+    assert "docker compose build" in content
 
 
 def test_health_check_script_exists_and_contains_curl():
@@ -25,8 +25,23 @@ def test_health_check_script_exists_and_contains_curl():
     assert "curl" in content
 
 
-def test_rollback_runbook_mentions_stop_stack():
+def test_publish_image_script_exists_and_pushes():
+    script = SCRIPTS_DIR / "publish_image.sh"
+    assert script.exists()
+    content = script.read_text()
+    assert "docker compose push" in content
+
+
+def test_docker_compose_defines_image_for_devsynth():
+    compose_file = ROOT / "docker-compose.yml"
+    assert compose_file.exists()
+    text = compose_file.read_text()
+    assert "image: ghcr.io/devsynth/devsynth" in text
+
+
+def test_rollback_runbook_mentions_scripts():
     runbook = RUNBOOKS_DIR / "rollback.md"
     assert runbook.exists()
     text = runbook.read_text()
     assert "stop_stack.sh" in text
+    assert "publish_image.sh" in text


### PR DESCRIPTION
## Summary
- add `bootstrap.sh` and parameterized `health_check.sh` under deployment scripts
- introduce `publish_image.sh` and tag devsynth image in docker-compose
- document rollback republish step and verify automation via integration test

## Testing
- `SKIP=fix-code-blocks poetry run pre-commit run --files scripts/deployment/bootstrap.sh scripts/deployment/publish_image.sh scripts/deployment/health_check.sh docker-compose.yml docs/deployment/runbooks/rollback.md tests/integration/general/test_deployment_automation.py`
- `poetry run pytest --no-cov tests/integration/general/test_deployment_automation.py`


------
https://chatgpt.com/codex/tasks/task_e_68962590f7888333a7afa9888cf8f1da