### PR TITLE
Align sprint planning and automate EDRR retrospectives

### DIFF
--- a/docs/implementation/edrr_assessment.md
+++ b/docs/implementation/edrr_assessment.md
@@ -97,6 +97,13 @@ Additional alias phases—Analysis, Implementation, and Refinement—are now sup
 
 **Overall Integration Completeness**: 90%
 
+### Recent Integration Updates
+
+- Sprint planning helpers are now centralized in
+  `devsynth.application.sprint.planning`.
+- Retrospective reviews can be automated through
+  `devsynth.methodology.edrr_coordinator.EDRRCoordinator`.
+
 ## Current Status
 
 The EDRR framework is now feature complete. Phase transition logic, context

--- a/docs/technical_reference/sprint_edrr_integration.md
+++ b/docs/technical_reference/sprint_edrr_integration.md
@@ -117,8 +117,8 @@ The Retrospect phase naturally aligns with sprint retrospectives:
 DevSynth's `SprintAdapter` now automatically converts requirement
 analysis outputs from the Expand phase into a structured sprint plan and
 summarizes Retrospect phase results for sprint metrics. These mappings are
-implemented in `devsynth.application.edrr.sprint_planning` and
-`devsynth.application.edrr.sprint_retrospective`.
+implemented in `devsynth.application.sprint.planning` and
+`devsynth.application.sprint.retrospective`.
 
 
 ## 3. Time-Boxing EDRR Cycles

--- a/src/devsynth/agents/wsde_team_coordinator.py
+++ b/src/devsynth/agents/wsde_team_coordinator.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import Any, Dict, List
 
-from devsynth.application.edrr.sprint_retrospective import map_retrospective_to_summary
+from devsynth.application.sprint.retrospective import map_retrospective_to_summary
 from devsynth.logging_setup import DevSynthLogger
 
 logger = DevSynthLogger(__name__)

--- a/src/devsynth/application/cli/sprint_cmd.py
+++ b/src/devsynth/application/cli/sprint_cmd.py
@@ -6,8 +6,8 @@ import json
 from pathlib import Path
 from typing import Any, Dict, Optional
 
-from devsynth.application.edrr.sprint_planning import map_requirements_to_plan
-from devsynth.application.edrr.sprint_retrospective import map_retrospective_to_summary
+from devsynth.application.sprint.planning import map_requirements_to_plan
+from devsynth.application.sprint.retrospective import map_retrospective_to_summary
 from devsynth.logging_setup import DevSynthLogger
 
 logger = DevSynthLogger(__name__)

--- a/src/devsynth/application/edrr/sprint_planning.py
+++ b/src/devsynth/application/edrr/sprint_planning.py
@@ -1,33 +1,12 @@
-"""Sprint planning adapter for EDRR integration.
+"""Backward-compatible sprint planning utilities.
 
-This module provides helpers that translate requirement analysis results
-from the Expand phase into a structured sprint plan. The sprint adapter
-uses this mapping to align upcoming work with documented requirements.
+This module re-exports sprint planning helpers from
+:mod:`devsynth.application.sprint.planning`.
 """
 
-from __future__ import annotations
+from devsynth.application.sprint.planning import (
+    SPRINT_PLANNING_PHASE,
+    map_requirements_to_plan,
+)
 
-from typing import Any, Dict
-
-# EDRR phase associated with sprint planning. Stored as a string to avoid
-# circular import issues with the methodology package.
-SPRINT_PLANNING_PHASE = "expand"
-
-
-def map_requirements_to_plan(requirement_results: Dict[str, Any]) -> Dict[str, Any]:
-    """Return sprint planning information derived from requirement analysis.
-
-    Args:
-        requirement_results: Results produced by the Expand phase's
-            requirements analysis step.
-
-    Returns:
-        Dictionary containing planned scope, objectives and success criteria
-        for the next sprint.
-    """
-
-    return {
-        "planned_scope": requirement_results.get("recommended_scope", []),
-        "objectives": requirement_results.get("objectives", []),
-        "success_criteria": requirement_results.get("success_criteria", []),
-    }
+__all__ = ["SPRINT_PLANNING_PHASE", "map_requirements_to_plan"]

--- a/src/devsynth/application/edrr/sprint_retrospective.py
+++ b/src/devsynth/application/edrr/sprint_retrospective.py
@@ -1,39 +1,12 @@
-"""Sprint retrospective adapter for EDRR integration.
+"""Backward-compatible sprint retrospective utilities.
 
-Utilities in this module convert raw retrospective results from the
-Retrospect phase into summaries suitable for sprint metrics.
+This module re-exports helpers from
+:mod:`devsynth.application.sprint.retrospective`.
 """
 
-from __future__ import annotations
+from devsynth.application.sprint.retrospective import (
+    SPRINT_RETROSPECTIVE_PHASE,
+    map_retrospective_to_summary,
+)
 
-from typing import Any, Dict
-
-# EDRR phase associated with sprint retrospectives, stored as a string to
-# keep imports lightweight.
-SPRINT_RETROSPECTIVE_PHASE = "retrospect"
-
-
-def map_retrospective_to_summary(
-    retrospective: Dict[str, Any], sprint: int
-) -> Dict[str, Any]:
-    """Return summarized retrospective information.
-
-    Args:
-        retrospective: Results produced by the Retrospect phase.
-        sprint: Current sprint number.
-
-    Returns:
-        Summary dictionary containing positives, improvements and action
-        items. If no retrospective data is provided an empty dict is
-        returned.
-    """
-
-    if not retrospective:
-        return {}
-
-    return {
-        "positives": retrospective.get("positives", []),
-        "improvements": retrospective.get("improvements", []),
-        "action_items": retrospective.get("action_items", []),
-        "sprint": sprint,
-    }
+__all__ = ["SPRINT_RETROSPECTIVE_PHASE", "map_retrospective_to_summary"]

--- a/src/devsynth/application/sprint/__init__.py
+++ b/src/devsynth/application/sprint/__init__.py
@@ -1,0 +1,1 @@
+"""Sprint integration helpers for DevSynth."""

--- a/src/devsynth/application/sprint/planning.py
+++ b/src/devsynth/application/sprint/planning.py
@@ -1,0 +1,33 @@
+"""Sprint planning adapter for EDRR integration.
+
+This module provides helpers that translate requirement analysis results
+from the Expand phase into a structured sprint plan. The sprint adapter
+uses this mapping to align upcoming work with documented requirements.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict
+
+# EDRR phase associated with sprint planning. Stored as a string to avoid
+# circular import issues with the methodology package.
+SPRINT_PLANNING_PHASE = "expand"
+
+
+def map_requirements_to_plan(requirement_results: Dict[str, Any]) -> Dict[str, Any]:
+    """Return sprint planning information derived from requirement analysis.
+
+    Args:
+        requirement_results: Results produced by the Expand phase's
+            requirements analysis step.
+
+    Returns:
+        Dictionary containing planned scope, objectives and success criteria
+        for the next sprint.
+    """
+
+    return {
+        "planned_scope": requirement_results.get("recommended_scope", []),
+        "objectives": requirement_results.get("objectives", []),
+        "success_criteria": requirement_results.get("success_criteria", []),
+    }

--- a/src/devsynth/application/sprint/retrospective.py
+++ b/src/devsynth/application/sprint/retrospective.py
@@ -1,0 +1,39 @@
+"""Sprint retrospective adapter for EDRR integration.
+
+Utilities in this module convert raw retrospective results from the
+Retrospect phase into summaries suitable for sprint metrics.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict
+
+# EDRR phase associated with sprint retrospectives, stored as a string to
+# keep imports lightweight.
+SPRINT_RETROSPECTIVE_PHASE = "retrospect"
+
+
+def map_retrospective_to_summary(
+    retrospective: Dict[str, Any], sprint: int
+) -> Dict[str, Any]:
+    """Return summarized retrospective information.
+
+    Args:
+        retrospective: Results produced by the Retrospect phase.
+        sprint: Current sprint number.
+
+    Returns:
+        Summary dictionary containing positives, improvements and action
+        items. If no retrospective data is provided an empty dict is
+        returned.
+    """
+
+    if not retrospective:
+        return {}
+
+    return {
+        "positives": retrospective.get("positives", []),
+        "improvements": retrospective.get("improvements", []),
+        "action_items": retrospective.get("action_items", []),
+        "sprint": sprint,
+    }

--- a/src/devsynth/methodology/edrr_coordinator.py
+++ b/src/devsynth/methodology/edrr_coordinator.py
@@ -1,0 +1,30 @@
+"""Methodology utilities for EDRR coordination.
+
+This module provides lightweight helpers to automate retrospective reviews
+using sprint integration helpers.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict
+
+from devsynth.application.sprint.retrospective import map_retrospective_to_summary
+
+
+class EDRRCoordinator:
+    """Coordinate simple EDRR routines for methodology adapters."""
+
+    def automate_retrospective_review(
+        self, retrospective: Dict[str, Any], sprint: int
+    ) -> Dict[str, Any]:
+        """Return a standardized retrospective summary.
+
+        Args:
+            retrospective: Raw results from the Retrospect phase.
+            sprint: Current sprint number.
+
+        Returns:
+            Dictionary summarizing positives, improvements and action items.
+        """
+
+        return map_retrospective_to_summary(retrospective, sprint)

--- a/src/devsynth/methodology/sprint.py
+++ b/src/devsynth/methodology/sprint.py
@@ -8,8 +8,8 @@ import datetime
 import time
 from typing import Any, Dict, List, Optional
 
-from devsynth.application.edrr.sprint_planning import map_requirements_to_plan
-from devsynth.application.edrr.sprint_retrospective import map_retrospective_to_summary
+from devsynth.application.sprint.planning import map_requirements_to_plan
+from devsynth.application.sprint.retrospective import map_retrospective_to_summary
 from devsynth.logging_setup import DevSynthLogger
 from devsynth.methodology.base import BaseMethodologyAdapter, Phase
 from devsynth.methodology.sprint_adapter import map_ceremony_to_phase

--- a/tests/integration/general/test_sprint_edrr_integration.py
+++ b/tests/integration/general/test_sprint_edrr_integration.py
@@ -1,7 +1,7 @@
 import pytest
 
-from devsynth.application.edrr.sprint_planning import SPRINT_PLANNING_PHASE
-from devsynth.application.edrr.sprint_retrospective import SPRINT_RETROSPECTIVE_PHASE
+from devsynth.application.sprint.planning import SPRINT_PLANNING_PHASE
+from devsynth.application.sprint.retrospective import SPRINT_RETROSPECTIVE_PHASE
 from devsynth.methodology.base import Phase
 from devsynth.methodology.sprint import SprintAdapter
 

--- a/tests/unit/application/sprint/__init__.py
+++ b/tests/unit/application/sprint/__init__.py
@@ -1,0 +1,1 @@
+"""Unit tests for sprint application helpers."""

--- a/tests/unit/application/sprint/test_planning.py
+++ b/tests/unit/application/sprint/test_planning.py
@@ -1,0 +1,18 @@
+"""Tests for sprint planning helpers."""
+
+from devsynth.application.sprint.planning import map_requirements_to_plan
+
+
+def test_map_requirements_to_plan_extracts_fields() -> None:
+    """It maps requirement analysis results to a plan structure."""
+    requirements = {
+        "recommended_scope": ["feat"],
+        "objectives": ["goal"],
+        "success_criteria": ["metric"],
+    }
+    expected = {
+        "planned_scope": ["feat"],
+        "objectives": ["goal"],
+        "success_criteria": ["metric"],
+    }
+    assert map_requirements_to_plan(requirements) == expected

--- a/tests/unit/methodology/test_edrr_coordinator.py
+++ b/tests/unit/methodology/test_edrr_coordinator.py
@@ -1,0 +1,16 @@
+"""Tests for the methodology EDRR coordinator."""
+
+from devsynth.methodology.edrr_coordinator import EDRRCoordinator
+
+
+def test_automate_retrospective_review_summarizes_results() -> None:
+    """It returns a summary with sprint number and categories."""
+    coordinator = EDRRCoordinator()
+    raw = {
+        "positives": ["good"],
+        "improvements": ["better"],
+        "action_items": ["do"],
+    }
+    summary = coordinator.automate_retrospective_review(raw, 2)
+    assert summary["positives"] == ["good"]
+    assert summary["sprint"] == 2


### PR DESCRIPTION
## Summary
- Centralize sprint planning and retrospective helpers under `devsynth.application.sprint`
- Introduce `EDRRCoordinator` to automate retrospective review summaries
- Document sprint integration updates in EDRR assessment

## Testing
- `poetry run pre-commit run --files docs/implementation/edrr_assessment.md docs/technical_reference/sprint_edrr_integration.md src/devsynth/agents/wsde_team_coordinator.py src/devsynth/application/cli/sprint_cmd.py src/devsynth/application/edrr/sprint_planning.py src/devsynth/application/edrr/sprint_retrospective.py src/devsynth/methodology/sprint.py src/devsynth/application/sprint/__init__.py src/devsynth/application/sprint/planning.py src/devsynth/application/sprint/retrospective.py src/devsynth/methodology/edrr_coordinator.py tests/integration/general/test_sprint_edrr_integration.py tests/unit/application/sprint/__init__.py tests/unit/application/sprint/test_planning.py tests/unit/methodology/test_edrr_coordinator.py`
- `poetry run pip check`
- `poetry run pip list | grep -i prometheus`
- `poetry run pytest -m "not memory_intensive"` *(fails: TypeError: AgentConfig... etc)*
- `poetry run python tests/verify_test_organization.py`

------
https://chatgpt.com/codex/tasks/task_e_6897e31e44788333a20cf2312b38474d