### PR TITLE
feat: enhance init progress and metrics option

### DIFF
--- a/docs/user_guides/cli_reference.md
+++ b/docs/user_guides/cli_reference.md
@@ -164,7 +164,7 @@ Initialize a new DevSynth project or onboard an existing one.
 devsynth init [--path PATH] [--template TEMPLATE] [--project-root ROOT] [--language LANG]
              [--source-dirs DIRS] [--test-dirs DIRS] [--docs-dirs DIRS]
              [--extra-languages LANGS] [--goals TEXT] [--constraints FILE]
-             [--wizard]
+             [--wizard] [--metrics-dashboard]
 ```
 
 **Options:**
@@ -183,9 +183,11 @@ devsynth init [--path PATH] [--template TEMPLATE] [--project-root ROOT] [--langu
 - `--goals`: High-level goals or constraints for the project
 - `--constraints`: Path to a constraint configuration file
 - `--wizard`: Launch the guided setup wizard even outside a detected project
+- `--metrics-dashboard`: Print instructions for enabling the optional MVUU metrics dashboard
 
 
 This command detects existing projects and launches an interactive wizard when run inside a directory containing `pyproject.toml` or `project.yaml`. Use the `--wizard` flag to start the wizard explicitly in any directory. The command uses provided options and `DEVSYNTH_INIT_*` environment variables directly, prompting only for missing values. Supplying `--defaults` or `--non-interactive` skips prompts entirely.
+Progress messages show when configuration is saved and when scaffolding files are generated.
 The wizard reads configuration using the [Unified Config Loader](../implementation/config_loader_workflow.md),
 which prefers the `[tool.devsynth]` table in `pyproject.toml` when both files are present.
 During the wizard you will:
@@ -193,6 +195,19 @@ During the wizard you will:
 1. Select the memory backend (``memory``, ``file``, ``Kuzu`` or ``ChromaDB``).
 2. Choose whether to enable optional features such as ``wsde_collaboration`` and ``dialectical_reasoning``.
 3. Decide if DevSynth should operate in offline mode.
+
+Developers writing custom commands can leverage the progress utilities to show
+step-based status updates:
+
+```python
+from devsynth.interface.progress_utils import step_progress
+
+with step_progress(bridge, ["Saving configuration", "Generating project files"]) as progress:
+    progress.advance(status="writing config")
+    # perform work
+    progress.advance(status="scaffolding")
+    # perform next step
+```
 
 
 The resulting `.devsynth/project.yaml` is validated against

--- a/src/devsynth/interface/progress_utils.py
+++ b/src/devsynth/interface/progress_utils.py
@@ -4,15 +4,15 @@ This module provides utilities for creating and managing progress indicators
 for long-running operations in a consistent way across all DevSynth commands.
 """
 
-from typing import Any, Callable, Dict, List, Optional, TypeVar, Union
-from contextlib import contextmanager
-import time
 import functools
+import time
+from contextlib import contextmanager
+from typing import Any, Callable, Dict, List, Optional, TypeVar, Union
 
-from devsynth.interface.ux_bridge import UXBridge, ProgressIndicator
+from devsynth.interface.ux_bridge import ProgressIndicator, UXBridge
 
 # Type variable for generic functions
-T = TypeVar('T')
+T = TypeVar("T")
 
 
 class ProgressManager:
@@ -31,7 +31,9 @@ class ProgressManager:
         self.bridge = bridge
         self.active_indicators: Dict[str, ProgressIndicator] = {}
 
-    def create(self, description: str, total: int = 100, key: Optional[str] = None) -> ProgressIndicator:
+    def create(
+        self, description: str, total: int = 100, key: Optional[str] = None
+    ) -> ProgressIndicator:
         """Create a progress indicator.
 
         Args:
@@ -43,11 +45,11 @@ class ProgressManager:
             The created progress indicator
         """
         indicator = self.bridge.create_progress(description, total=total)
-        
+
         # Store the indicator if a key is provided
         if key:
             self.active_indicators[key] = indicator
-            
+
         return indicator
 
     def get(self, key: str) -> Optional[ProgressIndicator]:
@@ -78,7 +80,9 @@ class ProgressManager:
             self.complete(key)
 
     @contextmanager
-    def progress(self, description: str, total: int = 100, key: Optional[str] = None) -> ProgressIndicator:
+    def progress(
+        self, description: str, total: int = 100, key: Optional[str] = None
+    ) -> ProgressIndicator:
         """Context manager for progress indicators.
 
         Args:
@@ -97,7 +101,9 @@ class ProgressManager:
             if key and key in self.active_indicators:
                 del self.active_indicators[key]
 
-    def track(self, items: List[Any], description: str, key: Optional[str] = None) -> List[Any]:
+    def track(
+        self, items: List[Any], description: str, key: Optional[str] = None
+    ) -> List[Any]:
         """Track progress through a list of items.
 
         Args:
@@ -111,7 +117,7 @@ class ProgressManager:
         total = len(items)
         if total == 0:
             return items
-            
+
         with self.progress(description, total, key) as indicator:
             # Return the original list, but with a side effect of updating the progress
             # indicator each time an item is accessed
@@ -126,10 +132,12 @@ class ProgressManager:
                         # For single items, update progress by 1
                         indicator.update(advance=1)
                     return super().__getitem__(index)
-                    
+
             return TrackedList(items)
 
-    def with_progress(self, description: str, total: int = 100, key: Optional[str] = None) -> Callable[[Callable[..., T]], Callable[..., T]]:
+    def with_progress(
+        self, description: str, total: int = 100, key: Optional[str] = None
+    ) -> Callable[[Callable[..., T]], Callable[..., T]]:
         """Decorator for functions that should show progress.
 
         Args:
@@ -140,14 +148,17 @@ class ProgressManager:
         Returns:
             Decorator function
         """
+
         def decorator(func: Callable[..., T]) -> Callable[..., T]:
             @functools.wraps(func)
             def wrapper(*args: Any, **kwargs: Any) -> T:
                 with self.progress(description, total, key) as indicator:
                     # Add the progress indicator to kwargs
-                    kwargs['progress'] = indicator
+                    kwargs["progress"] = indicator
                     return func(*args, **kwargs)
+
             return wrapper
+
         return decorator
 
 
@@ -158,8 +169,13 @@ class ProgressTracker:
     process items in batches or with unknown total steps.
     """
 
-    def __init__(self, indicator: ProgressIndicator, total: Optional[int] = None, 
-                 update_interval: float = 0.1, auto_complete: bool = True):
+    def __init__(
+        self,
+        indicator: ProgressIndicator,
+        total: Optional[int] = None,
+        update_interval: float = 0.1,
+        auto_complete: bool = True,
+    ):
         """Initialize the progress tracker.
 
         Args:
@@ -185,7 +201,7 @@ class ProgressTracker:
             force: Whether to force an update regardless of the update interval
         """
         self.count += advance
-        
+
         # Update the estimated total if no total was provided
         if self.total is None:
             # Estimate based on current progress and elapsed time
@@ -193,23 +209,25 @@ class ProgressTracker:
             if elapsed > 0 and self.count > 0:
                 # Estimate total based on current rate and a time estimate
                 rate = self.count / elapsed
-                estimated_time = max(10.0, elapsed * 2)  # At least 10 seconds, or double current time
+                estimated_time = max(
+                    10.0, elapsed * 2
+                )  # At least 10 seconds, or double current time
                 self.estimated_total = max(100, int(rate * estimated_time))
-        
+
         # Only update the indicator if enough time has passed or if forced
         current_time = time.time()
         if force or (current_time - self.last_update_time) >= self.update_interval:
             # Calculate percentage based on actual total or estimated total
             total = self.total or self.estimated_total
             percentage = min(100, int(self.count / total * 100))
-            
+
             # Update the indicator
             self.indicator.update(
                 advance=0,  # Don't advance, we'll set the percentage directly
                 description=f"Processed {self.count} items",
-                status=f"{percentage}% complete"
+                status=f"{percentage}% complete",
             )
-            
+
             # Update the last update time
             self.last_update_time = current_time
 
@@ -218,13 +236,79 @@ class ProgressTracker:
         if self.auto_complete:
             self.indicator.complete()
 
-    def __enter__(self) -> 'ProgressTracker':
+    def __enter__(self) -> "ProgressTracker":
         """Enter the context manager."""
         return self
 
     def __exit__(self, exc_type, exc_val, exc_tb) -> None:
         """Exit the context manager."""
         self.complete()
+
+
+class StepProgress:
+    """Simple helper for sequential step-based progress.
+
+    This utility wraps a :class:`~devsynth.interface.ux_bridge.ProgressIndicator`
+    and provides a lightweight API for updating it as a series of named steps
+    are executed. Each call to :meth:`advance` marks the previous step complete
+    and updates the description for the next step.
+    """
+
+    def __init__(
+        self, bridge: UXBridge, steps: List[str], *, description: Optional[str] = None
+    ) -> None:
+        self._steps = steps
+        self._index = 0
+        self._indicator = bridge.create_progress(
+            description or steps[0], total=len(steps)
+        )
+
+    def advance(self, status: Optional[str] = None) -> None:
+        """Advance to the next step.
+
+        Args:
+            status: Optional status text to display alongside the step
+                description.
+        """
+
+        if self._index >= len(self._steps):
+            return
+
+        desc = self._steps[self._index]
+        advance = 0 if self._index == 0 else 1
+        self._indicator.update(description=desc, status=status or desc, advance=advance)
+        self._index += 1
+
+    def complete(self) -> None:
+        """Complete the progress indicator."""
+
+        remaining = len(self._steps) - self._index
+        if remaining > 0:
+            self._indicator.update(advance=remaining)
+        self._indicator.complete()
+
+    def __enter__(self) -> "StepProgress":
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:  # pragma: no cover - defensive
+        self.complete()
+
+
+def step_progress(
+    bridge: UXBridge, steps: List[str], *, description: Optional[str] = None
+) -> StepProgress:
+    """Create a :class:`StepProgress` helper.
+
+    Args:
+        bridge: The UXBridge used to create the underlying progress indicator.
+        steps: Ordered list of step descriptions.
+        description: Optional overall description for the progress indicator.
+
+    Returns:
+        A :class:`StepProgress` instance.
+    """
+
+    return StepProgress(bridge, steps, description=description)
 
 
 def create_progress_manager(bridge: UXBridge) -> ProgressManager:
@@ -240,7 +324,9 @@ def create_progress_manager(bridge: UXBridge) -> ProgressManager:
 
 
 @contextmanager
-def progress_indicator(bridge: UXBridge, description: str, total: int = 100) -> ProgressIndicator:
+def progress_indicator(
+    bridge: UXBridge, description: str, total: int = 100
+) -> ProgressIndicator:
     """Context manager for creating a progress indicator.
 
     Args:
@@ -273,7 +359,9 @@ def track_progress(bridge: UXBridge, items: List[Any], description: str) -> List
     return manager.track(items, description)
 
 
-def with_progress(bridge: UXBridge, description: str, total: int = 100) -> Callable[[Callable[..., T]], Callable[..., T]]:
+def with_progress(
+    bridge: UXBridge, description: str, total: int = 100
+) -> Callable[[Callable[..., T]], Callable[..., T]]:
     """Decorator for functions that should show progress.
 
     Args:


### PR DESCRIPTION
## Summary
- streamline init prompts and error messaging
- add sequential step progress helper and progress validation
- document metrics dashboard flag and richer progress output

## Testing
- `poetry run pre-commit run --files docs/user_guides/cli_reference.md src/devsynth/application/cli/commands/init_cmd.py src/devsynth/interface/progress_utils.py tests/unit/application/cli/test_init_cmd.py`
- `poetry run pytest tests/unit/application/cli/test_init_cmd.py --cov-fail-under=0`
- `poetry run python tests/verify_test_organization.py` *(fails: missing __init__.py files and test classes with __init__)*

------
https://chatgpt.com/codex/tasks/task_e_689789e78c908333893f301c4dbf7f50