### PR TITLE
docs: dedupe alpha milestone in release plan

### DIFF
--- a/docs/roadmap/release_plan.md
+++ b/docs/roadmap/release_plan.md
@@ -31,27 +31,15 @@ git tag v0.1.0-alpha.1
 git push origin v0.1.0-alpha.1
 ```
 
-- MVUU engine prototype for Minimum Viable Utility Units
-- Atomic-Rewrite workflow baseline
-- MVUU JSON schema finalization
-- Commit-linter enforcement
-- Traceability automation and ticket linkage
-- Automatic issue comments for commit traceability
-- Baseline Dear PyGui parity tasks:
-  - Wizard forms
-  - Progress UI
-  - CLI mapping
-
-### 0.1.0-alpha.1
 - Refresh system architecture diagrams under `docs/architecture/`.
 - Standardize metadata headers across all project documentation.
 - Publish the consolidated release plan for team-wide alignment.
-- MVUU engine refinement
-- Atomic-Rewrite workflow integration
-- MVUU JSON schema finalization
-- Commit-linter enforcement
-- Traceability automation and ticket linkage
-- Automatic issue comments for commit traceability
+- MVUU engine prototype and refinement for Minimum Viable Utility Units.
+- Atomic-Rewrite workflow baseline and integration.
+- MVUU JSON schema finalization.
+- Commit-linter enforcement.
+- Traceability automation and ticket linkage.
+- Automatic issue comments for commit traceability.
 - Baseline Dear PyGui parity tasks:
   - Wizard forms
   - Progress UI


### PR DESCRIPTION
## Summary
- remove duplicate `0.1.0-alpha.1` block in release plan and merge its tasks for a single chronological entry

## Testing
- `poetry run pre-commit run --files docs/roadmap/release_plan.md`
- `poetry run pytest` *(fails: KeyError: <WorkerController gw0>, 959 failed)*


------
https://chatgpt.com/codex/tasks/task_e_689795e339848333906570997fc7a3ec