### PR TITLE
Log peer review failures

### DIFF
--- a/src/devsynth/application/memory/sync_manager.py
+++ b/src/devsynth/application/memory/sync_manager.py
@@ -360,8 +360,8 @@ class SyncManager:
                 result[f"{target}_to_{source}"] = reverse
         try:
             self.memory_manager._notify_sync_hooks(None)
-        except Exception:
-            pass
+        except Exception as exc:
+            logger.warning("Peer review failed: %s", exc)
         return result
 
     def synchronize_core(self) -> Dict[str, int]:
@@ -413,8 +413,8 @@ class SyncManager:
         self.stats["synchronized"] += 1
         try:
             self.memory_manager._notify_sync_hooks(item)
-        except Exception:
-            pass
+        except Exception as exc:
+            logger.warning("Peer review failed: %s", exc)
         return True
 
     def queue_update(self, store: str, item: MemoryItem) -> None:
@@ -425,8 +425,8 @@ class SyncManager:
             self.schedule_flush()
         try:
             self.memory_manager._notify_sync_hooks(item)
-        except Exception:
-            pass
+        except Exception as exc:
+            logger.warning("Peer review failed: %s", exc)
 
     def flush_queue(self) -> None:
         """Propagate all queued updates."""
@@ -440,8 +440,8 @@ class SyncManager:
             self._queue = []
         try:
             self.memory_manager._notify_sync_hooks(None)
-        except Exception:
-            pass
+        except Exception as exc:
+            logger.warning("Peer review failed: %s", exc)
 
     async def flush_queue_async(self) -> None:
         """Asynchronously propagate queued updates."""
@@ -456,8 +456,8 @@ class SyncManager:
             self._queue = []
         try:
             self.memory_manager._notify_sync_hooks(None)
-        except Exception:
-            pass
+        except Exception as exc:
+            logger.warning("Peer review failed: %s", exc)
 
     def schedule_flush(self, delay: float = 0.1) -> None:
         async def _delayed():

--- a/src/devsynth/domain/models/wsde_utils.py
+++ b/src/devsynth/domain/models/wsde_utils.py
@@ -95,7 +95,8 @@ def request_peer_review(
     """Create and track a peer review cycle."""
     try:  # pragma: no cover - external dependency best effort
         from devsynth.application.collaboration.peer_review import PeerReview
-    except Exception:  # pragma: no cover - peer review unavailable
+    except Exception as exc:  # pragma: no cover - peer review unavailable
+        logger.warning("Peer review failed: %s", exc)
         return None
 
     review = PeerReview(


### PR DESCRIPTION
## Summary
- warn when peer review setup fails instead of silently passing
- warn if memory sync manager hook notifications raise
- test peer review warning path

## Testing
- `poetry run pip check`
- `poetry run pip list | grep prometheus`
- `SKIP=devsynth-align poetry run pre-commit run --files src/devsynth/application/memory/sync_manager.py src/devsynth/domain/models/wsde_utils.py tests/unit/domain/models/test_wsde_utils.py`
- `poetry run pytest tests/unit/domain/models/test_wsde_utils.py --no-cov`
- `poetry run python tests/verify_test_organization.py`


------
https://chatgpt.com/codex/tasks/task_e_6897cf161f80833393f54843e393dcfe