### PR TITLE
feat: add non interactive ingest flags

### DIFF
--- a/docs/getting_started/ingestion.md
+++ b/docs/getting_started/ingestion.md
@@ -6,11 +6,15 @@ The `devsynth ingest` command runs the Expand, Differentiate, Refine, and Retros
 
 Use `--non-interactive` to bypass prompts. Combine it with `--yes` or the
 `DEVSYNTH_AUTO_CONFIRM=1` environment variable to auto-approve confirmations.
-You can also set defaults such as project priority with `--priority` or by
-using `DEVSYNTH_INGEST_PRIORITY`.
+For a one-flag solution, `--defaults` implies both options. You can also set
+defaults such as project priority with `--priority` or by using
+`DEVSYNTH_INGEST_PRIORITY`.
 
 ```bash
 devsynth ingest manifest.yaml --non-interactive --yes --priority high
+
+# Equivalent shorthand
+devsynth ingest --defaults --priority high
 ```
 
 Setting `DEVSYNTH_INGEST_NONINTERACTIVE=1` enables non-interactive mode by

--- a/docs/user_guides/ingestion.md
+++ b/docs/user_guides/ingestion.md
@@ -25,13 +25,15 @@ Disable prompts when automating workflows by running:
 devsynth ingest --non-interactive --yes
 ```
 
-The `--defaults` flag combines both options:
+The `--defaults` flag combines both options and applies sensible defaults:
 
 ```bash
 devsynth ingest --defaults
 ```
 
-Setting `DEVSYNTH_INGEST_NONINTERACTIVE=1` enables non-interactive mode by default. Pair with `DEVSYNTH_AUTO_CONFIRM=1` or `--yes` to auto-approve prompts.
+Setting `DEVSYNTH_INGEST_NONINTERACTIVE=1` enables non-interactive mode by default.
+Pair with `DEVSYNTH_AUTO_CONFIRM=1` or `--yes` to auto-approve prompts. Using
+`--defaults` on the CLI sets both environment variables automatically.
 
 ## Implementation Status
 

--- a/issues/117.md
+++ b/issues/117.md
@@ -3,3 +3,6 @@
 Milestone: 0.1.0-alpha.1
 
 The documentation ingestion workflow still requires user prompts, blocking automation and hermetic tests. Provide non-interactive flags and sensible defaults so projects can be ingested via the CLI without manual input.
+
+Status: resolved. The `devsynth ingest` command now accepts `--non-interactive`
+and `--defaults` flags that bypass prompts and apply default responses.

--- a/src/devsynth/application/cli/ingest_cmd.py
+++ b/src/devsynth/application/cli/ingest_cmd.py
@@ -68,7 +68,8 @@ def ingest_cmd(
         auto_phase_transitions: If True, EDRR phases advance automatically.
         non_interactive: If True, disable interactive prompts for automation.
         defaults: If True, use default responses and imply ``yes`` and
-            ``non_interactive``.
+            ``non_interactive``. These flags mirror ``--non-interactive`` and
+            ``--defaults`` on the CLI.
     """
     bridge = bridge or DEFAULT_BRIDGE
 
@@ -117,6 +118,7 @@ def ingest_cmd(
         if non_interactive:
             yes = True
             os.environ["DEVSYNTH_NONINTERACTIVE"] = "1"
+            os.environ["DEVSYNTH_INGEST_NONINTERACTIVE"] = "1"
 
         if not yes:
             yes = os.environ.get("DEVSYNTH_AUTO_CONFIRM", "0").lower() in {

--- a/tests/unit/application/cli/test_ingest_cmd.py
+++ b/tests/unit/application/cli/test_ingest_cmd.py
@@ -44,3 +44,42 @@ def test_ingest_cmd_non_interactive_skips_prompts(
     bridge.confirm_choice.assert_not_called()
     assert os.environ.get("DEVSYNTH_NONINTERACTIVE") == "1"
     assert os.environ.get("DEVSYNTH_AUTO_CONFIRM") == "1"
+
+
+@pytest.mark.medium
+@patch("devsynth.application.cli.ingest_cmd.validate_manifest")
+@patch("devsynth.application.cli.ingest_cmd.Ingestion")
+def test_ingest_cmd_defaults_enable_non_interactive(
+    mock_ingestion,
+    _mock_validate_manifest,
+    monkeypatch,
+):
+    """``--defaults`` implies ``--non-interactive`` and skips prompts."""
+
+    monkeypatch.delenv("DEVSYNTH_NONINTERACTIVE", raising=False)
+    monkeypatch.delenv("DEVSYNTH_AUTO_CONFIRM", raising=False)
+
+    bridge = CLIUXBridge()
+    bridge.ask_question = MagicMock()
+    bridge.confirm_choice = MagicMock()
+
+    mock_instance = mock_ingestion.return_value
+    mock_instance.run_ingestion.return_value = {"success": True, "metrics": {}}
+
+    ingest_cmd(
+        manifest_path=None,
+        dry_run=False,
+        verbose=False,
+        validate_only=False,
+        yes=False,
+        priority=None,
+        auto_phase_transitions=True,
+        defaults=True,
+        non_interactive=False,
+        bridge=bridge,
+    )
+
+    bridge.ask_question.assert_not_called()
+    bridge.confirm_choice.assert_not_called()
+    assert os.environ.get("DEVSYNTH_NONINTERACTIVE") == "1"
+    assert os.environ.get("DEVSYNTH_AUTO_CONFIRM") == "1"


### PR DESCRIPTION
## Summary
- support `--non-interactive` and `--defaults` flags in ingest command
- document non-interactive ingestion usage and resolve issue #117
- test non-interactive ingestion path and defaults flag

## Testing
- `poetry run pre-commit run --files docs/getting_started/ingestion.md docs/user_guides/ingestion.md issues/117.md src/devsynth/application/cli/ingest_cmd.py tests/unit/application/cli/test_ingest_cmd.py`
- `poetry run pip check`
- `poetry run pip list | grep prometheus-client`
- `poetry run python tests/verify_test_organization.py`
- `poetry run pytest --no-cov -m "not memory_intensive" tests/unit/application/cli/test_ingest_cmd.py`

------
https://chatgpt.com/codex/tasks/task_e_68982b9d2188833381948203cd63b748