### PR TITLE
feat(config): add kuzu embedded default

### DIFF
--- a/src/devsynth/config/loader.py
+++ b/src/devsynth/config/loader.py
@@ -3,17 +3,17 @@ from __future__ import annotations
 """Unified configuration loader for DevSynth projects."""
 
 import os
+from dataclasses import field
 from pathlib import Path
-from typing import Optional, Dict, Any
+from typing import Any, Dict, Optional
+
+import toml
+import yaml
+from pydantic.dataclasses import dataclass
 
 from devsynth import __version__ as project_version
-from devsynth.logging_setup import DevSynthLogger
 from devsynth.exceptions import ConfigurationError
-
-import yaml
-import toml
-from pydantic.dataclasses import dataclass
-from dataclasses import field
+from devsynth.logging_setup import DevSynthLogger
 
 
 @dataclass
@@ -54,6 +54,7 @@ class ConfigModel:
         }
     )
     memory_store_type: str = "memory"
+    kuzu_embedded: bool = True
     offline_mode: bool = False
     resources: Dict[str, Any] | None = None
     edrr_settings: Dict[str, Any] = field(
@@ -102,6 +103,7 @@ class ConfigModel:
             "directories": self.directories,
             "features": self.features,
             "memory_store_type": self.memory_store_type,
+            "kuzu_embedded": self.kuzu_embedded,
             "offline_mode": self.offline_mode,
             "resources": self.resources or {},
             "edrr_settings": self.edrr_settings,

--- a/src/devsynth/config/settings.py
+++ b/src/devsynth/config/settings.py
@@ -19,6 +19,9 @@ from devsynth.exceptions import ConfigurationError, DevSynthError
 
 from .loader import load_config
 
+# Default settings
+DEFAULT_KUZU_EMBEDDED = True
+
 
 def _parse_bool_env(value: Any, field: str) -> bool:
     """Parse a boolean environment variable securely."""
@@ -187,7 +190,7 @@ class Settings(BaseSettings):
     # falls back to a lightweight in-memory implementation. The value can be
     # overridden via the ``DEVSYNTH_KUZU_EMBEDDED`` environment variable.
     kuzu_embedded: bool = Field(
-        default=True,
+        default=DEFAULT_KUZU_EMBEDDED,
         description="Use embedded KuzuDB backend instead of in-memory fallback",
         json_schema_extra={"env": "DEVSYNTH_KUZU_EMBEDDED"},
     )

--- a/src/devsynth/config/unified_loader.py
+++ b/src/devsynth/config/unified_loader.py
@@ -1,12 +1,12 @@
 from __future__ import annotations
 
-from pathlib import Path
 from dataclasses import dataclass
+from pathlib import Path
 from typing import Optional
 
 import toml
 
-from .loader import ConfigModel, load_config, save_config, _find_config_path
+from .loader import ConfigModel, _find_config_path, load_config, save_config
 
 
 @dataclass
@@ -36,6 +36,10 @@ class UnifiedConfig:
 
     def set_goals(self, goals: str) -> None:
         self.config.goals = goals
+
+    def set_kuzu_embedded(self, embedded: bool) -> None:
+        """Enable or disable the embedded Kuzu backend."""
+        self.config.kuzu_embedded = embedded
 
     def save(self) -> Path:
         return save_config(

--- a/tests/integration/general/test_kuzu_memory_integration.py
+++ b/tests/integration/general/test_kuzu_memory_integration.py
@@ -1,6 +1,7 @@
 import os
 import sys
 import types
+from pathlib import Path
 from unittest.mock import patch
 
 import pytest
@@ -113,6 +114,18 @@ def test_ephemeral_store_cleanup(no_kuzu):
     assert store._store._use_fallback
     store.cleanup()
     assert not os.path.exists(path)
+
+
+def test_configured_path_usage(fake_kuzu):
+    """Store initialises at configured path when provided."""
+    project_dir = Path(os.environ["DEVSYNTH_PROJECT_DIR"])
+    config_path = project_dir / "configured"
+    config_path.mkdir()
+    store = KuzuMemoryStore(str(config_path))
+    try:
+        assert store.persist_directory == str(config_path)
+    finally:
+        store.cleanup()
 
 
 def test_provider_fallback_on_empty_embedding(tmp_path, no_kuzu):


### PR DESCRIPTION
## Summary
- default to embedded KuzuDB backend in settings
- surface `kuzu_embedded` through UnifiedConfigLoader and config model
- cover Kuzu store ephemeral and configured paths in integration tests

## Testing
- `poetry run pre-commit run --files src/devsynth/config/settings.py src/devsynth/config/loader.py src/devsynth/config/unified_loader.py tests/integration/general/test_kuzu_memory_integration.py`
- `poetry run pytest --no-cov -n 0 tests/integration/general/test_kuzu_memory_integration.py tests/unit/config/test_unified_loader.py tests/unit/core/test_config_loader.py`

------
https://chatgpt.com/codex/tasks/task_e_6898079f86b8833390ccd3807ef12909