### PR TITLE
Persist priority to project config

### DIFF
--- a/src/devsynth/application/cli/requirements_wizard.py
+++ b/src/devsynth/application/cli/requirements_wizard.py
@@ -11,6 +11,7 @@ import json
 from pathlib import Path
 from typing import Optional, Sequence
 
+from devsynth.config import get_project_config, save_config
 from devsynth.config.settings import ensure_path_exists
 from devsynth.domain.models.requirement import RequirementPriority, RequirementType
 from devsynth.interface.ux_bridge import UXBridge
@@ -115,6 +116,12 @@ def requirements_wizard(
     output_path = Path(out_dir) / path.name
     with open(output_path, "w", encoding="utf-8") as fh:
         json.dump(result, fh, indent=2)
+
+    cfg = get_project_config(Path("."))
+    cfg.priority = responses.get("priority", RequirementPriority.MEDIUM.value)
+    cfg.constraints = responses.get("constraints", "")
+    # Always persist to .devsynth/project.yaml to mirror gather flows.
+    save_config(cfg, use_pyproject=False)
 
     bridge.display_result(f"[green]Requirements saved to {output_path}[/green]")
 

--- a/src/devsynth/application/requirements/interactions.py
+++ b/src/devsynth/application/requirements/interactions.py
@@ -8,8 +8,8 @@ from typing import Optional, Sequence
 
 import yaml
 
-from devsynth.interface.ux_bridge import UXBridge
 from devsynth.config import get_project_config, save_config
+from devsynth.interface.ux_bridge import UXBridge
 
 
 class RequirementsCollector:
@@ -121,7 +121,8 @@ def gather_requirements(
     cfg.constraints = responses["constraints"]
     if hasattr(cfg, "priority"):
         setattr(cfg, "priority", responses["priority"])
-    save_config(cfg, use_pyproject=(Path("pyproject.toml").exists()))
+    # Always write to .devsynth/project.yaml so gathered data is centralized.
+    save_config(cfg, use_pyproject=False)
 
     bridge.display_result(f"[green]Requirements saved to {output_file}[/green]")
 

--- a/src/devsynth/core/workflows.py
+++ b/src/devsynth/core/workflows.py
@@ -1,13 +1,14 @@
 """Wrapper functions and utilities for executing workflows."""
 
-from typing import Any, Dict, Optional, Union
-from pathlib import Path
 import json
+from pathlib import Path
+from typing import Any, Dict, Optional, Union
+
 import yaml
 
-from devsynth.interface.ux_bridge import UXBridge
-from devsynth.config import get_project_config, save_config
 from devsynth.agents.critique_agent import CritiqueAgent
+from devsynth.config import get_project_config, save_config
+from devsynth.interface.ux_bridge import UXBridge
 from devsynth.logging_setup import DevSynthLogger
 
 logger = DevSynthLogger(__name__)
@@ -18,6 +19,7 @@ def _get_workflow_manager():
     from devsynth.application.orchestration.workflow import workflow_manager
 
     return workflow_manager
+
 
 # Expose the singleton so it can be imported directly from this module.
 # Importing the application workflow may require optional dependencies, so we
@@ -112,7 +114,10 @@ def run_pipeline(
 
 
 def update_config(
-    key: Union[str, None] = None, value: Union[str, None] = None, *, list_models: bool = False
+    key: Union[str, None] = None,
+    value: Union[str, None] = None,
+    *,
+    list_models: bool = False,
 ) -> Dict[str, Any]:
     """View or set configuration options."""
     args = filter_args({"key": key, "value": value})
@@ -176,6 +181,7 @@ def gather_requirements(
     cfg.constraints = constraints
     if hasattr(cfg, "priority"):
         setattr(cfg, "priority", priority)
-    save_config(cfg, use_pyproject=(Path("pyproject.toml").exists()))
+    # Persist to .devsynth/project.yaml regardless of pyproject presence.
+    save_config(cfg, use_pyproject=False)
 
     bridge.display_result(f"[green]Requirements saved to {output_file}[/green]")

--- a/src/devsynth/logger.py
+++ b/src/devsynth/logger.py
@@ -36,6 +36,8 @@ class DevSynthLogger(_BaseDevSynthLogger):
     def _log(self, level: int, msg: str, *args, **kwargs) -> None:  # type: ignore[override]
         exc = kwargs.get("exc_info")
         if isinstance(exc, BaseException):
+            # Convert bare exception objects to the tuple form expected by the
+            # standard logging machinery so the traceback is preserved.
             kwargs["exc_info"] = (exc.__class__, exc, exc.__traceback__)
         super()._log(level, msg, *args, **kwargs)
 

--- a/tests/behavior/steps/test_requirements_gathering_steps.py
+++ b/tests/behavior/steps/test_requirements_gathering_steps.py
@@ -105,3 +105,9 @@ def check_file(tmp_project_dir):
     assert data.get("priority") == "high"
     assert data.get("goals") == ["Goal one", "Goal two"]
     assert data.get("constraints") == ["Constraint A", "Constraint B"]
+
+    cfg_path = os.path.join(tmp_project_dir, ".devsynth", "project.yaml")
+    cfg = yaml.safe_load(open(cfg_path))
+    assert cfg.get("priority") == "high"
+    assert cfg.get("goals") == "Goal one,Goal two"
+    assert cfg.get("constraints") == "Constraint A,Constraint B"

--- a/tests/integration/general/test_requirements_gathering.py
+++ b/tests/integration/general/test_requirements_gathering.py
@@ -91,3 +91,8 @@ def test_requirements_wizard_persists_priority_succeeds(tmp_path, monkeypatch):
     assert data["priority"] == "high"
     assert data["title"] == "My Title"
     assert data["description"] == "A description"
+
+    cfg_path = tmp_path / ".devsynth" / "project.yaml"
+    cfg = yaml.safe_load(open(cfg_path, encoding="utf-8"))
+    assert cfg.get("priority") == "high"
+    assert cfg.get("constraints") == "c1,c2"

--- a/tests/unit/general/test_logger.py
+++ b/tests/unit/general/test_logger.py
@@ -7,23 +7,26 @@ import logging
 from logging.handlers import RotatingFileHandler
 from pathlib import Path
 
+from _pytest.logging import LogCaptureHandler
+
 import devsynth.logger as ds_logger
 
 
 def test_configure_logging_creates_rotating_handler(tmp_path, monkeypatch):
     """configure_logging should set up a rotating file handler."""
     # Reload module to reset internal state
-    ds_logger = importlib.reload(ds_logger)
+    module = importlib.reload(ds_logger)
 
     # Run in temporary directory so test logs are isolated
     monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("DEVSYNTH_NO_FILE_LOGGING", "0")
 
     # Ensure root logger has no handlers
     root = logging.getLogger()
     for handler in list(root.handlers):
         root.removeHandler(handler)
 
-    ds_logger.configure_logging(log_level=logging.DEBUG, max_bytes=200, backup_count=1)
+    module.configure_logging(log_level=logging.DEBUG, max_bytes=200, backup_count=1)
 
     log_path = Path("logs") / "devsynth.log"
     assert log_path.exists(), "log file should be created"
@@ -31,3 +34,19 @@ def test_configure_logging_creates_rotating_handler(tmp_path, monkeypatch):
     handlers = [h for h in root.handlers if isinstance(h, RotatingFileHandler)]
     assert handlers, "rotating file handler not configured"
     assert root.level == logging.DEBUG
+
+
+def test_dev_synth_logger_normalizes_exc_info(monkeypatch):
+    """Bare exception instances should be converted into ``exc_info`` tuples."""
+    monkeypatch.setenv("DEVSYNTH_NO_FILE_LOGGING", "1")
+    ds_logger.configure_logging()
+    logger = ds_logger.get_logger(__name__)
+    handler = LogCaptureHandler()
+    logging.getLogger().addHandler(handler)
+    try:
+        raise RuntimeError("boom")
+    except RuntimeError as err:  # pragma: no cover - demonstration
+        logger.error("oops", exc_info=err)
+    logging.getLogger().removeHandler(handler)
+    record = handler.records[0]
+    assert record.exc_info and record.exc_info[0] is RuntimeError


### PR DESCRIPTION
## Summary
- normalize exc_info objects in DevSynthLogger
- persist requirement priority and constraints to .devsynth/project.yaml
- force gather flows to save requirements data in project config and verify via tests

## Testing
- `pre-commit run --files src/devsynth/logger.py src/devsynth/application/cli/requirements_wizard.py src/devsynth/application/requirements/interactions.py src/devsynth/core/workflows.py tests/integration/general/test_requirements_gathering.py tests/behavior/steps/test_requirements_gathering_steps.py tests/behavior/steps/test_interactive_requirements_steps.py tests/unit/general/test_logger.py`
- `PYTEST_ADDOPTS="--no-cov" poetry run pytest tests/unit/general/test_logger.py tests/integration/general/test_requirements_gathering.py tests/behavior/steps/test_requirements_gathering_steps.py tests/behavior/steps/test_interactive_requirements_steps.py`


------
https://chatgpt.com/codex/tasks/task_e_6897a09b6b7c8333861aeaf34b639de1