### PR TITLE
Persist requirement priority and test logger exc_info

### DIFF
--- a/src/devsynth/application/cli/requirements_commands.py
+++ b/src/devsynth/application/cli/requirements_commands.py
@@ -29,6 +29,7 @@ from devsynth.application.requirements.dialectical_reasoner import (
     DialecticalReasonerService,
 )
 from devsynth.application.requirements.requirement_service import RequirementService
+from devsynth.config import get_project_config, save_config
 from devsynth.config.settings import ensure_path_exists
 from devsynth.domain.models.requirement import (
     ChangeType,
@@ -921,6 +922,11 @@ def wizard_cmd(
     output_path = Path(out_dir) / path.name
     with open(output_path, "w", encoding="utf-8") as f:
         json.dump(result, f, indent=2)
+
+    cfg = get_project_config(Path("."))
+    cfg.priority = responses.get("priority", RequirementPriority.MEDIUM.value)
+    cfg.constraints = responses.get("constraints", "")
+    save_config(cfg, use_pyproject=False)
 
     bridge.display_result(f"[green]Requirements saved to {output_path}[/green]")
 


### PR DESCRIPTION
## Summary
- ensure requirements wizard command saves priority and constraints to project config
- regression test confirms gather command logs exceptions with tuple-based `exc_info`

## Testing
- `poetry run pre-commit run --files tests/unit/application/cli/test_requirements_gathering.py src/devsynth/application/cli/requirements_commands.py`
- `poetry run python tests/verify_test_organization.py`
- `poetry run pytest -m "not memory_intensive" -o addopts="" tests/unit/application/cli/test_requirements_gathering.py tests/unit/application/cli/test_requirements_commands.py tests/integration/general/test_requirements_gathering.py`

------
https://chatgpt.com/codex/tasks/task_e_689807acb3408333b02d3d8a212c30d0