### PR TITLE
docs: add 0.1.0-alpha.1 release notes

### DIFF
--- a/docs/release/0.1.0-alpha.1.md
+++ b/docs/release/0.1.0-alpha.1.md
@@ -1,0 +1,31 @@
+# DevSynth 0.1.0-alpha.1
+
+## Setup
+
+1. Run the environment provisioning script:
+   ```bash
+   scripts/codex_setup.sh
+   ```
+2. Install dependencies with development and test extras:
+   ```bash
+   poetry install --with dev --extras "tests retrieval chromadb api"
+   ```
+3. Execute repository checks:
+   ```bash
+   poetry run pre-commit run --files <changed>
+   poetry run devsynth run-tests
+   poetry run python tests/verify_test_organization.py
+   ```
+
+## Green Criteria
+
+- All CI workflows pass.
+- `PIP_NO_INDEX=1 poetry run pip check` succeeds in offline mode.
+- `poetry run devsynth run-tests` completes without unexpected failures.
+
+## Known P1 Issues and Test Gaps
+
+- WSDE/EDRR integration suites fail ([Issue 112](../../issues/112.md)).
+- Kuzu-backed memory store fails to initialise during tests ([Issue 113](../../issues/113.md)).
+- Requirements wizard logging and persistence errors break integration tests ([Issue 114](../../issues/114.md)).
+- Full test suite terminates early with multiple unit failures ([Issue 116](../../issues/116.md)).


### PR DESCRIPTION
## Summary
- document release 0.1.0-alpha.1 setup steps, green criteria, and open P1 issues

## Testing
- `poetry run pre-commit run --files docs/release/0.1.0-alpha.1.md`
- `poetry run devsynth run-tests` *(fails: KeyError: <WorkerController gw3>)*
- `poetry run python tests/verify_test_organization.py`
- `PIP_NO_INDEX=1 poetry run pip check`


------
https://chatgpt.com/codex/tasks/task_e_689a339b33648333aa5ac27c2f995c59