### PR TITLE
test: add memory adapter and CLI flag scenarios

### DIFF
--- a/src/devsynth/adapters/memory/memory_adapter.py
+++ b/src/devsynth/adapters/memory/memory_adapter.py
@@ -415,6 +415,13 @@ class MemorySystemAdapter:
             raise ValueError("Memory store is not initialized")
         return self.memory_store.store(memory_item)
 
+    def write(self, memory_item: Any) -> str:
+        """Write a memory item to the underlying store.
+
+        This is a convenience wrapper around ``store`` used by tests.
+        """
+        return self.store(memory_item)
+
     def query_by_type(self, memory_type: Any) -> List[Any]:
         """
         Query memory items by type.
@@ -510,6 +517,13 @@ class MemorySystemAdapter:
         if self.memory_store is None:
             raise ValueError("Memory store is not initialized")
         return self.memory_store.retrieve(item_id)
+
+    def read(self, item_id: str) -> Any:
+        """Read a memory item from the underlying store.
+
+        This mirrors ``retrieve`` to provide a symmetric API for tests.
+        """
+        return self.retrieve(item_id)
 
     def get_all(self) -> List[Any]:
         """

--- a/tests/behavior/features/general/ingest_command.feature
+++ b/tests/behavior/features/general/ingest_command.feature
@@ -29,3 +29,13 @@ Feature: Ingest Command
     When I run the command "devsynth ingest non_existent_manifest.yaml"
     Then the command should fail
     And the system should display an error message indicating the file does not exist
+
+  Scenario: Ingest a project in non-interactive mode
+    When I run the command "devsynth ingest manifest.yaml --non-interactive"
+    Then the command should execute successfully
+    And the ingest command should run in non-interactive mode
+
+  Scenario: Ingest a project using defaults
+    When I run the command "devsynth ingest manifest.yaml --defaults"
+    Then the command should execute successfully
+    And the ingest command should apply defaults and run non-interactively

--- a/tests/behavior/features/memory/memory_operations.feature
+++ b/tests/behavior/features/memory/memory_operations.feature
@@ -1,0 +1,6 @@
+Feature: Memory adapter read and write operations
+  Scenario: Store and retrieve a memory item
+    Given a memory system adapter
+    When I write "test content" to memory
+    And I read the item from memory
+    Then the retrieved content should be "test content"

--- a/tests/behavior/steps/test_ingest_command_steps.py
+++ b/tests/behavior/steps/test_ingest_command_steps.py
@@ -1,28 +1,36 @@
 import os
 import sys
+from unittest.mock import MagicMock, patch
+
+import click
 import pytest
-from pytest_bdd import given, when, then, parsers, scenarios
-from unittest.mock import patch, MagicMock
+from pytest_bdd import given, parsers, scenarios, then, when
 
 # Import the scenarios from the feature file
-scenarios('../features/general/ingest_command.feature')
+scenarios("../features/general/ingest_command.feature")
+
 
 # Fixtures for test isolation
 @pytest.fixture
 def context():
     """Fixture to provide a context object for sharing data between steps."""
+
     class Context:
         def __init__(self):
             self.result = None
             self.manifest_path = None
             self.error_message = None
+
     return Context()
+
 
 @pytest.fixture
 def mock_ingest_cmd():
     """Fixture to mock the ingest_cmd function."""
-    with patch('devsynth.application.cli.ingest_cmd.ingest_cmd') as mock:
-        yield mock
+    with patch("devsynth.application.cli.ingest_cmd.ingest_cmd") as mock:
+        with patch("devsynth.application.cli.commands.ingest_cmd._ingest_cmd", mock):
+            yield mock
+
 
 # Step definitions
 @pytest.mark.medium
@@ -35,10 +43,11 @@ def valid_manifest_file(context, manifest_file, tmp_path):
       description: A test project for ingest command
     """
     manifest_path = tmp_path / manifest_file
-    with open(manifest_path, 'w') as f:
+    with open(manifest_path, "w") as f:
         f.write(manifest_content)
-    
+
     context.manifest_path = str(manifest_path)
+
 
 @pytest.mark.medium
 @given(parsers.parse('I have an invalid project manifest file "{manifest_file}"'))
@@ -49,16 +58,18 @@ def invalid_manifest_file(context, manifest_file, tmp_path):
       - this is not a valid manifest
     """
     manifest_path = tmp_path / manifest_file
-    with open(manifest_path, 'w') as f:
+    with open(manifest_path, "w") as f:
         f.write(manifest_content)
-    
+
     context.manifest_path = str(manifest_path)
 
+
 @pytest.mark.medium
-@given('the DevSynth CLI is installed')
+@given("the DevSynth CLI is installed")
 def devsynth_cli_installed():
     """Verify that the DevSynth CLI is installed."""
     assert "devsynth" in sys.modules
+
 
 @pytest.mark.medium
 @when(parsers.parse('I run the command "{command}"'))
@@ -73,55 +84,73 @@ def run_command(context, command, mock_ingest_cmd, monkeypatch):
         command = command.replace("invalid_manifest.yaml", context.manifest_path)
     elif "non_existent_manifest.yaml" in command:
         # Use a non-existent file path
-        command = command.replace("non_existent_manifest.yaml", "/tmp/non_existent_file.yaml")
-    
+        command = command.replace(
+            "non_existent_manifest.yaml", "/tmp/non_existent_file.yaml"
+        )
+
     # Parse the command to extract arguments
     args = command.split()[1:]  # Skip 'devsynth'
-    
+
     # Set up the mock behavior based on the scenario
     if "non_existent_manifest.yaml" in command or "invalid_manifest.yaml" in command:
         mock_ingest_cmd.side_effect = Exception("Error ingesting project")
         try:
-            # Simulate running the command
             from devsynth.adapters.cli.typer_adapter import parse_args
+
             parse_args(args)
             context.result = "success"
+        except (click.exceptions.Exit, SystemExit) as e:
+            code = e.exit_code if isinstance(e, click.exceptions.Exit) else e.code
+            context.result = "success" if code == 0 else "failure"
+            if code != 0:
+                context.error_message = str(e)
         except Exception as e:
             context.result = "failure"
             context.error_message = str(e)
     else:
         mock_ingest_cmd.return_value = None  # Successful execution
         try:
-            # Simulate running the command
             from devsynth.adapters.cli.typer_adapter import parse_args
+
             parse_args(args)
             context.result = "success"
+        except (click.exceptions.Exit, SystemExit) as e:
+            code = e.exit_code if isinstance(e, click.exceptions.Exit) else e.code
+            context.result = "success" if code == 0 else "failure"
+            if code != 0:
+                context.error_message = str(e)
         except Exception as e:
             context.result = "failure"
             context.error_message = str(e)
 
-@pytest.mark.medium
-@then('the command should execute successfully')
-def command_successful(context):
-    """Verify that the command executed successfully."""
-    assert context.result == "success", f"Command failed with error: {context.error_message}"
 
 @pytest.mark.medium
-@then('the command should fail')
+@then("the command should execute successfully")
+def command_successful(context):
+    """Verify that the command executed successfully."""
+    assert (
+        context.result == "success"
+    ), f"Command failed with error: {context.error_message}"
+
+
+@pytest.mark.medium
+@then("the command should fail")
 def command_failed(context):
     """Verify that the command failed."""
     assert context.result == "failure", "Command succeeded but was expected to fail"
 
+
 @pytest.mark.medium
-@then('the system should display a success message')
+@then("the system should display a success message")
 def success_message_displayed(context, capsys):
     """Verify that a success message was displayed."""
     # This would check the captured stdout for success messages
     # Since we're mocking, we'll just verify the command was successful
     assert context.result == "success"
 
+
 @pytest.mark.medium
-@then('the system should display an error message explaining the issue')
+@then("the system should display an error message explaining the issue")
 def error_message_displayed(context, capsys):
     """Verify that an error message was displayed."""
     # This would check the captured stdout for error messages
@@ -129,26 +158,46 @@ def error_message_displayed(context, capsys):
     assert context.result == "failure"
     assert context.error_message is not None
 
+
 @pytest.mark.medium
-@then('the system should display detailed progress information')
+@then("the system should display detailed progress information")
 def detailed_progress_displayed(context, capsys):
     """Verify that detailed progress information was displayed."""
     # This would check the captured stdout for detailed progress information
     # Since we're mocking, we'll just verify the command was successful
     assert context.result == "success"
 
+
 @pytest.mark.medium
-@then('the project should be ingested into the system')
+@then("the project should be ingested into the system")
 def project_ingested(context, mock_ingest_cmd):
     """Verify that the project was ingested into the system."""
     # Verify that the ingest_cmd function was called
     mock_ingest_cmd.assert_called_once()
 
+
 @pytest.mark.medium
-@then('the system should display an error message indicating the file does not exist')
+@then("the system should display an error message indicating the file does not exist")
 def file_not_exist_error_displayed(context, capsys):
     """Verify that an error message about a non-existent file was displayed."""
     # This would check the captured stdout for error messages about non-existent files
     # Since we're mocking, we'll just verify the command failed
     assert context.result == "failure"
     assert context.error_message is not None
+
+
+@pytest.mark.medium
+@then("the ingest command should run in non-interactive mode")
+def ingest_non_interactive(mock_ingest_cmd):
+    """Verify non-interactive flag passed to ingest command."""
+    args = mock_ingest_cmd.call_args.kwargs
+    assert args.get("non_interactive") is True
+
+
+@pytest.mark.medium
+@then("the ingest command should apply defaults and run non-interactively")
+def ingest_defaults_mode(mock_ingest_cmd):
+    """Verify defaults imply non-interactive mode."""
+    args = mock_ingest_cmd.call_args.kwargs
+    assert args.get("defaults") is True
+    assert args.get("non_interactive") is True

--- a/tests/behavior/steps/test_memory_steps.py
+++ b/tests/behavior/steps/test_memory_steps.py
@@ -1,0 +1,42 @@
+import pytest
+from pytest_bdd import given, parsers, scenarios, then, when
+
+from devsynth.adapters.memory.memory_adapter import MemorySystemAdapter
+from devsynth.domain.models.memory import MemoryItem, MemoryType
+
+scenarios("../features/memory/memory_operations.feature")
+
+
+@pytest.fixture
+def context():
+    class Context:
+        adapter: MemorySystemAdapter
+        item_id: str
+        retrieved: MemoryItem
+
+    return Context()
+
+
+@pytest.mark.fast
+@given("a memory system adapter")
+def given_adapter(context):
+    context.adapter = MemorySystemAdapter.create_for_testing()
+
+
+@pytest.mark.fast
+@when(parsers.parse('I write "{content}" to memory'))
+def write_memory(context, content):
+    item = MemoryItem(id="", content=content, memory_type=MemoryType.CONTEXT)
+    context.item_id = context.adapter.write(item)
+
+
+@pytest.mark.fast
+@when("I read the item from memory")
+def read_memory(context):
+    context.retrieved = context.adapter.read(context.item_id)
+
+
+@pytest.mark.fast
+@then(parsers.parse('the retrieved content should be "{content}"'))
+def check_content(context, content):
+    assert context.retrieved.content == content


### PR DESCRIPTION
## Summary
- add Gherkin specs for memory adapter read/write
- extend ingest command features to cover --non-interactive and --defaults
- expose convenient read/write wrappers on memory adapter

## Testing
- `poetry run pytest tests/behavior/steps/test_memory_steps.py tests/behavior/steps/test_ingest_command_steps.py -k 'non-interactive or defaults' -q`
- `poetry run devsynth run-tests` *(fails: KeyError: <WorkerController gw2>)*
- `poetry run python tests/verify_test_organization.py`


------
https://chatgpt.com/codex/tasks/task_e_689a8ad7ab048333b368cdb0057f368e