### PR TITLE
Expose reasoning loop and improve consensus logging

### DIFF
--- a/src/devsynth/logger.py
+++ b/src/devsynth/logger.py
@@ -123,16 +123,25 @@ def setup_logging(name: str, log_level: int | str | None = None) -> DevSynthLogg
 
 
 def log_consensus_failure(
-    logger: DevSynthLogger, error: Exception, extra: Dict[str, Any] | None = None
+    logger: DevSynthLogger,
+    error: Exception,
+    extra: Dict[str, Any] | None = None,
 ) -> None:
     """Log a consensus failure using ``logger``.
+
+    The log record captures both the string representation of ``error`` and its
+    class name under ``error_type`` so downstream consumers can easily
+    differentiate failure categories.
 
     Args:
         logger: Logger instance to emit the log.
         error: The exception that triggered the failure.
         extra: Optional additional context for the log record.
     """
-    data: Dict[str, Any] = {"error": str(error)}
+    data: Dict[str, Any] = {
+        "error": str(error),
+        "error_type": error.__class__.__name__,
+    }
     if extra:
         data.update(extra)
     # Include the original exception so that stack traces are preserved.

--- a/src/devsynth/methodology/__init__.py
+++ b/src/devsynth/methodology/__init__.py
@@ -1,11 +1,13 @@
 from .adhoc import AdHocAdapter
-from .sprint import SprintAdapter
+from .dialectical_reasoning import reasoning_loop
 from .kanban import KanbanAdapter
 from .milestone import MilestoneAdapter
+from .sprint import SprintAdapter
 
 __all__ = [
     "AdHocAdapter",
     "SprintAdapter",
     "KanbanAdapter",
     "MilestoneAdapter",
+    "reasoning_loop",
 ]

--- a/tests/unit/methodology/test_dialectical_reasoning_loop.py
+++ b/tests/unit/methodology/test_dialectical_reasoning_loop.py
@@ -41,3 +41,24 @@ def test_reasoning_loop_logs_consensus_failure(monkeypatch, caplog):
     with caplog.at_level(logging.ERROR):
         assert reasoning_loop(MagicMock(), {"solution": "initial"}, MagicMock()) == []
     assert "Consensus failure" in caplog.text
+    # ``log_consensus_failure`` should include the error type in the log record.
+    assert caplog.records[0].error_type == "DummyConsensusError"
+
+
+def test_reasoning_loop_respects_max_iterations(monkeypatch):
+    calls = []
+
+    def fake_apply(team, task, critic, memory):
+        calls.append(1)
+        return {"status": "in_progress"}
+
+    monkeypatch.setattr(
+        "devsynth.methodology.dialectical_reasoning._apply_dialectical_reasoning",
+        fake_apply,
+    )
+
+    results = reasoning_loop(
+        MagicMock(), {"solution": "initial"}, MagicMock(), max_iterations=2
+    )
+    assert len(results) == 2
+    assert len(calls) == 2


### PR DESCRIPTION
## Summary
- expose `reasoning_loop` at the methodology package level
- enrich consensus failure logging with error type metadata
- extend dialectical reasoning loop tests for error type logging and iteration limits

## Testing
- `SKIP=fix-code-blocks poetry run pre-commit run --files src/devsynth/logger.py src/devsynth/methodology/__init__.py tests/unit/methodology/test_dialectical_reasoning_loop.py`
- `poetry run python tests/verify_test_organization.py`
- `poetry run pytest -m "not memory_intensive"` *(fails: KeyError <WorkerController gw0>; 822 failed, 1989 passed, 84 skipped, 144 errors)*
- `poetry run pytest tests/unit/methodology/test_dialectical_reasoning_loop.py -m "not memory_intensive" -n 0 --cov-fail-under=0`

------
https://chatgpt.com/codex/tasks/task_e_6897e30f714c83338a4d23de4f73fd3e