### PR TITLE
docs: add code analysis guide

### DIFF
--- a/docs/developer_guides/code_analysis.md
+++ b/docs/developer_guides/code_analysis.md
@@ -1,0 +1,59 @@
+---
+author: DevSynth Team
+date: '2025-07-12'
+last_reviewed: '2025-07-12'
+status: published
+tags:
+- developer-guide
+- code-analysis
+title: Code Analysis Guide
+version: "0.1.0-alpha.1"
+---
+<div class="breadcrumbs">
+<a href="../index.md">Documentation</a> &gt; <a href="index.md">Developer Guides</a> &gt; Code Analysis Guide
+</div>
+
+# Code Analysis Guide
+
+DevSynth includes utilities for analyzing repository structure and transforming
+code via Python's Abstract Syntax Tree (AST). This guide introduces the
+`RepoAnalyzer`, the `AstTransformer`, and several built-in transformations.
+
+## RepoAnalyzer
+
+`RepoAnalyzer` walks a project directory, recording the folder hierarchy and
+extracting top-level imports from Python files to map dependencies. The
+`analyze` method returns a dictionary with separate `dependencies` and
+`structure` keys, providing a lightweight overview of project composition.
+
+## AstTransformer
+
+`AstTransformer` offers programmatic code modifications using Python's AST. It
+supports operations like renaming identifiers and extracting functions while
+preserving valid syntax. The transformer logs initialization and each change for
+traceability.
+
+## Sample Transformations
+
+DevSynth ships with several `AstTransformer` subclasses for common refactors:
+
+- `UnusedImportRemover` drops imports that are never referenced.
+- `RedundantAssignmentRemover` removes assignments whose values are immediately
+  returned or self-assigned.
+- `UnusedVariableRemover` strips variables that are declared but not used.
+- `StringLiteralOptimizer` collapses string concatenations and trims excess
+  whitespace.
+
+These transformations can be combined through higher-level utilities to clean
+entire files or directories.
+
+## Related Specifications and Tests
+
+- Specification: [DevSynth Post-MVP Testing Infrastructure](../specifications/testing_infrastructure.md).
+- Unit tests: [`test_repo_analyzer.py`](../../tests/unit/application/code_analysis/test_repo_analyzer.py) and
+  [`test_transformer.py`](../../tests/unit/application/code_analysis/test_transformer.py).
+
+## Further Reading
+
+See the [Technical Reference for AST Transformer](../technical_reference/ast_transformer.md)
+for detailed API documentation.

--- a/docs/developer_guides/index.md
+++ b/docs/developer_guides/index.md
@@ -35,6 +35,7 @@ This section is for developers contributing to the DevSynth project or those loo
 - **[Repository Structure](../repo_structure.md)**: An overview of how the DevSynth repository is organized.
 - **[Requirements Wizard Structure](requirements_wizard_structure.md)**: Overview of the requirements wizard helpers.
 - **[Agent Tools](agent_tools.md)**: Overview of the tool registry and how to add new tools.
+- **[Code Analysis Guide](code_analysis.md)**: Overview of repository analysis and AST transformation utilities.
 
 ## Testing Guides
 

--- a/docs/specifications/index.md
+++ b/docs/specifications/index.md
@@ -68,6 +68,8 @@ If you're new to DevSynth's specifications, we recommend starting with the [DevS
 - [Architecture](../architecture/index.md) - Overview of DevSynth's architecture
 - [Technical Reference](../technical_reference/index.md) - Technical reference documentation
 - [Developer Guides](../developer_guides/index.md) - Information for developers contributing to DevSynth
+- [Code Analysis Guide](../developer_guides/code_analysis.md) - Overview of repository analysis and AST-based transformations
+
 ## Implementation Status
 
 Most specifications correspond to implemented modules under `src/devsynth`. Refer to each document for specific paths and implementation details.


### PR DESCRIPTION
## Summary
- document RepoAnalyzer and AST-based transformations
- cross-reference testing specification and related unit tests
- link new guide from specification and developer guide indexes

## Testing
- `poetry run pre-commit run --files docs/developer_guides/code_analysis.md docs/specifications/index.md docs/developer_guides/index.md`
- `poetry run pytest -m "not memory_intensive"` *(fails: 71 failed, 1 error)*
- `poetry run python tests/verify_test_organization.py`
- `poetry run python scripts/verify_test_markers.py` *(Interrupted: KeyboardInterrupt)*
- `poetry run python scripts/verify_requirements_traceability.py`
- `poetry run python scripts/verify_version_sync.py`
- `poetry run mkdocs build` *(fails: ValueError in mkdocs-autorefs)*

------
https://chatgpt.com/codex/tasks/task_e_689c072ff63c8333a5c698684e0de58a