### PR TITLE
feat: dynamically cache optional extras

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,7 +10,7 @@ DevSynth values clarity, collaboration, and dependable automation. Keep these pr
 - Pytest markers such as `memory_intensive` gate resource-heavy tests; skip them unless specifically required.
 - Run `scripts/codex_setup.sh` before beginning any development to provision the environment. Update the script as appropriate and according to best practices.
 - References to this file or `scripts/codex_setup.sh` must not appear elsewhere in the repository. Outside these files, refer to it generically as the environment provisioning script.
-- Keep optional extras in `pyproject.toml` synchronized with the cache list in `scripts/codex_setup.sh` so offline setups remain reproducible.
+- Optional extras in `pyproject.toml` are automatically cached by the environment provisioning script, keeping them synchronized with the project configuration while skipping heavy GPU packages.
 - Update this file, your instructions and initial context, as appropriate and according to best-practices.
 - Documents in `docs/inspirational_docs/` are for inspiration only and must not be directly referenced; use these documents for inspiration.
 - Documents in `docs/external_research_papers/` are copies of academic papers and can be referenced using best-practices.


### PR DESCRIPTION
## Summary
- automatically sync optional extras from `pyproject.toml` when caching dependencies
- note automatic extras caching in contributor guidance

## Testing
- `bash scripts/codex_setup.sh`
- `poetry run pre-commit run --files AGENTS.md scripts/codex_setup.sh`
- `poetry run devsynth run-tests --speed=fast` *(fails: Benchmarks are automatically disabled because xdist plugin is active)*
- `poetry run python tests/verify_test_organization.py`


------
https://chatgpt.com/codex/tasks/task_e_689a867be41883339fe4a34f48d5e1df