### PR TITLE
Expose Kuzu default and track ephemeral store initialization

### DIFF
--- a/src/devsynth/config/settings.py
+++ b/src/devsynth/config/settings.py
@@ -798,3 +798,14 @@ def get_llm_settings(reload: bool = False, **kwargs) -> Dict[str, Any]:
         llm_settings["api_key"] = settings.openai_api_key
 
     return llm_settings
+
+
+__all__ = [
+    "Settings",
+    "get_settings",
+    "get_llm_settings",
+    "load_dotenv",
+    "is_devsynth_managed_project",
+    "ensure_path_exists",
+    "DEFAULT_KUZU_EMBEDDED",
+]


### PR DESCRIPTION
## Summary
- export `DEFAULT_KUZU_EMBEDDED` from settings for other modules
- ensure `KuzuMemoryStore` falls back to embedded default and tracks ephemeral directories

## Testing
- `poetry run pre-commit run --files src/devsynth/config/settings.py src/devsynth/adapters/kuzu_memory_store.py`
- `poetry run pip check`
- `poetry run pip list | grep prometheus-client`
- `poetry run pytest tests/integration/general/test_kuzu_memory_integration.py --cov-fail-under=0`

Closes #113

------
https://chatgpt.com/codex/tasks/task_e_689826e3be2883339c558e20c6083568