### PR TITLE
Handle optional extras in codex setup

### DIFF
--- a/scripts/codex_setup.sh
+++ b/scripts/codex_setup.sh
@@ -75,27 +75,42 @@ required = [
     "yaml",
     "typer",
     "tiktoken",
-    "chromadb",
     "fastapi",
     "streamlit",
-    "lmstudio",
     "tinydb",
     "duckdb",
     "lmdb",
+    "astor",
+    "httpx",
+    "prometheus_client",
+]
+optional = [
     "kuzu",
     "faiss",
-    "prometheus_client",
-    "httpx",
     "dearpygui",
+    "chromadb",
+    "lmstudio",
 ]
+
 missing = []
 for pkg in required:
     try:
         importlib.import_module(pkg)
     except Exception:
         missing.append(pkg)
+
+optional_missing = []
+for pkg in optional:
+    try:
+        importlib.import_module(pkg)
+    except Exception:
+        optional_missing.append(pkg)
+
 if missing:
     sys.exit("Missing packages: " + ", ".join(missing))
+
+for pkg in optional_missing:
+    print(f"[warning] optional package {pkg} is not installed", file=sys.stderr)
 EOF
 
 # Ensure dependency tree is healthy after installing extras


### PR DESCRIPTION
## Summary
- Limit required package checks in `codex_setup.sh` to those installed with `poetry install --with dev --extras tests`
- Warn and continue when optional extras such as kuzu, faiss, dearpygui, chromadb, and lmstudio are missing

## Testing
- `SKIP=fix-code-blocks poetry run pre-commit run --files scripts/codex_setup.sh`
- `poetry run pip check`
- `poetry run pip list | grep prometheus-client || poetry run pip list | grep prometheus_client`
- `PYTEST_ADDOPTS="--maxfail=1 --disable-warnings --cov-fail-under=0" poetry run pytest` *(fails: ModuleNotFoundError: No module named 'chromadb')*
- `PYTEST_ADDOPTS="--cov-fail-under=0" bash scripts/codex_setup.sh`

------
https://chatgpt.com/codex/tasks/task_e_68978f555d748333a11bc3d60c88e688