### PR TITLE
Fix logging exc_info handling and add requirements coverage

### DIFF
--- a/src/devsynth/logging_setup.py
+++ b/src/devsynth/logging_setup.py
@@ -380,10 +380,13 @@ class DevSynthLogger:
         stacklevel = kwargs.pop("stacklevel", None)
         extra = kwargs.pop("extra", None)
 
-        if isinstance(exc, BaseException):
-            exc = (exc.__class__, exc, exc.__traceback__)
-        elif exc is True:
-            exc = sys.exc_info()
+        if exc:
+            if isinstance(exc, BaseException):
+                exc = (exc.__class__, exc, exc.__traceback__)
+            elif exc is True:
+                exc = sys.exc_info()
+            elif not isinstance(exc, tuple):
+                exc = sys.exc_info()
 
         if kwargs:
             RESERVED = {

--- a/tests/integration/general/test_requirements_gathering.py
+++ b/tests/integration/general/test_requirements_gathering.py
@@ -1,17 +1,22 @@
 import json
+import logging
 import os
 
 import pytest
 import yaml
+from _pytest.logging import LogCaptureHandler
 
 # ``json`` is used to verify the wizard's output file contents
 
 # Ensures gather_requirements persists priority, goals, and constraints
 pytestmark = pytest.mark.usefixtures("stub_optional_deps")
 
+from devsynth.application.cli import requirements_commands as rc
 from devsynth.application.cli.config import CLIConfig
+from devsynth.application.cli.errors import handle_error
 from devsynth.application.cli.requirements_wizard import requirements_wizard
 from devsynth.application.requirements.interactions import gather_requirements
+from devsynth.logging_setup import configure_logging
 
 
 def test_gather_updates_config_succeeds(tmp_path, monkeypatch):
@@ -98,3 +103,72 @@ def test_requirements_wizard_persists_priority_succeeds(tmp_path, monkeypatch):
     cfg = yaml.safe_load(open(cfg_path, encoding="utf-8"))
     assert cfg.get("priority") == "high"
     assert cfg.get("constraints") == "c1,c2"
+
+
+def test_requirements_wizard_backtracks_priority_succeeds(tmp_path, monkeypatch):
+    """Priority persists when navigating back and changing choices."""
+    os.chdir(tmp_path)
+    monkeypatch.setenv("DEVSYNTH_PROJECT_DIR", str(tmp_path))
+    answers = [
+        "Title",  # title
+        "Desc",  # description
+        "functional",  # type
+        "low",  # initial priority
+        "back",  # go back from constraints to priority
+        "high",  # updated priority
+        "c1",  # constraints
+    ]
+
+    class Bridge:
+        def __init__(self):
+            self.i = 0
+
+        def ask_question(self, *a, **k):
+            val = answers[self.i]
+            self.i += 1
+            return val
+
+        def display_result(self, *a, **k):  # pragma: no cover - no output
+            pass
+
+    bridge = Bridge()
+    output = tmp_path / "requirements_wizard_back.json"
+    requirements_wizard(bridge, output_file=str(output), config=CLIConfig())
+    data = json.load(open(output, encoding="utf-8"))
+    assert data["priority"] == "high"
+
+    cfg_path = tmp_path / ".devsynth" / "project.yaml"
+    cfg = yaml.safe_load(open(cfg_path, encoding="utf-8"))
+    assert cfg.get("priority") == "high"
+
+
+def test_gather_cmd_logging_exc_info_succeeds(tmp_path, monkeypatch):
+    """gather_requirements_cmd logs exceptions without crashing."""
+    os.chdir(tmp_path)
+    monkeypatch.setenv("DEVSYNTH_PROJECT_DIR", str(tmp_path))
+    monkeypatch.setenv("DEVSYNTH_NO_FILE_LOGGING", "1")
+    configure_logging(create_dir=False)
+    handler = LogCaptureHandler()
+    logging.getLogger().addHandler(handler)
+
+    def boom(*_a, **_k):
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr("devsynth.core.workflows.gather_requirements", boom)
+
+    class Bridge:
+        def display_result(self, *_a, **_k):  # pragma: no cover - no output
+            pass
+
+        def handle_error(self, *_a, **_k):  # pragma: no cover - no output
+            pass
+
+    bridge = Bridge()
+    try:
+        rc.gather_requirements_cmd(bridge=bridge)
+    except RuntimeError as err:
+        handle_error(bridge, err)
+
+    logging.getLogger().removeHandler(handler)
+    record = next(rec for rec in handler.records if rec.exc_info)
+    assert record.exc_info[0] is RuntimeError


### PR DESCRIPTION
## Summary
- safely normalize `exc_info` in `DevSynthLogger` to prevent logging crashes
- extend requirements gathering tests to cover priority backtracking and exc_info logging

## Testing
- `poetry run pytest tests/integration/general/test_requirements_gathering.py -q`
- `poetry run devsynth run-tests` *(fails: KeyError: <WorkerController gw4>)*
- `poetry run python tests/verify_test_organization.py`


------
https://chatgpt.com/codex/tasks/task_e_689a8648c1bc833394af87361b732ed8