### PR TITLE
Add requirement IDs for memory integration tests

### DIFF
--- a/tests/integration/memory/test_backend_persistence.py
+++ b/tests/integration/memory/test_backend_persistence.py
@@ -15,7 +15,7 @@ pytestmark = [
 
 
 def test_multi_store_persistence(tmp_path, monkeypatch):
-    """LMDB, FAISS and Kuzu stores should persist across adapter instances."""
+    """LMDB, FAISS and Kuzu stores should persist across adapter instances. ReqID: FR-37"""
     # Avoid network calls by providing a trivial embedding function
     ef = pytest.importorskip("chromadb.utils.embedding_functions")
     monkeypatch.setattr(ef, "DefaultEmbeddingFunction", lambda: (lambda x: [0.0] * 5))

--- a/tests/integration/memory/test_chromadb_adapter_transactions.py
+++ b/tests/integration/memory/test_chromadb_adapter_transactions.py
@@ -11,7 +11,7 @@ pytestmark = [pytest.mark.requires_resource("chromadb")]
 
 
 def test_chromadb_transaction_commit_and_rollback(tmp_path, monkeypatch):
-    """Vectors added within a transaction should rollback correctly."""
+    """Vectors added within a transaction should rollback correctly. ReqID: FR-60"""
     ef = pytest.importorskip("chromadb.utils.embedding_functions")
     # Avoid network calls by supplying a no-op embedding function
     monkeypatch.setattr(ef, "DefaultEmbeddingFunction", lambda: (lambda x: [0.0] * 5))

--- a/tests/integration/memory/test_circuit_breaker_integration.py
+++ b/tests/integration/memory/test_circuit_breaker_integration.py
@@ -1,10 +1,12 @@
 import time
+
 import pytest
 
 from devsynth.application.memory.circuit_breaker import CircuitBreaker
 
 
 def test_circuit_breaker_resets_after_timeout():
+    """Circuit breaker transitions to CLOSED after timeout. ReqID: FR-60"""
     breaker = CircuitBreaker("demo", failure_threshold=1, reset_timeout=0.1)
 
     def boom():

--- a/tests/integration/memory/test_cross_store_sync.py
+++ b/tests/integration/memory/test_cross_store_sync.py
@@ -48,6 +48,7 @@ def _manager(lmdb, faiss, kuzu, chroma, chroma_vec):
 
 @pytest.mark.medium
 def test_full_backend_synchronization(tmp_path, monkeypatch):
+    """Synchronizes data across memory backends. ReqID: FR-60"""
     monkeypatch.setenv("DEVSYNTH_NO_FILE_LOGGING", "1")
     monkeypatch.setenv("ENABLE_CHROMADB", "1")
     ef = pytest.importorskip("chromadb.utils.embedding_functions")

--- a/tests/integration/memory/test_transactional_sync.py
+++ b/tests/integration/memory/test_transactional_sync.py
@@ -48,6 +48,7 @@ def _manager(lmdb, faiss, kuzu, chroma, chroma_vec):
 
 @pytest.mark.medium
 def test_transactional_sync_rollback(tmp_path, monkeypatch):
+    """Rolls back when synchronization target fails. ReqID: FR-60"""
     monkeypatch.setenv("DEVSYNTH_NO_FILE_LOGGING", "1")
     monkeypatch.setenv("ENABLE_CHROMADB", "1")
     ef = pytest.importorskip("chromadb.utils.embedding_functions")


### PR DESCRIPTION
## Summary
- add `ReqID` markers to memory integration tests to improve traceability

## Testing
- `poetry run pre-commit run --files tests/integration/memory/test_backend_persistence.py tests/integration/memory/test_chromadb_adapter_transactions.py tests/integration/memory/test_circuit_breaker_integration.py tests/integration/memory/test_cross_store_sync.py tests/integration/memory/test_transactional_sync.py`
- `poetry run devsynth run-tests` *(fails: INTERNALERROR, 894 failed, 1812 passed, 112 skipped, 107 errors)*
- `poetry run python tests/verify_test_organization.py`
- `poetry run python scripts/verify_requirements_traceability.py docs/requirements_traceability.md`


------
https://chatgpt.com/codex/tasks/task_e_689a10e1c9648333bc9a0f49b44d2f44