### PR TITLE
chore: mark 0.1.0-alpha.1 as unreleased

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ DevSynth has not yet reached an official release. Versions in the `0.1.x` range
 represent pre-release milestones leading up to the first stable release. No
 version has been published yet.
 
-## [0.1.0] - Unreleased
+## [0.1.0-alpha.1] - Unreleased
 
 ### Added
 - Modular, hexagonal architecture
@@ -48,19 +48,16 @@ version has been published yet.
 - Renamed CLI commands: `adaptive`→`refactor`, `analyze`→`inspect`, `run`→`run-pipeline`, `replay`→`retrace`
 - Synchronized feature status reports with latest implementation
 - Stabilized pre-release references to maintain version `0.1.0-alpha.1` across configuration and documentation
-
-### Fixed
-- Improved error handling in the EDRR coordinator
-
-## [Unreleased]
-### Changed
 - Updated documentation to reflect implementation of WebUI, CLI overhaul,
   hybrid memory architecture, and basic metrics system.
+
 ### Deprecated
 - `scripts/alignment_check.py` and `scripts/validate_manifest.py` replaced by
   CLI commands `devsynth align` and `devsynth validate-manifest`. These scripts
   will be removed in v1.0 per the deprecation policy.
+
 ### Fixed
+- Improved error handling in the EDRR coordinator
 - Optional tiktoken dependency no longer breaks Kuzu memory initialization
 - Added missing step definitions for enhanced memory scenarios
 - Linked remaining alpha tasks (WebUI, Kuzu memory, WSDE collaboration, CLI ingestion) to milestone `0.1.0-alpha.1` and updated development status.

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ tags:
   - "overview"
   - "documentation"
   - "readme"
-status: "published"
+status: "draft"
 author: "DevSynth Team"
 last_reviewed: "2025-08-05"
 ---

--- a/docs/release/0.1.0-alpha.1.md
+++ b/docs/release/0.1.0-alpha.1.md
@@ -1,3 +1,15 @@
+---
+title: "DevSynth 0.1.0-alpha.1"
+date: "2025-08-12"
+version: "0.1.0-alpha.1"
+tags:
+  - "devsynth"
+  - "release"
+status: "draft"
+author: "DevSynth Team"
+last_reviewed: "2025-08-12"
+---
+
 # DevSynth 0.1.0-alpha.1
 
 ## Setup

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,10 +1,11 @@
 [tool.poetry]
 name = "devsynth"
-version = "0.1.0a1"
+version = "0.1.0-alpha.1"
 description = "DevSynth project"
 authors = ["DevSynth Team"]
 readme = "README.md"
 packages = [{include = "devsynth", from = "src"}]
+classifiers = ["Development Status :: 3 - Alpha"]
 
 [tool.poetry.dependencies]
 python = "<3.13,>=3.12"


### PR DESCRIPTION
## Summary
- mark 0.1.0-alpha.1 as an unreleased milestone in the changelog
- set README and release notes to draft status to reflect unreleased state

## Testing
- `SKIP=fix-code-blocks poetry run pre-commit run --files CHANGELOG.md README.md docs/release/0.1.0-alpha.1.md`
- `poetry run devsynth run-tests` *(fails: KeyError: <WorkerController gw3>)*
- `poetry run python tests/verify_test_organization.py`


------
https://chatgpt.com/codex/tasks/task_e_689a8acd3f4883338c221ad9b9864397