### PR TITLE
test: reduce memory usage in adapters tests

### DIFF
--- a/tests/unit/adapters/memory/test_memory_adapter.py
+++ b/tests/unit/adapters/memory/test_memory_adapter.py
@@ -361,6 +361,10 @@ class TestMemorySystemAdapter:
         from devsynth.application.memory.sync_manager import SyncManager
 
         monkeypatch.delitem(sys.modules, "kuzu", raising=False)
+        ef = pytest.importorskip("chromadb.utils.embedding_functions")
+        monkeypatch.setattr(
+            ef, "DefaultEmbeddingFunction", lambda: (lambda x: [0.0] * 5)
+        )
         kuzu_store = KuzuMemoryStore.create_ephemeral(use_provider_system=False)
         lmdb_store = LMDBStore(str(tmp_path / "lmdb"))
         try:

--- a/tests/unit/adapters/providers/test_provider_factory.py
+++ b/tests/unit/adapters/providers/test_provider_factory.py
@@ -1,5 +1,7 @@
 import pytest
 
+pytestmark = [pytest.mark.memory_intensive]
+
 from devsynth.adapters.providers.provider_factory import (
     LMStudioProvider,
     OpenAIProvider,

--- a/tests/unit/application/cli/test_doctor_cmd.py
+++ b/tests/unit/application/cli/test_doctor_cmd.py
@@ -10,6 +10,8 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+pytestmark = [pytest.mark.memory_intensive]
+
 # Create minimal stubs to avoid importing heavy dependencies when loading doctor_cmd
 devsynth_pkg = ModuleType("devsynth")
 devsynth_pkg.__path__ = []


### PR DESCRIPTION
## Summary
- mark provider factory and doctor CLI tests as memory intensive to limit resource usage
- stub embedding function in LMDB-Kuzu sync test to avoid network calls

## Testing
- `poetry run pre-commit run --files tests/unit/adapters/providers/test_provider_factory.py tests/unit/application/cli/test_doctor_cmd.py tests/unit/adapters/memory/test_memory_adapter.py`
- `poetry run pytest tests/unit/adapters/memory/test_memory_adapter.py -vv`
- `poetry run python scripts/run_all_tests.py` *(fails: No such option: --tests Did you mean --target?)*
- `poetry run python tests/verify_test_organization.py`


------
https://chatgpt.com/codex/tasks/task_e_689967ebab3c8333ab8f5181c08b8062