### PR TITLE
docs: outline release preparation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -71,6 +71,21 @@ poetry run python tests/verify_test_organization.py
 poetry run python scripts/verify_requirements_traceability.py
 ```
 
+## Release Preparation
+
+1. Run `poetry run task release:prep` to generate release artifacts.
+   - **Key Questions**
+     - What files or version bumps did the command produce?
+     - Did the command complete without errors?
+2. Tag the release with `git tag -a <version>` and push the tag.
+   - **Key Questions**
+     - Does the tag follow semantic versioning?
+     - Have the tag and release notes been pushed to the remote?
+3. Conduct a dialectical review with at least one other contributor.
+   - **Key Questions**
+     - What assumptions underlie the release changes?
+     - What counterarguments or alternative perspectives have been considered?
+
 ## Automation
 
 - Most DevSynth CLI commands accept `--non-interactive` and `--defaults` to bypass prompts.

--- a/docs/developer_guides/development_setup.md
+++ b/docs/developer_guides/development_setup.md
@@ -36,8 +36,9 @@ Welcome to the DevSynth project! This comprehensive guide will help you set up y
 5. [Development Workflow](#development-workflow)
 6. [Running Tests](#running-tests)
 7. [Common Development Tasks](#common-development-tasks)
-8. [Communication and Getting Help](#communication-and-getting-help)
-9. [Next Steps](#next-steps)
+8. [Release Preparation](#release-preparation)
+9. [Communication and Getting Help](#communication-and-getting-help)
+10. [Next Steps](#next-steps)
 
 
 ## Project Overview
@@ -336,6 +337,21 @@ mkdocs build
 
 mkdocs serve
 ```
+
+## Release Preparation
+
+1. Run `poetry run task release:prep` to generate release artifacts.
+   - **Key Questions**
+     - What files or version updates did the command produce?
+     - Did any errors occur during execution?
+2. Tag the release with `git tag -a <version>` and push the tag.
+   - **Key Questions**
+     - Does the tag follow semantic versioning?
+     - Have you pushed the tag and associated notes to the remote?
+3. Conduct a dialectical review with a collaborator.
+   - **Key Questions**
+     - Which assumptions about the release have been examined?
+     - What alternative viewpoints or counterarguments were considered?
 
 ## Communication and Getting Help
 


### PR DESCRIPTION
## Summary
- add release preparation steps with Socratic questions in AGENTS and development setup guide

## Testing
- `SKIP=fix-code-blocks poetry run pre-commit run --files AGENTS.md docs/developer_guides/development_setup.md`
- `poetry run devsynth run-tests --speed fast` *(fails: ModuleNotFoundError: No module named 'chromadb')*
- `poetry run python tests/verify_test_organization.py`
- `poetry run python scripts/verify_requirements_traceability.py`


------
https://chatgpt.com/codex/tasks/task_e_689ab94f481c8333a375eb8992edf0e4