### PR TITLE
Sanitize EDRR recursion thresholds

### DIFF
--- a/docs/implementation/edrr_assessment.md
+++ b/docs/implementation/edrr_assessment.md
@@ -109,7 +109,8 @@ Additional alias phases—Analysis, Implementation, and Refinement—are now sup
 The EDRR framework is now feature complete. Phase transition logic, context
 persistence, and recursion limits are implemented in the coordinator. Advanced
 collaboration features can be toggled with feature flags, but the base workflow
-is stable and ready for production use. See the
+is stable and ready for production use. Configuration values for recursion are
+sanitized to prevent misconfiguration attacks. See the
 [Feature Status Matrix](feature_status_matrix.md) for ongoing enhancements.
 
 ## Critical Gaps and Priorities

--- a/docs/specifications/delimiting_recursion_algorithms.md
+++ b/docs/specifications/delimiting_recursion_algorithms.md
@@ -57,6 +57,13 @@ the system balances exploration with cost and quality constraints.
 
 These heuristics are implemented in `EDRRCoordinator.should_terminate_recursion`
 and referenced in the [Recursive EDRR Pseudocode](recursive_edrr_pseudocode.md).
+
+## Security Considerations
+
+Configuration values for recursion limits and thresholds are validated. Invalid or
+out-of-range settings fall back to safe defaults, preventing attempts to bypass
+recursion controls.
+
 ## Implementation Status
 
 This feature is **implemented**. The heuristics are available in `src/devsynth/application/edrr/coordinator.py`.

--- a/tests/integration/edrr/test_recursion_security.py
+++ b/tests/integration/edrr/test_recursion_security.py
@@ -1,0 +1,36 @@
+from unittest.mock import MagicMock
+
+import pytest
+
+from devsynth.application.edrr.coordinator import EDRRCoordinator
+
+
+def _build_coord(config):
+    return EDRRCoordinator(
+        memory_manager=MagicMock(),
+        wsde_team=MagicMock(),
+        code_analyzer=MagicMock(),
+        ast_transformer=MagicMock(),
+        prompt_manager=MagicMock(),
+        documentation_manager=MagicMock(),
+        config=config,
+    )
+
+
+def test_recursion_threshold_sanitization():
+    """Ensure recursion thresholds fall back to safe defaults. ReqID: FR-40"""
+    bad_config = {
+        "edrr": {
+            "max_recursion_depth": -5,
+            "recursion": {"thresholds": {"granularity": -1, "quality": 2}},
+        }
+    }
+    coord = _build_coord(bad_config)
+    assert coord.max_recursion_depth == EDRRCoordinator.DEFAULT_MAX_RECURSION_DEPTH
+
+    # Task should trigger granularity termination using default threshold 0.2
+    terminate, reason = coord.should_terminate_recursion(
+        {"granularity_score": 0.1, "quality_score": 0.95}
+    )
+    assert terminate is True
+    assert reason == "granularity threshold"


### PR DESCRIPTION
## Summary
- validate recursion depth and threshold config values in `EDRRCoordinator`
- document recursion threshold sanitization
- add integration test for invalid recursion settings

## Testing
- `poetry run pre-commit run --files docs/implementation/edrr_assessment.md docs/specifications/delimiting_recursion_algorithms.md src/devsynth/application/edrr/coordinator.py tests/integration/edrr/test_recursion_security.py`
- `poetry run pytest -m "not memory_intensive" -q` *(fails: 34 errors during collection)*
- `poetry run pip check`
- `poetry run python scripts/run_all_tests.py` *(fails: KeyboardInterrupt)*
- `poetry run python tests/verify_test_organization.py`


------
https://chatgpt.com/codex/tasks/task_e_689846ba7ac48333959b2dbfdde45985