### PR TITLE
Integrate dialectical reasoning loop into EDRR coordinator

### DIFF
--- a/src/devsynth/methodology/dialectical_reasoning.py
+++ b/src/devsynth/methodology/dialectical_reasoning.py
@@ -8,9 +8,10 @@ from devsynth.domain.models.wsde_dialectical import (
     apply_dialectical_reasoning as _apply_dialectical_reasoning,
 )
 from devsynth.exceptions import ConsensusError
-from devsynth.logger import get_logger, log_consensus_failure
+from devsynth.logger import log_consensus_failure
+from devsynth.logging_setup import DevSynthLogger
 
-logger = get_logger(__name__)
+logger = DevSynthLogger(__name__)
 
 
 def reasoning_loop(

--- a/tests/unit/application/edrr/test_coordinator_reasoning.py
+++ b/tests/unit/application/edrr/test_coordinator_reasoning.py
@@ -1,0 +1,54 @@
+import logging
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from devsynth.application.code_analysis.analyzer import CodeAnalyzer
+from devsynth.application.code_analysis.ast_transformer import AstTransformer
+from devsynth.application.documentation.documentation_manager import (
+    DocumentationManager,
+)
+from devsynth.application.edrr.coordinator import EDRRCoordinator
+from devsynth.application.memory.memory_manager import MemoryManager
+from devsynth.application.requirements.prompt_manager import PromptManager
+
+
+@pytest.fixture
+def coordinator():
+    mm = MagicMock(spec=MemoryManager)
+    wsde_team = MagicMock()
+    coord = EDRRCoordinator(
+        memory_manager=mm,
+        wsde_team=wsde_team,
+        code_analyzer=MagicMock(spec=CodeAnalyzer),
+        ast_transformer=MagicMock(spec=AstTransformer),
+        prompt_manager=MagicMock(spec=PromptManager),
+        documentation_manager=MagicMock(spec=DocumentationManager),
+    )
+    coord.cycle_id = "cid"
+    return coord
+
+
+def test_apply_dialectical_reasoning_success(coordinator):
+    final = {"status": "completed", "synthesis": "done"}
+    with patch(
+        "devsynth.application.edrr.coordinator.reasoning_loop",
+        return_value=[{"synthesis": "next"}, final],
+    ) as rl:
+        result = coordinator.apply_dialectical_reasoning(
+            {"solution": "initial"}, MagicMock()
+        )
+    rl.assert_called_once()
+    coordinator.memory_manager.flush_updates.assert_called_once()
+    assert result == final
+
+
+def test_apply_dialectical_reasoning_consensus_failure(coordinator, caplog):
+    with patch("devsynth.application.edrr.coordinator.reasoning_loop", return_value=[]):
+        with caplog.at_level(logging.WARNING):
+            result = coordinator.apply_dialectical_reasoning(
+                {"solution": "initial"}, MagicMock()
+            )
+    assert result == {}
+    assert coordinator.performance_metrics["consensus_failures"]
+    assert "Consensus failure" in caplog.text


### PR DESCRIPTION
## Summary
- call dialectical reasoning loop from `EDRRCoordinator` and track consensus failures
- log reasoning iterations using `DevSynthLogger`
- test coordinator reasoning workflow and failure handling

## Testing
- `poetry run pre-commit run --files src/devsynth/application/edrr/coordinator.py src/devsynth/methodology/dialectical_reasoning.py tests/unit/application/edrr/test_coordinator_reasoning.py` *(failed: ImportError: cannot import name 'CodeAnalyzer' from partially initialized module)*
- `poetry run python tests/verify_test_organization.py` *(failed: missing __init__ files and test class constructors)*
- `poetry run pytest --no-cov tests/unit/application/edrr/test_coordinator_reasoning.py`
- `poetry run pip check`
- `poetry run pip list | grep prometheus-client`

------
https://chatgpt.com/codex/tasks/task_e_6896d54eb94c833384f4ed74ce7f6a4c