### PR TITLE
feat: log EDRR consensus failures

### DIFF
--- a/src/devsynth/methodology/edrr_coordinator.py
+++ b/src/devsynth/methodology/edrr_coordinator.py
@@ -10,6 +10,11 @@ from typing import Any, Dict, Optional
 
 from devsynth.application.sprint.retrospective import map_retrospective_to_summary
 from devsynth.domain.models.memory import MemoryType
+from devsynth.exceptions import ConsensusError
+from devsynth.logger import log_consensus_failure
+from devsynth.logging_setup import DevSynthLogger
+
+logger = DevSynthLogger(__name__)
 
 
 class EDRRCoordinator:
@@ -58,6 +63,11 @@ class EDRRCoordinator:
 
         self._store_phase_result(results, MemoryType.KNOWLEDGE, "REFINE")
         return results
+
+    def record_consensus_failure(self, error: ConsensusError) -> None:
+        """Log a consensus failure for later analysis."""
+
+        log_consensus_failure(logger, error)
 
     def automate_retrospective_review(
         self, retrospective: Dict[str, Any], sprint: int

--- a/tests/unit/methodology/test_dialectical_reasoning.py
+++ b/tests/unit/methodology/test_dialectical_reasoning.py
@@ -1,0 +1,42 @@
+"""Tests for the dialectical reasoning utilities."""
+
+from devsynth.exceptions import ConsensusError
+from devsynth.methodology.dialectical_reasoning import reasoning_loop
+from devsynth.methodology.edrr_coordinator import EDRRCoordinator
+
+
+def test_reasoning_loop_records_results(mocker) -> None:
+    """It stores results through the coordinator."""
+
+    coordinator = mocker.create_autospec(EDRRCoordinator, instance=True)
+    result = {"status": "completed"}
+    mocker.patch(
+        "devsynth.methodology.dialectical_reasoning._apply_dialectical_reasoning",
+        return_value=result,
+    )
+
+    output = reasoning_loop(None, {}, None, coordinator=coordinator)
+
+    assert output == [result]
+    coordinator.record_refine_results.assert_called_once_with(result)
+    coordinator.record_consensus_failure.assert_not_called()
+
+
+def test_reasoning_loop_logs_consensus_failure(mocker) -> None:
+    """It delegates consensus failures to the coordinator."""
+
+    coordinator = mocker.create_autospec(EDRRCoordinator, instance=True)
+
+    class DummyConsensusError(ConsensusError):
+        def __init__(self, message: str):
+            Exception.__init__(self, message)
+
+    mocker.patch(
+        "devsynth.methodology.dialectical_reasoning._apply_dialectical_reasoning",
+        side_effect=DummyConsensusError("no consensus"),
+    )
+
+    output = reasoning_loop(None, {}, None, coordinator=coordinator)
+
+    assert output == []
+    coordinator.record_consensus_failure.assert_called_once()


### PR DESCRIPTION
## Summary
- allow dialectical reasoning loop to delegate logging and result storage to an EDRR coordinator
- log consensus failures within methodology EDRR coordinator
- test dialectical reasoning integration with coordinator hooks

## Testing
- `poetry run pre-commit run --files src/devsynth/methodology/dialectical_reasoning.py src/devsynth/methodology/edrr_coordinator.py tests/unit/methodology/test_dialectical_reasoning.py`
- `poetry run pytest tests/unit/methodology/test_dialectical_reasoning.py tests/unit/methodology/test_edrr_coordinator.py -m "not memory_intensive"`
- `poetry run pip check`
- `poetry run python scripts/run_all_tests.py` *(fails: No module named 'chromadb')*
- `poetry run python tests/verify_test_organization.py`


------
https://chatgpt.com/codex/tasks/task_e_68992b8db628833381eade5a990ce30f