### PR TITLE
Remove constructor in LLM adapter test helper

### DIFF
--- a/tests/unit/adapters/llm/test_llm_adapter.py
+++ b/tests/unit/adapters/llm/test_llm_adapter.py
@@ -33,13 +33,13 @@ def test_llm_backend_adapter_init_succeeds(mock_factory):
 
     ReqID: N/A"""
 
-    # Create a custom adapter that doesn't use the global factory
-    class LLMBackendAdapterForTest(LLMBackendAdapter):
-        def __init__(self, custom_factory=None):
-            self.factory = custom_factory or mock_factory
+    # Create a helper adapter and override the factory after instantiation
+    class LLMBackendAdapterTestHelper(LLMBackendAdapter):
+        """Test helper for injecting a custom factory."""
 
     # Use our custom adapter instead of the original one
-    adapter = LLMBackendAdapterForTest()
+    adapter = LLMBackendAdapterTestHelper()
+    adapter.factory = mock_factory
     assert adapter.factory is mock_factory
     assert isinstance(adapter.factory, MagicMock)
     assert adapter.factory._spec_class == SimpleLLMProviderFactory


### PR DESCRIPTION
## Summary
- replace custom `__init__` by setting factory attribute on helper adapter in test
- ensure helper class no longer conflicts with pytest `Test*` conventions

## Testing
- `poetry run pre-commit run --files tests/unit/adapters/llm/test_llm_adapter.py`
- `poetry run pytest tests/unit/adapters/llm/test_llm_adapter.py --no-cov`
- `poetry run python tests/verify_test_organization.py`


------
https://chatgpt.com/codex/tasks/task_e_6897c0b4b2e483338f8c9ca1c77520b5