### PR TITLE
Add dialectical reasoning loop and consensus logging

### DIFF
--- a/src/devsynth/application/orchestration/dialectical_reasoner.py
+++ b/src/devsynth/application/orchestration/dialectical_reasoner.py
@@ -3,6 +3,7 @@
 from typing import Any, Dict, Optional
 
 from devsynth.exceptions import ConsensusError
+from devsynth.logger import log_consensus_failure
 from devsynth.logging_setup import DevSynthLogger
 
 logger = DevSynthLogger(__name__)
@@ -26,8 +27,5 @@ class DialecticalReasoner:
                 task, critic_agent, memory_integration
             )
         except ConsensusError as exc:  # pragma: no cover - logging path
-            logger.error(
-                "Consensus failure during dialectical reasoning",
-                extra={"error": str(exc)},
-            )
+            log_consensus_failure(logger, exc)
             return None

--- a/src/devsynth/application/orchestration/edrr_coordinator.py
+++ b/src/devsynth/application/orchestration/edrr_coordinator.py
@@ -2,10 +2,8 @@
 
 from typing import Any, Callable, Dict, List, Optional
 
-from devsynth.domain.models.wsde_dialectical import (
-    apply_dialectical_reasoning as _apply_dialectical_reasoning,
-)
 from devsynth.logging_setup import DevSynthLogger
+from devsynth.methodology.dialectical_reasoning import reasoning_loop
 
 logger = DevSynthLogger(__name__)
 
@@ -64,8 +62,6 @@ class EDRRCoordinator:
             Result from :func:`apply_dialectical_reasoning`.
         """
         logger.info("EDRRCoordinator invoking dialectical reasoning")
-        result = _apply_dialectical_reasoning(
-            self.wsde_team, task, critic_agent, memory_integration
-        )
+        results = reasoning_loop(self.wsde_team, task, critic_agent, memory_integration)
         self._sync_memory()
-        return result
+        return results[-1] if results else {}

--- a/src/devsynth/logger.py
+++ b/src/devsynth/logger.py
@@ -13,6 +13,7 @@ import os
 import sys
 from logging.handlers import RotatingFileHandler
 from pathlib import Path
+from typing import Any, Dict
 
 from devsynth.logging_setup import (
     DevSynthLogger,
@@ -101,10 +102,27 @@ def setup_logging(name: str, log_level: int | str | None = None) -> DevSynthLogg
     return DevSynthLogger(name)
 
 
+def log_consensus_failure(
+    logger: DevSynthLogger, error: Exception, extra: Dict[str, Any] | None = None
+) -> None:
+    """Log a consensus failure using ``logger``.
+
+    Args:
+        logger: Logger instance to emit the log.
+        error: The exception that triggered the failure.
+        extra: Optional additional context for the log record.
+    """
+    data: Dict[str, Any] = {"error": str(error)}
+    if extra:
+        data.update(extra)
+    logger.error("Consensus failure", extra=data)
+
+
 __all__ = [
     "configure_logging",
     "get_logger",
     "setup_logging",
+    "log_consensus_failure",
     "DevSynthLogger",
     "set_request_context",
     "clear_request_context",

--- a/src/devsynth/methodology/dialectical_reasoning.py
+++ b/src/devsynth/methodology/dialectical_reasoning.py
@@ -1,0 +1,41 @@
+"""Dialectical reasoning loop utilities for EDRR workflows."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional
+
+from devsynth.domain.models.wsde_dialectical import (
+    apply_dialectical_reasoning as _apply_dialectical_reasoning,
+)
+from devsynth.exceptions import ConsensusError
+from devsynth.logger import get_logger, log_consensus_failure
+
+logger = get_logger(__name__)
+
+
+def reasoning_loop(
+    wsde_team: Any,
+    task: Dict[str, Any],
+    critic_agent: Any,
+    memory_integration: Optional[Any] = None,
+    max_iterations: int = 3,
+) -> List[Dict[str, Any]]:
+    """Iteratively apply dialectical reasoning until completion or failure."""
+    results: List[Dict[str, Any]] = []
+    current_task = task
+    for iteration in range(max_iterations):
+        logger.info("Dialectical reasoning iteration %s", iteration + 1)
+        try:
+            result = _apply_dialectical_reasoning(
+                wsde_team, current_task, critic_agent, memory_integration
+            )
+        except ConsensusError as exc:  # pragma: no cover - logging path
+            log_consensus_failure(logger, exc)
+            break
+        results.append(result)
+        if result.get("status") == "completed":
+            break
+        synthesis = result.get("synthesis")
+        if synthesis is not None:
+            current_task = {**current_task, "solution": synthesis}
+    return results

--- a/tests/unit/application/orchestration/test_dialectical_reasoner.py
+++ b/tests/unit/application/orchestration/test_dialectical_reasoner.py
@@ -19,8 +19,8 @@ def test_edrr_coordinator_delegates_to_helper():
     task = {"solution": {}}
     critic = MagicMock()
     with patch(
-        "devsynth.application.orchestration.edrr_coordinator._apply_dialectical_reasoning",
-        return_value={"ok": True},
+        "devsynth.application.orchestration.edrr_coordinator.reasoning_loop",
+        return_value=[{"ok": True}],
     ) as helper:
         result = coordinator.apply_dialectical_reasoning(task, critic)
     helper.assert_called_once_with(team, task, critic, None)

--- a/tests/unit/methodology/test_dialectical_reasoning_loop.py
+++ b/tests/unit/methodology/test_dialectical_reasoning_loop.py
@@ -1,0 +1,43 @@
+import logging
+from unittest.mock import MagicMock
+
+from devsynth.exceptions import ConsensusError
+from devsynth.methodology.dialectical_reasoning import reasoning_loop
+
+
+class DummyConsensusError(ConsensusError):
+    def __init__(self, message: str):  # pragma: no cover - simple helper
+        Exception.__init__(self, message)
+
+
+def test_reasoning_loop_runs_until_complete(monkeypatch):
+    calls = []
+
+    def fake_apply(team, task, critic, memory):
+        calls.append(task.get("solution"))
+        if len(calls) == 1:
+            return {"status": "in_progress", "synthesis": "next"}
+        return {"status": "completed", "synthesis": "final"}
+
+    monkeypatch.setattr(
+        "devsynth.methodology.dialectical_reasoning._apply_dialectical_reasoning",
+        fake_apply,
+    )
+
+    results = reasoning_loop(MagicMock(), {"solution": "initial"}, MagicMock())
+    assert len(results) == 2
+    assert results[-1]["synthesis"] == "final"
+
+
+def test_reasoning_loop_logs_consensus_failure(monkeypatch, caplog):
+    def fail_apply(team, task, critic, memory):
+        raise DummyConsensusError("no consensus")
+
+    monkeypatch.setattr(
+        "devsynth.methodology.dialectical_reasoning._apply_dialectical_reasoning",
+        fail_apply,
+    )
+
+    with caplog.at_level(logging.ERROR):
+        assert reasoning_loop(MagicMock(), {"solution": "initial"}, MagicMock()) == []
+    assert "Consensus failure" in caplog.text


### PR DESCRIPTION
## Summary
- Add iterative dialectical reasoning loop and integrate it into EDRR coordinator
- Implement centralized consensus-failure logging helper and use it in dialectical reasoner
- Expand methodology unit tests to cover reasoning loop

## Testing
- `poetry run pre-commit run --files src/devsynth/methodology/dialectical_reasoning.py src/devsynth/application/orchestration/edrr_coordinator.py src/devsynth/logger.py src/devsynth/application/orchestration/dialectical_reasoner.py tests/unit/methodology/test_dialectical_reasoning_loop.py tests/unit/application/orchestration/test_dialectical_reasoner.py`
- `poetry run pre-commit run --files tests/unit/methodology/test_dialectical_reasoning_loop.py`
- `poetry run pytest tests/unit/methodology/test_dialectical_reasoning_loop.py tests/unit/application/orchestration/test_dialectical_reasoner.py --no-cov`


------
https://chatgpt.com/codex/tasks/task_e_6896661a802c8333867079dcb5fc3113