### PR TITLE
feat: scaffold integration tests

### DIFF
--- a/docs/policies/consistency_checklist.md
+++ b/docs/policies/consistency_checklist.md
@@ -153,6 +153,7 @@ This document provides a checklist for ensuring consistency across all diagrams,
 - [x] Create pseudocode examples for the prompt optimization framework
 - [x] Add examples of iterative prompt adjustment
 - [x] Include examples of integration with the agent system
+- [x] Provide prompt templates that address edge cases and failure scenarios
 
 
 ### Behavior Files

--- a/tests/integration/generated_tests/README.md
+++ b/tests/integration/generated_tests/README.md
@@ -1,0 +1,12 @@
+# Generated Test Scaffolds
+
+This directory contains integration test scaffolds produced by `TestAgent`.
+
+## Review Workflow
+1. Review each scaffold file for accuracy and completeness.
+2. Replace placeholder logic with real assertions and interactions.
+3. Remove the `pytest.skip` marker once the test is ready to run.
+4. Commit the verified test to replace the scaffold.
+
+Scaffolds are overwritten on each generation, so move completed tests elsewhere
+before re-running generators.

--- a/tests/integration/generated_tests/test_scaffold_output.py
+++ b/tests/integration/generated_tests/test_scaffold_output.py
@@ -1,0 +1,17 @@
+"""Verify that integration test scaffolds are written to disk."""
+
+from pathlib import Path
+
+from devsynth.application.agents.test import TestAgent
+
+
+def test_scaffold_integration_tests_creates_files(tmp_path: Path) -> None:
+    agent = TestAgent()
+    result = agent.scaffold_integration_tests(["sample"], output_dir=tmp_path)
+
+    expected = tmp_path / "test_sample.py"
+    assert expected.exists(), "scaffold file should be created"
+    content = expected.read_text()
+    assert "pytest.mark.skip" in content
+    assert "Integration test scaffold for sample" in content
+    assert "test_sample.py" in result


### PR DESCRIPTION
## Summary
- output integration test scaffolds for given names
- document review workflow for generated test scaffolds
- add verification test and update consistency checklist for prompt edge cases

## Testing
- `poetry run pre-commit run --files src/devsynth/application/agents/test.py docs/policies/consistency_checklist.md tests/integration/generated_tests/README.md tests/integration/generated_tests/__init__.py tests/integration/generated_tests/test_scaffold_output.py`
- `poetry run python scripts/run_all_tests.py` *(fails: INTERNALERROR with many failing tests)*
- `poetry run python tests/verify_test_organization.py`
- `poetry run pytest tests/integration/generated_tests/test_scaffold_output.py --cov=src/devsynth --cov-fail-under=0 -q`

------
https://chatgpt.com/codex/tasks/task_e_6898be13402c8333b6a6ad82b25d356f