### PR TITLE
docs: consolidate chromadb adapter module docstring

### DIFF
--- a/src/devsynth/application/memory/adapters/chromadb_vector_adapter.py
+++ b/src/devsynth/application/memory/adapters/chromadb_vector_adapter.py
@@ -1,16 +1,14 @@
-"""
-ChromaDB Vector Adapter Module
+"""ChromaDB vector adapter module.
 
-This module provides a memory adapter that handles vector-based operations
-for similarity search using ChromaDB as the backend.
-"""
+This module implements a :class:`VectorStore` backed by ChromaDB. It
+persists and retrieves ``MemoryVector`` objects from a ChromaDB collection
+and supports similarity search as well as basic CRUD operations.
 
-"""
-Adapter for using ChromaDB as a simple vector store.
+Typical usage::
 
-The previous implementation only stored vectors in a local dictionary.  This
-update provides real interactions with ChromaDB using its client API so that
-vectors are persisted and retrieved from a ChromaDB collection.
+    adapter = ChromaDBVectorAdapter(collection_name="demo")
+    adapter.store_vector(memory_vector)
+
 """
 
 import uuid


### PR DESCRIPTION
## Summary
- combine duplicate docstrings in `chromadb_vector_adapter` into a single module docstring with usage example

## Testing
- `poetry run pre-commit run --files src/devsynth/application/memory/adapters/chromadb_vector_adapter.py`
- `poetry run pytest --no-cov tests/unit/adapters/test_chromadb_vector_adapter.py`


------
https://chatgpt.com/codex/tasks/task_e_6897792378d08333a788d19fb841640a