### PR TITLE
Add default for kuzu_embedded and expand integration tests

### DIFF
--- a/src/devsynth/config/settings.py
+++ b/src/devsynth/config/settings.py
@@ -22,6 +22,12 @@ from .loader import load_config
 # Default settings
 DEFAULT_KUZU_EMBEDDED = True
 
+# Module-level defaults for Kuzu integration
+kuzu_db_path: Optional[str] = None
+kuzu_embedded: bool = DEFAULT_KUZU_EMBEDDED
+# Backward-compatible constant for older imports
+KUZU_EMBEDDED = kuzu_embedded
+
 
 def _parse_bool_env(value: Any, field: str) -> bool:
     """Parse a boolean environment variable securely."""
@@ -817,4 +823,6 @@ __all__ = [
     "is_devsynth_managed_project",
     "ensure_path_exists",
     "DEFAULT_KUZU_EMBEDDED",
+    "kuzu_embedded",
+    "KUZU_EMBEDDED",
 ]


### PR DESCRIPTION
## Summary
- add module-level defaults for `kuzu_embedded` and expose constants
- exercise Kuzu memory integration tests in embedded and fallback modes
- parametrize env-variable test for both embedded and non-embedded settings

## Testing
- `SKIP=fix-code-blocks poetry run pre-commit run --files src/devsynth/config/settings.py tests/integration/general/test_kuzu_memory_integration.py`
- `poetry run devsynth run-tests` *(fails: KeyError <WorkerController gw1>)*
- `poetry run python tests/verify_test_organization.py`
- `poetry run pytest tests/integration/general/test_kuzu_memory_integration.py -q` *(fails: Fatal Python error: gilstate_tss_set)*

------
https://chatgpt.com/codex/tasks/task_e_689a2a59f5088333b0e78017e73665b7