### PR TITLE
Add sprint planning alignment and retrospective review metrics

### DIFF
--- a/docs/roadmap/development_plan.md
+++ b/docs/roadmap/development_plan.md
@@ -49,6 +49,14 @@ This document presents a comprehensive plan for continuing the development of De
 The project roadmap is broken into progressive phases. A consolidated list of phases and version milestones is available in the [Release Plan](release_plan.md).
 
 
+## Workflow Steps
+
+The development workflow for each sprint follows these steps:
+
+1. **Sprint Planning Alignment** – Map upcoming work to the appropriate EDRR phase so planning outputs feed the Expand phase.
+2. **Phase Execution** – Carry out the Expand, Differentiate, Refine and Retrospect phases to process and refine artifacts.
+3. **Retrospective Review** – Summarize outcomes, capture lessons learned and feed action items into the next planning cycle.
+
 ## Implementation Plan for Phase 1: Foundation Stabilization
 
 ### Strategic Framework

--- a/src/devsynth/methodology/edrr_coordinator.py
+++ b/src/devsynth/methodology/edrr_coordinator.py
@@ -83,5 +83,12 @@ class EDRRCoordinator:
         """
 
         summary = map_retrospective_to_summary(retrospective, sprint)
+        if not summary:
+            return {}
+
+        summary["positive_count"] = len(summary.get("positives", []))
+        summary["improvement_count"] = len(summary.get("improvements", []))
+        summary["action_item_count"] = len(summary.get("action_items", []))
+
         self._store_phase_result(summary, MemoryType.PEER_REVIEW, "RETROSPECT")
         return summary

--- a/src/devsynth/methodology/sprint_adapter.py
+++ b/src/devsynth/methodology/sprint_adapter.py
@@ -9,7 +9,7 @@ can automatically link ceremonies with EDRR phases.
 
 from __future__ import annotations
 
-from typing import Dict, Optional
+from typing import Any, Dict, Optional
 
 from .base import Phase
 
@@ -38,3 +38,28 @@ def map_ceremony_to_phase(ceremony: str) -> Optional[Phase]:
     """
 
     return CEREMONY_PHASE_MAP.get(ceremony.lower())
+
+
+def align_sprint_planning(planning_sections: Dict[str, Any]) -> Dict[Phase, Any]:
+    """Align sprint planning data with EDRR phases.
+
+    The provided ``planning_sections`` dictionary should have ceremony names
+    (e.g., ``"planning"`` or ``"review"``) as keys. Any sections that map to a
+    known EDRR phase are returned in a new dictionary keyed by that phase. This
+    allows sprint tooling to quickly associate planning details with the phase
+    of the upcoming EDRR cycle.
+
+    Args:
+        planning_sections: Mapping of ceremony names to planning data.
+
+    Returns:
+        Dictionary keyed by :class:`Phase` for ceremonies that have a known
+        mapping. Ceremonies without a mapping are ignored.
+    """
+
+    aligned: Dict[Phase, Any] = {}
+    for ceremony, data in planning_sections.items():
+        phase = map_ceremony_to_phase(ceremony)
+        if phase is not None:
+            aligned[phase] = data
+    return aligned


### PR DESCRIPTION
## Summary
- add helper to align sprint ceremonies with EDRR phases
- expand retrospective review to record item counts
- outline sprint workflow steps in development plan

## Testing
- `poetry run pre-commit run --files src/devsynth/methodology/sprint_adapter.py src/devsynth/methodology/edrr_coordinator.py docs/roadmap/development_plan.md`
- `poetry run pytest -m "not memory_intensive"` *(fails: KeyboardInterrupt)*
- `poetry run pip check` *(fails: google-auth 2.40.3 requires cachetools<6.0,>=2.0.0, but you have cachetools 6.1.0)*
- `poetry run python scripts/run_all_tests.py` *(interrupted)*
- `poetry run python tests/verify_test_organization.py`


------
https://chatgpt.com/codex/tasks/task_e_689937302d28833388078bf43dd06863