### PR TITLE
Streamline init command and progress feedback

### DIFF
--- a/docs/architecture/uxbridge_architecture.md
+++ b/docs/architecture/uxbridge_architecture.md
@@ -145,11 +145,11 @@ from devsynth.interface.ux_bridge import UXBridge, ProgressIndicator, sanitize_o
 
 class MinimalUXBridge(UXBridge):
     """A minimal UXBridge implementation."""
-    
+
     def display_result(self, message: str, *, highlight: bool = False) -> None:
         """Display a message to the user."""
         print(sanitize_output(message))
-    
+
     def ask_question(
         self,
         message: str,
@@ -165,7 +165,7 @@ class MinimalUXBridge(UXBridge):
         if default and show_default:
             print(f"Default: {default}")
         return input("> ") or default or ""
-    
+
     def confirm_choice(self, message: str, *, default: bool = False) -> bool:
         """Ask for confirmation and return a boolean."""
         print(sanitize_output(message))
@@ -174,10 +174,10 @@ class MinimalUXBridge(UXBridge):
         if not response:
             return default
         return response.startswith("y")
-    
+
     class _MinimalProgress(ProgressIndicator):
         """A minimal progress indicator."""
-        
+
         def __init__(self, description: str, total: int) -> None:
             """Initialize with a description and total steps."""
             self.description = description
@@ -185,19 +185,28 @@ class MinimalUXBridge(UXBridge):
             self.current = 0
             self.subtasks = {}
             print(f"Starting: {description} (0/{total})")
-        
-        def update(self, *, advance: float = 1, description: Optional[str] = None) -> None:
+
+        def update(
+            self,
+            *,
+            advance: float = 1,
+            description: Optional[str] = None,
+            status: Optional[str] = None,
+        ) -> None:
             """Update progress by the specified amount."""
             self.current += advance
             if description:
                 self.description = description
-            print(f"Progress: {self.description} ({self.current}/{self.total})")
-        
+            status_msg = status or ""
+            print(
+                f"Progress: {self.description} ({self.current}/{self.total}) {status_msg}"
+            )
+
         def complete(self) -> None:
             """Mark the progress as complete."""
             self.current = self.total
             print(f"Completed: {self.description}")
-        
+
         def add_subtask(self, description: str, total: int = 100) -> str:
             """Add a subtask with its own progress tracking."""
             task_id = f"subtask_{len(self.subtasks)}"
@@ -208,30 +217,30 @@ class MinimalUXBridge(UXBridge):
             }
             print(f"Subtask started: {description} (0/{total})")
             return task_id
-        
+
         def update_subtask(
             self, task_id: str, advance: float = 1, description: Optional[str] = None
         ) -> None:
             """Update a subtask's progress."""
             if task_id not in self.subtasks:
                 raise ValueError(f"Unknown subtask ID: {task_id}")
-            
+
             subtask = self.subtasks[task_id]
             subtask["current"] += advance
             if description:
                 subtask["description"] = description
-            
+
             print(f"Subtask progress: {subtask['description']} ({subtask['current']}/{subtask['total']})")
-        
+
         def complete_subtask(self, task_id: str) -> None:
             """Mark a subtask as complete."""
             if task_id not in self.subtasks:
                 raise ValueError(f"Unknown subtask ID: {task_id}")
-            
+
             subtask = self.subtasks[task_id]
             subtask["current"] = subtask["total"]
             print(f"Subtask completed: {subtask['description']}")
-    
+
     def create_progress(
         self, description: str, *, total: int = 100
     ) -> ProgressIndicator:

--- a/docs/user_guides/cli_reference.md
+++ b/docs/user_guides/cli_reference.md
@@ -58,6 +58,7 @@ This document provides a comprehensive reference for the DevSynth Command Line I
   - [ingest](#ingest)
   - [apispec](#apispec)
   - [serve](#serve)
+  - [completion](#completion)
   - [mvu](#mvu)
 - [Environment Variables](#environment-variables)
 - [Configuration File](#configuration-file)
@@ -124,8 +125,9 @@ test-metrics
 generate-docs
 ingest
 apispec
-mvu
 serve
+completion
+mvu
 ```
 
 ### help
@@ -183,7 +185,7 @@ devsynth init [--path PATH] [--template TEMPLATE] [--project-root ROOT] [--langu
 - `--wizard`: Launch the guided setup wizard even outside a detected project
 
 
-This command detects existing projects and launches an interactive wizard when run inside a directory containing `pyproject.toml` or `project.yaml`. Use the `--wizard` flag to start the wizard explicitly in any directory.
+This command detects existing projects and launches an interactive wizard when run inside a directory containing `pyproject.toml` or `project.yaml`. Use the `--wizard` flag to start the wizard explicitly in any directory. The command uses provided options and `DEVSYNTH_INIT_*` environment variables directly, prompting only for missing values. Supplying `--defaults` or `--non-interactive` skips prompts entirely.
 The wizard reads configuration using the [Unified Config Loader](../implementation/config_loader_workflow.md),
 which prefers the `[tool.devsynth]` table in `pyproject.toml` when both files are present.
 During the wizard you will:
@@ -618,8 +620,33 @@ test-metrics
 generate-docs
 ingest
 apispec
-mvu
 serve
+completion
+mvu
+```
+
+### completion
+
+Generate or install shell completion scripts for the DevSynth CLI.
+
+```bash
+devsynth completion [--shell bash|zsh|fish] [--install] [--output PATH]
+```
+
+**Options:**
+
+- `--shell`: Target shell. Defaults to the current shell.
+- `--install`: Install the completion script into the user's shell configuration.
+- `--output`: Write the generated script to a file instead of printing.
+
+**Examples:**
+
+```bash
+# Show the completion script for your current shell
+devsynth completion
+
+# Install zsh completions
+devsynth completion --shell zsh --install
 ```
 
 ### mvu

--- a/src/devsynth/application/cli/progress.py
+++ b/src/devsynth/application/cli/progress.py
@@ -6,23 +6,24 @@ provided by the UXBridge abstraction with more detailed and visually appealing
 progress indicators.
 """
 
-from typing import Optional, Dict, Any, List, Callable
-from rich.console import Console
-from rich.progress import (
-    Progress,
-    TextColumn,
-    BarColumn,
-    TaskProgressColumn,
-    TimeRemainingColumn,
-    SpinnerColumn,
-)
-from rich.panel import Panel
-from rich.table import Table
-from rich.markdown import Markdown
+from typing import Any, Callable, Dict, List, Optional
 
-from devsynth.interface.ux_bridge import ProgressIndicator, UXBridge
+from rich.console import Console
+from rich.markdown import Markdown
+from rich.panel import Panel
+from rich.progress import (
+    BarColumn,
+    Progress,
+    SpinnerColumn,
+    TaskProgressColumn,
+    TextColumn,
+    TimeRemainingColumn,
+)
+from rich.table import Table
+
 from devsynth.interface.cli import CLIProgressIndicator
 from devsynth.interface.progress_utils import run_with_progress
+from devsynth.interface.ux_bridge import ProgressIndicator, UXBridge
 
 
 class EnhancedProgressIndicator(CLIProgressIndicator):
@@ -85,7 +86,9 @@ class EnhancedProgressIndicator(CLIProgressIndicator):
         self._subtasks[desc] = task_id
         return desc
 
-    def update_subtask(self, subtask_id: str, advance: float = 1, description: Optional[str] = None) -> None:
+    def update_subtask(
+        self, subtask_id: str, advance: float = 1, description: Optional[str] = None
+    ) -> None:
         """Update a subtask's progress.
 
         Args:
@@ -107,7 +110,9 @@ class EnhancedProgressIndicator(CLIProgressIndicator):
                     desc = "<description>"
 
                 formatted_desc = f"  ↳ {desc}"
-                self._progress.update(task_id, advance=advance, description=formatted_desc)
+                self._progress.update(
+                    task_id, advance=advance, description=formatted_desc
+                )
 
                 # Update the subtask ID in the dictionary if the description has changed
                 if desc != subtask_id:
@@ -126,25 +131,34 @@ class EnhancedProgressIndicator(CLIProgressIndicator):
             task_id = self._subtasks[subtask_id]
             self._progress.update(task_id, completed=True)
 
-    def update(self, *, advance: float = 1, description: Optional[str] = None) -> None:
+    def update(
+        self,
+        *,
+        advance: float = 1,
+        description: Optional[str] = None,
+        status: Optional[str] = None,
+    ) -> None:
         """Update the progress indicator.
 
         Args:
             advance: The amount to advance the progress
             description: The new description of the task
+            status: Status message to display
         """
-        # If a new description is provided, sanitize it
+        update_kwargs: Dict[str, Any] = {"advance": advance}
+
         if description is not None:
             try:
                 desc_str = str(description)
                 desc = desc_str
             except Exception:
-                # Fallback for objects that can't be safely converted to string
                 desc = "<description>"
+            update_kwargs["description"] = desc
 
-            self._progress.update(self._task, advance=advance, description=desc)
-        else:
-            self._progress.update(self._task, advance=advance)
+        if status is not None:
+            update_kwargs["status"] = status
+
+        self._progress.update(self._task, **update_kwargs)
 
     def complete(self) -> None:
         """Mark the task as complete."""
@@ -173,7 +187,9 @@ class ProgressManager:
         self.bridge = bridge
         self.indicators: Dict[str, ProgressIndicator] = {}
 
-    def create_progress(self, task_id: str, description: str, total: int = 100) -> ProgressIndicator:
+    def create_progress(
+        self, task_id: str, description: str, total: int = 100
+    ) -> ProgressIndicator:
         """Create a progress indicator for a task.
 
         Args:
@@ -199,7 +215,9 @@ class ProgressManager:
         """
         return self.indicators.get(task_id)
 
-    def update_progress(self, task_id: str, advance: float = 1, description: Optional[str] = None) -> None:
+    def update_progress(
+        self, task_id: str, advance: float = 1, description: Optional[str] = None
+    ) -> None:
         """Update the progress indicator for a task.
 
         Args:
@@ -223,7 +241,9 @@ class ProgressManager:
             del self.indicators[task_id]
 
 
-def create_enhanced_progress(console: Console, description: str, total: int = 100) -> EnhancedProgressIndicator:
+def create_enhanced_progress(
+    console: Console, description: str, total: int = 100
+) -> EnhancedProgressIndicator:
     """Create an enhanced progress indicator.
 
     Args:
@@ -254,13 +274,15 @@ def create_task_table(tasks: List[Dict[str, Any]], title: str = "Tasks") -> Tabl
 
     for task in tasks:
         status = task.get("status", "Pending")
-        status_style = "green" if status == "Complete" else "yellow" if status == "In Progress" else "red"
+        status_style = (
+            "green"
+            if status == "Complete"
+            else "yellow" if status == "In Progress" else "red"
+        )
         table.add_row(
             task.get("name", ""),
             f"[{status_style}]{status}[/{status_style}]",
-            task.get("description", "")
+            task.get("description", ""),
         )
 
     return table
-
-

--- a/src/devsynth/interface/ux_bridge.py
+++ b/src/devsynth/interface/ux_bridge.py
@@ -40,8 +40,20 @@ class ProgressIndicator(ABC):
         self.complete()
 
     @abstractmethod
-    def update(self, *, advance: float = 1, description: Optional[str] = None) -> None:
-        """Advance the progress indicator."""
+    def update(
+        self,
+        *,
+        advance: float = 1,
+        description: Optional[str] = None,
+        status: Optional[str] = None,
+    ) -> None:
+        """Advance the progress indicator.
+
+        Args:
+            advance: Amount to advance the progress.
+            description: Optional new description for the task.
+            status: Optional short status message.
+        """
 
     @abstractmethod
     def complete(self) -> None:
@@ -112,7 +124,11 @@ class UXBridge(ABC):
 
         class _DummyProgress(ProgressIndicator):
             def update(
-                self, *, advance: float = 1, description: Optional[str] = None
+                self,
+                *,
+                advance: float = 1,
+                description: Optional[str] = None,
+                status: Optional[str] = None,
             ) -> None:  # pragma: no cover - simple no-op
                 pass
 


### PR DESCRIPTION
## Summary
- Refactor `init` command to rely on provided options, validate configuration, and surface clearer errors
- Extend progress indicators with status messages across bridges for richer feedback
- Document shell completion scripts and usage in CLI reference

## Testing
- `SKIP=fix-code-blocks poetry run pre-commit run --files docs/architecture/uxbridge_architecture.md docs/user_guides/cli_reference.md`
- `SKIP=fix-code-blocks poetry run pre-commit run --files src/devsynth/application/cli/commands/init_cmd.py src/devsynth/application/cli/progress.py src/devsynth/interface/agentapi_enhanced.py src/devsynth/interface/dpg_bridge.py src/devsynth/interface/ux_bridge.py src/devsynth/interface/webui.py`
- `poetry run pip check`
- `poetry run pip list | grep -i prometheus`
- `poetry run pytest` *(fails: ImportError and 967 failed, 1901 passed, 134 skipped, 163 errors)*

------
https://chatgpt.com/codex/tasks/task_e_6896d56d98e08333a3016d081f741519