### PR TITLE
chore: add docker publish workflow and tests

### DIFF
--- a/.github/workflows/build-and-push.yml.disabled
+++ b/.github/workflows/build-and-push.yml.disabled
@@ -26,9 +26,5 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - name: Build and push
-        uses: docker/build-push-action@v5
-        with:
-          context: .
-          push: true
-          tags: ghcr.io/${{ github.repository }}:latest
+      - name: Publish image
+        run: scripts/deployment/publish_image.sh ${{ github.sha }}

--- a/.github/workflows/ci.yml.disabled
+++ b/.github/workflows/ci.yml.disabled
@@ -20,3 +20,23 @@ jobs:
           poetry install --with dev --extras tests retrieval chromadb api
       - name: Run security checks
         run: poetry run pre-commit run --all-files bandit safety
+
+  publish-image:
+    needs: security
+    if: github.event_name == 'push'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Publish image
+        run: scripts/deployment/publish_image.sh ${{ github.sha }}

--- a/tests/integration/general/test_deployment_automation.py
+++ b/tests/integration/general/test_deployment_automation.py
@@ -45,6 +45,7 @@ def test_rollback_runbook_mentions_scripts():
     text = runbook.read_text()
     assert "rollback.sh" in text
     assert "publish_image.sh" in text
+    assert "health_check.sh" in text
 
 
 def test_rollback_script_exists_and_redeploys():


### PR DESCRIPTION
## Summary
- add Docker image publish job to CI workflows
- verify rollback runbook includes health check instructions

## Testing
- `SKIP=fix-code-blocks poetry run pre-commit run --files .github/workflows/build-and-push.yml.disabled .github/workflows/ci.yml.disabled tests/integration/general/test_deployment_automation.py`
- `poetry run python scripts/run_all_tests.py` *(failed: KeyboardInterrupt)*
- `poetry run python tests/verify_test_organization.py`


------
https://chatgpt.com/codex/tasks/task_e_689976499224833381b9918b46a3f3c7