### PR TITLE
Add deployment hardening and EDRR coordination hooks

### DIFF
--- a/docs/analysis/critical_recommendations.md
+++ b/docs/analysis/critical_recommendations.md
@@ -29,6 +29,11 @@ version: "0.1.0-alpha.1"
 **Priority Classification:** Critical, High, Medium, Low
 **Implementation Timeline:** Immediate (0-3 months), Short-term (3-6 months), Medium-term (6-12 months), Long-term (12+ months)
 
+## Recent Updates
+
+- Deployment security hardening utilities are now available in `src/devsynth/security`.
+- EDRR coordination steps now capture results from the Expand, Differentiate and Refine phases.
+
 ## Critical Issues Requiring Immediate Action
 
 ### 1. Implementation-Documentation Misalignment [CRITICAL]

--- a/src/devsynth/security/__init__.py
+++ b/src/devsynth/security/__init__.py
@@ -3,6 +3,12 @@
 from .audit import audit_event
 from .authentication import authenticate, hash_password, verify_password
 from .authorization import is_authorized
+from .deployment import (
+    apply_secure_umask,
+    check_required_env_vars,
+    harden_runtime,
+    require_non_root_user,
+)
 from .encryption import decrypt_bytes, encrypt_bytes, generate_key
 from .review import is_review_due, next_review_date
 from .sanitization import sanitize_input, validate_safe_input
@@ -32,4 +38,8 @@ __all__ = [
     "TLSConfig",
     "is_review_due",
     "next_review_date",
+    "harden_runtime",
+    "require_non_root_user",
+    "check_required_env_vars",
+    "apply_secure_umask",
 ]

--- a/src/devsynth/security/deployment.py
+++ b/src/devsynth/security/deployment.py
@@ -1,0 +1,72 @@
+"""Deployment security hardening utilities.
+
+This module provides lightweight helpers that enforce secure defaults
+for runtime environments. These checks are intended to be called early
+in application start-up to catch insecure deployment configurations.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Iterable
+
+from .validation import parse_bool_env
+
+
+def require_non_root_user() -> None:
+    """Raise ``RuntimeError`` if running as root when non-root is required.
+
+    The check is enabled when the ``DEVSYNTH_REQUIRE_NON_ROOT`` environment
+    variable evaluates to ``true``. It is a no-op otherwise.
+    """
+
+    if not parse_bool_env("DEVSYNTH_REQUIRE_NON_ROOT", False):
+        return
+    # ``os.geteuid`` is not available on some platforms (e.g., Windows)
+    geteuid = getattr(os, "geteuid", None)
+    if callable(geteuid) and geteuid() == 0:
+        raise RuntimeError("Running as root is not permitted")
+
+
+def check_required_env_vars(names: Iterable[str]) -> None:
+    """Ensure all required environment variables are present.
+
+    Args:
+        names: Iterable of environment variable names to validate.
+
+    Raises:
+        RuntimeError: If any variables are missing.
+    """
+
+    missing = [name for name in names if not os.environ.get(name)]
+    if missing:
+        joined = ", ".join(sorted(missing))
+        raise RuntimeError(f"Missing required environment variables: {joined}")
+
+
+def apply_secure_umask(default: int = 0o077) -> int:
+    """Set a restrictive umask for newly created files.
+
+    Args:
+        default: Mask to apply. Defaults to ``0o077`` which restricts access to
+        the owner only.
+
+    Returns:
+        The previous umask value.
+    """
+
+    return os.umask(default)
+
+
+def harden_runtime(required_env: Iterable[str] | None = None) -> None:
+    """Apply basic deployment hardening checks.
+
+    This helper can be called at program start-up to enforce non-root
+    execution, verify required environment variables and apply a secure
+    default ``umask``.
+    """
+
+    if required_env:
+        check_required_env_vars(required_env)
+    require_non_root_user()
+    apply_secure_umask()


### PR DESCRIPTION
## Summary
- add deployment security helpers for non-root execution, env validation, and restrictive umask
- record Expand, Differentiate, and Refine results in EDRRCoordinator
- document recent security and coordination improvements in analysis report

## Testing
- `pre-commit run --files src/devsynth/security/deployment.py src/devsynth/security/__init__.py src/devsynth/methodology/edrr_coordinator.py docs/analysis/critical_recommendations.md`
- `pytest -m "not memory_intensive"` *(fails: many tests, TypeError and others)*
- `pip check` *(fails: google-auth 2.40.3 requires cachetools<6.0,>=2.0.0, but cachetools 6.1.0 is installed)*
- `python scripts/run_all_tests.py` *(interrupt: KeyboardInterrupt)*
- `python tests/verify_test_organization.py`


------
https://chatgpt.com/codex/tasks/task_e_689922d0104c833389540a5ca8345332