### PR TITLE
Fix logger exc_info handling and persist priority in wizard state

### DIFF
--- a/src/devsynth/interface/wizard_state_manager.py
+++ b/src/devsynth/interface/wizard_state_manager.py
@@ -6,8 +6,10 @@ ensuring consistency between WebUIBridge and WizardState.
 """
 
 import logging
+from pathlib import Path
 from typing import Any, Dict, Optional, Sequence
 
+from devsynth.config import get_project_config, save_config
 from devsynth.interface.state_access import get_session_value, set_session_value
 from devsynth.interface.webui_state import WizardState
 from devsynth.logging_setup import DevSynthLogger
@@ -219,7 +221,17 @@ class WizardStateManager:
             The value from the wizard state or the default value
         """
         wizard_state = self.get_wizard_state()
-        return wizard_state.get(key, default)
+        value = wizard_state.get(key, default)
+        if key == "priority":
+            try:
+                cfg = get_project_config(Path("."))
+                cfg.priority = value
+                save_config(cfg, use_pyproject=False)
+            except Exception as exc:  # pragma: no cover - defensive
+                logger.debug(
+                    "Error persisting priority for %s: %s", self.wizard_name, str(exc)
+                )
+        return value
 
     def set_value(self, key: str, value: Any) -> bool:
         """Set a value in the wizard state.

--- a/src/devsynth/logger.py
+++ b/src/devsynth/logger.py
@@ -36,16 +36,16 @@ class DevSynthLogger(_BaseDevSynthLogger):
     """
 
     def _log(self, level: int, msg: str, *args, **kwargs) -> None:  # type: ignore[override]
-        exc = kwargs.get("exc_info")
+        exc = kwargs.pop("exc_info", None)
         if isinstance(exc, BaseException):
             # Convert bare exception objects to the tuple form expected by the
             # standard logging machinery so the traceback is preserved.
-            kwargs["exc_info"] = (exc.__class__, exc, exc.__traceback__)
+            exc = (exc.__class__, exc, exc.__traceback__)
         elif exc is True:
             # ``True`` means "use the current exception"; normalize to a tuple
             # to keep behaviour consistent with our exception-object handling.
-            kwargs["exc_info"] = sys.exc_info()
-        super()._log(level, msg, *args, **kwargs)
+            exc = sys.exc_info()
+        super()._log(level, msg, *args, exc_info=exc, **kwargs)
 
 
 DEFAULT_LOG_FORMAT = "%(asctime)s - %(name)s - %(levelname)s - %(message)s"


### PR DESCRIPTION
## Summary
- normalize and forward `exc_info` in custom logger
- persist requirement priority to config when accessed via WizardStateManager

## Testing
- `poetry run pre-commit run --files src/devsynth/logger.py src/devsynth/interface/wizard_state_manager.py`
- `poetry run python scripts/run_all_tests.py` *(fails: KeyError <WorkerController gw4>, 802 failed)*
- `poetry run python tests/verify_test_organization.py`
- `poetry run pip check`
- `poetry run pytest --no-cov tests/integration/general/test_requirements_gathering.py -q`


------
https://chatgpt.com/codex/tasks/task_e_6898db38b8848333bac6bb9aa532b406