### PR TITLE
harden deployment scripts and add micro edrr hooks

### DIFF
--- a/deployment/README.md
+++ b/deployment/README.md
@@ -7,6 +7,9 @@ This directory contains Docker Compose files and helper scripts for running DevS
 - `bootstrap_env.sh` – build and start DevSynth with monitoring
 - `health_check.sh` – verify running services
 
+All scripts perform basic security checks, refusing to run as root,
+verifying required tooling, and warning if `.env` files are world-readable.
+
 Use these files together to spin up a complete local environment:
 
 ```bash

--- a/deployment/bootstrap_env.sh
+++ b/deployment/bootstrap_env.sh
@@ -1,7 +1,30 @@
 #!/usr/bin/env bash
 set -euo pipefail
+IFS=$'\n\t'
 
 # Bootstrap the local DevSynth environment.
 # Builds and starts DevSynth along with monitoring stack.
+
+# Refuse to run as root to avoid privilege escalation issues.
+if [[ $EUID -eq 0 ]]; then
+  echo "This script should not be run as root." >&2
+  exit 1
+fi
+
+# Ensure required tools are present.
+command -v docker >/dev/null 2>&1 || {
+  echo "docker is required but not installed." >&2
+  exit 1
+}
+command -v docker compose >/dev/null 2>&1 || {
+  echo "docker compose plugin is required." >&2
+  exit 1
+}
+
+# Verify .env file permissions are restricted if it exists.
+if [[ -f .env ]] && [[ $(stat -c '%a' .env) -gt 600 ]]; then
+  echo ".env file permissions are too permissive; run 'chmod 600 .env'." >&2
+  exit 1
+fi
 
 docker compose -f deployment/docker-compose.yml -f deployment/docker-compose.monitoring.yml up -d --build --pull=always

--- a/deployment/deploy_production.sh
+++ b/deployment/deploy_production.sh
@@ -1,7 +1,30 @@
 #!/usr/bin/env bash
 set -euo pipefail
+IFS=$'\n\t'
 
 # Build and run DevSynth in production mode
+
+# Refuse to run as root for better security.
+if [[ $EUID -eq 0 ]]; then
+  echo "This script should not be run as root." >&2
+  exit 1
+fi
+
+# Ensure docker and compose are available
+command -v docker >/dev/null 2>&1 || {
+  echo "docker is required but not installed." >&2
+  exit 1
+}
+command -v docker compose >/dev/null 2>&1 || {
+  echo "docker compose plugin is required." >&2
+  exit 1
+}
+
+# Ensure sensitive env files are not world-readable
+if [[ -f .env ]] && [[ $(stat -c '%a' .env) -gt 600 ]]; then
+  echo ".env file permissions are too permissive; run 'chmod 600 .env'." >&2
+  exit 1
+fi
 
 docker compose -f deployment/docker-compose.yml -f deployment/docker-compose.monitoring.yml build --pull --no-cache
 

--- a/deployment/health_check.sh
+++ b/deployment/health_check.sh
@@ -1,8 +1,19 @@
 #!/usr/bin/env bash
 set -euo pipefail
+IFS=$'\n\t'
 
 # Check the health of DevSynth services.
 # Verifies API and monitoring endpoints respond successfully.
+
+if [[ $EUID -eq 0 ]]; then
+  echo "This script should not be run as root." >&2
+  exit 1
+fi
+
+command -v curl >/dev/null 2>&1 || {
+  echo "curl is required but not installed." >&2
+  exit 1
+}
 
 curl -fsS --max-time 10 http://localhost:8000/health > /dev/null
 curl -fsS --max-time 10 http://localhost:3000/api/health > /dev/null

--- a/docs/deployment/index.md
+++ b/docs/deployment/index.md
@@ -21,7 +21,8 @@ last_reviewed: "2025-07-10"
 
 This section provides documentation on deploying DevSynth in various environments and configurations.
 
-- **[Deployment Guide](deployment_guide.md)**: A comprehensive guide to deploying DevSynth in production environments, now with enhanced security practices such as TLS enforcement, container hardening, and automated secret rotation.
+ - **[Deployment Guide](deployment_guide.md)**: A comprehensive guide to deploying DevSynth in production environments, now with enhanced security practices such as TLS enforcement, container hardening, and automated secret rotation.
+ - **[Security Guidelines](security_guidelines.md)**: Mandatory preflight checks and safeguards for all deployment scripts.
 
 ## Related Documentation
 

--- a/docs/deployment/security_guidelines.md
+++ b/docs/deployment/security_guidelines.md
@@ -1,0 +1,45 @@
+---
+title: "Deployment Security Guidelines"
+date: "2025-07-10"
+version: "0.1.0-alpha.1"
+tags:
+  - deployment
+  - security
+status: "active"
+author: "DevSynth Team"
+last_reviewed: "2025-07-10"
+---
+<div class="breadcrumbs">
+<a href="../index.md">Documentation</a> &gt; <a href="index.md">Deployment</a> &gt; Deployment Security Guidelines
+</div>
+
+# Deployment Security Guidelines
+
+These guidelines describe the baseline safeguards enforced by the deployment
+scripts. Following them helps reduce accidental exposure of credentials and
+limits the blast radius of compromised containers.
+
+## Preflight Checks
+
+The helper scripts perform several checks before taking action:
+
+- Refuse to run as the `root` user to encourage least-privilege operation.
+- Verify required tooling is available (`docker`, `docker compose`, and
+  `curl` for health checks).
+- Abort if a local `.env` file is more permissive than `600`.
+
+## Runtime Safeguards
+
+- Images are pulled with `--pull=always` and production builds use
+  `--no-cache` to ensure the latest patched layers are used.
+- Containers start with Docker's `no-new-privileges` option and include
+  health checks that timeout quickly.
+
+## Additional Recommendations
+
+- Store secrets outside of version control and rotate them regularly.
+- Review container logs for unusual activity and keep Docker up to date.
+
+These practices will evolve as DevSynth matures; contributors should keep this
+document current when introducing new deployment mechanisms.
+

--- a/tests/behavior/steps/micro_edrr_cycle_steps.py
+++ b/tests/behavior/steps/micro_edrr_cycle_steps.py
@@ -16,6 +16,7 @@ import os
 import tempfile
 from pathlib import Path
 from typing import Dict, Tuple
+from unittest.mock import MagicMock
 
 from devsynth.application.code_analysis.analyzer import CodeAnalyzer
 from devsynth.application.code_analysis.ast_transformer import AstTransformer
@@ -25,6 +26,7 @@ from devsynth.application.documentation.documentation_manager import (
 from devsynth.application.edrr.coordinator import EDRRCoordinator
 from devsynth.application.memory.memory_manager import MemoryManager
 from devsynth.application.requirements.prompt_manager import PromptManager
+from devsynth.domain.models.memory import MemoryItem
 from devsynth.domain.models.wsde_facade import WSDETeam
 from devsynth.methodology.base import Phase
 
@@ -38,6 +40,7 @@ def context():
             """Initialize the context with empty attributes."""
             self.edrr_coordinator = None
             self.memory_manager = None
+            self.memory_adapter = None
             self.wsde_team = None
             self.code_analyzer = None
             self.ast_transformer = None
@@ -49,6 +52,8 @@ def context():
             self.task_description = None
             self.sub_task_description = None
             self.phase = None
+            self.start_called = False
+            self.end_called = False
 
     return Context()
 
@@ -74,12 +79,31 @@ def edrr_coordinator_initialized(context):
     # Create a temporary directory for the test
     temp_dir = tempfile.mkdtemp()
 
-    # Initialize memory manager
-    context.memory_manager = MemoryManager()
-    assert context.memory_manager is not None, "Memory manager initialization failed"
+    # Initialize an in-memory adapter to avoid external dependencies
+    class InMemoryAdapter:
+        def __init__(self):
+            self.items = []
+
+        def store(self, item: MemoryItem) -> str:
+            item.id = str(len(self.items) + 1)
+            self.items.append(item)
+            return item.id
+
+        def query_by_metadata(self, metadata):
+            return [
+                item
+                for item in self.items
+                if all(item.metadata.get(k) == v for k, v in metadata.items())
+            ]
+
+    context.memory_adapter = InMemoryAdapter()
+    context.memory_manager = MemoryManager(
+        adapters={"in_memory": context.memory_adapter}
+    )
 
     # Initialize WSDE team (mock)
-    context.wsde_team = WSDETeam(name="TestMicroEdrrCycleStepsTeam")
+    context.wsde_team = MagicMock()
+    context.wsde_team.generate_diverse_ideas.return_value = []
     assert context.wsde_team is not None, "WSDE team initialization failed"
 
     # Initialize code analyzer and AST transformer
@@ -93,7 +117,7 @@ def edrr_coordinator_initialized(context):
     assert context.prompt_manager is not None, "Prompt manager initialization failed"
 
     # Initialize documentation manager
-    context.documentation_manager = DocumentationManager()
+    context.documentation_manager = DocumentationManager(context.memory_manager)
     assert (
         context.documentation_manager is not None
     ), "Documentation manager initialization failed"
@@ -114,6 +138,20 @@ def edrr_coordinator_initialized(context):
 
     # Store the parent cycle for later reference
     context.parent_cycle = context.edrr_coordinator
+
+
+@given("I register micro cycle monitoring hooks")
+def register_micro_cycle_hooks(context):
+    """Register hooks that track micro cycle lifecycle."""
+
+    def start_hook(info):
+        context.start_called = True
+
+    def end_hook(info):
+        context.end_called = True
+
+    context.edrr_coordinator.register_micro_cycle_hook("start", start_hook)
+    context.edrr_coordinator.register_micro_cycle_hook("end", end_hook)
 
 
 @when(parsers.parse('I start an EDRR cycle for "{task_description}"'))
@@ -274,6 +312,13 @@ def verify_parent_includes_micro(context):
         {"cycle_id": context.micro_cycle.cycle_id}
     )
     assert len(memory_items) > 0, "Micro cycle should have memory items"
+
+
+@then("the hooks should record the micro cycle lifecycle")
+def hooks_recorded(context):
+    """Ensure start and end hooks were triggered."""
+    assert context.start_called is True
+    assert context.end_called is True
 
 
 # noqa: F401,F403


### PR DESCRIPTION
## Summary
- enforce non-root execution and tool checks in deployment scripts
- document deployment security guidelines
- add missing micro EDRR BDD hooks and lifecycle assertions

## Testing
- `poetry run pre-commit run --files deployment/bootstrap_env.sh deployment/deploy_production.sh deployment/health_check.sh deployment/README.md docs/deployment/security_guidelines.md docs/deployment/index.md tests/behavior/steps/test_micro_edrr_cycle_steps.py tests/behavior/steps/micro_edrr_cycle_steps.py`
- `poetry run pytest tests/behavior/steps/test_micro_edrr_cycle_steps.py -q --no-cov`


------
https://chatgpt.com/codex/tasks/task_e_68967306c0f483338d843fec6cec6e30