### PR TITLE
Integrate requirements reasoning with EDRR workflow

### DIFF
--- a/src/devsynth/domain/interfaces/requirement.py
+++ b/src/devsynth/domain/interfaces/requirement.py
@@ -156,7 +156,9 @@ class ChatRepositoryInterface:
 class DialecticalReasonerInterface:
     """Base dialectical reasoner implementation."""
 
-    def evaluate_change(self, change: RequirementChange) -> DialecticalReasoning:
+    def evaluate_change(
+        self, change: RequirementChange, edrr_phase: str = "REFINE"
+    ) -> DialecticalReasoning:
         reasoning = DialecticalReasoning(change_id=change.id)
         reasoning.thesis = f"Proposed change {change.id}"
         reasoning.antithesis = "Opposing view"
@@ -175,7 +177,9 @@ class DialecticalReasonerInterface:
     ) -> ChatSession:
         return ChatSession(user_id=user_id, change_id=change_id)
 
-    def assess_impact(self, change: RequirementChange) -> ImpactAssessment:
+    def assess_impact(
+        self, change: RequirementChange, edrr_phase: str = "REFINE"
+    ) -> ImpactAssessment:
         return ImpactAssessment(change_id=change.id, analysis="")
 
 

--- a/src/devsynth/ports/requirement_port.py
+++ b/src/devsynth/ports/requirement_port.py
@@ -1,6 +1,7 @@
 """
 Ports for the requirements management system.
 """
+
 from abc import ABC, abstractmethod
 from typing import Dict, List, Optional, Union
 from uuid import UUID
@@ -315,12 +316,15 @@ class DialecticalReasonerPort(ABC):
     """Port for dialectical reasoner."""
 
     @abstractmethod
-    def evaluate_change(self, change: RequirementChange) -> DialecticalReasoning:
+    def evaluate_change(
+        self, change: RequirementChange, edrr_phase: str = "REFINE"
+    ) -> DialecticalReasoning:
         """
         Evaluate a requirement change using dialectical reasoning.
 
         Args:
             change: The requirement change to evaluate.
+            edrr_phase: The EDRR phase context for memory storage.
 
         Returns:
             The dialectical reasoning result.
@@ -361,12 +365,15 @@ class DialecticalReasonerPort(ABC):
         return ChatSession(user_id=user_id, change_id=change_id)
 
     @abstractmethod
-    def assess_impact(self, change: RequirementChange) -> ImpactAssessment:
+    def assess_impact(
+        self, change: RequirementChange, edrr_phase: str = "REFINE"
+    ) -> ImpactAssessment:
         """
         Assess the impact of a requirement change.
 
         Args:
             change: The requirement change to assess.
+            edrr_phase: The EDRR phase context for memory storage.
 
         Returns:
             The impact assessment.

--- a/tests/unit/application/requirements/test_dialectical_reasoner.py
+++ b/tests/unit/application/requirements/test_dialectical_reasoner.py
@@ -12,7 +12,12 @@ from devsynth.domain.interfaces.requirement import (
     ImpactAssessmentRepositoryInterface,
     RequirementRepositoryInterface,
 )
-from devsynth.domain.models.requirement import RequirementChange
+from devsynth.domain.models.memory import MemoryType
+from devsynth.domain.models.requirement import (
+    ChangeType,
+    Requirement,
+    RequirementChange,
+)
 
 
 class DummyNotification:
@@ -37,7 +42,18 @@ class DummyLLM:
         return self.response
 
 
-def _build_service(llm_response: str) -> DialecticalReasonerService:
+class DummyMemoryManager:
+    def __init__(self):
+        self.calls = []
+
+    def store_with_edrr_phase(self, content, memory_type, edrr_phase, metadata=None):
+        self.calls.append((content, memory_type, edrr_phase, metadata))
+        return "mem-id"
+
+
+def _build_service(
+    llm_response: str, memory_manager=None
+) -> DialecticalReasonerService:
     service = DialecticalReasonerService(
         requirement_repository=RequirementRepositoryInterface(),
         reasoning_repository=DialecticalReasoningRepositoryInterface(),
@@ -45,6 +61,7 @@ def _build_service(llm_response: str) -> DialecticalReasonerService:
         chat_repository=ChatRepositoryInterface(),
         notification_service=DummyNotification(),
         llm_service=DummyLLM(llm_response),
+        memory_manager=memory_manager,
     )
 
     # Simplify generation steps to isolate consensus logic
@@ -79,3 +96,45 @@ def test_evaluate_change_logs_consensus_failure(caplog):
 
     assert "Consensus not reached" in caplog.text
     assert not service.reasoning_repository.reasonings
+
+
+def test_evaluate_change_stores_with_phase():
+    memory = DummyMemoryManager()
+    service = _build_service("yes", memory_manager=memory)
+    change = RequirementChange(requirement_id=uuid4(), created_by="carol")
+
+    service.evaluate_change(change, edrr_phase="EXPAND")
+
+    assert memory.calls
+    assert memory.calls[0][1] == MemoryType.DIALECTICAL_REASONING
+    assert memory.calls[0][2] == "EXPAND"
+
+
+def test_evaluate_change_failure_stores_retrospect():
+    memory = DummyMemoryManager()
+    service = _build_service("no", memory_manager=memory)
+    change = RequirementChange(requirement_id=uuid4(), created_by="dave")
+
+    with pytest.raises(ConsensusError):
+        service.evaluate_change(change, edrr_phase="EXPAND")
+
+    assert memory.calls
+    assert memory.calls[0][2] == "RETROSPECT"
+
+
+def test_assess_impact_stores_with_phase():
+    memory = DummyMemoryManager()
+    service = _build_service("yes", memory_manager=memory)
+    new_req = Requirement(title="title", description="desc", created_by="erin")
+    change = RequirementChange(
+        requirement_id=uuid4(),
+        change_type=ChangeType.ADD,
+        new_state=new_req,
+        created_by="erin",
+    )
+
+    service.assess_impact(change, edrr_phase="RETROSPECT")
+
+    assert memory.calls
+    assert memory.calls[0][1] == MemoryType.DOCUMENTATION
+    assert memory.calls[0][2] == "RETROSPECT"


### PR DESCRIPTION
## Summary
- connect requirements dialectical reasoner to EDRR with phase-aware memory storage
- log peer-review consensus failures with structured metadata
- cover EDRR phases and impact storage in dialectical reasoner unit tests

## Testing
- `poetry run pre-commit run --files src/devsynth/application/requirements/dialectical_reasoner.py src/devsynth/application/collaboration/peer_review.py src/devsynth/domain/interfaces/requirement.py src/devsynth/ports/requirement_port.py tests/unit/application/requirements/test_dialectical_reasoner.py`
- `poetry run pytest tests/unit/application/requirements/test_dialectical_reasoner.py -m "not memory_intensive"`
- `poetry run python tests/verify_test_organization.py`
- `poetry run pip check`
- `poetry run python scripts/run_all_tests.py` *(interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_68996e9c84f883338fdafb4e70df5140