### PR TITLE
docs: add dialectical audit guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -62,8 +62,8 @@ DevSynth values clarity, collaboration, and dependable automation. Keep these pr
 
 ## Specification-First Workflow
 
-- Draft a specification for any new functionality under `docs/specifications/`.
-- Add a failing BDD feature under `tests/behavior/features/` before writing code.
+- Always draft a specification for any new functionality in `docs/specifications/` (see the [specification index](docs/specifications/index.md)) **before** implementation.
+- Always add a failing BDD feature under `tests/behavior/features/` prior to writing code.
 - Use this Socratic checklist when preparing specs and tests:
   - What is the problem?
   - What proofs confirm the solution?
@@ -85,14 +85,18 @@ poetry run python scripts/verify_requirements_traceability.py
    - **Key Questions**
      - What files or version bumps did the command produce?
      - Did the command complete without errors?
-2. Tag the release with `git tag -a <version>` and push the tag.
+2. Run `poetry run python scripts/dialectical_audit.py` to produce a dialectical audit log. See the [Dialectical Audit Policy](docs/policies/dialectical_audit.md).
    - **Key Questions**
-     - Does the tag follow semantic versioning?
-     - Have the tag and release notes been pushed to the remote?
+     - What inconsistencies or open questions did the audit uncover?
+     - Are these items resolved or tracked?
 3. Conduct a dialectical review with at least one other contributor.
    - **Key Questions**
      - What assumptions underlie the release changes?
      - What counterarguments or alternative perspectives have been considered?
+4. Tag the release with `git tag -a <version>` and push the tag.
+   - **Key Questions**
+     - Does the tag follow semantic versioning?
+     - Have the tag and release notes been pushed to the remote?
 
 ## Automation
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,7 +21,7 @@ Thank you for your interest in contributing to DevSynth! This document provides 
 1. **Fork and clone** the repository
 2. **Set up** your development environment with Poetry
 3. **Create a branch** for your changes
-4. **Draft a specification** in `docs/specifications/` and add a failing BDD feature in `tests/behavior/features/` answering the Socratic checklist before writing code
+4. **Draft a specification** in [docs/specifications/](docs/specifications/index.md) and add a failing BDD feature in `tests/behavior/features/` answering the Socratic checklist **before** writing code
 5. **Implement** your changes following our coding standards
 6. **Submit** a pull request with a clear description
 
@@ -105,11 +105,11 @@ poetry run python scripts/verify_requirements_traceability.py
 
 ## Release Process
 
-Maintainers preparing a tagged release should build distributable artifacts and
-run a quick smoke test before tagging:
+Maintainers preparing a tagged release should build distributable artifacts, run a dialectical audit (see the [Dialectical Audit Policy](docs/policies/dialectical_audit.md)), and run a quick smoke test before tagging:
 
 ```bash
-task release:prep
+poetry run task release:prep
+poetry run python scripts/dialectical_audit.py
 git tag v0.1.0-alpha.1
 git push origin v0.1.0-alpha.1
 ```


### PR DESCRIPTION
## Summary
- reference spec index and BDD feature requirement ahead of implementation
- require running dialectical audit script before tagging releases
- document release process linkage to Dialectical Audit Policy

## Testing
- `poetry run pre-commit run --files AGENTS.md CONTRIBUTING.md`
- `poetry run devsynth run-tests` *(fails: KeyError: 'feature')*
- `poetry run python tests/verify_test_organization.py`
- `poetry run python scripts/verify_requirements_traceability.py`


------
https://chatgpt.com/codex/tasks/task_e_689ace61f1888333bf17f2a240658098