### PR TITLE
feat: add deployment health checks and CI image publishing

### DIFF
--- a/docker-compose.production.yml
+++ b/docker-compose.production.yml
@@ -2,6 +2,7 @@ version: '3.8'
 
 services:
   devsynth-api:
+    image: ghcr.io/devsynth/devsynth:${DEVSYNTH_IMAGE_TAG:-latest}
     build:
       context: .
       target: production
@@ -25,6 +26,7 @@ services:
       start_period: 5s
 
   devsynth-cli:
+    image: ghcr.io/devsynth/devsynth-cli:${DEVSYNTH_IMAGE_TAG:-latest}
     build:
       context: .
       target: production
@@ -68,7 +70,9 @@ services:
     build:
       context: .
       target: production
-    entrypoint: ["/bin/bash", "scripts/deployment/publish_image.sh", "${DEVSYNTH_IMAGE_TAG:-latest}"]
+    entrypoint: ["/bin/bash", "scripts/deployment/publish_image.sh", "${DEVSYNTH_IMAGE_TAG:-latest}", "devsynth-api"]
+    environment:
+      - COMPOSE_FILE=docker-compose.production.yml
     profiles:
       - ci
 

--- a/docs/deployment/release_automation.md
+++ b/docs/deployment/release_automation.md
@@ -1,0 +1,50 @@
+---
+title: "Release Automation"
+author: "DevSynth Team"
+date: "2025-07-21"
+last_reviewed: "2025-07-21"
+status: "draft"
+version: "0.1.0-alpha.1"
+tags:
+  - deployment
+  - ci
+---
+<div class="breadcrumbs">
+<a href="../index.md">Documentation</a> &gt; <a href="index.md">Deployment</a> &gt; Release Automation
+</div>
+
+# Release Automation
+
+This guide describes automated image publishing and rollback for DevSynth.
+
+## Publishing images
+
+Use the CI profile to build and push the production image:
+
+```bash
+docker compose -f docker-compose.production.yml --profile ci run --rm publish
+```
+
+This command invokes `scripts/deployment/publish_image.sh` and pushes the `devsynth-api` image to the configured registry.
+
+## Rollback
+
+If a deployment fails, roll back to a known tag:
+
+```bash
+docker compose -f docker-compose.production.yml --profile ci run --rm rollback <previous_tag>
+```
+
+The `rollback` utility executes `scripts/deployment/rollback.sh` and validates service health via `scripts/deployment/health_check.sh`.
+
+## Related Documents
+
+- [Rollback Procedures](rollback.md)
+
+## Tests
+
+Run deployment tests after publishing or rolling back:
+
+```bash
+poetry run python scripts/run_all_tests.py
+```

--- a/scripts/deployment/bootstrap.sh
+++ b/scripts/deployment/bootstrap.sh
@@ -32,7 +32,8 @@ if [[ -f "$ENV_FILE" ]] && [[ $(stat -c %a "$ENV_FILE") != "600" ]]; then
   exit 1
 fi
 
-# Build images for the current compose configuration
+# Pull latest base images and build the current compose configuration
+docker compose pull
 docker compose build
 
 # Start the stack for the requested environment

--- a/scripts/deployment/health_check.sh
+++ b/scripts/deployment/health_check.sh
@@ -3,10 +3,11 @@ set -euo pipefail
 
 # Check the health of DevSynth services.
 # Verifies API and monitoring endpoints respond successfully.
-# Usage: health_check.sh [api_url] [grafana_url]
+# Usage: health_check.sh [api_url] [grafana_url] [prometheus_url]
 
 API_URL=${1:-http://localhost:8000/health}
 GRAFANA_URL=${2:-http://localhost:3000/api/health}
+PROMETHEUS_URL=${3:-http://localhost:9090/-/ready}
 
 if [[ "$EUID" -eq 0 ]]; then
   echo "Please run this script as a non-root user." >&2
@@ -18,7 +19,7 @@ if ! command -v curl >/dev/null 2>&1; then
   exit 1
 fi
 
-for url in "$API_URL" "$GRAFANA_URL"; do
+for url in "$API_URL" "$GRAFANA_URL" "$PROMETHEUS_URL"; do
   if [[ ! "$url" =~ ^https?:// ]]; then
     echo "Invalid URL: $url" >&2
     exit 1

--- a/scripts/deployment/publish_image.sh
+++ b/scripts/deployment/publish_image.sh
@@ -2,10 +2,12 @@
 set -euo pipefail
 
 # Build and publish the DevSynth image to a registry.
-# Usage: publish_image.sh [tag]
+# Usage: publish_image.sh [tag] [service]
 #   tag: image tag to publish (default: latest)
+#   service: compose service to publish (default: devsynth-api)
 
 TAG=${1:-latest}
+SERVICE=${2:-devsynth-api}
 if [[ "$EUID" -eq 0 ]]; then
   echo "Please run this script as a non-root user." >&2
   exit 1
@@ -20,13 +22,17 @@ if [[ ! "$TAG" =~ ^[a-zA-Z0-9._-]+$ ]]; then
   echo "Invalid tag: $TAG" >&2
   exit 1
 fi
+if [[ ! "$SERVICE" =~ ^[a-zA-Z0-9._-]+$ ]]; then
+  echo "Invalid service: $SERVICE" >&2
+  exit 1
+fi
 
 export DEVSYNTH_IMAGE_TAG="$TAG"
 
 # Build the image with the specified tag
 
-docker compose build devsynth
+docker compose -f docker-compose.production.yml build "$SERVICE"
 
 # Push the image to the configured registry
 
-docker compose push devsynth
+docker compose -f docker-compose.production.yml push "$SERVICE"


### PR DESCRIPTION
## Summary
- include Prometheus in health checks and pull images during bootstrap
- allow CI to publish production images via docker-compose
- document release automation and rollback workflow

## Testing
- `poetry run pre-commit run --files docker-compose.production.yml scripts/deployment/bootstrap.sh scripts/deployment/health_check.sh scripts/deployment/publish_image.sh docs/deployment/release_automation.md`
- `poetry run python scripts/run_all_tests.py` *(fails: ModuleNotFoundError: No module named 'chromadb.api')*
- `poetry run python tests/verify_test_organization.py`
- `poetry run pip check`


------
https://chatgpt.com/codex/tasks/task_e_68994899fbfc833382c99e4e19edc700