### PR TITLE
Add Prometheus retry metrics and circuit breaker integration

### DIFF
--- a/src/devsynth/metrics.py
+++ b/src/devsynth/metrics.py
@@ -1,41 +1,77 @@
-"""Utility module for tracking runtime metrics."""
+"""Utility module for tracking runtime metrics.
 
-from collections import Counter
+The module exposes helper functions for incrementing counters used throughout
+the project.  Internally the counters are maintained both as simple in-memory
+``Counter`` objects for unit tests and as `prometheus_client` counters for
+runtime scraping.
+"""
+
+from __future__ import annotations
+
+from collections import Counter as DictCounter
 from typing import Dict
 
-# Counters for operations
-_memory_metrics: Counter = Counter()
-_provider_metrics: Counter = Counter()
-_retry_metrics: Counter = Counter()
+from prometheus_client import Counter
+
+# ---------------------------------------------------------------------------
+# In-memory counters used by tests and internal introspection
+# ---------------------------------------------------------------------------
+_memory_metrics: DictCounter[str] = DictCounter()
+_provider_metrics: DictCounter[str] = DictCounter()
+_retry_metrics: DictCounter[str] = DictCounter()
 # Per-function retry count metrics
-_retry_count_metrics: Counter = Counter()
+_retry_count_metrics: DictCounter[str] = DictCounter()
 # Per-exception retry metrics
-_retry_error_metrics: Counter = Counter()
+_retry_error_metrics: DictCounter[str] = DictCounter()
+
+# ---------------------------------------------------------------------------
+# Prometheus counters
+# ---------------------------------------------------------------------------
+_memory_counter = Counter(
+    "devsynth_memory_operations_total", "Memory operations", ["op"]
+)
+_provider_counter = Counter(
+    "devsynth_provider_operations_total", "Provider operations", ["op"]
+)
+retry_event_counter = Counter(
+    "devsynth_retry_events_total", "Retry events", ["status"]
+)
+retry_function_counter = Counter(
+    "devsynth_retry_function_total", "Retry attempts per function", ["function"]
+)
+retry_error_counter = Counter(
+    "devsynth_retry_errors_total", "Retry events grouped by exception", ["error_type"]
+)
 
 
 def inc_memory(op: str) -> None:
     """Increment memory operation counter."""
     _memory_metrics[op] += 1
+    _memory_counter.labels(op=op).inc()
 
 
 def inc_provider(op: str) -> None:
     """Increment provider operation counter."""
     _provider_metrics[op] += 1
+    _provider_counter.labels(op=op).inc()
 
 
 def inc_retry(op: str) -> None:
     """Increment retry operation counter."""
     _retry_metrics[op] += 1
+    retry_event_counter.labels(status=op).inc()
 
 
 def inc_retry_count(func_name: str) -> None:
     """Increment retry count for a specific function."""
     _retry_count_metrics[func_name] += 1
+    retry_function_counter.labels(function=func_name).inc()
 
 
 def inc_retry_error(error_name: str) -> None:
     """Increment retry counter for a specific error type."""
     _retry_error_metrics[error_name] += 1
+    retry_error_counter.labels(error_type=error_name).inc()
 
 
 def get_memory_metrics() -> Dict[str, int]:
@@ -70,3 +106,10 @@ def reset_metrics() -> None:
     _retry_metrics.clear()
     _retry_count_metrics.clear()
     _retry_error_metrics.clear()
+
+    _memory_counter.clear()
+    _provider_counter.clear()
+    retry_event_counter.clear()
+    retry_function_counter.clear()
+    retry_error_counter.clear()
+

--- a/tests/unit/fallback/test_retry_metrics_prometheus_integration.py
+++ b/tests/unit/fallback/test_retry_metrics_prometheus_integration.py
@@ -1,0 +1,42 @@
+from unittest.mock import Mock
+
+import pytest
+
+from devsynth import metrics
+from devsynth.fallback import (
+    reset_prometheus_metrics,
+    retry_event_counter as fallback_retry_event_counter,
+    retry_with_exponential_backoff,
+)
+from devsynth.metrics import retry_event_counter as metrics_retry_event_counter
+
+
+@pytest.mark.medium
+def test_retry_metrics_synced_with_prometheus() -> None:
+    """Retry decorator updates both in-memory and Prometheus counters."""
+
+    metrics.reset_metrics()
+    reset_prometheus_metrics()
+
+    func = Mock(side_effect=[Exception("err"), "ok"])
+    func.__name__ = "func"
+
+    wrapped = retry_with_exponential_backoff(
+        max_retries=2, initial_delay=0, track_metrics=True
+    )(func)
+
+    result = wrapped()
+
+    assert result == "ok"
+
+    # In-memory counters via metrics module
+    assert metrics.get_retry_metrics() == {"attempt": 1, "success": 1}
+
+    # Prometheus counters in fallback.py
+    assert fallback_retry_event_counter.labels(status="attempt")._value.get() == 1
+    assert fallback_retry_event_counter.labels(status="success")._value.get() == 1
+
+    # Prometheus counters exposed by metrics module
+    assert metrics_retry_event_counter.labels(status="attempt")._value.get() == 1
+    assert metrics_retry_event_counter.labels(status="success")._value.get() == 1
+


### PR DESCRIPTION
## Summary
- instrument retry metrics with prometheus counters
- wire retry logic to shared counters and document configurable callbacks
- add regression test ensuring in-memory and Prometheus metrics stay in sync

## Testing
- `poetry run pytest -n0 --no-cov tests/unit/fallback/test_retry_metrics_prometheus_integration.py tests/unit/fallback/test_retry_metrics.py tests/unit/fallback/test_retry_logic.py tests/unit/test_metrics_module.py`


------
https://chatgpt.com/codex/tasks/task_e_6896732d6920833396f4cdd80a406980