### PR TITLE
feat: add wsde role accessors

### DIFF
--- a/src/devsynth/domain/models/wsde_facade.py
+++ b/src/devsynth/domain/models/wsde_facade.py
@@ -165,6 +165,49 @@ def _simple_assign_roles_for_phase(self: WSDETeam, phase, task):
 WSDETeam.assign_roles_for_phase = _simple_assign_roles_for_phase
 
 
+def _get_worker(self: WSDETeam):
+    """Return the current worker if assigned."""
+
+    return self.roles.get("worker")
+
+
+def _get_supervisor(self: WSDETeam):
+    """Return the current supervisor if assigned."""
+
+    return self.roles.get("supervisor")
+
+
+def _get_designer(self: WSDETeam):
+    """Return the current designer if assigned."""
+
+    return self.roles.get("designer")
+
+
+def _get_evaluator(self: WSDETeam):
+    """Return the current evaluator if assigned."""
+
+    return self.roles.get("evaluator")
+
+
+def _get_agent(self: WSDETeam, name: str):
+    """Retrieve an agent by name."""
+
+    for agent in self.agents:
+        agent_name = getattr(agent, "name", None) or getattr(
+            getattr(agent, "config", None), "name", None
+        )
+        if agent_name == name:
+            return agent
+    return None
+
+
+WSDETeam.get_worker = _get_worker
+WSDETeam.get_supervisor = _get_supervisor
+WSDETeam.get_designer = _get_designer
+WSDETeam.get_evaluator = _get_evaluator
+WSDETeam.get_agent = _get_agent
+
+
 def _simple_conduct_peer_review(
     self: WSDETeam,
     work_product,


### PR DESCRIPTION
## Summary
- add role accessors for WSDE teams
- support agent lookup and evaluator retrieval to enable peer review

## Testing
- `poetry run pre-commit run --files src/devsynth/domain/models/wsde_facade.py`
- `poetry run pytest tests/integration/general/test_wsde_edrr_component_interactions.py tests/integration/general/test_wsde_edrr_integration_advanced.py tests/integration/general/test_wsde_edrr_integration_end_to_end.py tests/integration/general/test_wsde_memory_edrr_integration.py tests/integration/general/test_wsde_peer_review_memory_integration.py tests/integration/general/test_wsde_peer_review_workflow.py --cov-fail-under=0`

------
https://chatgpt.com/codex/tasks/task_e_68979a17234083339c290caaaf47e066