### PR TITLE
chore: add requirements traceability verification

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -32,6 +32,12 @@ repos:
       language: system
       pass_filenames: false
       stages: [push]
+    - id: verify-requirements-traceability
+      name: verify requirements traceability
+      entry: poetry run python scripts/verify_requirements_traceability.py
+      language: system
+      pass_filenames: false
+      files: ^docs/requirements_traceability.md$
     - id: update-traceability
       name: update traceability
       entry: python scripts/update_traceability.py

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -34,6 +34,13 @@
   entry: python scripts/verify_mvuu_references.py
   language: system
   pass_filenames: false
+- id: verify-requirements-traceability
+  name: verify requirements traceability
+  description: "Ensure requirements traceability matrix links requirements to code and tests"
+  entry: poetry run python scripts/verify_requirements_traceability.py
+  language: system
+  pass_filenames: false
+  files: ^docs/requirements_traceability.md$
 - id: update-traceability
   name: update traceability
   description: "Update traceability data"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -68,6 +68,7 @@ Before opening a pull request, run:
 poetry run pre-commit run --files <changed>
 poetry run devsynth run-tests
 poetry run python tests/verify_test_organization.py
+poetry run python scripts/verify_requirements_traceability.py
 ```
 
 ## Automation

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -77,6 +77,17 @@ poetry run pytest --cov=src --cov-report=term-missing
 
 Good documentation is essential. Please update relevant documentation for any changes and ensure your code includes proper docstrings.
 
+## Pre-PR Checks
+
+Before opening a pull request, run:
+
+```bash
+poetry run pre-commit run --files <changed>
+poetry run devsynth run-tests
+poetry run python tests/verify_test_organization.py
+poetry run python scripts/verify_requirements_traceability.py
+```
+
 ## Pull Request Process
 
 1. Ensure your fork is up to date with the main repository

--- a/docs/requirements_traceability_script_limitations.md
+++ b/docs/requirements_traceability_script_limitations.md
@@ -1,0 +1,34 @@
+---
+
+title: "Requirements Traceability Script Limitations"
+date: "2025-08-05"
+version: "0.1.0-alpha.1"
+tags:
+  - "requirements"
+  - "traceability"
+  - "documentation"
+status: "published"
+author: "DevSynth Team"
+last_reviewed: "2025-08-05"
+---
+<div class="breadcrumbs">
+<a href="../index.md">Documentation</a> &gt; Requirements Traceability Script Limitations
+</div>
+
+<div class="breadcrumbs">
+<a href="../index.md">Documentation</a> &gt; Requirements Traceability Script Limitations
+</div>
+
+# Requirements Traceability Script Limitations
+
+The `scripts/verify_requirements_traceability.py` script checks that each requirement in `docs/requirements_traceability.md` links to code and tests. While useful, it has several limitations:
+
+- It only verifies that the code and test reference cells are non-empty; it does not confirm that the referenced modules or tests actually exist.
+- Requirements with fewer than six table columns are ignored, allowing malformed rows to pass.
+- Only rows beginning with `| FR`, `| NFR`, or `| IR` are evaluated; other requirement types are skipped.
+- Duplicate requirement identifiers are not detected.
+- The parser assumes a simple pipe-delimited format and may misinterpret rows with embedded pipe characters or multiline cells.
+- Placeholder text such as `TODO` or `TBD` is treated as a valid reference.
+- Table structure, headers, and column alignment are not validated.
+
+These edge cases could allow traceability gaps to go unnoticed. Enhancements to the script could include verifying file paths, detecting duplicate IDs, and validating the overall structure of the traceability matrix.

--- a/scripts/verify_requirements_traceability.py
+++ b/scripts/verify_requirements_traceability.py
@@ -41,7 +41,11 @@ def main() -> None:
         description="Verify requirements traceability matrix"
     )
     parser.add_argument(
-        "matrix", type=pathlib.Path, help="Path to requirements_traceability.md"
+        "matrix",
+        nargs="?",
+        type=pathlib.Path,
+        default=pathlib.Path("docs/requirements_traceability.md"),
+        help="Path to requirements_traceability.md",
     )
     args = parser.parse_args()
     sys.exit(verify_traceability(args.matrix))


### PR DESCRIPTION
## Summary
- add requirements traceability verification to pre-PR instructions
- run script automatically via pre-commit
- document script limitations and edge cases

## Testing
- `SKIP=devsynth-align,check-frontmatter,fix-code-blocks poetry run pre-commit run --files .pre-commit-config.yaml .pre-commit-hooks.yaml AGENTS.md CONTRIBUTING.md scripts/verify_requirements_traceability.py docs/requirements_traceability_script_limitations.md`
- `poetry run devsynth run-tests` *(fails: many failing tests)*
- `poetry run python tests/verify_test_organization.py`
- `poetry run python scripts/verify_requirements_traceability.py`


------
https://chatgpt.com/codex/tasks/task_e_689aa4658be4833389421406a655155e