### PR TITLE
chore: add security audits to CI and deployment

### DIFF
--- a/.github/workflows/ci.yml.disabled
+++ b/.github/workflows/ci.yml.disabled
@@ -18,5 +18,7 @@ jobs:
           python -m pip install --upgrade pip
           pip install poetry
           poetry install --with dev
+      - name: Run Bandit static analysis
+        run: poetry run bandit -q -r src
       - name: Run security audit
         run: poetry run python scripts/security_audit.py

--- a/deployment/deploy_production.sh
+++ b/deployment/deploy_production.sh
@@ -20,6 +20,13 @@ command -v docker compose >/dev/null 2>&1 || {
   exit 1
 }
 
+# Run policy checks before deployment
+command -v poetry >/dev/null 2>&1 || {
+  echo "poetry is required but not installed." >&2
+  exit 1
+}
+poetry run python scripts/security_audit.py
+
 # Ensure sensitive env files are not world-readable
 if [[ -f .env ]] && [[ $(stat -c '%a' .env) -gt 600 ]]; then
   echo ".env file permissions are too permissive; run 'chmod 600 .env'." >&2

--- a/docs/policies/security_audits.md
+++ b/docs/policies/security_audits.md
@@ -13,19 +13,17 @@ manner and maintains a secure supply chain.
 - Audit reports are reviewed at least quarterly.
 - Additional reviews occur before major releases.
 
-## Review Process
+## Periodic Audit Process
 
-1. Run the security checks:
+1. Execute the bundled audit script:
    ```bash
-   poetry run pre-commit run --all-files bandit safety
+   poetry run python scripts/security_audit.py
    ```
-   or
-   ```bash
-   poetry run python scripts/dependency_safety_check.py
-   ```
-2. Record findings in the issue tracker.
-3. Prioritize and remediate identified vulnerabilities.
-4. Close issues once fixes are merged and verified.
+   This runs Bandit static analysis and Safety dependency checks.
+2. Capture the output and store it with the audit logs.
+3. Record findings in the issue tracker.
+4. Prioritize and remediate identified vulnerabilities.
+5. Close issues once fixes are merged and verified and document completion in the next audit.
 
 ## Responsibilities
 


### PR DESCRIPTION
## Summary
- run Bandit static analysis in disabled CI workflow
- require security audit script in deployment script
- document periodic security audit process

## Testing
- `SKIP=devsynth-align,fix-code-blocks poetry run pre-commit run --files .github/workflows/ci.yml.disabled deployment/deploy_production.sh docs/policies/security_audits.md`
- `poetry run pytest tests/unit/security/test_security_audit.py` *(fails: Coverage failure: total of 9 is less than fail-under=25)*

------
https://chatgpt.com/codex/tasks/task_e_689761c4748483339deb20c03b89dc26