### PR TITLE
chore: verify prometheus client in Codex setup

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,11 +44,11 @@ confirm that dependencies are consistent and that test extras are present:
 
 ```bash
 poetry run pip check
-poetry run pip list | grep pytest-bdd
+poetry run pip list | grep prometheus-client
 ```
 
-These commands surface version conflicts and verify that the `pytest-bdd` plugin
-needed for behavior-driven tests is installed.
+These commands surface version conflicts and verify that the `prometheus-client`
+library required for metrics is installed.
 
 ## Troubleshooting Test Collection Failures
 
@@ -58,7 +58,7 @@ plugin import errors), rerun the setup script to reinstall dependencies:
 ```bash
 bash scripts/codex_setup.sh
 poetry run pip check
-poetry run pip list | grep pytest-bdd
+poetry run pip list | grep prometheus-client
 poetry run pytest --maxfail=1
 ```
 
@@ -101,8 +101,8 @@ if [ -f CODEX_ENVIRONMENT_SETUP_FAILED ]; then bash scripts/codex_setup.sh; fi
 Fix the script and rerun it offline to finish provisioning:
 
 1. Review and update `scripts/codex_setup.sh` so it installs all project
-   dependencies with `poetry install --with dev,docs --all-extras` (or the
-   `--minimal` variant) and verifies key packages such as `pytest-bdd` are
+   dependencies with `poetry install --with dev --extras tests` (or the
+   `--minimal` variant) and verifies key packages such as `prometheus-client` are
    available.
 2. Run `bash scripts/codex_setup.sh` (without network access) until it completes
    without errors. After it finishes, verify the environment, dependencies,
@@ -131,7 +131,7 @@ for pkg in (
 ):
     importlib.import_module(pkg)
 EOF
-  poetry run pip list | grep pytest-bdd
+  poetry run pip list | grep prometheus-client
   ```
 3. Remove the failure marker with `rm CODEX_ENVIRONMENT_SETUP_FAILED`.
 4. Execute `poetry run pytest --maxfail=1` to verify the environment quickly.

--- a/scripts/codex_setup.sh
+++ b/scripts/codex_setup.sh
@@ -24,17 +24,19 @@ poetry env use "$(command -v python3.12 || command -v python3.11)"
 # Verify that the virtual environment was created
 poetry env info --path >/dev/null
 
-# Install all extras required for the test suite. Large GPU packages provided by
-# the `offline` extra are intentionally excluded to keep setup fast. Add the
+# Install development dependencies and test extras. Large GPU packages provided
+# by the `offline` extra are intentionally excluded to keep setup fast. Add the
 # `offline` extra manually if GPU features are needed.
 poetry install \
-  --with dev,docs \
-  --all-extras \
+  --with dev \
+  --extras tests \
   --no-interaction
 
-# Ensure pytest-bdd is available after installation
-poetry run python -c "import pytest_bdd"
-poetry run pip list | grep pytest-bdd >/dev/null
+# Ensure prometheus-client is available after installation
+poetry run python -c "import prometheus_client"
+# Handle normalized package names with underscores
+poetry run pip list | grep prometheus-client >/dev/null || \
+  poetry run pip list | grep prometheus_client >/dev/null
 
 # Install the DevSynth CLI with pipx and verify it works. On subsequent
 # runs, skip the installation step to avoid network access.


### PR DESCRIPTION
## Summary
- ensure Codex setup installs dev deps and test extras only
- verify prometheus-client installation in setup and docs

## Testing
- `poetry run pip check`
- `poetry run pip list | grep prometheus-client` *(no output)*
- `poetry run pip list | grep prometheus_client`
- `poetry run pytest --maxfail=1` *(fails: Duplicated timeseries in CollectorRegistry)*

------
https://chatgpt.com/codex/tasks/task_e_6896b9db954c83339271b806b314c5bb