### PR TITLE
Enable pytest speed filter plugin and document usage

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,9 +35,7 @@ DevSynth values clarity, collaboration, and dependable automation. Keep these pr
   responses so unit tests remain deterministic.
 - `tests/conftest_extensions.py` categorizes tests with `fast`, `medium`, and
 `slow` markers and adds a `--speed` option so you can run only tests of a
- given runtime, e.g. `poetry run pytest --speed=fast`. Due to
- [Issue 119](issues/119.md), this option is currently unrecognized; use
- marker expressions like `-m "not memory_intensive"` until resolved.
+ given runtime, e.g. `poetry run pytest --speed=fast -m fast`.
 
 ## Quick Start
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -79,6 +79,9 @@ poetry run pytest
 
 # Run with coverage
 poetry run pytest --cov=src --cov-report=term-missing
+
+# Run only fast tests
+poetry run pytest --speed=fast -m fast
 ```
 
 ## Documentation

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,6 +5,8 @@ This module provides fixtures for ensuring all tests are hermetic (isolated from
 and don't pollute the developer's environment, file system, or depend on external services.
 """
 
+pytest_plugins = ["tests.conftest_extensions"]
+
 import logging
 import os
 import shutil

--- a/tests/unit/general/test_speed_option.py
+++ b/tests/unit/general/test_speed_option.py
@@ -1,0 +1,30 @@
+import subprocess
+import sys
+from pathlib import Path
+
+
+def test_speed_option_recognized():
+    repo_root = Path(__file__).resolve().parents[3]
+    test_file = repo_root / "tests" / "tmp_speed_dummy.py"
+    test_file.write_text(
+        "import pytest\n@pytest.mark.fast\ndef test_dummy():\n    assert True\n"
+    )
+    try:
+        result = subprocess.run(
+            [
+                sys.executable,
+                "-m",
+                "pytest",
+                "--speed=fast",
+                "-m",
+                "fast",
+                str(test_file),
+            ],
+            capture_output=True,
+            text=True,
+            cwd=repo_root,
+        )
+        assert result.returncode == 0, result.stderr
+    finally:
+        if test_file.exists():
+            test_file.unlink()


### PR DESCRIPTION
## Summary
- load `tests.conftest_extensions` via `pytest_plugins` so the `--speed` option is recognized
- document `--speed` test filtering in AGENTS and CONTRIBUTING guides
- add unit test ensuring `pytest --speed=fast -m fast` is accepted

## Testing
- `poetry run pre-commit run --files AGENTS.md CONTRIBUTING.md tests/conftest.py tests/unit/general/test_speed_option.py`
- `poetry run pytest tests/unit/general/test_speed_option.py -q`
- `poetry run python tests/verify_test_organization.py`
- `poetry run python scripts/verify_requirements_traceability.py`
- `poetry run python scripts/verify_version_sync.py`


------
https://chatgpt.com/codex/tasks/task_e_689bdf33c2ec8333a4a9e7b321498277