### PR TITLE
docs: update test-related issue progress

### DIFF
--- a/issues/118.md
+++ b/issues/118.md
@@ -26,3 +26,6 @@ exit status and report.
 - After provisioning the environment, `poetry run devsynth run-tests --speed=fast`
   still stalls after printing the startup banner and requires manual
   interruption, with `/tmp/tests.log` showing no pytest output.
+- Running `timeout 10s poetry run devsynth run-tests` emits only an
+  `LMStudioProvider` warning and produces no further output, confirming the
+  hang persists.

--- a/issues/119.md
+++ b/issues/119.md
@@ -13,3 +13,8 @@ The `tests/conftest_extensions.py` plugin is expected to register this flag but 
 2. Observe the unrecognized argument error and exit status 4.
 
 Investigate why the plugin fails to register the option so tests can be filtered by speed again.
+
+## Progress
+
+- Running `poetry run pytest --speed=fast` still produces the unrecognized
+  argument error, preventing speed-based test selection.


### PR DESCRIPTION
## Summary
- note hanging `devsynth run-tests` behavior
- document persistence of `--speed` flag failure

## Testing
- `SKIP=fix-code-blocks poetry run pre-commit run --files issues/118.md issues/119.md`
- `poetry run pytest tests/behavior/steps/test_alignment_metrics_steps.py --maxfail=1`
- `poetry run python tests/verify_test_organization.py`
- `poetry run python scripts/verify_requirements_traceability.py`
- `PIP_NO_INDEX=1 poetry run pip check`


------
https://chatgpt.com/codex/tasks/task_e_689b7ff0b0b08333bab6e0add5af7695