### PR TITLE
feat: add fallback conditions and retry metrics

### DIFF
--- a/src/devsynth/metrics.py
+++ b/src/devsynth/metrics.py
@@ -82,6 +82,11 @@ retry_condition_counter = Counter(
     "Retry aborts grouped by failed condition",
     ["condition"],
 )
+retry_stat_counter = Counter(
+    "devsynth_retry_stat_total",
+    "Retry outcomes grouped by function and status",
+    ["function", "status"],
+)
 # Dashboard events counter
 dashboard_event_counter = Counter(
     "devsynth_dashboard_events_total", "Dashboard events", ["event"]
@@ -134,6 +139,7 @@ def inc_retry_stat(func_name: str, status: str) -> None:
     """Record the outcome of a retry attempt for a function."""
     key = f"{func_name}:{status}"
     _retry_stat_metrics[key] += 1
+    retry_stat_counter.labels(function=func_name, status=status).inc()
 
 
 def inc_circuit_breaker_state(func_name: str, state: str) -> None:
@@ -237,5 +243,6 @@ def reset_metrics() -> None:
     retry_function_counter.clear()
     retry_error_counter.clear()
     retry_condition_counter.clear()
+    retry_stat_counter.clear()
     dashboard_event_counter.clear()
     circuit_breaker_state_counter.clear()


### PR DESCRIPTION
## Summary
- allow configuring fallback conditions and circuit breaker integration
- expose retry stat metrics via prometheus counters
- cover retry metrics and fallback circuit breaker logic with regression tests

## Testing
- `poetry run pre-commit run --files src/devsynth/fallback.py src/devsynth/metrics.py tests/unit/fallback/test_retry_logic.py`
- `poetry run python tests/verify_test_organization.py`
- `poetry run pip check`
- `poetry run python scripts/run_all_tests.py` *(fails: KeyboardInterrupt)*


------
https://chatgpt.com/codex/tasks/task_e_68997653049c8333a2f9cc9d31200eff