### PR TITLE
feat: improve init wizard and CLI tooling

### DIFF
--- a/docs/user_guides/cli_reference.md
+++ b/docs/user_guides/cli_reference.md
@@ -94,6 +94,7 @@ These options can be used with any command:
 | `--quiet`, `-q` | Suppress all output except errors | False |
 | `--config-file` | Path to configuration file | ~/.devsynth/config.yaml |
 | `--log-level` | Set logging level (debug, info, warning, error) | info |
+| `--dashboard-hook` | Python path to function receiving dashboard metric events | - |
 | `--help`, `-h` | Show help message and exit | - |
 
 ## Command Reference
@@ -187,6 +188,7 @@ devsynth init [--path PATH] [--template TEMPLATE] [--project-root ROOT] [--langu
 
 
 This command detects existing projects and launches an interactive wizard when run inside a directory containing `pyproject.toml` or `project.yaml`. Use the `--wizard` flag to start the wizard explicitly in any directory. The command uses provided options and `DEVSYNTH_INIT_*` environment variables directly, prompting only for missing values. Supplying `--defaults` or `--non-interactive` skips prompts entirely.
+The wizard presents a streamlined, step-by-step flow with progress indicators and optional quick presets (`minimal`, `standard`, `advanced`).
 Progress messages show when configuration is saved and when scaffolding files are generated.
 The wizard reads configuration using the [Unified Config Loader](../implementation/config_loader_workflow.md),
 which prefers the `[tool.devsynth]` table in `pyproject.toml` when both files are present.
@@ -668,17 +670,19 @@ devsynth ingest manifest.yaml --non-interactive --yes --priority high
 
 ### completion
 
-Generate or install shell completion scripts for the DevSynth CLI.
+Generate or install shell completion scripts for the DevSynth CLI. Typer's
+built-in completion support is also available via the global
+`--install-completion` and `--show-completion` flags.
 
 ```bash
-devsynth completion [--shell bash|zsh|fish] [--install] [--output PATH]
+devsynth completion [--shell bash|zsh|fish] [--install] [--path PATH]
 ```
 
 **Options:**
 
 - `--shell`: Target shell. Defaults to the current shell.
 - `--install`: Install the completion script into the user's shell configuration.
-- `--output`: Write the generated script to a file instead of printing.
+- `--path`: Write the generated script to a file instead of printing.
 
 **Examples:**
 
@@ -688,6 +692,9 @@ devsynth completion
 
 # Install zsh completions
 devsynth completion --shell zsh --install
+
+# Write script to file
+devsynth completion --shell bash --path ~/.devsynth-completion.bash
 ```
 
 ### mvu

--- a/scripts/completions/devsynth-completion.bash
+++ b/scripts/completions/devsynth-completion.bash
@@ -24,7 +24,7 @@ _devsynth_completion() {
     serve_opts="--host --port --verbose"
     dbschema_opts="--input-file --output-file --verbose"
     doctor_opts="--fix --verbose"
-    completion_opts="--shell --install --output"
+    completion_opts="--shell --install --path"
 
     # Handle command-specific options
     if [[ ${COMP_CWORD} -eq 1 ]]; then
@@ -84,7 +84,7 @@ _devsynth_completion() {
 
     # Handle option arguments
     case "${prev}" in
-        --path|--root|--output-dir|--output-file|--requirements-file|--spec-file|--test-file|--file|--input-file|--output)
+        --path|--root|--output-dir|--output-file|--requirements-file|--spec-file|--test-file|--file|--input-file)
             # File/directory completion
             COMPREPLY=( $(compgen -f -- "${cur}") )
             return 0

--- a/scripts/completions/devsynth-completion.fish
+++ b/scripts/completions/devsynth-completion.fish
@@ -17,7 +17,7 @@ set -l webapp_opts --framework --output-dir --verbose
 set -l serve_opts --host --port --verbose
 set -l dbschema_opts --input-file --output-file --verbose
 set -l doctor_opts --fix --verbose
-set -l completion_opts --shell --install --output
+set -l completion_opts --shell --install --path
 
 # Define option arguments
 set -l languages python javascript typescript java csharp go rust
@@ -118,7 +118,7 @@ complete -c devsynth -n "__fish_seen_subcommand_from doctor" -l verbose -d "Enab
 # completion command
 complete -c devsynth -n "__fish_seen_subcommand_from completion" -l shell -d "Target shell" -r -a "bash zsh fish"
 complete -c devsynth -n "__fish_seen_subcommand_from completion" -l install -d "Install completion script"
-complete -c devsynth -n "__fish_seen_subcommand_from completion" -l output -d "Path to write completion script" -r
+complete -c devsynth -n "__fish_seen_subcommand_from completion" -l path -d "Path to write completion script" -r
 
 # help command
 complete -c devsynth -n "__fish_seen_subcommand_from help" -a "$commands" -d "Show help for command"

--- a/scripts/completions/devsynth-completion.zsh
+++ b/scripts/completions/devsynth-completion.zsh
@@ -114,7 +114,7 @@ _devsynth() {
     completion_opts=(
         '--shell=[Target shell]:shell:(bash zsh fish)'
         '--install[Install completion script]'
-        '--output=[Write completion script to path]:file:_files'
+        '--path=[Write completion script to path]:file:_files'
     )
 
     _arguments -C \

--- a/src/devsynth/application/cli/progress.py
+++ b/src/devsynth/application/cli/progress.py
@@ -33,12 +33,23 @@ class ProgressManager:
         return self.indicators.get(task_id)
 
     def update_progress(
-        self, task_id: str, advance: float = 1, description: Optional[str] = None
+        self,
+        task_id: str,
+        advance: float = 1,
+        description: Optional[str] = None,
+        status: Optional[str] = None,
     ) -> None:
-        """Update the indicator associated with ``task_id``."""
+        """Update the indicator associated with ``task_id``.
+
+        Args:
+            task_id: Identifier of the progress task to update.
+            advance: Amount to advance the indicator.
+            description: Optional new description for the task.
+            status: Optional short status message.
+        """
         indicator = self.indicators.get(task_id)
         if indicator is not None:
-            indicator.update(advance=advance, description=description)
+            indicator.update(advance=advance, description=description, status=status)
 
     def complete_progress(self, task_id: str) -> None:
         """Complete and remove the indicator for ``task_id``."""

--- a/tests/unit/application/cli/test_completion_cmd.py
+++ b/tests/unit/application/cli/test_completion_cmd.py
@@ -11,15 +11,23 @@ from devsynth.adapters.cli import typer_adapter
 def test_completion_cmd_outputs_script(monkeypatch):
     """completion_cmd outputs a completion script when not installing."""
     bridge = MagicMock()
+    monkeypatch.setattr(
+        "devsynth.adapters.cli.typer_adapter.typer_completion.get_completion_script",
+        lambda **_: "script",
+    )
     typer_adapter.completion_cmd(shell="bash", bridge=bridge)
-    bridge.show_completion.assert_called_once()
+    bridge.show_completion.assert_called_once_with("script")
 
 
 @pytest.mark.medium
-def test_completion_cmd_installs_script(tmp_path):
+def test_completion_cmd_installs_script(tmp_path, monkeypatch):
     """completion_cmd writes script to path when install=True."""
     bridge = MagicMock()
     target = tmp_path / "comp.sh"
+    monkeypatch.setattr(
+        "devsynth.adapters.cli.typer_adapter.typer_completion.get_completion_script",
+        lambda **_: "script",
+    )
     typer_adapter.completion_cmd(shell="bash", install=True, path=target, bridge=bridge)
     assert target.exists()
     bridge.show_completion.assert_called_once_with(str(target))

--- a/tests/unit/general/test_metrics_dashboard_hook.py
+++ b/tests/unit/general/test_metrics_dashboard_hook.py
@@ -1,0 +1,26 @@
+import pytest
+
+from devsynth.metrics import (
+    clear_dashboard_hook,
+    get_dashboard_metrics,
+    inc_dashboard,
+    register_dashboard_hook,
+    reset_metrics,
+)
+
+
+@pytest.mark.medium
+def test_dashboard_hook_receives_events():
+    """Registering a dashboard hook forwards events."""
+    reset_metrics()
+    received = []
+
+    def hook(event: str) -> None:
+        received.append(event)
+
+    register_dashboard_hook(hook)
+    inc_dashboard("startup")
+    clear_dashboard_hook()
+
+    assert received == ["startup"]
+    assert get_dashboard_metrics()["startup"] == 1


### PR DESCRIPTION
## Summary
- streamline `devsynth init` wizard with progress and quick presets
- add Typer-based shell completion and dashboard metrics hook flag
- support dashboard metric callbacks and progress status updates

## Testing
- `poetry run pre-commit run --files src/devsynth/application/cli/progress.py src/devsynth/application/cli/setup_wizard.py src/devsynth/metrics.py src/devsynth/adapters/cli/typer_adapter.py docs/user_guides/cli_reference.md tests/unit/adapters/cli/test_typer_adapter.py tests/unit/application/cli/test_completion_cmd.py tests/unit/general/test_metrics_dashboard_hook.py scripts/completions/devsynth-completion.bash scripts/completions/devsynth-completion.zsh scripts/completions/devsynth-completion.fish`
- `poetry run pytest tests/unit/adapters/cli/test_typer_adapter.py tests/unit/application/cli/test_completion_cmd.py tests/unit/general/test_metrics_dashboard_hook.py -q`
- `poetry run python tests/verify_test_organization.py`
- `poetry run pip check`


------
https://chatgpt.com/codex/tasks/task_e_68996e7899148333b194007dd4fd4ac3