### PR TITLE
Ensure retrospective flushes memory

### DIFF
--- a/src/devsynth/agents/wsde_team_coordinator.py
+++ b/src/devsynth/agents/wsde_team_coordinator.py
@@ -42,17 +42,19 @@ class WSDETeamCoordinatorAgent:
             aggregated["action_items"].extend(item.get("action_items", []))
 
         summary = map_retrospective_to_summary(aggregated, sprint)
+
         if hasattr(self._team, "record_retrospective"):
             self._team.record_retrospective(summary)
-            memory_manager = getattr(self._team, "memory_manager", None)
-            if memory_manager and hasattr(memory_manager, "flush_updates"):
-                try:
-                    memory_manager.flush_updates()
-                except Exception:  # pragma: no cover - defensive
-                    logger.debug(
-                        "Memory synchronization failed during retrospective",
-                        exc_info=True,
-                    )
         else:  # pragma: no cover - defensive
             logger.debug("Team object lacks 'record_retrospective' method")
+
+        memory_manager = getattr(self._team, "memory_manager", None)
+        if memory_manager and hasattr(memory_manager, "flush_updates"):
+            try:
+                memory_manager.flush_updates()
+            except Exception:  # pragma: no cover - defensive
+                logger.debug(
+                    "Memory synchronization failed during retrospective",
+                    exc_info=True,
+                )
         return summary


### PR DESCRIPTION
## Summary
- add regression test for pending memory flush without record method
- ensure WSDE team coordinator flushes memory regardless of record_retrospective

## Testing
- `poetry run pytest tests/integration/general/test_wsde_edrr_component_interactions.py -q`
- `poetry run pytest tests/integration/general/test_wsde_edrr_integration_end_to_end.py -q`
- `poetry run pytest tests/integration/general/test_wsde_edrr_integration_advanced.py -q`
- `poetry run pytest tests/integration/general/test_wsde_memory_edrr_integration.py -q`
- `poetry run pre-commit run --files tests/integration/general/test_wsde_edrr_component_interactions.py src/devsynth/agents/wsde_team_coordinator.py`
- `poetry run devsynth run-tests` (failed: KeyError <WorkerController gw4>)
- `poetry run python tests/verify_test_organization.py`


------
https://chatgpt.com/codex/tasks/task_e_689a79086a9883338e797d59a0e5b362