### PR TITLE
Ensure retrospective memory sync

### DIFF
--- a/src/devsynth/agents/wsde_team_coordinator.py
+++ b/src/devsynth/agents/wsde_team_coordinator.py
@@ -44,6 +44,15 @@ class WSDETeamCoordinatorAgent:
         summary = map_retrospective_to_summary(aggregated, sprint)
         if hasattr(self._team, "record_retrospective"):
             self._team.record_retrospective(summary)
+            memory_manager = getattr(self._team, "memory_manager", None)
+            if memory_manager and hasattr(memory_manager, "flush_updates"):
+                try:
+                    memory_manager.flush_updates()
+                except Exception:  # pragma: no cover - defensive
+                    logger.debug(
+                        "Memory synchronization failed during retrospective",
+                        exc_info=True,
+                    )
         else:  # pragma: no cover - defensive
             logger.debug("Team object lacks 'record_retrospective' method")
         return summary

--- a/tests/integration/general/test_wsde_edrr_integration_end_to_end.py
+++ b/tests/integration/general/test_wsde_edrr_integration_end_to_end.py
@@ -278,6 +278,23 @@ def test_peer_review_integration_in_edrr_workflow_succeeds(coordinator):
             mock_flush.assert_called()
 
 
+def test_retrospective_phase_synchronizes_memory(coordinator):
+    """Ensure retrospective phase flushes memory updates."""
+
+    with patch.object(coordinator.memory_manager, "flush_updates") as mock_flush:
+        task = {
+            "description": "Sum two numbers",
+            "language": "python",
+            "domain": "math",
+        }
+        coordinator.start_cycle(task)
+        for phase in [Phase.DIFFERENTIATE, Phase.REFINE, Phase.RETROSPECT]:
+            coordinator.progress_to_phase(phase)
+            coordinator.execute_current_phase()
+
+        mock_flush.assert_called()
+
+
 def test_memory_sync_hook_captures_events_during_team_sync():
     """Ensure memory synchronization hooks capture memory updates."""
 


### PR DESCRIPTION
## Summary
- flush WSDE team memory after recording retrospective
- add integration test verifying retrospective phase triggers sync

## Testing
- `poetry run pre-commit run --files src/devsynth/agents/wsde_team_coordinator.py tests/integration/general/test_wsde_edrr_integration_end_to_end.py`
- `poetry run pytest --override-ini "addopts=-p no:warnings -n 0" tests/integration/general/test_wsde_edrr_component_interactions.py tests/integration/general/test_wsde_edrr_integration_advanced.py tests/integration/general/test_wsde_edrr_integration_end_to_end.py` *(fails: 'WSDETeam' object has no attribute 'generate_diverse_ideas')*

------
https://chatgpt.com/codex/tasks/task_e_6896992e48f08333a6afa9496fd3a8fa