### PR TITLE
feat: use sha256 for documentation hash

### DIFF
--- a/src/devsynth/application/documentation/ingestion.py
+++ b/src/devsynth/application/documentation/ingestion.py
@@ -418,7 +418,8 @@ class DocumentationIngestionManager:
 
         # Create a unique ID based on content and source
         source = metadata.get("source", "unknown")
-        content_hash = hashlib.md5(content.encode()).hexdigest()
+        # Use SHA-256 for a more secure and collision-resistant hash
+        content_hash = hashlib.sha256(content.encode()).hexdigest()
         doc_id = f"doc_{source}_{content_hash}"
 
         # Record the documentation type in metadata for easier querying.


### PR DESCRIPTION
## Summary
- use SHA-256 for documentation content hashing to generate IDs

## Testing
- `poetry run pre-commit run --files src/devsynth/application/documentation/ingestion.py`
- `poetry run pytest -m "not memory_intensive"` (fails: 34 errors during collection)
- `poetry run pip check`
- `poetry run python scripts/run_all_tests.py` (fails: KeyError in xdist worker)
- `poetry run python tests/verify_test_organization.py`


------
https://chatgpt.com/codex/tasks/task_e_6898f0b724dc83339b4e9186facf7de6