### PR TITLE
feat(testing): scaffold integration tests

### DIFF
--- a/docs/testing/auto_generated_tests.md
+++ b/docs/testing/auto_generated_tests.md
@@ -1,0 +1,14 @@
+# Auto-generated integration tests
+
+DevSynth can scaffold integration tests to highlight missing coverage while teams iterate on APIs.
+
+## Workflow
+
+1. Use `scaffold_integration_tests` or `write_scaffolded_tests` in `src/devsynth/testing/generation.py` to create placeholder tests. The generated modules are marked with `pytest.mark.skip` so the suite stays green.
+2. Review each scaffolded file:
+   - Replace the placeholder body with real assertions.
+   - Remove the `pytest.mark.skip` marker when the test is complete.
+3. Use the prompt in `src/devsynth/testing/prompts.py` as guidance when authoring tests or when generating them automatically. The prompt emphasizes edge cases such as empty inputs, extreme values, permission errors, and network failures.
+4. Run `poetry run pytest -m "not memory_intensive"` and `poetry run pre-commit run --files ...` before submitting changes.
+
+This process ensures that auto-generated tests receive human oversight and evolve into reliable integration coverage.

--- a/src/devsynth/testing/generation.py
+++ b/src/devsynth/testing/generation.py
@@ -7,6 +7,7 @@ coverage is highlighted during review without breaking the suite.
 
 from __future__ import annotations
 
+from pathlib import Path
 from typing import Dict, Iterable
 
 PLACEHOLDER_TEMPLATE = (
@@ -18,6 +19,8 @@ PLACEHOLDER_TEMPLATE = (
     '    """Integration test placeholder for {name}."""\n'
     '    raise NotImplementedError("Add integration test for {name}")\n'
 )
+
+__all__ = ["scaffold_integration_tests", "write_scaffolded_tests"]
 
 
 def scaffold_integration_tests(names: Iterable[str]) -> Dict[str, str]:
@@ -36,3 +39,29 @@ def scaffold_integration_tests(names: Iterable[str]) -> Dict[str, str]:
         filename = f"test_{name}.py"
         placeholders[filename] = PLACEHOLDER_TEMPLATE.format(name=name)
     return placeholders
+
+
+def write_scaffolded_tests(directory: Path, names: Iterable[str]) -> Dict[Path, str]:
+    """Write placeholder integration tests to ``directory``.
+
+    This helper builds on :func:`scaffold_integration_tests` by emitting the
+    generated placeholder test files to disk. Each file is created with a
+    ``pytest.mark.skip`` marker so the suite remains green until the
+    placeholder is replaced.
+
+    Args:
+        directory: Destination folder for the scaffolded tests.
+        names: Iterable of base names for the tests.
+
+    Returns:
+        Mapping of file paths to the content written.
+    """
+
+    directory.mkdir(parents=True, exist_ok=True)
+    generated = scaffold_integration_tests(names)
+    written: Dict[Path, str] = {}
+    for filename, content in generated.items():
+        path = directory / filename
+        path.write_text(content)
+        written[path] = content
+    return written

--- a/src/devsynth/testing/prompts.py
+++ b/src/devsynth/testing/prompts.py
@@ -8,9 +8,11 @@ INTEGRATION_TEST_PROMPT = (
     "You are an expert software tester. Given a description of a module, "
     "write pytest integration tests that exercise realistic workflows and boundary conditions. "
     "Cover invalid inputs, error-handling paths, and concurrency or asynchronous behavior where applicable. "
+    "Account for edge cases such as empty or malformed payloads, extreme values, missing permissions, "
+    "network or filesystem failures, and cleanup of external resources. "
     "Use fixtures and parameterization to reduce duplication. "
     "Ensure each test contains meaningful assertions, applies 'pytest.mark.asyncio' for async code, "
-    "and avoids placeholders like 'assert True' or 'pass'."
+    "avoids placeholders like 'assert True' or 'pass', and never performs real network calls."
 )
 
 __all__ = ["INTEGRATION_TEST_PROMPT"]


### PR DESCRIPTION
## Summary
- add utility to write scaffolded integration tests to disk
- expand integration test prompt to cover edge conditions and network failures
- document review workflow for auto-generated tests

## Testing
- `poetry run pre-commit run --files src/devsynth/testing/generation.py src/devsynth/testing/prompts.py docs/testing/auto_generated_tests.md`
- `poetry run pytest -m "not memory_intensive"` (fails: tests/integration/general/test_error_handling_at_integration_points.py::TestErrorHandlingAtIntegrationPoints::test_error_handling_in_cross_component_integration_raises_error, ...)
- `poetry run pip check` (fails: google-auth 2.40.3 has requirement cachetools<6.0,>=2.0.0, but you have cachetools 6.1.0.)
- `poetry run python scripts/run_all_tests.py` (fails: KeyboardInterrupt)
- `poetry run python tests/verify_test_organization.py`


------
https://chatgpt.com/codex/tasks/task_e_689943aa1a5083339e7cdd95e03e7587