### PR TITLE
Add kuzu embedded setting and ephemeral adapter

### DIFF
--- a/src/devsynth/config/settings.py
+++ b/src/devsynth/config/settings.py
@@ -183,12 +183,13 @@ class Settings(BaseSettings):
     kuzu_db_path: Optional[str] = Field(
         default=None, json_schema_extra={"env": "DEVSYNTH_KUZU_DB_PATH"}
     )
-    # Enable or disable the embedded KuzuDB backend.  When set to ``False`` the
-    # system always falls back to the lightweight in-memory implementation.  The
-    # value can be overridden via the ``DEVSYNTH_KUZU_EMBEDDED`` environment
-    # variable.
+    # Enable or disable the embedded KuzuDB backend. When ``False`` the system
+    # falls back to a lightweight in-memory implementation. The value can be
+    # overridden via the ``DEVSYNTH_KUZU_EMBEDDED`` environment variable.
     kuzu_embedded: bool = Field(
-        default=True, json_schema_extra={"env": "DEVSYNTH_KUZU_EMBEDDED"}
+        default=True,
+        description="Use embedded KuzuDB backend instead of in-memory fallback",
+        json_schema_extra={"env": "DEVSYNTH_KUZU_EMBEDDED"},
     )
     max_context_size: int = Field(
         default=1000, json_schema_extra={"env": "DEVSYNTH_MAX_CONTEXT_SIZE"}


### PR DESCRIPTION
## Summary
- document `kuzu_embedded` configuration option for toggling embedded Kuzu backend
- support ephemeral KuzuAdapter instances with temp directories and cleanup helpers

## Testing
- `poetry run pre-commit run --files src/devsynth/adapters/memory/kuzu_adapter.py src/devsynth/config/settings.py`
- `poetry run pip check`
- `poetry run pip list | grep prometheus-client`
- `poetry run pytest tests/integration/general/test_kuzu_memory_integration.py -m "not memory_intensive" --no-cov`


------
https://chatgpt.com/codex/tasks/task_e_6897edb27734833382394791e7cdc5c4