### PR TITLE
feat: add security audit integrations

### DIFF
--- a/.github/workflows.disabled/dependency_check.yml
+++ b/.github/workflows.disabled/dependency_check.yml
@@ -10,7 +10,7 @@ on:
   workflow_dispatch:
 
 jobs:
-  safety:
+  security-audit:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -23,10 +23,10 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install poetry safety
+          pip install poetry bandit safety
           poetry install --with dev,docs --all-extras --no-root
 
-      - name: Run dependency safety check
+      - name: Run dependency and static analysis check
         run: python scripts/dependency_safety_check.py
       - name: Run project checks
         # Runs tests and documentation checks; fails if any script exits non-zero

--- a/.github/workflows.disabled/static_analysis.yml
+++ b/.github/workflows.disabled/static_analysis.yml
@@ -8,7 +8,7 @@ on:
   workflow_dispatch:
 
 jobs:
-  bandit:
+  static-analysis:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -19,9 +19,10 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -e .[dev,docs] bandit
-      - name: Run Bandit
-        run: bandit -r src -ll
+          pip install poetry bandit safety
+          poetry install --with dev,docs --all-extras --no-root
+      - name: Run security checks
+        run: python scripts/dependency_safety_check.py --skip-safety
       - name: Run project checks
         # Runs tests and documentation checks; fails if any script exits non-zero
         run: |

--- a/docs/policies/security_audit.md
+++ b/docs/policies/security_audit.md
@@ -16,25 +16,27 @@ ensure code quality and supply chain safety.
 
 ## Running Locally
 
-Use the bundled script, which delegates to
-`src/devsynth/security/audit.py`:
+Run the bundled script to execute both tools:
 
 ```bash
-poetry run python scripts/security_audit.py
+poetry run python scripts/dependency_safety_check.py
 ```
 
-To skip checks:
+To skip checks or update dependencies first:
 
 ```bash
-poetry run python scripts/security_audit.py --skip-bandit --skip-safety
+poetry run python scripts/dependency_safety_check.py --skip-bandit --skip-safety
+poetry run python scripts/dependency_safety_check.py --update
 ```
 
 ## Continuous Integration
 
-`bandit` and `safety` run in CI via a disabled workflow
-[`.github/workflows/ci.yml.disabled`](../../.github/workflows/ci.yml.disabled).
-The workflow installs dependencies with Poetry and executes the bundled
-`scripts/security_audit.py` utility on pull requests and pushes to
+`bandit` and `safety` run in CI via disabled workflows
+[`dependency_check.yml`](../../.github/workflows.disabled/dependency_check.yml)
+and
+[`static_analysis.yml`](../../.github/workflows.disabled/static_analysis.yml).
+These workflows install dependencies with Poetry and execute the
+`scripts/dependency_safety_check.py` utility on pull requests and pushes to
 `main` when enabled.
 
 ## Logging

--- a/scripts/dependency_safety_check.py
+++ b/scripts/dependency_safety_check.py
@@ -1,21 +1,30 @@
 #!/usr/bin/env python3
-"""Run safety checks and optional dependency updates.
+"""Run static analysis and dependency safety checks.
 
-This script exports project dependencies and executes a vulnerability scan using
-``safety``. Optionally, it can run ``poetry update`` before checking.
+This script exports project dependencies and executes a vulnerability scan
+using ``safety`` and runs ``bandit`` for static analysis. Optionally, it can
+run ``poetry update`` before checking and supports skipping individual tools.
 """
 
 from __future__ import annotations
 
 import argparse
+import os
 import subprocess
 import sys
 import tempfile
+from typing import Sequence
+
+
+def run_bandit() -> None:
+    """Execute Bandit static analysis."""
+    subprocess.check_call(["poetry", "run", "bandit", "-q", "-r", "src"])
 
 
 def run_safety() -> None:
     """Export dependencies and execute ``safety``."""
-    with tempfile.NamedTemporaryFile("w+", delete=False) as req_file:
+    req_file = tempfile.NamedTemporaryFile("w+", delete=False)
+    try:
         subprocess.check_call(
             [
                 "poetry",
@@ -28,8 +37,19 @@ def run_safety() -> None:
             ]
         )
         subprocess.check_call(
-            ["safety", "check", "--file", req_file.name, "--full-report"]
+            [
+                "poetry",
+                "run",
+                "safety",
+                "check",
+                "--file",
+                req_file.name,
+                "--full-report",
+            ]
         )
+    finally:
+        req_file.close()
+        os.unlink(req_file.name)
 
 
 def run_update() -> None:
@@ -37,21 +57,34 @@ def run_update() -> None:
     subprocess.check_call(["poetry", "update"])
 
 
-def main() -> None:
+def main(argv: Sequence[str] | None = None) -> None:
     """Parse arguments and run the desired commands."""
     parser = argparse.ArgumentParser(
-        description="Run dependency safety checks or update dependencies."
+        description="Run dependency safety checks or update dependencies.",
     )
     parser.add_argument(
         "--update",
         action="store_true",
-        help="Run 'poetry update' before the safety check.",
+        help="Run 'poetry update' before running checks.",
     )
-    args = parser.parse_args()
+    parser.add_argument(
+        "--skip-bandit",
+        action="store_true",
+        help="Skip Bandit static analysis.",
+    )
+    parser.add_argument(
+        "--skip-safety",
+        action="store_true",
+        help="Skip Safety dependency vulnerability scan.",
+    )
+    args = parser.parse_args(argv)
 
     if args.update:
         run_update()
-    run_safety()
+    if not args.skip_bandit:
+        run_bandit()
+    if not args.skip_safety:
+        run_safety()
 
 
 if __name__ == "__main__":

--- a/tests/unit/security/test_security_audit.py
+++ b/tests/unit/security/test_security_audit.py
@@ -1,26 +1,26 @@
-"""Tests for the security audit script."""
+"""Tests for the dependency safety check script."""
 
 import sys
 from unittest.mock import patch
 
 sys.path.append("scripts")
 
-import security_audit  # type: ignore
+import dependency_safety_check  # type: ignore
 
 
-@patch("security_audit.run_safety")
-@patch("security_audit.run_bandit")
+@patch("dependency_safety_check.run_safety")
+@patch("dependency_safety_check.run_bandit")
 def test_main_runs_all_checks(mock_bandit, mock_safety) -> None:
     """The script should execute Bandit and Safety by default."""
-    security_audit.main([])
+    dependency_safety_check.main([])
     mock_bandit.assert_called_once()
     mock_safety.assert_called_once()
 
 
-@patch("security_audit.run_safety")
-@patch("security_audit.run_bandit")
+@patch("dependency_safety_check.run_safety")
+@patch("dependency_safety_check.run_bandit")
 def test_main_respects_skip_flags(mock_bandit, mock_safety) -> None:
     """Skip flags should prevent running the associated tools."""
-    security_audit.main(["--skip-bandit", "--skip-safety"])
+    dependency_safety_check.main(["--skip-bandit", "--skip-safety"])
     mock_bandit.assert_not_called()
     mock_safety.assert_not_called()


### PR DESCRIPTION
## Summary
- extend dependency safety check to run Bandit and Safety with optional skip flags
- wire static analysis script into disabled CI workflows
- document audit procedures and add unit tests

## Testing
- `SKIP=fix-code-blocks poetry run pre-commit run --files scripts/dependency_safety_check.py .github/workflows.disabled/dependency_check.yml .github/workflows.disabled/static_analysis.yml docs/policies/security_audit.md tests/unit/security/test_security_audit.py`
- `poetry run pytest tests/unit/security/test_security_audit.py -n 0 --no-cov`

------
https://chatgpt.com/codex/tasks/task_e_689634a0f7ac8333ba1a2783d7768937