### PR TITLE
Document non-interactive ingestion and quick test marker

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,15 +27,15 @@ poetry run pre-commit run --files path/to/file1.py [path/to/file2.py ...]
 ### Tests
 
 ```bash
-poetry run pytest
+poetry run pytest -m "not memory_intensive"
 ```
 
-Running hooks and tests through `poetry run` ensures they execute inside the project's virtual environment and prevents missing-package errors. Always invoke the pre-commit hooks on the files you are about to commit using the `--files` option shown above.
+Use the `-m "not memory_intensive"` marker to skip memory-heavy tests during quick runs. Running hooks and tests through `poetry run` ensures they execute inside the project's virtual environment and prevents missing-package errors. Always invoke the pre-commit hooks on the files you are about to commit using the `--files` option shown above.
 All linting and test commands must be executed via `poetry run`; running them
 without the prefix may result in missing dependencies. If `poetry run pytest`
 reports missing packages, rerun `scripts/codex_setup.sh` or
 `poetry install --with dev --extras tests` to install the required
-dependencies.
+dependencies before running the full suite without the marker.
 
 ## Dependency Validation
 

--- a/docs/user_guides/cli_reference.md
+++ b/docs/user_guides/cli_reference.md
@@ -640,6 +640,32 @@ completion
 mvu
 ```
 
+### ingest
+
+Run the Expand, Differentiate, Refine, Retrospect pipeline for a project.
+
+```bash
+devsynth ingest [MANIFEST] [--non-interactive] [--yes] [--defaults] [--priority PRIORITY]
+```
+
+**Options:**
+
+- `MANIFEST` (optional): Path to the project manifest. Defaults to `.devsynth/project.yaml` or `DEVSYNTH_MANIFEST_PATH`.
+- `--non-interactive`: Run without prompts.
+- `--yes`, `--auto-confirm`: Automatically approve confirmations.
+- `--defaults`: Apply sensible defaults and skip prompts (implies `--non-interactive` and `--yes`).
+- `--priority`: Set project priority.
+
+**Examples:**
+
+```bash
+# Ingest using defaults and no prompts
+devsynth ingest --defaults
+
+# Non-interactive ingestion with explicit manifest and high priority
+devsynth ingest manifest.yaml --non-interactive --yes --priority high
+```
+
 ### completion
 
 Generate or install shell completion scripts for the DevSynth CLI.

--- a/docs/user_guides/ingestion.md
+++ b/docs/user_guides/ingestion.md
@@ -35,4 +35,6 @@ Setting `DEVSYNTH_INGEST_NONINTERACTIVE=1` enables non-interactive mode by defau
 
 ## Implementation Status
 
-.
+Non-interactive CLI ingestion is fully implemented. Use `--non-interactive` or
+`--defaults` to bypass prompts, or set `DEVSYNTH_INGEST_NONINTERACTIVE=1` to
+enable non-interactive mode by default.


### PR DESCRIPTION
## Summary
- note to run `poetry run pytest -m "not memory_intensive"` for quick checks
- document CLI ingestion's non-interactive mode
- add `ingest` command details to CLI reference

## Testing
- `poetry run pre-commit run --files AGENTS.md docs/user_guides/ingestion.md docs/user_guides/cli_reference.md`
- `poetry run pip check`
- `poetry run pip list | grep prometheus-client` *(no output)*
- `poetry run pytest -m "not memory_intensive"` *(fails: AttributeError...)*

------
https://chatgpt.com/codex/tasks/task_e_6897cf529ba88333b9c9dd8ad9f6b86e