### PR TITLE
test: mark memory-intensive tests

### DIFF
--- a/tests/integration/general/test_graph_memory_error_handling.py
+++ b/tests/integration/general/test_graph_memory_error_handling.py
@@ -4,11 +4,15 @@ Integration tests for error handling in GraphMemoryAdapter.
 
 import os
 import tempfile
-import pytest
 from unittest.mock import MagicMock, patch
+
+import pytest
+
 from devsynth.application.memory.adapters.graph_memory_adapter import GraphMemoryAdapter
 from devsynth.domain.models.memory import MemoryItem, MemoryType
-from devsynth.exceptions import MemoryStoreError, MemoryItemNotFoundError
+from devsynth.exceptions import MemoryItemNotFoundError, MemoryStoreError
+
+pytestmark = pytest.mark.memory_intensive
 
 
 class TestGraphMemoryErrorHandling:

--- a/tests/unit/adapters/memory/test_memory_adapter_factory.py
+++ b/tests/unit/adapters/memory/test_memory_adapter_factory.py
@@ -6,7 +6,7 @@ from devsynth.application.memory.context_manager import (
     SimpleContextManager,
 )
 
-pytestmark = pytest.mark.isolation
+pytestmark = [pytest.mark.memory_intensive, pytest.mark.isolation]
 
 
 @pytest.mark.medium

--- a/tests/unit/adapters/memory/test_memory_adapter_transactions.py
+++ b/tests/unit/adapters/memory/test_memory_adapter_transactions.py
@@ -5,7 +5,7 @@ import types
 
 import pytest
 
-pytestmark = pytest.mark.isolation
+pytestmark = [pytest.mark.memory_intensive, pytest.mark.isolation]
 
 
 def _import_adapter():

--- a/tests/unit/adapters/memory/test_vector_store_provider_factory.py
+++ b/tests/unit/adapters/memory/test_vector_store_provider_factory.py
@@ -6,7 +6,7 @@ from devsynth.application.memory.vector_providers import (
 from devsynth.domain.interfaces.memory import MemoryVector, VectorStore
 from devsynth.exceptions import ValidationError
 
-pytestmark = pytest.mark.isolation
+pytestmark = [pytest.mark.memory_intensive, pytest.mark.isolation]
 
 
 class StubStore(VectorStore):


### PR DESCRIPTION
## Summary
- mark memory adapter factory and transaction tests as memory intensive
- skip graph memory error handling tests by default

## Testing
- `poetry run pre-commit run --files tests/integration/general/test_graph_memory_error_handling.py tests/unit/adapters/memory/test_memory_adapter_factory.py tests/unit/adapters/memory/test_memory_adapter_transactions.py tests/unit/adapters/memory/test_vector_store_provider_factory.py`
- `poetry run python tests/verify_test_organization.py`
- `poetry run pytest -m "not memory_intensive"` *(fails: ModuleNotFoundError: No module named 'chromadb')*


------
https://chatgpt.com/codex/tasks/task_e_68982b906df08333a3e6457be99bad8c