### PR TITLE
feat: support feature flags in test runner CLI

### DIFF
--- a/tests/unit/application/cli/test_run_tests_cmd.py
+++ b/tests/unit/application/cli/test_run_tests_cmd.py
@@ -1,0 +1,28 @@
+"""Tests for run-tests CLI feature flag handling."""
+
+from unittest.mock import patch
+
+from typer.testing import CliRunner
+
+from devsynth.adapters.cli.typer_adapter import build_app
+from devsynth.application.cli.commands import run_tests_cmd as module
+
+
+def test_parse_feature_options() -> None:
+    """`_parse_feature_options` converts option values to booleans."""
+
+    result = module._parse_feature_options(["a", "b=false", "c=1"])
+    assert result == {"a": True, "b": False, "c": True}
+
+
+def test_cli_accepts_feature_flags() -> None:
+    """CLI invocation with ``--feature`` delegates to `run_tests`."""
+
+    runner = CliRunner()
+    with patch.object(module, "run_tests", return_value=(True, "")) as mock_run:
+        app = build_app()
+        result = runner.invoke(
+            app, ["run-tests", "--feature", "foo=true", "--feature", "bar=false"]
+        )
+        assert result.exit_code == 0
+        mock_run.assert_called_once()


### PR DESCRIPTION
## Summary
- add `--feature` options to `run-tests` command and log parsed flags
- convert legacy `--features` JSON to new `--feature` flags in `run_all_tests.py`
- test feature flag parsing and CLI invocation

## Testing
- `poetry run pre-commit run --files src/devsynth/application/cli/commands/run_tests_cmd.py scripts/run_all_tests.py tests/unit/application/cli/test_run_tests_cmd.py`
- `poetry run pytest tests/unit/application/cli/test_run_tests_cmd.py tests/unit/application/cli/commands/test_run_tests_cmd.py --cov-fail-under=0`


------
https://chatgpt.com/codex/tasks/task_e_68969f1280488333bc0e83ba37d78557