### PR TITLE
Ensure environment provisioning script runs CLI tests

### DIFF
--- a/scripts/codex_setup.sh
+++ b/scripts/codex_setup.sh
@@ -172,5 +172,10 @@ fi
 # Run a smoke test to catch failures early
 poetry run pytest tests/behavior/steps/test_alignment_metrics_steps.py --maxfail=1
 
+# Use the CLI to run a fast, non-interactive test sweep. The timeout prevents
+# hangs while the log aids in diagnosing failures.
+# What evidence shows the CLI can run tests non-interactively?
+timeout 15m poetry run devsynth run-tests --speed=fast --no-parallel | tee devsynth_cli_tests.log
+
 # Cleanup any failure marker if the setup completes successfully
 [ -f CODEX_ENVIRONMENT_SETUP_FAILED ] && rm CODEX_ENVIRONMENT_SETUP_FAILED


### PR DESCRIPTION
## Summary
- Run a fast DevSynth CLI test sweep with a timeout to catch hangs during environment provisioning
- Log CLI test output for easier diagnosis of future failures

## Testing
- `poetry run pre-commit run --files scripts/codex_setup.sh`
- `timeout 15m poetry run devsynth run-tests --speed=fast --no-parallel`
- `poetry run python tests/verify_test_organization.py`
- `poetry run python scripts/verify_requirements_traceability.py`
- `poetry run python scripts/verify_version_sync.py`


------
https://chatgpt.com/codex/tasks/task_e_689be587fa188333bb7b21bf601bd76a