### PR TITLE
test: trim memory-hungry test fixtures

### DIFF
--- a/tests/integration/general/test_graph_memory_error_handling.py
+++ b/tests/integration/general/test_graph_memory_error_handling.py
@@ -12,7 +12,8 @@ from devsynth.application.memory.adapters.graph_memory_adapter import GraphMemor
 from devsynth.domain.models.memory import MemoryItem, MemoryType
 from devsynth.exceptions import MemoryItemNotFoundError, MemoryStoreError
 
-pytestmark = pytest.mark.memory_intensive
+# Mark the entire module as medium speed; only specific tests are memory intensive
+pytestmark = pytest.mark.medium
 
 
 class TestGraphMemoryErrorHandling:
@@ -142,13 +143,14 @@ class TestGraphMemoryErrorHandling:
         assert retrieved_item is not None
         assert retrieved_item.content == memory_item.content
 
-    @pytest.mark.medium
+    @pytest.mark.slow
     @pytest.mark.memory_intensive
     def test_store_with_very_large_content_succeeds(self, graph_adapter):
         """Test storing a memory item with very large content.
 
         ReqID: N/A"""
-        large_content = "x" * 1000000
+        # Use a reduced payload to avoid excessive memory usage
+        large_content = "x" * 10000
         memory_item = MemoryItem(
             id="test-id",
             content=large_content,

--- a/tests/unit/adapters/memory/test_memory_adapter.py
+++ b/tests/unit/adapters/memory/test_memory_adapter.py
@@ -89,7 +89,8 @@ class TestMemorySystemAdapter:
         config = {
             "memory_store_type": "file",
             "memory_file_path": temp_dir,
-            "max_context_size": 1000,
+            # Use a small context size to keep memory usage low during tests
+            "max_context_size": 10,
             "context_expiration_days": 1,
             "vector_store_enabled": False,
         }
@@ -109,7 +110,8 @@ class TestMemorySystemAdapter:
         config = {
             "memory_store_type": "tinydb",
             "memory_file_path": temp_dir,
-            "max_context_size": 1000,
+            # Smaller context prevents large preallocation during TinyDB tests
+            "max_context_size": 10,
             "context_expiration_days": 1,
             "vector_store_enabled": False,
         }
@@ -146,7 +148,8 @@ class TestMemorySystemAdapter:
             config = {
                 "memory_store_type": "duckdb",
                 "memory_file_path": temp_dir,
-                "max_context_size": 1000,
+                # Minimize context to reduce memory footprint in DuckDB tests
+                "max_context_size": 10,
                 "context_expiration_days": 1,
                 "vector_store_enabled": True,
             }
@@ -168,7 +171,8 @@ class TestMemorySystemAdapter:
         config = {
             "memory_store_type": "lmdb",
             "memory_file_path": temp_dir,
-            "max_context_size": 1000,
+            # Small context size keeps tests lightweight
+            "max_context_size": 10,
             "context_expiration_days": 1,
             "vector_store_enabled": False,
         }
@@ -191,7 +195,8 @@ class TestMemorySystemAdapter:
         config = {
             "memory_store_type": "kuzu",
             "memory_file_path": temp_dir,
-            "max_context_size": 1000,
+            # Limit context size for lightweight RDFLib tests
+            "max_context_size": 10,
             "context_expiration_days": 1,
             "vector_store_enabled": True,
         }
@@ -215,7 +220,8 @@ class TestMemorySystemAdapter:
         config = {
             "memory_store_type": "faiss",
             "memory_file_path": temp_dir,
-            "max_context_size": 1000,
+            # Ensure minimal context allocation for vector store tests
+            "max_context_size": 10,
             "context_expiration_days": 1,
             "vector_store_enabled": True,
         }
@@ -241,7 +247,8 @@ class TestMemorySystemAdapter:
             config = {
                 "memory_store_type": "faiss",
                 "memory_file_path": temp_dir,
-                "max_context_size": 1000,
+                # Reduce context size to avoid large in-memory structures
+                "max_context_size": 10,
                 "context_expiration_days": 1,
                 "vector_store_enabled": True,
             }
@@ -283,7 +290,8 @@ class TestMemorySystemAdapter:
             config = {
                 "memory_store_type": "faiss",
                 "memory_file_path": temp_dir,
-                "max_context_size": 1000,
+                # Keep context small for Kuzu adapter tests
+                "max_context_size": 10,
                 "context_expiration_days": 1,
                 "vector_store_enabled": True,
             }
@@ -325,7 +333,8 @@ class TestMemorySystemAdapter:
         config = {
             "memory_store_type": "rdflib",
             "memory_file_path": temp_dir,
-            "max_context_size": 1000,
+            # Smaller context suffices for in-memory store tests
+            "max_context_size": 10,
             "context_expiration_days": 1,
             "vector_store_enabled": True,
         }

--- a/tests/unit/adapters/memory/test_memory_adapter_transactions.py
+++ b/tests/unit/adapters/memory/test_memory_adapter_transactions.py
@@ -16,7 +16,8 @@ def _import_adapter():
             get_settings=lambda: types.SimpleNamespace(
                 memory_store_type="file",
                 memory_file_path="/tmp",
-                max_context_size=100,
+                # Keep test lightweight by restricting context size
+                max_context_size=10,
                 context_expiration_days=1,
                 vector_store_enabled=False,
                 provider_type=None,


### PR DESCRIPTION
## Summary
- shrink memory adapter contexts to tiny sizes
- limit transaction fixture context to keep tests lightweight
- reduce graph memory payload and mark only one test as memory intensive

## Testing
- `poetry run pytest --maxfail=1 tests/unit/adapters/memory/test_memory_adapter.py tests/unit/adapters/memory/test_memory_adapter_transactions.py tests/integration/general/test_graph_memory_error_handling.py`
- `poetry run pre-commit run --files tests/unit/adapters/memory/test_memory_adapter.py tests/unit/adapters/memory/test_memory_adapter_transactions.py tests/integration/general/test_graph_memory_error_handling.py`
- `poetry run devsynth run-tests` *(fails: Plugin raised PluggyTeardownRaisedWarning)*
- `poetry run python tests/verify_test_organization.py`


------
https://chatgpt.com/codex/tasks/task_e_689a6727214c8333bde4dc1a32ac4c27