### PR TITLE
feat: add retry condition metrics

### DIFF
--- a/tests/unit/fallback/test_retry_condition_metrics.py
+++ b/tests/unit/fallback/test_retry_condition_metrics.py
@@ -1,0 +1,54 @@
+from unittest.mock import Mock
+
+import pytest
+
+from devsynth import metrics
+from devsynth.fallback import reset_prometheus_metrics, retry_with_exponential_backoff
+from devsynth.metrics import retry_condition_counter
+
+
+@pytest.mark.medium
+def test_named_retry_condition_records_metrics_on_abort() -> None:
+    """Named retry conditions record metrics when they fail."""
+    metrics.reset_metrics()
+    reset_prometheus_metrics()
+
+    func = Mock(side_effect=Exception("boom"))
+    func.__name__ = "func"
+
+    wrapped = retry_with_exponential_backoff(
+        max_retries=2,
+        initial_delay=0,
+        retry_conditions={"needs_retry": "retry"},
+        track_metrics=True,
+    )(func)
+
+    with pytest.raises(Exception):
+        wrapped()
+
+    assert func.call_count == 1
+    assert metrics.get_retry_condition_metrics() == {"needs_retry": 1}
+    assert retry_condition_counter.labels(condition="needs_retry")._value.get() == 1
+
+
+@pytest.mark.medium
+def test_named_retry_condition_allows_retry() -> None:
+    """Successful named conditions do not increment metrics."""
+    metrics.reset_metrics()
+    reset_prometheus_metrics()
+
+    func = Mock(side_effect=[Exception("please retry"), "ok"])
+    func.__name__ = "func"
+
+    wrapped = retry_with_exponential_backoff(
+        max_retries=2,
+        initial_delay=0,
+        retry_conditions={"needs_retry": "retry"},
+        track_metrics=True,
+    )(func)
+
+    result = wrapped()
+
+    assert result == "ok"
+    assert func.call_count == 2
+    assert metrics.get_retry_condition_metrics() == {}


### PR DESCRIPTION
## Summary
- allow retry conditions to be named for targeted metrics
- expose retry condition counters and helpers
- test retry condition metrics and Prometheus integration

## Testing
- `poetry run pip check`
- `poetry run pip list | grep prometheus_client`
- `poetry run pre-commit run --files src/devsynth/metrics.py src/devsynth/fallback.py tests/unit/fallback/test_retry_condition_metrics.py`
- `poetry run python tests/verify_test_organization.py tests/unit/fallback`
- `poetry run pytest tests/unit/fallback/test_retry_condition_metrics.py tests/unit/fallback/test_retry_metrics_prometheus_integration.py`


------
https://chatgpt.com/codex/tasks/task_e_6896e2596a9c833382c92c8448e867c0