### PR TITLE
feat: support non-interactive ingestion defaults

### DIFF
--- a/docs/getting_started/ingestion.md
+++ b/docs/getting_started/ingestion.md
@@ -4,10 +4,15 @@ The `devsynth ingest` command runs the Expand, Differentiate, Refine, and Retros
 
 ## Non-interactive usage
 
-Use the `--yes` flag to auto-confirm prompts and `--priority` to set a project priority without manual input:
+Use `--non-interactive` to bypass prompts. Combine it with `--yes` or the
+`DEVSYNTH_AUTO_CONFIRM=1` environment variable to auto-approve confirmations.
+You can also set defaults such as project priority with `--priority` or by
+using `DEVSYNTH_INGEST_PRIORITY`.
 
 ```bash
-devsynth ingest manifest.yaml --yes --priority high
+devsynth ingest manifest.yaml --non-interactive --yes --priority high
 ```
 
-These options are useful in scripts or CI environments where no user interaction is available.
+Setting `DEVSYNTH_INGEST_NONINTERACTIVE=1` enables non-interactive mode by
+default. These options are useful in scripts or CI environments where no user
+interaction is available.

--- a/docs/user_guides/cli_reference.md
+++ b/docs/user_guides/cli_reference.md
@@ -693,6 +693,10 @@ DevSynth uses the following environment variables:
 | `DEVSYNTH_INGEST_DRY_RUN` | Set to `1` to enable `--dry-run` by default | 0 |
 | `DEVSYNTH_INGEST_VERBOSE` | Set to `1` to enable verbose ingestion output | 0 |
 | `DEVSYNTH_INGEST_VALIDATE_ONLY` | Set to `1` to run only manifest validation | 0 |
+| `DEVSYNTH_INGEST_PRIORITY` | Persist project priority without prompting | None |
+| `DEVSYNTH_INGEST_AUTO_PHASE_TRANSITIONS` | Set to `0` to require manual EDRR phase transitions | 1 |
+| `DEVSYNTH_INGEST_NONINTERACTIVE` | Set to `1` to disable prompts during ingestion | 0 |
+| `DEVSYNTH_AUTO_CONFIRM` | Auto-approve prompts across commands | 0 |
 
 ## Configuration File
 

--- a/docs/user_guides/ingestion.md
+++ b/docs/user_guides/ingestion.md
@@ -25,6 +25,12 @@ Disable prompts when automating workflows by running:
 devsynth ingest --non-interactive --yes
 ```
 
+The `--defaults` flag combines both options:
+
+```bash
+devsynth ingest --defaults
+```
+
 Setting `DEVSYNTH_INGEST_NONINTERACTIVE=1` enables non-interactive mode by default. Pair with `DEVSYNTH_AUTO_CONFIRM=1` or `--yes` to auto-approve prompts.
 
 ## Implementation Status


### PR DESCRIPTION
## Summary
- add `--defaults` flag and environment variable fallbacks to `ingest` command
- document non-interactive ingestion and related environment variables
- test initialization without prompts via environment variables

## Testing
- `poetry run pre-commit run --files src/devsynth/application/cli/commands/ingest_cmd.py docs/getting_started/ingestion.md docs/user_guides/cli_reference.md docs/user_guides/ingestion.md tests/unit/application/cli/test_init_cmd.py`
- `poetry run pytest --no-cov tests/unit/application/cli/test_init_cmd.py`

------
https://chatgpt.com/codex/tasks/task_e_6897a0b37c3883339a738722016d60b7