### PR TITLE
Fix memory sync hook notifications in WSDE/EDRR integration tests

### DIFF
--- a/src/devsynth/application/memory/memory_manager.py
+++ b/src/devsynth/application/memory/memory_manager.py
@@ -161,7 +161,6 @@ class MemoryManager:
 
         # Use the sync manager to propagate to all stores
         self.sync_manager.update_item(primary_store, memory_item)
-        self._notify_sync_hooks(memory_item)
         return memory_item.id
 
     def retrieve_with_edrr_phase(
@@ -737,16 +736,12 @@ class MemoryManager:
     def update_item(self, store: str, item: MemoryItem) -> bool:
         """Update an item and propagate to other stores."""
 
-        result = self.sync_manager.update_item(store, item)
-        if result:
-            self._notify_sync_hooks(item)
-        return result
+        return self.sync_manager.update_item(store, item)
 
     def queue_update(self, store: str, item: MemoryItem) -> None:
         """Queue an update for asynchronous propagation."""
 
         self.sync_manager.queue_update(store, item)
-        self._notify_sync_hooks(item)
 
     def flush_updates(self) -> None:
         """Flush queued updates synchronously and persist adapters."""
@@ -762,13 +757,11 @@ class MemoryManager:
                     adapter.memory_store.flush()
             except Exception:
                 logger.debug("Adapter flush failed", exc_info=True)
-        self._notify_sync_hooks(None)
 
     async def flush_updates_async(self) -> None:
         """Flush queued updates asynchronously."""
 
         await self.sync_manager.flush_queue_async()
-        self._notify_sync_hooks(None)
 
     async def wait_for_sync(self) -> None:
         """Wait for asynchronous sync tasks to complete."""

--- a/tests/integration/general/test_wsde_edrr_component_interactions.py
+++ b/tests/integration/general/test_wsde_edrr_component_interactions.py
@@ -305,5 +305,4 @@ class TestWSDEEDRRComponentInteractions:
         memory_manager.update_item("default", item)
         memory_manager.flush_updates()
 
-        assert events[0] == "test-item"
-        assert events[-1] is None
+        assert events == ["test-item", None]

--- a/tests/integration/general/test_wsde_edrr_integration_advanced.py
+++ b/tests/integration/general/test_wsde_edrr_integration_advanced.py
@@ -248,5 +248,4 @@ def test_memory_sync_hook_handles_wsde_events():
     mm.update_item("tinydb" if "tinydb" in mm.adapters else "default", item)
     mm.flush_updates()
 
-    assert events[0] == "adv-item"
-    assert events[-1] is None
+    assert events == ["adv-item", None]

--- a/tests/integration/general/test_wsde_edrr_integration_end_to_end.py
+++ b/tests/integration/general/test_wsde_edrr_integration_end_to_end.py
@@ -311,5 +311,4 @@ def test_memory_sync_hook_captures_events_during_team_sync():
     mm.update_item("tinydb" if "tinydb" in mm.adapters else "default", item)
     mm.flush_updates()
 
-    assert events[0] == "end-item"
-    assert events[-1] is None
+    assert events == ["end-item", None]


### PR DESCRIPTION
## Summary
- Avoid duplicate sync hook notifications by letting `SyncManager` handle them
- Ensure flush only emits a single synchronization event
- Tighten WSDE-EDRR integration tests to expect one update and final sentinel

## Testing
- `poetry run pre-commit run --files src/devsynth/application/memory/memory_manager.py tests/integration/general/test_wsde_edrr_component_interactions.py tests/integration/general/test_wsde_edrr_integration_advanced.py tests/integration/general/test_wsde_edrr_integration_end_to_end.py`
- `poetry run pytest tests/integration/general/test_wsde_edrr_component_interactions.py tests/integration/general/test_wsde_edrr_integration_advanced.py tests/integration/general/test_wsde_edrr_integration_end_to_end.py -q`
- `poetry run devsynth run-tests` *(fails: 914 failed, 1890 passed, 114 skipped, 107 errors)*
- `poetry run python tests/verify_test_organization.py`
- `poetry run pip check`


------
https://chatgpt.com/codex/tasks/task_e_68997f1720848333a85c3f527ce15c8c