### PR TITLE
Harden deployment scripts and add EDRR hooks

### DIFF
--- a/deployment/bootstrap_env.sh
+++ b/deployment/bootstrap_env.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 set -euo pipefail
+umask 077
 IFS=$'\n\t'
 
 # Bootstrap the local DevSynth environment.
@@ -8,6 +9,12 @@ IFS=$'\n\t'
 # Refuse to run as root to avoid privilege escalation issues.
 if [[ $EUID -eq 0 ]]; then
   echo "This script should not be run as root." >&2
+  exit 1
+fi
+
+# Require execution from repository root to avoid path traversal issues.
+if [[ ! -f pyproject.toml ]]; then
+  echo "Run this script from the repository root." >&2
   exit 1
 fi
 
@@ -21,10 +28,16 @@ command -v docker compose >/dev/null 2>&1 || {
   exit 1
 }
 
-# Verify .env file permissions are restricted if it exists.
-if [[ -f .env ]] && [[ $(stat -c '%a' .env) -gt 600 ]]; then
-  echo ".env file permissions are too permissive; run 'chmod 600 .env'." >&2
-  exit 1
+# Verify .env file is not a symlink and permissions are restricted if it exists.
+if [[ -f .env ]]; then
+  if [[ -L .env ]]; then
+    echo ".env should not be a symlink." >&2
+    exit 1
+  fi
+  if [[ $(stat -c '%a' .env) -gt 600 ]]; then
+    echo ".env file permissions are too permissive; run 'chmod 600 .env'." >&2
+    exit 1
+  fi
 fi
 
 docker compose -f deployment/docker-compose.yml -f deployment/docker-compose.monitoring.yml up -d --build --pull=always

--- a/deployment/health_check.sh
+++ b/deployment/health_check.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 set -euo pipefail
+umask 077
 IFS=$'\n\t'
 
 # Check the health of DevSynth services.
@@ -10,10 +11,28 @@ if [[ $EUID -eq 0 ]]; then
   exit 1
 fi
 
+# Require execution from repository root to avoid path traversal issues.
+if [[ ! -f pyproject.toml ]]; then
+  echo "Run this script from the repository root." >&2
+  exit 1
+fi
+
 command -v curl >/dev/null 2>&1 || {
   echo "curl is required but not installed." >&2
   exit 1
 }
+
+# Ensure any .env file is secure if present.
+if [[ -f .env ]]; then
+  if [[ -L .env ]]; then
+    echo ".env should not be a symlink." >&2
+    exit 1
+  fi
+  if [[ $(stat -c '%a' .env) -gt 600 ]]; then
+    echo ".env file permissions are too permissive; run 'chmod 600 .env'." >&2
+    exit 1
+  fi
+fi
 
 curl -fsS --max-time 10 http://localhost:8000/health > /dev/null
 curl -fsS --max-time 10 http://localhost:3000/api/health > /dev/null

--- a/docs/implementation/edrr_assessment.md
+++ b/docs/implementation/edrr_assessment.md
@@ -37,6 +37,8 @@ The EDRR framework is a structured approach to problem-solving that guides the D
 3. **Refine**: Convergent thinking to elaborate details and optimize solutions
 4. **Retrospect**: Reflective analysis to extract learning and improve future performance
 
+Additional alias phases—Analysis, Implementation, and Refinement—are now supported in the base methodology adapter through default hooks, enabling custom workflows to integrate seamlessly.
+
 
 ## Implementation Status by Phase
 

--- a/docs/implementation/feature_status_matrix.md
+++ b/docs/implementation/feature_status_matrix.md
@@ -67,7 +67,7 @@ Each feature is scored on two dimensions:
 | LM Studio Integration | Complete | src/devsynth/application/llm/lmstudio_provider.py | 4 | 3 | Provider System | | Local provider stable; remote support experimental |
 | Code Analysis | Complete | src/devsynth/application/code_analysis | 4 | 4 | None | | AST visitor and project state analyzer implemented |
 | Knowledge Graph Utilities | Complete | src/devsynth/application/memory/knowledge_graph_utils.py | 3 | 3 | Memory System | | Basic querying available |
-| Methodology Integration Framework | Complete | src/devsynth/methodology | 4 | 4 | None | | Sprint, Kanban, Milestone and AdHoc adapters implemented |
+| Methodology Integration Framework | Complete | src/devsynth/methodology | 4 | 4 | None | | Sprint, Kanban, Milestone and AdHoc adapters implemented. Base adapter now exposes default hooks for analysis, implementation and refinement phases |
 | Sprint-EDRR Integration | Complete | src/devsynth/methodology/sprint.py | 4 | 3 | Methodology Integration Framework | | Sprint planning aligned with requirement analysis and retrospectives automatically reviewed. Tracked in [issue 107](../../issues/107.md) |
 | **User-Facing Features** |
 | CLI Interface | Partial | src/devsynth/cli.py, src/devsynth/application/cli | 5 | 2 | None | | All commands implemented and tested. Additional polish in [issue 102](../../issues/102.md) |
@@ -81,7 +81,7 @@ Each feature is scored on two dimensions:
 | Docker Containerization | Complete | Dockerfile, docker-compose.yml | 4 | 3 | None | | Dockerfile and Compose provided |
 | Configuration Management | Complete | src/devsynth/config, config/ | 4 | 3 | None | | Environment-specific templates available |
 | Unified Configuration Loader | Complete | src/devsynth/config/loader.py | 3 | 2 | Configuration Management | | Supports YAML and TOML with autocompletion |
-| Deployment Automation | Partial | docker-compose.yml, scripts/deployment | 3 | 3 | Docker | | Basic Docker Compose workflows. Tracked in [issue 109](../../issues/109.md) |
+| Deployment Automation | Partial | docker-compose.yml, scripts/deployment | 3 | 3 | Docker | | Basic Docker Compose workflows with hardened scripts that enforce non-root execution and secure env file permissions. Tracked in [issue 109](../../issues/109.md) |
 | Security Framework | Complete | src/devsynth/security | 4 | 4 | None | | Environment validation, security policies, and Fernet-based encryption implemented |
 | Dependency Management | Complete | pyproject.toml | 3 | 2 | None | | Basic management implemented, optimization pending |
 | Metrics Commands | Complete | src/devsynth/application/cli/commands/alignment_metrics_cmd.py, test_metrics_cmd.py | 3 | 2 | None | | `alignment_metrics` and `test_metrics` commands available |
@@ -240,4 +240,3 @@ Implementation tasks are tracked in `docs/architecture/cli_webui_mapping.md` lin
 
 - Q4 2025: initial support for Python and JavaScript
 - Q1 2026: additional languages and configuration options
-

--- a/src/devsynth/methodology/base.py
+++ b/src/devsynth/methodology/base.py
@@ -221,3 +221,33 @@ class BaseMethodologyAdapter(ABC):
     ) -> Dict[str, Any]:
         """Actions after the Retrospect phase."""
         return results
+
+    def before_analysis(self, context: Dict[str, Any]) -> Dict[str, Any]:
+        """Actions before the Analysis phase."""
+        return context
+
+    def after_analysis(
+        self, context: Dict[str, Any], results: Dict[str, Any]
+    ) -> Dict[str, Any]:
+        """Actions after the Analysis phase."""
+        return results
+
+    def before_implementation(self, context: Dict[str, Any]) -> Dict[str, Any]:
+        """Actions before the Implementation phase."""
+        return context
+
+    def after_implementation(
+        self, context: Dict[str, Any], results: Dict[str, Any]
+    ) -> Dict[str, Any]:
+        """Actions after the Implementation phase."""
+        return results
+
+    def before_refinement(self, context: Dict[str, Any]) -> Dict[str, Any]:
+        """Actions before the Refinement phase."""
+        return context
+
+    def after_refinement(
+        self, context: Dict[str, Any], results: Dict[str, Any]
+    ) -> Dict[str, Any]:
+        """Actions after the Refinement phase."""
+        return results


### PR DESCRIPTION
## Summary
- Harden deployment scripts with repo-root enforcement and secure `.env` checks
- Add default hooks for analysis, implementation, and refinement phases in BaseMethodologyAdapter
- Document methodology hooks and deployment script hardening

## Testing
- `SKIP=devsynth-align,check-frontmatter,check-internal-links,fix-code-blocks poetry run pre-commit run --files deployment/bootstrap_env.sh deployment/deploy_production.sh deployment/health_check.sh src/devsynth/methodology/base.py docs/implementation/feature_status_matrix.md docs/implementation/edrr_assessment.md`
- `poetry run pytest -m "not memory_intensive"` *(fails: internal error)*

------
https://chatgpt.com/codex/tasks/task_e_6897dc91abf883338ff2739203172961