### PR TITLE
docs: clarify environment provisioning script reference

### DIFF
--- a/docs/release/0.1.0-alpha.1.md
+++ b/docs/release/0.1.0-alpha.1.md
@@ -4,7 +4,7 @@
 
 1. Run the environment provisioning script:
    ```bash
-   scripts/codex_setup.sh
+   the environment provisioning script
    ```
 2. Install dependencies with development and test extras:
    ```bash


### PR DESCRIPTION
## Summary
- refer to `codex_setup.sh` generically as the environment provisioning script in release notes

## Testing
- `poetry run pre-commit run --files docs/release/0.1.0-alpha.1.md`
- `poetry run devsynth run-tests --speed fast` *(fails: Benchmarks disabled; tests failed)*
- `poetry run python tests/verify_test_organization.py`


------
https://chatgpt.com/codex/tasks/task_e_689a86597ca48333a4d9c39bbbaf85d2