### PR TITLE
Handle non-interactive ingest

### DIFF
--- a/src/devsynth/application/cli/ingest_cmd.py
+++ b/src/devsynth/application/cli/ingest_cmd.py
@@ -115,6 +115,7 @@ def ingest_cmd(
             non_interactive = True
 
         if non_interactive:
+            yes = True
             os.environ["DEVSYNTH_NONINTERACTIVE"] = "1"
 
         if not yes:

--- a/tests/unit/application/cli/test_ingest_cmd.py
+++ b/tests/unit/application/cli/test_ingest_cmd.py
@@ -1,0 +1,46 @@
+import os
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from devsynth.application.cli.cli_commands import ingest_cmd
+from devsynth.interface.cli import CLIUXBridge
+
+
+@pytest.mark.medium
+@patch("devsynth.application.cli.ingest_cmd.validate_manifest")
+@patch("devsynth.application.cli.ingest_cmd.Ingestion")
+def test_ingest_cmd_non_interactive_skips_prompts(
+    mock_ingestion,
+    _mock_validate_manifest,
+    monkeypatch,
+):
+    """``--non-interactive`` skips prompts and auto-confirms."""
+
+    monkeypatch.delenv("DEVSYNTH_NONINTERACTIVE", raising=False)
+    monkeypatch.delenv("DEVSYNTH_AUTO_CONFIRM", raising=False)
+
+    bridge = CLIUXBridge()
+    bridge.ask_question = MagicMock()
+    bridge.confirm_choice = MagicMock()
+
+    mock_instance = mock_ingestion.return_value
+    mock_instance.run_ingestion.return_value = {"success": True, "metrics": {}}
+
+    ingest_cmd(
+        manifest_path=None,
+        dry_run=False,
+        verbose=False,
+        validate_only=False,
+        yes=False,
+        priority=None,
+        auto_phase_transitions=True,
+        defaults=False,
+        non_interactive=True,
+        bridge=bridge,
+    )
+
+    bridge.ask_question.assert_not_called()
+    bridge.confirm_choice.assert_not_called()
+    assert os.environ.get("DEVSYNTH_NONINTERACTIVE") == "1"
+    assert os.environ.get("DEVSYNTH_AUTO_CONFIRM") == "1"


### PR DESCRIPTION
## Summary
- make ingest command auto-confirm when running in non-interactive or defaults mode
- add test verifying ingest skips prompts and sets non-interactive env flags

## Testing
- `pre-commit run --files src/devsynth/application/cli/ingest_cmd.py tests/unit/application/cli/test_ingest_cmd.py`
- `pytest --no-cov -m "not memory_intensive" tests/unit/application/cli/test_ingest_cmd.py tests/unit/general/test_ingest_cmd.py`
- `python tests/verify_test_organization.py`


------
https://chatgpt.com/codex/tasks/task_e_68980e69bd948333b5d2724835fa43d7