### PR TITLE
Replace run_all_tests references with `devsynth run-tests` and add wrapper tests

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,7 +45,7 @@ Before opening a pull request, run:
 
 ```bash
 poetry run pre-commit run --files <changed>
-poetry run python scripts/run_all_tests.py
+poetry run devsynth run-tests
 poetry run python tests/verify_test_organization.py
 ```
 

--- a/README.md
+++ b/README.md
@@ -346,6 +346,16 @@ The [Repository Structure](docs/repo_structure.md) document provides a comprehen
 - `docs/specifications/` – Current and archived specifications
 - `deployment/` – Deployment scripts and configuration
 
+## Testing
+
+Run the full test suite with:
+
+```bash
+poetry run devsynth run-tests
+```
+
+The legacy `scripts/run_all_tests.py` wrapper remains for backward compatibility but will be removed in a future release.
+
 ## Current Limitations
 
 DevSynth is under active development. Collaborative WSDE features, dialectical reasoning,

--- a/docs/deployment/release_automation.md
+++ b/docs/deployment/release_automation.md
@@ -46,5 +46,5 @@ The `rollback` utility executes `scripts/deployment/rollback.sh` and validates s
 Run deployment tests after publishing or rolling back:
 
 ```bash
-poetry run python scripts/run_all_tests.py
+poetry run devsynth run-tests
 ```

--- a/docs/policies/deprecation_policy.md
+++ b/docs/policies/deprecation_policy.md
@@ -45,7 +45,7 @@ The following legacy scripts are deprecated and will be removed in v1.0
 |-------------------|---------------------|-----------------|
 | `scripts/alignment_check.py` | `devsynth align` | v1.0 |
 | `scripts/validate_manifest.py` | `devsynth validate-manifest` | v1.0 |
-| `scripts/run_all_tests.py` | `devsynth run-pipeline` | v1.0 |
+| `scripts/run_all_tests.py` | `devsynth run-tests` | v1.0 |
 | `scripts/run_tests.sh` | `devsynth run-pipeline` | v1.0 |
 | `scripts/validate_config.py` | `devsynth inspect-config` | v1.0 |
 | `scripts/test_metrics.py` | `devsynth test-metrics` | v1.0 |

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -4,29 +4,30 @@ This directory contains scripts for comprehensive testing of the DevSynth projec
 
 ## Available Scripts
 
-### 1. Run All Tests (`run_all_tests.py`)
+### 1. Run Tests (`devsynth run-tests`)
 
 This script executes all unit, integration, and behavior tests and generates a comprehensive report of the results.
 
 ```bash
 # Run all tests
-./scripts/run_all_tests.py
+poetry run devsynth run-tests
 
 # Run only unit tests
-./scripts/run_all_tests.py --target unit-tests
+poetry run devsynth run-tests --target unit-tests
 
 # Run only integration tests
-./scripts/run_all_tests.py --target integration-tests
+poetry run devsynth run-tests --target integration-tests
 
 # Run only behavior tests
-./scripts/run_all_tests.py --target behavior-tests
+poetry run devsynth run-tests --target behavior-tests
 
 # Generate HTML report
-./scripts/run_all_tests.py --report
+poetry run devsynth run-tests --report
 
 # Show verbose output
-./scripts/run_all_tests.py --verbose
+poetry run devsynth run-tests --verbose
 ```
+
 
 ### 2. Manual CLI Testing (`manual_cli_testing.py`)
 
@@ -168,7 +169,7 @@ jobs:
         poetry install
     - name: Run all tests
       run: |
-        ./scripts/run_all_tests.py --report
+        poetry run devsynth run-tests --report
     - name: Upload test report
       uses: actions/upload-artifact@v2
       with:

--- a/scripts/apply_test_markers.py
+++ b/scripts/apply_test_markers.py
@@ -31,72 +31,100 @@ Examples:
     python scripts/apply_test_markers.py --verbose
 """
 
+import argparse
+import json
 import os
 import re
 import sys
-import json
-import argparse
 from pathlib import Path
-from typing import Dict, List, Tuple, Set, Optional, Any
+from typing import Any, Dict, List, Optional, Set, Tuple
 
 # Constants
 PROGRESS_FILE = ".test_categorization_progress.json"
 CACHE_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)), ".cache")
 
+
 def parse_args():
     """Parse command-line arguments."""
     parser = argparse.ArgumentParser(description="Apply speed markers to test files")
-    
+
     # Module or directory to analyze
     group = parser.add_mutually_exclusive_group()
-    group.add_argument("--module", help="Apply markers to tests in the specified module")
-    group.add_argument("--directory", default="tests", help="Apply markers to tests in the specified directory")
-    
+    group.add_argument(
+        "--module", help="Apply markers to tests in the specified module"
+    )
+    group.add_argument(
+        "--directory",
+        default="tests",
+        help="Apply markers to tests in the specified directory",
+    )
+
     # Other options
-    parser.add_argument("--progress-file", default=PROGRESS_FILE, help="Path to the progress file")
-    parser.add_argument("--dry-run", action="store_true", help="Show what would be done without making changes")
+    parser.add_argument(
+        "--progress-file", default=PROGRESS_FILE, help="Path to the progress file"
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Show what would be done without making changes",
+    )
     parser.add_argument("--verbose", action="store_true", help="Show verbose output")
-    parser.add_argument("--force", action="store_true", help="Apply markers even if they already exist")
-    
+    parser.add_argument(
+        "--force", action="store_true", help="Apply markers even if they already exist"
+    )
+
     return parser.parse_args()
+
 
 def load_progress(progress_file: str) -> Dict[str, Any]:
     """
     Load the test categorization progress from a file.
-    
+
     Args:
         progress_file: Path to the progress file
-        
+
     Returns:
         Dictionary containing categorization progress
     """
     if not os.path.exists(progress_file):
         print(f"Progress file {progress_file} not found")
-        return {"categorized_tests": {}, "categorization_counts": {"fast": 0, "medium": 0, "slow": 0, "total": 0}}
-    
+        return {
+            "categorized_tests": {},
+            "categorization_counts": {"fast": 0, "medium": 0, "slow": 0, "total": 0},
+        }
+
     try:
-        with open(progress_file, 'r') as f:
+        with open(progress_file, "r") as f:
             progress = json.load(f)
-            
+
         # Ensure the progress file has the expected structure
         if "categorized_tests" not in progress:
             progress["categorized_tests"] = {}
-            
+
         if "categorization_counts" not in progress:
-            progress["categorization_counts"] = {"fast": 0, "medium": 0, "slow": 0, "total": 0}
-            
+            progress["categorization_counts"] = {
+                "fast": 0,
+                "medium": 0,
+                "slow": 0,
+                "total": 0,
+            }
+
         return progress
     except (json.JSONDecodeError, IOError) as e:
         print(f"Error loading progress file: {e}")
-        return {"categorized_tests": {}, "categorization_counts": {"fast": 0, "medium": 0, "slow": 0, "total": 0}}
+        return {
+            "categorized_tests": {},
+            "categorization_counts": {"fast": 0, "medium": 0, "slow": 0, "total": 0},
+        }
+
 
 def find_test_files(directory: str) -> List[Path]:
     """
     Find all test files in a directory.
-    
+
     Args:
         directory: Directory to search for test files
-        
+
     Returns:
         List of test file paths
     """
@@ -107,13 +135,18 @@ def find_test_files(directory: str) -> List[Path]:
                 test_files.append(Path(os.path.join(root, file)))
     return test_files
 
-def analyze_test_file(file_path: Path) -> Tuple[Dict[str, List[str]], Dict[int, str], Dict[int, List[int]], List[Tuple[int, int]]]:
+
+def analyze_test_file(
+    file_path: Path,
+) -> Tuple[
+    Dict[str, List[str]], Dict[int, str], Dict[int, List[int]], List[Tuple[int, int]]
+]:
     """
     Analyze a test file to find existing markers and test line numbers.
-    
+
     Args:
         file_path: Path to the test file
-        
+
     Returns:
         Tuple containing:
             - Dictionary mapping test names to existing markers
@@ -125,41 +158,50 @@ def analyze_test_file(file_path: Path) -> Tuple[Dict[str, List[str]], Dict[int, 
     test_line_numbers = {}
     misplaced_markers = {}
     blank_line_ranges = []
-    
-    with open(file_path, 'r') as f:
+
+    with open(file_path, "r") as f:
         lines = f.readlines()
-    
+
     # Find all test functions and their markers
     current_markers = []
     current_test_line = None
     i = 0
     while i < len(lines):
         line = lines[i]
-        
+
         # Check for marker lines
         if "@pytest.mark." in line:
-            marker_match = re.search(r'@pytest\.mark\.(\w+)', line)
+            marker_match = re.search(r"@pytest\.mark\.(\w+)", line)
             if marker_match:
                 marker = marker_match.group(1)
                 if marker in ["fast", "medium", "slow"]:
                     # Check if this marker is properly placed (before a test function)
                     is_properly_placed = False
-                    
+
                     # Look ahead for a test function definition
-                    for j in range(i+1, min(i+5, len(lines))):
-                        if lines[j].strip().startswith("def test_") or lines[j].strip().startswith("async def test_"):
+                    for j in range(i + 1, min(i + 5, len(lines))):
+                        if lines[j].strip().startswith("def test_") or lines[
+                            j
+                        ].strip().startswith("async def test_"):
                             # Only consider it properly placed if there's nothing but blank lines or comments between
-                            if all(lines[k].strip() == "" or lines[k].strip().startswith("#") for k in range(i+1, j)):
+                            if all(
+                                lines[k].strip() == ""
+                                or lines[k].strip().startswith("#")
+                                for k in range(i + 1, j)
+                            ):
                                 is_properly_placed = True
-                                
+
                                 # Check for blank lines between marker and test function
                                 blank_start = i + 1
                                 blank_end = j - 1
-                                if blank_end >= blank_start and all(lines[k].strip() == "" for k in range(blank_start, blank_end + 1)):
+                                if blank_end >= blank_start and all(
+                                    lines[k].strip() == ""
+                                    for k in range(blank_start, blank_end + 1)
+                                ):
                                     blank_line_ranges.append((blank_start, blank_end))
-                                
+
                                 break
-                    
+
                     if is_properly_placed:
                         current_markers.append(marker)
                     else:
@@ -168,60 +210,62 @@ def analyze_test_file(file_path: Path) -> Tuple[Dict[str, List[str]], Dict[int, 
                             if current_test_line not in misplaced_markers:
                                 misplaced_markers[current_test_line] = []
                             misplaced_markers[current_test_line].append(i)
-        
+
         # Check for test function definitions
-        elif line.strip().startswith("def test_") or line.strip().startswith("async def test_"):
+        elif line.strip().startswith("def test_") or line.strip().startswith(
+            "async def test_"
+        ):
             # Extract the test name
-            test_match = re.search(r'def\s+(test_\w+)', line)
+            test_match = re.search(r"def\s+(test_\w+)", line)
             if test_match:
                 test_name = test_match.group(1)
-                
+
                 # Get the full test name (including class prefix if applicable)
                 full_test_name = test_name
-                
+
                 # Store the test line number
                 test_line_numbers[i] = full_test_name
                 current_test_line = i
-                
+
                 if current_markers:
                     existing_markers[full_test_name] = current_markers.copy()
-                
+
                 current_markers = []
-        
+
         # Check for markers inside docstrings
         elif '"""' in line or "'''" in line:
             # We're entering or leaving a docstring, check the next few lines for misplaced markers
             docstring_start = i
             docstring_end = None
-            
+
             # Determine the docstring delimiter
             delimiter = '"""' if '"""' in line else "'''"
-            
+
             # Check if this is a single-line docstring
             if line.count(delimiter) == 2:
                 docstring_end = i
             else:
                 # Find the end of the docstring
-                for j in range(i+1, len(lines)):
+                for j in range(i + 1, len(lines)):
                     if delimiter in lines[j]:
                         docstring_end = j
                         break
-            
+
             if docstring_end is not None:
                 # Check for markers inside the docstring
-                for j in range(docstring_start, docstring_end+1):
+                for j in range(docstring_start, docstring_end + 1):
                     if "@pytest.mark." in lines[j]:
                         # This is a misplaced marker inside a docstring
                         if current_test_line is not None:
                             if current_test_line not in misplaced_markers:
                                 misplaced_markers[current_test_line] = []
                             misplaced_markers[current_test_line].append(j)
-                
+
                 # Skip to the end of the docstring
                 i = docstring_end
-        
+
         i += 1
-    
+
     # Check for duplicate markers (multiple markers for the same test)
     duplicate_markers = {}
     for test_line, test_name in test_line_numbers.items():
@@ -229,12 +273,12 @@ def analyze_test_file(file_path: Path) -> Tuple[Dict[str, List[str]], Dict[int, 
         markers_for_test = []
         for i in range(max(0, test_line - 10), test_line):
             if i < len(lines) and "@pytest.mark." in lines[i]:
-                marker_match = re.search(r'@pytest\.mark\.(\w+)', lines[i])
+                marker_match = re.search(r"@pytest\.mark\.(\w+)", lines[i])
                 if marker_match:
                     marker = marker_match.group(1)
                     if marker in ["fast", "medium", "slow"]:
                         markers_for_test.append(i)
-        
+
         # If there are multiple markers, track them
         if len(markers_for_test) > 1:
             duplicate_markers[test_line] = markers_for_test
@@ -242,92 +286,107 @@ def analyze_test_file(file_path: Path) -> Tuple[Dict[str, List[str]], Dict[int, 
             if test_line not in misplaced_markers:
                 misplaced_markers[test_line] = []
             misplaced_markers[test_line].extend(markers_for_test[:-1])
-    
+
     return existing_markers, test_line_numbers, misplaced_markers, blank_line_ranges
 
+
 def update_test_file(
-    file_path: Path, 
-    test_markers: Dict[str, str], 
+    file_path: Path,
+    test_markers: Dict[str, str],
     dry_run: bool = False,
     verbose: bool = False,
-    force: bool = False
+    force: bool = False,
 ) -> Tuple[int, int, int]:
     """
     Update a test file with appropriate markers.
-    
+
     Args:
         file_path: Path to the test file
         test_markers: Dictionary mapping test paths to markers
         dry_run: If True, show what would be done without making changes
         verbose: If True, show verbose output
         force: If True, apply markers even if they already exist
-        
+
     Returns:
         Tuple containing counts of (added, updated, unchanged) markers
     """
     added = 0
     updated = 0
     unchanged = 0
-    
+
     # Analyze the file
-    existing_markers, test_line_numbers, misplaced_markers, blank_line_ranges = analyze_test_file(file_path)
-    
+    existing_markers, test_line_numbers, misplaced_markers, blank_line_ranges = (
+        analyze_test_file(file_path)
+    )
+
     if verbose:
         print(f"\nAnalyzing file {file_path}")
         print(f"Found {len(test_line_numbers)} test functions/methods")
         for line_num, test_name in test_line_numbers.items():
             print(f"Line {line_num}: {test_name}")
         if misplaced_markers:
-            print(f"Found {sum(len(lines) for lines in misplaced_markers.values())} misplaced markers")
+            print(
+                f"Found {sum(len(lines) for lines in misplaced_markers.values())} misplaced markers"
+            )
             for test_line, marker_lines in misplaced_markers.items():
                 test_name = test_line_numbers.get(test_line, "Unknown")
-                print(f"  Test {test_name} at line {test_line} has misplaced markers at lines: {marker_lines}")
-    
+                print(
+                    f"  Test {test_name} at line {test_line} has misplaced markers at lines: {marker_lines}"
+                )
+
     if not test_line_numbers:
         if verbose:
             print("No test functions/methods found in file")
         return added, updated, unchanged
-    
-    with open(file_path, 'r') as f:
+
+    with open(file_path, "r") as f:
         lines = f.readlines()
-    
+
     # Check if pytest is imported
-    has_pytest_import = any('import pytest' in line for line in lines)
-    
+    has_pytest_import = any("import pytest" in line for line in lines)
+
     # Add pytest import if needed
-    if not has_pytest_import and test_line_numbers and any(test_name in test_markers for test_name in test_line_numbers.values()):
+    if (
+        not has_pytest_import
+        and test_line_numbers
+        and any(test_name in test_markers for test_name in test_line_numbers.values())
+    ):
         # Find the last import line
         last_import_line = 0
         for i, line in enumerate(lines):
-            if line.strip().startswith('import ') or line.strip().startswith('from '):
+            if line.strip().startswith("import ") or line.strip().startswith("from "):
                 last_import_line = i
-        
+
         # Insert pytest import after the last import
-        lines.insert(last_import_line + 1, 'import pytest\n')
-        
+        lines.insert(last_import_line + 1, "import pytest\n")
+
         # Update line numbers for all tests
         test_line_numbers = {k + 1: v for k, v in test_line_numbers.items()}
-        misplaced_markers = {k + 1: [m + 1 for m in v] for k, v in misplaced_markers.items()}
-        
+        misplaced_markers = {
+            k + 1: [m + 1 for m in v] for k, v in misplaced_markers.items()
+        }
+
         if dry_run:
             print(f"Would add to {file_path}:{last_import_line+2} - import pytest")
-    
+
     # First, remove all misplaced markers
     removed_lines = 0
     lines_to_remove = []
-    
+
     # Collect all misplaced marker lines
     for test_line, marker_lines in misplaced_markers.items():
         lines_to_remove.extend(marker_lines)
-    
+
     # Sort in reverse order to avoid index shifting when removing lines
     for line_idx in sorted(lines_to_remove, reverse=True):
         if line_idx < len(lines):
             if verbose:
-                print(f"Removing misplaced marker at line {line_idx+1}: {lines[line_idx].strip()}")
+                print(
+                    f"Removing misplaced marker at line {line_idx+1}: {lines[line_idx].strip()}"
+                )
             lines.pop(line_idx)
             removed_lines += 1
-    
+
     # Update line numbers after removing misplaced markers
     if removed_lines > 0:
         # Adjust line numbers for test functions
@@ -337,103 +396,114 @@ def update_test_file(
             shift = sum(1 for l in lines_to_remove if l < line_num)
             new_test_line_numbers[line_num - shift] = test_name
         test_line_numbers = new_test_line_numbers
-    
+
     # Process each test function
     modified_lines = []  # Track which lines we've modified to avoid duplicate changes
-    
+
     for line_num, test_name in sorted(test_line_numbers.items()):
         if verbose:
             print(f"\nProcessing test {test_name} at line {line_num}")
-        
+
         # Find the marker for this test
         new_marker = None
-        
+
         # Try different ways to match the test name with the markers dictionary
         # 1. Direct match with the test name
         if test_name in test_markers:
             new_marker = test_markers[test_name]
             if verbose:
                 print(f"Direct match found for {test_name}: {new_marker}")
-        
+
         # 2. Match with file path and test name
         if new_marker is None:
             file_name = file_path.name
             file_path_str = str(file_path)
-            
+
             # Try different patterns for matching
-            patterns = [
-                f"{file_path_str}::{test_name}",
-                f"{file_name}::{test_name}"
-            ]
-            
+            patterns = [f"{file_path_str}::{test_name}", f"{file_name}::{test_name}"]
+
             for pattern in patterns:
                 if pattern in test_markers:
                     new_marker = test_markers[pattern]
                     if verbose:
                         print(f"Pattern match found for {pattern}: {new_marker}")
                     break
-            
+
             # If still no match, try a more flexible approach
             if new_marker is None:
                 for marker_path, marker in test_markers.items():
-                    if isinstance(marker_path, str) and test_name in marker_path and (file_name in marker_path or file_path_str in marker_path):
+                    if (
+                        isinstance(marker_path, str)
+                        and test_name in marker_path
+                        and (file_name in marker_path or file_path_str in marker_path)
+                    ):
                         new_marker = marker
                         if verbose:
-                            print(f"Flexible match found for {marker_path}: {new_marker}")
+                            print(
+                                f"Flexible match found for {marker_path}: {new_marker}"
+                            )
                         break
-        
+
         if new_marker is None:
             if verbose:
                 print(f"No marker found for {test_name}, skipping")
             continue
-        
+
         # Check if the test already has the correct marker
-        if test_name in existing_markers and new_marker in existing_markers[test_name] and not force:
+        if (
+            test_name in existing_markers
+            and new_marker in existing_markers[test_name]
+            and not force
+        ):
             if verbose:
                 print(f"Test {test_name} already has marker {new_marker}, skipping")
             unchanged += 1
             continue
-        
+
         # Find the appropriate position to add or update the marker
         # We want to place it directly before the test function definition
         marker_position = line_num
-        
+
         # Check if we need to update an existing marker or add a new one
         existing_marker_line = None
-        
+
         # Search up to 5 lines before the test function to find existing markers
         search_start = max(0, line_num - 5)
         for i in range(search_start, line_num):
             if i >= len(lines):
                 continue
-                
-            if any(f'@pytest.mark.{m}' in lines[i] for m in ('fast', 'medium', 'slow')):
+
+            if any(f"@pytest.mark.{m}" in lines[i] for m in ("fast", "medium", "slow")):
                 existing_marker_line = i
                 break
-        
+
         # Also check for docstring before the test function
         has_docstring = False
         for i in range(line_num + 1, min(line_num + 10, len(lines))):
             if '"""' in lines[i] or "'''" in lines[i]:
                 has_docstring = True
                 break
-        
+
         if existing_marker_line is not None:
             # Update existing marker
             old_line = lines[existing_marker_line]
             lines[existing_marker_line] = old_line.replace(
                 f'@pytest.mark.{next(m for m in ("fast", "medium", "slow") if f"@pytest.mark.{m}" in old_line)}',
-                f'@pytest.mark.{new_marker}'
+                f"@pytest.mark.{new_marker}",
             )
             modified_lines.append(existing_marker_line)
-            
+
             if dry_run:
-                print(f"Would update {file_path}:{existing_marker_line+1} - {old_line.strip()} -> {lines[existing_marker_line].strip()}")
+                print(
+                    f"Would update {file_path}:{existing_marker_line+1} - {old_line.strip()} -> {lines[existing_marker_line].strip()}"
+                )
             else:
                 if verbose:
-                    print(f"Updated {file_path}:{existing_marker_line+1} - {old_line.strip()} -> {lines[existing_marker_line].strip()}")
+                    print(
+                        f"Updated {file_path}:{existing_marker_line+1} - {old_line.strip()} -> {lines[existing_marker_line].strip()}"
+                    )
             updated += 1
-            
+
             # Remove any extra blank lines between the marker and the test function
             i = existing_marker_line + 1
             while i < line_num:
@@ -441,94 +511,104 @@ def update_test_file(
                     lines.pop(i)
                     line_num -= 1
                     # Update line numbers for subsequent tests
-                    test_line_numbers = {k - 1 if k > i else k: v for k, v in test_line_numbers.items()}
+                    test_line_numbers = {
+                        k - 1 if k > i else k: v for k, v in test_line_numbers.items()
+                    }
                 else:
                     i += 1
         else:
             # Add new marker
             # Get the indentation of the test function
-            indent = re.match(r'(\s*)', lines[line_num]).group(1)
+            indent = re.match(r"(\s*)", lines[line_num]).group(1)
             marker_line = f"{indent}@pytest.mark.{new_marker}\n"
-            
+
             # Insert marker directly before the test function
             lines.insert(line_num, marker_line)
             modified_lines.append(line_num)
-            
+
             # Update line numbers for subsequent tests
-            test_line_numbers = {k + 1 if k >= line_num else k: v for k, v in test_line_numbers.items()}
-            
+            test_line_numbers = {
+                k + 1 if k >= line_num else k: v for k, v in test_line_numbers.items()
+            }
+
             if dry_run:
                 print(f"Would add to {file_path}:{line_num+1} - {marker_line.strip()}")
             else:
                 if verbose:
                     print(f"Added to {file_path}:{line_num+1} - {marker_line.strip()}")
             added += 1
-    
+
     # Write changes back to the file
     if not dry_run and (added > 0 or updated > 0 or removed_lines > 0):
-        with open(file_path, 'w') as f:
+        with open(file_path, "w") as f:
             f.writelines(lines)
-    
+
     return added, updated, unchanged
+
 
 def main():
     """Main function."""
     args = parse_args()
-    
+
     # Determine the directory to analyze
     directory = args.module if args.module else args.directory
-    
+
     print(f"Applying markers to tests in {directory}...")
-    
+
     # Load progress
     progress = load_progress(args.progress_file)
     categorized_tests = progress.get("categorized_tests", {})
-    
-    print(f"Loaded {len(categorized_tests)} categorized tests from {args.progress_file}")
-    
+
+    print(
+        f"Loaded {len(categorized_tests)} categorized tests from {args.progress_file}"
+    )
+
     # Find test files
     test_files = find_test_files(directory)
     print(f"Found {len(test_files)} test files")
-    
+
     # Apply markers to test files
     total_added = 0
     total_updated = 0
     total_unchanged = 0
-    
+
     for file_path in test_files:
         if args.verbose:
             print(f"\nProcessing file {file_path}")
-        
+
         added, updated, unchanged = update_test_file(
-            file_path, 
-            categorized_tests, 
-            args.dry_run, 
-            args.verbose,
-            args.force
+            file_path, categorized_tests, args.dry_run, args.verbose, args.force
         )
-        
+
         total_added += added
         total_updated += updated
         total_unchanged += unchanged
-    
+
     action = "Would " if args.dry_run else ""
-    print(f"\n{action}Add {total_added} markers, update {total_updated} markers, leave {total_unchanged} markers unchanged")
-    
+    print(
+        f"\n{action}Add {total_added} markers, update {total_updated} markers, leave {total_unchanged} markers unchanged"
+    )
+
     print("\nMarker application complete")
-    
+
     # Print tips for running tests by speed category
     print("\nTips for running tests by speed category:")
-    print("  - Run fast tests: python scripts/run_all_tests.py --fast")
-    print("  - Run medium tests: python scripts/run_all_tests.py --medium")
-    print("  - Run slow tests: python scripts/run_all_tests.py --slow")
-    print("  - Run fast and medium tests: python scripts/run_all_tests.py --fast --medium")
-    
+    print("  - Run fast tests: poetry run devsynth run-tests --fast")
+    print("  - Run medium tests: poetry run devsynth run-tests --medium")
+    print("  - Run slow tests: poetry run devsynth run-tests --slow")
+    print(
+        "  - Run fast and medium tests: poetry run devsynth run-tests --fast --medium"
+    )
+
     # Print tips for verifying markers
     print("\nTo verify markers:")
     print("  - Run verify_test_markers.py: python scripts/verify_test_markers.py")
-    print("  - Verify markers in a specific module: python scripts/verify_test_markers.py --module tests/unit/interface")
-    
+    print(
+        "  - Verify markers in a specific module: python scripts/verify_test_markers.py --module tests/unit/interface"
+    )
+
     return 0
+
 
 if __name__ == "__main__":
     sys.exit(main())

--- a/scripts/categorize_behavior_tests.py
+++ b/scripts/categorize_behavior_tests.py
@@ -21,17 +21,17 @@ Options:
     --step-file FILE      Specific step definition file to analyze
 """
 
+import argparse
+import json
 import os
 import re
-import sys
-import json
-import time
 import signal
-import argparse
 import subprocess
-from pathlib import Path
+import sys
+import time
 from datetime import datetime
-from typing import Dict, List, Tuple, Set, Optional, Any
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Set, Tuple
 
 # Import common test utilities
 sys.path.append(os.path.dirname(os.path.abspath(__file__)))
@@ -42,114 +42,113 @@ FAST_THRESHOLD = 1.0
 MEDIUM_THRESHOLD = 5.0
 
 # Regex patterns for finding and updating markers
-MARKER_PATTERN = re.compile(r'@pytest\.mark\.(fast|medium|slow|isolation)')
-FUNCTION_PATTERN = re.compile(r'def (test_\w+)\(')
+MARKER_PATTERN = re.compile(r"@pytest\.mark\.(fast|medium|slow|isolation)")
+FUNCTION_PATTERN = re.compile(r"def (test_\w+)\(")
 SCENARIO_PATTERN = re.compile(r'@scenario\([\'"](.+?)[\'"],\s*[\'"](.+?)[\'"]\)')
 SCENARIOS_PATTERN = re.compile(r'scenarios\([\'"](.+?)[\'"]\)')
 
 # Cache directory for test timing data
 CACHE_DIR = ".test_timing_cache"
 
+
 def parse_args():
     """Parse command line arguments."""
-    parser = argparse.ArgumentParser(
-        description='Categorize behavior tests by speed.'
-    )
+    parser = argparse.ArgumentParser(description="Categorize behavior tests by speed.")
     parser.add_argument(
-        '--batch-size',
+        "--batch-size",
         type=int,
         default=20,
-        help='Number of tests to run in each batch (default: 20)'
+        help="Number of tests to run in each batch (default: 20)",
     )
     parser.add_argument(
-        '--max-tests',
+        "--max-tests",
         type=int,
         default=100,
-        help='Maximum number of tests to analyze in this run (default: 100)'
+        help="Maximum number of tests to analyze in this run (default: 100)",
     )
     parser.add_argument(
-        '--fast-threshold',
+        "--fast-threshold",
         type=float,
         default=1.0,
-        help='Threshold for fast tests in seconds (default: 1.0)'
+        help="Threshold for fast tests in seconds (default: 1.0)",
     )
     parser.add_argument(
-        '--medium-threshold',
+        "--medium-threshold",
         type=float,
         default=5.0,
-        help='Threshold for medium tests in seconds (default: 5.0)'
+        help="Threshold for medium tests in seconds (default: 5.0)",
     )
     parser.add_argument(
-        '--dry-run',
-        action='store_true',
-        help='Show changes without modifying files'
+        "--dry-run", action="store_true", help="Show changes without modifying files"
     )
     parser.add_argument(
-        '--update',
-        action='store_true',
-        help='Update test files with appropriate markers'
+        "--update",
+        action="store_true",
+        help="Update test files with appropriate markers",
     )
     parser.add_argument(
-        '--timeout',
+        "--timeout",
         type=int,
         default=60,
-        help='Timeout for each test in seconds (default: 60)'
+        help="Timeout for each test in seconds (default: 60)",
     )
-    parser.add_argument(
-        '--feature',
-        help='Specific feature file to analyze'
-    )
-    parser.add_argument(
-        '--step-file',
-        help='Specific step definition file to analyze'
-    )
+    parser.add_argument("--feature", help="Specific feature file to analyze")
+    parser.add_argument("--step-file", help="Specific step definition file to analyze")
     return parser.parse_args()
+
 
 def find_behavior_test_files() -> Dict[str, Path]:
     """Find all behavior test files."""
     test_files = {}
-    for root, _, files in os.walk('tests/behavior'):
+    for root, _, files in os.walk("tests/behavior"):
         for file in files:
-            if file.startswith('test_') and file.endswith('.py') and not root.endswith('steps'):
+            if (
+                file.startswith("test_")
+                and file.endswith(".py")
+                and not root.endswith("steps")
+            ):
                 path = Path(os.path.join(root, file))
                 test_files[file] = path
     return test_files
 
+
 def find_feature_files() -> Dict[str, Path]:
     """Find all feature files."""
     feature_files = {}
-    for root, _, files in os.walk('tests/behavior/features'):
+    for root, _, files in os.walk("tests/behavior/features"):
         for file in files:
-            if file.endswith('.feature'):
+            if file.endswith(".feature"):
                 path = Path(os.path.join(root, file))
                 feature_files[file] = path
     return feature_files
 
+
 def find_step_files() -> Dict[str, Path]:
     """Find all step definition files."""
     step_files = {}
-    for root, _, files in os.walk('tests/behavior/steps'):
+    for root, _, files in os.walk("tests/behavior/steps"):
         for file in files:
-            if file.endswith('_steps.py'):
+            if file.endswith("_steps.py"):
                 path = Path(os.path.join(root, file))
                 step_files[file] = path
     return step_files
 
+
 def collect_behavior_tests() -> List[str]:
     """Collect all behavior tests."""
     print("Collecting behavior tests...")
-    
+
     # Create cache directory if it doesn't exist
     os.makedirs(CACHE_DIR, exist_ok=True)
-    
+
     # Check if we have a cached collection
     cache_file = os.path.join(CACHE_DIR, "behavior_tests.json")
-    
+
     if os.path.exists(cache_file):
         try:
-            with open(cache_file, 'r') as f:
+            with open(cache_file, "r") as f:
                 cached_data = json.load(f)
-            
+
             # Use cache if it's less than 1 hour old
             cache_time = datetime.fromisoformat(cached_data["timestamp"])
             if (datetime.now() - cache_time).total_seconds() < 3600:  # 1 hour
@@ -158,173 +157,180 @@ def collect_behavior_tests() -> List[str]:
         except (json.JSONDecodeError, KeyError):
             # Invalid cache, ignore and collect tests
             pass
-    
+
     # Collect tests using pytest
     collect_cmd = [
-        sys.executable, "-m", "pytest",
+        sys.executable,
+        "-m",
+        "pytest",
         "tests/behavior/",
         "--collect-only",
-        "-q"
+        "-q",
     ]
-    
+
     try:
-        collect_result = subprocess.run(collect_cmd, check=False, capture_output=True, text=True)
+        collect_result = subprocess.run(
+            collect_cmd, check=False, capture_output=True, text=True
+        )
         test_list = []
-        
+
         # Parse the output to get the list of tests
-        for line in collect_result.stdout.split('\n'):
-            if line.startswith('tests/behavior/'):
+        for line in collect_result.stdout.split("\n"):
+            if line.startswith("tests/behavior/"):
                 test_list.append(line.strip())
-        
+
         if not test_list:
             print(f"No behavior tests found")
             return []
-        
+
         print(f"Found {len(test_list)} behavior tests")
-        
+
         # Cache the results
-        cache_data = {
-            "timestamp": datetime.now().isoformat(),
-            "tests": test_list
-        }
-        with open(cache_file, 'w') as f:
+        cache_data = {"timestamp": datetime.now().isoformat(), "tests": test_list}
+        with open(cache_file, "w") as f:
             json.dump(cache_data, f, indent=2)
-        
+
         return test_list
     except Exception as e:
         print(f"Error collecting tests: {e}")
         return []
 
+
 def run_test_with_timing(test_path: str, timeout: int = 60) -> Tuple[float, bool, bool]:
     """
     Run a single test and measure its execution time.
-    
+
     Args:
         test_path: Path to the test to run
         timeout: Timeout in seconds
-        
+
     Returns:
         Tuple of (execution_time, passed, skipped)
     """
     # Check if we have a cached timing
-    cache_key = test_path.replace('/', '_').replace(':', '_')
+    cache_key = test_path.replace("/", "_").replace(":", "_")
     cache_file = os.path.join(CACHE_DIR, f"{cache_key}_timing.json")
-    
+
     if os.path.exists(cache_file):
         try:
-            with open(cache_file, 'r') as f:
+            with open(cache_file, "r") as f:
                 cached_data = json.load(f)
-            
+
             # Use cache if it's less than 24 hours old
             cache_time = datetime.fromisoformat(cached_data["timestamp"])
             if (datetime.now() - cache_time).total_seconds() < 86400:  # 24 hours
-                return cached_data["execution_time"], cached_data["passed"], cached_data["skipped"]
+                return (
+                    cached_data["execution_time"],
+                    cached_data["passed"],
+                    cached_data["skipped"],
+                )
         except (json.JSONDecodeError, KeyError):
             # Invalid cache, ignore and run test
             pass
-    
+
     # Run the test and measure execution time
-    cmd = [
-        sys.executable, "-m", "pytest",
-        test_path,
-        "-v"
-    ]
-    
+    cmd = [sys.executable, "-m", "pytest", test_path, "-v"]
+
     start_time = time.time()
-    
+
     try:
         # Set up a timeout handler
         def timeout_handler(signum, frame):
             raise TimeoutError(f"Test timed out after {timeout} seconds")
-        
+
         signal.signal(signal.SIGALRM, timeout_handler)
         signal.alarm(timeout)
-        
+
         result = subprocess.run(cmd, check=False, capture_output=True, text=True)
-        
+
         # Cancel the alarm
         signal.alarm(0)
-        
+
         end_time = time.time()
         execution_time = end_time - start_time
-        
+
         # Check if the test passed or was skipped
         passed = result.returncode == 0
         skipped = "SKIPPED" in result.stdout
-        
+
         # Cache the results
         cache_data = {
             "timestamp": datetime.now().isoformat(),
             "execution_time": execution_time,
             "passed": passed,
-            "skipped": skipped
+            "skipped": skipped,
         }
-        with open(cache_file, 'w') as f:
+        with open(cache_file, "w") as f:
             json.dump(cache_data, f, indent=2)
-        
+
         return execution_time, passed, skipped
     except TimeoutError as e:
         print(f"Test timed out: {test_path}")
-        
+
         # Cache the timeout
         cache_data = {
             "timestamp": datetime.now().isoformat(),
             "execution_time": timeout,
             "passed": False,
-            "skipped": False
+            "skipped": False,
         }
-        with open(cache_file, 'w') as f:
+        with open(cache_file, "w") as f:
             json.dump(cache_data, f, indent=2)
-        
+
         return timeout, False, False
     except Exception as e:
         print(f"Error running test: {e}")
         return 0.0, False, False
 
+
 def measure_test_times(
-    test_list: List[str], 
-    batch_size: int = 20, 
-    max_tests: Optional[int] = None, 
-    timeout: int = 60
+    test_list: List[str],
+    batch_size: int = 20,
+    max_tests: Optional[int] = None,
+    timeout: int = 60,
 ) -> Dict[str, Dict[str, Any]]:
     """
     Measure execution times for a list of tests.
-    
+
     Args:
         test_list: List of tests to measure
         batch_size: Number of tests to run in each batch
         max_tests: Maximum number of tests to measure (None for all)
         timeout: Timeout for each test in seconds
-        
+
     Returns:
         Dictionary mapping test names to timing data
     """
     if not test_list:
         return {}
-    
+
     # Limit the number of tests if specified
     if max_tests is not None and max_tests > 0:
         test_list = test_list[:max_tests]
-    
-    print(f"Measuring execution times for {len(test_list)} tests in batches of {batch_size}...")
-    
+
+    print(
+        f"Measuring execution times for {len(test_list)} tests in batches of {batch_size}..."
+    )
+
     test_times = {}
-    
+
     # Process tests in batches
     for i in range(0, len(test_list), batch_size):
-        batch = test_list[i:i+batch_size]
-        print(f"\nProcessing batch {i//batch_size + 1}/{(len(test_list) + batch_size - 1)//batch_size}...")
-        
+        batch = test_list[i : i + batch_size]
+        print(
+            f"\nProcessing batch {i//batch_size + 1}/{(len(test_list) + batch_size - 1)//batch_size}..."
+        )
+
         for test_path in batch:
             print(f"Running {test_path}...")
             execution_time, passed, skipped = run_test_with_timing(test_path, timeout)
-            
+
             test_times[test_path] = {
                 "execution_time": execution_time,
                 "passed": passed,
-                "skipped": skipped
+                "skipped": skipped,
             }
-            
+
             # Determine marker based on execution time
             # Assign a speed category even for skipped tests
             if execution_time < FAST_THRESHOLD:
@@ -333,73 +339,75 @@ def measure_test_times(
                 marker = "medium"
             else:
                 marker = "slow"
-            
+
             test_times[test_path]["marker"] = marker
-            
-            print(f"  Execution time: {execution_time:.2f}s, Marker: {marker}, Passed: {passed}, Skipped: {skipped}")
-    
+
+            print(
+                f"  Execution time: {execution_time:.2f}s, Marker: {marker}, Passed: {passed}, Skipped: {skipped}"
+            )
+
     return test_times
+
 
 def extract_test_info(test_path: str) -> Dict[str, Any]:
     """
     Extract information about a behavior test.
-    
+
     Args:
         test_path: Path to the test
-        
+
     Returns:
         Dictionary containing test information
     """
     # Parse the test path to extract file and test name
-    parts = test_path.split('::')
+    parts = test_path.split("::")
     file_path = parts[0]
     test_name = parts[-1] if len(parts) > 1 else None
-    
+
     # Read the file content
-    with open(file_path, 'r') as f:
+    with open(file_path, "r") as f:
         content = f.read()
-    
+
     # Extract feature file references
     feature_files = []
-    
+
     # Check for scenarios() function calls
     scenarios_matches = SCENARIOS_PATTERN.findall(content)
     feature_files.extend(scenarios_matches)
-    
+
     # Check for @scenario decorators
     scenario_matches = SCENARIO_PATTERN.findall(content)
     for _, scenario_name in scenario_matches:
         feature_files.append(scenario_name)
-    
+
     return {
         "file_path": file_path,
         "test_name": test_name,
-        "feature_files": feature_files
+        "feature_files": feature_files,
     }
 
+
 def update_test_file(
-    file_path: str, 
-    test_markers: Dict[str, str], 
-    dry_run: bool = False
+    file_path: str, test_markers: Dict[str, str], dry_run: bool = False
 ) -> Tuple[int, int, int]:
     """
     Update a test file with appropriate markers.
-    
+
     Args:
         file_path: Path to the test file
         test_markers: Dictionary mapping test names to markers
         dry_run: Whether to show changes without modifying files
-        
+
     Returns:
         Tuple containing counts of (added, updated, unchanged) markers
     """
     added = 0
     updated = 0
     unchanged = 0
-    
-    with open(file_path, 'r') as f:
+
+    with open(file_path, "r") as f:
         lines = f.readlines()
-    
+
     # Find test functions and their line numbers
     test_lines = {}
     for i, line in enumerate(lines):
@@ -407,7 +415,7 @@ def update_test_file(
         if match:
             test_name = match.group(1)
             test_lines[test_name] = i
-    
+
     # Find existing markers
     existing_markers = {}
     for test_name, line_num in test_lines.items():
@@ -418,66 +426,87 @@ def update_test_file(
                 if test_name not in existing_markers:
                     existing_markers[test_name] = []
                 existing_markers[test_name].append(match.group(1))
-    
+
     # Update markers
     modified_lines = lines.copy()
     line_offset = 0  # Track line number changes due to insertions
-    
+
     for test_name, line_num in test_lines.items():
         if test_name in test_markers:
             new_marker = test_markers[test_name]
-            
+
             # Check if the test already has the correct marker
-            if test_name in existing_markers and new_marker in existing_markers[test_name]:
+            if (
+                test_name in existing_markers
+                and new_marker in existing_markers[test_name]
+            ):
                 unchanged += 1
                 continue
-            
+
             # Check if we need to update an existing marker or add a new one
-            if test_name in existing_markers and any(m in ('fast', 'medium', 'slow') for m in existing_markers[test_name]):
+            if test_name in existing_markers and any(
+                m in ("fast", "medium", "slow") for m in existing_markers[test_name]
+            ):
                 # Update existing marker
-                for i in range(max(0, line_num + line_offset - 5), line_num + line_offset):
-                    if i >= 0 and i < len(modified_lines) and any(f'@pytest.mark.{m}' in modified_lines[i] for m in ('fast', 'medium', 'slow')):
+                for i in range(
+                    max(0, line_num + line_offset - 5), line_num + line_offset
+                ):
+                    if (
+                        i >= 0
+                        and i < len(modified_lines)
+                        and any(
+                            f"@pytest.mark.{m}" in modified_lines[i]
+                            for m in ("fast", "medium", "slow")
+                        )
+                    ):
                         old_line = modified_lines[i]
                         modified_lines[i] = old_line.replace(
                             f'@pytest.mark.{next(m for m in ("fast", "medium", "slow") if f"@pytest.mark.{m}" in old_line)}',
-                            f'@pytest.mark.{new_marker}'
+                            f"@pytest.mark.{new_marker}",
                         )
                         if dry_run:
-                            print(f"Would update {file_path}:{i+1} - {old_line.strip()} -> {modified_lines[i].strip()}")
+                            print(
+                                f"Would update {file_path}:{i+1} - {old_line.strip()} -> {modified_lines[i].strip()}"
+                            )
                         updated += 1
                         break
             else:
                 # Add new marker
-                indent = re.match(r'(\s*)', modified_lines[line_num + line_offset]).group(1)
-                marker_line = f'{indent}@pytest.mark.{new_marker}\n'
+                indent = re.match(
+                    r"(\s*)", modified_lines[line_num + line_offset]
+                ).group(1)
+                marker_line = f"{indent}@pytest.mark.{new_marker}\n"
                 modified_lines.insert(line_num + line_offset, marker_line)
                 line_offset += 1
-                
+
                 if dry_run:
-                    print(f"Would add to {file_path}:{line_num+1} - {marker_line.strip()}")
+                    print(
+                        f"Would add to {file_path}:{line_num+1} - {marker_line.strip()}"
+                    )
                 added += 1
-    
+
     # Write changes back to the file
     if not dry_run and (added > 0 or updated > 0):
-        with open(file_path, 'w') as f:
+        with open(file_path, "w") as f:
             f.writelines(modified_lines)
-    
+
     return added, updated, unchanged
+
 
 def main():
     """Main function."""
     args = parse_args()
-    
+
     # Set global thresholds based on command-line arguments
     global FAST_THRESHOLD, MEDIUM_THRESHOLD
     FAST_THRESHOLD = args.fast_threshold
     MEDIUM_THRESHOLD = args.medium_threshold
-    
+
     print(f"Fast threshold: {FAST_THRESHOLD}s, Medium threshold: {MEDIUM_THRESHOLD}s")
-    
+
     # Create cache directory if it doesn't exist
     os.makedirs(CACHE_DIR, exist_ok=True)
-    
+
     # Collect behavior tests
     if args.feature:
         # Analyze a specific feature file
@@ -485,14 +514,17 @@ def main():
         if not os.path.exists(feature_path):
             print(f"Feature file not found: {feature_path}")
             return 1
-        
+
         # Find tests that use this feature file
         test_list = []
         for test_path in collect_behavior_tests():
             test_info = extract_test_info(test_path)
-            if any(os.path.basename(feature_path) == os.path.basename(f) for f in test_info["feature_files"]):
+            if any(
+                os.path.basename(feature_path) == os.path.basename(f)
+                for f in test_info["feature_files"]
+            ):
                 test_list.append(test_path)
-        
+
         print(f"Found {len(test_list)} tests using feature file {feature_path}")
     elif args.step_file:
         # Analyze a specific step definition file
@@ -500,87 +532,102 @@ def main():
         if not os.path.exists(step_file):
             print(f"Step file not found: {step_file}")
             return 1
-        
+
         # Find tests that use this step file
         # This is more complex and would require parsing imports or running tests with coverage
         # For now, we'll just collect all behavior tests
         test_list = collect_behavior_tests()
-        print(f"Analyzing all {len(test_list)} behavior tests (can't determine which ones use {step_file})")
+        print(
+            f"Analyzing all {len(test_list)} behavior tests (can't determine which ones use {step_file})"
+        )
     else:
         # Collect all behavior tests
         test_list = collect_behavior_tests()
-    
+
     if not test_list:
         print("No behavior tests found to analyze.")
         return 0
-    
+
     # Measure test execution times
-    test_times = measure_test_times(test_list, args.batch_size, args.max_tests, args.timeout)
-    
+    test_times = measure_test_times(
+        test_list, args.batch_size, args.max_tests, args.timeout
+    )
+
     if not test_times:
         print("No test timing data collected.")
         return 0
-    
+
     # Extract markers for each test
     test_markers = {}
     for test_path, data in test_times.items():
         # Extract the test name from the path
-        parts = test_path.split('::')
+        parts = test_path.split("::")
         if len(parts) > 1:
             test_name = parts[-1]
             test_markers[test_name] = data["marker"]
-    
+
     # Group tests by file
     tests_by_file = {}
     for test_path in test_times:
-        file_path = test_path.split('::')[0]
+        file_path = test_path.split("::")[0]
         if file_path not in tests_by_file:
             tests_by_file[file_path] = []
         tests_by_file[file_path].append(test_path)
-    
+
     # Update test files if requested
     if args.update or args.dry_run:
         total_added = 0
         total_updated = 0
         total_unchanged = 0
-        
+
         print(f"\nUpdating {len(tests_by_file)} test files...")
-        
+
         for file_path, tests in tests_by_file.items():
             file_markers = {}
             for test_path in tests:
-                parts = test_path.split('::')
+                parts = test_path.split("::")
                 if len(parts) > 1:
                     test_name = parts[-1]
                     if test_name in test_markers:
                         file_markers[test_name] = test_markers[test_name]
-            
-            added, updated, unchanged = update_test_file(file_path, file_markers, args.dry_run)
+
+            added, updated, unchanged = update_test_file(
+                file_path, file_markers, args.dry_run
+            )
             total_added += added
             total_updated += updated
             total_unchanged += unchanged
-        
+
         action = "Would " if args.dry_run else ""
-        print(f"\n{action}Add {total_added} markers, update {total_updated} markers, leave {total_unchanged} markers unchanged")
-    
+        print(
+            f"\n{action}Add {total_added} markers, update {total_updated} markers, leave {total_unchanged} markers unchanged"
+        )
+
     # Print summary
     print("\nBehavior Test Categorization Summary:")
     fast_count = sum(1 for data in test_times.values() if data["marker"] == "fast")
     medium_count = sum(1 for data in test_times.values() if data["marker"] == "medium")
     slow_count = sum(1 for data in test_times.values() if data["marker"] == "slow")
-    
+
     print(f"  - Fast tests: {fast_count} ({fast_count/len(test_times)*100:.1f}%)")
     print(f"  - Medium tests: {medium_count} ({medium_count/len(test_times)*100:.1f}%)")
     print(f"  - Slow tests: {slow_count} ({slow_count/len(test_times)*100:.1f}%)")
     print(f"  - Total tests analyzed: {len(test_times)}")
-    
+
     # Print tips for running tests by speed category
     print("\nTips for running behavior tests by speed category:")
-    print("  - Run fast behavior tests: python scripts/run_all_tests.py --behavior --fast")
-    print("  - Run medium behavior tests: python scripts/run_all_tests.py --behavior --medium")
-    print("  - Run slow behavior tests: python scripts/run_all_tests.py --behavior --slow")
-    
+    print(
+        "  - Run fast behavior tests: poetry run devsynth run-tests --behavior --fast"
+    )
+    print(
+        "  - Run medium behavior tests: poetry run devsynth run-tests --behavior --medium"
+    )
+    print(
+        "  - Run slow behavior tests: poetry run devsynth run-tests --behavior --slow"
+    )
+
     return 0
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     sys.exit(main())

--- a/scripts/categorize_tests.py
+++ b/scripts/categorize_tests.py
@@ -8,77 +8,77 @@ It also identifies tests that might need the isolation marker.
 """
 
 import argparse
+import datetime
+import json
 import os
 import re
 import subprocess
-import json
 import time
-import datetime
 from pathlib import Path
-from typing import Dict, List, Tuple, Set
+from typing import Dict, List, Set, Tuple
 
 # Thresholds for categorizing tests (in seconds)
 FAST_THRESHOLD = 1.0
 MEDIUM_THRESHOLD = 5.0
 
 # Regex patterns for finding and updating markers
-MARKER_PATTERN = re.compile(r'@pytest\.mark\.(fast|medium|slow|isolation)')
-FUNCTION_PATTERN = re.compile(r'def (test_\w+)\(')
+MARKER_PATTERN = re.compile(r"@pytest\.mark\.(fast|medium|slow|isolation)")
+FUNCTION_PATTERN = re.compile(r"def (test_\w+)\(")
 
 
 def parse_args():
     """Parse command line arguments."""
     parser = argparse.ArgumentParser(
-        description='Analyze test execution times and add appropriate markers.'
+        description="Analyze test execution times and add appropriate markers."
     )
     parser.add_argument(
-        '-d', '--directory',
-        default='tests',
-        help='Directory containing tests to analyze (default: tests)'
+        "-d",
+        "--directory",
+        default="tests",
+        help="Directory containing tests to analyze (default: tests)",
     )
     parser.add_argument(
-        '-o', '--output',
-        default='test_timing_report.json',
-        help='Output file for timing report (default: test_timing_report.json)'
+        "-o",
+        "--output",
+        default="test_timing_report.json",
+        help="Output file for timing report (default: test_timing_report.json)",
     )
     parser.add_argument(
-        '--dry-run',
-        action='store_true',
-        help='Show changes without modifying files'
+        "--dry-run", action="store_true", help="Show changes without modifying files"
     )
     parser.add_argument(
-        '--update',
-        action='store_true',
-        help='Update test files with appropriate markers'
+        "--update",
+        action="store_true",
+        help="Update test files with appropriate markers",
     )
     parser.add_argument(
-        '--batch-size',
+        "--batch-size",
         type=int,
         default=100,
-        help='Number of tests to run in each batch (default: 100)'
+        help="Number of tests to run in each batch (default: 100)",
     )
     parser.add_argument(
-        '--skip-benchmarks',
-        action='store_true',
-        help='Skip running benchmarks (use existing timing report)'
+        "--skip-benchmarks",
+        action="store_true",
+        help="Skip running benchmarks (use existing timing report)",
     )
     parser.add_argument(
-        '--fast-threshold',
+        "--fast-threshold",
         type=float,
         default=1.0,
-        help='Threshold for fast tests in seconds (default: 1.0)'
+        help="Threshold for fast tests in seconds (default: 1.0)",
     )
     parser.add_argument(
-        '--medium-threshold',
+        "--medium-threshold",
         type=float,
         default=5.0,
-        help='Threshold for medium tests in seconds (default: 5.0)'
+        help="Threshold for medium tests in seconds (default: 5.0)",
     )
     parser.add_argument(
-        '--category',
-        choices=['unit', 'integration', 'behavior', 'all'],
-        default='all',
-        help='Only analyze tests in the specified category'
+        "--category",
+        choices=["unit", "integration", "behavior", "all"],
+        default="all",
+        help="Only analyze tests in the specified category",
     )
     return parser.parse_args()
 
@@ -86,79 +86,80 @@ def parse_args():
 def run_benchmarks(directory: str, batch_size: int = 100) -> Dict:
     """
     Run tests with pytest-benchmark to measure execution times.
-    
+
     Args:
         directory: Directory containing tests to benchmark
         batch_size: Number of tests to run in each batch
-        
+
     Returns:
         Dictionary with benchmark results
     """
     print(f"Running benchmarks for tests in {directory}...")
-    
+
     # Create a temporary directory for benchmark results
-    os.makedirs('.benchmarks', exist_ok=True)
-    
+    os.makedirs(".benchmarks", exist_ok=True)
+
     # First collect all tests
-    collect_cmd = [
-        'python', '-m', 'pytest',
-        directory,
-        '--collect-only',
-        '-q'
-    ]
-    
+    collect_cmd = ["python", "-m", "pytest", directory, "--collect-only", "-q"]
+
     try:
-        collect_result = subprocess.run(collect_cmd, check=True, capture_output=True, text=True)
+        collect_result = subprocess.run(
+            collect_cmd, check=True, capture_output=True, text=True
+        )
         test_list = []
-        
+
         # Parse the output to get the list of tests
-        for line in collect_result.stdout.split('\n'):
+        for line in collect_result.stdout.split("\n"):
             if line.startswith(directory):
                 test_list.append(line.strip())
-        
+
         if not test_list:
             print(f"No tests found in {directory}")
             return {}
-        
-        print(f"Found {len(test_list)} tests, running benchmarks in batches of {batch_size}...")
-        
+
+        print(
+            f"Found {len(test_list)} tests, running benchmarks in batches of {batch_size}..."
+        )
+
         # Initialize an empty benchmark data structure
-        benchmark_data = {
-            'benchmarks': []
-        }
-        
+        benchmark_data = {"benchmarks": []}
+
         # Run tests in batches
         for i in range(0, len(test_list), batch_size):
-            batch = test_list[i:i+batch_size]
-            print(f"\nRunning batch {i//batch_size + 1}/{(len(test_list) + batch_size - 1)//batch_size}...")
-            
+            batch = test_list[i : i + batch_size]
+            print(
+                f"\nRunning batch {i//batch_size + 1}/{(len(test_list) + batch_size - 1)//batch_size}..."
+            )
+
             # Create a unique filename for this batch
-            batch_filename = f'.benchmarks/timing_batch_{i//batch_size + 1}.json'
-            
+            batch_filename = f".benchmarks/timing_batch_{i//batch_size + 1}.json"
+
             # Run pytest with benchmark plugin for this batch
             cmd = [
-                'python', '-m', 'pytest',
+                "python",
+                "-m",
+                "pytest",
                 *batch,
-                '--benchmark-only',
-                f'--benchmark-json={batch_filename}',
-                '-v'
+                "--benchmark-only",
+                f"--benchmark-json={batch_filename}",
+                "-v",
             ]
-            
+
             try:
                 subprocess.run(cmd, check=True)
-                
+
                 # Load benchmark results for this batch
-                with open(batch_filename, 'r') as f:
+                with open(batch_filename, "r") as f:
                     batch_data = json.load(f)
-                
+
                 # Append the benchmarks from this batch to the overall results
-                if 'benchmarks' in batch_data:
-                    benchmark_data['benchmarks'].extend(batch_data['benchmarks'])
+                if "benchmarks" in batch_data:
+                    benchmark_data["benchmarks"].extend(batch_data["benchmarks"])
             except subprocess.CalledProcessError:
                 print(f"Error running benchmarks for batch {i//batch_size + 1}")
             except FileNotFoundError:
                 print(f"Benchmark results file not found for batch {i//batch_size + 1}")
-        
+
         return benchmark_data
     except subprocess.CalledProcessError:
         print("Error collecting tests")
@@ -171,24 +172,24 @@ def run_benchmarks(directory: str, batch_size: int = 100) -> Dict:
 def analyze_benchmarks(benchmark_data: Dict) -> Dict[str, str]:
     """Analyze benchmark data and determine appropriate markers."""
     test_markers = {}
-    
-    if not benchmark_data or 'benchmarks' not in benchmark_data:
+
+    if not benchmark_data or "benchmarks" not in benchmark_data:
         return test_markers
-    
-    for benchmark in benchmark_data['benchmarks']:
-        test_name = benchmark['name']
-        test_time = benchmark['stats']['mean']
-        
+
+    for benchmark in benchmark_data["benchmarks"]:
+        test_name = benchmark["name"]
+        test_time = benchmark["stats"]["mean"]
+
         # Determine marker based on execution time
         if test_time < FAST_THRESHOLD:
-            marker = 'fast'
+            marker = "fast"
         elif test_time < MEDIUM_THRESHOLD:
-            marker = 'medium'
+            marker = "medium"
         else:
-            marker = 'slow'
-        
+            marker = "slow"
+
         test_markers[test_name] = marker
-    
+
     return test_markers
 
 
@@ -197,7 +198,7 @@ def find_test_files(directory: str) -> List[Path]:
     test_files = []
     for root, _, files in os.walk(directory):
         for file in files:
-            if file.startswith('test_') and file.endswith('.py'):
+            if file.startswith("test_") and file.endswith(".py"):
                 test_files.append(Path(os.path.join(root, file)))
     return test_files
 
@@ -205,7 +206,7 @@ def find_test_files(directory: str) -> List[Path]:
 def analyze_test_file(file_path: Path) -> Tuple[Dict[str, str], Dict[str, List[str]]]:
     """
     Analyze a test file to extract existing markers and test functions.
-    
+
     Returns:
         Tuple containing:
         - Dictionary mapping test names to their existing markers
@@ -213,17 +214,17 @@ def analyze_test_file(file_path: Path) -> Tuple[Dict[str, str], Dict[str, List[s
     """
     existing_markers = {}
     test_line_numbers = {}
-    
-    with open(file_path, 'r') as f:
+
+    with open(file_path, "r") as f:
         lines = f.readlines()
-    
+
     current_markers = []
     for i, line in enumerate(lines):
         # Check for markers
         marker_match = MARKER_PATTERN.search(line)
         if marker_match:
             current_markers.append(marker_match.group(1))
-        
+
         # Check for test functions
         func_match = FUNCTION_PATTERN.search(line)
         if func_match:
@@ -232,109 +233,133 @@ def analyze_test_file(file_path: Path) -> Tuple[Dict[str, str], Dict[str, List[s
             if current_markers:
                 existing_markers[test_name] = current_markers.copy()
             current_markers = []
-    
+
     return existing_markers, test_line_numbers
 
 
 def update_test_file(
-    file_path: Path, 
-    test_markers: Dict[str, str], 
-    dry_run: bool = False
+    file_path: Path, test_markers: Dict[str, str], dry_run: bool = False
 ) -> Tuple[int, int, int]:
     """
     Update a test file with appropriate markers.
-    
+
     Returns:
         Tuple containing counts of (added, updated, unchanged) markers
     """
     added = 0
     updated = 0
     unchanged = 0
-    
+
     # Analyze the file
     existing_markers, test_line_numbers = analyze_test_file(file_path)
-    
+
     if not test_line_numbers:
         return added, updated, unchanged
-    
-    with open(file_path, 'r') as f:
+
+    with open(file_path, "r") as f:
         lines = f.readlines()
-    
+
     # Process each test function
     for line_num, test_name in test_line_numbers.items():
         if test_name not in test_markers:
             continue
-        
+
         new_marker = test_markers[test_name]
-        
+
         # Check if the test already has the correct marker
         if test_name in existing_markers and new_marker in existing_markers[test_name]:
             unchanged += 1
             continue
-        
+
         # Check if we need to update an existing marker or add a new one
-        if test_name in existing_markers and any(m in ('fast', 'medium', 'slow') for m in existing_markers[test_name]):
+        if test_name in existing_markers and any(
+            m in ("fast", "medium", "slow") for m in existing_markers[test_name]
+        ):
             # Update existing marker
-            for i in range(line_num - 5, line_num):  # Look at a few lines before the test
-                if i >= 0 and i < len(lines) and any(f'@pytest.mark.{m}' in lines[i] for m in ('fast', 'medium', 'slow')):
+            for i in range(
+                line_num - 5, line_num
+            ):  # Look at a few lines before the test
+                if (
+                    i >= 0
+                    and i < len(lines)
+                    and any(
+                        f"@pytest.mark.{m}" in lines[i]
+                        for m in ("fast", "medium", "slow")
+                    )
+                ):
                     old_line = lines[i]
                     lines[i] = old_line.replace(
                         f'@pytest.mark.{next(m for m in ("fast", "medium", "slow") if f"@pytest.mark.{m}" in old_line)}',
-                        f'@pytest.mark.{new_marker}'
+                        f"@pytest.mark.{new_marker}",
                     )
                     if dry_run:
-                        print(f"Would update {file_path}:{i+1} - {old_line.strip()} -> {lines[i].strip()}")
+                        print(
+                            f"Would update {file_path}:{i+1} - {old_line.strip()} -> {lines[i].strip()}"
+                        )
                     updated += 1
                     break
         else:
             # Add new marker
-            marker_line = f'@pytest.mark.{new_marker}\n'
+            marker_line = f"@pytest.mark.{new_marker}\n"
             lines.insert(line_num, marker_line)
-            
+
             # Update line numbers for subsequent tests
-            test_line_numbers = {k + 1 if k >= line_num else k: v for k, v in test_line_numbers.items()}
-            
+            test_line_numbers = {
+                k + 1 if k >= line_num else k: v for k, v in test_line_numbers.items()
+            }
+
             if dry_run:
                 print(f"Would add to {file_path}:{line_num+1} - {marker_line.strip()}")
             added += 1
-    
+
     # Write changes back to the file
     if not dry_run and (added > 0 or updated > 0):
-        with open(file_path, 'w') as f:
+        with open(file_path, "w") as f:
             f.writelines(lines)
-    
+
     return added, updated, unchanged
 
 
 def identify_isolation_candidates(directory: str) -> Set[str]:
     """
     Identify tests that might need the isolation marker.
-    
+
     This looks for tests that modify global state, use files, or have side effects.
     """
     isolation_candidates = set()
-    
+
     # Run tests with special flags to detect isolation needs
     cmd = [
-        'python', '-m', 'pytest', 
+        "python",
+        "-m",
+        "pytest",
         directory,
-        '-v',
-        '--collect-only',
-        '--no-header',
-        '--no-summary'
+        "-v",
+        "--collect-only",
+        "--no-header",
+        "--no-summary",
     ]
-    
+
     try:
         result = subprocess.run(cmd, check=True, capture_output=True, text=True)
-        
+
         # Analyze output to find tests that might need isolation
         for line in result.stdout.splitlines():
-            if any(pattern in line for pattern in [
-                'test_file', 'test_io', 'test_network', 'test_database',
-                'test_global', 'test_env', 'test_environment', 'test_config'
-            ]):
+            if any(
+                pattern in line
+                for pattern in [
+                    "test_file",
+                    "test_io",
+                    "test_network",
+                    "test_database",
+                    "test_global",
+                    "test_env",
+                    "test_environment",
+                    "test_config",
+                ]
+            ):
                 isolation_candidates.add(line.strip())
-        
+
         return isolation_candidates
     except subprocess.CalledProcessError:
         print("Error analyzing tests for isolation needs")
@@ -344,34 +369,39 @@ def identify_isolation_candidates(directory: str) -> Set[str]:
 def main():
     """Main function."""
     args = parse_args()
-    
+
     # Set global thresholds based on command-line arguments
     global FAST_THRESHOLD, MEDIUM_THRESHOLD
     FAST_THRESHOLD = args.fast_threshold
     MEDIUM_THRESHOLD = args.medium_threshold
-    
+
     # Determine the directory to analyze
     directory = args.directory
-    if args.category != 'all':
-        if args.category == 'unit':
-            directory = 'tests/unit'
-        elif args.category == 'integration':
-            directory = 'tests/integration'
-        elif args.category == 'behavior':
-            directory = 'tests/behavior'
-    
+    if args.category != "all":
+        if args.category == "unit":
+            directory = "tests/unit"
+        elif args.category == "integration":
+            directory = "tests/integration"
+        elif args.category == "behavior":
+            directory = "tests/behavior"
+
     print(f"Analyzing tests in {directory}...")
     print(f"Fast threshold: {FAST_THRESHOLD}s, Medium threshold: {MEDIUM_THRESHOLD}s")
-    
+
     # Run benchmarks or load existing timing report
     if args.skip_benchmarks:
         print("Skipping benchmarks, using existing timing report...")
         try:
-            with open(args.output, 'r') as f:
+            with open(args.output, "r") as f:
                 report = json.load(f)
-                test_markers = {name: data['marker'] for name, data in report.get('tests', {}).items()}
+                test_markers = {
+                    name: data["marker"]
+                    for name, data in report.get("tests", {}).items()
+                }
                 if not test_markers:
-                    print("No test markers found in timing report, running benchmarks...")
+                    print(
+                        "No test markers found in timing report, running benchmarks..."
+                    )
                     benchmark_data = run_benchmarks(directory, args.batch_size)
                     test_markers = analyze_benchmarks(benchmark_data)
         except (FileNotFoundError, json.JSONDecodeError):
@@ -384,68 +414,92 @@ def main():
         benchmark_data = run_benchmarks(directory, args.batch_size)
         end_time = time.time()
         print(f"Benchmarking completed in {end_time - start_time:.2f} seconds")
-        
+
         # Analyze benchmark data
         test_markers = analyze_benchmarks(benchmark_data)
-    
+
     # Save timing report
-    with open(args.output, 'w') as f:
-        json.dump({
-            'timestamp': datetime.datetime.now().isoformat(),
-            'directory': directory,
-            'fast_threshold': FAST_THRESHOLD,
-            'medium_threshold': MEDIUM_THRESHOLD,
-            'test_count': len(test_markers),
-            'fast_tests': sum(1 for marker in test_markers.values() if marker == 'fast'),
-            'medium_tests': sum(1 for marker in test_markers.values() if marker == 'medium'),
-            'slow_tests': sum(1 for marker in test_markers.values() if marker == 'slow'),
-            'tests': {name: {'marker': marker} for name, marker in test_markers.items()}
-        }, f, indent=2)
-    
+    with open(args.output, "w") as f:
+        json.dump(
+            {
+                "timestamp": datetime.datetime.now().isoformat(),
+                "directory": directory,
+                "fast_threshold": FAST_THRESHOLD,
+                "medium_threshold": MEDIUM_THRESHOLD,
+                "test_count": len(test_markers),
+                "fast_tests": sum(
+                    1 for marker in test_markers.values() if marker == "fast"
+                ),
+                "medium_tests": sum(
+                    1 for marker in test_markers.values() if marker == "medium"
+                ),
+                "slow_tests": sum(
+                    1 for marker in test_markers.values() if marker == "slow"
+                ),
+                "tests": {
+                    name: {"marker": marker} for name, marker in test_markers.items()
+                },
+            },
+            f,
+            indent=2,
+        )
+
     print(f"Timing report saved to {args.output}")
     print(f"Test counts by speed category:")
-    print(f"  - Fast tests: {sum(1 for marker in test_markers.values() if marker == 'fast')}")
-    print(f"  - Medium tests: {sum(1 for marker in test_markers.values() if marker == 'medium')}")
-    print(f"  - Slow tests: {sum(1 for marker in test_markers.values() if marker == 'slow')}")
-    
+    print(
+        f"  - Fast tests: {sum(1 for marker in test_markers.values() if marker == 'fast')}"
+    )
+    print(
+        f"  - Medium tests: {sum(1 for marker in test_markers.values() if marker == 'medium')}"
+    )
+    print(
+        f"  - Slow tests: {sum(1 for marker in test_markers.values() if marker == 'slow')}"
+    )
+
     # Identify tests that might need isolation
     isolation_candidates = identify_isolation_candidates(directory)
     if isolation_candidates:
         print("\nTests that might need the isolation marker:")
         for test in isolation_candidates:
             print(f"  - {test}")
-    
+
     # Update test files if requested
     if args.update or args.dry_run:
         test_files = find_test_files(directory)
-        
+
         total_added = 0
         total_updated = 0
         total_unchanged = 0
-        
+
         print(f"\nUpdating {len(test_files)} test files...")
-        
+
         for i, file_path in enumerate(test_files):
             if i % 10 == 0:
                 print(f"Processing file {i+1}/{len(test_files)}...")
-            
-            added, updated, unchanged = update_test_file(file_path, test_markers, args.dry_run)
+
+            added, updated, unchanged = update_test_file(
+                file_path, test_markers, args.dry_run
+            )
             total_added += added
             total_updated += updated
             total_unchanged += unchanged
-        
+
         action = "Would " if args.dry_run else ""
-        print(f"\n{action}Add {total_added} markers, update {total_updated} markers, leave {total_unchanged} markers unchanged")
-    
+        print(
+            f"\n{action}Add {total_added} markers, update {total_updated} markers, leave {total_unchanged} markers unchanged"
+        )
+
     print("\nTest categorization complete")
-    
+
     # Print tips for running tests by speed category
     print("\nTips for running tests by speed category:")
-    print("  - Run fast tests: python scripts/run_all_tests.py --fast")
-    print("  - Run medium tests: python scripts/run_all_tests.py --medium")
-    print("  - Run slow tests: python scripts/run_all_tests.py --slow")
-    print("  - Run fast and medium tests: python scripts/run_all_tests.py --fast --medium")
+    print("  - Run fast tests: poetry run devsynth run-tests --fast")
+    print("  - Run medium tests: poetry run devsynth run-tests --medium")
+    print("  - Run slow tests: poetry run devsynth run-tests --slow")
+    print(
+        "  - Run fast and medium tests: poetry run devsynth run-tests --fast --medium"
+    )
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/scripts/categorize_tests_improved.py
+++ b/scripts/categorize_tests_improved.py
@@ -30,23 +30,23 @@ Options:
 """
 
 import argparse
+import datetime
+import json
 import os
 import re
-import subprocess
-import json
-import time
-import datetime
 import signal
+import subprocess
+import time
 from pathlib import Path
-from typing import Dict, List, Tuple, Set, Optional, Any
+from typing import Any, Dict, List, Optional, Set, Tuple
 
 # Thresholds for categorizing tests (in seconds)
 FAST_THRESHOLD = 1.0
 MEDIUM_THRESHOLD = 5.0
 
 # Regex patterns for finding and updating markers
-MARKER_PATTERN = re.compile(r'@pytest\.mark\.(fast|medium|slow|isolation)')
-FUNCTION_PATTERN = re.compile(r'def (test_\w+)\(')
+MARKER_PATTERN = re.compile(r"@pytest\.mark\.(fast|medium|slow|isolation)")
+FUNCTION_PATTERN = re.compile(r"def (test_\w+)\(")
 
 # Cache directory for test timing data
 CACHE_DIR = ".test_timing_cache"
@@ -55,68 +55,68 @@ CACHE_DIR = ".test_timing_cache"
 def parse_args():
     """Parse command line arguments."""
     parser = argparse.ArgumentParser(
-        description='Analyze test execution times and add appropriate markers.'
+        description="Analyze test execution times and add appropriate markers."
     )
     parser.add_argument(
-        '-d', '--directory',
-        default='tests',
-        help='Directory containing tests to analyze (default: tests)'
+        "-d",
+        "--directory",
+        default="tests",
+        help="Directory containing tests to analyze (default: tests)",
     )
     parser.add_argument(
-        '-o', '--output',
-        default='test_timing_report.json',
-        help='Output file for timing report (default: test_timing_report.json)'
+        "-o",
+        "--output",
+        default="test_timing_report.json",
+        help="Output file for timing report (default: test_timing_report.json)",
     )
     parser.add_argument(
-        '--dry-run',
-        action='store_true',
-        help='Show changes without modifying files'
+        "--dry-run", action="store_true", help="Show changes without modifying files"
     )
     parser.add_argument(
-        '--update',
-        action='store_true',
-        help='Update test files with appropriate markers'
+        "--update",
+        action="store_true",
+        help="Update test files with appropriate markers",
     )
     parser.add_argument(
-        '--batch-size',
+        "--batch-size",
         type=int,
         default=20,
-        help='Number of tests to run in each batch (default: 20)'
+        help="Number of tests to run in each batch (default: 20)",
     )
     parser.add_argument(
-        '--skip-benchmarks',
-        action='store_true',
-        help='Skip running benchmarks (use existing timing report)'
+        "--skip-benchmarks",
+        action="store_true",
+        help="Skip running benchmarks (use existing timing report)",
     )
     parser.add_argument(
-        '--fast-threshold',
+        "--fast-threshold",
         type=float,
         default=1.0,
-        help='Threshold for fast tests in seconds (default: 1.0)'
+        help="Threshold for fast tests in seconds (default: 1.0)",
     )
     parser.add_argument(
-        '--medium-threshold',
+        "--medium-threshold",
         type=float,
         default=5.0,
-        help='Threshold for medium tests in seconds (default: 5.0)'
+        help="Threshold for medium tests in seconds (default: 5.0)",
     )
     parser.add_argument(
-        '--category',
-        choices=['unit', 'integration', 'behavior', 'all'],
-        default='all',
-        help='Only analyze tests in the specified category'
+        "--category",
+        choices=["unit", "integration", "behavior", "all"],
+        default="all",
+        help="Only analyze tests in the specified category",
     )
     parser.add_argument(
-        '--max-tests',
+        "--max-tests",
         type=int,
         default=None,
-        help='Maximum number of tests to analyze (default: all)'
+        help="Maximum number of tests to analyze (default: all)",
     )
     parser.add_argument(
-        '--timeout',
+        "--timeout",
         type=int,
         default=30,
-        help='Timeout for each test in seconds (default: 30)'
+        help="Timeout for each test in seconds (default: 30)",
     )
     return parser.parse_args()
 
@@ -124,67 +124,66 @@ def parse_args():
 def collect_tests(directory: str) -> List[str]:
     """
     Collect all tests in the given directory.
-    
+
     Args:
         directory: Directory containing tests to collect
-        
+
     Returns:
         List of test paths
     """
     print(f"Collecting tests in {directory}...")
-    
+
     # Create cache directory if it doesn't exist
     os.makedirs(CACHE_DIR, exist_ok=True)
-    
+
     # Check if we have a cached collection
-    cache_key = directory.replace('/', '_')
+    cache_key = directory.replace("/", "_")
     cache_file = os.path.join(CACHE_DIR, f"{cache_key}_tests.json")
-    
+
     if os.path.exists(cache_file):
         try:
-            with open(cache_file, 'r') as f:
+            with open(cache_file, "r") as f:
                 cached_data = json.load(f)
-            
+
             # Use cache if it's less than 1 hour old
             cache_time = datetime.datetime.fromisoformat(cached_data["timestamp"])
             if (datetime.datetime.now() - cache_time).total_seconds() < 3600:  # 1 hour
-                print(f"Using cached test collection for {directory} (less than 1 hour old)")
+                print(
+                    f"Using cached test collection for {directory} (less than 1 hour old)"
+                )
                 return cached_data["tests"]
         except (json.JSONDecodeError, KeyError):
             # Invalid cache, ignore and collect tests
             pass
-    
+
     # Collect tests using pytest
-    collect_cmd = [
-        'python', '-m', 'pytest',
-        directory,
-        '--collect-only',
-        '-q'
-    ]
-    
+    collect_cmd = ["python", "-m", "pytest", directory, "--collect-only", "-q"]
+
     try:
-        collect_result = subprocess.run(collect_cmd, check=False, capture_output=True, text=True)
+        collect_result = subprocess.run(
+            collect_cmd, check=False, capture_output=True, text=True
+        )
         test_list = []
-        
+
         # Parse the output to get the list of tests
-        for line in collect_result.stdout.split('\n'):
+        for line in collect_result.stdout.split("\n"):
             if line.startswith(directory):
                 test_list.append(line.strip())
-        
+
         if not test_list:
             print(f"No tests found in {directory}")
             return []
-        
+
         print(f"Found {len(test_list)} tests")
-        
+
         # Cache the results
         cache_data = {
             "timestamp": datetime.datetime.now().isoformat(),
-            "tests": test_list
+            "tests": test_list,
         }
-        with open(cache_file, 'w') as f:
+        with open(cache_file, "w") as f:
             json.dump(cache_data, f, indent=2)
-        
+
         return test_list
     except Exception as e:
         print(f"Error collecting tests: {e}")
@@ -194,132 +193,143 @@ def collect_tests(directory: str) -> List[str]:
 def run_test_with_timing(test_path: str, timeout: int = 30) -> Tuple[float, bool, bool]:
     """
     Run a single test and measure its execution time.
-    
+
     Args:
         test_path: Path to the test to run
         timeout: Timeout in seconds
-        
+
     Returns:
         Tuple of (execution_time, passed, skipped)
     """
     # Check if we have a cached timing
-    cache_key = test_path.replace('/', '_').replace(':', '_')
+    cache_key = test_path.replace("/", "_").replace(":", "_")
     cache_file = os.path.join(CACHE_DIR, f"{cache_key}_timing.json")
-    
+
     if os.path.exists(cache_file):
         try:
-            with open(cache_file, 'r') as f:
+            with open(cache_file, "r") as f:
                 cached_data = json.load(f)
-            
+
             # Use cache if it's less than 24 hours old
             cache_time = datetime.datetime.fromisoformat(cached_data["timestamp"])
-            if (datetime.datetime.now() - cache_time).total_seconds() < 86400:  # 24 hours
-                return cached_data["execution_time"], cached_data["passed"], cached_data["skipped"]
+            if (
+                datetime.datetime.now() - cache_time
+            ).total_seconds() < 86400:  # 24 hours
+                return (
+                    cached_data["execution_time"],
+                    cached_data["passed"],
+                    cached_data["skipped"],
+                )
         except (json.JSONDecodeError, KeyError):
             # Invalid cache, ignore and run test
             pass
-    
+
     # Run the test and measure execution time
-    cmd = [
-        'python', '-m', 'pytest',
-        test_path,
-        '-v'
-    ]
-    
+    cmd = ["python", "-m", "pytest", test_path, "-v"]
+
     start_time = time.time()
-    
+
     try:
         # Set up a timeout handler
         def timeout_handler(signum, frame):
             raise TimeoutError(f"Test timed out after {timeout} seconds")
-        
+
         signal.signal(signal.SIGALRM, timeout_handler)
         signal.alarm(timeout)
-        
+
         result = subprocess.run(cmd, check=False, capture_output=True, text=True)
-        
+
         # Cancel the alarm
         signal.alarm(0)
-        
+
         end_time = time.time()
         execution_time = end_time - start_time
-        
+
         # Check if the test passed or was skipped
         passed = result.returncode == 0
         skipped = "SKIPPED" in result.stdout
-        
+
         # Cache the results
         cache_data = {
             "timestamp": datetime.datetime.now().isoformat(),
             "execution_time": execution_time,
             "passed": passed,
-            "skipped": skipped
+            "skipped": skipped,
         }
-        with open(cache_file, 'w') as f:
+        with open(cache_file, "w") as f:
             json.dump(cache_data, f, indent=2)
-        
+
         return execution_time, passed, skipped
     except TimeoutError as e:
         print(f"Test timed out: {test_path}")
-        
+
         # Cache the timeout
         cache_data = {
             "timestamp": datetime.datetime.now().isoformat(),
             "execution_time": timeout,
             "passed": False,
-            "skipped": False
+            "skipped": False,
         }
-        with open(cache_file, 'w') as f:
+        with open(cache_file, "w") as f:
             json.dump(cache_data, f, indent=2)
-        
+
         return timeout, False, False
     except Exception as e:
         print(f"Error running test: {e}")
         return 0.0, False, False
 
 
-def measure_test_times(test_list: List[str], batch_size: int = 20, max_tests: Optional[int] = None, timeout: int = 30) -> Dict[str, Dict[str, Any]]:
+def measure_test_times(
+    test_list: List[str],
+    batch_size: int = 20,
+    max_tests: Optional[int] = None,
+    timeout: int = 30,
+) -> Dict[str, Dict[str, Any]]:
     """
     Measure execution times for a list of tests.
-    
+
     Args:
         test_list: List of tests to measure
         batch_size: Number of tests to run in each batch
         max_tests: Maximum number of tests to measure (None for all)
         timeout: Timeout for each test in seconds
-        
+
     Returns:
         Dictionary mapping test names to timing data
     """
     if not test_list:
         return {}
-    
+
     # Limit the number of tests if specified
     if max_tests is not None and max_tests > 0:
         test_list = test_list[:max_tests]
-    
-    print(f"Measuring execution times for {len(test_list)} tests in batches of {batch_size}...")
-    
+
+    print(
+        f"Measuring execution times for {len(test_list)} tests in batches of {batch_size}..."
+    )
+
     test_times = {}
-    
+
     # Process tests in batches
     for i in range(0, len(test_list), batch_size):
-        batch = test_list[i:i+batch_size]
-        print(f"\nProcessing batch {i//batch_size + 1}/{(len(test_list) + batch_size - 1)//batch_size}...")
-        
+        batch = test_list[i : i + batch_size]
+        print(
+            f"\nProcessing batch {i//batch_size + 1}/{(len(test_list) + batch_size - 1)//batch_size}..."
+        )
+
         for test_path in batch:
             print(f"Running {test_path}...")
             execution_time, passed, skipped = run_test_with_timing(test_path, timeout)
-            
+
             # Extract the test name from the path
-            test_name = test_path.split('::')[-1]
-            
+            test_name = test_path.split("::")[-1]
+
             test_times[test_name] = {
                 "execution_time": execution_time,
                 "passed": passed,
-                "skipped": skipped
+                "skipped": skipped,
             }
-            
+
             # Determine marker based on execution time
             if skipped:
                 marker = "unknown"
@@ -329,11 +339,13 @@ def measure_test_times(test_list: List[str], batch_size: int = 20, max_tests: Op
                 marker = "medium"
             else:
                 marker = "slow"
-            
+
             test_times[test_name]["marker"] = marker
-            
-            print(f"  Execution time: {execution_time:.2f}s, Marker: {marker}, Passed: {passed}, Skipped: {skipped}")
-    
+
+            print(
+                f"  Execution time: {execution_time:.2f}s, Marker: {marker}, Passed: {passed}, Skipped: {skipped}"
+            )
+
     return test_times
 
 
@@ -342,7 +354,7 @@ def find_test_files(directory: str) -> List[Path]:
     test_files = []
     for root, _, files in os.walk(directory):
         for file in files:
-            if file.startswith('test_') and file.endswith('.py'):
+            if file.startswith("test_") and file.endswith(".py"):
                 test_files.append(Path(os.path.join(root, file)))
     return test_files
 
@@ -350,7 +362,7 @@ def find_test_files(directory: str) -> List[Path]:
 def analyze_test_file(file_path: Path) -> Tuple[Dict[str, List[str]], Dict[int, str]]:
     """
     Analyze a test file to extract existing markers and test functions.
-    
+
     Returns:
         Tuple containing:
         - Dictionary mapping test names to their existing markers
@@ -358,17 +370,17 @@ def analyze_test_file(file_path: Path) -> Tuple[Dict[str, List[str]], Dict[int, 
     """
     existing_markers = {}
     test_line_numbers = {}
-    
-    with open(file_path, 'r') as f:
+
+    with open(file_path, "r") as f:
         lines = f.readlines()
-    
+
     current_markers = []
     for i, line in enumerate(lines):
         # Check for markers
         marker_match = MARKER_PATTERN.search(line)
         if marker_match:
             current_markers.append(marker_match.group(1))
-        
+
         # Check for test functions
         func_match = FUNCTION_PATTERN.search(line)
         if func_match:
@@ -377,209 +389,256 @@ def analyze_test_file(file_path: Path) -> Tuple[Dict[str, List[str]], Dict[int, 
             if current_markers:
                 existing_markers[test_name] = current_markers.copy()
             current_markers = []
-    
+
     return existing_markers, test_line_numbers
 
 
 def update_test_file(
-    file_path: Path, 
-    test_markers: Dict[str, str], 
-    dry_run: bool = False
+    file_path: Path, test_markers: Dict[str, str], dry_run: bool = False
 ) -> Tuple[int, int, int]:
     """
     Update a test file with appropriate markers.
-    
+
     Returns:
         Tuple containing counts of (added, updated, unchanged) markers
     """
     added = 0
     updated = 0
     unchanged = 0
-    
+
     # Analyze the file
     existing_markers, test_line_numbers = analyze_test_file(file_path)
-    
+
     if not test_line_numbers:
         return added, updated, unchanged
-    
-    with open(file_path, 'r') as f:
+
+    with open(file_path, "r") as f:
         lines = f.readlines()
-    
+
     # Process each test function
     for line_num, test_name in test_line_numbers.items():
         if test_name not in test_markers:
             continue
-        
+
         new_marker = test_markers[test_name]
-        
+
         # Skip unknown markers (from skipped tests)
         if new_marker == "unknown":
             continue
-        
+
         # Check if the test already has the correct marker
         if test_name in existing_markers and new_marker in existing_markers[test_name]:
             unchanged += 1
             continue
-        
+
         # Check if we need to update an existing marker or add a new one
-        if test_name in existing_markers and any(m in ('fast', 'medium', 'slow') for m in existing_markers[test_name]):
+        if test_name in existing_markers and any(
+            m in ("fast", "medium", "slow") for m in existing_markers[test_name]
+        ):
             # Update existing marker
-            for i in range(line_num - 5, line_num):  # Look at a few lines before the test
-                if i >= 0 and i < len(lines) and any(f'@pytest.mark.{m}' in lines[i] for m in ('fast', 'medium', 'slow')):
+            for i in range(
+                line_num - 5, line_num
+            ):  # Look at a few lines before the test
+                if (
+                    i >= 0
+                    and i < len(lines)
+                    and any(
+                        f"@pytest.mark.{m}" in lines[i]
+                        for m in ("fast", "medium", "slow")
+                    )
+                ):
                     old_line = lines[i]
                     lines[i] = old_line.replace(
                         f'@pytest.mark.{next(m for m in ("fast", "medium", "slow") if f"@pytest.mark.{m}" in old_line)}',
-                        f'@pytest.mark.{new_marker}'
+                        f"@pytest.mark.{new_marker}",
                     )
                     if dry_run:
-                        print(f"Would update {file_path}:{i+1} - {old_line.strip()} -> {lines[i].strip()}")
+                        print(
+                            f"Would update {file_path}:{i+1} - {old_line.strip()} -> {lines[i].strip()}"
+                        )
                     updated += 1
                     break
         else:
             # Add new marker
-            marker_line = f'@pytest.mark.{new_marker}\n'
+            marker_line = f"@pytest.mark.{new_marker}\n"
             lines.insert(line_num, marker_line)
-            
+
             # Update line numbers for subsequent tests
-            test_line_numbers = {k + 1 if k >= line_num else k: v for k, v in test_line_numbers.items()}
-            
+            test_line_numbers = {
+                k + 1 if k >= line_num else k: v for k, v in test_line_numbers.items()
+            }
+
             if dry_run:
                 print(f"Would add to {file_path}:{line_num+1} - {marker_line.strip()}")
             added += 1
-    
+
     # Write changes back to the file
     if not dry_run and (added > 0 or updated > 0):
-        with open(file_path, 'w') as f:
+        with open(file_path, "w") as f:
             f.writelines(lines)
-    
+
     return added, updated, unchanged
 
 
 def identify_isolation_candidates(test_times: Dict[str, Dict[str, Any]]) -> Set[str]:
     """
     Identify tests that might need the isolation marker.
-    
+
     This looks for tests that are slow or have failed.
     """
     isolation_candidates = set()
-    
+
     for test_name, data in test_times.items():
         # Tests that are slow or have failed might need isolation
         if data["marker"] == "slow" or not data["passed"]:
             isolation_candidates.add(test_name)
-    
+
     return isolation_candidates
 
 
 def main():
     """Main function."""
     args = parse_args()
-    
+
     # Set global thresholds based on command-line arguments
     global FAST_THRESHOLD, MEDIUM_THRESHOLD
     FAST_THRESHOLD = args.fast_threshold
     MEDIUM_THRESHOLD = args.medium_threshold
-    
+
     # Determine the directory to analyze
     directory = args.directory
-    if args.category != 'all':
-        if args.category == 'unit':
-            directory = 'tests/unit'
-        elif args.category == 'integration':
-            directory = 'tests/integration'
-        elif args.category == 'behavior':
-            directory = 'tests/behavior'
-    
+    if args.category != "all":
+        if args.category == "unit":
+            directory = "tests/unit"
+        elif args.category == "integration":
+            directory = "tests/integration"
+        elif args.category == "behavior":
+            directory = "tests/behavior"
+
     print(f"Analyzing tests in {directory}...")
     print(f"Fast threshold: {FAST_THRESHOLD}s, Medium threshold: {MEDIUM_THRESHOLD}s")
-    
+
     # Create cache directory if it doesn't exist
     os.makedirs(CACHE_DIR, exist_ok=True)
-    
+
     # Collect tests
     test_list = collect_tests(directory)
-    
+
     # Measure test execution times or load from existing report
     if args.skip_benchmarks:
         print("Skipping benchmarks, using existing timing report...")
         try:
-            with open(args.output, 'r') as f:
+            with open(args.output, "r") as f:
                 report = json.load(f)
-                test_times = report.get('tests', {})
+                test_times = report.get("tests", {})
                 if not test_times:
-                    print("No test timing data found in report, measuring execution times...")
-                    test_times = measure_test_times(test_list, args.batch_size, args.max_tests, args.timeout)
+                    print(
+                        "No test timing data found in report, measuring execution times..."
+                    )
+                    test_times = measure_test_times(
+                        test_list, args.batch_size, args.max_tests, args.timeout
+                    )
         except (FileNotFoundError, json.JSONDecodeError):
             print("Timing report not found or invalid, measuring execution times...")
-            test_times = measure_test_times(test_list, args.batch_size, args.max_tests, args.timeout)
+            test_times = measure_test_times(
+                test_list, args.batch_size, args.max_tests, args.timeout
+            )
     else:
         # Measure test execution times
         start_time = time.time()
-        test_times = measure_test_times(test_list, args.batch_size, args.max_tests, args.timeout)
+        test_times = measure_test_times(
+            test_list, args.batch_size, args.max_tests, args.timeout
+        )
         end_time = time.time()
         print(f"Measurement completed in {end_time - start_time:.2f} seconds")
-    
+
     # Extract markers from test times
-    test_markers = {name: data["marker"] for name, data in test_times.items() if data["marker"] != "unknown"}
-    
+    test_markers = {
+        name: data["marker"]
+        for name, data in test_times.items()
+        if data["marker"] != "unknown"
+    }
+
     # Save timing report
-    with open(args.output, 'w') as f:
-        json.dump({
-            'timestamp': datetime.datetime.now().isoformat(),
-            'directory': directory,
-            'fast_threshold': FAST_THRESHOLD,
-            'medium_threshold': MEDIUM_THRESHOLD,
-            'test_count': len(test_markers),
-            'fast_tests': sum(1 for marker in test_markers.values() if marker == 'fast'),
-            'medium_tests': sum(1 for marker in test_markers.values() if marker == 'medium'),
-            'slow_tests': sum(1 for marker in test_markers.values() if marker == 'slow'),
-            'tests': test_times
-        }, f, indent=2)
-    
+    with open(args.output, "w") as f:
+        json.dump(
+            {
+                "timestamp": datetime.datetime.now().isoformat(),
+                "directory": directory,
+                "fast_threshold": FAST_THRESHOLD,
+                "medium_threshold": MEDIUM_THRESHOLD,
+                "test_count": len(test_markers),
+                "fast_tests": sum(
+                    1 for marker in test_markers.values() if marker == "fast"
+                ),
+                "medium_tests": sum(
+                    1 for marker in test_markers.values() if marker == "medium"
+                ),
+                "slow_tests": sum(
+                    1 for marker in test_markers.values() if marker == "slow"
+                ),
+                "tests": test_times,
+            },
+            f,
+            indent=2,
+        )
+
     print(f"Timing report saved to {args.output}")
     print(f"Test counts by speed category:")
-    print(f"  - Fast tests: {sum(1 for marker in test_markers.values() if marker == 'fast')}")
-    print(f"  - Medium tests: {sum(1 for marker in test_markers.values() if marker == 'medium')}")
-    print(f"  - Slow tests: {sum(1 for marker in test_markers.values() if marker == 'slow')}")
-    
+    print(
+        f"  - Fast tests: {sum(1 for marker in test_markers.values() if marker == 'fast')}"
+    )
+    print(
+        f"  - Medium tests: {sum(1 for marker in test_markers.values() if marker == 'medium')}"
+    )
+    print(
+        f"  - Slow tests: {sum(1 for marker in test_markers.values() if marker == 'slow')}"
+    )
+
     # Identify tests that might need isolation
     isolation_candidates = identify_isolation_candidates(test_times)
     if isolation_candidates:
         print("\nTests that might need the isolation marker:")
         for test in isolation_candidates:
             print(f"  - {test}")
-    
+
     # Update test files if requested
     if args.update or args.dry_run:
         test_files = find_test_files(directory)
-        
+
         total_added = 0
         total_updated = 0
         total_unchanged = 0
-        
+
         print(f"\nUpdating {len(test_files)} test files...")
-        
+
         for i, file_path in enumerate(test_files):
             if i % 10 == 0:
                 print(f"Processing file {i+1}/{len(test_files)}...")
-            
-            added, updated, unchanged = update_test_file(file_path, test_markers, args.dry_run)
+
+            added, updated, unchanged = update_test_file(
+                file_path, test_markers, args.dry_run
+            )
             total_added += added
             total_updated += updated
             total_unchanged += unchanged
-        
+
         action = "Would " if args.dry_run else ""
-        print(f"\n{action}Add {total_added} markers, update {total_updated} markers, leave {total_unchanged} markers unchanged")
-    
+        print(
+            f"\n{action}Add {total_added} markers, update {total_updated} markers, leave {total_unchanged} markers unchanged"
+        )
+
     print("\nTest categorization complete")
-    
+
     # Print tips for running tests by speed category
     print("\nTips for running tests by speed category:")
-    print("  - Run fast tests: python scripts/run_all_tests.py --fast")
-    print("  - Run medium tests: python scripts/run_all_tests.py --medium")
-    print("  - Run slow tests: python scripts/run_all_tests.py --slow")
-    print("  - Run fast and medium tests: python scripts/run_all_tests.py --fast --medium")
+    print("  - Run fast tests: poetry run devsynth run-tests --fast")
+    print("  - Run medium tests: poetry run devsynth run-tests --medium")
+    print("  - Run slow tests: poetry run devsynth run-tests --slow")
+    print(
+        "  - Run fast and medium tests: poetry run devsynth run-tests --fast --medium"
+    )
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/scripts/incremental_test_categorization.py
+++ b/scripts/incremental_test_categorization.py
@@ -28,24 +28,24 @@ Options:
 """
 
 import argparse
+import datetime
+import json
 import os
 import re
-import subprocess
-import json
-import time
-import datetime
 import signal
+import subprocess
+import time
 from pathlib import Path
-from typing import Dict, List, Tuple, Set, Optional, Any
+from typing import Any, Dict, List, Optional, Set, Tuple
 
 # Thresholds for categorizing tests (in seconds)
 FAST_THRESHOLD = 1.0
 MEDIUM_THRESHOLD = 5.0
 
 # Regex patterns for finding and updating markers
-MARKER_PATTERN = re.compile(r'@pytest\.mark\.(fast|medium|slow|isolation)')
-FUNCTION_PATTERN = re.compile(r'def (test_\w+)\(')
-CLASS_PATTERN = re.compile(r'class\s+(Test\w+)\s*\(')
+MARKER_PATTERN = re.compile(r"@pytest\.mark\.(fast|medium|slow|isolation)")
+FUNCTION_PATTERN = re.compile(r"def (test_\w+)\(")
+CLASS_PATTERN = re.compile(r"class\s+(Test\w+)\s*\(")
 
 # Cache directory for test timing data
 CACHE_DIR = ".test_timing_cache"
@@ -57,66 +57,64 @@ DEFAULT_PROGRESS_FILE = ".test_categorization_progress.json"
 def parse_args():
     """Parse command line arguments."""
     parser = argparse.ArgumentParser(
-        description='Categorize tests by speed incrementally.'
+        description="Categorize tests by speed incrementally."
     )
     parser.add_argument(
-        '-d', '--directory',
-        default='tests',
-        help='Directory containing tests to analyze (default: tests)'
+        "-d",
+        "--directory",
+        default="tests",
+        help="Directory containing tests to analyze (default: tests)",
     )
     parser.add_argument(
-        '-m', '--module',
-        help='Specific module to analyze (e.g., tests/unit/interface)'
+        "-m", "--module", help="Specific module to analyze (e.g., tests/unit/interface)"
     )
     parser.add_argument(
-        '--batch-size',
+        "--batch-size",
         type=int,
         default=20,
-        help='Number of tests to run in each batch (default: 20)'
+        help="Number of tests to run in each batch (default: 20)",
     )
     parser.add_argument(
-        '--max-tests',
+        "--max-tests",
         type=int,
         default=100,
-        help='Maximum number of tests to analyze in this run (default: 100)'
+        help="Maximum number of tests to analyze in this run (default: 100)",
     )
     parser.add_argument(
-        '--fast-threshold',
+        "--fast-threshold",
         type=float,
         default=1.0,
-        help='Threshold for fast tests in seconds (default: 1.0)'
+        help="Threshold for fast tests in seconds (default: 1.0)",
     )
     parser.add_argument(
-        '--medium-threshold',
+        "--medium-threshold",
         type=float,
         default=5.0,
-        help='Threshold for medium tests in seconds (default: 5.0)'
+        help="Threshold for medium tests in seconds (default: 5.0)",
     )
     parser.add_argument(
-        '--dry-run',
-        action='store_true',
-        help='Show changes without modifying files'
+        "--dry-run", action="store_true", help="Show changes without modifying files"
     )
     parser.add_argument(
-        '--update',
-        action='store_true',
-        help='Update test files with appropriate markers'
+        "--update",
+        action="store_true",
+        help="Update test files with appropriate markers",
     )
     parser.add_argument(
-        '--force',
-        action='store_true',
-        help='Force recategorization of tests, even if they have already been categorized'
+        "--force",
+        action="store_true",
+        help="Force recategorization of tests, even if they have already been categorized",
     )
     parser.add_argument(
-        '--progress-file',
+        "--progress-file",
         default=DEFAULT_PROGRESS_FILE,
-        help=f'File to track categorization progress (default: {DEFAULT_PROGRESS_FILE})'
+        help=f"File to track categorization progress (default: {DEFAULT_PROGRESS_FILE})",
     )
     parser.add_argument(
-        '--timeout',
+        "--timeout",
         type=int,
         default=30,
-        help='Timeout for each test in seconds (default: 30)'
+        help="Timeout for each test in seconds (default: 30)",
     )
     return parser.parse_args()
 
@@ -124,16 +122,16 @@ def parse_args():
 def load_progress(progress_file: str) -> Dict[str, Any]:
     """
     Load categorization progress from file.
-    
+
     Args:
         progress_file: Path to the progress file
-        
+
     Returns:
         Dictionary containing categorization progress
     """
     if os.path.exists(progress_file):
         try:
-            with open(progress_file, 'r') as f:
+            with open(progress_file, "r") as f:
                 return json.load(f)
         except json.JSONDecodeError:
             print(f"Error loading progress file {progress_file}, creating new progress")
@@ -145,8 +143,8 @@ def load_progress(progress_file: str) -> Dict[str, Any]:
                     "fast": 0,
                     "medium": 0,
                     "slow": 0,
-                    "total": 0
-                }
+                    "total": 0,
+                },
             }
     else:
         print(f"Progress file {progress_file} not found, creating new progress")
@@ -154,94 +152,88 @@ def load_progress(progress_file: str) -> Dict[str, Any]:
             "timestamp": datetime.datetime.now().isoformat(),
             "categorized_tests": {},
             "categorized_files": [],
-            "categorization_counts": {
-                "fast": 0,
-                "medium": 0,
-                "slow": 0,
-                "total": 0
-            }
+            "categorization_counts": {"fast": 0, "medium": 0, "slow": 0, "total": 0},
         }
 
 
 def save_progress(progress: Dict[str, Any], progress_file: str):
     """
     Save categorization progress to file.
-    
+
     Args:
         progress: Dictionary containing categorization progress
         progress_file: Path to the progress file
     """
     # Update timestamp
     progress["timestamp"] = datetime.datetime.now().isoformat()
-    
-    with open(progress_file, 'w') as f:
+
+    with open(progress_file, "w") as f:
         json.dump(progress, f, indent=2)
 
 
 def collect_tests(directory: str) -> List[str]:
     """
     Collect all tests in the given directory.
-    
+
     Args:
         directory: Directory containing tests to collect
-        
+
     Returns:
         List of test paths
     """
     print(f"Collecting tests in {directory}...")
-    
+
     # Create cache directory if it doesn't exist
     os.makedirs(CACHE_DIR, exist_ok=True)
-    
+
     # Check if we have a cached collection
-    cache_key = directory.replace('/', '_')
+    cache_key = directory.replace("/", "_")
     cache_file = os.path.join(CACHE_DIR, f"{cache_key}_tests.json")
-    
+
     if os.path.exists(cache_file):
         try:
-            with open(cache_file, 'r') as f:
+            with open(cache_file, "r") as f:
                 cached_data = json.load(f)
-            
+
             # Use cache if it's less than 1 hour old
             cache_time = datetime.datetime.fromisoformat(cached_data["timestamp"])
             if (datetime.datetime.now() - cache_time).total_seconds() < 3600:  # 1 hour
-                print(f"Using cached test collection for {directory} (less than 1 hour old)")
+                print(
+                    f"Using cached test collection for {directory} (less than 1 hour old)"
+                )
                 return cached_data["tests"]
         except (json.JSONDecodeError, KeyError):
             # Invalid cache, ignore and collect tests
             pass
-    
+
     # Collect tests using pytest
-    collect_cmd = [
-        'python', '-m', 'pytest',
-        directory,
-        '--collect-only',
-        '-q'
-    ]
-    
+    collect_cmd = ["python", "-m", "pytest", directory, "--collect-only", "-q"]
+
     try:
-        collect_result = subprocess.run(collect_cmd, check=False, capture_output=True, text=True)
+        collect_result = subprocess.run(
+            collect_cmd, check=False, capture_output=True, text=True
+        )
         test_list = []
-        
+
         # Parse the output to get the list of tests
-        for line in collect_result.stdout.split('\n'):
+        for line in collect_result.stdout.split("\n"):
             if line.startswith(directory):
                 test_list.append(line.strip())
-        
+
         if not test_list:
             print(f"No tests found in {directory}")
             return []
-        
+
         print(f"Found {len(test_list)} tests")
-        
+
         # Cache the results
         cache_data = {
             "timestamp": datetime.datetime.now().isoformat(),
-            "tests": test_list
+            "tests": test_list,
         }
-        with open(cache_file, 'w') as f:
+        with open(cache_file, "w") as f:
             json.dump(cache_data, f, indent=2)
-        
+
         return test_list
     except Exception as e:
         print(f"Error collecting tests: {e}")
@@ -251,84 +243,86 @@ def collect_tests(directory: str) -> List[str]:
 def run_test_with_timing(test_path: str, timeout: int = 30) -> Tuple[float, bool, bool]:
     """
     Run a single test and measure its execution time.
-    
+
     Args:
         test_path: Path to the test to run
         timeout: Timeout in seconds
-        
+
     Returns:
         Tuple of (execution_time, passed, skipped)
     """
     # Check if we have a cached timing
-    cache_key = test_path.replace('/', '_').replace(':', '_')
+    cache_key = test_path.replace("/", "_").replace(":", "_")
     cache_file = os.path.join(CACHE_DIR, f"{cache_key}_timing.json")
-    
+
     if os.path.exists(cache_file):
         try:
-            with open(cache_file, 'r') as f:
+            with open(cache_file, "r") as f:
                 cached_data = json.load(f)
-            
+
             # Use cache if it's less than 24 hours old
             cache_time = datetime.datetime.fromisoformat(cached_data["timestamp"])
-            if (datetime.datetime.now() - cache_time).total_seconds() < 86400:  # 24 hours
-                return cached_data["execution_time"], cached_data["passed"], cached_data["skipped"]
+            if (
+                datetime.datetime.now() - cache_time
+            ).total_seconds() < 86400:  # 24 hours
+                return (
+                    cached_data["execution_time"],
+                    cached_data["passed"],
+                    cached_data["skipped"],
+                )
         except (json.JSONDecodeError, KeyError):
             # Invalid cache, ignore and run test
             pass
-    
+
     # Run the test and measure execution time
-    cmd = [
-        'python', '-m', 'pytest',
-        test_path,
-        '-v'
-    ]
-    
+    cmd = ["python", "-m", "pytest", test_path, "-v"]
+
     start_time = time.time()
-    
+
     try:
         # Set up a timeout handler
         def timeout_handler(signum, frame):
             raise TimeoutError(f"Test timed out after {timeout} seconds")
-        
+
         signal.signal(signal.SIGALRM, timeout_handler)
         signal.alarm(timeout)
-        
+
         result = subprocess.run(cmd, check=False, capture_output=True, text=True)
-        
+
         # Cancel the alarm
         signal.alarm(0)
-        
+
         end_time = time.time()
         execution_time = end_time - start_time
-        
+
         # Check if the test passed or was skipped
         passed = result.returncode == 0
         skipped = "SKIPPED" in result.stdout
-        
+
         # Cache the results
         cache_data = {
             "timestamp": datetime.datetime.now().isoformat(),
             "execution_time": execution_time,
             "passed": passed,
-            "skipped": skipped
+            "skipped": skipped,
         }
-        with open(cache_file, 'w') as f:
+        with open(cache_file, "w") as f:
             json.dump(cache_data, f, indent=2)
-        
+
         return execution_time, passed, skipped
     except TimeoutError as e:
         print(f"Test timed out: {test_path}")
-        
+
         # Cache the timeout
         cache_data = {
             "timestamp": datetime.datetime.now().isoformat(),
             "execution_time": timeout,
             "passed": False,
-            "skipped": False
+            "skipped": False,
         }
-        with open(cache_file, 'w') as f:
+        with open(cache_file, "w") as f:
             json.dump(cache_data, f, indent=2)
-        
+
         return timeout, False, False
     except Exception as e:
         print(f"Error running test: {e}")
@@ -338,34 +332,36 @@ def run_test_with_timing(test_path: str, timeout: int = 30) -> Tuple[float, bool
 def find_test_files(directory: str) -> List[Path]:
     """
     Find all test files in the given directory or return the file if directory is a file path.
-    
+
     Args:
         directory: Directory or file path to search
-        
+
     Returns:
         List of test file paths
     """
     print(f"DEBUG: Finding test files in {directory}")
-    
+
     # Check if directory is actually a file path
     if os.path.isfile(directory):
-        if directory.endswith('.py') and os.path.basename(directory).startswith('test_'):
+        if directory.endswith(".py") and os.path.basename(directory).startswith(
+            "test_"
+        ):
             file_path = Path(directory)
             print(f"DEBUG: Found test file (direct): {file_path}")
             return [file_path]
         else:
             print(f"DEBUG: {directory} is a file but not a test file")
             return []
-    
+
     # If it's a directory, search for test files
     test_files = []
     for root, _, files in os.walk(directory):
         for file in files:
-            if file.startswith('test_') and file.endswith('.py'):
+            if file.startswith("test_") and file.endswith(".py"):
                 file_path = Path(os.path.join(root, file))
                 test_files.append(file_path)
                 print(f"DEBUG: Found test file: {file_path}")
-    
+
     print(f"DEBUG: Found {len(test_files)} test files")
     return test_files
 
@@ -373,7 +369,7 @@ def find_test_files(directory: str) -> List[Path]:
 def analyze_test_file(file_path: Path) -> Tuple[Dict[str, List[str]], Dict[int, str]]:
     """
     Analyze a test file to extract existing markers and test functions.
-    
+
     Returns:
         Tuple containing:
         - Dictionary mapping test names to their existing markers
@@ -381,19 +377,19 @@ def analyze_test_file(file_path: Path) -> Tuple[Dict[str, List[str]], Dict[int, 
     """
     existing_markers = {}
     test_line_numbers = {}
-    
-    with open(file_path, 'r') as f:
+
+    with open(file_path, "r") as f:
         lines = f.readlines()
-    
+
     current_markers = []
     current_class = None
-    
+
     for i, line in enumerate(lines):
         # Check for markers
         marker_match = MARKER_PATTERN.search(line)
         if marker_match:
             current_markers.append(marker_match.group(1))
-        
+
         # Check for class definitions
         class_match = CLASS_PATTERN.search(line)
         if class_match:
@@ -401,101 +397,109 @@ def analyze_test_file(file_path: Path) -> Tuple[Dict[str, List[str]], Dict[int, 
             # Reset markers when entering a new class
             current_markers = []
             continue
-        
+
         # Check for test functions or methods
         func_match = FUNCTION_PATTERN.search(line)
         if func_match:
             test_name = func_match.group(1)
-            
+
             # For class methods, prefix with class name
             if current_class:
                 full_test_name = f"{current_class}::{test_name}"
             else:
                 full_test_name = test_name
-                
+
             test_line_numbers[i] = full_test_name
-            
+
             if current_markers:
                 existing_markers[full_test_name] = current_markers.copy()
-            
+
             current_markers = []
-    
+
     return existing_markers, test_line_numbers
 
 
 def update_test_file(
-    file_path: Path, 
-    test_markers: Dict[str, str], 
+    file_path: Path,
+    test_markers: Dict[str, str],
     dry_run: bool = False,
-    verbose: bool = True
+    verbose: bool = True,
 ) -> Tuple[int, int, int]:
     """
     Update a test file with appropriate markers.
-    
+
     Returns:
         Tuple containing counts of (added, updated, unchanged) markers
     """
     added = 0
     updated = 0
     unchanged = 0
-    
+
     # Analyze the file
     existing_markers, test_line_numbers = analyze_test_file(file_path)
-    
+
     if verbose:
         print(f"\nDEBUG: Analyzing file {file_path}")
         print(f"DEBUG: Found {len(test_line_numbers)} test functions/methods")
         for line_num, test_name in test_line_numbers.items():
             print(f"DEBUG: Line {line_num}: {test_name}")
         print(f"DEBUG: Test markers dictionary has {len(test_markers)} entries")
-        print(f"DEBUG: First 5 entries in test_markers: {list(test_markers.items())[:5]}")
-    
+        print(
+            f"DEBUG: First 5 entries in test_markers: {list(test_markers.items())[:5]}"
+        )
+
     if not test_line_numbers:
         if verbose:
             print("DEBUG: No test functions/methods found in file")
         return added, updated, unchanged
-    
-    with open(file_path, 'r') as f:
+
+    with open(file_path, "r") as f:
         lines = f.readlines()
-    
+
     # Check if pytest is imported
-    has_pytest_import = any('import pytest' in line for line in lines)
-    
+    has_pytest_import = any("import pytest" in line for line in lines)
+
     # Add pytest import if needed
-    if not has_pytest_import and test_line_numbers and any(test_name in test_markers for test_name in test_line_numbers.values()):
+    if (
+        not has_pytest_import
+        and test_line_numbers
+        and any(test_name in test_markers for test_name in test_line_numbers.values())
+    ):
         # Find the last import line
         last_import_line = 0
         for i, line in enumerate(lines):
-            if line.strip().startswith('import ') or line.strip().startswith('from '):
+            if line.strip().startswith("import ") or line.strip().startswith("from "):
                 last_import_line = i
-        
+
         # Insert pytest import after the last import
-        lines.insert(last_import_line + 1, 'import pytest\n')
-        
+        lines.insert(last_import_line + 1, "import pytest\n")
+
         # Update line numbers for all tests
         test_line_numbers = {k + 1: v for k, v in test_line_numbers.items()}
-        
+
         if dry_run:
             print(f"Would add to {file_path}:{last_import_line+2} - import pytest")
-    
+
     # Process each test function
     modified_lines = []  # Track which lines we've modified to avoid duplicate changes
-    
+
     for line_num, test_name in sorted(test_line_numbers.items()):
         if verbose:
             print(f"\nDEBUG: Processing test {test_name} at line {line_num}")
-            
+
         # Extract the base test name (without class prefix)
         if "::" in test_name:
             class_name, base_test_name = test_name.split("::")
             if verbose:
-                print(f"DEBUG: Class-based test: class={class_name}, method={base_test_name}")
+                print(
+                    f"DEBUG: Class-based test: class={class_name}, method={base_test_name}"
+                )
         else:
             class_name = None
             base_test_name = test_name
             if verbose:
                 print(f"DEBUG: Function-based test: {base_test_name}")
-            
+
         # Check if the test name is directly in the markers dictionary
         if test_name in test_markers:
             new_marker = test_markers[test_name]
@@ -505,47 +509,59 @@ def update_test_file(
             # Try with just the base test name (without class prefix)
             new_marker = test_markers[base_test_name]
             if verbose:
-                print(f"DEBUG: Base name match found for {base_test_name}: {new_marker}")
+                print(
+                    f"DEBUG: Base name match found for {base_test_name}: {new_marker}"
+                )
         else:
             # Try to find a matching test path in the markers dictionary
             # This handles cases where the same test name appears in multiple files
             file_name = file_path.name
             if verbose:
-                print(f"DEBUG: No direct match, trying patterns with file_name={file_name}")
-            
+                print(
+                    f"DEBUG: No direct match, trying patterns with file_name={file_name}"
+                )
+
             # Try different patterns for matching
             patterns = [
                 f"{file_name}::{test_name}",  # Full path with class prefix
                 f"{file_name}::{base_test_name}",  # Path with base test name
-                f"{file_name}::{class_name}::{base_test_name}" if class_name else None  # Path with explicit class
+                (
+                    f"{file_name}::{class_name}::{base_test_name}"
+                    if class_name
+                    else None
+                ),  # Path with explicit class
             ]
             patterns = [p for p in patterns if p]
-            
+
             if verbose:
                 print(f"DEBUG: Trying patterns: {patterns}")
-            
+
             # Look for any matching path
             matching_paths = []
             for pattern in patterns:
                 pattern_matches = [
-                    path for path in test_markers.keys() 
+                    path
+                    for path in test_markers.keys()
                     if isinstance(path, str) and pattern in path
                 ]
                 if verbose and pattern_matches:
                     print(f"DEBUG: Pattern {pattern} matched: {pattern_matches}")
                 matching_paths.extend(pattern_matches)
-            
+
             # Also try matching just by test name
             if not matching_paths:
                 if verbose:
                     print(f"DEBUG: No pattern matches, trying base name + file name")
                 matching_paths = [
-                    path for path in test_markers.keys() 
-                    if isinstance(path, str) and base_test_name in path and file_name in path
+                    path
+                    for path in test_markers.keys()
+                    if isinstance(path, str)
+                    and base_test_name in path
+                    and file_name in path
                 ]
                 if verbose and matching_paths:
                     print(f"DEBUG: Base name + file name matched: {matching_paths}")
-            
+
             if matching_paths:
                 # Use the marker from the first matching path
                 new_marker = test_markers[matching_paths[0]]
@@ -556,141 +572,154 @@ def update_test_file(
                 if verbose:
                     print(f"DEBUG: No match found for {test_name}, skipping")
                 continue
-        
+
         # Check if the test already has the correct marker
         if test_name in existing_markers and new_marker in existing_markers[test_name]:
             unchanged += 1
             continue
-        
+
         # Find the appropriate position to add or update the marker
         # We want to place it directly before the test function definition
         marker_position = line_num
-        
+
         # Check if we need to update an existing marker or add a new one
         existing_marker_line = None
-        
+
         # Search up to 5 lines before the test function to find existing markers
         search_start = max(0, line_num - 5)
         for i in range(search_start, line_num):
             if i >= len(lines):
                 continue
-                
-            if any(f'@pytest.mark.{m}' in lines[i] for m in ('fast', 'medium', 'slow')):
+
+            if any(f"@pytest.mark.{m}" in lines[i] for m in ("fast", "medium", "slow")):
                 existing_marker_line = i
                 break
-        
+
         if existing_marker_line is not None:
             # Update existing marker
             old_line = lines[existing_marker_line]
             lines[existing_marker_line] = old_line.replace(
                 f'@pytest.mark.{next(m for m in ("fast", "medium", "slow") if f"@pytest.mark.{m}" in old_line)}',
-                f'@pytest.mark.{new_marker}'
+                f"@pytest.mark.{new_marker}",
             )
             modified_lines.append(existing_marker_line)
-            
+
             if dry_run:
-                print(f"Would update {file_path}:{existing_marker_line+1} - {old_line.strip()} -> {lines[existing_marker_line].strip()}")
+                print(
+                    f"Would update {file_path}:{existing_marker_line+1} - {old_line.strip()} -> {lines[existing_marker_line].strip()}"
+                )
             updated += 1
         else:
             # Add new marker
             # Get the indentation of the test function
-            indent = re.match(r'(\s*)', lines[line_num]).group(1)
+            indent = re.match(r"(\s*)", lines[line_num]).group(1)
             marker_line = f"{indent}@pytest.mark.{new_marker}\n"
-            
+
             # Insert marker directly before the test function
             # First, check if there's a blank line before the function
             # If not, add one for better readability
-            if line_num > 0 and not lines[line_num-1].strip() == '':
-                lines.insert(line_num, '\n')
+            if line_num > 0 and not lines[line_num - 1].strip() == "":
+                lines.insert(line_num, "\n")
                 line_num += 1
                 # Update line numbers for subsequent tests
-                test_line_numbers = {k + 1 if k >= line_num - 1 else k: v for k, v in test_line_numbers.items()}
-            
+                test_line_numbers = {
+                    k + 1 if k >= line_num - 1 else k: v
+                    for k, v in test_line_numbers.items()
+                }
+
             # Now add the marker
             lines.insert(line_num, marker_line)
             modified_lines.append(line_num)
-            
+
             # Update line numbers for subsequent tests
-            test_line_numbers = {k + 1 if k >= line_num else k: v for k, v in test_line_numbers.items()}
-            
+            test_line_numbers = {
+                k + 1 if k >= line_num else k: v for k, v in test_line_numbers.items()
+            }
+
             if dry_run:
                 print(f"Would add to {file_path}:{line_num+1} - {marker_line.strip()}")
             added += 1
-    
+
     # Write changes back to the file
     if not dry_run and (added > 0 or updated > 0):
-        with open(file_path, 'w') as f:
+        with open(file_path, "w") as f:
             f.writelines(lines)
-    
+
     return added, updated, unchanged
 
 
-def filter_uncategorized_tests(test_list: List[str], progress: Dict[str, Any], force: bool = False) -> List[str]:
+def filter_uncategorized_tests(
+    test_list: List[str], progress: Dict[str, Any], force: bool = False
+) -> List[str]:
     """
     Filter out tests that have already been categorized.
-    
+
     Args:
         test_list: List of test paths
         progress: Dictionary containing categorization progress
         force: If True, include all tests regardless of categorization status
-        
+
     Returns:
         List of uncategorized test paths
     """
     if force:
         return test_list
-        
+
     categorized_tests = progress.get("categorized_tests", {})
     return [test for test in test_list if test not in categorized_tests]
 
 
 def measure_test_times(
-    test_list: List[str], 
-    batch_size: int = 20, 
-    max_tests: Optional[int] = None, 
-    timeout: int = 30
+    test_list: List[str],
+    batch_size: int = 20,
+    max_tests: Optional[int] = None,
+    timeout: int = 30,
 ) -> Dict[str, Dict[str, Any]]:
     """
     Measure execution times for a list of tests.
-    
+
     Args:
         test_list: List of tests to measure
         batch_size: Number of tests to run in each batch
         max_tests: Maximum number of tests to measure (None for all)
         timeout: Timeout for each test in seconds
-        
+
     Returns:
         Dictionary mapping test names to timing data
     """
     if not test_list:
         return {}
-    
+
     # Limit the number of tests if specified
     if max_tests is not None and max_tests > 0:
         test_list = test_list[:max_tests]
-    
-    print(f"Measuring execution times for {len(test_list)} tests in batches of {batch_size}...")
-    
+
+    print(
+        f"Measuring execution times for {len(test_list)} tests in batches of {batch_size}..."
+    )
+
     test_times = {}
-    
+
     # Process tests in batches
     for i in range(0, len(test_list), batch_size):
-        batch = test_list[i:i+batch_size]
-        print(f"\nProcessing batch {i//batch_size + 1}/{(len(test_list) + batch_size - 1)//batch_size}...")
-        
+        batch = test_list[i : i + batch_size]
+        print(
+            f"\nProcessing batch {i//batch_size + 1}/{(len(test_list) + batch_size - 1)//batch_size}..."
+        )
+
         for test_path in batch:
             print(f"Running {test_path}...")
             execution_time, passed, skipped = run_test_with_timing(test_path, timeout)
-            
+
             # Extract the test name from the path
-            test_name = test_path.split('::')[-1]
-            
+            test_name = test_path.split("::")[-1]
+
             test_times[test_path] = {
                 "execution_time": execution_time,
                 "passed": passed,
-                "skipped": skipped
+                "skipped": skipped,
             }
-            
+
             # Determine marker based on execution time
             # Assign a speed category even for skipped tests
             if execution_time < FAST_THRESHOLD:
@@ -699,49 +728,45 @@ def measure_test_times(
                 marker = "medium"
             else:
                 marker = "slow"
-            
+
             test_times[test_path]["marker"] = marker
-            
-            print(f"  Execution time: {execution_time:.2f}s, Marker: {marker}, Passed: {passed}, Skipped: {skipped}")
-    
+
+            print(
+                f"  Execution time: {execution_time:.2f}s, Marker: {marker}, Passed: {passed}, Skipped: {skipped}"
+            )
+
     return test_times
 
 
-def update_progress(progress: Dict[str, Any], test_times: Dict[str, Dict[str, Any]], force: bool = False) -> Dict[str, Any]:
+def update_progress(
+    progress: Dict[str, Any], test_times: Dict[str, Dict[str, Any]], force: bool = False
+) -> Dict[str, Any]:
     """
     Update categorization progress with new test times.
-    
+
     Args:
         progress: Dictionary containing categorization progress
         test_times: Dictionary mapping test paths to timing data
         force: If True, update counts for all tests regardless of previous categorization
-        
+
     Returns:
         Updated progress dictionary
     """
     categorized_tests = progress.get("categorized_tests", {})
-    categorization_counts = progress.get("categorization_counts", {
-        "fast": 0,
-        "medium": 0,
-        "slow": 0,
-        "total": 0
-    })
-    
+    categorization_counts = progress.get(
+        "categorization_counts", {"fast": 0, "medium": 0, "slow": 0, "total": 0}
+    )
+
     # If force is True, reset the counts
     if force:
-        categorization_counts = {
-            "fast": 0,
-            "medium": 0,
-            "slow": 0,
-            "total": 0
-        }
-    
+        categorization_counts = {"fast": 0, "medium": 0, "slow": 0, "total": 0}
+
     # Update categorized tests and counts
     for test_path, data in test_times.items():
         marker = data["marker"]
         old_marker = categorized_tests.get(test_path)
         categorized_tests[test_path] = marker
-        
+
         # Update counts if this is a new categorization or if force is True
         if force or test_path not in progress.get("categorized_tests", {}):
             categorization_counts["total"] += 1
@@ -754,62 +779,68 @@ def update_progress(progress: Dict[str, Any], test_times: Dict[str, Dict[str, An
         elif old_marker is None:
             categorization_counts["total"] += 1
             categorization_counts[marker] += 1
-    
+
     progress["categorized_tests"] = categorized_tests
     progress["categorization_counts"] = categorization_counts
-    
+
     return progress
 
 
 def main():
     """Main function."""
     args = parse_args()
-    
+
     # Set global thresholds based on command-line arguments
     global FAST_THRESHOLD, MEDIUM_THRESHOLD
     FAST_THRESHOLD = args.fast_threshold
     MEDIUM_THRESHOLD = args.medium_threshold
-    
+
     # Determine the directory to analyze
     directory = args.module if args.module else args.directory
-    
+
     print(f"Analyzing tests in {directory}...")
     print(f"Fast threshold: {FAST_THRESHOLD}s, Medium threshold: {MEDIUM_THRESHOLD}s")
-    
+
     # Create cache directory if it doesn't exist
     os.makedirs(CACHE_DIR, exist_ok=True)
-    
+
     # Load progress
     progress = load_progress(args.progress_file)
-    
+
     # Collect tests
     test_list = collect_tests(directory)
-    
+
     # Filter out tests that have already been categorized
     uncategorized_tests = filter_uncategorized_tests(test_list, progress, args.force)
-    
-    print(f"Found {len(uncategorized_tests)} uncategorized tests out of {len(test_list)} total tests")
-    
+
+    print(
+        f"Found {len(uncategorized_tests)} uncategorized tests out of {len(test_list)} total tests"
+    )
+
     if not uncategorized_tests:
         print("No uncategorized tests found.")
         return 0
-    
+
     # Measure test execution times
-    test_times = measure_test_times(uncategorized_tests, args.batch_size, args.max_tests, args.timeout)
-    
+    test_times = measure_test_times(
+        uncategorized_tests, args.batch_size, args.max_tests, args.timeout
+    )
+
     # Update progress
     progress = update_progress(progress, test_times, args.force)
-    
+
     # Save progress
     save_progress(progress, args.progress_file)
-    
+
     print(f"Progress saved to {args.progress_file}")
     print(f"Categorization counts:")
     print(f"  - Fast tests: {progress['categorization_counts']['fast']}")
     print(f"  - Medium tests: {progress['categorization_counts']['medium']}")
     print(f"  - Slow tests: {progress['categorization_counts']['slow']}")
-    print(f"  - Total categorized: {progress['categorization_counts']['total']} out of {len(test_list)} tests")
-    
+    print(
+        f"  - Total categorized: {progress['categorization_counts']['total']} out of {len(test_list)} tests"
+    )
+
     # Extract markers from test times (include all tests, even skipped ones)
     test_markers = {}
     for test_path, data in test_times.items():
@@ -817,62 +848,80 @@ def main():
         if "::" in test_path:
             file_path, *test_parts = test_path.split("::")
             test_name = test_parts[-1]
-            
+
             # Handle parameterized tests
             if "(" in test_name:
                 test_name = test_name.split("(")[0]
-                
+
             # Add the test name to the markers dictionary
             test_markers[test_name] = data["marker"]
-            
+
             # Also add the full test path to handle cases where the same test name appears in multiple files
             test_markers[test_path] = data["marker"]
         else:
             # If there's no "::" in the path, just use the filename as the key
             test_markers[os.path.basename(test_path)] = data["marker"]
-    
+
     # Update test files if requested
     if args.update or args.dry_run:
         test_files = find_test_files(directory)
-        
+
         total_added = 0
         total_updated = 0
         total_unchanged = 0
-        
+
         print(f"\nUpdating {len(test_files)} test files...")
         print(f"DEBUG: test_markers dictionary has {len(test_markers)} entries")
-        print(f"DEBUG: First 5 entries in test_markers: {list(test_markers.items())[:5]}")
-        
+        print(
+            f"DEBUG: First 5 entries in test_markers: {list(test_markers.items())[:5]}"
+        )
+
         for i, file_path in enumerate(test_files):
             if i % 10 == 0:
                 print(f"Processing file {i+1}/{len(test_files)}...")
-            
+
             print(f"\nDEBUG: Processing file {file_path}")
-            added, updated, unchanged = update_test_file(file_path, test_markers, args.dry_run, verbose=True)
-            print(f"DEBUG: Results for {file_path}: added={added}, updated={updated}, unchanged={unchanged}")
+            added, updated, unchanged = update_test_file(
+                file_path, test_markers, args.dry_run, verbose=True
+            )
+            print(
+                f"DEBUG: Results for {file_path}: added={added}, updated={updated}, unchanged={unchanged}"
+            )
             total_added += added
             total_updated += updated
             total_unchanged += unchanged
-        
+
         action = "Would " if args.dry_run else ""
-        print(f"\n{action}Add {total_added} markers, update {total_updated} markers, leave {total_unchanged} markers unchanged")
-    
+        print(
+            f"\n{action}Add {total_added} markers, update {total_updated} markers, leave {total_unchanged} markers unchanged"
+        )
+
     print("\nIncremental test categorization complete")
-    
+
     # Print tips for running tests by speed category
     print("\nTips for running tests by speed category:")
-    print("  - Run fast tests: python scripts/run_all_tests.py --fast")
-    print("  - Run medium tests: python scripts/run_all_tests.py --medium")
-    print("  - Run slow tests: python scripts/run_all_tests.py --slow")
-    print("  - Run fast and medium tests: python scripts/run_all_tests.py --fast --medium")
-    
+    print("  - Run fast tests: poetry run devsynth run-tests --fast")
+    print("  - Run medium tests: poetry run devsynth run-tests --medium")
+    print("  - Run slow tests: poetry run devsynth run-tests --slow")
+    print(
+        "  - Run fast and medium tests: poetry run devsynth run-tests --fast --medium"
+    )
+
     # Print tips for continuing categorization
     print("\nTo continue categorization:")
-    print(f"  - Run this script again: python scripts/incremental_test_categorization.py --update")
-    print(f"  - Categorize a specific module: python scripts/incremental_test_categorization.py --module tests/unit/interface --update")
-    print(f"  - Adjust batch size: python scripts/incremental_test_categorization.py --batch-size 10 --update")
-    print(f"  - Adjust max tests: python scripts/incremental_test_categorization.py --max-tests 50 --update")
+    print(
+        f"  - Run this script again: python scripts/incremental_test_categorization.py --update"
+    )
+    print(
+        f"  - Categorize a specific module: python scripts/incremental_test_categorization.py --module tests/unit/interface --update"
+    )
+    print(
+        f"  - Adjust batch size: python scripts/incremental_test_categorization.py --batch-size 10 --update"
+    )
+    print(
+        f"  - Adjust max tests: python scripts/incremental_test_categorization.py --max-tests 50 --update"
+    )
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/src/devsynth/interface/enhanced_error_handler.py
+++ b/src/devsynth/interface/enhanced_error_handler.py
@@ -4,19 +4,19 @@ This module extends the basic error handler with more specific error patterns
 and suggestions, as well as improved formatting for error messages.
 """
 
-from typing import Dict, List, Optional, Union, Any, Tuple
-import re
 import inspect
-import traceback
+import re
 import sys
+import traceback
 from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple, Union
 
-from rich.panel import Panel
-from rich.text import Text
 from rich.console import Console
 from rich.markdown import Markdown
-from rich.table import Table
+from rich.panel import Panel
 from rich.syntax import Syntax
+from rich.table import Table
+from rich.text import Text
 
 from devsynth.interface.error_handler import EnhancedErrorHandler, ErrorSuggestion
 from devsynth.logging_setup import DevSynthLogger
@@ -58,26 +58,26 @@ class ActionableErrorSuggestion(ErrorSuggestion):
     def __str__(self) -> str:
         """Return a string representation of the suggestion."""
         parts = [self.suggestion]
-        
+
         if self.actionable_steps:
             parts.append("\nActionable steps:")
             for i, step in enumerate(self.actionable_steps, 1):
                 parts.append(f"{i}. {step}")
-        
+
         if self.documentation_link:
             parts.append(f"\nDocumentation: {self.documentation_link}")
-        
+
         if self.command_example:
             parts.append(f"\nExample command: {self.command_example}")
-        
+
         if self.code_example:
             parts.append(f"\nExample code:\n{self.code_example}")
-        
+
         if self.related_errors:
             parts.append("\nRelated errors:")
             for error in self.related_errors:
                 parts.append(f"- {error}")
-        
+
         return "\n".join(parts)
 
 
@@ -97,7 +97,7 @@ class ImprovedErrorHandler(EnhancedErrorHandler):
                     "Check that all memory stores are properly configured",
                     "Verify that the memory synchronization service is running",
                     "Check the memory integration logs for errors",
-                    "Try restarting the memory synchronization service"
+                    "Try restarting the memory synchronization service",
                 ],
                 code_example="""
 # Example of proper memory store configuration
@@ -112,8 +112,8 @@ memory_manager = MemoryManager(
                 related_errors=[
                     "MemorySyncError",
                     "CrossStoreIntegrationError",
-                    "MemoryAdapterNotFoundError"
-                ]
+                    "MemoryAdapterNotFoundError",
+                ],
             ),
         ),
         # WSDE peer review errors
@@ -127,7 +127,7 @@ memory_manager = MemoryManager(
                     "Verify that the WSDE team is properly configured",
                     "Check that all required roles are assigned",
                     "Ensure that the peer review workflow is enabled",
-                    "Check the WSDE logs for errors"
+                    "Check the WSDE logs for errors",
                 ],
                 code_example="""
 # Example of proper WSDE team configuration
@@ -143,8 +143,8 @@ wsde_team = WSDETeam(
                 related_errors=[
                     "WSPEPeerReviewError",
                     "WorkflowConfigurationError",
-                    "MissingTeamMemberError"
-                ]
+                    "MissingTeamMemberError",
+                ],
             ),
         ),
         # Test failures
@@ -153,12 +153,12 @@ wsde_team = WSDETeam(
             ActionableErrorSuggestion(
                 "There may be issues with the tests.",
                 "https://devsynth.readthedocs.io/en/latest/developer_guides/testing.html",
-                "python scripts/run_all_tests.py --report",
+                "devsynth run-tests --report",
                 actionable_steps=[
                     "Run the tests with the --verbose flag to get more information",
                     "Check the test logs for specific error messages",
                     "Verify that the test environment is properly configured",
-                    "Try running the failing tests individually"
+                    "Try running the failing tests individually",
                 ],
                 code_example="""
 # Example of running specific tests
@@ -170,8 +170,8 @@ python -m pytest -m "fast" -v
                 related_errors=[
                     "AssertionError",
                     "TestSetupError",
-                    "TestEnvironmentError"
-                ]
+                    "TestEnvironmentError",
+                ],
             ),
         ),
         # CLI UX errors
@@ -185,7 +185,7 @@ python -m pytest -m "fast" -v
                     "Check that the terminal supports Rich formatting",
                     "Verify that the CLI UX bridge is properly configured",
                     "Try running with the --no-color flag if terminal formatting is causing issues",
-                    "Check the CLI logs for errors"
+                    "Check the CLI logs for errors",
                 ],
                 code_example="""
 # Example of proper CLI UX bridge configuration
@@ -195,8 +195,8 @@ bridge.display_result("Message", message_type="info")
                 related_errors=[
                     "CLIUXBridgeError",
                     "OutputFormattingError",
-                    "TerminalCompatibilityError"
-                ]
+                    "TerminalCompatibilityError",
+                ],
             ),
         ),
         # Web UI errors
@@ -210,7 +210,7 @@ bridge.display_result("Message", message_type="info")
                     "Check that Streamlit is properly installed and configured",
                     "Verify that the WebUI state is properly initialized",
                     "Check the WebUI logs for errors",
-                    "Try restarting the WebUI server"
+                    "Try restarting the WebUI server",
                 ],
                 code_example="""
 # Example of proper WebUI state initialization
@@ -222,8 +222,8 @@ if 'wizard_state' not in st.session_state:
                 related_errors=[
                     "WebUIStateError",
                     "StreamlitError",
-                    "WizardStateError"
-                ]
+                    "WizardStateError",
+                ],
             ),
         ),
         # Shell completion errors
@@ -237,7 +237,7 @@ if 'wizard_state' not in st.session_state:
                     "Verify that the shell completion script is installed",
                     "Check that the shell completion script is sourced in your shell configuration",
                     "Try reinstalling the shell completion script",
-                    "Check that your shell supports completion scripts"
+                    "Check that your shell supports completion scripts",
                 ],
                 code_example="""
 # Add to ~/.bashrc or ~/.bash_profile for Bash
@@ -251,8 +251,8 @@ compinit
                 related_errors=[
                     "ShellCompletionError",
                     "CompletionScriptNotFoundError",
-                    "ShellConfigurationError"
-                ]
+                    "ShellConfigurationError",
+                ],
             ),
         ),
         # Command output formatting errors
@@ -266,7 +266,7 @@ compinit
                     "Check that the output formatter is properly configured",
                     "Verify that the terminal supports the requested output format",
                     "Try using a different output format (--format=text)",
-                    "Check the output formatter logs for errors"
+                    "Check the output formatter logs for errors",
                 ],
                 code_example="""
 # Example of proper output formatter configuration
@@ -276,8 +276,8 @@ formatter.format_command_output(data, format_name="rich")
                 related_errors=[
                     "OutputFormattingError",
                     "UnsupportedFormatError",
-                    "TerminalCompatibilityError"
-                ]
+                    "TerminalCompatibilityError",
+                ],
             ),
         ),
     ]
@@ -289,13 +289,15 @@ formatter.format_command_output(data, format_name="rich")
             console: Optional Rich console for output
         """
         super().__init__(console)
-        
+
         # Combine the base error patterns with the additional ones
         self.ERROR_PATTERNS = self.ERROR_PATTERNS + self.ADDITIONAL_ERROR_PATTERNS
-        
+
         logger.debug("Initialized ImprovedErrorHandler with additional error patterns")
 
-    def _find_suggestions(self, error_message: str) -> List[Union[ErrorSuggestion, ActionableErrorSuggestion]]:
+    def _find_suggestions(
+        self, error_message: str
+    ) -> List[Union[ErrorSuggestion, ActionableErrorSuggestion]]:
         """Find suggestions for an error message.
 
         This method overrides the base method to provide more specific suggestions
@@ -308,51 +310,57 @@ formatter.format_command_output(data, format_name="rich")
             A list of suggestions
         """
         suggestions = super()._find_suggestions(error_message)
-        
+
         # Add context-specific suggestions based on the current state of the system
         try:
             # Check if this is a test-related error
             if "pytest" in sys.modules or "unittest" in sys.modules:
-                suggestions.append(ActionableErrorSuggestion(
-                    "This error occurred during test execution.",
-                    "https://devsynth.readthedocs.io/en/latest/developer_guides/testing.html",
-                    "python scripts/run_all_tests.py --verbose",
-                    actionable_steps=[
-                        "Check the test logs for more information",
-                        "Try running the test with increased verbosity",
-                        "Verify that the test environment is properly configured"
-                    ]
-                ))
-            
+                suggestions.append(
+                    ActionableErrorSuggestion(
+                        "This error occurred during test execution.",
+                        "https://devsynth.readthedocs.io/en/latest/developer_guides/testing.html",
+                        "devsynth run-tests --verbose",
+                        actionable_steps=[
+                            "Check the test logs for more information",
+                            "Try running the test with increased verbosity",
+                            "Verify that the test environment is properly configured",
+                        ],
+                    )
+                )
+
             # Check if this is a CLI-related error
             if "devsynth.interface.cli" in sys.modules:
-                suggestions.append(ActionableErrorSuggestion(
-                    "This error occurred in the CLI interface.",
-                    "https://devsynth.readthedocs.io/en/latest/user_guides/cli_reference.html",
-                    "devsynth --help",
-                    actionable_steps=[
-                        "Check the command syntax",
-                        "Verify that all required parameters are provided",
-                        "Try running with the --verbose flag for more information"
-                    ]
-                ))
-            
+                suggestions.append(
+                    ActionableErrorSuggestion(
+                        "This error occurred in the CLI interface.",
+                        "https://devsynth.readthedocs.io/en/latest/user_guides/cli_reference.html",
+                        "devsynth --help",
+                        actionable_steps=[
+                            "Check the command syntax",
+                            "Verify that all required parameters are provided",
+                            "Try running with the --verbose flag for more information",
+                        ],
+                    )
+                )
+
             # Check if this is a WebUI-related error
             if "streamlit" in sys.modules or "devsynth.interface.webui" in sys.modules:
-                suggestions.append(ActionableErrorSuggestion(
-                    "This error occurred in the Web UI.",
-                    "https://devsynth.readthedocs.io/en/latest/user_guides/webui.html",
-                    "devsynth webui --debug",
-                    actionable_steps=[
-                        "Check the WebUI logs for more information",
-                        "Try restarting the WebUI server",
-                        "Verify that Streamlit is properly configured"
-                    ]
-                ))
+                suggestions.append(
+                    ActionableErrorSuggestion(
+                        "This error occurred in the Web UI.",
+                        "https://devsynth.readthedocs.io/en/latest/user_guides/webui.html",
+                        "devsynth webui --debug",
+                        actionable_steps=[
+                            "Check the WebUI logs for more information",
+                            "Try restarting the WebUI server",
+                            "Verify that Streamlit is properly configured",
+                        ],
+                    )
+                )
         except Exception as e:
             # Don't let errors in suggestion generation prevent the main error from being displayed
             logger.warning(f"Error while generating context-specific suggestions: {e}")
-        
+
         return suggestions
 
     def _format_rich_error(
@@ -360,7 +368,7 @@ formatter.format_command_output(data, format_name="rich")
         error_message: str,
         error_type: str,
         error_traceback: str,
-        suggestions: List[Union[ErrorSuggestion, ActionableErrorSuggestion]]
+        suggestions: List[Union[ErrorSuggestion, ActionableErrorSuggestion]],
     ) -> Panel:
         """Format an error with Rich formatting.
 
@@ -379,16 +387,17 @@ formatter.format_command_output(data, format_name="rich")
         error_table = Table(show_header=False, box=None)
         error_table.add_column("Key", style="bold red")
         error_table.add_column("Value")
-        
+
         # Add error type and message
         error_table.add_row("Error Type:", error_type)
         error_table.add_row("Message:", error_message)
-        
+
         # Add timestamp
         from datetime import datetime
+
         timestamp = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
         error_table.add_row("Timestamp:", timestamp)
-        
+
         # Add traceback if available
         if error_traceback:
             syntax = Syntax(
@@ -399,71 +408,76 @@ formatter.format_command_output(data, format_name="rich")
                 word_wrap=True,
             )
             error_table.add_row("Traceback:", "")
-            
+
         # Create a table for the suggestions
         if suggestions:
             suggestion_table = Table(title="Suggestions", show_header=False, box=None)
             suggestion_table.add_column("Suggestion", style="bold green")
-            
+
             for suggestion in suggestions:
                 if isinstance(suggestion, ActionableErrorSuggestion):
                     # Format actionable suggestion
                     suggestion_text = Text()
-                    suggestion_text.append(f"{suggestion.suggestion}\n\n", style="bold green")
-                    
+                    suggestion_text.append(
+                        f"{suggestion.suggestion}\n\n", style="bold green"
+                    )
+
                     if suggestion.actionable_steps:
                         suggestion_text.append("Actionable steps:\n", style="bold")
                         for i, step in enumerate(suggestion.actionable_steps, 1):
                             suggestion_text.append(f"{i}. {step}\n", style="green")
                         suggestion_text.append("\n")
-                    
+
                     if suggestion.documentation_link:
                         suggestion_text.append(f"Documentation: ", style="bold")
                         suggestion_text.append(f"{suggestion.documentation_link}\n\n")
-                    
+
                     if suggestion.command_example:
                         suggestion_text.append(f"Example command: ", style="bold")
                         suggestion_text.append(f"{suggestion.command_example}\n\n")
-                    
+
                     if suggestion.code_example:
                         suggestion_text.append(f"Example code:\n", style="bold")
                         suggestion_text.append(f"{suggestion.code_example}\n\n")
-                    
+
                     if suggestion.related_errors:
                         suggestion_text.append(f"Related errors:\n", style="bold")
                         for error in suggestion.related_errors:
                             suggestion_text.append(f"- {error}\n")
-                    
+
                     suggestion_table.add_row(suggestion_text)
                 else:
                     # Format basic suggestion
                     suggestion_table.add_row(str(suggestion))
-        
+
         # Combine the tables into a panel
         content = Text()
-        content.append("An error occurred while executing the command.\n\n", style="bold red")
-        
+        content.append(
+            "An error occurred while executing the command.\n\n", style="bold red"
+        )
+
         # Add the error table
         from rich.console import Console
+
         console = Console(file=None)
         with console.capture() as capture:
             console.print(error_table)
         content.append(capture.get())
-        
+
         # Add the traceback if available
         if error_traceback:
             content.append("\nTraceback:\n", style="bold red")
             with console.capture() as capture:
                 console.print(syntax)
             content.append(capture.get())
-        
+
         # Add the suggestion table if available
         if suggestions:
             content.append("\nSuggestions:\n", style="bold green")
             with console.capture() as capture:
                 console.print(suggestion_table)
             content.append(capture.get())
-        
+
         # Create the panel
         return Panel(
             content,
@@ -487,7 +501,7 @@ formatter.format_command_output(data, format_name="rich")
         """
         # Use the base implementation for the basic formatting
         formatted_error = super().format_error(error)
-        
+
         # Add additional context if available
         if isinstance(formatted_error, Panel):
             # Add a footer with additional help information
@@ -495,8 +509,11 @@ formatter.format_command_output(data, format_name="rich")
             footer.append("\nFor more help, run: ", style="dim")
             footer.append("devsynth doctor", style="bold blue")
             footer.append(" or visit: ", style="dim")
-            footer.append("https://devsynth.readthedocs.io/en/latest/user_guides/troubleshooting.html", style="bold blue")
-            
+            footer.append(
+                "https://devsynth.readthedocs.io/en/latest/user_guides/troubleshooting.html",
+                style="bold blue",
+            )
+
             # Create a new panel with the footer
             new_panel = Panel(
                 formatted_error.renderable,
@@ -505,9 +522,9 @@ formatter.format_command_output(data, format_name="rich")
                 border_style=formatted_error.border_style,
                 expand=formatted_error.expand,
             )
-            
+
             return new_panel
-        
+
         return formatted_error
 
 

--- a/src/devsynth/testing/run_tests.py
+++ b/src/devsynth/testing/run_tests.py
@@ -2,8 +2,7 @@
 
 This module provides a :func:`run_tests` function that executes pytest with
 options compatible with DevSynth's CLI test commands. It is intended to be
-reused by helper scripts such as ``scripts/run_all_tests.py`` and
-``scripts/manual_cli_testing.py``.
+intended for use by helper scripts such as ``scripts/manual_cli_testing.py``.
 """
 
 from __future__ import annotations

--- a/tests/README.md
+++ b/tests/README.md
@@ -100,7 +100,7 @@ Tests are grouped by runtime using pytest markers:
 These markers make it easy to select subsets of the suite. For example:
 
 ```bash
-poetry run python scripts/run_all_tests.py --fast --medium
+poetry run devsynth run-tests --fast --medium
 ```
 
 ## Conditional Test Execution
@@ -311,16 +311,16 @@ To see which tests would be skipped due to missing resources:
 poetry run pytest --collect-only -v
 ```
 
-### Using `run_all_tests.py`
+### Using `devsynth run-tests`
 
-The helper script `scripts/run_all_tests.py` wraps `pytest` and expects all
-required plugins to be installed via Poetry. Invoke it from the Poetry
-environment to run the full suite or selected groups:
+The `devsynth run-tests` CLI wraps `pytest` and expects all
+required plugins to be installed via Poetry.
+Invoke the command from the Poetry environment to run the full suite or selected groups:
 
 ```bash
-poetry run python scripts/run_all_tests.py                     # run all tests
-poetry run python scripts/run_all_tests.py --target unit-tests  # run only unit tests
-poetry run python scripts/run_all_tests.py --report             # generate HTML report under test_reports/
+poetry run devsynth run-tests                     # run all tests
+poetry run devsynth run-tests --target unit-tests  # run only unit tests
+poetry run devsynth run-tests --report             # generate HTML report under test_reports/
 ```
 
 For additional utilities like flaky-test fixes and incremental categorization, see [Test Stabilization Tools](../docs/developer_guides/test_stabilization_tools.md).

--- a/tests/unit/scripts/test_run_all_tests_wrapper.py
+++ b/tests/unit/scripts/test_run_all_tests_wrapper.py
@@ -1,0 +1,54 @@
+"""Tests for the legacy run_all_tests wrapper. ReqID: QA-06"""
+
+from types import SimpleNamespace
+
+import scripts.run_all_tests as run_all_tests
+
+
+def test_wrapper_invokes_cli(monkeypatch):
+    """Ensure wrapper invokes devsynth run-tests."""
+    called = {}
+
+    def fake_run(cmd, capture_output, text):
+        called["cmd"] = cmd
+        return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr(run_all_tests, "subprocess", SimpleNamespace(run=fake_run))
+    monkeypatch.setattr(
+        run_all_tests,
+        "sys",
+        SimpleNamespace(
+            argv=["run_all_tests.py"],
+            stdout=SimpleNamespace(write=lambda _: None),
+            stderr=SimpleNamespace(write=lambda _: None),
+        ),
+    )
+
+    assert run_all_tests.main() == 0
+    assert called["cmd"][:2] == ["devsynth", "run-tests"]
+    assert "--no-parallel" in called["cmd"]
+
+
+def test_wrapper_translates_features(monkeypatch):
+    """Convert legacy --features JSON into --feature flags."""
+    called = {}
+
+    def fake_run(cmd, capture_output, text):
+        called["cmd"] = cmd
+        return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr(run_all_tests, "subprocess", SimpleNamespace(run=fake_run))
+    monkeypatch.setattr(
+        run_all_tests,
+        "sys",
+        SimpleNamespace(
+            argv=["run_all_tests.py", "--features", '{"foo": true, "bar": false}'],
+            stdout=SimpleNamespace(write=lambda _: None),
+            stderr=SimpleNamespace(write=lambda _: None),
+        ),
+    )
+
+    assert run_all_tests.main() == 0
+    assert called["cmd"].count("--feature") == 2
+    assert "foo=True" in called["cmd"]
+    assert "bar=False" in called["cmd"]


### PR DESCRIPTION
## Summary
- document and automation now use `devsynth run-tests` instead of the deprecated `scripts/run_all_tests.py`
- clearly mark legacy `run_all_tests.py` wrapper in README and keep for backward compatibility
- add unit tests ensuring the wrapper forwards arguments to the new CLI

## Testing
- `poetry run pre-commit run --files AGENTS.md README.md docs/deployment/release_automation.md docs/policies/deprecation_policy.md scripts/README.md scripts/apply_test_markers.py scripts/categorize_behavior_tests.py scripts/categorize_tests.py scripts/categorize_tests_improved.py scripts/incremental_test_categorization.py src/devsynth/interface/enhanced_error_handler.py src/devsynth/testing/run_tests.py tests/README.md tests/unit/scripts/test_run_all_tests_wrapper.py`
- `poetry run pre-commit run --files docs/deployment/release_automation.md docs/policies/deprecation_policy.md tests/unit/scripts/test_run_all_tests_wrapper.py`
- `poetry run pytest tests/unit/scripts/test_run_all_tests_wrapper.py -q`
- `poetry run devsynth run-tests --target unit-tests --speed fast` *(fails: Benchmarks are automatically disabled because xdist plugin is active ... Tests failed)*
- `poetry run python tests/verify_test_organization.py`
- `poetry run pip check`


------
https://chatgpt.com/codex/tasks/task_e_6899768e4eac8333b8a29f8817e985db