### PR TITLE
Integrate security audits and add pre-deploy policy checks

### DIFF
--- a/docs/security/periodic_review.md
+++ b/docs/security/periodic_review.md
@@ -1,0 +1,13 @@
+# Periodic Security Review
+
+Regular security reviews ensure that DevSynth's safeguards remain effective and compliant.
+
+## Review Cadence
+- Conduct a review at least once per quarter.
+- Trigger an additional review after significant dependency or architecture changes.
+
+## Procedure
+1. Run `scripts/security_audit.py` to execute Bandit and Safety scans.
+2. Address or document all reported issues.
+3. Verify that pre-deploy policy checks pass via `require_pre_deploy_checks`.
+4. Record outcomes in the project's security log for traceability.

--- a/scripts/security_audit.py
+++ b/scripts/security_audit.py
@@ -1,4 +1,4 @@
-"""Run static and dependency security checks."""
+"""Run Bandit static analysis and Safety dependency checks."""
 
 from __future__ import annotations
 
@@ -6,14 +6,20 @@ import subprocess
 import sys
 
 from devsynth.logger import setup_logging
-from devsynth.security.audit import main as audit_main
+from devsynth.security import audit
 
 logger = setup_logging(__name__)
 
 
+def run() -> None:
+    """Execute Bandit and Safety security checks."""
+    audit.run_bandit()
+    audit.run_safety()
+
+
 if __name__ == "__main__":
     try:
-        audit_main()
+        run()
     except subprocess.CalledProcessError as exc:
         logger.exception("Security audit failed with code %s", exc.returncode)
         sys.exit(exc.returncode)

--- a/src/devsynth/security/validation.py
+++ b/src/devsynth/security/validation.py
@@ -17,7 +17,7 @@ def validate_int_range(
     field: str,
     *,
     min_value: Union[int, None] = None,
-    max_value: Union[int, None] = None
+    max_value: Union[int, None] = None,
 ) -> int:
     """Validate that a value is an int within an optional range."""
     try:
@@ -78,3 +78,15 @@ def parse_bool_env(var: str, default: bool = False) -> bool:
     if val in {"0", "false", "no"}:
         return False
     raise ValidationError("Invalid boolean", field=var, value=value)
+
+
+def require_pre_deploy_checks() -> None:
+    """Ensure mandatory pre-deployment policy checks have passed.
+
+    The ``DEVSYNTH_PRE_DEPLOY_APPROVED`` environment variable must evaluate to
+    ``true`` according to :func:`parse_bool_env`. A ``RuntimeError`` is raised
+    otherwise.
+    """
+
+    if not parse_bool_env("DEVSYNTH_PRE_DEPLOY_APPROVED", False):
+        raise RuntimeError("Pre-deploy policy checks have not been approved")


### PR DESCRIPTION
## Summary
- run Bandit and Safety checks through `security_audit.py`
- enforce pre-deploy policy approval with new validator
- document periodic security review procedures

## Testing
- `poetry run pre-commit run --files scripts/security_audit.py src/devsynth/security/validation.py docs/security/periodic_review.md`
- `poetry run python scripts/run_all_tests.py` *(fails: Tests failed; LMStudioProvider not available)*
- `poetry run python tests/verify_test_organization.py`
- `poetry run pip check`


------
https://chatgpt.com/codex/tasks/task_e_68995addd93483338d27c2d40e38be36