### PR TITLE
Add embedded Kuzu configuration and adapter cleanup test

### DIFF
--- a/src/devsynth/application/memory/kuzu_store.py
+++ b/src/devsynth/application/memory/kuzu_store.py
@@ -61,7 +61,7 @@ class KuzuStore(MemoryStore):
         # overrides that may have been applied after module import.  Rely on
         # the settings object rather than module-level constants so changes are
         # consistently respected.
-        settings = settings_module.get_settings()
+        settings = settings_module.get_settings(reload=True)
 
         # ``ensure_path_exists`` handles path redirection and optional
         # directory creation based on the test environment.  Use the returned
@@ -103,7 +103,11 @@ class KuzuStore(MemoryStore):
         # explicit value is provided, consult the live settings to honour any
         # environment variable overrides that may have been applied after the
         # module was imported.
-        raw_embedded = settings.kuzu_embedded if use_embedded is None else use_embedded
+        raw_embedded = (
+            getattr(settings, "kuzu_embedded", settings_module.kuzu_embedded)
+            if use_embedded is None
+            else use_embedded
+        )
         if isinstance(raw_embedded, str):
             raw_embedded = raw_embedded.lower() in {"1", "true", "yes"}
         self.use_embedded = bool(raw_embedded)

--- a/src/devsynth/config/settings.py
+++ b/src/devsynth/config/settings.py
@@ -24,6 +24,9 @@ DEFAULT_KUZU_EMBEDDED = True
 
 # Module-level defaults for Kuzu integration
 kuzu_db_path: Optional[str] = None
+# Whether to use the embedded KuzuDB backend by default. Tests and runtime
+# environments may override this via the ``DEVSYNTH_KUZU_EMBEDDED``
+# environment variable.
 kuzu_embedded: bool = DEFAULT_KUZU_EMBEDDED
 # Backward-compatible constant for older imports
 KUZU_EMBEDDED = kuzu_embedded

--- a/tests/unit/adapters/memory/test_kuzu_adapter.py
+++ b/tests/unit/adapters/memory/test_kuzu_adapter.py
@@ -1,0 +1,31 @@
+import os
+import tempfile
+
+import pytest
+
+from devsynth.adapters.memory.kuzu_adapter import KuzuAdapter
+from devsynth.config import settings as settings_module
+
+
+@pytest.mark.medium
+def test_ephemeral_adapter_cleanup(monkeypatch, tmp_path):
+    """Ephemeral adapters should clean up redirected and original paths."""
+    monkeypatch.setenv("DEVSYNTH_PROJECT_DIR", str(tmp_path))
+    settings_module.get_settings(reload=True)
+    created: list[str] = []
+    real_mkdtemp = tempfile.mkdtemp
+
+    def fake_mkdtemp(prefix: str):
+        d = real_mkdtemp(prefix=prefix)
+        created.append(d)
+        return d
+
+    monkeypatch.setattr(tempfile, "mkdtemp", fake_mkdtemp)
+
+    adapter = KuzuAdapter.create_ephemeral()
+    original_dir = created[0]
+    redirected_dir = adapter.persist_directory
+    adapter.cleanup()
+
+    assert not os.path.exists(original_dir)
+    assert not os.path.exists(redirected_dir)


### PR DESCRIPTION
## Summary
- document embedded KuzuDB default in settings
- reload settings and respect embedded flag in `KuzuStore`
- add unit test covering ephemeral `KuzuAdapter` cleanup

## Testing
- `poetry run pre-commit run --files src/devsynth/application/memory/kuzu_store.py src/devsynth/config/settings.py tests/unit/adapters/memory/test_kuzu_adapter.py`
- `poetry run python tests/verify_test_organization.py`
- `poetry run python scripts/verify_requirements_traceability.py`
- `poetry run devsynth run-tests tests/integration/general/test_kuzu_memory_integration.py tests/unit/adapters/memory/test_kuzu_adapter.py` *(fails: unexpected extra arguments)*
- `poetry run pytest -p no:xdist tests/unit/adapters/memory/test_kuzu_adapter.py`
- `poetry run pytest -p no:xdist tests/integration/general/test_kuzu_memory_integration.py` *(fails: Fatal Python error: gilstate_tss_set)*

------
https://chatgpt.com/codex/tasks/task_e_689ace16662483339324736ea0532f4a