### PR TITLE
docs: generalize codex_setup references

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,8 +8,8 @@ DevSynth values clarity, collaboration, and dependable automation. Keep these pr
 
 - Run **all** commands through `poetry run` to ensure the correct virtual environment is used.
 - Pytest markers such as `memory_intensive` gate resource-heavy tests; skip them unless specifically required.
-- Run `scripts/codex_setup.sh` before beginning any development to provision the environment. Update the script as appropriate and according to best practices.
-- References to this file or `scripts/codex_setup.sh` must not appear elsewhere in the repository. Outside these files, refer to it generically as the environment provisioning script.
+- Run the environment provisioning script before beginning any development to provision the environment. Update the script as appropriate and according to best practices.
+- References to this file or the script's path must not appear elsewhere in the repository. Outside these files, refer to it generically as the environment provisioning script.
 - Optional extras in `pyproject.toml` are automatically cached by the environment provisioning script, keeping them synchronized with the project configuration while skipping heavy GPU packages.
 - Update this file, your instructions and initial context, as appropriate and according to best-practices.
 - Documents in `docs/inspirational_docs/` are for inspiration only and must not be directly referenced; use these documents for inspiration.

--- a/issues/120.md
+++ b/issues/120.md
@@ -7,7 +7,7 @@ Running the environment provisioning script followed by
 failing tests, particularly in the code analysis pipeline.
 
 ## Steps to reproduce
-1. Execute `scripts/codex_setup.sh`.
+1. Execute the environment provisioning script.
 2. Run `poetry run pytest -m "not memory_intensive"`.
 
 ## Progress


### PR DESCRIPTION
## Summary
- refer to the environment provisioning script instead of `scripts/codex_setup.sh`
- clarify AGENTS instructions around the script's path

## Testing
- `SKIP=fix-code-blocks poetry run pre-commit run --files AGENTS.md issues/120.md`
- `poetry run devsynth run-tests` *(fails: command hung, interrupted)*
- `poetry run pytest -m "not memory_intensive"` *(fails: 148 failed, 47 passed, 38 skipped, 53 deselected, 1 error, 1 interrupt)*
- `poetry run python tests/verify_test_organization.py`
- `poetry run python scripts/verify_requirements_traceability.py`
- `poetry run python scripts/verify_version_sync.py`

------
https://chatgpt.com/codex/tasks/task_e_689bd3ebc47883339142cce357c7d9f3