### PR TITLE
test: isolate API token in health tests

### DIFF
--- a/tests/unit/general/test_api_health.py
+++ b/tests/unit/general/test_api_health.py
@@ -1,5 +1,3 @@
-import os
-
 import pytest
 
 from devsynth.api import app
@@ -7,11 +5,19 @@ from devsynth.api import app
 pytest.importorskip("fastapi")
 from fastapi.testclient import TestClient
 
-os.environ["DEVSYNTH_ACCESS_TOKEN"] = "test-token"
 client = TestClient(app)
 
 
-def test_health_endpoint_succeeds():
+@pytest.fixture
+def api_token_env(monkeypatch):
+    """Provide a test access token for API requests."""
+    monkeypatch.setenv("DEVSYNTH_ACCESS_TOKEN", "test-token")
+    from devsynth import api as api_module
+
+    monkeypatch.setattr(api_module.settings, "access_token", "test-token")
+
+
+def test_health_endpoint_succeeds(api_token_env):
     """Test that health endpoint succeeds.
 
     ReqID: N/A"""
@@ -20,7 +26,7 @@ def test_health_endpoint_succeeds():
     assert resp.json() == {"status": "ok"}
 
 
-def test_metrics_endpoint_succeeds():
+def test_metrics_endpoint_succeeds(api_token_env):
     """Test that metrics endpoint succeeds.
 
     ReqID: N/A"""


### PR DESCRIPTION
## Summary
- ensure API health tests use per-test env token via fixture

## Testing
- `poetry run pre-commit run --files tests/unit/general/test_api_health.py`
- `poetry run pytest tests/unit/general/test_api_health.py tests/unit/general/test_isolation.py`
- `poetry run devsynth run-tests --target unit-tests --speed fast` *(fails: Tests failed)*
- `poetry run python tests/verify_test_organization.py`


------
https://chatgpt.com/codex/tasks/task_e_689a2e0de9808333b1b8102e4f684a40