### PR TITLE
feat(cli): inject configuration for non-interactive mode

### DIFF
--- a/src/devsynth/application/cli/config.py
+++ b/src/devsynth/application/cli/config.py
@@ -1,0 +1,34 @@
+"""Shared configuration objects for CLI commands."""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+
+
+@dataclass
+class CLIConfig:
+    """Configuration options for CLI interactions.
+
+    Attributes
+    ----------
+    non_interactive:
+        When ``True`` commands should avoid interactive prompts and rely on
+        provided defaults instead.
+    """
+
+    non_interactive: bool = False
+
+    @classmethod
+    def from_env(cls) -> "CLIConfig":
+        """Create a configuration populated from environment variables."""
+
+        val = os.environ.get("DEVSYNTH_NONINTERACTIVE", "0").lower() in {
+            "1",
+            "true",
+            "yes",
+        }
+        return cls(non_interactive=val)
+
+
+__all__ = ["CLIConfig"]

--- a/tests/behavior/steps/test_interactive_requirements_steps.py
+++ b/tests/behavior/steps/test_interactive_requirements_steps.py
@@ -1,11 +1,10 @@
-import os
 import json
+import os
 import sys
 from unittest.mock import MagicMock
 
 import pytest
-from pytest_bdd import scenarios, given, when, then
-
+from pytest_bdd import given, scenarios, then, when
 
 scenarios("../features/general/interactive_requirements.feature")
 
@@ -21,6 +20,7 @@ def cli_installed():
 def run_wizard(tmp_project_dir, monkeypatch):
     monkeypatch.setitem(sys.modules, "chromadb", MagicMock())
     monkeypatch.setitem(sys.modules, "uvicorn", MagicMock())
+    from devsynth.application.cli.config import CLIConfig
     from devsynth.application.cli.requirements_commands import wizard_cmd
 
     output = os.path.join(tmp_project_dir, "requirements_wizard.json")
@@ -29,8 +29,7 @@ def run_wizard(tmp_project_dir, monkeypatch):
     monkeypatch.setenv("DEVSYNTH_REQ_TYPE", "functional")
     monkeypatch.setenv("DEVSYNTH_REQ_PRIORITY", "medium")
     monkeypatch.setenv("DEVSYNTH_REQ_CONSTRAINTS", "")
-    monkeypatch.setenv("DEVSYNTH_NONINTERACTIVE", "1")
-    wizard_cmd(output_file=output)
+    wizard_cmd(output_file=output, config=CLIConfig(non_interactive=True))
 
 
 @pytest.mark.medium

--- a/tests/integration/general/test_requirements_gathering.py
+++ b/tests/integration/general/test_requirements_gathering.py
@@ -7,6 +7,7 @@ import yaml
 # Ensures gather_requirements persists priority, goals, and constraints
 pytestmark = pytest.mark.usefixtures("stub_optional_deps")
 
+from devsynth.application.cli.config import CLIConfig
 from devsynth.application.cli.requirements_wizard import requirements_wizard
 from devsynth.application.requirements.interactions import gather_requirements
 
@@ -85,7 +86,7 @@ def test_requirements_wizard_persists_priority_succeeds(tmp_path, monkeypatch):
 
     bridge = Bridge()
     output = tmp_path / "requirements_wizard.json"
-    requirements_wizard(bridge, output_file=str(output))
+    requirements_wizard(bridge, output_file=str(output), config=CLIConfig())
     data = json.load(open(output, encoding="utf-8"))
     assert data["priority"] == "high"
     assert data["title"] == "My Title"


### PR DESCRIPTION
## Summary
- add `CLIConfig` for injectable CLI settings
- wire requirements wizard and commands to use config instead of global flag
- update tests to pass configuration explicitly

## Testing
- `poetry run pip check`
- `poetry run pip list | grep prometheus-client` *(no output)*
- `poetry run python tests/verify_test_organization.py` *(fails: missing __init__.py files and naming issues)*
- `poetry run pre-commit run --files src/devsynth/application/cli/config.py src/devsynth/application/cli/requirements_wizard.py src/devsynth/application/cli/requirements_commands.py tests/unit/application/cli/test_requirements_commands.py tests/integration/general/test_requirements_gathering.py tests/behavior/steps/test_interactive_requirements_steps.py` *(fails: ImportError in devsynth align hook)*
- `poetry run pytest tests/unit/application/cli/test_requirements_commands.py tests/integration/general/test_requirements_gathering.py tests/behavior/steps/test_interactive_requirements_steps.py` *(fails: Coverage failure: total of 15 is less than fail-under=25)*

------
https://chatgpt.com/codex/tasks/task_e_6896cfcb6e74833390567e35e199076f