### PR TITLE
docs: note run-tests issue

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -79,6 +79,10 @@ poetry run python tests/verify_test_organization.py
 poetry run python scripts/verify_requirements_traceability.py
 ```
 
+*Note*: `devsynth run-tests` may hang due to [Issue 118](issues/118.md). Until
+it is resolved, run `poetry run pytest -m "not memory_intensive"` as a
+temporary fallback to execute the suite.
+
 ## Release Preparation
 
 1. Run `poetry run task release:prep` to generate release artifacts.

--- a/issues/118.md
+++ b/issues/118.md
@@ -23,3 +23,6 @@ exit status and report.
   treat the run as unsuccessful.
 - Further work is needed to handle empty test selections and suppress benign
   warnings so the command exits cleanly.
+- After provisioning the environment, `poetry run devsynth run-tests --speed=fast`
+  still stalls after printing the startup banner and requires manual
+  interruption, with `/tmp/tests.log` showing no pytest output.


### PR DESCRIPTION
## Summary
- document temporary fallback when the test wrapper hangs
- record additional troubleshooting details for run-tests CLI issue

## Testing
- `poetry run pre-commit run --files AGENTS.md issues/118.md` (with `SKIP=fix-code-blocks`)
- `poetry run python tests/verify_test_organization.py`
- `poetry run python scripts/verify_requirements_traceability.py`
- `poetry run devsynth run-tests --speed=fast` *(fails: hangs after banner)*
- `poetry run pytest tests/unit/application/cli/test_run_tests_cmd.py::test_parse_feature_options -q`


------
https://chatgpt.com/codex/tasks/task_e_689b5da3d8b48333b6c22c838729450f