### PR TITLE
Handle exc_info in logger and retain wizard priority

### DIFF
--- a/src/devsynth/application/cli/requirements_commands.py
+++ b/src/devsynth/application/cli/requirements_commands.py
@@ -871,7 +871,8 @@ def wizard_cmd(
         or CLIConfig.from_env()
     )
 
-    responses: dict[str, str] = {}
+    # Pre-populate responses with defaults so moving backward retains values.
+    responses: dict[str, str] = {key: (default or "") for key, _, _, default in steps}
     if title is not None:
         responses["title"] = title
     if description is not None:

--- a/src/devsynth/application/cli/requirements_wizard.py
+++ b/src/devsynth/application/cli/requirements_wizard.py
@@ -62,9 +62,9 @@ def requirements_wizard(
         ("constraints", "Constraints (comma separated, optional)", None, ""),
     ]
 
-    # Seed responses with any provided values so they act as defaults when
-    # prompting or allow fully non-interactive operation.
-    responses: dict[str, str] = {}
+    # Seed responses with step defaults so navigation preserves previous
+    # answers.  Provided values override these defaults.
+    responses: dict[str, str] = {key: (default or "") for key, _, _, default in steps}
     if title is not None:
         responses["title"] = title
     if description is not None:


### PR DESCRIPTION
## Summary
- Wrap DevSynthLogger to normalize `exc_info` values before dispatching logs
- Pre-populate wizard responses so priority survives step navigation
- Ensure CLI requirements wizard keeps user-provided priority

## Testing
- `poetry run pre-commit run --files src/devsynth/logger.py src/devsynth/application/cli/requirements_wizard.py src/devsynth/application/cli/requirements_commands.py`
- `poetry run pytest tests/integration/general/test_requirements_gathering.py --cov-fail-under=0 -n 1`

------
https://chatgpt.com/codex/tasks/task_e_689761cde0988333ba8943515553c208