### PR TITLE
Document test extras and handle optional APIs in tests

### DIFF
--- a/.github/workflows/ci.yml.disabled
+++ b/.github/workflows/ci.yml.disabled
@@ -17,6 +17,6 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install poetry
-          poetry install --with dev
+          poetry install --with dev --extras tests retrieval chromadb api
       - name: Run security checks
         run: poetry run pre-commit run --all-files bandit safety

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,10 +11,10 @@ DevSynth values clarity, collaboration, and dependable automation. Keep these pr
 
 ## Quick Start
 
-1. Install dependencies:
+1. Install dependencies (including test extras):
 
    ```bash
-   poetry install
+   poetry install --with dev --extras tests retrieval chromadb api
    ```
 
 2. Lint changed files:

--- a/docs/developer_guides/testing.md
+++ b/docs/developer_guides/testing.md
@@ -272,17 +272,12 @@ The ChromaDB tests use fixtures for isolation and provider integration:
 
 ## Running Tests
 
-Before executing tests, install DevSynth with its development extras so that all test dependencies are available. Running the **full** suite requires the `minimal`, `retrieval`, `memory`, `llm`, `api`, `webui`, `lmstudio`, and `chromadb` extras. Environment provisioning is handled automatically in Codex environments. For manual setups run `poetry install`.
+Before executing tests, install DevSynth with its development extras so that all test dependencies are available. Running the **full** suite requires the `minimal`, `retrieval`, `memory`, `llm`, `api`, `webui`, `lmstudio`, and `chromadb` extras. Environment provisioning is handled automatically in Codex environments. For manual setups run:
 
 ```bash
-poetry install --with dev,docs
-poetry sync --all-extras --all-groups
+poetry install --with dev --extras tests retrieval chromadb api
+```
 
-# The Codex environment runs a similar command automatically
-poetry install \
-  --with dev,docs \
-  --all-extras \
-  --no-interaction
 
 # Verify that pytest can start without import errors
 
@@ -290,14 +285,16 @@ poetry run pytest -q
 
 # pip commands are for installing from PyPI only
 
-```
+```text
 Always run tests with `poetry run pytest`. If `pytest` reports missing packages, run `poetry install` to restore them.
 
 ## Running All Tests
 
 ```bash
+
 poetry run pytest
-```
+
+```text
 
 ### Using `devsynth run-pipeline`
 
@@ -306,6 +303,7 @@ entire suite or selected groups of tests. It also supports generating HTML
 reports with `pytest-html`.
 
 ```bash
+
 # Run the full suite (unit tests)
 devsynth run-pipeline --target unit-tests
 
@@ -314,7 +312,8 @@ devsynth run-pipeline --target integration-tests
 
 # Produce an HTML report in `test_reports/`
 devsynth run-pipeline --target unit-tests --report
-```
+
+```text
 
 Combine options (for example, integration tests with a report) as needed.
 
@@ -341,13 +340,16 @@ poetry run pytest tests/integration/
 # Run unit tests
 
 poetry run pytest tests/unit/
-```
+
+```text
 
 ## Running a Specific Test File
 
 ```bash
+
 poetry run pytest tests/behavior/test_chromadb_integration.py
-```
+
+```text
 
 ### Running Tests with Provider Selection
 
@@ -360,7 +362,8 @@ DEVSYNTH_PROVIDER=openai poetry run pytest
 # Use LM Studio provider
 
 DEVSYNTH_PROVIDER=lmstudio poetry run pytest
-```
+
+```text
 
 ## Review Workflow
 
@@ -370,19 +373,19 @@ All test changes should undergo a brief review cycle before merging:
 
    ```bash
    poetry run pre-commit run --files <file1> [<file2> ...]
-   ```
+   ```text
 
 2. Verify the project test layout:
 
    ```bash
    poetry run python tests/verify_test_organization.py
-   ```
+   ```text
 
 3. Execute the relevant test suites, typically:
 
    ```bash
    poetry run pytest -m "not memory_intensive"
-   ```
+   ```text
 
 4. Request peer review and ensure reviewers confirm meaningful assertions and
    adequate coverage. See
@@ -415,7 +418,8 @@ export DEVSYNTH_RESOURCE_CLI_AVAILABLE=true
 # Run the entire test suite
 
 poetry run pytest
-```
+
+```text
 
 Make sure LM Studio is running in API mode on the endpoint above and the
 `devsynth` CLI is installed in your path. When these variables are set, the
@@ -429,9 +433,11 @@ They are disabled by default. Enable them by setting `formalVerification.propert
 `DEVSYNTH_PROPERTY_TESTING` environment variable:
 
 ```bash
+
 devsynth config formalVerification.propertyTesting true
 export DEVSYNTH_PROPERTY_TESTING=true  # optional override
 poetry run pytest tests/property/
+
 ```
 
 When the flag is `false`, tests marked with `@pytest.mark.property` are automatically skipped.

--- a/tests/README.md
+++ b/tests/README.md
@@ -280,10 +280,10 @@ poetry shell
 For a lightweight setup that skips GPU/LLM libraries use:
 
 ```bash
-poetry install --with dev --extras tests
+poetry install --with dev --extras tests retrieval chromadb api
 ```
 
-Optional backends such as **ChromaDB**, **FAISS**, or **LMDB** require extra packages:
+Optional backends such as **FAISS** or **LMDB** may require additional extras:
 
 ```bash
 poetry install --extras retrieval

--- a/tests/behavior/steps/test_agent_api_health_metrics_steps.py
+++ b/tests/behavior/steps/test_agent_api_health_metrics_steps.py
@@ -1,13 +1,15 @@
 """Steps for testing the Agent API health and metrics endpoints."""
 
-from types import ModuleType
-from unittest.mock import MagicMock
 import importlib
 import sys
+from types import ModuleType
+from unittest.mock import MagicMock
 
 import pytest
+
+pytest.importorskip("fastapi")
 from fastapi.testclient import TestClient
-from pytest_bdd import given, when, then, scenarios, parsers
+from pytest_bdd import given, parsers, scenarios, then, when
 
 scenarios("../features/general/agent_api_health_metrics.feature")
 
@@ -22,8 +24,9 @@ def api_context(monkeypatch):
 
     # Import and reload the API module to apply the mocked settings
     import devsynth.interface.agentapi_enhanced as agentapi
+
     importlib.reload(agentapi)
-    
+
     client = TestClient(agentapi.app)
     return {
         "client": client,
@@ -65,7 +68,7 @@ def get_health_with_valid_token(api_context):
     """Send a GET request to the health endpoint with a valid token."""
     response = api_context["client"].get(
         "/health",
-        headers={"Authorization": f"Bearer {api_context['settings'].access_token}"}
+        headers={"Authorization": f"Bearer {api_context['settings'].access_token}"},
     )
     api_context["last_response"] = response
 
@@ -75,8 +78,7 @@ def get_health_with_valid_token(api_context):
 def get_health_with_invalid_token(api_context):
     """Send a GET request to the health endpoint with an invalid token."""
     response = api_context["client"].get(
-        "/health",
-        headers={"Authorization": "Bearer invalid_token"}
+        "/health", headers={"Authorization": "Bearer invalid_token"}
     )
     api_context["last_response"] = response
 
@@ -95,7 +97,7 @@ def get_metrics_with_valid_token(api_context):
     """Send a GET request to the metrics endpoint with a valid token."""
     response = api_context["client"].get(
         "/metrics",
-        headers={"Authorization": f"Bearer {api_context['settings'].access_token}"}
+        headers={"Authorization": f"Bearer {api_context['settings'].access_token}"},
     )
     api_context["last_response"] = response
 
@@ -105,8 +107,7 @@ def get_metrics_with_valid_token(api_context):
 def get_metrics_with_invalid_token(api_context):
     """Send a GET request to the metrics endpoint with an invalid token."""
     response = api_context["client"].get(
-        "/metrics",
-        headers={"Authorization": "Bearer invalid_token"}
+        "/metrics", headers={"Authorization": "Bearer invalid_token"}
     )
     api_context["last_response"] = response
 

--- a/tests/behavior/steps/test_agent_api_steps.py
+++ b/tests/behavior/steps/test_agent_api_steps.py
@@ -1,13 +1,15 @@
 """Steps exercising the Agent API endpoints."""
 
-from types import ModuleType
-from unittest.mock import MagicMock
 import importlib
 import sys
+from types import ModuleType
+from unittest.mock import MagicMock
 
 import pytest
+
+pytest.importorskip("fastapi")
 from fastapi.testclient import TestClient
-from pytest_bdd import given, when, then, scenarios, parsers
+from pytest_bdd import given, parsers, scenarios, then, when
 
 scenarios("../features/general/agent_api_interactions.feature")
 
@@ -49,25 +51,33 @@ def api_context(monkeypatch):
 
     # Mock doctor_cmd
     doctor_stub = ModuleType("devsynth.application.cli.commands.doctor_cmd")
+
     def doctor_cmd(path=".", fix=False, *, bridge):
         bridge.display_result(f"doctor:{path}:{fix}")
+
     doctor_stub.doctor_cmd = MagicMock(side_effect=doctor_cmd)
-    monkeypatch.setitem(sys.modules, "devsynth.application.cli.commands.doctor_cmd", doctor_stub)
+    monkeypatch.setitem(
+        sys.modules, "devsynth.application.cli.commands.doctor_cmd", doctor_stub
+    )
 
     # Mock edrr_cycle_cmd
     edrr_stub = ModuleType("devsynth.application.cli.commands.edrr_cycle_cmd")
+
     def edrr_cycle_cmd(prompt, context=None, max_iterations=3, *, bridge):
         bridge.display_result(f"edrr:{prompt}")
+
     edrr_stub.edrr_cycle_cmd = MagicMock(side_effect=edrr_cycle_cmd)
-    monkeypatch.setitem(sys.modules, "devsynth.application.cli.commands.edrr_cycle_cmd", edrr_stub)
+    monkeypatch.setitem(
+        sys.modules, "devsynth.application.cli.commands.edrr_cycle_cmd", edrr_stub
+    )
 
     import devsynth.interface.agentapi as agentapi
 
     importlib.reload(agentapi)
     client = TestClient(agentapi.app)
     return {
-        "client": client, 
-        "cli": cli_stub, 
+        "client": client,
+        "cli": cli_stub,
         "doctor_cmd": doctor_stub.doctor_cmd,
         "edrr_cycle_cmd": edrr_stub.edrr_cycle_cmd,
         "last_request": {},
@@ -106,8 +116,7 @@ def post_synthesize(api_context):
 @when(parsers.parse('I POST to /spec with requirements file "{requirements_file}"'))
 def post_spec(api_context, requirements_file):
     response = api_context["client"].post(
-        "/spec", 
-        json={"requirements_file": requirements_file}
+        "/spec", json={"requirements_file": requirements_file}
     )
     api_context["last_request"]["requirements_file"] = requirements_file
     api_context["last_response"] = response
@@ -116,10 +125,7 @@ def post_spec(api_context, requirements_file):
 @pytest.mark.medium
 @when(parsers.parse('I POST to /test with spec file "{spec_file}"'))
 def post_test(api_context, spec_file):
-    response = api_context["client"].post(
-        "/test", 
-        json={"spec_file": spec_file}
-    )
+    response = api_context["client"].post("/test", json={"spec_file": spec_file})
     api_context["last_request"]["spec_file"] = spec_file
     api_context["last_response"] = response
 
@@ -136,8 +142,7 @@ def post_code(api_context):
 def post_doctor(api_context, path, fix):
     fix_bool = fix.lower() == "true"
     response = api_context["client"].post(
-        "/doctor", 
-        json={"path": path, "fix": fix_bool}
+        "/doctor", json={"path": path, "fix": fix_bool}
     )
     api_context["last_request"]["path"] = path
     api_context["last_request"]["fix"] = fix
@@ -147,10 +152,7 @@ def post_doctor(api_context, path, fix):
 @pytest.mark.medium
 @when(parsers.parse('I POST to /edrr-cycle with prompt "{prompt}"'))
 def post_edrr_cycle(api_context, prompt):
-    response = api_context["client"].post(
-        "/edrr-cycle", 
-        json={"prompt": prompt}
-    )
+    response = api_context["client"].post("/edrr-cycle", json={"prompt": prompt})
     api_context["last_request"]["prompt"] = prompt
     api_context["last_response"] = response
 

--- a/tests/behavior/test_agentapi.py
+++ b/tests/behavior/test_agentapi.py
@@ -1,31 +1,35 @@
-from types import ModuleType
-from unittest.mock import MagicMock
 import importlib
 import sys
-from fastapi.testclient import TestClient
+from types import ModuleType
+from unittest.mock import MagicMock
+
 import pytest
+
+pytest.importorskip("fastapi")
+from fastapi.testclient import TestClient
 
 
 def _setup(monkeypatch):
-    cli_stub = ModuleType('devsynth.application.cli')
+    cli_stub = ModuleType("devsynth.application.cli")
 
-    def init_cmd(path='.', project_root=None, language=None, goals=None, *,
-        bridge):
-        bridge.display_result('init')
+    def init_cmd(path=".", project_root=None, language=None, goals=None, *, bridge):
+        bridge.display_result("init")
 
-    def gather_cmd(output_file='requirements_plan.yaml', *, bridge):
-        g = bridge.ask_question('g')
-        c = bridge.ask_question('c')
-        p = bridge.ask_question('p')
-        bridge.display_result(f'{g},{c},{p}')
+    def gather_cmd(output_file="requirements_plan.yaml", *, bridge):
+        g = bridge.ask_question("g")
+        c = bridge.ask_question("c")
+        p = bridge.ask_question("p")
+        bridge.display_result(f"{g},{c},{p}")
 
     def run_pipeline_cmd(target=None, *, bridge):
-        bridge.display_result(f'run:{target}')
+        bridge.display_result(f"run:{target}")
+
     cli_stub.init_cmd = MagicMock(side_effect=init_cmd)
     cli_stub.gather_cmd = MagicMock(side_effect=gather_cmd)
     cli_stub.run_pipeline_cmd = MagicMock(side_effect=run_pipeline_cmd)
-    monkeypatch.setitem(sys.modules, 'devsynth.application.cli', cli_stub)
+    monkeypatch.setitem(sys.modules, "devsynth.application.cli", cli_stub)
     import devsynth.interface.agentapi as agentapi
+
     importlib.reload(agentapi)
     return cli_stub, agentapi
 
@@ -34,19 +38,20 @@ def _setup(monkeypatch):
 def test_json_requests_succeeds(monkeypatch):
     """Test that json requests succeeds.
 
-ReqID: N/A"""
+    ReqID: N/A"""
     cli_stub, agentapi = _setup(monkeypatch)
     client = TestClient(agentapi.app)
-    resp = client.post('/init', json={'path': 'proj'})
+    resp = client.post("/init", json={"path": "proj"})
     assert resp.status_code == 200
-    assert resp.json() == {'messages': ['init']}
-    resp = client.post('/gather', json={'goals': 'g1', 'constraints': 'c1',
-        'priority': 'high'})
-    assert resp.json() == {'messages': ['g1,c1,high']}
-    resp = client.post('/synthesize', json={'target': 'unit'})
-    assert resp.json() == {'messages': ['run:unit']}
-    status = client.get('/status')
-    assert status.json() == {'messages': ['run:unit']}
+    assert resp.json() == {"messages": ["init"]}
+    resp = client.post(
+        "/gather", json={"goals": "g1", "constraints": "c1", "priority": "high"}
+    )
+    assert resp.json() == {"messages": ["g1,c1,high"]}
+    resp = client.post("/synthesize", json={"target": "unit"})
+    assert resp.json() == {"messages": ["run:unit"]}
+    status = client.get("/status")
+    assert status.json() == {"messages": ["run:unit"]}
     assert cli_stub.init_cmd.called
     assert cli_stub.gather_cmd.called
     assert cli_stub.run_pipeline_cmd.called

--- a/tests/behavior/test_chromadb_integration.py
+++ b/tests/behavior/test_chromadb_integration.py
@@ -6,6 +6,8 @@ import os
 
 import pytest
 
+pytest.importorskip("chromadb")
+
 chromadb_enabled = os.environ.get("ENABLE_CHROMADB", "false").lower() not in {
     "0",
     "false",

--- a/tests/behavior/test_cross_interface_consistency.py
+++ b/tests/behavior/test_cross_interface_consistency.py
@@ -11,6 +11,8 @@ from types import ModuleType
 from unittest.mock import MagicMock, patch
 
 import pytest
+
+pytest.importorskip("fastapi")
 from pytest_bdd import given, scenarios, then, when
 
 # Import step definitions implemented for FR-67

--- a/tests/behavior/test_enhanced_chromadb_integration.py
+++ b/tests/behavior/test_enhanced_chromadb_integration.py
@@ -6,6 +6,8 @@ import os
 
 import pytest
 
+pytest.importorskip("chromadb")
+
 chromadb_enabled = os.environ.get("ENABLE_CHROMADB", "false").lower() not in {
     "0",
     "false",

--- a/tests/integration/general/test_agent_api.py
+++ b/tests/integration/general/test_agent_api.py
@@ -1,170 +1,185 @@
 import pytest
 
-from types import ModuleType
-from unittest.mock import MagicMock
+pytest.importorskip("fastapi")
+
 import importlib
 import sys
+from types import ModuleType
+from unittest.mock import MagicMock
+
 from fastapi.testclient import TestClient
 
 
 def _setup(monkeypatch):
-    cli_stub = ModuleType('devsynth.application.cli')
+    cli_stub = ModuleType("devsynth.application.cli")
 
-    def init_cmd(path='.', project_root=None, language=None, goals=None, *,
-        bridge):
-        bridge.display_result('init')
+    def init_cmd(path=".", project_root=None, language=None, goals=None, *, bridge):
+        bridge.display_result("init")
 
-    def gather_cmd(output_file='requirements_plan.yaml', *, bridge):
-        g = bridge.ask_question('g')
-        c = bridge.ask_question('c')
-        p = bridge.ask_question('p')
-        bridge.display_result(f'{g},{c},{p}')
+    def gather_cmd(output_file="requirements_plan.yaml", *, bridge):
+        g = bridge.ask_question("g")
+        c = bridge.ask_question("c")
+        p = bridge.ask_question("p")
+        bridge.display_result(f"{g},{c},{p}")
 
     def run_pipeline_cmd(target=None, *, bridge):
-        bridge.display_result(f'run:{target}')
+        bridge.display_result(f"run:{target}")
 
-    def spec_cmd(requirements_file='requirements.md', *, bridge):
-        bridge.display_result(f'spec:{requirements_file}')
+    def spec_cmd(requirements_file="requirements.md", *, bridge):
+        bridge.display_result(f"spec:{requirements_file}")
 
-    def test_cmd(spec_file='specs.md', output_dir=None, *, bridge):
+    def test_cmd(spec_file="specs.md", output_dir=None, *, bridge):
         """Test that cmd succeeds.
 
-ReqID: N/A"""
-        bridge.display_result(f'test:{spec_file}')
+        ReqID: N/A"""
+        bridge.display_result(f"test:{spec_file}")
 
     def code_cmd(output_dir=None, *, bridge):
-        bridge.display_result('code')
+        bridge.display_result("code")
+
     cli_stub.init_cmd = MagicMock(side_effect=init_cmd)
     cli_stub.gather_cmd = MagicMock(side_effect=gather_cmd)
     cli_stub.run_pipeline_cmd = MagicMock(side_effect=run_pipeline_cmd)
     cli_stub.spec_cmd = MagicMock(side_effect=spec_cmd)
     cli_stub.test_cmd = MagicMock(side_effect=test_cmd)
     cli_stub.code_cmd = MagicMock(side_effect=code_cmd)
-    monkeypatch.setitem(sys.modules, 'devsynth.application.cli', cli_stub)
-    doctor_stub = ModuleType('devsynth.application.cli.commands.doctor_cmd')
+    monkeypatch.setitem(sys.modules, "devsynth.application.cli", cli_stub)
+    doctor_stub = ModuleType("devsynth.application.cli.commands.doctor_cmd")
 
-    def doctor_cmd(path='.', fix=False, *, bridge):
-        bridge.display_result(f'doctor:{path}:{fix}')
+    def doctor_cmd(path=".", fix=False, *, bridge):
+        bridge.display_result(f"doctor:{path}:{fix}")
+
     doctor_stub.doctor_cmd = MagicMock(side_effect=doctor_cmd)
-    monkeypatch.setitem(sys.modules,
-        'devsynth.application.cli.commands.doctor_cmd', doctor_stub)
-    edrr_stub = ModuleType('devsynth.application.cli.commands.edrr_cycle_cmd')
+    monkeypatch.setitem(
+        sys.modules, "devsynth.application.cli.commands.doctor_cmd", doctor_stub
+    )
+    edrr_stub = ModuleType("devsynth.application.cli.commands.edrr_cycle_cmd")
 
     def edrr_cycle_cmd(prompt, context=None, max_iterations=3, *, bridge):
-        bridge.display_result(f'edrr:{prompt}')
+        bridge.display_result(f"edrr:{prompt}")
+
     edrr_stub.edrr_cycle_cmd = MagicMock(side_effect=edrr_cycle_cmd)
-    monkeypatch.setitem(sys.modules,
-        'devsynth.application.cli.commands.edrr_cycle_cmd', edrr_stub)
+    monkeypatch.setitem(
+        sys.modules, "devsynth.application.cli.commands.edrr_cycle_cmd", edrr_stub
+    )
     import devsynth.interface.agentapi as agentapi
+
     importlib.reload(agentapi)
-    return {'cli': cli_stub, 'agentapi': agentapi, 'doctor_cmd':
-        doctor_stub.doctor_cmd, 'edrr_cycle_cmd': edrr_stub.edrr_cycle_cmd}
+    return {
+        "cli": cli_stub,
+        "agentapi": agentapi,
+        "doctor_cmd": doctor_stub.doctor_cmd,
+        "edrr_cycle_cmd": edrr_stub.edrr_cycle_cmd,
+    }
 
 
 def test_init_route_succeeds(monkeypatch):
     """Test that init route.
 
-ReqID: N/A"""
+    ReqID: N/A"""
     setup = _setup(monkeypatch)
-    client = TestClient(setup['agentapi'].app)
-    resp = client.post('/init', json={'path': 'proj'})
+    client = TestClient(setup["agentapi"].app)
+    resp = client.post("/init", json={"path": "proj"})
     assert resp.status_code == 200
-    assert resp.json() == {'messages': ['init']}
-    setup['cli'].init_cmd.assert_called_once()
+    assert resp.json() == {"messages": ["init"]}
+    setup["cli"].init_cmd.assert_called_once()
 
 
 @pytest.mark.medium
 def test_gather_route_succeeds(monkeypatch):
     """Test that gather route.
 
-ReqID: N/A"""
+    ReqID: N/A"""
     setup = _setup(monkeypatch)
-    client = TestClient(setup['agentapi'].app)
-    resp = client.post('/gather', json={'goals': 'g1', 'constraints': 'c1',
-        'priority': 'high'})
+    client = TestClient(setup["agentapi"].app)
+    resp = client.post(
+        "/gather", json={"goals": "g1", "constraints": "c1", "priority": "high"}
+    )
     assert resp.status_code == 200
-    assert resp.json() == {'messages': ['g1,c1,high']}
-    setup['cli'].gather_cmd.assert_called_once()
+    assert resp.json() == {"messages": ["g1,c1,high"]}
+    setup["cli"].gather_cmd.assert_called_once()
 
 
 @pytest.mark.medium
 def test_synthesize_and_status_succeeds(monkeypatch):
     """Test that synthesize and status.
 
-ReqID: N/A"""
+    ReqID: N/A"""
     setup = _setup(monkeypatch)
-    client = TestClient(setup['agentapi'].app)
-    resp = client.post('/synthesize', json={'target': 'unit'})
-    assert resp.json() == {'messages': ['run:unit']}
-    status = client.get('/status')
-    assert status.json() == {'messages': ['run:unit']}
-    setup['cli'].run_pipeline_cmd.assert_called_once()
+    client = TestClient(setup["agentapi"].app)
+    resp = client.post("/synthesize", json={"target": "unit"})
+    assert resp.json() == {"messages": ["run:unit"]}
+    status = client.get("/status")
+    assert status.json() == {"messages": ["run:unit"]}
+    setup["cli"].run_pipeline_cmd.assert_called_once()
 
 
 @pytest.mark.medium
 def test_spec_route_succeeds(monkeypatch):
     """Test that spec route.
 
-ReqID: N/A"""
+    ReqID: N/A"""
     setup = _setup(monkeypatch)
-    client = TestClient(setup['agentapi'].app)
-    resp = client.post('/spec', json={'requirements_file': 'custom_reqs.md'})
+    client = TestClient(setup["agentapi"].app)
+    resp = client.post("/spec", json={"requirements_file": "custom_reqs.md"})
     assert resp.status_code == 200
-    assert resp.json() == {'messages': ['spec:custom_reqs.md']}
-    setup['cli'].spec_cmd.assert_called_once()
-    args, kwargs = setup['cli'].spec_cmd.call_args
-    assert kwargs['requirements_file'] == 'custom_reqs.md'
+    assert resp.json() == {"messages": ["spec:custom_reqs.md"]}
+    setup["cli"].spec_cmd.assert_called_once()
+    args, kwargs = setup["cli"].spec_cmd.call_args
+    assert kwargs["requirements_file"] == "custom_reqs.md"
 
 
 @pytest.mark.medium
 def test_test_route_succeeds(monkeypatch):
     """Test that test route.
 
-ReqID: N/A"""
+    ReqID: N/A"""
     setup = _setup(monkeypatch)
-    client = TestClient(setup['agentapi'].app)
-    resp = client.post('/test', json={'spec_file': 'custom_specs.md',
-        'output_dir': 'tests'})
+    client = TestClient(setup["agentapi"].app)
+    resp = client.post(
+        "/test", json={"spec_file": "custom_specs.md", "output_dir": "tests"}
+    )
     assert resp.status_code == 200
-    assert resp.json() == {'messages': ['test:custom_specs.md']}
-    setup['cli'].test_cmd.assert_called_once()
+    assert resp.json() == {"messages": ["test:custom_specs.md"]}
+    setup["cli"].test_cmd.assert_called_once()
 
 
 @pytest.mark.medium
 def test_code_route_succeeds(monkeypatch):
     """Test that code route.
 
-ReqID: N/A"""
+    ReqID: N/A"""
     setup = _setup(monkeypatch)
-    client = TestClient(setup['agentapi'].app)
-    resp = client.post('/code', json={'output_dir': 'src'})
+    client = TestClient(setup["agentapi"].app)
+    resp = client.post("/code", json={"output_dir": "src"})
     assert resp.status_code == 200
-    assert resp.json() == {'messages': ['code']}
-    setup['cli'].code_cmd.assert_called_once()
+    assert resp.json() == {"messages": ["code"]}
+    setup["cli"].code_cmd.assert_called_once()
 
 
 @pytest.mark.medium
 def test_doctor_route_succeeds(monkeypatch):
     """Test that doctor route.
 
-ReqID: N/A"""
+    ReqID: N/A"""
     setup = _setup(monkeypatch)
-    client = TestClient(setup['agentapi'].app)
-    resp = client.post('/doctor', json={'path': 'project', 'fix': True})
+    client = TestClient(setup["agentapi"].app)
+    resp = client.post("/doctor", json={"path": "project", "fix": True})
     assert resp.status_code == 200
-    assert resp.json() == {'messages': ['doctor:project:True']}
-    setup['doctor_cmd'].assert_called_once()
+    assert resp.json() == {"messages": ["doctor:project:True"]}
+    setup["doctor_cmd"].assert_called_once()
 
 
 @pytest.mark.medium
 def test_edrr_cycle_route_succeeds(monkeypatch):
     """Test that edrr cycle route.
 
-ReqID: N/A"""
+    ReqID: N/A"""
     setup = _setup(monkeypatch)
-    client = TestClient(setup['agentapi'].app)
-    resp = client.post('/edrr-cycle', json={'prompt': 'Improve code',
-        'max_iterations': 5})
+    client = TestClient(setup["agentapi"].app)
+    resp = client.post(
+        "/edrr-cycle", json={"prompt": "Improve code", "max_iterations": 5}
+    )
     assert resp.status_code == 200
-    assert resp.json() == {'messages': ['edrr:Improve code']}
-    setup['edrr_cycle_cmd'].assert_called_once()
+    assert resp.json() == {"messages": ["edrr:Improve code"]}
+    setup["edrr_cycle_cmd"].assert_called_once()

--- a/tests/integration/general/test_agent_api_security.py
+++ b/tests/integration/general/test_agent_api_security.py
@@ -1,94 +1,108 @@
 """Integration tests for Agent API security and error handling."""
-from types import ModuleType
-from unittest.mock import MagicMock, patch
+
 import importlib
 import sys
+from types import ModuleType
+from unittest.mock import MagicMock, patch
+
 import pytest
+
+pytest.importorskip("fastapi")
 from fastapi.testclient import TestClient
 
 
-def _setup_with_auth(monkeypatch, access_token='test_token'):
+def _setup_with_auth(monkeypatch, access_token="test_token"):
     """Set up the API with authentication enabled."""
     settings_stub = MagicMock()
     settings_stub.access_token = access_token
-    monkeypatch.setattr('devsynth.api.settings', settings_stub)
-    cli_stub = ModuleType('devsynth.application.cli')
+    monkeypatch.setattr("devsynth.api.settings", settings_stub)
+    cli_stub = ModuleType("devsynth.application.cli")
 
-    def init_cmd(path='.', project_root=None, language=None, goals=None, *,
-        bridge):
-        bridge.display_result('init')
+    def init_cmd(path=".", project_root=None, language=None, goals=None, *, bridge):
+        bridge.display_result("init")
+
     cli_stub.init_cmd = MagicMock(side_effect=init_cmd)
-    monkeypatch.setitem(sys.modules, 'devsynth.application.cli', cli_stub)
+    monkeypatch.setitem(sys.modules, "devsynth.application.cli", cli_stub)
     import devsynth.interface.agentapi as agentapi
+
     importlib.reload(agentapi)
-    return {'client': TestClient(agentapi.app), 'cli': cli_stub, 'settings':
-        settings_stub}
+    return {
+        "client": TestClient(agentapi.app),
+        "cli": cli_stub,
+        "settings": settings_stub,
+    }
 
 
 @pytest.mark.medium
 def test_api_requires_authentication_succeeds(monkeypatch):
     """Test that API endpoints require authentication when access control is enabled.
 
-ReqID: N/A"""
+    ReqID: N/A"""
     setup = _setup_with_auth(monkeypatch)
-    client = setup['client']
-    resp = client.post('/init', json={'path': 'proj'})
+    client = setup["client"]
+    resp = client.post("/init", json={"path": "proj"})
     assert resp.status_code == 401
-    assert resp.json() == {'detail': 'Unauthorized'}
-    resp = client.post('/init', json={'path': 'proj'}, headers={
-        'Authorization': 'Bearer invalid_token'})
+    assert resp.json() == {"detail": "Unauthorized"}
+    resp = client.post(
+        "/init",
+        json={"path": "proj"},
+        headers={"Authorization": "Bearer invalid_token"},
+    )
     assert resp.status_code == 401
-    assert resp.json() == {'detail': 'Unauthorized'}
-    resp = client.post('/init', json={'path': 'proj'}, headers={
-        'Authorization': 'Bearer test_token'})
+    assert resp.json() == {"detail": "Unauthorized"}
+    resp = client.post(
+        "/init", json={"path": "proj"}, headers={"Authorization": "Bearer test_token"}
+    )
     assert resp.status_code == 200
-    assert resp.json() == {'messages': ['init']}
+    assert resp.json() == {"messages": ["init"]}
 
 
 @pytest.mark.medium
 def test_api_authentication_disabled_succeeds(monkeypatch):
     """Test that API endpoints don't require authentication when access control is disabled.
 
-ReqID: N/A"""
-    setup = _setup_with_auth(monkeypatch, access_token='')
-    client = setup['client']
-    resp = client.post('/init', json={'path': 'proj'})
+    ReqID: N/A"""
+    setup = _setup_with_auth(monkeypatch, access_token="")
+    client = setup["client"]
+    resp = client.post("/init", json={"path": "proj"})
     assert resp.status_code == 200
-    assert resp.json() == {'messages': ['init']}
-    resp = client.post('/init', json={'path': 'proj'}, headers={
-        'Authorization': 'Bearer any_token'})
+    assert resp.json() == {"messages": ["init"]}
+    resp = client.post(
+        "/init", json={"path": "proj"}, headers={"Authorization": "Bearer any_token"}
+    )
     assert resp.status_code == 200
-    assert resp.json() == {'messages': ['init']}
+    assert resp.json() == {"messages": ["init"]}
 
 
 @pytest.mark.medium
 def test_api_error_handling_raises_error(monkeypatch):
     """Test that API endpoints handle errors properly.
 
-ReqID: N/A"""
-    setup = _setup_with_auth(monkeypatch, access_token='')
-    client = setup['client']
-    cli = setup['cli']
+    ReqID: N/A"""
+    setup = _setup_with_auth(monkeypatch, access_token="")
+    client = setup["client"]
+    cli = setup["cli"]
 
     def init_cmd_error(*args, **kwargs):
-        raise ValueError('Test error')
+        raise ValueError("Test error")
+
     cli.init_cmd.side_effect = init_cmd_error
-    resp = client.post('/init', json={'path': 'proj'})
+    resp = client.post("/init", json={"path": "proj"})
     assert resp.status_code == 500
-    assert 'error' in resp.json()
-    assert 'Test error' in resp.json()['error']
+    assert "error" in resp.json()
+    assert "Test error" in resp.json()["error"]
 
 
 @pytest.mark.medium
 def test_api_validation_is_valid(monkeypatch):
     """Test that API endpoints validate request parameters.
 
-ReqID: N/A"""
-    setup = _setup_with_auth(monkeypatch, access_token='')
-    client = setup['client']
-    resp = client.post('/gather', json={})
+    ReqID: N/A"""
+    setup = _setup_with_auth(monkeypatch, access_token="")
+    client = setup["client"]
+    resp = client.post("/gather", json={})
     assert resp.status_code == 422
-    resp = client.post('/synthesize', json={'target': 123})
+    resp = client.post("/synthesize", json={"target": 123})
     assert resp.status_code == 422
 
 
@@ -96,27 +110,25 @@ ReqID: N/A"""
 def test_api_health_endpoint_succeeds(monkeypatch):
     """Test the health endpoint.
 
-ReqID: N/A"""
+    ReqID: N/A"""
     setup = _setup_with_auth(monkeypatch)
-    client = setup['client']
-    resp = client.get('/health')
+    client = setup["client"]
+    resp = client.get("/health")
     assert resp.status_code == 401
-    resp = client.get('/health', headers={'Authorization': 'Bearer test_token'}
-        )
+    resp = client.get("/health", headers={"Authorization": "Bearer test_token"})
     assert resp.status_code == 200
-    assert resp.json() == {'status': 'ok'}
+    assert resp.json() == {"status": "ok"}
 
 
 @pytest.mark.medium
 def test_api_metrics_endpoint_succeeds(monkeypatch):
     """Test the metrics endpoint.
 
-ReqID: N/A"""
+    ReqID: N/A"""
     setup = _setup_with_auth(monkeypatch)
-    client = setup['client']
-    resp = client.get('/metrics')
+    client = setup["client"]
+    resp = client.get("/metrics")
     assert resp.status_code == 401
-    resp = client.get('/metrics', headers={'Authorization':
-        'Bearer test_token'})
+    resp = client.get("/metrics", headers={"Authorization": "Bearer test_token"})
     assert resp.status_code == 200
-    assert 'request_count' in resp.text
+    assert "request_count" in resp.text

--- a/tests/integration/general/test_agentapi_routes.py
+++ b/tests/integration/general/test_agentapi_routes.py
@@ -1,32 +1,36 @@
 import pytest
 
-from types import ModuleType
-from unittest.mock import MagicMock
+pytest.importorskip("fastapi")
+
 import importlib
 import sys
+from types import ModuleType
+from unittest.mock import MagicMock
+
 from fastapi.testclient import TestClient
 
 
 def _setup(monkeypatch):
-    cli_stub = ModuleType('devsynth.application.cli')
+    cli_stub = ModuleType("devsynth.application.cli")
 
-    def init_cmd(path='.', project_root=None, language=None, goals=None, *,
-        bridge):
-        bridge.display_result('init')
+    def init_cmd(path=".", project_root=None, language=None, goals=None, *, bridge):
+        bridge.display_result("init")
 
-    def gather_cmd(output_file='requirements_plan.yaml', *, bridge):
-        g = bridge.ask_question('g')
-        c = bridge.ask_question('c')
-        p = bridge.ask_question('p')
-        bridge.display_result(f'{g},{c},{p}')
+    def gather_cmd(output_file="requirements_plan.yaml", *, bridge):
+        g = bridge.ask_question("g")
+        c = bridge.ask_question("c")
+        p = bridge.ask_question("p")
+        bridge.display_result(f"{g},{c},{p}")
 
     def run_pipeline_cmd(target=None, *, bridge):
-        bridge.display_result(f'run:{target}')
+        bridge.display_result(f"run:{target}")
+
     cli_stub.init_cmd = MagicMock(side_effect=init_cmd)
     cli_stub.gather_cmd = MagicMock(side_effect=gather_cmd)
     cli_stub.run_pipeline_cmd = MagicMock(side_effect=run_pipeline_cmd)
-    monkeypatch.setitem(sys.modules, 'devsynth.application.cli', cli_stub)
+    monkeypatch.setitem(sys.modules, "devsynth.application.cli", cli_stub)
     import devsynth.interface.agentapi as agentapi
+
     importlib.reload(agentapi)
     return cli_stub, agentapi
 
@@ -34,12 +38,12 @@ def _setup(monkeypatch):
 def test_init_route_succeeds(monkeypatch):
     """Test that init route succeeds.
 
-ReqID: N/A"""
+    ReqID: N/A"""
     cli_stub, agentapi = _setup(monkeypatch)
     client = TestClient(agentapi.app)
-    resp = client.post('/init', json={'path': 'proj'})
+    resp = client.post("/init", json={"path": "proj"})
     assert resp.status_code == 200
-    assert resp.json() == {'messages': ['init']}
+    assert resp.json() == {"messages": ["init"]}
     cli_stub.init_cmd.assert_called_once()
 
 
@@ -47,13 +51,14 @@ ReqID: N/A"""
 def test_gather_route_succeeds(monkeypatch):
     """Test that gather route succeeds.
 
-ReqID: N/A"""
+    ReqID: N/A"""
     cli_stub, agentapi = _setup(monkeypatch)
     client = TestClient(agentapi.app)
-    resp = client.post('/gather', json={'goals': 'g1', 'constraints': 'c1',
-        'priority': 'high'})
+    resp = client.post(
+        "/gather", json={"goals": "g1", "constraints": "c1", "priority": "high"}
+    )
     assert resp.status_code == 200
-    assert resp.json() == {'messages': ['g1,c1,high']}
+    assert resp.json() == {"messages": ["g1,c1,high"]}
     cli_stub.gather_cmd.assert_called_once()
 
 
@@ -61,11 +66,11 @@ ReqID: N/A"""
 def test_synthesize_and_status_succeeds(monkeypatch):
     """Test that synthesize and status succeeds.
 
-ReqID: N/A"""
+    ReqID: N/A"""
     cli_stub, agentapi = _setup(monkeypatch)
     client = TestClient(agentapi.app)
-    resp = client.post('/synthesize', json={'target': 'unit'})
-    assert resp.json() == {'messages': ['run:unit']}
-    status = client.get('/status')
-    assert status.json() == {'messages': ['run:unit']}
+    resp = client.post("/synthesize", json={"target": "unit"})
+    assert resp.json() == {"messages": ["run:unit"]}
+    status = client.get("/status")
+    assert status.json() == {"messages": ["run:unit"]}
     cli_stub.run_pipeline_cmd.assert_called_once()

--- a/tests/integration/general/test_cli_webui_agentapi_pipeline.py
+++ b/tests/integration/general/test_cli_webui_agentapi_pipeline.py
@@ -3,23 +3,29 @@
 This test verifies that commands issued through the CLI or WebUI correctly flow
 through the AgentAPI and return the expected results.
 """
+
 import os
-import pytest
+import shutil
 import sys
 import tempfile
-import shutil
-from unittest.mock import MagicMock, patch
 from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+pytest.importorskip("fastapi")
 from fastapi.testclient import TestClient
+
+from devsynth.interface.agentapi import WorkflowResponse
+from devsynth.interface.agentapi import app as agentapi_app
 from devsynth.interface.cli import CLIUXBridge
 from devsynth.interface.webui import WebUI
-from devsynth.interface.agentapi import app as agentapi_app, WorkflowResponse
 
 
 class TestCLIWebUIAgentAPIPipeline:
     """Test the complete pipeline from CLI/WebUI to AgentAPI and back.
 
-ReqID: N/A"""
+    ReqID: N/A"""
 
     @pytest.fixture
     def temp_project_dir(self):
@@ -35,7 +41,9 @@ ReqID: N/A"""
         """Mock streamlit for WebUI testing."""
         import sys
         from types import ModuleType
-        st = ModuleType('streamlit')
+
+        st = ModuleType("streamlit")
+
         # Create session_state as a dictionary with get method
         class SessionState(dict):
             def __init__(self, *args, **kwargs):
@@ -65,7 +73,7 @@ ReqID: N/A"""
         st.write = MagicMock()
         st.markdown = MagicMock()
         st.empty = MagicMock()
-        monkeypatch.setitem(sys.modules, 'streamlit', st)
+        monkeypatch.setitem(sys.modules, "streamlit", st)
         return st
 
     @pytest.fixture
@@ -84,173 +92,191 @@ ReqID: N/A"""
         return WebUI()
 
     @pytest.mark.medium
-    def test_init_command_pipeline_succeeds(self, temp_project_dir,
-        api_client, cli_bridge, webui_bridge, monkeypatch):
+    def test_init_command_pipeline_succeeds(
+        self, temp_project_dir, api_client, cli_bridge, webui_bridge, monkeypatch
+    ):
         """Test the init command pipeline from CLI/WebUI through AgentAPI.
 
-ReqID: N/A"""
+        ReqID: N/A"""
         # Test the WebUI part of the pipeline
-        with patch('devsynth.application.cli.cli_commands.init_cmd'
-            ) as mock_init_cmd:
-            mock_init_cmd.return_value = {'status': 'success', 'message':
-                'Project initialized'}
-            with patch('devsynth.interface.webui.init_cmd', side_effect=
-                mock_init_cmd):
-                mock_streamlit = sys.modules['streamlit']
-                mock_streamlit.text_input.side_effect = [temp_project_dir,
-                    'python', '']
+        with patch("devsynth.application.cli.cli_commands.init_cmd") as mock_init_cmd:
+            mock_init_cmd.return_value = {
+                "status": "success",
+                "message": "Project initialized",
+            }
+            with patch("devsynth.interface.webui.init_cmd", side_effect=mock_init_cmd):
+                mock_streamlit = sys.modules["streamlit"]
+                mock_streamlit.text_input.side_effect = [temp_project_dir, "python", ""]
                 webui_bridge.onboarding_page()
                 mock_init_cmd.assert_called_once()
                 args, kwargs = mock_init_cmd.call_args
-                assert kwargs.get('path') == temp_project_dir
+                assert kwargs.get("path") == temp_project_dir
 
     @pytest.mark.medium
-    def test_spec_command_pipeline_succeeds(self, temp_project_dir,
-        api_client, cli_bridge, webui_bridge, monkeypatch):
+    def test_spec_command_pipeline_succeeds(
+        self, temp_project_dir, api_client, cli_bridge, webui_bridge, monkeypatch
+    ):
         """Test the spec command pipeline from CLI/WebUI through AgentAPI.
 
-ReqID: N/A"""
+        ReqID: N/A"""
         # Test the WebUI part of the pipeline
-        requirements_dir = os.path.join(temp_project_dir, 'docs')
+        requirements_dir = os.path.join(temp_project_dir, "docs")
         os.makedirs(requirements_dir, exist_ok=True)
-        requirements_file = os.path.join(requirements_dir, 'requirements.md')
-        with open(requirements_file, 'w') as f:
-            f.write('# Requirements\n\n1. Requirement 1\n2. Requirement 2\n')
-        with patch('devsynth.application.cli.cli_commands.spec_cmd'
-            ) as mock_spec_cmd:
-            mock_spec_cmd.return_value = {'status': 'success', 'message':
-                'Specifications generated'}
-            with patch('devsynth.interface.webui.spec_cmd', side_effect=
-                mock_spec_cmd):
-                mock_streamlit = sys.modules['streamlit']
+        requirements_file = os.path.join(requirements_dir, "requirements.md")
+        with open(requirements_file, "w") as f:
+            f.write("# Requirements\n\n1. Requirement 1\n2. Requirement 2\n")
+        with patch("devsynth.application.cli.cli_commands.spec_cmd") as mock_spec_cmd:
+            mock_spec_cmd.return_value = {
+                "status": "success",
+                "message": "Specifications generated",
+            }
+            with patch("devsynth.interface.webui.spec_cmd", side_effect=mock_spec_cmd):
+                mock_streamlit = sys.modules["streamlit"]
                 mock_streamlit.text_input.return_value = requirements_file
-                if hasattr(webui_bridge, 'spec_page'):
+                if hasattr(webui_bridge, "spec_page"):
                     webui_bridge.spec_page()
                     mock_spec_cmd.assert_called_once()
                     args, kwargs = mock_spec_cmd.call_args
-                    assert kwargs.get('requirements_file') == requirements_file
+                    assert kwargs.get("requirements_file") == requirements_file
 
     @pytest.mark.medium
-    def test_test_command_pipeline_succeeds(self, temp_project_dir,
-        api_client, cli_bridge, monkeypatch):
+    def test_test_command_pipeline_succeeds(
+        self, temp_project_dir, api_client, cli_bridge, monkeypatch
+    ):
         """Test the test command pipeline from CLI through AgentAPI.
 
-ReqID: N/A"""
+        ReqID: N/A"""
         # Test the CLI part of the pipeline directly
-        spec_file = os.path.join(temp_project_dir, 'specs.md')
-        with open(spec_file, 'w') as f:
-            f.write('# Specifications\n\n1. Spec 1\n2. Spec 2\n')
-        with patch('devsynth.application.cli.cli_commands.test_cmd'
-            ) as mock_test_cmd:
-            mock_test_cmd.return_value = {'status': 'success', 'message':
-                'Tests generated'}
+        spec_file = os.path.join(temp_project_dir, "specs.md")
+        with open(spec_file, "w") as f:
+            f.write("# Specifications\n\n1. Spec 1\n2. Spec 2\n")
+        with patch("devsynth.application.cli.cli_commands.test_cmd") as mock_test_cmd:
+            mock_test_cmd.return_value = {
+                "status": "success",
+                "message": "Tests generated",
+            }
             # Call the CLI command directly
             from devsynth.application.cli import test_cmd
+
             result = test_cmd(spec_file=spec_file, bridge=cli_bridge)
             assert result == mock_test_cmd.return_value
             mock_test_cmd.assert_called_once()
             args, kwargs = mock_test_cmd.call_args
-            assert kwargs.get('spec_file') == spec_file
+            assert kwargs.get("spec_file") == spec_file
 
     @pytest.mark.medium
-    def test_code_command_pipeline_succeeds(self, temp_project_dir,
-        api_client, cli_bridge, monkeypatch):
+    def test_code_command_pipeline_succeeds(
+        self, temp_project_dir, api_client, cli_bridge, monkeypatch
+    ):
         """Test the code command pipeline from CLI through AgentAPI.
 
-ReqID: N/A"""
+        ReqID: N/A"""
         # Test the CLI part of the pipeline directly
-        with patch('devsynth.application.cli.cli_commands.code_cmd'
-            ) as mock_code_cmd:
-            mock_code_cmd.return_value = {'status': 'success', 'message':
-                'Code generated'}
+        with patch("devsynth.application.cli.cli_commands.code_cmd") as mock_code_cmd:
+            mock_code_cmd.return_value = {
+                "status": "success",
+                "message": "Code generated",
+            }
             # Call the CLI command directly
             from devsynth.application.cli import code_cmd
+
             result = code_cmd(bridge=cli_bridge)
             assert result == mock_code_cmd.return_value
             mock_code_cmd.assert_called_once()
             args, kwargs = mock_code_cmd.call_args
 
     @pytest.mark.medium
-    def test_edrr_cycle_command_pipeline_succeeds(self, temp_project_dir,
-        api_client, cli_bridge, monkeypatch):
+    def test_edrr_cycle_command_pipeline_succeeds(
+        self, temp_project_dir, api_client, cli_bridge, monkeypatch
+    ):
         """Test the EDRR cycle command pipeline from CLI through AgentAPI.
 
-ReqID: N/A"""
+        ReqID: N/A"""
         # Test the CLI part of the pipeline directly
         with patch(
-            'devsynth.application.cli.commands.edrr_cycle_cmd.edrr_cycle_cmd'
-            ) as mock_edrr_cycle_cmd:
-            mock_edrr_cycle_cmd.return_value = {'status': 'success',
-                'message': 'EDRR cycle completed'}
+            "devsynth.application.cli.commands.edrr_cycle_cmd.edrr_cycle_cmd"
+        ) as mock_edrr_cycle_cmd:
+            mock_edrr_cycle_cmd.return_value = {
+                "status": "success",
+                "message": "EDRR cycle completed",
+            }
             # Call the CLI command directly
             from devsynth.application.cli.commands.edrr_cycle_cmd import edrr_cycle_cmd
-            result = edrr_cycle_cmd(prompt='Improve code', max_iterations=3, bridge=cli_bridge)
+
+            result = edrr_cycle_cmd(
+                prompt="Improve code", max_iterations=3, bridge=cli_bridge
+            )
             assert result == mock_edrr_cycle_cmd.return_value
             mock_edrr_cycle_cmd.assert_called_once()
             args, kwargs = mock_edrr_cycle_cmd.call_args
-            assert kwargs.get('prompt') == 'Improve code'
-            assert kwargs.get('max_iterations') == 3
+            assert kwargs.get("prompt") == "Improve code"
+            assert kwargs.get("max_iterations") == 3
 
     @pytest.mark.medium
-    def test_error_handling_in_pipeline_raises_error(self, temp_project_dir,
-        cli_bridge, monkeypatch):
+    def test_error_handling_in_pipeline_raises_error(
+        self, temp_project_dir, cli_bridge, monkeypatch
+    ):
         """Test error handling in the CLI/WebUI/AgentAPI pipeline.
 
-ReqID: N/A"""
+        ReqID: N/A"""
         # Test error handling in the CLI part of the pipeline directly
-        with patch('devsynth.application.cli.cli_commands.init_cmd'
-            ) as mock_init_cmd:
-            mock_init_cmd.side_effect = ValueError('Test error')
+        with patch("devsynth.application.cli.cli_commands.init_cmd") as mock_init_cmd:
+            mock_init_cmd.side_effect = ValueError("Test error")
             # Call the CLI command directly and expect an exception
             from devsynth.application.cli import init_cmd
+
             try:
                 init_cmd(bridge=cli_bridge)
                 assert False, "Expected ValueError was not raised"
             except ValueError as e:
-                assert str(e) == 'Test error'
+                assert str(e) == "Test error"
             mock_init_cmd.assert_called_once()
-            
+
     @pytest.mark.medium
-    def test_webui_command_pipeline_succeeds(self, temp_project_dir,
-        api_client, cli_bridge, monkeypatch):
+    def test_webui_command_pipeline_succeeds(
+        self, temp_project_dir, api_client, cli_bridge, monkeypatch
+    ):
         """Test the WebUI command pipeline from CLI through AgentAPI.
 
-ReqID: N/A"""
+        ReqID: N/A"""
         # Test the CLI part of the pipeline directly
-        with patch('devsynth.application.cli.cli_commands.webui_cmd'
-            ) as mock_webui_cmd:
+        with patch("devsynth.application.cli.cli_commands.webui_cmd") as mock_webui_cmd:
             mock_webui_cmd.return_value = None  # webui_cmd doesn't return a value
-            
+
             # Mock the run function to avoid actually launching the WebUI
-            with patch('devsynth.interface.webui.run') as mock_run:
+            with patch("devsynth.interface.webui.run") as mock_run:
                 # Call the CLI command directly
                 from devsynth.application.cli import webui_cmd
+
                 webui_cmd(bridge=cli_bridge)
-                
+
                 # Verify that webui_cmd was called
                 mock_webui_cmd.assert_called_once()
-                
+
                 # Verify that the run function was called
                 mock_run.assert_called_once()
-                
+
     @pytest.mark.medium
-    def test_webui_command_error_handling_succeeds(self, temp_project_dir,
-        cli_bridge, monkeypatch):
+    def test_webui_command_error_handling_succeeds(
+        self, temp_project_dir, cli_bridge, monkeypatch
+    ):
         """Test error handling in the WebUI command pipeline.
 
-ReqID: N/A"""
+        ReqID: N/A"""
         # Test error handling in the CLI part of the pipeline directly
-        with patch('devsynth.interface.webui.run',
-            side_effect=ImportError('No module named "streamlit"')
-            ) as mock_run:
-            
+        with patch(
+            "devsynth.interface.webui.run",
+            side_effect=ImportError('No module named "streamlit"'),
+        ) as mock_run:
+
             # Call the CLI command directly
             from devsynth.application.cli import webui_cmd
+
             webui_cmd(bridge=cli_bridge)
-            
+
             # Verify that the run function was called
             mock_run.assert_called_once()
-            
+
             # Verify that an error message was displayed
             # Since we're using a real CLI bridge, we can't easily check the output
             # In a real test, we would use a mock bridge and verify the display_result call

--- a/tests/integration/memory/test_backend_persistence.py
+++ b/tests/integration/memory/test_backend_persistence.py
@@ -1,5 +1,7 @@
 import pytest
 
+pytest.importorskip("chromadb")
+
 MultiStoreSyncManager = pytest.importorskip(
     "devsynth.adapters.memory.sync_manager"
 ).MultiStoreSyncManager

--- a/tests/integration/memory/test_chromadb_adapter_transactions.py
+++ b/tests/integration/memory/test_chromadb_adapter_transactions.py
@@ -1,5 +1,7 @@
 import pytest
 
+pytest.importorskip("chromadb")
+
 ChromaDBAdapter = pytest.importorskip(
     "devsynth.adapters.memory.chroma_db_adapter"
 ).ChromaDBAdapter

--- a/tests/integration/memory/test_cross_store_sync.py
+++ b/tests/integration/memory/test_cross_store_sync.py
@@ -1,16 +1,23 @@
 import sys
+
 import pytest
+
+pytest.importorskip("chromadb")
 
 LMDBStore = pytest.importorskip("devsynth.application.memory.lmdb_store").LMDBStore
 FAISSStore = pytest.importorskip("devsynth.application.memory.faiss_store").FAISSStore
 from devsynth.adapters.kuzu_memory_store import KuzuMemoryStore
 from devsynth.application.memory.kuzu_store import KuzuStore
-ChromaDBStore = pytest.importorskip("devsynth.application.memory.chromadb_store").ChromaDBStore
-ChromaDBAdapter = pytest.importorskip("devsynth.adapters.memory.chroma_db_adapter").ChromaDBAdapter
+
+ChromaDBStore = pytest.importorskip(
+    "devsynth.application.memory.chromadb_store"
+).ChromaDBStore
+ChromaDBAdapter = pytest.importorskip(
+    "devsynth.adapters.memory.chroma_db_adapter"
+).ChromaDBAdapter
 from devsynth.application.memory.memory_manager import MemoryManager
 from devsynth.application.memory.sync_manager import SyncManager
-from devsynth.domain.models.memory import MemoryItem, MemoryVector, MemoryType
-
+from devsynth.domain.models.memory import MemoryItem, MemoryType, MemoryVector
 
 pytestmark = [
     pytest.mark.requires_resource("lmdb"),

--- a/tests/integration/memory/test_transactional_sync.py
+++ b/tests/integration/memory/test_transactional_sync.py
@@ -1,17 +1,23 @@
 import sys
+
 import pytest
+
+pytest.importorskip("chromadb")
 
 LMDBStore = pytest.importorskip("devsynth.application.memory.lmdb_store").LMDBStore
 FAISSStore = pytest.importorskip("devsynth.application.memory.faiss_store").FAISSStore
 from devsynth.adapters.kuzu_memory_store import KuzuMemoryStore
 from devsynth.application.memory.kuzu_store import KuzuStore
-ChromaDBStore = pytest.importorskip("devsynth.application.memory.chromadb_store").ChromaDBStore
+
+ChromaDBStore = pytest.importorskip(
+    "devsynth.application.memory.chromadb_store"
+).ChromaDBStore
 ChromaDBAdapter = pytest.importorskip(
     "devsynth.adapters.memory.chroma_db_adapter"
 ).ChromaDBAdapter
 from devsynth.application.memory.memory_manager import MemoryManager
 from devsynth.application.memory.sync_manager import SyncManager
-from devsynth.domain.models.memory import MemoryItem, MemoryVector, MemoryType
+from devsynth.domain.models.memory import MemoryItem, MemoryType, MemoryVector
 
 pytestmark = [
     pytest.mark.requires_resource("lmdb"),

--- a/tests/performance/test_api_benchmarks.py
+++ b/tests/performance/test_api_benchmarks.py
@@ -1,5 +1,8 @@
 """Benchmarks for API endpoints. ReqID: PERF-03"""
 
+import pytest
+
+pytest.importorskip("fastapi")
 from fastapi.testclient import TestClient
 
 from devsynth.api import app

--- a/tests/test_chromadb_store_import.py
+++ b/tests/test_chromadb_store_import.py
@@ -1,3 +1,6 @@
+import pytest
+
+pytest.importorskip("chromadb")
 from tests.lightweight_imports import apply_lightweight_imports
 
 

--- a/tests/unit/general/test_api_health.py
+++ b/tests/unit/general/test_api_health.py
@@ -1,25 +1,29 @@
 import os
+
+import pytest
+
 from devsynth.api import app
+
+pytest.importorskip("fastapi")
 from fastapi.testclient import TestClient
-os.environ['DEVSYNTH_ACCESS_TOKEN'] = 'test-token'
+
+os.environ["DEVSYNTH_ACCESS_TOKEN"] = "test-token"
 client = TestClient(app)
 
 
 def test_health_endpoint_succeeds():
     """Test that health endpoint succeeds.
 
-ReqID: N/A"""
-    resp = client.get('/health', headers={'Authorization': 'Bearer test-token'}
-        )
+    ReqID: N/A"""
+    resp = client.get("/health", headers={"Authorization": "Bearer test-token"})
     assert resp.status_code == 200
-    assert resp.json() == {'status': 'ok'}
+    assert resp.json() == {"status": "ok"}
 
 
 def test_metrics_endpoint_succeeds():
     """Test that metrics endpoint succeeds.
 
-ReqID: N/A"""
-    resp = client.get('/metrics', headers={'Authorization':
-        'Bearer test-token'})
+    ReqID: N/A"""
+    resp = client.get("/metrics", headers={"Authorization": "Bearer test-token"})
     assert resp.status_code == 200
-    assert b'request_count' in resp.content
+    assert b"request_count" in resp.content

--- a/tests/unit/interface/test_api_advanced.py
+++ b/tests/unit/interface/test_api_advanced.py
@@ -1,28 +1,36 @@
 import pytest
+
+pytest.importorskip("fastapi")
+from unittest.mock import MagicMock, patch
+
 from fastapi import HTTPException
 from fastapi.testclient import TestClient
-from unittest.mock import patch, MagicMock
+
 from devsynth.api import app
 from devsynth.interface.agentapi import (
-    init_endpoint,
-    gather_endpoint,
-    synthesize_endpoint,
-    spec_endpoint,
-    test_endpoint,
-    code_endpoint,
-    doctor_endpoint,
-    edrr_cycle_endpoint,
-    status_endpoint,
-    InitRequest,
-    GatherRequest,
-    SynthesizeRequest,
-    SpecRequest,
-    TestSpecRequest as APITestSpecRequest,
+    LATEST_MESSAGES,
     CodeRequest,
     DoctorRequest,
     EDRRCycleRequest,
-    LATEST_MESSAGES,
-)  # Uncommented closing parenthesis
+    GatherRequest,
+    InitRequest,
+    SpecRequest,
+    SynthesizeRequest,
+)
+from devsynth.interface.agentapi import (
+    TestSpecRequest as APITestSpecRequest,  # Uncommented closing parenthesis
+)
+from devsynth.interface.agentapi import (
+    code_endpoint,
+    doctor_endpoint,
+    edrr_cycle_endpoint,
+    gather_endpoint,
+    init_endpoint,
+    spec_endpoint,
+    status_endpoint,
+    synthesize_endpoint,
+    test_endpoint,
+)
 
 
 @pytest.fixture

--- a/tests/unit/interface/test_api_endpoints.py
+++ b/tests/unit/interface/test_api_endpoints.py
@@ -1,27 +1,33 @@
 import pytest
+
+pytest.importorskip("fastapi")
+from unittest.mock import MagicMock, patch
+
 from fastapi import HTTPException
 from fastapi.testclient import TestClient
-from unittest.mock import patch, MagicMock
+
 from devsynth.api import app
 from devsynth.interface.agentapi import (
-    init_endpoint,
-    gather_endpoint,
-    synthesize_endpoint,
-    spec_endpoint,
-    test_endpoint,
-    code_endpoint,
-    doctor_endpoint,
-    edrr_cycle_endpoint,
-    status_endpoint,
-    InitRequest,
-    GatherRequest,
-    SynthesizeRequest,
-    SpecRequest,
-    TestSpecRequest as APITestSpecRequest,
+    LATEST_MESSAGES,
     CodeRequest,
     DoctorRequest,
     EDRRCycleRequest,
-    LATEST_MESSAGES,
+    GatherRequest,
+    InitRequest,
+    SpecRequest,
+    SynthesizeRequest,
+)
+from devsynth.interface.agentapi import TestSpecRequest as APITestSpecRequest
+from devsynth.interface.agentapi import (
+    code_endpoint,
+    doctor_endpoint,
+    edrr_cycle_endpoint,
+    gather_endpoint,
+    init_endpoint,
+    spec_endpoint,
+    status_endpoint,
+    synthesize_endpoint,
+    test_endpoint,
 )
 
 

--- a/tests/unit/security/test_api_authentication.py
+++ b/tests/unit/security/test_api_authentication.py
@@ -1,63 +1,67 @@
 import pytest
+
+pytest.importorskip("fastapi")
+from unittest.mock import MagicMock, patch
+
 from fastapi import HTTPException
-from unittest.mock import patch, MagicMock
+
 from devsynth.api import verify_token
 
 
 @pytest.fixture
 def mock_settings():
     """Mock settings with a test token."""
-    with patch('devsynth.api.settings') as mock_settings:
-        mock_settings.access_token = 'test_token'
+    with patch("devsynth.api.settings") as mock_settings:
+        mock_settings.access_token = "test_token"
         yield mock_settings
 
 
 def test_verify_token_valid_is_valid(mock_settings):
     """Test that verify_token accepts a valid token.
 
-ReqID: N/A"""
-    authorization = 'Bearer test_token'
+    ReqID: N/A"""
+    authorization = "Bearer test_token"
     verify_token(authorization)
 
 
 def test_verify_token_invalid_is_valid(mock_settings):
     """Test that verify_token rejects an invalid token.
 
-ReqID: N/A"""
-    authorization = 'Bearer invalid_token'
+    ReqID: N/A"""
+    authorization = "Bearer invalid_token"
     with pytest.raises(HTTPException) as excinfo:
         verify_token(authorization)
     assert excinfo.value.status_code == 401
-    assert excinfo.value.detail == 'Unauthorized'
+    assert excinfo.value.detail == "Unauthorized"
 
 
 def test_verify_token_missing_succeeds(mock_settings):
     """Test that verify_token rejects a missing token.
 
-ReqID: N/A"""
+    ReqID: N/A"""
     authorization = None
     with pytest.raises(HTTPException) as excinfo:
         verify_token(authorization)
     assert excinfo.value.status_code == 401
-    assert excinfo.value.detail == 'Unauthorized'
+    assert excinfo.value.detail == "Unauthorized"
 
 
 def test_verify_token_wrong_format_succeeds(mock_settings):
     """Test that verify_token rejects a token in the wrong format.
 
-ReqID: N/A"""
-    authorization = 'test_token'
+    ReqID: N/A"""
+    authorization = "test_token"
     with pytest.raises(HTTPException) as excinfo:
         verify_token(authorization)
     assert excinfo.value.status_code == 401
-    assert excinfo.value.detail == 'Unauthorized'
+    assert excinfo.value.detail == "Unauthorized"
 
 
 def test_verify_token_access_control_disabled_succeeds(mock_settings):
     """Test that verify_token accepts any token when access control is disabled.
 
-ReqID: N/A"""
-    mock_settings.access_token = ''
-    verify_token('Bearer any_token')
-    verify_token('any_token')
+    ReqID: N/A"""
+    mock_settings.access_token = ""
+    verify_token("Bearer any_token")
+    verify_token("any_token")
     verify_token(None)


### PR DESCRIPTION
## Summary
- document installing test dependencies with `poetry install --with dev --extras tests retrieval chromadb api`
- skip FastAPI- and ChromaDB-dependent tests when extras are missing
- ensure CI installs test extras

## Testing
- `poetry run pip check`
- `poetry run pytest tests/unit/general/test_api_health.py::test_health_endpoint_succeeds -q` *(fails: Coverage failure)*
- `poetry run python tests/verify_test_organization.py`
- `poetry run python scripts/run_all_tests.py` *(fails: KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_6898f0c90cc88333b6ad1568d6c3d21d