### PR TITLE
Handle missing kuzu_embedded setting

### DIFF
--- a/src/devsynth/adapters/kuzu_memory_store.py
+++ b/src/devsynth/adapters/kuzu_memory_store.py
@@ -67,8 +67,14 @@ class KuzuMemoryStore(MemoryStore):
         normalized_path = os.path.abspath(os.path.expanduser(base_directory))
         redirected_path = settings_module.ensure_path_exists(normalized_path)
 
-        # Determine embedded mode from configuration
-        use_embedded = settings_module.get_settings().kuzu_embedded
+        # Determine embedded mode from configuration.  Some older versions of
+        # the settings module may not expose ``kuzu_embedded`` directly, so use
+        # ``getattr`` with a sensible default.
+        use_embedded = getattr(
+            settings_module.get_settings(),
+            "kuzu_embedded",
+            getattr(settings_module, "kuzu_embedded", True),
+        )
         if not _is_kuzu_available():
             logger.info("Kuzu not available; using in-memory fallback store")
             use_embedded = False

--- a/src/devsynth/config/settings.py
+++ b/src/devsynth/config/settings.py
@@ -650,8 +650,9 @@ _settings_instance = None
 _settings = Settings()
 
 # Expose commonly used settings at module level
+kuzu_db_path = _settings.kuzu_db_path
 kuzu_embedded = _settings.kuzu_embedded
-# Backward-compatible constant
+# Backward-compatible constant for older imports
 KUZU_EMBEDDED = kuzu_embedded
 
 


### PR DESCRIPTION
## Summary
- expose `kuzu_embedded` in settings and add `kuzu_db_path` helper
- guard Kuzu memory stores against missing `kuzu_embedded` attribute

## Testing
- `poetry run pre-commit run --files src/devsynth/config/settings.py src/devsynth/adapters/kuzu_memory_store.py src/devsynth/application/memory/kuzu_store.py`
- `poetry run pytest tests/integration/general/test_kuzu_memory_integration.py --no-cov -q`


------
https://chatgpt.com/codex/tasks/task_e_68979d8e8f2c8333806a1a099ac338ea