### PR TITLE
Add sprint planning CLI and WSDE retrospective coordinator

### DIFF
--- a/src/devsynth/agents/wsde_team_coordinator.py
+++ b/src/devsynth/agents/wsde_team_coordinator.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+"""Agent coordinating WSDE team retrospective reviews."""
+
+from typing import Any, Dict, List
+
+from devsynth.application.edrr.sprint_retrospective import map_retrospective_to_summary
+from devsynth.logging_setup import DevSynthLogger
+
+logger = DevSynthLogger(__name__)
+
+
+class WSDETeamCoordinatorAgent:
+    """Coordinate WSDE team retrospective reviews."""
+
+    def __init__(self, team: Any) -> None:
+        """Initialize the coordinator with a team object."""
+        self._team = team
+
+    def run_retrospective(
+        self, notes: List[Dict[str, Any]], sprint: int
+    ) -> Dict[str, Any]:
+        """Aggregate notes and record a retrospective summary.
+
+        Args:
+            notes: List of retrospective notes from team members.
+            sprint: Current sprint number.
+
+        Returns:
+            Summary dictionary produced by
+            :func:`map_retrospective_to_summary`.
+        """
+
+        aggregated: Dict[str, Any] = {
+            "positives": [],
+            "improvements": [],
+            "action_items": [],
+        }
+        for item in notes:
+            aggregated["positives"].extend(item.get("positives", []))
+            aggregated["improvements"].extend(item.get("improvements", []))
+            aggregated["action_items"].extend(item.get("action_items", []))
+
+        summary = map_retrospective_to_summary(aggregated, sprint)
+        if hasattr(self._team, "record_retrospective"):
+            self._team.record_retrospective(summary)
+        else:  # pragma: no cover - defensive
+            logger.debug("Team object lacks 'record_retrospective' method")
+        return summary

--- a/src/devsynth/application/cli/sprint_cmd.py
+++ b/src/devsynth/application/cli/sprint_cmd.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+"""Sprint planning and retrospective CLI helpers."""
+
+import json
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+from devsynth.application.edrr.sprint_planning import map_requirements_to_plan
+from devsynth.application.edrr.sprint_retrospective import map_retrospective_to_summary
+from devsynth.logging_setup import DevSynthLogger
+
+logger = DevSynthLogger(__name__)
+
+
+def sprint_planning_cmd(requirements: str) -> Dict[str, Any]:
+    """Generate a sprint plan from requirement analysis results.
+
+    Args:
+        requirements: Path to a JSON file or a JSON string containing
+            requirement analysis results from the Expand phase.
+
+    Returns:
+        Dictionary describing the planned sprint scope.
+    """
+
+    data = _load_json(requirements)
+    if data is None:
+        return {}
+
+    plan = map_requirements_to_plan(data)
+    logger.info(
+        "Generated sprint plan with %d items", len(plan.get("planned_scope", []))
+    )
+    return plan
+
+
+def sprint_retrospective_cmd(retrospective: str, sprint: int) -> Dict[str, Any]:
+    """Summarize retrospective information for a sprint.
+
+    Args:
+        retrospective: Path to a JSON file or a JSON string containing
+            retrospective notes from the Retrospect phase.
+        sprint: Current sprint number.
+
+    Returns:
+        Summary dictionary with positives, improvements and action items.
+    """
+
+    data = _load_json(retrospective)
+    if data is None:
+        return {}
+
+    summary = map_retrospective_to_summary(data, sprint)
+    logger.info("Generated retrospective summary for sprint %d", sprint)
+    return summary
+
+
+def _load_json(source: str) -> Optional[Dict[str, Any]]:
+    """Load JSON from a file path or raw string."""
+
+    try:
+        path = Path(source)
+        if path.exists():
+            return json.loads(path.read_text())
+        return json.loads(source)
+    except Exception as exc:  # pragma: no cover - defensive
+        logger.error("Failed to load JSON: %s", exc)
+        return None

--- a/tests/integration/sprint_edrr/__init__.py
+++ b/tests/integration/sprint_edrr/__init__.py
@@ -1,0 +1,1 @@
+"""Integration tests for sprint planning and retrospectives."""

--- a/tests/integration/sprint_edrr/test_sprint_edrr_integration.py
+++ b/tests/integration/sprint_edrr/test_sprint_edrr_integration.py
@@ -1,0 +1,51 @@
+"""Integration tests for sprint planning CLI and WSDE coordinator."""
+
+import json
+
+from devsynth.agents.wsde_team_coordinator import WSDETeamCoordinatorAgent
+from devsynth.application.cli.sprint_cmd import sprint_planning_cmd
+
+
+class DummyTeam:
+    """Simple team that records retrospectives."""
+
+    def __init__(self) -> None:
+        self.recorded = None
+
+    def record_retrospective(self, summary):
+        self.recorded = summary
+
+
+def test_sprint_planning_cmd_maps_requirements(tmp_path):
+    """Sprint planning command maps requirement results to a plan."""
+    data = {
+        "recommended_scope": ["task1"],
+        "objectives": ["obj1"],
+        "success_criteria": ["crit1"],
+    }
+    path = tmp_path / "req.json"
+    path.write_text(json.dumps(data))
+
+    plan = sprint_planning_cmd(str(path))
+
+    assert plan["planned_scope"] == ["task1"]
+    assert plan["objectives"] == ["obj1"]
+    assert plan["success_criteria"] == ["crit1"]
+
+
+def test_wsde_team_coordinator_aggregates_retrospective():
+    """Coordinator aggregates notes and records summary."""
+    team = DummyTeam()
+    agent = WSDETeamCoordinatorAgent(team)
+    notes = [
+        {"positives": ["good"], "improvements": ["better"], "action_items": ["do"]},
+        {"positives": ["great"], "improvements": [], "action_items": []},
+    ]
+
+    summary = agent.run_retrospective(notes, sprint=1)
+
+    assert summary["positives"] == ["good", "great"]
+    assert summary["improvements"] == ["better"]
+    assert summary["action_items"] == ["do"]
+    assert summary["sprint"] == 1
+    assert team.recorded == summary


### PR DESCRIPTION
## Summary
- add `sprint_planning_cmd` and `sprint_retrospective_cmd` CLI helpers for sprint mapping
- create `WSDETeamCoordinatorAgent` to aggregate and record retrospective notes
- cover sprint planning and retrospective coordination with integration tests

## Testing
- `poetry run pre-commit run --files src/devsynth/application/cli/sprint_cmd.py src/devsynth/agents/wsde_team_coordinator.py tests/integration/sprint_edrr/__init__.py tests/integration/sprint_edrr/test_sprint_edrr_integration.py`
- `poetry run pytest tests/integration/sprint_edrr/ --cov-fail-under=0`
- `poetry run pytest tests` *(fails: Fatal Python error: Segmentation fault)*

------
https://chatgpt.com/codex/tasks/task_e_68968ba573dc8333a7810268bba706d9