### PR TITLE
Add requirements wizard logging spec and tests

### DIFF
--- a/docs/specifications/index.md
+++ b/docs/specifications/index.md
@@ -31,6 +31,7 @@ This section contains the official specifications for the DevSynth project, outl
 - **[Hybrid Memory Architecture](hybrid_memory_architecture.md)**: Specification for DevSynth's hybrid memory architecture.
 - **[Interactive Requirements Wizard](interactive_requirements_wizard.md)**: Guided collection of requirements via CLI and WebUI.
 - **[Interactive Requirements Gathering](interactive_requirements_gathering.md)**: Wizard for capturing project goals and constraints.
+- **[Requirements Wizard Logging](requirements_wizard_logging.md)**: Expected log structure and persistence rules for the requirements wizard.
 
 ## Implementation Plans
 

--- a/docs/specifications/requirements_wizard_logging.md
+++ b/docs/specifications/requirements_wizard_logging.md
@@ -1,0 +1,47 @@
+---
+title: Requirements Wizard Logging
+author: DevSynth Team
+date: 2025-02-14
+status: draft
+---
+
+# Summary
+
+Defines expected logging behaviour for the requirements wizard, including structured JSON fields and persistence rules.
+
+## Socratic Checklist
+- What is the problem?
+- What proofs confirm the solution?
+
+## Motivation
+
+Reliable logs ensure troubleshooting and compliance for requirement gathering flows. This specification outlines the structure for log entries and where they are stored.
+
+## Specification
+
+### Log Structure
+
+Each log entry produced by the requirements wizard SHALL contain:
+
+- `timestamp`: ISO-8601 timestamp of the event.
+- `level`: severity such as `INFO` or `ERROR`.
+- `logger`: emitting logger name.
+- `message`: human readable text.
+- `module`, `function`, `line`: resolved call site.
+- `actual_module`, `actual_function`, `actual_line`: original call site prior to overrides.
+- `request_id` and `phase` when available from context.
+- `exception` object with `type`, `message`, and `traceback` when an error occurs.
+- Arbitrary extra fields supplied via logging `extra` kwargs after filtering reserved keys.
+
+### Persistence Rules
+
+- Logs SHALL be written in JSON lines format to the configured log file (default `logs/devsynth.log`).
+- The log directory SHALL only be created when `configure_logging` is invoked.
+- When the environment variable `DEVSYNTH_NO_FILE_LOGGING` is set to `1`, file logging SHALL be disabled.
+- Log records MUST survive navigation between wizard steps and reflect the last recorded state for `priority` and `constraints`.
+
+## Acceptance Criteria
+
+- A failing BDD scenario captures logging expectations.
+- Unit tests verify logger handling of `exc_info` and reserved `extra` keys without errors.
+- Requirements wizard persists `priority` and `constraints` after navigating backwards.

--- a/src/devsynth/logging_setup.py
+++ b/src/devsynth/logging_setup.py
@@ -388,31 +388,35 @@ class DevSynthLogger:
             elif not isinstance(exc, tuple):
                 exc = sys.exc_info()
 
+        RESERVED = {
+            "name",
+            "msg",
+            "args",
+            "levelname",
+            "levelno",
+            "pathname",
+            "filename",
+            "module",
+            "exc_info",
+            "exc_text",
+            "stack_info",
+            "lineno",
+            "funcName",
+            "created",
+            "msecs",
+            "relativeCreated",
+            "thread",
+            "threadName",
+            "processName",
+            "process",
+            "message",
+            "asctime",
+        }
+
+        if extra is not None:
+            extra = {k: v for k, v in dict(extra).items() if k not in RESERVED}
+
         if kwargs:
-            RESERVED = {
-                "name",
-                "msg",
-                "args",
-                "levelname",
-                "levelno",
-                "pathname",
-                "filename",
-                "module",
-                "exc_info",
-                "exc_text",
-                "stack_info",
-                "lineno",
-                "funcName",
-                "created",
-                "msecs",
-                "relativeCreated",
-                "thread",
-                "threadName",
-                "processName",
-                "process",
-                "message",
-                "asctime",
-            }
             safe_kwargs = {k: v for k, v in kwargs.items() if k not in RESERVED}
             if extra is None:
                 extra = safe_kwargs

--- a/tests/behavior/features/general/requirements_wizard_logging.feature
+++ b/tests/behavior/features/general/requirements_wizard_logging.feature
@@ -1,0 +1,9 @@
+Feature: Requirements Wizard Logging
+  As a developer
+  I want detailed logs for the requirements wizard
+  So that interactions can be audited and debugged
+
+  Scenario: Logs capture wizard steps
+    Given the DevSynth CLI is installed
+    When I run the requirements wizard with logging enabled
+    Then log entries for each wizard step should be persisted

--- a/tests/behavior/test_requirements_wizard_logging.py
+++ b/tests/behavior/test_requirements_wizard_logging.py
@@ -1,0 +1,12 @@
+import os
+
+from pytest_bdd import scenarios
+
+feature_file = os.path.join(
+    os.path.dirname(__file__),
+    "features",
+    "general",
+    "requirements_wizard_logging.feature",
+)
+
+scenarios(feature_file)

--- a/tests/unit/application/requirements/test_wizard.py
+++ b/tests/unit/application/requirements/test_wizard.py
@@ -1,0 +1,40 @@
+import json
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import yaml
+
+from devsynth.application.cli.config import CLIConfig
+from devsynth.application.requirements.wizard import requirements_wizard
+from devsynth.interface.ux_bridge import UXBridge
+
+
+def test_priority_and_constraints_persist_after_navigation(tmp_path, monkeypatch):
+    """User selections persist when navigating backwards."""
+    monkeypatch.chdir(tmp_path)
+    responses = iter(
+        [
+            "Title",  # title
+            "Desc",  # description
+            "functional",  # type
+            "high",  # priority initial
+            "back",  # navigate back from constraints
+            "low",  # updated priority
+            "cpu,gpu",  # constraints
+        ]
+    )
+
+    bridge = MagicMock(spec=UXBridge)
+    bridge.ask_question.side_effect = lambda *args, **kwargs: next(responses)
+    bridge.display_result = MagicMock()
+
+    requirements_wizard(bridge, output_file="req.json", config=CLIConfig())
+
+    data = json.loads(Path("req.json").read_text())
+    assert data["priority"] == "low"
+    assert data["constraints"] == ["cpu", "gpu"]
+
+    project_yaml = Path(".devsynth/project.yaml")
+    cfg_data = yaml.safe_load(project_yaml.read_text())
+    assert cfg_data["priority"] == "low"
+    assert cfg_data["constraints"] == "cpu,gpu"

--- a/tests/unit/general/test_logging_setup.py
+++ b/tests/unit/general/test_logging_setup.py
@@ -60,3 +60,18 @@ def test_exc_info_true_uses_current_exception(monkeypatch):
     logging.getLogger().removeHandler(handler)
     record = handler.records[0]
     assert record.exc_info and record.exc_info[0] is ZeroDivisionError
+
+
+def test_extra_kwargs_and_reserved_keys_safely_handled(monkeypatch):
+    """Reserved keys in kwargs or extra should not raise errors."""
+
+    monkeypatch.setenv("DEVSYNTH_NO_FILE_LOGGING", "1")
+    configure_logging(create_dir=False)
+    logger = get_logger(__name__)
+    handler = LogCaptureHandler()
+    logging.getLogger().addHandler(handler)
+    logger.info("hello", module="fake", extra={"module": "fake", "foo": "bar"})
+    logging.getLogger().removeHandler(handler)
+    record = handler.records[0]
+    assert getattr(record, "foo") == "bar"
+    assert record.module != "fake"


### PR DESCRIPTION
## Summary
- specify logging structure and persistence for the requirements wizard
- harden DevSynthLogger against reserved extra kwargs
- test persistence of wizard priority and constraints
- add placeholder BDD scenario for wizard logging

## Testing
- `poetry run pre-commit run --files docs/specifications/index.md docs/specifications/requirements_wizard_logging.md src/devsynth/logging_setup.py tests/unit/general/test_logging_setup.py tests/behavior/features/general/requirements_wizard_logging.feature tests/behavior/test_requirements_wizard_logging.py tests/unit/application/requirements/test_wizard.py`
- `poetry run python tests/verify_test_organization.py`
- `poetry run python scripts/verify_test_markers.py` *(failed: KeyboardInterrupt)*
- `poetry run python scripts/verify_requirements_traceability.py`
- `poetry run python scripts/verify_version_sync.py`
- `poetry run devsynth run-tests --speed=fast` *(failed: lmstudio module missing)*

------
https://chatgpt.com/codex/tasks/task_e_689c1b98400c8333b4a79e0a661f3094