### PR TITLE
Gate real LLM tests behind resource marker

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -568,6 +568,18 @@ def is_anthropic_available() -> bool:
     return bool(os.environ.get("ANTHROPIC_API_KEY"))
 
 
+def is_llm_provider_available() -> bool:
+    """Check if a real LLM provider is configured."""
+    if (
+        os.environ.get("DEVSYNTH_RESOURCE_LLM_PROVIDER_AVAILABLE", "true").lower()
+        == "false"
+    ):
+        return False
+    return bool(
+        os.environ.get("OPENAI_API_KEY") or os.environ.get("LM_STUDIO_ENDPOINT")
+    )
+
+
 def is_resource_available(resource: str) -> bool:
     """
     Check if a resource is available.
@@ -585,6 +597,7 @@ def is_resource_available(resource: str) -> bool:
     # Map resource names to checker functions
     checker_map = {
         "anthropic": is_anthropic_available,
+        "llm_provider": is_llm_provider_available,
         "lmstudio": is_lmstudio_available,
         "codebase": is_codebase_available,
         "cli": is_cli_available,

--- a/tests/integration/general/test_edrr_real_llm_integration.py
+++ b/tests/integration/general/test_edrr_real_llm_integration.py
@@ -5,7 +5,6 @@ This test uses real LLM providers from the provider system to test the EDRR cycl
 It requires valid API keys or endpoints to be configured in environment variables.
 """
 
-import os
 import tempfile
 from pathlib import Path
 from typing import Any, Dict, Optional
@@ -30,10 +29,7 @@ from devsynth.domain.models.wsde_facade import WSDETeam
 from devsynth.methodology.base import Phase
 
 
-@pytest.mark.skipif(
-    not os.environ.get("OPENAI_API_KEY") and not os.environ.get("LM_STUDIO_ENDPOINT"),
-    reason="No LLM provider configured. Set OPENAI_API_KEY or LM_STUDIO_ENDPOINT.",
-)
+@pytest.mark.requires_resource("llm_provider")
 def test_edrr_cycle_with_real_llm_has_expected(tmp_path):
     """Test EDRR cycle with a real LLM provider and verify memory integration.
 
@@ -107,10 +103,7 @@ def test_edrr_cycle_with_real_llm_has_expected(tmp_path):
     print(f"Memory integration verified with GraphMemoryAdapter")
 
 
-@pytest.mark.skipif(
-    not os.environ.get("OPENAI_API_KEY") and not os.environ.get("LM_STUDIO_ENDPOINT"),
-    reason="No LLM provider configured. Set OPENAI_API_KEY or LM_STUDIO_ENDPOINT.",
-)
+@pytest.mark.requires_resource("llm_provider")
 def test_edrr_cycle_with_real_project_succeeds(tmp_path):
     """Test EDRR cycle with a real LLM provider on a more complex project.
 


### PR DESCRIPTION
## Summary
- mark real LLM integration tests with `@pytest.mark.requires_resource("llm_provider")`
- add `llm_provider` resource checker that looks for `OPENAI_API_KEY` or `LM_STUDIO_ENDPOINT`

## Testing
- `poetry run pre-commit run --files tests/conftest.py tests/integration/general/test_edrr_real_llm_integration.py`
- `poetry run devsynth run-tests` *(fails: KeyError <WorkerController gw2> and many test failures)*
- `poetry run python tests/verify_test_organization.py`
- `poetry run python scripts/verify_requirements_traceability.py`

------
https://chatgpt.com/codex/tasks/task_e_689aac5660508333997f22fd74032088