### PR TITLE
feat: persist wizard priority

### DIFF
--- a/src/devsynth/application/cli/requirements_commands.py
+++ b/src/devsynth/application/cli/requirements_commands.py
@@ -830,8 +830,20 @@ def wizard_cmd(
     title = title or os.environ.get("DEVSYNTH_REQ_TITLE")
     description = description or os.environ.get("DEVSYNTH_REQ_DESCRIPTION")
     req_type = req_type or os.environ.get("DEVSYNTH_REQ_TYPE")
-    priority = priority or os.environ.get("DEVSYNTH_REQ_PRIORITY")
-    constraints = constraints or os.environ.get("DEVSYNTH_REQ_CONSTRAINTS")
+
+    project_cfg = get_project_config(Path("."))
+    priority = (
+        priority
+        or os.environ.get("DEVSYNTH_REQ_PRIORITY")
+        or project_cfg.priority
+        or RequirementPriority.MEDIUM.value
+    )
+    constraints = (
+        constraints
+        or os.environ.get("DEVSYNTH_REQ_CONSTRAINTS")
+        or project_cfg.constraints
+        or ""
+    )
 
     steps = [
         (
@@ -856,13 +868,13 @@ def wizard_cmd(
             "priority",
             "Requirement priority",
             [p.value for p in RequirementPriority],
-            RequirementPriority.MEDIUM.value,
+            priority,
         ),
         (
             "constraints",
             "Constraints (comma separated, optional)",
             None,
-            "",
+            constraints,
         ),
     ]
 

--- a/tests/unit/general/test_logging_setup.py
+++ b/tests/unit/general/test_logging_setup.py
@@ -43,3 +43,20 @@ def test_exc_info_passes_through_succeeds(caplog, monkeypatch):
     logging.getLogger().removeHandler(handler)
     record = handler.records[0]
     assert record.exc_info and record.exc_info[0] is ValueError
+
+
+def test_exc_info_true_uses_current_exception(monkeypatch):
+    """Passing exc_info=True attaches the active exception."""
+
+    monkeypatch.setenv("DEVSYNTH_NO_FILE_LOGGING", "1")
+    configure_logging(create_dir=False)
+    logger = get_logger(__name__)
+    handler = LogCaptureHandler()
+    logging.getLogger().addHandler(handler)
+    try:
+        1 / 0
+    except ZeroDivisionError:  # pragma: no cover - demonstration
+        logger.error("boom", exc_info=True)
+    logging.getLogger().removeHandler(handler)
+    record = handler.records[0]
+    assert record.exc_info and record.exc_info[0] is ZeroDivisionError


### PR DESCRIPTION
## Summary
- load and persist requirement priority and constraints in wizard
- test DevSynthLogger handling of exc_info=True

## Testing
- `poetry run pre-commit run --files src/devsynth/application/cli/requirements_commands.py tests/unit/general/test_logging_setup.py`
- `poetry run pytest tests/unit/general/test_logging_setup.py tests/integration/general/test_requirements_gathering.py tests/behavior/features/requirements/*`
- `poetry run pytest tests/unit/general/test_logging_setup.py tests/integration/general/test_requirements_gathering.py --no-cov -q`


------
https://chatgpt.com/codex/tasks/task_e_689826f4894c833391e175479f5cab51