### PR TITLE
Mark memory adapter tests as slow

### DIFF
--- a/tests/unit/adapters/memory/test_memory_adapter.py
+++ b/tests/unit/adapters/memory/test_memory_adapter.py
@@ -96,6 +96,7 @@ class TestMemorySystemAdapter:
         assert adapter.vector_store is None
 
     @pytest.mark.medium
+    @pytest.mark.slow
     def test_init_with_tinydb_storage_succeeds(self, temp_dir):
         """Test initialization with TinyDB storage.
 
@@ -115,6 +116,7 @@ class TestMemorySystemAdapter:
         assert adapter.vector_store is None
 
     @pytest.mark.medium
+    @pytest.mark.slow
     def test_init_with_duckdb_storage_succeeds(self, temp_dir, monkeypatch):
         """Test initialization with DuckDB storage.
 
@@ -151,6 +153,7 @@ class TestMemorySystemAdapter:
             assert adapter.vector_store is adapter.memory_store
 
     @pytest.mark.medium
+    @pytest.mark.slow
     @pytest.mark.requires_resource("lmdb")
     def test_init_with_lmdb_storage_succeeds(self, temp_dir):
         """Test initialization with LMDB storage.


### PR DESCRIPTION
## Summary
- add `slow` markers to heavy memory adapter initialization tests

## Testing
- `poetry run pytest -m "not memory_intensive" --no-cov --maxfail=1` *(fails: No module named 'chromadb')*
- `poetry run pytest tests/unit/adapters/memory/test_memory_adapter.py --no-cov --maxfail=1 -vv`


------
https://chatgpt.com/codex/tasks/task_e_6897f82547a4833386832821051912d1