### PR TITLE
feat: add non-interactive ingest CLI

### DIFF
--- a/docs/user_guides/ingestion.md
+++ b/docs/user_guides/ingestion.md
@@ -1,0 +1,32 @@
+---
+title: Ingestion
+date: "2025-07-12"
+version: "0.1.0-alpha.1"
+tags:
+  - user-guide
+  - ingestion
+status: draft
+author: "DevSynth Team"
+last_reviewed: "2025-07-12"
+---
+<div class="breadcrumbs">
+<a href="../index.md">Documentation</a> &gt; <a href="index.md">User Guides</a> &gt; Ingestion
+</div>
+
+# Ingestion
+
+Use the `devsynth ingest` command to run the Expand, Differentiate, Refine, Retrospect pipeline for a project.
+
+## Non-interactive mode
+
+Disable prompts when automating workflows by running:
+
+```bash
+devsynth ingest --non-interactive --yes
+```
+
+Setting `DEVSYNTH_INGEST_NONINTERACTIVE=1` enables non-interactive mode by default. Pair with `DEVSYNTH_AUTO_CONFIRM=1` or `--yes` to auto-approve prompts.
+
+## Implementation Status
+
+.

--- a/src/devsynth/application/cli/commands/__init__.py
+++ b/src/devsynth/application/cli/commands/__init__.py
@@ -2,18 +2,20 @@
 Command modules for the CLI application.
 """
 
+from .align_cmd import align_cmd
+from .alignment_metrics_cmd import alignment_metrics_cmd
+from .analyze_manifest_cmd import analyze_manifest_cmd
+from .doctor_cmd import doctor_cmd
+from .edrr_cycle_cmd import edrr_cycle_cmd
+from .generate_docs_cmd import generate_docs_cmd
+from .ingest_cmd import ingest_cmd
+
 # Import the command functions to make them available from this package
 from .inspect_code_cmd import inspect_code_cmd
 from .inspect_config_cmd import inspect_config_cmd
-from .doctor_cmd import doctor_cmd
-from .edrr_cycle_cmd import edrr_cycle_cmd
-from .align_cmd import align_cmd
+from .test_metrics_cmd import test_metrics_cmd
 from .validate_manifest_cmd import validate_manifest_cmd
 from .validate_metadata_cmd import validate_metadata_cmd
-from .alignment_metrics_cmd import alignment_metrics_cmd
-from .test_metrics_cmd import test_metrics_cmd
-from .generate_docs_cmd import generate_docs_cmd
-from .analyze_manifest_cmd import analyze_manifest_cmd
 
 __all__ = [
     "inspect_code_cmd",
@@ -27,4 +29,5 @@ __all__ = [
     "test_metrics_cmd",
     "generate_docs_cmd",
     "analyze_manifest_cmd",
+    "ingest_cmd",
 ]

--- a/tests/integration/general/test_ingestion_pipeline.py
+++ b/tests/integration/general/test_ingestion_pipeline.py
@@ -17,6 +17,7 @@ import yaml
 
 from devsynth.adapters.kuzu_memory_store import KuzuMemoryStore
 from devsynth.adapters.memory.memory_adapter import MemorySystemAdapter
+from devsynth.application.cli.commands.ingest_cmd import ingest_cmd as cli_ingest_cmd
 from devsynth.application.cli.ingest_cmd import ingest_cmd
 from devsynth.application.ingestion import (
     ArtifactStatus,
@@ -112,6 +113,18 @@ def test_ingest_cmd_non_interactive_priority_persists(
 
     cfg = UnifiedConfigLoader.load(temp_project_dir)
     assert cfg.config.priority == "high"
+
+
+@patch("devsynth.application.cli.commands.ingest_cmd._ingest_cmd")
+def test_cli_ingest_respects_env_non_interactive(mock_ingest, monkeypatch):
+    """CLI wrapper defaults to non-interactive from environment."""
+
+    monkeypatch.setenv("DEVSYNTH_INGEST_NONINTERACTIVE", "1")
+    monkeypatch.setenv("DEVSYNTH_AUTO_CONFIRM", "1")
+
+    cli_ingest_cmd(manifest_path="manifest.yaml")
+
+    assert mock_ingest.call_args.kwargs["non_interactive"] is True
 
 
 class TestIngestionMetrics:


### PR DESCRIPTION
## Summary
- add dedicated CLI wrapper for ingestion with non-interactive defaults
- document ingest command and non-interactive environment variables
- test CLI wrapper respects non-interactive environment flag

## Testing
- `SKIP=devsynth-align,fix-code-blocks poetry run pre-commit run --files src/devsynth/application/cli/commands/ingest_cmd.py src/devsynth/application/cli/commands/__init__.py docs/user_guides/ingestion.md tests/integration/general/test_ingestion_pipeline.py`
- `poetry run python tests/verify_test_organization.py` (fails: missing __init__.py files and naming)
- `poetry run pip check`
- `poetry run pip list | grep prometheus-client` (no output)
- `poetry run pytest tests/integration/general/test_ingestion_pipeline.py::test_ingest_cmd_non_interactive_priority_persists tests/integration/general/test_ingestion_pipeline.py::test_cli_ingest_respects_env_non_interactive` (fails: ImportError: FAISSStore requires the 'faiss' package)

------
https://chatgpt.com/codex/tasks/task_e_68977379b0688333a54bfc5b789ddb42