### PR TITLE
Add deployment bootstrap scripts with CI publishing and rollback

### DIFF
--- a/docker-compose.production.yml
+++ b/docker-compose.production.yml
@@ -63,6 +63,23 @@ services:
     networks:
       - devsynth-network
 
+  # CI utilities
+  publish:
+    build:
+      context: .
+      target: production
+    entrypoint: ["/bin/bash", "scripts/deployment/publish_image.sh", "${DEVSYNTH_IMAGE_TAG:-latest}"]
+    profiles:
+      - ci
+
+  rollback:
+    build:
+      context: .
+      target: production
+    entrypoint: ["/bin/bash", "scripts/deployment/rollback.sh", "${DEVSYNTH_ROLLBACK_TAG:-latest}", "production"]
+    profiles:
+      - ci
+
 volumes:
   grafana-data:
     name: devsynth-grafana-data

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -166,6 +166,23 @@ services:
         max-size: "10m"
         max-file: "3"
 
+  # CI utilities for publishing and rollback
+  publish:
+    build:
+      context: .
+      target: production
+    entrypoint: ["/bin/bash", "scripts/deployment/publish_image.sh", "${DEVSYNTH_IMAGE_TAG:-latest}"]
+    profiles:
+      - ci
+
+  rollback:
+    build:
+      context: .
+      target: production
+    entrypoint: ["/bin/bash", "scripts/deployment/rollback.sh", "${DEVSYNTH_ROLLBACK_TAG:-latest}", "development"]
+    profiles:
+      - ci
+
 
 networks:
   devsynth-network:

--- a/scripts/deployment/health_check.sh
+++ b/scripts/deployment/health_check.sh
@@ -13,6 +13,11 @@ if [[ "$EUID" -eq 0 ]]; then
   exit 1
 fi
 
+if ! command -v curl >/dev/null 2>&1; then
+  echo "curl is required but could not be found in PATH." >&2
+  exit 1
+fi
+
 for url in "$API_URL" "$GRAFANA_URL"; do
   if [[ ! "$url" =~ ^https?:// ]]; then
     echo "Invalid URL: $url" >&2

--- a/tests/integration/deployment/test_deployment_scripts.py
+++ b/tests/integration/deployment/test_deployment_scripts.py
@@ -1,0 +1,28 @@
+import subprocess
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[3]
+SCRIPTS_DIR = ROOT / "scripts" / "deployment"
+
+
+def test_bootstrap_env_refuses_root():
+    result = subprocess.run(
+        ["bash", str(SCRIPTS_DIR / "bootstrap_env.sh")],
+        capture_output=True,
+        text=True,
+        cwd=ROOT,
+    )
+    assert result.returncode != 0
+    assert "Please run this script as a non-root user." in result.stderr
+
+
+def test_health_check_validates_url():
+    cmd = f"{SCRIPTS_DIR / 'health_check.sh'} https://example.com invalid-url"
+    result = subprocess.run(
+        ["su", "nobody", "-s", "/bin/bash", "-c", cmd],
+        capture_output=True,
+        text=True,
+        cwd=ROOT,
+    )
+    assert result.returncode != 0
+    assert "Invalid URL" in result.stderr


### PR DESCRIPTION
## Summary
- expand deployment bootstrap and health check scripts
- wire publish and rollback services into docker-compose setups
- cover deployment scripts with integration tests

## Testing
- `poetry run pre-commit run --files docker-compose.production.yml docker-compose.yml scripts/deployment/bootstrap_env.sh scripts/deployment/health_check.sh tests/integration/deployment/__init__.py tests/integration/deployment/test_deployment_scripts.py`
- `poetry run pre-commit run --files tests/integration/deployment/test_deployment_scripts.py`
- `poetry run pytest tests/integration/deployment/test_deployment_scripts.py -m "not memory_intensive" --cov-fail-under=0`
- `poetry run python scripts/run_all_tests.py` *(fails: INTERNALERROR: KeyError: <WorkerController gw2>)*
- `poetry run python tests/verify_test_organization.py`
- `poetry run pip check`


------
https://chatgpt.com/codex/tasks/task_e_6898c23521bc8333afbef00f95f49cd8