### PR TITLE
chore: disable xdist and isolate memory tests

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,6 +1,6 @@
 [pytest]
-# Limit parallel workers to reduce memory usage during test runs
-addopts = -p no:warnings --cov=src/devsynth --cov-report=term-missing --cov-fail-under=25 -n 2 --dist loadfile
+# Run tests sequentially to avoid resource contention with heavy fixtures
+addopts = -p no:warnings --cov=src/devsynth --cov-report=term-missing --cov-fail-under=25
 norecursedirs = templates
 # Run tests from the tests directory only
 # This prevents template files from being collected as tests.

--- a/tests/unit/adapters/memory/test_memory_adapter_factory.py
+++ b/tests/unit/adapters/memory/test_memory_adapter_factory.py
@@ -1,18 +1,28 @@
 import pytest
+
 from devsynth.adapters.memory.memory_adapter import MemorySystemAdapter
-from devsynth.application.memory.context_manager import SimpleContextManager, InMemoryStore
+from devsynth.application.memory.context_manager import (
+    InMemoryStore,
+    SimpleContextManager,
+)
+
+pytestmark = pytest.mark.isolation
+
 
 @pytest.mark.medium
 def test_create_for_testing_defaults_to_memory():
     adapter = MemorySystemAdapter.create_for_testing()
-    assert adapter.storage_type == 'memory'
+    assert adapter.storage_type == "memory"
     assert isinstance(adapter.memory_store, InMemoryStore)
     assert isinstance(adapter.context_manager, SimpleContextManager)
     assert adapter.vector_store is None
 
+
 @pytest.mark.medium
 def test_create_for_testing_file_does_not_create_path(tmp_path):
-    adapter = MemorySystemAdapter.create_for_testing(storage_type='file', memory_path=tmp_path)
-    assert adapter.storage_type == 'file'
+    adapter = MemorySystemAdapter.create_for_testing(
+        storage_type="file", memory_path=tmp_path
+    )
+    assert adapter.storage_type == "file"
     assert adapter.memory_path == str(tmp_path)
-    assert not (tmp_path / 'memory.json').exists()
+    assert not (tmp_path / "memory.json").exists()

--- a/tests/unit/adapters/memory/test_memory_adapter_transactions.py
+++ b/tests/unit/adapters/memory/test_memory_adapter_transactions.py
@@ -5,6 +5,8 @@ import types
 
 import pytest
 
+pytestmark = pytest.mark.isolation
+
 
 def _import_adapter():
     """Import ``memory_adapter`` with heavy dependencies patched out."""
@@ -50,8 +52,8 @@ def _import_adapter():
         sys.modules.setdefault(name, module)
 
     from devsynth.adapters.memory.memory_adapter import (  # type: ignore
-        MemorySystemAdapter,
         MemoryStoreError,
+        MemorySystemAdapter,
     )
 
     return MemorySystemAdapter, MemoryStoreError

--- a/tests/unit/adapters/memory/test_vector_store_provider_factory.py
+++ b/tests/unit/adapters/memory/test_vector_store_provider_factory.py
@@ -1,7 +1,13 @@
 import pytest
+
+from devsynth.application.memory.vector_providers import (
+    SimpleVectorStoreProviderFactory,
+)
+from devsynth.domain.interfaces.memory import MemoryVector, VectorStore
 from devsynth.exceptions import ValidationError
-from devsynth.application.memory.vector_providers import SimpleVectorStoreProviderFactory
-from devsynth.domain.interfaces.memory import VectorStore, MemoryVector
+
+pytestmark = pytest.mark.isolation
+
 
 class StubStore(VectorStore):
 
@@ -9,36 +15,38 @@ class StubStore(VectorStore):
         self.config = config
 
     def store_vector(self, vector: MemoryVector) -> str:
-        return 'id'
+        return "id"
 
     def retrieve_vector(self, vector_id: str):
         return None
 
-    def similarity_search(self, query_embedding, top_k: int=5):
+    def similarity_search(self, query_embedding, top_k: int = 5):
         return []
 
     def delete_vector(self, vector_id: str) -> bool:
         return True
 
     def get_collection_stats(self):
-        return {'name': 'stub'}
+        return {"name": "stub"}
+
 
 @pytest.mark.medium
 def test_register_and_create_succeeds():
     """Test that register and create succeeds.
 
-ReqID: N/A"""
+    ReqID: N/A"""
     factory = SimpleVectorStoreProviderFactory()
-    factory.register_provider_type('stub', StubStore)
-    provider = factory.create_provider('stub', {'foo': 'bar'})
+    factory.register_provider_type("stub", StubStore)
+    provider = factory.create_provider("stub", {"foo": "bar"})
     assert isinstance(provider, StubStore)
-    assert provider.config['foo'] == 'bar'
+    assert provider.config["foo"] == "bar"
+
 
 @pytest.mark.medium
 def test_unknown_type_succeeds():
     """Test that unknown type succeeds.
 
-ReqID: N/A"""
+    ReqID: N/A"""
     factory = SimpleVectorStoreProviderFactory()
     with pytest.raises(ValidationError):
-        factory.create_provider('missing')
+        factory.create_provider("missing")


### PR DESCRIPTION
## Summary
- run pytest sequentially by default to prevent xdist resource contention
- mark memory adapter tests as isolated and split heavy sync-manager test into LMDB and FAISS variants
- ensure vector-store fixtures close and clean up temporary data

## Testing
- `poetry run pre-commit run --files pytest.ini tests/unit/adapters/memory/test_memory_adapter.py tests/unit/adapters/memory/test_memory_adapter_factory.py tests/unit/adapters/memory/test_memory_adapter_transactions.py tests/unit/adapters/memory/test_vector_store_provider_factory.py`
- `poetry run pytest --no-cov tests/unit/adapters/memory/test_memory_adapter_factory.py::test_create_for_testing_defaults_to_memory -vv`
- `poetry run pytest --no-cov tests/unit/adapters/memory/test_memory_adapter_transactions.py::test_begin_transaction_unsupported_store_raises_error -vv`
- `poetry run pytest --no-cov tests/unit/adapters/memory/test_vector_store_provider_factory.py::test_register_and_create_succeeds -vv`
- `poetry run pytest --no-cov tests/unit/adapters/memory/test_memory_adapter.py::TestMemorySystemAdapter::test_lmdb_synchronizes_to_kuzu -vv`
- `poetry run pytest --no-cov tests/unit/adapters/memory/test_memory_adapter.py::TestMemorySystemAdapter::test_faiss_vectors_synchronize_to_kuzu -vv`


------
https://chatgpt.com/codex/tasks/task_e_68980e700b00833388b079bb4c9b2809