### PR TITLE
feat: scaffold integration tests and edge case prompts

### DIFF
--- a/docs/developer_guides/test_generation.md
+++ b/docs/developer_guides/test_generation.md
@@ -25,10 +25,13 @@ This guide describes how automatically generated tests should be reviewed and in
 ## Workflow
 
 1. **Generate tests** – run the test agent or related tooling to create initial tests.
-2. **Scaffold integration tests** – use the integration test scaffolder to create placeholder files when coverage is missing.
+2. **Scaffold integration tests** – use `devsynth.testing.generation.scaffold_integration_tests`
+   to create placeholder files when coverage is missing.
 3. **Manual review** – examine generated tests for correctness and completeness.
 4. **Replace placeholders** – implement real assertions and remove `assert False` markers.
-5. **Submit for review** – open a pull request and follow cross-functional review guidelines.
+5. **Lint and run tests** – execute `poetry run pre-commit run --files` on changed files
+   and `poetry run pytest` to verify behavior.
+6. **Submit for review** – open a pull request and follow cross-functional review guidelines.
 
 ## Review Checklist
 
@@ -42,4 +45,4 @@ Before merging generated tests, ensure reviewers verify the following:
 
 ## Edge Case Templates
 
-Edge case prompt templates live in `src/devsynth/application/prompts/templates/test_generation/`. Use these templates to guide the agent when generating tests for boundary values and error conditions.
+Edge case prompt templates live in `templates/test_generation/`. Use these templates to guide the agent when generating tests for boundary values and error conditions.

--- a/src/devsynth/testing/generation.py
+++ b/src/devsynth/testing/generation.py
@@ -1,0 +1,35 @@
+"""Integration test scaffolding utilities.
+
+This module provides helpers for creating placeholder integration test
+modules. The generated tests include failing assertions so missing
+coverage is obvious during review.
+"""
+
+from __future__ import annotations
+
+from typing import Dict, Iterable
+
+PLACEHOLDER_TEMPLATE = (
+    '"""Placeholder integration test for {name}."""\n\n'
+    "def test_{name}():\n"
+    '    """TODO: implement integration test for {name}."""\n'
+    '    assert False, "Integration test not yet implemented"\n'
+)
+
+
+def scaffold_integration_tests(names: Iterable[str]) -> Dict[str, str]:
+    """Create placeholder integration test modules.
+
+    Args:
+        names: Iterable of base names for the tests.
+
+    Returns:
+        Mapping of filenames to placeholder test content.
+    """
+    placeholders: Dict[str, str] = {}
+    sanitized = list(names) or ["placeholder"]
+    for raw in sanitized:
+        name = raw.strip().lower().replace(" ", "_")
+        filename = f"test_{name}.py"
+        placeholders[filename] = PLACEHOLDER_TEMPLATE.format(name=name)
+    return placeholders

--- a/templates/test_generation/edge_case_prompt.txt
+++ b/templates/test_generation/edge_case_prompt.txt
@@ -1,0 +1,1 @@
+List edge case scenarios for the provided module. Focus on boundary conditions, error paths, concurrency issues, and unusual inputs. Use this list to augment integration tests and validate robustness.

--- a/templates/test_generation/integration_prompt.txt
+++ b/templates/test_generation/integration_prompt.txt
@@ -1,0 +1,1 @@
+You are an expert software tester. Given a module description, write pytest integration tests that exercise realistic workflows. Cover typical interactions and edge cases such as invalid inputs, empty responses, or boundary values. Ensure each test contains meaningful assertions and avoids placeholders like `assert True`.


### PR DESCRIPTION
## Summary
- add `scaffold_integration_tests` utility for placeholder integration test modules
- add prompt templates for integration tests and edge case scenarios
- expand test generation review workflow with linting and template guidance

## Testing
- `poetry run pre-commit run --files src/devsynth/testing/generation.py templates/test_generation/integration_prompt.txt templates/test_generation/edge_case_prompt.txt docs/developer_guides/test_generation.md`
- `poetry run pytest` *(fails: segmentation fault and numerous failing tests)*

------
https://chatgpt.com/codex/tasks/task_e_6896992322788333a4fb40334bb96f16