### PR TITLE
feat: add security checks and policy docs

### DIFF
--- a/.github/workflows/security.yml.disabled
+++ b/.github/workflows/security.yml.disabled
@@ -1,0 +1,23 @@
+name: Security Checks
+
+# This workflow is disabled and runs only when manually triggered.
+
+on:
+  workflow_dispatch:
+
+jobs:
+  security:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install poetry
+          poetry install --with dev --all-extras
+      - name: Run security checks
+        run: |
+          poetry run pre-commit run --all-files bandit safety

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -45,6 +45,16 @@ repos:
       language: system
       stages: [commit-msg]
       pass_filenames: true
+    - id: bandit
+      name: bandit security check
+      entry: bandit -q -r src --exit-zero
+      language: system
+      pass_filenames: false
+    - id: safety
+      name: safety vulnerability check
+      entry: safety check --full-report
+      language: system
+      pass_filenames: false
 - repo: https://github.com/pre-commit/pre-commit-hooks
   rev: v4.4.0
   hooks:

--- a/docs/policies/security_audit.md
+++ b/docs/policies/security_audit.md
@@ -14,6 +14,17 @@ ensure code quality and supply chain safety.
 - **Bandit** – scans the `src` tree for common security issues.
 - **Safety** – checks project dependencies for known vulnerabilities.
 
+## Pre-commit Hooks
+
+`bandit` and `safety` are configured as pre-commit hooks. Run them against
+the files you are modifying:
+
+```bash
+poetry run pre-commit run bandit safety --files path/to/file1.py
+```
+
+Use `--all-files` to scan the entire repository.
+
 ## Running Locally
 
 Run the bundled script to execute both tools:

--- a/docs/policies/security_audits.md
+++ b/docs/policies/security_audits.md
@@ -1,0 +1,33 @@
+---
+title: "Security Audit Reviews"
+status: "draft"
+---
+
+# Security Audit Reviews
+
+Periodic reviews ensure DevSynth addresses security findings in a timely
+manner and maintains a secure supply chain.
+
+## Review Schedule
+
+- Audit reports are reviewed at least quarterly.
+- Additional reviews occur before major releases.
+
+## Review Process
+
+1. Run the security checks:
+   ```bash
+   poetry run pre-commit run --all-files bandit safety
+   ```
+   or
+   ```bash
+   poetry run python scripts/dependency_safety_check.py
+   ```
+2. Record findings in the issue tracker.
+3. Prioritize and remediate identified vulnerabilities.
+4. Close issues once fixes are merged and verified.
+
+## Responsibilities
+
+The security lead coordinates reviews and ensures remediation tasks are
+assigned to the appropriate maintainers.


### PR DESCRIPTION
## Summary
- add bandit and safety hooks to pre-commit
- document running hooks and periodic reviews
- add disabled workflow to run security checks in CI

## Testing
- `poetry run pre-commit run --files .pre-commit-config.yaml docs/policies/security_audit.md docs/policies/security_audits.md .github/workflows/security.yml.disabled`
- `poetry run pytest --maxfail=1` *(fails: Duplicated timeseries in CollectorRegistry)*

------
https://chatgpt.com/codex/tasks/task_e_6896991f8b8883338553c704d4c38c16