### PR TITLE
feat: add circuit breaker metrics and tests

### DIFF
--- a/tests/unit/fallback/test_circuit_breaker_metrics.py
+++ b/tests/unit/fallback/test_circuit_breaker_metrics.py
@@ -1,0 +1,29 @@
+from unittest.mock import Mock
+
+import pytest
+
+from devsynth import metrics
+from devsynth.exceptions import DevSynthError
+from devsynth.fallback import CircuitBreaker, retry_with_exponential_backoff
+
+
+@pytest.mark.medium
+def test_circuit_breaker_state_metrics() -> None:
+    """Circuit breaker state transitions are tracked in metrics module."""
+
+    metrics.reset_metrics()
+    breaker = CircuitBreaker(failure_threshold=1, recovery_timeout=60)
+
+    func = Mock(side_effect=Exception("boom"))
+    func.__name__ = "func"
+
+    wrapped = retry_with_exponential_backoff(
+        max_retries=1, initial_delay=0, jitter=False, circuit_breaker=breaker
+    )(func)
+
+    with pytest.raises(DevSynthError) as err:
+        wrapped()
+
+    assert err.value.error_code == "CIRCUIT_OPEN"
+    assert func.call_count == 1
+    assert metrics.get_circuit_breaker_state_metrics() == {"func:OPEN": 2}

--- a/tests/unit/fallback/test_condition_callbacks_prometheus.py
+++ b/tests/unit/fallback/test_condition_callbacks_prometheus.py
@@ -2,23 +2,12 @@ from unittest.mock import Mock
 
 import pytest
 
+from devsynth.application.memory import retry as memory_retry
 from devsynth.fallback import (
-    retry_with_exponential_backoff,
-    retry_event_counter,
     reset_prometheus_metrics,
+    retry_event_counter,
+    retry_with_exponential_backoff,
 )
-import importlib.util
-import pathlib
-import sys
-
-_memory_retry_path = pathlib.Path(__file__).resolve().parents[3] / "src/devsynth/application/memory/retry.py"
-spec = importlib.util.spec_from_file_location(
-    "memory_retry", _memory_retry_path
-)
-memory_retry = importlib.util.module_from_spec(spec)
-sys.modules["memory_retry"] = memory_retry
-assert spec.loader is not None
-spec.loader.exec_module(memory_retry)
 
 retry_with_backoff = memory_retry.retry_with_backoff
 memory_retry_event_counter = memory_retry.retry_event_counter
@@ -61,12 +50,8 @@ def test_prometheus_metrics_recorded():
     result = wrapped()
 
     assert result == "ok"
-    assert (
-        retry_event_counter.labels(status="attempt")._value.get() == 1
-    )
-    assert (
-        retry_event_counter.labels(status="success")._value.get() == 1
-    )
+    assert retry_event_counter.labels(status="attempt")._value.get() == 1
+    assert retry_event_counter.labels(status="success")._value.get() == 1
 
 
 @pytest.mark.medium
@@ -92,9 +77,5 @@ def test_memory_retry_metrics_and_callback():
 
     assert result == "ok"
     assert cb_called is True
-    assert (
-        memory_retry_event_counter.labels(status="attempt")._value.get() == 1
-    )
-    assert (
-        memory_retry_event_counter.labels(status="success")._value.get() == 1
-    )
+    assert memory_retry_event_counter.labels(status="attempt")._value.get() == 1
+    assert memory_retry_event_counter.labels(status="success")._value.get() == 1

--- a/tests/unit/fallback/test_retry_conditions.py
+++ b/tests/unit/fallback/test_retry_conditions.py
@@ -1,6 +1,7 @@
-import pytest
-from unittest.mock import Mock, patch
 import time
+from unittest.mock import Mock
+
+import pytest
 
 from devsynth.fallback import retry_with_exponential_backoff
 
@@ -137,8 +138,8 @@ def test_exponential_backoff(monkeypatch):
 @pytest.mark.medium
 def test_fallback_provider_order():
     from devsynth.adapters.provider_system import (
-        FallbackProvider,
         BaseProvider,
+        FallbackProvider,
         ProviderError,
     )
 

--- a/tests/unit/fallback/test_retry_counts.py
+++ b/tests/unit/fallback/test_retry_counts.py
@@ -1,12 +1,9 @@
-import pytest
 from unittest.mock import Mock
 
+import pytest
+
 from devsynth.fallback import retry_with_exponential_backoff
-from devsynth.metrics import (
-    get_retry_metrics,
-    get_retry_count_metrics,
-    reset_metrics,
-)
+from devsynth.metrics import get_retry_count_metrics, get_retry_metrics, reset_metrics
 
 
 class NetworkError(Exception):

--- a/tests/unit/fallback/test_retry_metrics.py
+++ b/tests/unit/fallback/test_retry_metrics.py
@@ -1,8 +1,9 @@
-import pytest
 from unittest.mock import Mock
 
+import pytest
+
 from devsynth.fallback import retry_with_exponential_backoff
-from devsynth.metrics import get_retry_metrics, reset_metrics, get_retry_error_metrics
+from devsynth.metrics import get_retry_error_metrics, get_retry_metrics, reset_metrics
 
 
 @pytest.mark.medium


### PR DESCRIPTION
## Summary
- expose circuit breaker state metrics in devsynth.metrics
- track circuit breaker transitions in fallback
- add regression tests for retry and circuit breaker metrics

## Testing
- `poetry run pip check`
- `poetry run pip list | grep prometheus-client`
- `poetry run pre-commit run --files src/devsynth/fallback.py src/devsynth/metrics.py tests/unit/fallback/test_condition_callbacks_prometheus.py tests/unit/fallback/test_retry_conditions.py tests/unit/fallback/test_retry_counts.py tests/unit/fallback/test_retry_metrics.py tests/unit/fallback/test_circuit_breaker_metrics.py`
- `poetry run python tests/verify_test_organization.py`
- `poetry run pytest tests/unit/fallback -m "not memory_intensive" --no-cov`


------
https://chatgpt.com/codex/tasks/task_e_6897dcba538483338b39ecff38fd8234