### PR TITLE
Ensure kuzu settings are exported for tests

### DIFF
--- a/src/devsynth/config/settings.py
+++ b/src/devsynth/config/settings.py
@@ -823,6 +823,7 @@ __all__ = [
     "is_devsynth_managed_project",
     "ensure_path_exists",
     "DEFAULT_KUZU_EMBEDDED",
+    "kuzu_db_path",
     "kuzu_embedded",
     "KUZU_EMBEDDED",
 ]


### PR DESCRIPTION
## Summary
- expose `kuzu_db_path` via `devsynth.config.settings.__all__`
- add integration test confirming `settings.kuzu_embedded` export and reset of state
- refresh settings during ephemeral store cleanup test

## Testing
- `poetry run pre-commit run --files src/devsynth/config/settings.py tests/integration/general/test_kuzu_memory_integration.py`
- `poetry run pytest tests/integration/general/test_kuzu_memory_integration.py`
- `poetry run devsynth run-tests` *(fails: KeyError <WorkerController gw1>)*
- `poetry run python tests/verify_test_organization.py`


------
https://chatgpt.com/codex/tasks/task_e_689a85ff1764833388506eda675088b7