### PR TITLE
Add requirement IDs to security tests

### DIFF
--- a/tests/unit/security/test_authentication.py
+++ b/tests/unit/security/test_authentication.py
@@ -12,7 +12,7 @@ from devsynth.security.authentication import (
 def test_hash_and_verify_password_succeeds():
     """Test that hash and verify password succeeds.
 
-    ReqID: N/A"""
+    ReqID: FR-61"""
     password = "Secret123!"
     hashed = hash_password(password)
     assert password not in hashed
@@ -24,7 +24,7 @@ def test_hash_and_verify_password_succeeds():
 def test_authenticate_success_succeeds():
     """Test that authenticate success succeeds.
 
-    ReqID: N/A"""
+    ReqID: FR-61"""
     pwd = "password"
     creds = {"alice": hash_password(pwd)}
     assert authenticate("alice", pwd, creds)
@@ -34,7 +34,7 @@ def test_authenticate_success_succeeds():
 def test_authenticate_failure_succeeds():
     """Test that authenticate failure succeeds.
 
-    ReqID: N/A"""
+    ReqID: FR-61"""
     creds = {"bob": hash_password("password")}
     try:
         authenticate("bob", "bad", creds)

--- a/tests/unit/security/test_authorization.py
+++ b/tests/unit/security/test_authorization.py
@@ -12,21 +12,21 @@ CASE_SENSITIVE_ACL = {"Admin": ["Read", "Write"], "user": ["read"]}
 def test_is_authorized_true_returns_expected_result():
     """Test that is_authorized returns True when the user has the required role.
 
-    ReqID: N/A"""
+    ReqID: FR-62"""
     assert is_authorized(["admin"], "write", ACL)
 
 
 def test_is_authorized_false_returns_expected_result():
     """Test that is_authorized returns False when the user doesn't have the required role.
 
-    ReqID: N/A"""
+    ReqID: FR-62"""
     assert not is_authorized(["user"], "write", ACL)
 
 
 def test_is_authorized_multiple_roles_succeeds():
     """Test that is_authorized works with multiple roles.
 
-    ReqID: N/A"""
+    ReqID: FR-62"""
     assert is_authorized(["user", "admin"], "write", ACL)
     assert is_authorized(["guest", "user"], "read", ACL)
     assert not is_authorized(["guest", "user"], "delete", ACL)
@@ -35,7 +35,7 @@ def test_is_authorized_multiple_roles_succeeds():
 def test_is_authorized_wildcard_succeeds():
     """Test that is_authorized works with wildcard actions.
 
-    ReqID: N/A"""
+    ReqID: FR-62"""
     assert is_authorized(["superuser"], "read", ACL)
     assert is_authorized(["superuser"], "write", ACL)
     assert is_authorized(["superuser"], "delete", ACL)
@@ -44,7 +44,7 @@ def test_is_authorized_wildcard_succeeds():
 def test_is_authorized_role_not_in_acl_returns_expected_result():
     """Test that is_authorized returns False when the role doesn't exist in the ACL.
 
-    ReqID: N/A"""
+    ReqID: FR-62"""
     assert not is_authorized(["guest"], "read", ACL)
     assert not is_authorized(["unknown"], "write", ACL)
 
@@ -52,7 +52,7 @@ def test_is_authorized_role_not_in_acl_returns_expected_result():
 def test_is_authorized_empty_roles_returns_expected_result():
     """Test that is_authorized returns False when the user has no roles.
 
-    ReqID: N/A"""
+    ReqID: FR-62"""
     assert not is_authorized([], "read", ACL)
     assert not is_authorized([], "write", ACL)
 
@@ -60,7 +60,7 @@ def test_is_authorized_empty_roles_returns_expected_result():
 def test_is_authorized_empty_acl_returns_expected_result():
     """Test that is_authorized returns False when the ACL is empty.
 
-    ReqID: N/A"""
+    ReqID: FR-62"""
     assert not is_authorized(["admin"], "read", EMPTY_ACL)
     assert not is_authorized(["user"], "write", EMPTY_ACL)
 
@@ -68,7 +68,7 @@ def test_is_authorized_empty_acl_returns_expected_result():
 def test_is_authorized_case_sensitivity_succeeds():
     """Test that is_authorized is case-sensitive for roles and actions.
 
-    ReqID: N/A"""
+    ReqID: FR-62"""
     assert not is_authorized(["Admin"], "write", ACL)
     assert is_authorized(["Admin"], "Write", CASE_SENSITIVE_ACL)
     assert not is_authorized(["admin"], "Write", ACL)
@@ -79,7 +79,7 @@ def test_is_authorized_case_sensitivity_succeeds():
 def test_is_authorized_iterable_roles_succeeds():
     """Test that is_authorized works with different iterable types for roles.
 
-    ReqID: N/A"""
+    ReqID: FR-62"""
     assert is_authorized(["admin"], "write", ACL)
     assert is_authorized(("admin",), "write", ACL)
     assert is_authorized({"admin"}, "write", ACL)
@@ -95,7 +95,7 @@ def test_is_authorized_iterable_roles_succeeds():
 def test_require_authorization_raises():
     """Test that require_authorization raises an AuthorizationError when the user doesn't have the required role.
 
-    ReqID: N/A"""
+    ReqID: FR-62"""
     with pytest.raises(AuthorizationError) as excinfo:
         require_authorization(["user"], "write", ACL)
     assert excinfo.value.message == "Permission denied"
@@ -106,7 +106,7 @@ def test_require_authorization_raises():
 def test_require_authorization_no_exception_raises_error():
     """Test that require_authorization doesn't raise an exception when the user is authorized.
 
-    ReqID: N/A"""
+    ReqID: FR-62"""
     require_authorization(["admin"], "write", ACL)
     require_authorization(["user"], "read", ACL)
     require_authorization(["superuser"], "delete", ACL)
@@ -115,7 +115,7 @@ def test_require_authorization_no_exception_raises_error():
 def test_require_authorization_empty_roles_raises_error():
     """Test that require_authorization raises an AuthorizationError when the user has no roles.
 
-    ReqID: N/A"""
+    ReqID: FR-62"""
     with pytest.raises(AuthorizationError) as excinfo:
         require_authorization([], "read", ACL)
     assert excinfo.value.message == "Permission denied"
@@ -126,7 +126,7 @@ def test_require_authorization_empty_roles_raises_error():
 def test_require_authorization_empty_acl_raises_error():
     """Test that require_authorization raises an AuthorizationError when the ACL is empty.
 
-    ReqID: N/A"""
+    ReqID: FR-62"""
     with pytest.raises(AuthorizationError) as excinfo:
         require_authorization(["admin"], "read", EMPTY_ACL)
     assert excinfo.value.message == "Permission denied"

--- a/tests/unit/security/test_sanitization.py
+++ b/tests/unit/security/test_sanitization.py
@@ -1,87 +1,88 @@
 import pytest
-from devsynth.security.sanitization import sanitize_input, validate_safe_input
+
 from devsynth.exceptions import InputSanitizationError
+from devsynth.security.sanitization import sanitize_input, validate_safe_input
 
 
 def test_sanitize_input_removes_script_succeeds():
     """Test that sanitize_input removes script tags.
 
-ReqID: N/A"""
+    ReqID: FR-63"""
     text = "<script>alert('x')</script>Hello"
     sanitized = sanitize_input(text)
-    assert sanitized == 'Hello'
+    assert sanitized == "Hello"
 
 
 def test_sanitize_input_removes_control_chars_succeeds():
     """Test that sanitize_input removes control characters.
 
-ReqID: N/A"""
-    text = 'Hello\x00World\x1fTest\x7f'
+    ReqID: FR-63"""
+    text = "Hello\x00World\x1fTest\x7f"
     sanitized = sanitize_input(text)
-    assert sanitized == 'HelloWorldTest'
+    assert sanitized == "HelloWorldTest"
 
 
 def test_sanitize_input_removes_both_succeeds():
     """Test that sanitize_input removes both script tags and control characters.
 
-ReqID: N/A"""
+    ReqID: FR-63"""
     text = "<script>alert('x')\x00</script>Hello\x1fWorld"
     sanitized = sanitize_input(text)
-    assert sanitized == 'HelloWorld'
+    assert sanitized == "HelloWorld"
 
 
 def test_sanitize_input_strips_whitespace_succeeds():
     """Test that sanitize_input strips whitespace.
 
-ReqID: N/A"""
-    text = '  Hello World  '
+    ReqID: FR-63"""
+    text = "  Hello World  "
     sanitized = sanitize_input(text)
-    assert sanitized == 'Hello World'
+    assert sanitized == "Hello World"
 
 
 def test_sanitize_input_no_script_tags_succeeds():
     """Test that sanitize_input works correctly when there are no script tags to remove.
 
-ReqID: N/A"""
-    text = 'Hello World'
+    ReqID: FR-63"""
+    text = "Hello World"
     sanitized = sanitize_input(text)
-    assert sanitized == 'Hello World'
+    assert sanitized == "Hello World"
 
 
 def test_sanitize_input_no_control_chars_succeeds():
     """Test that sanitize_input works correctly when there are no control characters to remove.
 
-ReqID: N/A"""
-    text = 'Hello World'
+    ReqID: FR-63"""
+    text = "Hello World"
     sanitized = sanitize_input(text)
-    assert sanitized == 'Hello World'
+    assert sanitized == "Hello World"
 
 
 def test_sanitize_input_complex_script_tags_succeeds():
     """Test that sanitize_input removes complex script tags with attributes and whitespace.
 
-ReqID: N/A"""
+    ReqID: FR-63"""
     text = (
         '<script type="text/javascript" src="malicious.js">alert("XSS")</script>Hello'
-        )
+    )
     sanitized = sanitize_input(text)
-    assert sanitized == 'Hello'
+    assert sanitized == "Hello"
 
 
 def test_sanitize_input_multiple_script_tags_succeeds():
     """Test that sanitize_input removes multiple script tags.
 
-ReqID: N/A"""
-    text = '<script>alert(1)</script>Hello<script>alert(2)</script>World'
+    ReqID: FR-63"""
+    text = "<script>alert(1)</script>Hello<script>alert(2)</script>World"
     sanitized = sanitize_input(text)
-    assert sanitized == 'HelloWorld'
+    assert sanitized == "HelloWorld"
 
 
 def test_validate_safe_input_with_safe_input_returns_expected_result():
     """Test that validate_safe_input returns the input when it's safe.
 
-ReqID: N/A"""
-    text = 'Hello World'
+    ReqID: FR-63"""
+    text = "Hello World"
     result = validate_safe_input(text)
     assert result == text
 
@@ -89,18 +90,18 @@ ReqID: N/A"""
 def test_validate_safe_input_raises_with_script_raises_error():
     """Test that validate_safe_input raises an exception when script tags are present.
 
-ReqID: N/A"""
+    ReqID: FR-63"""
     with pytest.raises(InputSanitizationError) as excinfo:
-        validate_safe_input('<script>bad</script>')
-    assert 'Unsafe input detected' in str(excinfo.value)
-    assert '<script>bad</script>' in str(excinfo.value.details)
+        validate_safe_input("<script>bad</script>")
+    assert "Unsafe input detected" in str(excinfo.value)
+    assert "<script>bad</script>" in str(excinfo.value.details)
 
 
 def test_validate_safe_input_raises_with_control_chars_raises_error():
     """Test that validate_safe_input raises an exception when control characters are present.
 
-ReqID: N/A"""
+    ReqID: FR-63"""
     with pytest.raises(InputSanitizationError) as excinfo:
-        validate_safe_input('Hello\x00World')
-    assert 'Unsafe input detected' in str(excinfo.value)
-    assert 'Hello\\x00World' in str(excinfo.value.details)
+        validate_safe_input("Hello\x00World")
+    assert "Unsafe input detected" in str(excinfo.value)
+    assert "Hello\\x00World" in str(excinfo.value.details)


### PR DESCRIPTION
## Summary
- reference authentication tests to requirement FR-61
- link authorization tests to requirement FR-62
- map sanitization tests to requirement FR-63

## Testing
- `poetry run pre-commit run --files tests/unit/security/test_authentication.py tests/unit/security/test_authorization.py tests/unit/security/test_sanitization.py`
- `poetry run devsynth run-tests` *(fails: 904 failed, 1874 passed, 112 skipped, 98 errors)*
- `poetry run python scripts/verify_requirements_traceability.py docs/requirements_traceability.md`
- `poetry run python tests/verify_test_organization.py`


------
https://chatgpt.com/codex/tasks/task_e_689aa45051a4833380b63b8dc80925ed