### PR TITLE
Harden deployment scripts and track EDRR phase quality

### DIFF
--- a/deployment/bootstrap_env.sh
+++ b/deployment/bootstrap_env.sh
@@ -40,4 +40,10 @@ if [[ -f .env ]]; then
   fi
 fi
 
+# Ensure required security token is present.
+if [[ -z "${DEVSYNTH_ACCESS_TOKEN:-}" ]]; then
+  echo "DEVSYNTH_ACCESS_TOKEN must be set." >&2
+  exit 1
+fi
+
 docker compose -f deployment/docker-compose.yml -f deployment/docker-compose.monitoring.yml up -d --build --pull=always

--- a/deployment/bootstrap_with_health_check.sh
+++ b/deployment/bootstrap_with_health_check.sh
@@ -15,6 +15,12 @@ if [[ ! -f pyproject.toml ]]; then
   exit 1
 fi
 
+# Ensure required security token is present.
+if [[ -z "${DEVSYNTH_ACCESS_TOKEN:-}" ]]; then
+  echo "DEVSYNTH_ACCESS_TOKEN must be set." >&2
+  exit 1
+fi
+
 # Build and start services, then run health checks.
 ./deployment/bootstrap_env.sh
 ./deployment/health_check.sh

--- a/deployment/deploy_production.sh
+++ b/deployment/deploy_production.sh
@@ -46,6 +46,12 @@ if [[ -f .env ]]; then
   fi
 fi
 
+# Ensure required security token is present.
+if [[ -z "${DEVSYNTH_ACCESS_TOKEN:-}" ]]; then
+  echo "DEVSYNTH_ACCESS_TOKEN must be set." >&2
+  exit 1
+fi
+
 docker compose -f deployment/docker-compose.yml -f deployment/docker-compose.monitoring.yml build --pull --no-cache
 
 docker compose -f docker-compose.production.yml up -d --pull=always

--- a/deployment/health_check.sh
+++ b/deployment/health_check.sh
@@ -34,6 +34,12 @@ if [[ -f .env ]]; then
   fi
 fi
 
+# Ensure required security token is present.
+if [[ -z "${DEVSYNTH_ACCESS_TOKEN:-}" ]]; then
+  echo "DEVSYNTH_ACCESS_TOKEN must be set." >&2
+  exit 1
+fi
+
 curl -fsS --max-time 10 http://localhost:8000/health > /dev/null
 curl -fsS --max-time 10 http://localhost:3000/api/health > /dev/null
 

--- a/docs/developer_guides/tdd_bdd_edrr_training.md
+++ b/docs/developer_guides/tdd_bdd_edrr_training.md
@@ -95,6 +95,10 @@ The Retrospect phase evaluates outcomes and plans for the next iteration. During
 - Identify lessons learned
 - Plan for the next iteration
 
+Each phase records a `quality_score` and sets `phase_complete` when predefined
+thresholds are met. These markers enable the coordinator to transition between
+phases automatically while preserving quality metrics for later review.
+
 ## 3. Integration Principles
 
 The integration of TDD/BDD with EDRR is guided by the following principles:
@@ -301,7 +305,7 @@ Feature: Methodology Adapters Integration
 
 **Pitfall**: Writing tests after implementing the code defeats the purpose of TDD/BDD.
 
-**Solution**: 
+**Solution**:
 - Use pre-commit hooks to enforce test-first development
 - Track test-first metrics to monitor adherence
 - Pair programming with a TDD/BDD advocate

--- a/docs/policies/security.md
+++ b/docs/policies/security.md
@@ -40,6 +40,7 @@ This policy is reviewed quarterly by the DevSynth team to ensure it remains curr
 - Encryption in transit can be enforced with `DEVSYNTH_ENCRYPTION_IN_TRANSIT`.
 - TLS verification and certificates are configured using `DEVSYNTH_TLS_VERIFY`, `DEVSYNTH_TLS_CERT_FILE`, `DEVSYNTH_TLS_KEY_FILE` and `DEVSYNTH_TLS_CA_FILE`.
 - Store API keys and secrets in environment variables or a secrets manager; never commit them to the repository.
+- Deployment scripts verify `DEVSYNTH_ACCESS_TOKEN` is set and ensure any `.env` file has restrictive permissions and is not a symlink.
 - Report suspected security issues or vulnerabilities through the issue tracker.
 - Review security settings as part of routine cross‑cutting concern audits.
 - Maintain logs for security relevant events and restrict access to them.

--- a/src/devsynth/application/edrr/coordinator.py
+++ b/src/devsynth/application/edrr/coordinator.py
@@ -2321,6 +2321,13 @@ class EDRRCoordinator:
             results = self._run_micro_cycles(self.current_phase, results)
             self.results[self.current_phase.name] = results
 
+            # Evaluate phase quality and completion status
+            assessment = self._assess_phase_quality(self.current_phase)
+            results["quality_score"] = assessment["quality"]
+            results["phase_complete"] = assessment["can_progress"]
+            results["quality_metrics"] = assessment["metrics"]
+            self.results[self.current_phase.name] = results
+
             if hasattr(self, "_preserved_context"):
                 results.setdefault("context", {})["previous_phases"] = copy.deepcopy(
                     self._preserved_context

--- a/tests/integration/general/test_edrr_phase_quality_assessment.py
+++ b/tests/integration/general/test_edrr_phase_quality_assessment.py
@@ -1,0 +1,106 @@
+import sys
+import types
+from unittest.mock import MagicMock
+
+import pytest
+
+argon2_mod = types.ModuleType("argon2")
+setattr(argon2_mod, "PasswordHasher", object)
+exceptions_mod = types.ModuleType("exceptions")
+setattr(exceptions_mod, "VerifyMismatchError", type("VerifyMismatchError", (), {}))
+setattr(argon2_mod, "exceptions", exceptions_mod)
+sys.modules.setdefault("argon2", argon2_mod)
+sys.modules.setdefault("argon2.exceptions", exceptions_mod)
+sys.modules.setdefault("requests", types.ModuleType("requests"))
+crypto_mod = types.ModuleType("cryptography")
+fernet_mod = types.ModuleType("fernet")
+setattr(fernet_mod, "Fernet", object)
+crypto_mod.fernet = fernet_mod
+sys.modules.setdefault("cryptography", crypto_mod)
+sys.modules.setdefault("cryptography.fernet", fernet_mod)
+sys.modules.setdefault("jsonschema", types.ModuleType("jsonschema"))
+rdflib_mod = types.ModuleType("rdflib")
+setattr(rdflib_mod, "Graph", object)
+setattr(rdflib_mod, "Literal", object)
+setattr(rdflib_mod, "URIRef", object)
+setattr(rdflib_mod, "Namespace", lambda *a, **k: object())
+setattr(rdflib_mod, "RDF", object)
+setattr(rdflib_mod, "RDFS", object)
+setattr(rdflib_mod, "XSD", object)
+namespace_mod = types.ModuleType("namespace")
+setattr(namespace_mod, "FOAF", object)
+setattr(namespace_mod, "DC", object)
+rdflib_mod.namespace = namespace_mod
+sys.modules.setdefault("rdflib", rdflib_mod)
+sys.modules.setdefault("rdflib.namespace", namespace_mod)
+astor_mod = types.ModuleType("astor")
+setattr(astor_mod, "to_source", lambda *a, **k: "")
+sys.modules.setdefault("astor", astor_mod)
+
+from devsynth.application.code_analysis.analyzer import CodeAnalyzer
+from devsynth.application.code_analysis.ast_transformer import AstTransformer
+from devsynth.application.documentation.documentation_manager import (
+    DocumentationManager,
+)
+from devsynth.application.edrr.coordinator import EDRRCoordinator
+from devsynth.application.memory.memory_manager import MemoryManager
+from devsynth.application.prompts.prompt_manager import PromptManager
+from devsynth.domain.models.wsde_facade import WSDETeam
+from devsynth.methodology.base import Phase
+
+
+class SimpleAgent:
+    def __init__(self, name):
+        self.name = name
+        self.expertise = []
+        self.current_role = None
+
+    def process(self, task):
+        return {"processed_by": self.name}
+
+
+@pytest.fixture
+def coordinator():
+    team = WSDETeam(name="TestEdrrQualityTeam")
+    team.add_agent(SimpleAgent("agent1"))
+    team.generate_diverse_ideas = MagicMock(return_value=["idea"])
+    team.create_comparison_matrix = MagicMock(return_value={})
+    team.evaluate_options = MagicMock(return_value=[])
+    team.analyze_trade_offs = MagicMock(return_value=[])
+    team.formulate_decision_criteria = MagicMock(return_value={})
+    team.select_best_option = MagicMock(return_value={})
+    team.elaborate_details = MagicMock(return_value=[])
+    team.create_implementation_plan = MagicMock(return_value=[])
+    team.optimize_implementation = MagicMock(return_value={})
+    team.perform_quality_assurance = MagicMock(return_value={})
+    team.extract_learnings = MagicMock(return_value=[])
+    team.recognize_patterns = MagicMock(return_value=[])
+    team.integrate_knowledge = MagicMock(return_value={})
+    team.generate_improvement_suggestions = MagicMock(return_value=[])
+    mm = MagicMock(spec=MemoryManager)
+    mm.retrieve_with_edrr_phase.side_effect = lambda *a, **k: {}
+    mm.retrieve_relevant_knowledge.return_value = []
+    mm.retrieve_historical_patterns.return_value = []
+    analyzer = MagicMock(spec=CodeAnalyzer)
+    analyzer.analyze_project_structure.return_value = []
+    return EDRRCoordinator(
+        memory_manager=mm,
+        wsde_team=team,
+        code_analyzer=analyzer,
+        ast_transformer=MagicMock(spec=AstTransformer),
+        prompt_manager=MagicMock(spec=PromptManager),
+        documentation_manager=MagicMock(spec=DocumentationManager),
+        enable_enhanced_logging=False,
+    )
+
+
+def test_phase_quality_markers_are_recorded(coordinator):
+    """Each phase records quality metrics and completion status.
+
+    ReqID: N/A"""
+    coordinator.start_cycle({"description": "macro"})
+    for phase in Phase:
+        phase_data = coordinator.results[phase.name]
+        assert isinstance(phase_data.get("phase_complete"), bool)
+        quality = phase_data.get("quality_score", -1.0)
+        assert 0.0 <= quality <= 1.0


### PR DESCRIPTION
## Summary
- Validate required access token in deployment scripts
- Record phase quality metrics and completion status in EDRR coordination
- Document security checks and phase quality markers

## Testing
- `poetry run pre-commit run --files deployment/bootstrap_env.sh deployment/bootstrap_with_health_check.sh deployment/deploy_production.sh deployment/health_check.sh docs/developer_guides/tdd_bdd_edrr_training.md docs/policies/security.md src/devsynth/application/edrr/coordinator.py tests/integration/general/test_edrr_phase_quality_assessment.py`
- `poetry run python scripts/run_all_tests.py` *(failed: KeyboardInterrupt)*
- `poetry run python tests/verify_test_organization.py`
- `poetry run pip check`


------
https://chatgpt.com/codex/tasks/task_e_68996e8e287c8333b84f297fa275906d