### PR TITLE
Handle optional duckdb dependency

### DIFF
--- a/tests/unit/adapters/memory/test_memory_adapter.py
+++ b/tests/unit/adapters/memory/test_memory_adapter.py
@@ -122,6 +122,7 @@ class TestMemorySystemAdapter:
 
     @pytest.mark.medium
     @pytest.mark.slow
+    @pytest.mark.skipif(duckdb is None, reason="duckdb not installed")
     def test_init_with_duckdb_storage_succeeds(self, temp_dir, monkeypatch):
         """Test initialization with DuckDB storage.
 

--- a/tests/unit/application/memory/test_duckdb_store.py
+++ b/tests/unit/application/memory/test_duckdb_store.py
@@ -1,18 +1,22 @@
-import os
 import json
+import os
 import uuid
-import pytest
-import numpy as np
-from typing import Dict, List, Any, Optional
 from datetime import datetime, timedelta
-from devsynth.domain.models.memory import MemoryItem, MemoryType, MemoryVector
+from typing import Any, Dict, List, Optional
+
+import numpy as np
+import pytest
+
+pytest.importorskip("duckdb")
 from devsynth.application.memory.duckdb_store import DuckDBStore
+from devsynth.domain.models.memory import MemoryItem, MemoryType, MemoryVector
 from devsynth.exceptions import MemoryStoreError
+
 
 class TestDuckDBStore:
     """Tests for the DuckDBStore class.
 
-ReqID: N/A"""
+    ReqID: N/A"""
 
     @pytest.fixture
     def temp_dir(self, tmp_path):
@@ -24,86 +28,128 @@ ReqID: N/A"""
         """Create a DuckDBStore instance for testing."""
         store = DuckDBStore(temp_dir)
         yield store
-        if os.path.exists(os.path.join(temp_dir, 'memory.duckdb')):
-            os.remove(os.path.join(temp_dir, 'memory.duckdb'))
+        if os.path.exists(os.path.join(temp_dir, "memory.duckdb")):
+            os.remove(os.path.join(temp_dir, "memory.duckdb"))
 
     @pytest.mark.medium
     def test_init_succeeds(self, store, temp_dir):
         """Test initialization of DuckDBStore.
 
-ReqID: N/A"""
+        ReqID: N/A"""
         assert store.base_path == temp_dir
-        assert store.db_file == os.path.join(temp_dir, 'memory.duckdb')
+        assert store.db_file == os.path.join(temp_dir, "memory.duckdb")
         assert store.token_count == 0
 
     @pytest.mark.medium
     def test_store_and_retrieve_succeeds(self, store):
         """Test storing and retrieving a memory item.
 
-ReqID: N/A"""
-        item = MemoryItem(id='', content='Test content', memory_type=MemoryType.SHORT_TERM, metadata={'key': 'value'}, created_at=datetime.now())
+        ReqID: N/A"""
+        item = MemoryItem(
+            id="",
+            content="Test content",
+            memory_type=MemoryType.SHORT_TERM,
+            metadata={"key": "value"},
+            created_at=datetime.now(),
+        )
         item_id = store.store(item)
         assert item_id
         assert item.id == item_id
         retrieved_item = store.retrieve(item_id)
         assert retrieved_item is not None
         assert retrieved_item.id == item_id
-        assert retrieved_item.content == 'Test content'
+        assert retrieved_item.content == "Test content"
         assert retrieved_item.memory_type == MemoryType.SHORT_TERM
-        assert retrieved_item.metadata == {'key': 'value'}
+        assert retrieved_item.metadata == {"key": "value"}
         assert isinstance(retrieved_item.created_at, datetime)
 
     @pytest.mark.medium
     def test_retrieve_nonexistent_succeeds(self, store):
         """Test retrieving a nonexistent memory item.
 
-ReqID: N/A"""
-        retrieved_item = store.retrieve('nonexistent')
+        ReqID: N/A"""
+        retrieved_item = store.retrieve("nonexistent")
         assert retrieved_item is None
 
     @pytest.mark.medium
     def test_search_succeeds(self, store):
         """Test searching for memory items.
 
-ReqID: N/A"""
-        items = [MemoryItem(id='', content='Content 1', memory_type=MemoryType.SHORT_TERM, metadata={'key': 'value1', 'tag': 'test'}, created_at=datetime.now()), MemoryItem(id='', content='Content 2', memory_type=MemoryType.LONG_TERM, metadata={'key': 'value2', 'tag': 'test'}, created_at=datetime.now()), MemoryItem(id='', content='Content 3', memory_type=MemoryType.SHORT_TERM, metadata={'key': 'value3', 'tag': 'other'}, created_at=datetime.now())]
+        ReqID: N/A"""
+        items = [
+            MemoryItem(
+                id="",
+                content="Content 1",
+                memory_type=MemoryType.SHORT_TERM,
+                metadata={"key": "value1", "tag": "test"},
+                created_at=datetime.now(),
+            ),
+            MemoryItem(
+                id="",
+                content="Content 2",
+                memory_type=MemoryType.LONG_TERM,
+                metadata={"key": "value2", "tag": "test"},
+                created_at=datetime.now(),
+            ),
+            MemoryItem(
+                id="",
+                content="Content 3",
+                memory_type=MemoryType.SHORT_TERM,
+                metadata={"key": "value3", "tag": "other"},
+                created_at=datetime.now(),
+            ),
+        ]
         for item in items:
             store.store(item)
-        results = store.search({'memory_type': MemoryType.SHORT_TERM})
+        results = store.search({"memory_type": MemoryType.SHORT_TERM})
         assert len(results) == 2
         assert all((item.memory_type == MemoryType.SHORT_TERM for item in results))
-        results = store.search({'metadata.tag': 'test'})
+        results = store.search({"metadata.tag": "test"})
         assert len(results) == 2
-        assert all((item.metadata.get('tag') == 'test' for item in results))
-        results = store.search({'content': 'Content 2'})
+        assert all((item.metadata.get("tag") == "test" for item in results))
+        results = store.search({"content": "Content 2"})
         assert len(results) == 1
-        assert results[0].content == 'Content 2'
-        results = store.search({'memory_type': MemoryType.SHORT_TERM, 'metadata.tag': 'test'})
+        assert results[0].content == "Content 2"
+        results = store.search(
+            {"memory_type": MemoryType.SHORT_TERM, "metadata.tag": "test"}
+        )
         assert len(results) == 1
         assert results[0].memory_type == MemoryType.SHORT_TERM
-        assert results[0].metadata.get('tag') == 'test'
+        assert results[0].metadata.get("tag") == "test"
 
     @pytest.mark.medium
     def test_delete_succeeds(self, store):
         """Test deleting a memory item.
 
-ReqID: N/A"""
-        item = MemoryItem(id='', content='Test content', memory_type=MemoryType.SHORT_TERM, metadata={'key': 'value'}, created_at=datetime.now())
+        ReqID: N/A"""
+        item = MemoryItem(
+            id="",
+            content="Test content",
+            memory_type=MemoryType.SHORT_TERM,
+            metadata={"key": "value"},
+            created_at=datetime.now(),
+        )
         item_id = store.store(item)
         assert store.retrieve(item_id) is not None
         result = store.delete(item_id)
         assert result is True
         assert store.retrieve(item_id) is None
-        result = store.delete('nonexistent')
+        result = store.delete("nonexistent")
         assert result is False
 
     @pytest.mark.medium
     def test_token_usage_succeeds(self, store):
         """Test token usage tracking.
 
-ReqID: N/A"""
+        ReqID: N/A"""
         assert store.get_token_usage() == 0
-        item = MemoryItem(id='', content='Test content', memory_type=MemoryType.SHORT_TERM, metadata={'key': 'value'}, created_at=datetime.now())
+        item = MemoryItem(
+            id="",
+            content="Test content",
+            memory_type=MemoryType.SHORT_TERM,
+            metadata={"key": "value"},
+            created_at=datetime.now(),
+        )
         store.store(item)
         assert store.get_token_usage() > 0
         store.retrieve(item.id)
@@ -113,72 +159,118 @@ ReqID: N/A"""
     def test_persistence_succeeds(self, temp_dir):
         """Test that data persists between store instances.
 
-ReqID: N/A"""
+        ReqID: N/A"""
         store1 = DuckDBStore(temp_dir)
-        item = MemoryItem(id='', content='Test content', memory_type=MemoryType.SHORT_TERM, metadata={'key': 'value'}, created_at=datetime.now())
+        item = MemoryItem(
+            id="",
+            content="Test content",
+            memory_type=MemoryType.SHORT_TERM,
+            metadata={"key": "value"},
+            created_at=datetime.now(),
+        )
         item_id = store1.store(item)
         store2 = DuckDBStore(temp_dir)
         retrieved_item = store2.retrieve(item_id)
         assert retrieved_item is not None
         assert retrieved_item.id == item_id
-        assert retrieved_item.content == 'Test content'
+        assert retrieved_item.content == "Test content"
 
     @pytest.mark.medium
     def test_store_vector_succeeds(self, store):
         """Test storing and retrieving a vector.
 
-ReqID: N/A"""
-        vector = MemoryVector(id='', content='Test vector content', embedding=[0.1, 0.2, 0.3, 0.4, 0.5], metadata={'key': 'value'}, created_at=datetime.now())
+        ReqID: N/A"""
+        vector = MemoryVector(
+            id="",
+            content="Test vector content",
+            embedding=[0.1, 0.2, 0.3, 0.4, 0.5],
+            metadata={"key": "value"},
+            created_at=datetime.now(),
+        )
         vector_id = store.store_vector(vector)
         assert vector_id
         assert vector.id == vector_id
         retrieved_vector = store.retrieve_vector(vector_id)
         assert retrieved_vector is not None
         assert retrieved_vector.id == vector_id
-        assert retrieved_vector.content == 'Test vector content'
+        assert retrieved_vector.content == "Test vector content"
         assert len(retrieved_vector.embedding) == 5
         assert np.allclose(retrieved_vector.embedding, [0.1, 0.2, 0.3, 0.4, 0.5])
-        assert retrieved_vector.metadata == {'key': 'value'}
+        assert retrieved_vector.metadata == {"key": "value"}
         assert isinstance(retrieved_vector.created_at, datetime)
 
     @pytest.mark.medium
     def test_similarity_search_succeeds(self, store):
         """Test similarity search for vectors.
 
-ReqID: N/A"""
-        vectors = [MemoryVector(id='', content='Vector 1', embedding=[0.1, 0.2, 0.3, 0.4, 0.5], metadata={'key': 'value1'}, created_at=datetime.now()), MemoryVector(id='', content='Vector 2', embedding=[0.5, 0.4, 0.3, 0.2, 0.1], metadata={'key': 'value2'}, created_at=datetime.now()), MemoryVector(id='', content='Vector 3', embedding=[0.1, 0.1, 0.1, 0.1, 0.1], metadata={'key': 'value3'}, created_at=datetime.now())]
+        ReqID: N/A"""
+        vectors = [
+            MemoryVector(
+                id="",
+                content="Vector 1",
+                embedding=[0.1, 0.2, 0.3, 0.4, 0.5],
+                metadata={"key": "value1"},
+                created_at=datetime.now(),
+            ),
+            MemoryVector(
+                id="",
+                content="Vector 2",
+                embedding=[0.5, 0.4, 0.3, 0.2, 0.1],
+                metadata={"key": "value2"},
+                created_at=datetime.now(),
+            ),
+            MemoryVector(
+                id="",
+                content="Vector 3",
+                embedding=[0.1, 0.1, 0.1, 0.1, 0.1],
+                metadata={"key": "value3"},
+                created_at=datetime.now(),
+            ),
+        ]
         for vector in vectors:
             store.store_vector(vector)
         query_embedding = [0.1, 0.2, 0.3, 0.4, 0.5]
         results = store.similarity_search(query_embedding, top_k=2)
         assert len(results) == 2
-        assert results[0].content == 'Vector 1'
-        assert results[1].content in ['Vector 2', 'Vector 3']
+        assert results[0].content == "Vector 1"
+        assert results[1].content in ["Vector 2", "Vector 3"]
 
     @pytest.mark.medium
     def test_delete_vector_succeeds(self, store):
         """Test deleting a vector.
 
-ReqID: N/A"""
-        vector = MemoryVector(id='', content='Test vector content', embedding=[0.1, 0.2, 0.3, 0.4, 0.5], metadata={'key': 'value'}, created_at=datetime.now())
+        ReqID: N/A"""
+        vector = MemoryVector(
+            id="",
+            content="Test vector content",
+            embedding=[0.1, 0.2, 0.3, 0.4, 0.5],
+            metadata={"key": "value"},
+            created_at=datetime.now(),
+        )
         vector_id = store.store_vector(vector)
         assert store.retrieve_vector(vector_id) is not None
         result = store.delete_vector(vector_id)
         assert result is True
         assert store.retrieve_vector(vector_id) is None
-        result = store.delete_vector('nonexistent')
+        result = store.delete_vector("nonexistent")
         assert result is False
 
     @pytest.mark.medium
     def test_get_collection_stats_succeeds(self, store):
         """Test getting collection statistics.
 
-ReqID: N/A"""
+        ReqID: N/A"""
         stats = store.get_collection_stats()
-        assert stats['num_vectors'] == 0
+        assert stats["num_vectors"] == 0
         for i in range(3):
-            vector = MemoryVector(id='', content=f'Vector {i}', embedding=[0.1, 0.2, 0.3, 0.4, 0.5], metadata={'index': i}, created_at=datetime.now())
+            vector = MemoryVector(
+                id="",
+                content=f"Vector {i}",
+                embedding=[0.1, 0.2, 0.3, 0.4, 0.5],
+                metadata={"index": i},
+                created_at=datetime.now(),
+            )
             store.store_vector(vector)
         stats = store.get_collection_stats()
-        assert stats['num_vectors'] == 3
-        assert stats['embedding_dimension'] == 5
+        assert stats["num_vectors"] == 3
+        assert stats["embedding_dimension"] == 5

--- a/tests/unit/application/memory/test_duckdb_store_hnsw.py
+++ b/tests/unit/application/memory/test_duckdb_store_hnsw.py
@@ -1,20 +1,24 @@
-import os
 import json
-import uuid
-import pytest
-import numpy as np
+import os
 import time
-from typing import Dict, List, Any, Optional
+import uuid
 from datetime import datetime, timedelta
-from unittest.mock import patch, MagicMock
-from devsynth.domain.models.memory import MemoryItem, MemoryType, MemoryVector
+from typing import Any, Dict, List, Optional
+from unittest.mock import MagicMock, patch
+
+import numpy as np
+import pytest
+
+pytest.importorskip("duckdb")
 from devsynth.application.memory.duckdb_store import DuckDBStore
+from devsynth.domain.models.memory import MemoryItem, MemoryType, MemoryVector
 from devsynth.exceptions import MemoryStoreError
+
 
 class TestDuckDBStoreHNSW:
     """Tests for the DuckDBStore class with HNSW index functionality.
 
-ReqID: N/A"""
+    ReqID: N/A"""
 
     @pytest.fixture
     def temp_dir(self, tmp_path):
@@ -26,68 +30,94 @@ ReqID: N/A"""
         """Create a DuckDBStore instance for testing."""
         store = DuckDBStore(temp_dir)
         yield store
-        if os.path.exists(os.path.join(temp_dir, 'memory.duckdb')):
-            os.remove(os.path.join(temp_dir, 'memory.duckdb'))
+        if os.path.exists(os.path.join(temp_dir, "memory.duckdb")):
+            os.remove(os.path.join(temp_dir, "memory.duckdb"))
 
     @pytest.fixture
     def store_with_hnsw(self, temp_dir):
         """Create a DuckDBStore instance with HNSW index enabled."""
         store = DuckDBStore(temp_dir, enable_hnsw=True)
         yield store
-        if os.path.exists(os.path.join(temp_dir, 'memory.duckdb')):
-            os.remove(os.path.join(temp_dir, 'memory.duckdb'))
+        if os.path.exists(os.path.join(temp_dir, "memory.duckdb")):
+            os.remove(os.path.join(temp_dir, "memory.duckdb"))
 
     @pytest.fixture
     def store_with_custom_hnsw(self, temp_dir):
         """Create a DuckDBStore instance with custom HNSW parameters."""
-        store = DuckDBStore(temp_dir, enable_hnsw=True, hnsw_config={'M': 16, 'efConstruction': 200, 'efSearch': 100})
+        store = DuckDBStore(
+            temp_dir,
+            enable_hnsw=True,
+            hnsw_config={"M": 16, "efConstruction": 200, "efSearch": 100},
+        )
         yield store
-        if os.path.exists(os.path.join(temp_dir, 'memory.duckdb')):
-            os.remove(os.path.join(temp_dir, 'memory.duckdb'))
+        if os.path.exists(os.path.join(temp_dir, "memory.duckdb")):
+            os.remove(os.path.join(temp_dir, "memory.duckdb"))
 
     @pytest.mark.medium
     def test_hnsw_initialization_succeeds(self, store_with_hnsw):
         """Test initialization of DuckDBStore with HNSW index enabled.
 
-ReqID: N/A"""
+        ReqID: N/A"""
         assert store_with_hnsw.enable_hnsw is True
-        assert store_with_hnsw.hnsw_config == {'M': 12, 'efConstruction': 100, 'efSearch': 50}
+        assert store_with_hnsw.hnsw_config == {
+            "M": 12,
+            "efConstruction": 100,
+            "efSearch": 50,
+        }
 
     @pytest.mark.medium
     def test_custom_hnsw_initialization_succeeds(self, store_with_custom_hnsw):
         """Test initialization of DuckDBStore with custom HNSW parameters.
 
-ReqID: N/A"""
+        ReqID: N/A"""
         assert store_with_custom_hnsw.enable_hnsw is True
-        assert store_with_custom_hnsw.hnsw_config == {'M': 16, 'efConstruction': 200, 'efSearch': 100}
+        assert store_with_custom_hnsw.hnsw_config == {
+            "M": 16,
+            "efConstruction": 200,
+            "efSearch": 100,
+        }
 
     @pytest.mark.medium
-    @patch('duckdb.connect')
+    @patch("duckdb.connect")
     def test_hnsw_index_creation_succeeds(self, mock_connect, temp_dir):
         """Test that HNSW index is created when storing vectors.
 
-ReqID: N/A"""
+        ReqID: N/A"""
         mock_conn = MagicMock()
         mock_result = MagicMock()
-        mock_result.fetchall.return_value = [('memory_vectors_hnsw_idx', 'hnsw', 'memory_vectors', 'embedding')]
+        mock_result.fetchall.return_value = [
+            ("memory_vectors_hnsw_idx", "hnsw", "memory_vectors", "embedding")
+        ]
         mock_conn.execute.return_value = mock_result
         mock_connect.return_value = mock_conn
         store = DuckDBStore(temp_dir, enable_hnsw=True)
         store.vector_extension_available = True
         for i in range(10):
-            vector = MemoryVector(id='', content=f'Vector {i}', embedding=np.random.rand(5).tolist(), metadata={'index': i})
+            vector = MemoryVector(
+                id="",
+                content=f"Vector {i}",
+                embedding=np.random.rand(5).tolist(),
+                metadata={"index": i},
+            )
             store.store_vector(vector)
-        result = store.conn.execute("\n            SELECT * FROM duckdb_indexes()\n            WHERE index_type = 'hnsw'\n        ").fetchall()
-        assert len(result) > 0, 'HNSW index was not created'
+        result = store.conn.execute(
+            "\n            SELECT * FROM duckdb_indexes()\n            WHERE index_type = 'hnsw'\n        "
+        ).fetchall()
+        assert len(result) > 0, "HNSW index was not created"
 
     @pytest.mark.medium
     def test_similarity_search_with_hnsw_succeeds(self, store_with_hnsw):
         """Test similarity search with HNSW index.
 
-ReqID: N/A"""
+        ReqID: N/A"""
         vectors = []
         for i in range(100):
-            vector = MemoryVector(id='', content=f'Vector {i}', embedding=np.random.rand(5).tolist(), metadata={'index': i})
+            vector = MemoryVector(
+                id="",
+                content=f"Vector {i}",
+                embedding=np.random.rand(5).tolist(),
+                metadata={"index": i},
+            )
             vector_id = store_with_hnsw.store_vector(vector)
             vectors.append((vector_id, vector.embedding))
         query_embedding = vectors[0][1]
@@ -96,11 +126,13 @@ ReqID: N/A"""
         assert results[0].id == vectors[0][0]
 
     @pytest.mark.medium
-    @patch('duckdb.connect')
-    def test_similarity_search_performance_comparison_succeeds(self, mock_connect, temp_dir):
+    @patch("duckdb.connect")
+    def test_similarity_search_performance_comparison_succeeds(
+        self, mock_connect, temp_dir
+    ):
         """Compare performance of similarity search with and without HNSW index.
 
-ReqID: N/A"""
+        ReqID: N/A"""
         mock_conn_without_hnsw = MagicMock()
         mock_conn_with_hnsw = MagicMock()
 
@@ -109,22 +141,33 @@ ReqID: N/A"""
             results = []
             for i in range(5):
                 distance = 0.1 * (i + 1) * (0.9 if with_hnsw else 1.0)
-                results.append((f'id_{i}', f'Vector {i}', [0.1, 0.2, 0.3, 0.4, 0.5], json.dumps({'index': i}), datetime.now().isoformat(), distance))
+                results.append(
+                    (
+                        f"id_{i}",
+                        f"Vector {i}",
+                        [0.1, 0.2, 0.3, 0.4, 0.5],
+                        json.dumps({"index": i}),
+                        datetime.now().isoformat(),
+                        distance,
+                    )
+                )
             mock_result.fetchall.return_value = results
             return mock_result
 
         def mock_execute_side_effect(query, *args, **kwargs):
-            if 'duckdb_indexes()' in query and "index_type = 'hnsw'" in query:
+            if "duckdb_indexes()" in query and "index_type = 'hnsw'" in query:
                 result = MagicMock()
-                result.fetchall.return_value = [('memory_vectors_hnsw_idx', 'hnsw', 'memory_vectors', 'embedding')]
+                result.fetchall.return_value = [
+                    ("memory_vectors_hnsw_idx", "hnsw", "memory_vectors", "embedding")
+                ]
                 return result
-            elif 'vector_distance' in query:
+            elif "vector_distance" in query:
                 return create_mock_result(with_hnsw=True)
-            elif 'SELECT embedding FROM memory_vectors LIMIT 1' in query:
+            elif "SELECT embedding FROM memory_vectors LIMIT 1" in query:
                 result = MagicMock()
                 result.fetchone.return_value = [[0.1, 0.2, 0.3, 0.4, 0.5]]
                 return result
-            elif 'SELECT COUNT(*) FROM memory_vectors' in query:
+            elif "SELECT COUNT(*) FROM memory_vectors" in query:
                 result = MagicMock()
                 result.fetchone.return_value = [10]
                 return result
@@ -133,29 +176,38 @@ ReqID: N/A"""
                 result.fetchall.return_value = []
                 result.fetchone.return_value = None
                 return result
+
         mock_conn_without_hnsw.execute.side_effect = mock_execute_side_effect
         mock_conn_with_hnsw.execute.side_effect = mock_execute_side_effect
-        mock_connect.side_effect = lambda db_file: mock_conn_with_hnsw if 'hnsw' in db_file else mock_conn_without_hnsw
-        store_without_hnsw = DuckDBStore(os.path.join(temp_dir, 'without_hnsw'))
-        store_with_hnsw = DuckDBStore(os.path.join(temp_dir, 'with_hnsw'), enable_hnsw=True)
+        mock_connect.side_effect = lambda db_file: (
+            mock_conn_with_hnsw if "hnsw" in db_file else mock_conn_without_hnsw
+        )
+        store_without_hnsw = DuckDBStore(os.path.join(temp_dir, "without_hnsw"))
+        store_with_hnsw = DuckDBStore(
+            os.path.join(temp_dir, "with_hnsw"), enable_hnsw=True
+        )
         store_without_hnsw.vector_extension_available = True
         store_with_hnsw.vector_extension_available = True
         vectors = []
         for i in range(10):
             embedding = np.random.rand(5).tolist()
-            vector = MemoryVector(id='', content=f'Vector {i}', embedding=embedding, metadata={'index': i})
+            vector = MemoryVector(
+                id="", content=f"Vector {i}", embedding=embedding, metadata={"index": i}
+            )
             store_without_hnsw.store_vector(vector)
             vector_id = store_with_hnsw.store_vector(vector)
             if i == 0:
                 vectors.append((vector_id, embedding))
         query_embedding = vectors[0][1]
         start_time = time.time()
-        results_without_hnsw = store_without_hnsw.similarity_search(query_embedding, top_k=5)
+        results_without_hnsw = store_without_hnsw.similarity_search(
+            query_embedding, top_k=5
+        )
         time_without_hnsw = time.time() - start_time
         start_time = time.time()
         results_with_hnsw = store_with_hnsw.similarity_search(query_embedding, top_k=5)
         time_with_hnsw = time.time() - start_time
         assert len(results_without_hnsw) == len(results_with_hnsw)
-        print(f'Time without HNSW: {time_without_hnsw:.6f}s')
-        print(f'Time with HNSW: {time_with_hnsw:.6f}s')
-        print(f'Speedup: {time_without_hnsw / time_with_hnsw:.2f}x')
+        print(f"Time without HNSW: {time_without_hnsw:.6f}s")
+        print(f"Time with HNSW: {time_with_hnsw:.6f}s")
+        print(f"Speedup: {time_without_hnsw / time_with_hnsw:.2f}x")

--- a/tests/unit/application/memory/test_import_without_duckdb.py
+++ b/tests/unit/application/memory/test_import_without_duckdb.py
@@ -1,19 +1,24 @@
 import builtins
 import importlib
 import sys
+
 import pytest
 
+
 @pytest.mark.medium
-def test_import_duckdb_store_without_duckdb_fails(monkeypatch):
-    """Importing DuckDBStore should raise ImportError when duckdb is missing."""
-    sys.modules.pop('devsynth.application.memory.duckdb_store', None)
-    sys.modules.pop('duckdb', None)
+def test_init_duckdb_store_without_duckdb_fails(monkeypatch, tmp_path):
+    """DuckDBStore initialization should fail when duckdb is missing."""
+    sys.modules.pop("devsynth.application.memory.duckdb_store", None)
+    sys.modules.pop("duckdb", None)
     real_import = builtins.__import__
 
     def fake_import(name, globals=None, locals=None, fromlist=(), level=0):
-        if name == 'duckdb':
+        if name == "duckdb":
             raise ImportError("No module named 'duckdb'")
         return real_import(name, globals, locals, fromlist, level)
-    monkeypatch.setattr(builtins, '__import__', fake_import)
-    with pytest.raises(ImportError, match='duckdb'):
-        importlib.import_module('devsynth.application.memory.duckdb_store')
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+    module = importlib.import_module("devsynth.application.memory.duckdb_store")
+    module.DuckDBStore.__abstractmethods__ = frozenset()
+    with pytest.raises(ImportError, match="duckdb"):
+        module.DuckDBStore(str(tmp_path))


### PR DESCRIPTION
## Summary
- guard duckdb import in memory store so the module loads even when duckdb isn't installed
- gracefully skip duckdb tests when the dependency is missing
- add coverage for failing initialization when duckdb absent

## Testing
- `poetry run pytest tests/unit/application/memory/test_duckdb_store.py -q --no-cov`
- `poetry run pytest tests/unit/application/memory/test_duckdb_store_hnsw.py -q --no-cov`
- `poetry run pytest tests/unit/application/memory/test_import_without_duckdb.py -q --no-cov`
- `poetry run pytest tests/unit/adapters/cli/test_typer_adapter.py::test_run_cli_succeeds -q --no-cov`
- `poetry run pre-commit run --files src/devsynth/application/memory/duckdb_store.py tests/unit/adapters/memory/test_memory_adapter.py tests/unit/application/memory/test_duckdb_store.py tests/unit/application/memory/test_duckdb_store_hnsw.py tests/unit/application/memory/test_import_without_duckdb.py`
- `poetry run devsynth run-tests` *(fails: PluggyTeardownRaisedWarning)*
- `poetry run python tests/verify_test_organization.py`


------
https://chatgpt.com/codex/tasks/task_e_689a2a8009b4833398ed4a3068c97eed