### PR TITLE
Add deployment helper scripts and rollback documentation

### DIFF
--- a/.github/workflows/deployment.yml.disabled
+++ b/.github/workflows/deployment.yml.disabled
@@ -1,0 +1,28 @@
+# This workflow is disabled by default. Rename the file to deployment.yml to enable it.
+name: Publish Docker Image
+
+on:
+  workflow_dispatch:
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build and push
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: true
+          tags: ghcr.io/${{ github.repository }}:latest

--- a/docs/deployment/index.md
+++ b/docs/deployment/index.md
@@ -23,6 +23,7 @@ This section provides documentation on deploying DevSynth in various environment
 
  - **[Deployment Guide](deployment_guide.md)**: A comprehensive guide to deploying DevSynth in production environments, now with enhanced security practices such as TLS enforcement, container hardening, and automated secret rotation.
  - **[Security Guidelines](security_guidelines.md)**: Mandatory preflight checks and safeguards for all deployment scripts.
+ - **[Rollback Procedures](rollback.md)**: Steps to revert to a previous release and validate the stack's health.
 
 ## Related Documentation
 

--- a/docs/deployment/rollback.md
+++ b/docs/deployment/rollback.md
@@ -1,0 +1,55 @@
+---
+ title: "Rollback Procedures"
+ author: "DevSynth Team"
+ date: "2025-07-10"
+ last_reviewed: "2025-07-10"
+ status: "draft"
+ version: "0.1.0-alpha.1"
+ tags:
+   - deployment
+   - rollback
+---
+<div class="breadcrumbs">
+<a href="../index.md">Documentation</a> &gt; <a href="index.md">Deployment</a> &gt; Rollback Procedures
+</div>
+
+# Rollback Procedures
+
+This guide describes how to revert the DevSynth stack to a previous release.
+
+## Steps
+
+1. Stop the current stack:
+
+   ```bash
+   scripts/deployment/stop_stack.sh
+   ```
+
+2. Pull the previous image tag:
+
+   ```bash
+   docker pull ghcr.io/OWNER/REPO:previous-tag
+   ```
+
+3. Start the stack with the earlier image:
+
+   ```bash
+   scripts/deployment/start_stack.sh
+   ```
+
+4. Verify service health:
+
+   ```bash
+   scripts/deployment/health_check.sh
+   ```
+
+## Tests
+
+After performing a rollback, validate the environment:
+
+```bash
+poetry run pytest tests/unit/deployment
+scripts/deployment/health_check.sh
+```
+
+These checks confirm that the core services and deployment scripts operate as expected.

--- a/scripts/deployment/bootstrap.sh
+++ b/scripts/deployment/bootstrap.sh
@@ -7,8 +7,13 @@ set -euo pipefail
 
 ENVIRONMENT=${1:-development}
 
-# Build images for the current compose configuration
+# Ensure Docker is available before continuing
+if ! command -v docker >/dev/null 2>&1; then
+  echo "Docker is required but could not be found in PATH." >&2
+  exit 1
+fi
 
+# Build images for the current compose configuration
 docker compose build
 
 # Start the stack for the requested environment

--- a/scripts/deployment/health_check.sh
+++ b/scripts/deployment/health_check.sh
@@ -8,7 +8,11 @@ set -euo pipefail
 API_URL=${1:-http://localhost:8000/health}
 GRAFANA_URL=${2:-http://localhost:3000/api/health}
 
-curl -fsS "$API_URL" > /dev/null
-curl -fsS "$GRAFANA_URL" > /dev/null
+for url in "$API_URL" "$GRAFANA_URL"; do
+  if ! curl -fsS "$url" > /dev/null; then
+    echo "Health check failed for $url" >&2
+    exit 1
+  fi
+done
 
 echo "All services are healthy"

--- a/tests/unit/deployment/test_scripts_dir.py
+++ b/tests/unit/deployment/test_scripts_dir.py
@@ -1,0 +1,18 @@
+import os
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[3]
+
+
+def test_scripts_bootstrap_exists():
+    """Bootstrap script in scripts/deployment should exist and be executable."""
+    script = ROOT / "scripts/deployment/bootstrap.sh"
+    assert script.is_file()
+    assert os.access(script, os.X_OK)
+
+
+def test_scripts_health_check_exists():
+    """Health check script in scripts/deployment should exist and be executable."""
+    script = ROOT / "scripts/deployment/health_check.sh"
+    assert script.is_file()
+    assert os.access(script, os.X_OK)


### PR DESCRIPTION
## Summary
- Harden deployment bootstrap script and add API health verification
- Loop over service endpoints in health check script
- Document rollback procedure and add disabled Docker publish workflow

## Testing
- `poetry run pre-commit run --files scripts/deployment/bootstrap.sh scripts/deployment/health_check.sh .github/workflows/deployment.yml.disabled docs/deployment/rollback.md docs/deployment/index.md tests/unit/deployment/test_scripts_dir.py`
- `poetry run pytest tests/unit/deployment/test_scripts_dir.py tests/unit/deployment/test_deployment_scripts.py --no-cov`

------
https://chatgpt.com/codex/tasks/task_e_6896731bbb9c8333b7715d23bbc37f35