### PR TITLE
feat: add realistic template integration test

### DIFF
--- a/tests/integration/templates/test_generated_module.py
+++ b/tests/integration/templates/test_generated_module.py
@@ -1,0 +1,34 @@
+"""Template integration tests for generated modules.
+
+Copy this file when scaffolding integration tests for new modules and replace
+placeholders with concrete assertions.
+This example demonstrates a simple workflow involving file output.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.skip(reason="Template for generated module integration tests")
+
+
+def process_data(value: int, output_path: Path) -> Path:
+    """Write a doubled value to ``output_path`` as JSON and return the path."""
+    result = {"doubled": value * 2}
+    output_path.write_text(json.dumps(result))
+    return output_path
+
+
+def test_generated_module_workflow(tmp_path: Path) -> None:
+    """Verify the generated module can create and read output files."""
+    output_file = tmp_path / "result.json"
+    returned_path = process_data(21, output_file)
+
+    assert returned_path == output_file
+    assert output_file.exists(), "process_data should create the file"
+
+    loaded = json.loads(output_file.read_text())
+    assert loaded["doubled"] == 42


### PR DESCRIPTION
## Summary
- add example integration test template that writes and reads JSON output
- include package file for `tests/integration/templates`

## Testing
- `poetry run pre-commit run --files tests/integration/templates/__init__.py tests/integration/templates/test_generated_module.py`
- `poetry run python tests/verify_test_organization.py` *(fails: test organization verification failed)*
- `poetry run pytest --no-cov tests/integration/templates/test_generated_module.py`
- `poetry run pip check`
- `poetry run pip list | grep prometheus-client` *(no output)*

------
https://chatgpt.com/codex/tasks/task_e_689795f202ec8333a6e462a8d315b19b