### PR TITLE
feat: defer package imports

### DIFF
--- a/src/devsynth/__init__.py
+++ b/src/devsynth/__init__.py
@@ -1,26 +1,60 @@
+"""DevSynth package metadata and lightweight helpers.
+
+The package previously imported logging helpers and application subpackages
+eagerly.  This made ``import devsynth`` expensive and caused unwanted side
+effects during test runs.  The module now exposes lightweight wrappers that
+lazy‑load logging utilities on demand and provides an explicit initialization
+helper for tests or applications that require certain subpackages to be loaded
+ahead of time.
+"""
+
+from __future__ import annotations
+
 # Version and metadata
 __version__ = "0.1.0-alpha.1"
 
-# Import the DevSynthLogger class first
-from devsynth.logger import DevSynthLogger, set_request_context, clear_request_context
+# Names that are re-exported lazily from :mod:`devsynth.logger`
+_EXPORTED = {
+    "DevSynthLogger",
+    "set_request_context",
+    "clear_request_context",
+    "get_logger",
+    "setup_logging",
+}
 
-# Now make it available for all modules
-__all__ = ["DevSynthLogger", "set_request_context", "clear_request_context"]
+__all__ = sorted(_EXPORTED | {"initialize_subpackages", "__version__"})
 
-# Initialize logger for this module
-logger = DevSynthLogger(__name__)
 
-# Ensure subpackages can be imported even if tests manipulate ``sys.modules``.
-import importlib
-import sys
+def __getattr__(name: str):
+    """Dynamically import attributes from :mod:`devsynth.logger`.
 
-if "devsynth.application" not in sys.modules:
-    try:  # pragma: no cover - safe fallback
-        importlib.import_module("devsynth.application")
-    except Exception:  # pragma: no cover - ignore if unavailable
-        pass
-if "devsynth.application.memory" not in sys.modules:
-    try:  # pragma: no cover - optional subpackage
-        importlib.import_module("devsynth.application.memory")
-    except Exception:  # pragma: no cover - ignore
-        pass
+    This keeps the package import light-weight while preserving the public API
+    that previously lived at the package root.
+    """
+
+    if name in _EXPORTED:
+        from . import logger as _logger  # Local import for lazy loading
+
+        value = getattr(_logger, name)
+        globals()[name] = value  # Cache for future lookups
+        return value
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+
+def initialize_subpackages() -> None:
+    """Explicitly import optional subpackages.
+
+    Historically these imports happened eagerly at package import time.  Tests
+    that rely on these side effects should call this helper instead.
+    """
+
+    import importlib
+    import sys
+
+    for module in ("devsynth.application", "devsynth.application.memory"):
+        if module in sys.modules:
+            continue
+        try:  # pragma: no cover - best effort
+            importlib.import_module(module)
+        except Exception:  # pragma: no cover - ignore if unavailable
+            pass

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -27,6 +27,11 @@ def _ensure_dev_synth_importable() -> None:
     try:  # pragma: no cover - quick check
         import devsynth  # noqa: F401
 
+        # Load optional subpackages explicitly to mirror historic behaviour
+        try:  # pragma: no cover - best effort
+            devsynth.initialize_subpackages()
+        except AttributeError:
+            pass
         return
     except Exception:
         pass


### PR DESCRIPTION
## Summary
- lazily expose logging helpers and provide explicit subpackage initializer
- ensure tests explicitly load optional subpackages

## Testing
- `SKIP=devsynth-align,fix-code-blocks poetry run pre-commit run --files src/devsynth/__init__.py tests/__init__.py`
- `poetry run python tests/verify_test_organization.py`
- `poetry run pytest`


------
https://chatgpt.com/codex/tasks/task_e_6896b9f8d1a8833398780fec24bc0bb0