### PR TITLE
Refine interface exception handling

### DIFF
--- a/src/devsynth/interface/state_access.py
+++ b/src/devsynth/interface/state_access.py
@@ -10,20 +10,22 @@ from typing import Any, Optional
 # Module level logger
 logger = logging.getLogger(__name__)
 
+
 def is_session_state_available(session_state) -> bool:
     """Check if session state is available and usable.
-    
+
     Args:
         session_state: The session state object to check
-        
+
     Returns:
         True if session state is available and usable, False otherwise
     """
     return session_state is not None
 
+
 def handle_state_error(operation: str, key: str, error: Exception) -> None:
     """Handle errors in state operations consistently.
-    
+
     Args:
         operation: The operation being performed (get, set, etc.)
         key: The key being accessed
@@ -31,76 +33,80 @@ def handle_state_error(operation: str, key: str, error: Exception) -> None:
     """
     logger.warning(f"Error {operation} session state key '{key}': {str(error)}")
 
+
 def get_session_value(session_state, key: str, default: Any = None) -> Any:
     """Get a value from session state consistently.
-    
+
     This function handles different implementations of session state
     and provides robust error handling.
-    
+
     Args:
         session_state: The session state object
         key: The key to retrieve from session state
         default: The default value to return if the key is not found
-        
+
     Returns:
         The value from session state or the default value
     """
     if not is_session_state_available(session_state):
         logger.warning(f"Session state not available, returning default for {key}")
         return default
-        
+
     try:
         # First try attribute access (common in production)
         value = getattr(session_state, key, None)
-        
+
         # If not found and session_state is dict-like, try dict access (common in tests)
         if value is None and hasattr(session_state, "get"):
             value = session_state.get(key, default)
-            
+
         # If still None but not explicitly set to None, return default
-        if value is None and key not in dir(session_state) and (
-            not hasattr(session_state, "get") or key not in session_state
+        if (
+            value is None
+            and key not in dir(session_state)
+            and (not hasattr(session_state, "get") or key not in session_state)
         ):
             return default
-            
+
         return value
-    except Exception as e:
+    except (AttributeError, TypeError) as e:
         # Log the error for debugging
         handle_state_error("accessing", key, e)
         return default
-        
+
+
 def set_session_value(session_state, key: str, value: Any) -> bool:
     """Set a value in session state consistently.
-    
+
     This function handles different implementations of session state
     and provides robust error handling.
-    
+
     Args:
         session_state: The session state object
         key: The key to set in session state
         value: The value to set
-        
+
     Returns:
         True if the value was set successfully, False otherwise
     """
     if not is_session_state_available(session_state):
         logger.warning(f"Session state not available, cannot set {key}")
         return False
-        
+
     success = False
     try:
         # Try attribute access first (common in production)
         setattr(session_state, key, value)
         success = True
-    except Exception as e:
+    except (AttributeError, TypeError) as e:
         handle_state_error("setting", key, e)
-        
+
     try:
         # Also try dict-like access (common in tests)
         if hasattr(session_state, "__setitem__"):
             session_state[key] = value
             success = True
-    except Exception as e:
+    except (TypeError, KeyError) as e:
         handle_state_error("setting via item", key, e)
-        
+
     return success

--- a/src/devsynth/interface/webui_state.py
+++ b/src/devsynth/interface/webui_state.py
@@ -5,30 +5,31 @@ This module provides common utilities for managing state in the WebUI components
 It ensures consistent state persistence and error handling across all WebUI pages.
 """
 
-import streamlit as st
-from typing import Any, Dict, Optional, TypeVar, Generic, Callable
 import logging
 from functools import wraps
+from typing import Any, Callable, Dict, Generic, Optional, TypeVar
 
-from devsynth.logging_setup import DevSynthLogger
+import streamlit as st
+
 from devsynth.interface.state_access import get_session_value as _get_session_value
 from devsynth.interface.state_access import set_session_value as _set_session_value
+from devsynth.logging_setup import DevSynthLogger
 
 # Module level logger
 logger = DevSynthLogger(__name__)
 
 # Type variable for generic functions
-T = TypeVar('T')
+T = TypeVar("T")
 
 
 def get_session_value(key: str, default: Any = None) -> Any:
     """
     Get a value from the session state with error handling.
-    
+
     Args:
         key: The key to retrieve from the session state
         default: The default value to return if the key is not found
-        
+
     Returns:
         The value from the session state or the default value
     """
@@ -38,11 +39,11 @@ def get_session_value(key: str, default: Any = None) -> Any:
 def set_session_value(key: str, value: Any) -> bool:
     """
     Set a value in the session state with error handling.
-    
+
     Args:
         key: The key to set in the session state
         value: The value to set
-        
+
     Returns:
         True if the value was set successfully, False otherwise
     """
@@ -55,16 +56,17 @@ def set_session_value(key: str, value: Any) -> bool:
 def with_state_management(prefix: str = "") -> Callable:
     """
     Decorator to add state management to a WebUI page or component.
-    
+
     This decorator adds get_session_value and set_session_value methods to the
     decorated function, with an optional prefix for the keys.
-    
+
     Args:
         prefix: Optional prefix for session state keys
-        
+
     Returns:
         Decorated function with state management
     """
+
     def decorator(func: Callable) -> Callable:
         @wraps(func)
         def wrapper(*args, **kwargs):
@@ -72,31 +74,33 @@ def with_state_management(prefix: str = "") -> Callable:
             def prefixed_get(key: str, default: Any = None) -> Any:
                 full_key = f"{prefix}_{key}" if prefix else key
                 return get_session_value(full_key, default)
-                
+
             def prefixed_set(key: str, value: Any) -> None:
                 full_key = f"{prefix}_{key}" if prefix else key
                 set_session_value(full_key, value)
-                
-            kwargs['get_session_value'] = prefixed_get
-            kwargs['set_session_value'] = prefixed_set
-            
+
+            kwargs["get_session_value"] = prefixed_get
+            kwargs["set_session_value"] = prefixed_set
+
             return func(*args, **kwargs)
+
         return wrapper
+
     return decorator
 
 
 class PageState(Generic[T]):
     """
     Class for managing state for a specific WebUI page.
-    
+
     This class provides a consistent interface for managing state across
     different pages, with proper error handling and logging.
     """
-    
+
     def __init__(self, page_name: str, initial_state: Optional[Dict[str, Any]] = None):
         """
         Initialize the page state.
-        
+
         Args:
             page_name: Name of the page (used as prefix for session state keys)
             initial_state: Optional initial state dictionary
@@ -104,35 +108,35 @@ class PageState(Generic[T]):
         self.page_name = page_name
         self.initial_state = initial_state or {}
         self._initialize_state()
-        
+
     def _initialize_state(self) -> None:
         """Initialize the state with default values if not already set."""
         for key, value in self.initial_state.items():
             if not self.has(key):
                 self.set(key, value)
-                
+
     def get(self, key: str, default: Any = None) -> Any:
         """
         Get a value from the page state.
-        
+
         Args:
             key: The key to retrieve
             default: The default value to return if the key is not found
-            
+
         Returns:
             The value from the state or the default value
         """
         full_key = f"{self.page_name}_{key}"
         return get_session_value(full_key, default)
-        
+
     def set(self, key: str, value: Any) -> bool:
         """
         Set a value in the page state.
-        
+
         Args:
             key: The key to set
             value: The value to set
-            
+
         Returns:
             True if the value was set successfully, False otherwise
         """
@@ -141,14 +145,14 @@ class PageState(Generic[T]):
         if not success:
             logger.error(f"Failed to set '{key}' in page state")
         return success
-        
+
     def has(self, key: str) -> bool:
         """
         Check if a key exists in the page state.
-        
+
         Args:
             key: The key to check
-            
+
         Returns:
             True if the key exists, False otherwise
         """
@@ -157,17 +161,18 @@ class PageState(Generic[T]):
         sentinel = object()
         value = get_session_value(full_key, sentinel)
         return value is not sentinel
-            
+
     def clear(self) -> None:
         """Clear all state for this page."""
         try:
-            if not hasattr(st, 'session_state'):
-                logger.warning(f"Session state not available, cannot clear {self.page_name} state")
+            if not hasattr(st, "session_state"):
+                logger.warning(
+                    f"Session state not available, cannot clear {self.page_name} state"
+                )
                 return
-                
+
             keys_to_remove = [
-                k for k in st.session_state.keys()
-                if k.startswith(f"{self.page_name}_")
+                k for k in st.session_state.keys() if k.startswith(f"{self.page_name}_")
             ]
             for key in keys_to_remove:
                 try:
@@ -178,11 +183,12 @@ class PageState(Generic[T]):
                     delattr(st.session_state, key)
                 except AttributeError:
                     pass
-                
+
             logger.debug(f"Cleared {len(keys_to_remove)} keys for {self.page_name}")
         except Exception as e:
-            logger.error(f"Error clearing state for {self.page_name}: {str(e)}")
-            
+            logger.exception(f"Error clearing state for {self.page_name}: {str(e)}")
+            raise
+
     def reset(self) -> None:
         """Reset the state to the initial values."""
         self.clear()
@@ -192,16 +198,20 @@ class PageState(Generic[T]):
 class WizardState(PageState):
     """
     Specialized state management for wizards with multiple steps.
-    
+
     This class extends PageState with additional functionality for
     managing wizard steps and navigation.
     """
-    
-    def __init__(self, wizard_name: str, steps: int, 
-                 initial_state: Optional[Dict[str, Any]] = None):
+
+    def __init__(
+        self,
+        wizard_name: str,
+        steps: int,
+        initial_state: Optional[Dict[str, Any]] = None,
+    ):
         """
         Initialize the wizard state.
-        
+
         Args:
             wizard_name: Name of the wizard (used as prefix for session state keys)
             steps: Total number of steps in the wizard
@@ -209,123 +219,131 @@ class WizardState(PageState):
         """
         # Add step tracking to initial state
         full_initial_state = initial_state or {}
-        full_initial_state.update({
-            'current_step': 1,
-            'total_steps': steps,
-            'completed': False
-        })
-        
+        full_initial_state.update(
+            {"current_step": 1, "total_steps": steps, "completed": False}
+        )
+
         super().__init__(wizard_name, full_initial_state)
-        
+
     def get_current_step(self) -> int:
         """
         Get the current step number.
-        
+
         Returns:
             The current step number (1-based)
         """
-        return self.get('current_step', 1)
-        
+        return self.get("current_step", 1)
+
     def get_total_steps(self) -> int:
         """
         Get the total number of steps.
-        
+
         Returns:
             The total number of steps
         """
-        return self.get('total_steps', 1)
-        
+        return self.get("total_steps", 1)
+
     def is_completed(self) -> bool:
         """
         Check if the wizard is completed.
-        
+
         Returns:
             True if the wizard is completed, False otherwise
         """
-        return self.get('completed', False)
-        
+        return self.get("completed", False)
+
     def set_completed(self, completed: bool = True) -> bool:
         """
         Set the wizard completion status.
-        
+
         Args:
             completed: Whether the wizard is completed
-            
+
         Returns:
             True if the completion status was set successfully, False otherwise
         """
-        success = self.set('completed', completed)
+        success = self.set("completed", completed)
         if success:
             logger.debug(f"Set {self.page_name} completion status to {completed}")
         else:
-            logger.error(f"Failed to set {self.page_name} completion status to {completed}")
+            logger.error(
+                f"Failed to set {self.page_name} completion status to {completed}"
+            )
         return success
-        
+
     def next_step(self) -> bool:
         """
         Move to the next step if possible.
-        
+
         Returns:
             True if the step was changed successfully, False otherwise
         """
         current = self.get_current_step()
         total = self.get_total_steps()
-        
+
         if current < total:
-            success = self.set('current_step', current + 1)
+            success = self.set("current_step", current + 1)
             if success:
                 logger.debug(f"Advanced {self.page_name} to step {current + 1}/{total}")
             else:
-                logger.error(f"Failed to advance {self.page_name} to step {current + 1}/{total}")
+                logger.error(
+                    f"Failed to advance {self.page_name} to step {current + 1}/{total}"
+                )
             return success
         else:
-            logger.debug(f"Already at last step ({current}/{total}) for {self.page_name}")
+            logger.debug(
+                f"Already at last step ({current}/{total}) for {self.page_name}"
+            )
             return True  # No change needed is considered success
-            
+
     def previous_step(self) -> bool:
         """
         Move to the previous step if possible.
-        
+
         Returns:
             True if the step was changed successfully, False otherwise
         """
         current = self.get_current_step()
-        
+
         if current > 1:
-            success = self.set('current_step', current - 1)
+            success = self.set("current_step", current - 1)
             if success:
                 logger.debug(f"Moved {self.page_name} back to step {current - 1}")
             else:
-                logger.error(f"Failed to move {self.page_name} back to step {current - 1}")
+                logger.error(
+                    f"Failed to move {self.page_name} back to step {current - 1}"
+                )
             return success
         else:
             logger.debug(f"Already at first step for {self.page_name}")
             return True  # No change needed is considered success
-            
+
     def go_to_step(self, step: int) -> bool:
         """
         Go to a specific step.
-        
+
         Args:
             step: The step number to go to (1-based)
-            
+
         Returns:
             True if the step was changed successfully, False otherwise
         """
         total = self.get_total_steps()
-        
+
         # Normalize step number
         normalized_step = max(1, min(step, total))
-        
+
         if normalized_step != step:
             logger.warning(
                 f"Normalized step from {step} to {normalized_step} "
                 f"(valid range: 1-{total})"
             )
-            
-        success = self.set('current_step', normalized_step)
+
+        success = self.set("current_step", normalized_step)
         if success:
             logger.debug(f"Set {self.page_name} to step {normalized_step}/{total}")
         else:
-            logger.error(f"Failed to set {self.page_name} to step {normalized_step}/{total}")
+            logger.error(
+                f"Failed to set {self.page_name} to step {normalized_step}/{total}"
+            )
         return success

--- a/tests/unit/interface/test_state_access.py
+++ b/tests/unit/interface/test_state_access.py
@@ -117,10 +117,10 @@ def test_get_session_value_with_exception(clean_state):
     # Create a custom mock class that raises an exception when attributes are accessed
     class ExceptionSessionState:
         def __getattr__(self, name):
-            raise Exception("Test error")
+            raise AttributeError("Test error")
 
-        def __getitem__(self, key):
-            raise Exception("Test error")
+        def get(self, key, default=None):
+            raise TypeError("Test error")
 
     session_state = ExceptionSessionState()
 
@@ -197,7 +197,7 @@ def test_set_session_value_with_attribute_exception(clean_state):
                 object.__setattr__(self, name, value)
             else:
                 # Raise exception for other attributes
-                raise Exception("Test error")
+                raise AttributeError("Test error")
 
         def __setitem__(self, key, value):
             # Allow item access to succeed
@@ -245,7 +245,7 @@ def test_set_session_value_with_dict_exception(clean_state):
             )
 
         def __setitem__(self, key, value):
-            raise Exception("Test error")
+            raise TypeError("Test error")
 
     session_state = DictExceptionSessionState()
 
@@ -270,10 +270,10 @@ def test_set_session_value_with_both_exceptions(clean_state):
     # Create a custom mock class that raises exceptions for both attribute and item access
     class BothExceptionsSessionState:
         def __setattr__(self, name, value):
-            raise Exception("Attribute error")
+            raise AttributeError("Attribute error")
 
         def __setitem__(self, key, value):
-            raise Exception("Item error")
+            raise TypeError("Item error")
 
     session_state = BothExceptionsSessionState()
 

--- a/tests/unit/interface/test_webui_state_errors.py
+++ b/tests/unit/interface/test_webui_state_errors.py
@@ -1,0 +1,20 @@
+import types
+
+import pytest
+
+from devsynth.interface import webui_state
+
+
+class BrokenSessionState(dict):
+    def keys(self):  # pragma: no cover - used for triggering error
+        raise RuntimeError("boom")
+
+
+def test_clear_reraises_after_logging(monkeypatch, caplog):
+    dummy_st = types.SimpleNamespace(session_state=BrokenSessionState())
+    monkeypatch.setattr(webui_state, "st", dummy_st)
+    page = webui_state.PageState("test")
+    with caplog.at_level("ERROR"):
+        with pytest.raises(RuntimeError):
+            page.clear()
+    assert "Error clearing state for test" in caplog.text


### PR DESCRIPTION
## Summary
- narrow session state error handling to attribute/type errors
- log and re-raise unknown failures when clearing web UI state
- add tests covering session access failures and web UI state clearing

## Testing
- `poetry run pre-commit run --files src/devsynth/interface/state_access.py src/devsynth/interface/webui_state.py tests/unit/interface/test_state_access.py tests/unit/interface/test_webui_state_errors.py`
- `poetry run pytest -m "not memory_intensive"` *(fails: 34 errors during collection)*
- `poetry run pip check`
- `poetry run python scripts/run_all_tests.py` *(fails: INTERNALERROR in xdist; many test failures)*
- `poetry run python tests/verify_test_organization.py`
- `poetry run pytest --no-cov tests/unit/interface/test_state_access.py tests/unit/interface/test_webui_state_errors.py`


------
https://chatgpt.com/codex/tasks/task_e_6898f0831ba48333bfce01e8a698e333