### PR TITLE
test: mark memory intensive tests

### DIFF
--- a/tests/unit/adapters/memory/test_memory_adapter.py
+++ b/tests/unit/adapters/memory/test_memory_adapter.py
@@ -9,7 +9,11 @@ import pytest
 # These tests exercise multiple backend implementations and can consume
 # significant memory when run in parallel. Mark them for isolation so
 # they execute sequentially and avoid xdist resource contention.
-pytestmark = [pytest.mark.memory_intensive, pytest.mark.isolation]
+pytestmark = [
+    pytest.mark.requires_resource("memory"),
+    pytest.mark.memory_intensive,
+    pytest.mark.isolation,
+]
 
 # Import duckdb safely
 try:
@@ -73,8 +77,9 @@ class TestMemorySystemAdapter:
 
     @pytest.fixture
     def temp_dir(self, tmp_path):
-        """Create a temporary directory for testing."""
-        return str(tmp_path)
+        """Provide a temporary directory for testing and ensure cleanup."""
+        path = tmp_path
+        yield str(path)
 
     @pytest.mark.medium
     def test_init_with_file_storage_succeeds(self, temp_dir):

--- a/tests/unit/adapters/memory/test_memory_adapter_factory.py
+++ b/tests/unit/adapters/memory/test_memory_adapter_factory.py
@@ -6,7 +6,11 @@ from devsynth.application.memory.context_manager import (
     SimpleContextManager,
 )
 
-pytestmark = [pytest.mark.memory_intensive, pytest.mark.isolation]
+pytestmark = [
+    pytest.mark.requires_resource("memory"),
+    pytest.mark.memory_intensive,
+    pytest.mark.isolation,
+]
 
 
 @pytest.mark.medium

--- a/tests/unit/adapters/test_chromadb_vector_adapter.py
+++ b/tests/unit/adapters/test_chromadb_vector_adapter.py
@@ -17,6 +17,7 @@ from devsynth.domain.models.memory import MemoryVector
 
 pytestmark = [
     pytest.mark.requires_resource("chromadb"),
+    pytest.mark.requires_resource("memory"),
     pytest.mark.memory_intensive,
 ]
 
@@ -46,6 +47,7 @@ def vector_adapter(temp_dir, mock_chromadb_client):
         )
         adapter.collection = mock_collection
         yield adapter
+        adapter.client = None
 
 
 @pytest.mark.medium


### PR DESCRIPTION
## Summary
- mark memory-heavy adapter tests with `requires_resource("memory")`
- clean up heavy fixtures to release mocked clients

## Testing
- `poetry run pre-commit run --files tests/unit/adapters/memory/test_memory_adapter.py tests/unit/adapters/memory/test_memory_adapter_factory.py tests/unit/adapters/test_chromadb_vector_adapter.py`
- `poetry run pytest tests/unit/adapters/memory/test_memory_adapter.py --no-cov`
- `poetry run pytest tests/unit/adapters/memory/test_memory_adapter_factory.py --no-cov`
- `poetry run pytest tests/unit/adapters/test_chromadb_vector_adapter.py --no-cov`
- `poetry run python scripts/run_all_tests.py` *(fails: 793 failed, 1874 passed, 89 skipped, 144 errors)*
- `poetry run python tests/verify_test_organization.py`
- `poetry run pip check`


------
https://chatgpt.com/codex/tasks/task_e_6898e3e0dedc8333ba3140cb4e2a4021