### PR TITLE
docs: clarify LM Studio mocking

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,6 +30,9 @@ DevSynth values clarity, collaboration, and dependable automation. Keep these pr
   - `DEVSYNTH_RESOURCE_<NAME>_AVAILABLE` – gates tests that rely on optional
     resources such as `DEVSYNTH_RESOURCE_LMSTUDIO_AVAILABLE`. Set to `true` or
     `false` to force-enable or disable a resource.
+- When optional services like LM Studio are unavailable, guard imports with
+  `pytest.importorskip("lmstudio")` and use mocks or HTTP stubs to simulate
+  responses so unit tests remain deterministic.
 - `tests/conftest_extensions.py` categorizes tests with `fast`, `medium`, and
 `slow` markers and adds a `--speed` option so you can run only tests of a
  given runtime, e.g. `poetry run pytest --speed=fast`. Due to

--- a/docs/developer_guides/testing.md
+++ b/docs/developer_guides/testing.md
@@ -298,6 +298,17 @@ poetry run pytest -m "not memory_intensive"
 
 Mark such tests with `@pytest.mark.memory_intensive`. For optional services, use resource markers such as `@pytest.mark.requires_resource("lmstudio")` and set `DEVSYNTH_RESOURCE_<NAME>_AVAILABLE=false` to skip them when unavailable.
 
+### Mocking LM Studio and other optional services
+
+When the `lmstudio` package or its server is unavailable, tests should
+gracefully skip or mock the dependency. Guard direct imports with
+`pytest.importorskip("lmstudio")` to avoid import errors. For unit tests,
+stub network interactions using `unittest.mock` or libraries like
+`responses` so that code paths remain deterministic. Integration tests that
+genuinely exercise LM Studio should be marked with
+`@pytest.mark.requires_resource("lmstudio")` and executed only when
+`DEVSYNTH_RESOURCE_LMSTUDIO_AVAILABLE=true`.
+
 ## Running All Tests
 
 ```bash

--- a/issues/121.md
+++ b/issues/121.md
@@ -1,0 +1,23 @@
+# Issue 121: LM Studio mock service for deterministic tests
+
+Milestone: 0.1.0-alpha.1
+
+Tests referencing the LM Studio provider currently rely on the optional
+`lmstudio` package and a running LM Studio server. When these are absent,
+warnings are emitted and some integration tests cannot run, reducing
+confidence in related code paths.
+
+## Steps to reproduce
+1. Ensure `lmstudio` is not installed.
+2. Run `poetry run pytest tests/integration/general/test_lmstudio_provider.py`.
+3. Observe that the module is skipped entirely due to missing dependency.
+
+## Suggested improvement
+Create a lightweight mock or HTTP stub of the LM Studio API so tests can
+exercise provider logic without requiring the real service. When the real
+service is available, keep resource markers so those tests can run against
+it.
+
+## Progress
+- Documented best practices for mocking optional services in
+  `docs/developer_guides/testing.md`.


### PR DESCRIPTION
## Summary
- document how to mock LM Studio and other optional services
- advise guarding LM Studio imports and using HTTP stubs in tests
- track need for LM Studio mock service in issues/121

## Testing
- `SKIP=fix-code-blocks poetry run pre-commit run --files AGENTS.md docs/developer_guides/testing.md issues/121.md`
- `poetry run pytest -m "not memory_intensive"` *(fails: TypeError, 628 failed)*
- `poetry run python tests/verify_test_organization.py`
- `poetry run python scripts/verify_requirements_traceability.py`
- `PIP_NO_INDEX=1 poetry run pip check`


------
https://chatgpt.com/codex/tasks/task_e_689b83b8beb48333a7cd13243bffa29a