### PR TITLE
Add transactional semantics and persistence tests

### DIFF
--- a/src/devsynth/adapters/memory/sync_manager.py
+++ b/src/devsynth/adapters/memory/sync_manager.py
@@ -77,6 +77,48 @@ class MultiStoreSyncManager:
 
         return self.manager.synchronize_core_stores()
 
+    # ------------------------------------------------------------------
+    # transactional helpers -------------------------------------------------
+
+    def transaction(self, stores: list[str] | None = None):
+        """Return a transaction context spanning ``stores``.
+
+        Parameters
+        ----------
+        stores:
+            Optional list of store names to include.  When omitted all
+            configured stores participate in the transaction.
+
+        Returns
+        -------
+        Context manager
+            The context manager yielded by :class:`SyncManager` which will
+            commit on successful exit and roll back if an exception occurs.
+        """
+
+        stores = stores or list(self.manager.adapters.keys())
+        return self.sync_manager.transaction(stores)
+
+    def begin_transaction(self, transaction_id: str | None = None) -> str:
+        """Begin an explicit transaction across all stores."""
+
+        return self.sync_manager.begin_transaction(transaction_id)
+
+    def commit_transaction(self, transaction_id: str) -> None:
+        """Commit a previously started transaction."""
+
+        self.sync_manager.commit_transaction(transaction_id)
+
+    def rollback_transaction(self, transaction_id: str) -> None:
+        """Rollback a previously started transaction."""
+
+        self.sync_manager.rollback_transaction(transaction_id)
+
+    def is_transaction_active(self, transaction_id: str) -> bool:
+        """Return ``True`` if ``transaction_id`` is active."""
+
+        return transaction_id in self.sync_manager._active_transactions
+
     def cleanup(self) -> None:
         """Release resources held by the underlying stores."""
         for store in (self.lmdb, self.faiss):

--- a/tests/integration/general/test_kuzu_adapter_transactions.py
+++ b/tests/integration/general/test_kuzu_adapter_transactions.py
@@ -1,0 +1,28 @@
+import pytest
+
+from devsynth.adapters.memory.kuzu_adapter import KuzuAdapter
+from devsynth.domain.models.memory import MemoryVector
+
+pytestmark = [pytest.mark.requires_resource("kuzu")]
+
+
+def test_kuzu_adapter_transaction_persistence(tmp_path):
+    """KuzuAdapter should commit and rollback vector operations with persistence."""
+
+    adapter = KuzuAdapter(str(tmp_path))
+    vec = MemoryVector(
+        id="v1", content="persist", embedding=[0.1, 0.2, 0.3], metadata={}
+    )
+
+    tid = adapter.begin_transaction()
+    adapter.store_vector(vec)
+    adapter.commit_transaction(tid)
+    assert adapter.retrieve_vector("v1") is not None
+
+    adapter2 = KuzuAdapter(str(tmp_path))
+    assert adapter2.retrieve_vector("v1") is not None
+
+    tid = adapter2.begin_transaction()
+    adapter2.delete_vector("v1")
+    adapter2.rollback_transaction(tid)
+    assert adapter2.retrieve_vector("v1") is not None


### PR DESCRIPTION
## Summary
- expose transaction helpers in MultiStoreSyncManager
- add context-managed transactions and snapshot-based rollback to ChromaDB and Kuzu adapters
- cover persistence for multi-store and Kuzu transactions in integration tests

## Testing
- `poetry run pre-commit run --files src/devsynth/adapters/memory/sync_manager.py src/devsynth/adapters/memory/chroma_db_adapter.py src/devsynth/adapters/memory/kuzu_adapter.py tests/integration/general/test_multi_store_sync_manager.py tests/integration/general/test_kuzu_adapter_transactions.py`
- `poetry run pytest -m "not memory_intensive"` *(killed after partial run)*
- `poetry run pip check` *(failed: google-auth 2.40.3 requires cachetools<6.0,>=2.0.0, but you have cachetools 6.1.0)*
- `poetry run python scripts/run_all_tests.py` *(keyboard interrupt)*
- `poetry run python tests/verify_test_organization.py`


------
https://chatgpt.com/codex/tasks/task_e_68992b91e8d883338b59d04e48d119df