### PR TITLE
Sync environment provisioning script with extras

### DIFF
--- a/scripts/codex_setup.sh
+++ b/scripts/codex_setup.sh
@@ -128,12 +128,13 @@ required = [
     "astor",
     "httpx",
     "prometheus_client",
+    "chromadb",
+    "numpy",
 ]
 optional = [
     "kuzu",
     "faiss",
     "dearpygui",
-    "chromadb",
     "lmstudio",
 ]
 


### PR DESCRIPTION
## Summary
- ensure environment provisioning script checks for chromadb and numpy as required packages
- clarify optional extras list for kuzu, faiss, dearpygui, and lmstudio

## Testing
- `PIP_NO_INDEX=1 bash scripts/codex_setup.sh`
- `SKIP=fix-code-blocks poetry run pre-commit run --files scripts/codex_setup.sh`
- `poetry run devsynth run-tests` *(fails: INTERNALERROR from xdist)*
- `poetry run python tests/verify_test_organization.py`
- `poetry run python scripts/verify_requirements_traceability.py`


------
https://chatgpt.com/codex/tasks/task_e_689ab96514648333b79445ad5b1c851c