### PR TITLE
feat: add metrics for anonymous retry conditions

### DIFF
--- a/src/devsynth/fallback.py
+++ b/src/devsynth/fallback.py
@@ -17,6 +17,7 @@ from .exceptions import DevSynthError
 from .logging_setup import DevSynthLogger
 from .metrics import (
     circuit_breaker_state_counter,
+    get_circuit_breaker_state_metrics,
     get_retry_condition_metrics,
     get_retry_count_metrics,
     get_retry_error_metrics,
@@ -40,6 +41,9 @@ R = TypeVar("R")
 
 # Create a logger for this module
 logger = DevSynthLogger("fallback")
+
+# Placeholder name used for metrics when anonymous retry conditions fail
+ANONYMOUS_CONDITION = "<anonymous>"
 
 
 def reset_prometheus_metrics() -> None:
@@ -67,6 +71,8 @@ __all__ = [
     "retry_error_counter",
     "retry_condition_counter",
     "circuit_breaker_state_counter",
+    "get_circuit_breaker_state_metrics",
+    "ANONYMOUS_CONDITION",
     "reset_prometheus_metrics",
 ]
 
@@ -280,6 +286,7 @@ def retry_with_exponential_backoff(
                         if track_metrics:
                             inc_retry("abort")
                             inc_retry_error(e.__class__.__name__)
+                            inc_retry_condition(ANONYMOUS_CONDITION)
                             inc_retry_stat(func.__name__, "abort")
                         raise
                     if (

--- a/tests/unit/fallback/test_retry.py
+++ b/tests/unit/fallback/test_retry.py
@@ -1,0 +1,92 @@
+from unittest.mock import Mock
+
+import pytest
+
+from devsynth.exceptions import DevSynthError
+from devsynth.fallback import (
+    ANONYMOUS_CONDITION,
+    CircuitBreaker,
+    circuit_breaker_state_counter,
+    reset_prometheus_metrics,
+    retry_with_exponential_backoff,
+)
+from devsynth.metrics import (
+    get_circuit_breaker_state_metrics,
+    get_retry_condition_metrics,
+    get_retry_metrics,
+    reset_metrics,
+)
+
+
+@pytest.mark.medium
+def test_anonymous_retry_condition_records_metrics() -> None:
+    """Anonymous retry conditions emit condition and retry metrics."""
+    reset_metrics()
+    reset_prometheus_metrics()
+
+    breaker = CircuitBreaker(failure_threshold=3, recovery_timeout=60)
+    func = Mock(side_effect=Exception("boom"))
+    func.__name__ = "func"
+
+    wrapped = retry_with_exponential_backoff(
+        max_retries=5,
+        initial_delay=0,
+        jitter=False,
+        retry_conditions=[lambda exc: False],
+        circuit_breaker=breaker,
+        track_metrics=True,
+    )(func)
+
+    with pytest.raises(Exception):
+        wrapped()
+
+    assert func.call_count == 1
+
+    retry_metrics = get_retry_metrics()
+    assert retry_metrics.get("abort") == 1
+
+    condition_metrics = get_retry_condition_metrics()
+    assert condition_metrics.get(ANONYMOUS_CONDITION) == 1
+    assert (
+        circuit_breaker_state_counter.labels(
+            function="func", state=CircuitBreaker.OPEN
+        )._value.get()
+        == 0
+    )
+    assert get_circuit_breaker_state_metrics() == {}
+
+
+@pytest.mark.medium
+def test_circuit_breaker_open_emits_metrics() -> None:
+    """Circuit breaker transitions to OPEN and emits metrics."""
+    reset_metrics()
+    reset_prometheus_metrics()
+
+    breaker = CircuitBreaker(failure_threshold=2, recovery_timeout=60)
+    func = Mock(side_effect=Exception("fail"))
+    func.__name__ = "func"
+
+    wrapped = retry_with_exponential_backoff(
+        max_retries=5,
+        initial_delay=0,
+        jitter=False,
+        circuit_breaker=breaker,
+        track_metrics=True,
+    )(func)
+
+    with pytest.raises(DevSynthError) as err:
+        wrapped()
+
+    assert err.value.error_code == "CIRCUIT_OPEN"
+    assert func.call_count == 2
+
+    assert (
+        circuit_breaker_state_counter.labels(
+            function="func", state=CircuitBreaker.OPEN
+        )._value.get()
+        == 2
+    )
+    metrics = get_circuit_breaker_state_metrics()
+    assert metrics.get("func:OPEN") == 2
+    retry_metrics = get_retry_metrics()
+    assert retry_metrics.get("abort") == 1


### PR DESCRIPTION
## Summary
- track anonymous retry condition failures with a named metric
- export circuit breaker metrics and anonymous condition helper
- add regression tests for anonymous retry conditions and circuit breaker metrics

## Testing
- `poetry run pre-commit run --files src/devsynth/fallback.py tests/unit/fallback/test_retry.py`
- `poetry run python scripts/run_all_tests.py --target tests/unit/fallback/test_retry.py` *(failed: tests failed)*
- `poetry run python tests/verify_test_organization.py`
- `poetry run pip check`


------
https://chatgpt.com/codex/tasks/task_e_68995ad807d88333abae515e574c12b7