### PR TITLE
docs: add non-interactive ingestion and coverage badge guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,6 +37,26 @@ reports missing packages, rerun `scripts/codex_setup.sh` or
 `poetry install --with dev --extras tests` to install the required
 dependencies before running the full suite without the marker.
 
+### Non-Interactive Ingestion
+
+Ingestion-related CLI commands accept `--non-interactive` or `--defaults` to bypass prompts and use default values. These flags enable fully automated project ingestion in scripts and tests.
+
+### Coverage Badge Update
+
+After running tests with coverage:
+
+```bash
+poetry run pytest --cov
+```
+
+Capture the reported coverage percentage and update the coverage shield in `README.md`:
+
+```markdown
+![Coverage](https://img.shields.io/badge/coverage-XX%25-brightgreen.svg)
+```
+
+Replace `XX` with the percentage from the test output and adjust the badge color if needed.
+
 ## Dependency Validation
 
 After setting up the environment with `scripts/codex_setup.sh` or `poetry install`,

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ last_reviewed: "2025-08-05"
 > Special note: LLMs have synthesized this project, with minimal manual editing, using a dialectical HITL methodology.
 
 # DevSynth
-![Coverage](https://img.shields.io/badge/coverage-75%25-brightgreen.svg)
+![Coverage](https://img.shields.io/badge/coverage-9%25-red.svg)
 
 DevSynth is an agentic software engineering platform that leverages LLMs, advanced memory systems, and dialectical reasoning to automate and enhance the software development lifecycle. The system is designed for extensibility, resilience, and traceability, supporting both autonomous and collaborative workflows.
 


### PR DESCRIPTION
## Summary
- document `--non-interactive`/`--defaults` flags for ingestion commands
- add instructions for updating README coverage shield after `pytest --cov`
- refresh README coverage badge

## Testing
- `poetry run pre-commit run --files AGENTS.md README.md`
- `poetry run pytest tests/unit/domain/models/test_project_model.py --cov=src/devsynth` *(fails: Required test coverage of 25% not reached. Total coverage: 9.01%)*

------
https://chatgpt.com/codex/tasks/task_e_68980ebcc9a48333a7b6131ab5883c1e