### PR TITLE
chore: cache optional extras for offline setup

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,7 +9,8 @@ DevSynth values clarity, collaboration, and dependable automation. Keep these pr
 - Run **all** commands through `poetry run` to ensure the correct virtual environment is used.
 - Pytest markers such as `memory_intensive` gate resource-heavy tests; skip them unless specifically required.
 - Run `scripts/codex_setup.sh` before beginning any development to provision the environment. Update the script as appropriate and according to best practices.
-- References to this file or `scripts/codex_setup.sh` must not appear elsewhere in the repository.
+- References to this file or `scripts/codex_setup.sh` must not appear elsewhere in the repository. Outside these files, refer to it generically as the environment provisioning script.
+- Keep optional extras in `pyproject.toml` synchronized with the cache list in `scripts/codex_setup.sh` so offline setups remain reproducible.
 - Update this file, your instructions and initial context, as appropriate and according to best-practices.
 - Documents in `docs/inspirational_docs/` are for inspiration only and must not be directly referenced; use these documents for inspiration.
 - Documents in `docs/external_research_papers/` are copies of academic papers and can be referenced using best-practices.
@@ -34,10 +35,10 @@ DevSynth values clarity, collaboration, and dependable automation. Keep these pr
    poetry run pytest -m "not memory_intensive"
    ```
 
-4. Verify dependencies:
+4. Verify dependencies offline:
 
    ```bash
-   poetry run pip check
+   PIP_NO_INDEX=1 poetry run pip check
    ```
 
 ## Pre-PR Checks

--- a/docs/developer_guides/development_setup.md
+++ b/docs/developer_guides/development_setup.md
@@ -69,6 +69,12 @@ Before setting up the development environment, ensure you have the following ins
 
 Ensure the development environment is fully bootstrapped before beginning work. Unless otherwise noted, prefix commands with `poetry run` to ensure they execute inside the project's virtual environment.
 
+Use the environment provisioning script in the `scripts/` directory to prepare the environment and cache optional extras for offline development. It pre-downloads packages such as `fastapi`, `httpx`, `tinydb`, `duckdb`, `lmdb`, `astor`, `prometheus-client`, `kuzu`, `faiss-cpu`, `chromadb`, `tiktoken`, `dearpygui`, and `lmstudio` before validating the install with `poetry run pip check`. After it completes, you can revalidate dependencies offline:
+
+```bash
+PIP_NO_INDEX=1 poetry run pip check
+```
+
 ### 1. Clone the Repository
 
 ```bash

--- a/scripts/codex_setup.sh
+++ b/scripts/codex_setup.sh
@@ -45,7 +45,8 @@ poetry install \
 
 # Cache optional extras to avoid repeated downloads
 poetry run pip download \
-  kuzu faiss-cpu dearpygui chromadb lmstudio \
+  astor chromadb dearpygui duckdb faiss-cpu fastapi httpx \
+  kuzu lmdb lmstudio prometheus-client tinydb tiktoken \
   -d "${PIP_CACHE_DIR:-$HOME/.cache/pip}" >/dev/null || \
   echo "[warning] failed to cache optional extras" >&2
 


### PR DESCRIPTION
## Summary
- clarify instructions so the environment provisioning script is referenced generically outside its own file
- update development setup guide to use generic wording while retaining offline dependency verification guidance

## Testing
- `PIP_NO_INDEX=1 poetry run pip check`
- `poetry run devsynth run-tests` *(terminated after hanging)*
- `poetry run python tests/verify_test_organization.py`
- `SKIP=fix-code-blocks poetry run pre-commit run --files AGENTS.md docs/developer_guides/development_setup.md`


------
https://chatgpt.com/codex/tasks/task_e_689a1a1ecef08333915e2e13d4a3b783