### PR TITLE
test: add optional dependency fixtures

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -79,4 +79,5 @@ pytest_plugins = [
     "tests.fixtures.kuzu",
     "tests.fixtures.state_access_fixture",
     "tests.fixtures.webui_wizard_state_fixture",
+    "tests.fixtures.optional_deps",
 ]

--- a/tests/fixtures/optional_deps.py
+++ b/tests/fixtures/optional_deps.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+import sys
+from types import ModuleType
+from typing import Mapping
+
+import pytest
+
+
+def _create_stub(name: str, attrs: Mapping[str, object] | None = None) -> ModuleType:
+    """Create a simple module stub with optional attributes."""
+    mod = ModuleType(name)
+    if attrs:
+        for key, value in attrs.items():
+            setattr(mod, key, value)
+    return mod
+
+
+@pytest.fixture
+def stub_optional_deps(monkeypatch):
+    """Provide lightweight stubs for optional heavy dependencies.
+
+    Stubs are only applied when the modules are missing, preventing expensive
+    imports during test collection while allowing tests to run against a
+    predictable interface.
+    """
+
+    modules = {
+        "langgraph": {},
+        "langgraph.checkpoint": {},
+        "langgraph.checkpoint.base": {
+            "BaseCheckpointSaver": object,
+            "empty_checkpoint": object(),
+        },
+        "langgraph.graph": {"END": None, "StateGraph": object},
+        "tiktoken": {"encoding_for_model": lambda *a, **k: None},
+        "duckdb": {},
+        "lmdb": {},
+        "faiss": {},
+        "httpx": {},
+    }
+
+    for name, attrs in modules.items():
+        if name not in sys.modules:
+            monkeypatch.setitem(sys.modules, name, _create_stub(name, attrs))
+
+
+@pytest.fixture
+def require_modules():
+    """Skip the test if any of the specified modules are missing."""
+
+    def _require(*module_names: str) -> None:
+        missing = [m for m in module_names if m not in sys.modules]
+        if missing:
+            pytest.skip("Missing required modules: " + ", ".join(missing))
+
+    return _require

--- a/tests/integration/general/test_requirements_gathering.py
+++ b/tests/integration/general/test_requirements_gathering.py
@@ -1,36 +1,11 @@
+import json
 import os
-import sys
-from types import ModuleType
 
+import pytest
 import yaml
 
 # Ensures gather_requirements persists priority, goals, and constraints
-
-# Stub optional heavy dependencies for test isolation
-for _name in [
-    "langgraph",
-    "langgraph.checkpoint",
-    "langgraph.checkpoint.base",
-    "langgraph.graph",
-    "tiktoken",
-    "duckdb",
-    "lmdb",
-    "faiss",
-    "httpx",
-]:
-    if _name not in sys.modules:
-        _mod = ModuleType(_name)
-        if _name == "langgraph.checkpoint.base":
-            _mod.BaseCheckpointSaver = object
-            _mod.empty_checkpoint = object()
-        if _name == "langgraph.graph":
-            _mod.END = None
-            _mod.StateGraph = object
-        if _name == "tiktoken":
-            _mod.encoding_for_model = lambda *a, **k: None
-        sys.modules[_name] = _mod
-
-import json
+pytestmark = pytest.mark.usefixtures("stub_optional_deps")
 
 from devsynth.application.cli.requirements_wizard import requirements_wizard
 from devsynth.application.requirements.interactions import gather_requirements


### PR DESCRIPTION
## Summary
- add reusable fixtures to stub or skip optional dependencies
- refactor requirements gathering tests to use new fixtures
- register optional dependency fixtures for tests

## Testing
- `poetry run pre-commit run --files tests/fixtures/optional_deps.py tests/__init__.py tests/integration/general/test_requirements_gathering.py`
- `poetry run pytest tests/integration/general/test_requirements_gathering.py -q --no-cov`


------
https://chatgpt.com/codex/tasks/task_e_6896aff7d04c8333a8284ca7af25e39c