### PR TITLE
Document venv practices and note missing pytest speed flag

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,8 +31,10 @@ DevSynth values clarity, collaboration, and dependable automation. Keep these pr
     resources such as `DEVSYNTH_RESOURCE_LMSTUDIO_AVAILABLE`. Set to `true` or
     `false` to force-enable or disable a resource.
 - `tests/conftest_extensions.py` categorizes tests with `fast`, `medium`, and
-  `slow` markers and adds a `--speed` option so you can run only tests of a
-  given runtime, e.g. `poetry run pytest --speed=fast`.
+`slow` markers and adds a `--speed` option so you can run only tests of a
+ given runtime, e.g. `poetry run pytest --speed=fast`. Due to
+ [Issue 119](issues/119.md), this option is currently unrecognized; use
+ marker expressions like `-m "not memory_intensive"` until resolved.
 
 ## Quick Start
 

--- a/docs/developer_guides/development_setup.md
+++ b/docs/developer_guides/development_setup.md
@@ -99,6 +99,16 @@ poetry shell
 These commands install all required packages and activate the Poetry-managed
 virtual environment. Once complete, proceed to configure environment variables.
 
+### Virtual environment best practices
+
+- Avoid installing packages globally; rely on the Poetry-managed environment.
+- Prefix commands with `poetry run` or work inside `poetry shell` to ensure the
+  correct interpreter is active.
+- Rerun the environment provisioning script whenever dependencies change so
+  cached optional extras stay in sync.
+- Exclude any `.venv` directories or other environment artifacts from version
+  control.
+
 ## 3. Set Up Environment Variables
 
 Create a `.env` file in the project root with the following variables:

--- a/issues/119.md
+++ b/issues/119.md
@@ -1,0 +1,15 @@
+# Issue 119: Pytest `--speed` option unrecognized
+
+Milestone: 0.1.0-alpha.1
+
+Running `poetry run pytest --speed=fast` results in:
+```
+pytest: error: unrecognized arguments: --speed=fast
+```
+The `tests/conftest_extensions.py` plugin is expected to register this flag but appears not to load.
+
+## Steps to reproduce
+1. Execute `poetry run pytest --speed=fast`.
+2. Observe the unrecognized argument error and exit status 4.
+
+Investigate why the plugin fails to register the option so tests can be filtered by speed again.


### PR DESCRIPTION
## Summary
- document virtual environment best practices in the development setup guide
- note that the pytest `--speed` flag is currently unrecognized in AGENTS.md
- track missing pytest speed option with issue 119

## Testing
- `poetry run pre-commit run --files AGENTS.md issues/119.md docs/developer_guides/development_setup.md`
- `poetry run pytest tests/unit/agents/test_alignment_metrics_tool.py -m "not memory_intensive" --maxfail=1`
- `poetry run python tests/verify_test_organization.py`
- `poetry run python scripts/verify_requirements_traceability.py`


------
https://chatgpt.com/codex/tasks/task_e_689b64deeb7c8333a32cd5bb9576e445