### PR TITLE
fix: stabilize bdd standalone test

### DIFF
--- a/issues/118.md
+++ b/issues/118.md
@@ -1,0 +1,16 @@
+# Issue 118: `devsynth run-tests` hangs without output
+
+Milestone: 0.1.0-alpha.1
+
+Running the `devsynth run-tests` command with or without `--speed` produces the startup banner
+but then hangs without completing or displaying results. The process terminates only after
+manual interruption, and no pytest processes remain active. This prevents executing the
+standard test suite via the provided CLI.
+
+## Steps to reproduce
+1. Execute `poetry run devsynth run-tests`.
+2. Observe that after the banner, no further output is produced.
+3. The command does not exit until interrupted.
+
+Investigate the CLI command so that it reliably runs the test suite and returns an appropriate
+exit status and report.

--- a/tests/behavior/simple_addition.feature
+++ b/tests/behavior/simple_addition.feature
@@ -1,0 +1,10 @@
+
+Feature: Simple Addition
+  As a user
+  I want to add two numbers
+  So that I can get their sum
+
+  Scenario: Add two numbers
+    Given I have the numbers 1 and 2
+    When I add them together
+    Then the result should be 3

--- a/tests/behavior/test_simple_standalone.py
+++ b/tests/behavior/test_simple_standalone.py
@@ -1,52 +1,39 @@
-"""
-A standalone test script to verify that pytest-bdd works without any dependencies.
-"""
+"""Standalone test to verify pytest-bdd integration."""
 
 import os
+
 import pytest
-from pytest_bdd import scenarios, given, when, then, parsers
+from pytest_bdd import given, parsers, scenarios, then, when
 
-# Define a simple feature string
-FEATURE = """
-Feature: Simple Addition
-  As a user
-  I want to add two numbers
-  So that I can get their sum
+# Load scenarios from the static feature file
+scenarios(os.path.join(os.path.dirname(__file__), "simple_addition.feature"))
 
-  Scenario: Add two numbers
-    Given I have the numbers 1 and 2
-    When I add them together
-    Then the result should be 3
-"""
-
-# Write the feature to a temporary file
-feature_file = os.path.join(os.path.dirname(__file__), "simple_addition.feature")
-with open(feature_file, "w") as f:
-    f.write(FEATURE)
-
-# Load the scenarios from the feature file
-scenarios(feature_file)
 
 @pytest.fixture
 def context():
-    """Create a context for the test."""
+    """Create a simple context object for the test."""
+
     class Context:
         def __init__(self):
             self.numbers = []
             self.result = None
+
     return Context()
+
 
 @given(parsers.parse("I have the numbers {num1:d} and {num2:d}"))
 def have_numbers(context, num1, num2):
-    """Store the numbers in the context."""
+    """Store the numbers for later addition."""
     context.numbers = [num1, num2]
+
 
 @when("I add them together")
 def add_numbers(context):
     """Add the numbers together."""
     context.result = sum(context.numbers)
 
+
 @then(parsers.parse("the result should be {expected:d}"))
 def check_result(context, expected):
-    """Check that the result matches the expected value."""
+    """Verify the addition result."""
     assert context.result == expected


### PR DESCRIPTION
## Summary
- replace dynamic feature creation in standalone BDD test with static feature file
- add missing simple_addition.feature file for pytest-bdd scenarios
- document `devsynth run-tests` CLI hang in issue 118

## Testing
- `poetry run pre-commit run --files tests/behavior/test_simple_standalone.py`
- `poetry run pre-commit run --files issues/118.md`
- `poetry run pytest tests/behavior/test_simple_standalone.py -q`
- `poetry run python tests/verify_test_organization.py`
- `poetry run python scripts/verify_requirements_traceability.py`
- `PIP_NO_INDEX=1 poetry run pip check`


------
https://chatgpt.com/codex/tasks/task_e_689ad796455c8333a8d0511d84add26f