### PR TITLE
Add dialectical audit script and policy documentation

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -161,6 +161,7 @@ tasks:
       - task: lint
       - task: test:coverage
       - poetry run python scripts/update_traceability.py
+      - poetry run python scripts/dialectical_audit.py
       - task: docs:build
 
   # Python-specific tasks

--- a/docs/policies/dialectical_audit.md
+++ b/docs/policies/dialectical_audit.md
@@ -1,0 +1,47 @@
+---
+
+author: DevSynth Team
+date: '2025-07-10'
+last_reviewed: '2025-07-10'
+status: published
+tags:
+
+- policy
+- audit
+- dialogue
+
+title: Dialectical Audit Policy
+version: '0.1.0-alpha.1'
+---
+<div class="breadcrumbs">
+<a href="../index.md">Documentation</a> &gt; <a href="index.md">Policies</a> &gt; Dialectical Audit Policy
+</div>
+
+<div class="breadcrumbs">
+<a href="../index.md">Documentation</a> &gt; <a href="index.md">Policies</a> &gt; Dialectical Audit Policy
+</div>
+
+# Dialectical Audit Policy
+
+This policy defines how Socratic dialogues support audits that seek consensus between documentation, implementation, and tests.
+
+## Preparation
+
+- Use automated tools to surface inconsistencies among docs, code, and tests.
+- Convert inconsistencies into open questions that challenge assumptions.
+
+## Dialogue Procedure
+
+1. Present each question to all relevant contributors.
+2. Record arguments, counterarguments, and supporting evidence.
+3. Capture resolutions or actions for unresolved questions.
+
+## Documentation
+
+- Maintain a log of questions and resolutions in `dialectical_audit.log` produced by the audit script.
+- Update docs, code, and tests to reflect agreed resolutions.
+
+## Review
+
+- Include the audit log in code reviews and release discussions.
+- Verify that all questions are resolved or tracked as issues before closing the audit.

--- a/docs/policies/index.md
+++ b/docs/policies/index.md
@@ -40,6 +40,7 @@ This document serves as the central index and navigation point for all Software 
 | **Data Retention** | [Data Retention Policy](data_retention.md) | How long different data types are stored | Implemented |
 | **Alignment** | [Continuous Alignment Process](continuous_alignment_process.md) | Processes, checks, and metrics for maintaining alignment between SDLC artifacts | Implemented |
 | **Periodic Review** | [Periodic Review Process](periodic_review.md) | Schedule and responsibilities for recurring policy reviews | Implemented |
+| **Dialectical Audit** | [Dialectical Audit Policy](dialectical_audit.md) | Socratic dialogue procedures for resolving inconsistencies | Implemented |
 
 ## Implementation Guides
 

--- a/scripts/dialectical_audit.py
+++ b/scripts/dialectical_audit.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+"""Cross-reference docs, code, and tests for conflicting statements.
+
+The audit looks for BDD feature titles referenced across documentation,
+code, and tests. Missing references generate questions that require
+follow-up during a dialectical review.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+from typing import Iterable, Set
+
+ROOT = Path(__file__).resolve().parents[1]
+DOCS = ROOT / "docs"
+TESTS = ROOT / "tests"
+SRC = ROOT / "src"
+LOG_PATH = ROOT / "dialectical_audit.log"
+
+
+def _extract_features_from_docs() -> Set[str]:
+    features: Set[str] = set()
+    for path in DOCS.rglob("*.md"):
+        for line in path.read_text(encoding="utf-8").splitlines():
+            match = re.match(r"^Feature:\s*(.+)", line)
+            if match:
+                features.add(match.group(1).strip())
+    return features
+
+
+def _extract_features_from_tests() -> Set[str]:
+    features: Set[str] = set()
+    for path in TESTS.rglob("*.feature"):
+        for line in path.read_text(encoding="utf-8").splitlines():
+            if line.startswith("Feature:"):
+                features.add(line.split("Feature:", 1)[1].strip())
+                break
+    return features
+
+
+def _extract_features_from_code() -> Set[str]:
+    features: Set[str] = set()
+    for path in SRC.rglob("*.py"):
+        try:
+            text = path.read_text(encoding="utf-8")
+        except UnicodeDecodeError:
+            continue
+        for line in text.splitlines():
+            match = re.search(r"#\s*Feature:\s*(.+)", line)
+            if match:
+                features.add(match.group(1).strip())
+    return features
+
+
+def _log_results(questions: Iterable[str]) -> None:
+    data = {
+        "questions": list(questions),
+        "resolved": [],
+    }
+    LOG_PATH.write_text(json.dumps(data, indent=2), encoding="utf-8")
+
+
+def main() -> int:
+    doc_features = _extract_features_from_docs()
+    test_features = _extract_features_from_tests()
+    code_features = _extract_features_from_code()
+
+    questions = []
+
+    for feature in sorted(test_features - doc_features):
+        questions.append(f"Feature '{feature}' has tests but is not documented.")
+    for feature in sorted(doc_features - test_features):
+        questions.append(
+            f"Feature '{feature}' is documented but has no corresponding tests."
+        )
+    for feature in sorted((doc_features | test_features) - code_features):
+        questions.append(
+            f"Feature '{feature}' is referenced in docs or tests but not in code."
+        )
+
+    _log_results(questions)
+
+    if questions:
+        print("Questions raised during dialectical audit:")
+        for q in questions:
+            print(f"- {q}")
+        return 1
+    print("No questions raised.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add dialectical audit script that cross-checks docs, code, and tests
- run dialectical audit during CI pipeline
- document Socratic dialogue procedure for audits

## Testing
- `SKIP=fix-code-blocks poetry run pre-commit run --files Taskfile.yml docs/policies/index.md docs/policies/dialectical_audit.md scripts/dialectical_audit.py`
- `poetry run devsynth run-tests` *(fails: KeyError <WorkerController gw4>)*
- `poetry run python tests/verify_test_organization.py`
- `poetry run python scripts/verify_requirements_traceability.py`

------
https://chatgpt.com/codex/tasks/task_e_689ac939e8f48333b5afb344e733c726