### PR TITLE
Add deployment rollback script and image publish workflow

### DIFF
--- a/.github/workflows/publish-image.yml.disabled
+++ b/.github/workflows/publish-image.yml.disabled
@@ -1,0 +1,24 @@
+# This workflow is disabled by default. Rename the file to publish-image.yml to enable it.
+name: Publish Docker Image
+
+on:
+  workflow_dispatch:
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Publish image
+        run: scripts/deployment/publish_image.sh ${{ github.sha }}

--- a/docs/deployment/runbooks/rollback.md
+++ b/docs/deployment/runbooks/rollback.md
@@ -1,21 +1,17 @@
 # Rollback Procedure
 
-If a deployment needs to be rolled back, use the following steps:
+If a deployment needs to be rolled back, use the dedicated rollback script.
 
-1. Stop the current stack:
+1. Revert the stack to a previous image tag:
    ```bash
-   scripts/deployment/stop_stack.sh
+   scripts/deployment/rollback.sh <previous_tag> [environment]
    ```
-2. Redeploy the previous image tag:
-   ```bash
-   docker compose pull devsynth:<previous_tag>
-   docker compose up -d
-   ```
-3. Verify services are healthy:
+   This stops the stack, pulls the specified tag, and redeploys the service.
+2. Verify services are healthy:
    ```bash
    scripts/deployment/health_check.sh
    ```
-4. (Optional) Republish the previous image tag as `latest` if the rollback is permanent:
+3. (Optional) Republish the previous image tag as `latest` if the rollback is permanent:
    ```bash
    scripts/deployment/publish_image.sh <previous_tag>
    ```

--- a/scripts/deployment/rollback.sh
+++ b/scripts/deployment/rollback.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Roll back DevSynth to a previous image tag.
+# Usage: rollback.sh <previous_tag> [environment]
+#   previous_tag: required image tag to roll back to
+#   environment: development (default), staging, production, testing
+
+PREVIOUS_TAG=${1:-}
+ENVIRONMENT=${2:-development}
+
+if [[ -z "$PREVIOUS_TAG" ]]; then
+  echo "Usage: rollback.sh <previous_tag> [environment]" >&2
+  exit 1
+fi
+
+# Enforce non-root execution for least privilege
+if [[ "$EUID" -eq 0 ]]; then
+  echo "Please run this script as a non-root user." >&2
+  exit 1
+fi
+
+# Allow only known environments
+ALLOWED_ENVIRONMENTS=(development staging production testing)
+if [[ ! " ${ALLOWED_ENVIRONMENTS[*]} " =~ " ${ENVIRONMENT} " ]]; then
+  echo "Invalid environment: ${ENVIRONMENT}" >&2
+  exit 1
+fi
+
+# Ensure Docker is available
+if ! command -v docker >/dev/null 2>&1; then
+  echo "Docker is required but could not be found in PATH." >&2
+  exit 1
+fi
+
+ENV_FILE=".env.${ENVIRONMENT}"
+if [[ -f "$ENV_FILE" ]] && [[ $(stat -c %a "$ENV_FILE") != "600" ]]; then
+  echo "Environment file $ENV_FILE must have 600 permissions" >&2
+  exit 1
+fi
+
+# Stop the current stack
+"$(dirname "$0")/stop_stack.sh" "$ENVIRONMENT"
+
+# Pull the specified tag and restart the service
+export DEVSYNTH_IMAGE_TAG="$PREVIOUS_TAG"
+docker compose --env-file "$ENV_FILE" --profile "${ENVIRONMENT}" pull devsynth
+docker compose --env-file "$ENV_FILE" --profile "${ENVIRONMENT}" up -d devsynth
+
+# Verify services are healthy
+"$(dirname "$0")/health_check.sh"

--- a/tests/integration/general/test_deployment_automation.py
+++ b/tests/integration/general/test_deployment_automation.py
@@ -43,5 +43,14 @@ def test_rollback_runbook_mentions_scripts():
     runbook = RUNBOOKS_DIR / "rollback.md"
     assert runbook.exists()
     text = runbook.read_text()
-    assert "stop_stack.sh" in text
+    assert "rollback.sh" in text
     assert "publish_image.sh" in text
+
+
+def test_rollback_script_exists_and_redeploys():
+    script = SCRIPTS_DIR / "rollback.sh"
+    assert script.exists()
+    content = script.read_text()
+    assert "docker compose --env-file" in content
+    assert "pull devsynth" in content
+    assert "up -d devsynth" in content


### PR DESCRIPTION
## Summary
- add rollback script to stop stack, pull previous image tag, and redeploy
- document rollback procedure and extend deployment tests
- introduce disabled workflow for publishing Docker images

## Testing
- `poetry run pip check`
- `poetry run pip list | grep prometheus-client || true`
- `SKIP=devsynth-align,fix-code-blocks poetry run pre-commit run --files scripts/deployment/rollback.sh docs/deployment/runbooks/rollback.md tests/integration/general/test_deployment_automation.py .github/workflows/publish-image.yml.disabled`
- `poetry run python tests/verify_test_organization.py` *(fails: missing __init__.py, naming patterns)*
- `poetry run pytest tests/integration/general/test_deployment_automation.py` *(fails: Required test coverage of 25% not reached)*

------
https://chatgpt.com/codex/tasks/task_e_6896df35ade883339dc15a9225708299