### PR TITLE
test: add run-tests help regression test

### DIFF
--- a/issues/115.md
+++ b/issues/115.md
@@ -1,5 +1,0 @@
-# Issue 115: run-tests CLI fails due to unsupported Dict[str, bool] parameter
-
-Running `devsynth run-tests` or the deprecated `scripts/run_all_tests.py` crashes before executing tests. The Typer CLI raises `RuntimeError: Type not yet supported: typing.Dict[str, bool]` while building commands.
-
-This prevents running any tests via the provided scripts. Update CLI parameter annotations (e.g., features) or adjust dependencies so Typer can handle `Dict[str, bool]` parameters.

--- a/tests/unit/application/cli/commands/test_run_tests_cmd.py
+++ b/tests/unit/application/cli/commands/test_run_tests_cmd.py
@@ -81,3 +81,15 @@ def test_run_tests_cli_full_invocation() -> None:
             50,  # segment_size
         )
         assert "Tests completed successfully" in result.output
+
+
+def test_run_tests_cli_help() -> None:
+    """The ``--help`` flag should render without Typer runtime errors."""
+
+    runner = CliRunner()
+    app = typer.Typer()
+    app.command(name="run-tests")(module.run_tests_cmd)
+    result = runner.invoke(app, ["run-tests", "--help"])
+
+    assert result.exit_code == 0
+    assert "Run DevSynth test suites." in result.output


### PR DESCRIPTION
## Summary
- remove obsolete issue 115
- add regression test to ensure `devsynth run-tests --help` works without Typer runtime errors

## Testing
- `poetry run pre-commit run --files tests/unit/application/cli/commands/test_run_tests_cmd.py` *(fails: ImportError: cannot import name 'CodeAnalyzer'...)*
- `poetry run python tests/verify_test_organization.py` *(fails: missing __init__.py files, naming issues)*
- `poetry run pytest tests/unit/application/cli/commands/test_run_tests_cmd.py::test_run_tests_cli_help -q` *(fails: Required test coverage of 25% not reached)*

------
https://chatgpt.com/codex/tasks/task_e_689767fc143c8333b921adbe6496d1a8