### PR TITLE
chore: mark high-cost tests and enhance flaky test script

### DIFF
--- a/scripts/fix_flaky_tests.py
+++ b/scripts/fix_flaky_tests.py
@@ -19,27 +19,30 @@ Options:
     --report              Generate a report of flaky test patterns without fixing
 """
 
-import os
-import sys
-import re
-import ast
 import argparse
+import ast
 import json
+import os
+import re
+import subprocess
+import sys
 from pathlib import Path
-from typing import Dict, List, Tuple, Any, Optional, Set
+from typing import Any, Dict, List, Optional, Set, Tuple
 
 # Import common test collector
 sys.path.append(os.path.dirname(os.path.abspath(__file__)))
 try:
     from common_test_collector import (
-        collect_tests, 
-        collect_tests_by_category, 
         check_test_has_marker,
+        clear_cache,
+        collect_tests,
+        collect_tests_by_category,
         invalidate_cache_for_files,
-        clear_cache
     )
 except ImportError:
-    print("Error: common_test_collector.py not found. Please ensure it exists in the scripts directory.")
+    print(
+        "Error: common_test_collector.py not found. Please ensure it exists in the scripts directory."
+    )
     sys.exit(1)
 
 # Test categories
@@ -48,7 +51,7 @@ TEST_CATEGORIES = {
     "integration": "tests/integration",
     "behavior": "tests/behavior",
     "performance": "tests/performance",
-    "property": "tests/property"
+    "property": "tests/property",
 }
 
 # High-priority modules
@@ -58,7 +61,7 @@ HIGH_PRIORITY_MODULES = [
     "tests/unit/adapters/llm",
     "tests/integration/memory",
     "tests/unit/application/wsde",
-    "tests/unit/interface/webui"
+    "tests/unit/interface/webui",
 ]
 
 # Flaky test patterns
@@ -67,7 +70,7 @@ FLAKY_PATTERNS = {
         {
             "pattern": r"mock\s*=\s*MagicMock\(\)",
             "fix": r"mock = MagicMock(spec=ClassName)",
-            "description": "Use MagicMock with spec to ensure mocks have the same interface as real objects"
+            "description": "Use MagicMock with spec to ensure mocks have the same interface as real objects",
         },
         {
             "pattern": r"monkeypatch\.setattr\([^,]+,\s*lambda[^:]+:[^)]+\)",
@@ -77,7 +80,7 @@ def mock_function(*args, **kwargs):
     return expected_result
 monkeypatch.setattr(target, mock_function)
 """,
-            "description": "Replace lambda functions with named functions for more robust mocking"
+            "description": "Replace lambda functions with named functions for more robust mocking",
         },
         {
             "pattern": r"answers\s*=\s*iter\(\[[^\]]+\]\)",
@@ -93,8 +96,8 @@ def mock_function(*args, **kwargs):
         return result
     return default_value  # Provide a default value
 """,
-            "description": "Use indexed lists instead of iterators to avoid StopIteration errors"
-        }
+            "description": "Use indexed lists instead of iterators to avoid StopIteration errors",
+        },
     ],
     "isolation": [
         {
@@ -105,7 +108,7 @@ import $1 as $2
 # Reload the module to ensure clean state
 importlib.reload($2)
 """,
-            "description": "Reload modules to ensure clean state for each test"
+            "description": "Reload modules to ensure clean state for each test",
         },
         {
             "pattern": r"monkeypatch\.setattr\(([^,]+),\s*([^)]+)\)",
@@ -118,8 +121,8 @@ finally:
     # Restore original if needed for cleanup
     pass
 """,
-            "description": "Use try/finally blocks to ensure cleanup after patching"
-        }
+            "description": "Use try/finally blocks to ensure cleanup after patching",
+        },
     ],
     "state": [
         {
@@ -128,7 +131,7 @@ finally:
 # Use a state manager class instead of direct session state access
 state.set($1, value)
 """,
-            "description": "Use a state manager class instead of direct session state access"
+            "description": "Use a state manager class instead of direct session state access",
         },
         {
             "pattern": r"def\s+test_[^(]+\(([^)]*)\):\s*(?!.*fixture)",
@@ -142,10 +145,11 @@ def clean_state():
 def test_$TEST_NAME($PARAMS, clean_state):
     # Test with clean state
 """,
-            "description": "Use fixtures to set up and clean up state for tests"
-        }
-    ]
+            "description": "Use fixtures to set up and clean up state for tests",
+        },
+    ],
 }
+
 
 def parse_args():
     """Parse command line arguments."""
@@ -153,61 +157,76 @@ def parse_args():
         description="Fix flaky tests by improving isolation and determinism."
     )
     parser.add_argument(
-        "--module",
-        help="Specific module to process (e.g., tests/unit/interface)"
+        "--module", help="Specific module to process (e.g., tests/unit/interface)"
     )
     parser.add_argument(
         "--category",
         choices=list(TEST_CATEGORIES.keys()) + ["all"],
         default="all",
-        help="Test category to process (default: all)"
+        help="Test category to process (default: all)",
     )
     parser.add_argument(
         "--max-tests",
         type=int,
         default=100,
-        help="Maximum number of tests to process in a single run (default: 100)"
+        help="Maximum number of tests to process in a single run (default: 100)",
     )
     parser.add_argument(
-        "--dry-run",
-        action="store_true",
-        help="Show changes without modifying files"
+        "--dry-run", action="store_true", help="Show changes without modifying files"
     )
     parser.add_argument(
-        "--verbose",
-        action="store_true",
-        help="Show detailed information"
+        "--verbose", action="store_true", help="Show detailed information"
     )
     parser.add_argument(
         "--pattern",
         choices=["mocking", "isolation", "state", "all"],
         default="all",
-        help="Specific pattern to fix (default: all)"
+        help="Specific pattern to fix (default: all)",
     )
     parser.add_argument(
         "--report",
         action="store_true",
-        help="Generate a report of flaky test patterns without fixing"
+        help="Generate a report of flaky test patterns without fixing",
+    )
+    parser.add_argument(
+        "--verify",
+        action="store_true",
+        help="Run affected tests repeatedly to check for stability",
+    )
+    parser.add_argument(
+        "--retries",
+        type=int,
+        default=3,
+        help="Number of times to rerun tests when verifying stability",
+    )
+    parser.add_argument(
+        "--speed",
+        choices=["fast", "medium", "slow"],
+        default="medium",
+        help="Speed marker to use when verifying test stability",
     )
     return parser.parse_args()
 
-def collect_test_files(category: str = "all", module: str = None, use_cache: bool = True) -> List[str]:
+
+def collect_test_files(
+    category: str = "all", module: str = None, use_cache: bool = True
+) -> List[str]:
     """
     Collect test files to process.
-    
+
     Args:
         category: Test category (unit, integration, behavior, all)
         module: Specific module to collect tests from
         use_cache: Whether to use cached test collection results
-        
+
     Returns:
         List of test file paths
     """
     print("Collecting test files...")
-    
+
     # Determine which categories to collect
     categories = [category] if category != "all" else list(TEST_CATEGORIES.keys())
-    
+
     # Collect all tests
     all_tests = []
     for cat in categories:
@@ -221,7 +240,7 @@ def collect_test_files(category: str = "all", module: str = None, use_cache: boo
             # Otherwise, collect all tests for the category
             tests = collect_tests_by_category(cat, use_cache=use_cache)
             all_tests.extend(tests)
-    
+
     # Extract unique file paths
     test_files = set()
     for test in all_tests:
@@ -230,175 +249,204 @@ def collect_test_files(category: str = "all", module: str = None, use_cache: boo
             test_files.add(file_path)
         else:
             test_files.add(test)
-    
+
     print(f"Found {len(test_files)} test files")
     return list(test_files)
+
 
 def prioritize_files(files: List[str], priority_modules: List[str]) -> List[str]:
     """
     Prioritize files based on module priority.
-    
+
     Args:
         files: List of file paths
         priority_modules: List of high-priority modules
-        
+
     Returns:
         Prioritized list of file paths
     """
     high_priority = []
     normal_priority = []
-    
+
     for file in files:
         if any(file.startswith(module) for module in priority_modules):
             high_priority.append(file)
         else:
             normal_priority.append(file)
-    
+
     return high_priority + normal_priority
 
-def analyze_file(file_path: str, patterns: Dict[str, List[Dict[str, str]]], verbose: bool = False) -> Dict[str, List[Dict[str, Any]]]:
+
+def analyze_file(
+    file_path: str, patterns: Dict[str, List[Dict[str, str]]], verbose: bool = False
+) -> Dict[str, List[Dict[str, Any]]]:
     """
     Analyze a file for flaky test patterns.
-    
+
     Args:
         file_path: Path to the file to analyze
         patterns: Dictionary of patterns to look for
         verbose: Whether to show detailed information
-        
+
     Returns:
         Dictionary of issues found in the file
     """
     if verbose:
         print(f"Analyzing {file_path}...")
-    
+
     try:
-        with open(file_path, 'r') as f:
+        with open(file_path, "r") as f:
             content = f.read()
-        
-        issues = {
-            "mocking": [],
-            "isolation": [],
-            "state": []
-        }
-        
+
+        issues = {"mocking": [], "isolation": [], "state": []}
+
         # Check for each pattern
         for pattern_type, pattern_list in patterns.items():
             for pattern_info in pattern_list:
                 pattern = pattern_info["pattern"]
                 matches = re.finditer(pattern, content)
-                
+
                 for match in matches:
-                    line_start = content[:match.start()].count('\n') + 1
-                    line_end = content[:match.end()].count('\n') + 1
-                    
+                    line_start = content[: match.start()].count("\n") + 1
+                    line_end = content[: match.end()].count("\n") + 1
+
                     # Get the context (a few lines before and after)
-                    lines = content.split('\n')
+                    lines = content.split("\n")
                     context_start = max(0, line_start - 3)
                     context_end = min(len(lines), line_end + 3)
-                    context = '\n'.join(lines[context_start:context_end])
-                    
-                    issues[pattern_type].append({
-                        "pattern": pattern,
-                        "description": pattern_info["description"],
-                        "fix": pattern_info["fix"],
-                        "line_start": line_start,
-                        "line_end": line_end,
-                        "match": match.group(0),
-                        "context": context
-                    })
-        
+                    context = "\n".join(lines[context_start:context_end])
+
+                    issues[pattern_type].append(
+                        {
+                            "pattern": pattern,
+                            "description": pattern_info["description"],
+                            "fix": pattern_info["fix"],
+                            "line_start": line_start,
+                            "line_end": line_end,
+                            "match": match.group(0),
+                            "context": context,
+                        }
+                    )
+
         return issues
-    
+
     except Exception as e:
         print(f"Error analyzing {file_path}: {e}")
         return {"mocking": [], "isolation": [], "state": []}
 
-def fix_file(file_path: str, issues: Dict[str, List[Dict[str, Any]]], dry_run: bool = True, verbose: bool = False) -> bool:
+
+def fix_file(
+    file_path: str,
+    issues: Dict[str, List[Dict[str, Any]]],
+    dry_run: bool = True,
+    verbose: bool = False,
+) -> bool:
     """
     Fix flaky test patterns in a file.
-    
+
     Args:
         file_path: Path to the file to fix
         issues: Dictionary of issues to fix
         dry_run: Whether to show changes without modifying the file
         verbose: Whether to show detailed information
-        
+
     Returns:
         Whether the file was modified
     """
     if verbose:
         print(f"Fixing {file_path}...")
-    
+
     try:
-        with open(file_path, 'r') as f:
+        with open(file_path, "r") as f:
             content = f.read()
-        
+
         modified = False
         new_content = content
-        
+
         # Process each issue type
         for issue_type, issue_list in issues.items():
             for issue in issue_list:
                 if verbose:
-                    print(f"  Found {issue_type} issue at lines {issue['line_start']}-{issue['line_end']}:")
+                    print(
+                        f"  Found {issue_type} issue at lines {issue['line_start']}-{issue['line_end']}:"
+                    )
                     print(f"    {issue['description']}")
                     print(f"    Match: {issue['match']}")
                     print(f"    Suggested fix: {issue['fix']}")
-                
+
                 # Apply the fix by replacing the matched pattern with the fix
-                match_text = issue['match']
-                fix_text = issue['fix']
-                
+                match_text = issue["match"]
+                fix_text = issue["fix"]
+
                 # For mocking issues, we need to adapt the fix to the specific context
                 if issue_type == "mocking":
                     if "spec=ClassName" in fix_text:
                         # Try to determine the actual class name from the context
-                        class_match = re.search(r"class\s+([A-Za-z0-9_]+)", issue['context'])
+                        class_match = re.search(
+                            r"class\s+([A-Za-z0-9_]+)", issue["context"]
+                        )
                         if class_match:
                             class_name = class_match.group(1)
                             fix_text = fix_text.replace("ClassName", class_name)
-                    
+
                     if "expected_result" in fix_text:
                         # Try to determine the expected result from the context
-                        result_match = re.search(r"return\s+([A-Za-z0-9_\"'{}[\]]+)", issue['context'])
+                        result_match = re.search(
+                            r"return\s+([A-Za-z0-9_\"'{}[\]]+)", issue["context"]
+                        )
                         if result_match:
                             expected_result = result_match.group(1)
-                            fix_text = fix_text.replace("expected_result", expected_result)
-                
+                            fix_text = fix_text.replace(
+                                "expected_result", expected_result
+                            )
+
                 # For state issues, adapt the fix to the specific context
                 if issue_type == "state":
                     if "state.set($1, value)" in fix_text:
                         # Extract the key from the match
-                        key_match = re.search(r"st\.session_state\[([^\]]+)\]", match_text)
+                        key_match = re.search(
+                            r"st\.session_state\[([^\]]+)\]", match_text
+                        )
                         if key_match:
                             key = key_match.group(1)
                             # Find the value being assigned
-                            value_match = re.search(r"st\.session_state\[[^\]]+\]\s*=\s*([^;\n]+)", issue['context'])
+                            value_match = re.search(
+                                r"st\.session_state\[[^\]]+\]\s*=\s*([^;\n]+)",
+                                issue["context"],
+                            )
                             if value_match:
                                 value = value_match.group(1)
-                                fix_text = fix_text.replace("$1", key).replace("value", value)
+                                fix_text = fix_text.replace("$1", key).replace(
+                                    "value", value
+                                )
                     elif "$TEST_NAME" in fix_text and "$PARAMS" in fix_text:
                         # Extract the test name and parameters
-                        test_match = re.search(r"def\s+test_([^(]+)\(([^)]*)\):", match_text)
+                        test_match = re.search(
+                            r"def\s+test_([^(]+)\(([^)]*)\):", match_text
+                        )
                         if test_match:
                             test_name = test_match.group(1)
                             params = test_match.group(2)
                             # Replace placeholders with actual values
-                            fix_text = fix_text.replace("$TEST_NAME", test_name).replace("$PARAMS", params)
-                
+                            fix_text = fix_text.replace(
+                                "$TEST_NAME", test_name
+                            ).replace("$PARAMS", params)
+
                 # Replace the match with the fix in the content
-                lines = new_content.split('\n')
-                match_lines = lines[issue['line_start']-1:issue['line_end']]
-                match_text_in_file = '\n'.join(match_lines)
-                
+                lines = new_content.split("\n")
+                match_lines = lines[issue["line_start"] - 1 : issue["line_end"]]
+                match_text_in_file = "\n".join(match_lines)
+
                 # For state issues with test functions, use a more flexible approach
                 if issue_type == "state" and "def test_" in match_text:
                     # Extract the test function name and parameters
-                    test_match = re.search(r"def\s+(test_[^(]+)\(([^)]*)\):", match_text)
+                    test_match = re.search(
+                        r"def\s+(test_[^(]+)\(([^)]*)\):", match_text
+                    )
                     if test_match:
                         test_name = test_match.group(1)
                         params = test_match.group(2)
-                        
+
                         # Find the line with the function definition
                         for i, line in enumerate(lines):
                             if f"def {test_name}(" in line:
@@ -406,19 +454,24 @@ def fix_file(file_path: str, issues: Dict[str, List[Dict[str, Any]]], dry_run: b
                                 if "clean_state" not in line:
                                     # Add clean_state parameter
                                     if params.strip():
-                                        new_line = line.replace(f"({params}", f"({params}, clean_state")
+                                        new_line = line.replace(
+                                            f"({params}", f"({params}, clean_state"
+                                        )
                                     else:
                                         new_line = line.replace("():", "(clean_state):")
-                                    
+
                                     lines[i] = new_line
-                                    
+
                                     # Add the fixture if it doesn't exist
                                     fixture_exists = False
-                                    for j in range(max(0, i-20), i):
-                                        if "@pytest.fixture" in lines[j] and "def clean_state():" in lines[j+1]:
+                                    for j in range(max(0, i - 20), i):
+                                        if (
+                                            "@pytest.fixture" in lines[j]
+                                            and "def clean_state():" in lines[j + 1]
+                                        ):
                                             fixture_exists = True
                                             break
-                                    
+
                                     if not fixture_exists:
                                         # Add the fixture before the function
                                         fixture_lines = [
@@ -428,23 +481,32 @@ def fix_file(file_path: str, issues: Dict[str, List[Dict[str, Any]]], dry_run: b
                                             "    # Set up clean state",
                                             "    yield",
                                             "    # Clean up state",
-                                            ""
+                                            "",
                                         ]
-                                        
+
                                         # Find a good insertion point (before the function)
                                         insertion_point = i
-                                        while insertion_point > 0 and not lines[insertion_point-1].strip():
+                                        while (
+                                            insertion_point > 0
+                                            and not lines[insertion_point - 1].strip()
+                                        ):
                                             insertion_point -= 1
-                                        
-                                        lines[insertion_point:insertion_point] = fixture_lines
-                                        
-                                    new_content = '\n'.join(lines)
+
+                                        lines[insertion_point:insertion_point] = (
+                                            fixture_lines
+                                        )
+
+                                    new_content = "\n".join(lines)
                                     modified = True
                                     if verbose:
-                                        print(f"    Applied fix for {issue_type} issue using flexible approach")
+                                        print(
+                                            f"    Applied fix for {issue_type} issue using flexible approach"
+                                        )
                                 else:
                                     if verbose:
-                                        print(f"    Function already has clean_state parameter")
+                                        print(
+                                            f"    Function already has clean_state parameter"
+                                        )
                                 break
                         else:
                             if verbose:
@@ -455,62 +517,66 @@ def fix_file(file_path: str, issues: Dict[str, List[Dict[str, Any]]], dry_run: b
                 # Only replace if we can find the exact match
                 elif match_text in match_text_in_file:
                     new_match_text = match_text_in_file.replace(match_text, fix_text)
-                    lines[issue['line_start']-1:issue['line_end']] = new_match_text.split('\n')
-                    new_content = '\n'.join(lines)
+                    lines[issue["line_start"] - 1 : issue["line_end"]] = (
+                        new_match_text.split("\n")
+                    )
+                    new_content = "\n".join(lines)
                     modified = True
                     if verbose:
                         print(f"    Applied fix for {issue_type} issue")
                 else:
                     if verbose:
                         print(f"    Could not apply fix: match not found in file")
-        
+
         if modified and not dry_run:
-            with open(file_path, 'w') as f:
+            with open(file_path, "w") as f:
                 f.write(new_content)
             print(f"Updated {file_path}")
-        
+
         return modified
-    
+
     except Exception as e:
         print(f"Error fixing {file_path}: {e}")
         return False
 
-def generate_report(results: Dict[str, Dict[str, List[Dict[str, Any]]]], output_file: str = "flaky_test_report.json"):
+
+def generate_report(
+    results: Dict[str, Dict[str, List[Dict[str, Any]]]],
+    output_file: str = "flaky_test_report.json",
+):
     """
     Generate a report of flaky test patterns.
-    
+
     Args:
         results: Dictionary of results by file
         output_file: Path to the output file
     """
     # Count issues by type
-    issue_counts = {
-        "mocking": 0,
-        "isolation": 0,
-        "state": 0,
-        "total": 0
-    }
-    
+    issue_counts = {"mocking": 0, "isolation": 0, "state": 0, "total": 0}
+
     for file_path, issues in results.items():
         for issue_type, issue_list in issues.items():
             issue_counts[issue_type] += len(issue_list)
             issue_counts["total"] += len(issue_list)
-    
+
     # Create the report
     report = {
         "summary": {
             "total_files": len(results),
-            "files_with_issues": sum(1 for file_path, issues in results.items() 
-                                    if sum(len(issue_list) for issue_list in issues.values()) > 0),
-            "issue_counts": issue_counts
+            "files_with_issues": sum(
+                1
+                for file_path, issues in results.items()
+                if sum(len(issue_list) for issue_list in issues.values()) > 0
+            ),
+            "issue_counts": issue_counts,
         },
-        "issues_by_file": results
+        "issues_by_file": results,
     }
-    
+
     # Write the report to a file
-    with open(output_file, 'w') as f:
+    with open(output_file, "w") as f:
         json.dump(report, f, indent=2)
-    
+
     print(f"Report generated: {output_file}")
     print(f"Summary:")
     print(f"  Total files analyzed: {report['summary']['total_files']}")
@@ -520,63 +586,99 @@ def generate_report(results: Dict[str, Dict[str, List[Dict[str, Any]]]], output_
     print(f"  Isolation issues: {report['summary']['issue_counts']['isolation']}")
     print(f"  State issues: {report['summary']['issue_counts']['state']}")
 
+
+def run_tests_until_stable(
+    paths: List[str], speed: str = "medium", retries: int = 3
+) -> bool:
+    """Run the given test paths repeatedly until they pass or retries are exhausted.
+
+    Args:
+        paths: List of test file paths to run
+        speed: Speed marker to include with test execution
+        retries: Number of attempts before giving up
+
+    Returns:
+        True if tests passed at least once, False otherwise
+    """
+    for attempt in range(1, retries + 1):
+        cmd = [
+            "poetry",
+            "run",
+            "devsynth",
+            "run-tests",
+            "--speed",
+            speed,
+            *paths,
+        ]
+        print(f"Running stability check attempt {attempt}/{retries}: {' '.join(cmd)}")
+        result = subprocess.run(cmd)
+        if result.returncode == 0:
+            return True
+    return False
+
+
 def main():
     """Main function."""
     args = parse_args()
-    
+
     # Determine which patterns to use
     patterns = {}
     if args.pattern == "all":
         patterns = FLAKY_PATTERNS
     else:
         patterns = {args.pattern: FLAKY_PATTERNS[args.pattern]}
-    
+
     # Collect test files
     test_files = collect_test_files(
-        category=args.category,
-        module=args.module,
-        use_cache=True
+        category=args.category, module=args.module, use_cache=True
     )
-    
+
     # Prioritize files
     test_files = prioritize_files(test_files, HIGH_PRIORITY_MODULES)
-    
+
     # Limit the number of files to process
     if args.max_tests > 0 and len(test_files) > args.max_tests:
         print(f"Limiting to {args.max_tests} files (out of {len(test_files)} files)")
-        test_files = test_files[:args.max_tests]
-    
+        test_files = test_files[: args.max_tests]
+
     # Process each file
     results = {}
     modified_files = []
-    
+
     for file_path in test_files:
         # Analyze the file
         issues = analyze_file(file_path, patterns, args.verbose)
-        
+
         # Store the results
         results[file_path] = issues
-        
+
         # Fix the file if needed
         if sum(len(issue_list) for issue_list in issues.values()) > 0:
             if fix_file(file_path, issues, args.dry_run, args.verbose):
                 modified_files.append(file_path)
-    
+
     # Generate a report if requested
     if args.report:
         generate_report(results)
-    
+
     # Print summary
     print("\nSummary:")
     print(f"  Total files processed: {len(test_files)}")
     print(f"  Files with issues: {len(modified_files)}")
-    
+
     if args.dry_run:
         print("\nNote: This was a dry run. Use without --dry-run to apply changes.")
     else:
         print(f"  Files modified: {len(modified_files)}")
-    
+
+    if args.verify:
+        targets = modified_files or test_files
+        stable = run_tests_until_stable(targets, speed=args.speed, retries=args.retries)
+        status = "passed" if stable else "failed"
+        print(f"\nStability check {status} after {args.retries} attempt(s)")
+
     print("\nDone!")
+
 
 if __name__ == "__main__":
     main()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -84,13 +84,15 @@ def test_environment(tmp_path, monkeypatch):
     with open(devsynth_dir / "project.yaml", "w") as f:
         f.write("language: python\n")
 
-    # Return the environment information
-    return {
+    # Provide the environment information to tests
+    env_info = {
         "project_dir": project_dir,
         "logs_dir": logs_dir,
         "memory_dir": memory_dir,
         "devsynth_dir": devsynth_dir,
     }
+    yield env_info
+    # Temporary directories created under tmp_path are cleaned up automatically
 
 
 @pytest.fixture

--- a/tests/unit/adapters/memory/test_memory_adapter.py
+++ b/tests/unit/adapters/memory/test_memory_adapter.py
@@ -101,7 +101,6 @@ class TestMemorySystemAdapter:
         assert isinstance(adapter.context_manager, PersistentContextManager)
         assert adapter.vector_store is None
 
-    @pytest.mark.medium
     @pytest.mark.slow
     def test_init_with_tinydb_storage_succeeds(self, temp_dir):
         """Test initialization with TinyDB storage.
@@ -121,8 +120,8 @@ class TestMemorySystemAdapter:
         assert isinstance(adapter.memory_store, TinyDBStore)
         assert isinstance(adapter.context_manager, PersistentContextManager)
         assert adapter.vector_store is None
+        del adapter
 
-    @pytest.mark.medium
     @pytest.mark.slow
     @pytest.mark.skipif(duckdb is None, reason="duckdb not installed")
     def test_init_with_duckdb_storage_succeeds(self, temp_dir, monkeypatch):
@@ -160,8 +159,8 @@ class TestMemorySystemAdapter:
             assert isinstance(adapter.context_manager, PersistentContextManager)
             assert adapter.vector_store is not None
             assert adapter.vector_store is adapter.memory_store
+            del adapter
 
-    @pytest.mark.medium
     @pytest.mark.slow
     @pytest.mark.requires_resource("lmdb")
     def test_init_with_lmdb_storage_succeeds(self, temp_dir):
@@ -185,6 +184,7 @@ class TestMemorySystemAdapter:
         assert isinstance(adapter.memory_store, LMDBStore)
         assert isinstance(adapter.context_manager, PersistentContextManager)
         assert adapter.vector_store is None
+        del adapter
 
     @pytest.mark.medium
     @pytest.mark.requires_resource("kuzu")
@@ -207,6 +207,7 @@ class TestMemorySystemAdapter:
         assert isinstance(adapter.context_manager, PersistentContextManager)
         assert adapter.vector_store is not None
         assert isinstance(adapter.vector_store, KuzuAdapter)
+        del adapter
 
     @pytest.mark.medium
     @pytest.mark.requires_resource("faiss")
@@ -232,6 +233,7 @@ class TestMemorySystemAdapter:
         assert isinstance(adapter.context_manager, PersistentContextManager)
         assert adapter.vector_store is not None
         assert isinstance(adapter.vector_store, FAISSStore)
+        del adapter
 
     @pytest.mark.medium
     @pytest.mark.requires_resource("faiss")
@@ -344,6 +346,7 @@ class TestMemorySystemAdapter:
         assert isinstance(adapter.memory_store, RDFLibStore)
         assert isinstance(adapter.context_manager, PersistentContextManager)
         assert adapter.vector_store is adapter.memory_store
+        del adapter
 
     @pytest.mark.medium
     def test_init_with_in_memory_storage_succeeds(self):
@@ -356,6 +359,7 @@ class TestMemorySystemAdapter:
         assert isinstance(adapter.memory_store, InMemoryStore)
         assert isinstance(adapter.context_manager, SimpleContextManager)
         assert adapter.vector_store is None
+        del adapter
 
     @pytest.mark.medium
     @pytest.mark.requires_resource("lmdb")

--- a/tests/unit/adapters/test_provider_system.py
+++ b/tests/unit/adapters/test_provider_system.py
@@ -1,12 +1,24 @@
 import asyncio
 import json
-from unittest.mock import AsyncMock, MagicMock, patch, call
-import pytest
+from unittest.mock import AsyncMock, MagicMock, call, patch
+
 import httpx
+import pytest
 import requests
+
 from devsynth.adapters import provider_system
-from devsynth.adapters.provider_system import ProviderError, ProviderFactory, BaseProvider, OpenAIProvider, LMStudioProvider, FallbackProvider, get_env_or_default, get_provider_config
+from devsynth.adapters.provider_system import (
+    BaseProvider,
+    FallbackProvider,
+    LMStudioProvider,
+    OpenAIProvider,
+    ProviderError,
+    ProviderFactory,
+    get_env_or_default,
+    get_provider_config,
+)
 from devsynth.fallback import retry_with_exponential_backoff
+
 
 @pytest.mark.medium
 def test_embed_success_succeeds():
@@ -15,10 +27,11 @@ def test_embed_success_succeeds():
     ReqID: N/A"""
     provider = MagicMock()
     provider.embed.return_value = [[1.0, 2.0]]
-    with patch.object(provider_system, 'get_provider', return_value=provider):
-        result = provider_system.embed('text', provider_type='lmstudio', fallback=False)
+    with patch.object(provider_system, "get_provider", return_value=provider):
+        result = provider_system.embed("text", provider_type="lmstudio", fallback=False)
         assert result == [[1.0, 2.0]]
         provider.embed.assert_called_once()
+
 
 @pytest.mark.medium
 def test_embed_error_succeeds():
@@ -26,10 +39,11 @@ def test_embed_error_succeeds():
 
     ReqID: N/A"""
     provider = MagicMock()
-    provider.embed.side_effect = ProviderError('fail')
-    with patch.object(provider_system, 'get_provider', return_value=provider):
+    provider.embed.side_effect = ProviderError("fail")
+    with patch.object(provider_system, "get_provider", return_value=provider):
         with pytest.raises(ProviderError):
-            provider_system.embed('text', provider_type='lmstudio', fallback=False)
+            provider_system.embed("text", provider_type="lmstudio", fallback=False)
+
 
 @pytest.mark.medium
 def test_aembed_success_succeeds():
@@ -40,11 +54,15 @@ def test_aembed_success_succeeds():
     provider.aembed = AsyncMock(return_value=[[3.0, 4.0]])
 
     async def run_test():
-        with patch.object(provider_system, 'get_provider', return_value=provider):
-            result = await provider_system.aembed('text', provider_type='lmstudio', fallback=False)
+        with patch.object(provider_system, "get_provider", return_value=provider):
+            result = await provider_system.aembed(
+                "text", provider_type="lmstudio", fallback=False
+            )
             assert result == [[3.0, 4.0]]
             provider.aembed.assert_awaited_once()
+
     asyncio.run(run_test())
+
 
 @pytest.mark.medium
 def test_aembed_error_succeeds():
@@ -52,13 +70,17 @@ def test_aembed_error_succeeds():
 
     ReqID: N/A"""
     provider = MagicMock()
-    provider.aembed = AsyncMock(side_effect=ProviderError('boom'))
+    provider.aembed = AsyncMock(side_effect=ProviderError("boom"))
 
     async def run_test():
-        with patch.object(provider_system, 'get_provider', return_value=provider):
+        with patch.object(provider_system, "get_provider", return_value=provider):
             with pytest.raises(ProviderError):
-                await provider_system.aembed('text', provider_type='lmstudio', fallback=False)
+                await provider_system.aembed(
+                    "text", provider_type="lmstudio", fallback=False
+                )
+
     asyncio.run(run_test())
+
 
 @pytest.mark.medium
 def test_complete_success_succeeds():
@@ -66,11 +88,16 @@ def test_complete_success_succeeds():
 
     ReqID: N/A"""
     provider = MagicMock()
-    provider.complete.return_value = 'Completed text'
-    with patch.object(provider_system, 'get_provider', return_value=provider):
-        result = provider_system.complete('prompt', system_prompt='system', provider_type='openai', fallback=False)
-        assert result == 'Completed text'
-        provider.complete.assert_called_once_with(prompt='prompt', system_prompt='system', temperature=0.7, max_tokens=2000)
+    provider.complete.return_value = "Completed text"
+    with patch.object(provider_system, "get_provider", return_value=provider):
+        result = provider_system.complete(
+            "prompt", system_prompt="system", provider_type="openai", fallback=False
+        )
+        assert result == "Completed text"
+        provider.complete.assert_called_once_with(
+            prompt="prompt", system_prompt="system", temperature=0.7, max_tokens=2000
+        )
+
 
 @pytest.mark.medium
 def test_complete_error_succeeds():
@@ -78,10 +105,11 @@ def test_complete_error_succeeds():
 
     ReqID: N/A"""
     provider = MagicMock()
-    provider.complete.side_effect = ProviderError('completion failed')
-    with patch.object(provider_system, 'get_provider', return_value=provider):
+    provider.complete.side_effect = ProviderError("completion failed")
+    with patch.object(provider_system, "get_provider", return_value=provider):
         with pytest.raises(ProviderError):
-            provider_system.complete('prompt', provider_type='openai', fallback=False)
+            provider_system.complete("prompt", provider_type="openai", fallback=False)
+
 
 @pytest.mark.medium
 def test_acomplete_success_succeeds():
@@ -89,14 +117,23 @@ def test_acomplete_success_succeeds():
 
     ReqID: N/A"""
     provider = MagicMock()
-    provider.acomplete = AsyncMock(return_value='Async completed text')
+    provider.acomplete = AsyncMock(return_value="Async completed text")
 
     async def run_test():
-        with patch.object(provider_system, 'get_provider', return_value=provider):
-            result = await provider_system.acomplete('prompt', system_prompt='system', provider_type='openai', fallback=False)
-            assert result == 'Async completed text'
-            provider.acomplete.assert_awaited_once_with(prompt='prompt', system_prompt='system', temperature=0.7, max_tokens=2000)
+        with patch.object(provider_system, "get_provider", return_value=provider):
+            result = await provider_system.acomplete(
+                "prompt", system_prompt="system", provider_type="openai", fallback=False
+            )
+            assert result == "Async completed text"
+            provider.acomplete.assert_awaited_once_with(
+                prompt="prompt",
+                system_prompt="system",
+                temperature=0.7,
+                max_tokens=2000,
+            )
+
     asyncio.run(run_test())
+
 
 @pytest.mark.medium
 def test_acomplete_error_succeeds():
@@ -104,54 +141,101 @@ def test_acomplete_error_succeeds():
 
     ReqID: N/A"""
     provider = MagicMock()
-    provider.acomplete = AsyncMock(side_effect=ProviderError('async completion failed'))
+    provider.acomplete = AsyncMock(side_effect=ProviderError("async completion failed"))
 
     async def run_test():
-        with patch.object(provider_system, 'get_provider', return_value=provider):
+        with patch.object(provider_system, "get_provider", return_value=provider):
             with pytest.raises(ProviderError):
-                await provider_system.acomplete('prompt', provider_type='openai', fallback=False)
+                await provider_system.acomplete(
+                    "prompt", provider_type="openai", fallback=False
+                )
+
     asyncio.run(run_test())
+
 
 @pytest.mark.medium
 def test_provider_factory_create_provider_succeeds():
     """Test that provider factory create provider succeeds.
 
     ReqID: N/A"""
-    with patch.object(provider_system, 'get_provider_config') as mock_config:
-        with patch.object(provider_system, 'OpenAIProvider') as mock_openai:
-            with patch.object(provider_system, 'LMStudioProvider') as mock_lmstudio:
+    with patch.object(provider_system, "get_provider_config") as mock_config:
+        with patch.object(provider_system, "OpenAIProvider") as mock_openai:
+            with patch.object(provider_system, "LMStudioProvider") as mock_lmstudio:
                 mock_openai_instance = MagicMock(spec=OpenAIProvider)
                 mock_openai.return_value = mock_openai_instance
                 mock_lmstudio_instance = MagicMock(spec=LMStudioProvider)
                 mock_lmstudio.return_value = mock_lmstudio_instance
-                mock_config.return_value = {'default_provider': 'openai', 'openai': {'api_key': 'test_key', 'model': 'gpt-4', 'base_url': 'https://api.openai.com/v1'}, 'retry': {'max_retries': 3, 'initial_delay': 1.0, 'exponential_base': 2.0, 'max_delay': 60.0, 'jitter': True}}
+                mock_config.return_value = {
+                    "default_provider": "openai",
+                    "openai": {
+                        "api_key": "test_key",
+                        "model": "gpt-4",
+                        "base_url": "https://api.openai.com/v1",
+                    },
+                    "retry": {
+                        "max_retries": 3,
+                        "initial_delay": 1.0,
+                        "exponential_base": 2.0,
+                        "max_delay": 60.0,
+                        "jitter": True,
+                    },
+                }
                 factory = ProviderFactory()
-                provider = factory.create_provider('openai')
+                provider = factory.create_provider("openai")
                 mock_openai.assert_called_once()
                 assert provider is mock_openai_instance
                 mock_openai.reset_mock()
-                mock_config.return_value = {'default_provider': 'lmstudio', 'lmstudio': {'endpoint': 'http://test-endpoint', 'model': 'default'}, 'retry': {'max_retries': 3, 'initial_delay': 1.0, 'exponential_base': 2.0, 'max_delay': 60.0, 'jitter': True}}
-                provider = factory.create_provider('lmstudio')
+                mock_config.return_value = {
+                    "default_provider": "lmstudio",
+                    "lmstudio": {
+                        "endpoint": "http://test-endpoint",
+                        "model": "default",
+                    },
+                    "retry": {
+                        "max_retries": 3,
+                        "initial_delay": 1.0,
+                        "exponential_base": 2.0,
+                        "max_delay": 60.0,
+                        "jitter": True,
+                    },
+                }
+                provider = factory.create_provider("lmstudio")
                 mock_lmstudio.assert_called_once()
                 assert provider is mock_lmstudio_instance
                 mock_openai.reset_mock()
-                mock_config.return_value = {'default_provider': 'openai', 'openai': {'api_key': 'default_key', 'model': 'gpt-3.5-turbo', 'base_url': 'https://api.openai.com/v1'}, 'retry': {'max_retries': 3, 'initial_delay': 1.0, 'exponential_base': 2.0, 'max_delay': 60.0, 'jitter': True}}
+                mock_config.return_value = {
+                    "default_provider": "openai",
+                    "openai": {
+                        "api_key": "default_key",
+                        "model": "gpt-3.5-turbo",
+                        "base_url": "https://api.openai.com/v1",
+                    },
+                    "retry": {
+                        "max_retries": 3,
+                        "initial_delay": 1.0,
+                        "exponential_base": 2.0,
+                        "max_delay": 60.0,
+                        "jitter": True,
+                    },
+                }
                 provider = factory.create_provider()
                 mock_openai.assert_called_once()
                 assert provider is mock_openai_instance
+
 
 @pytest.mark.medium
 def test_get_provider_succeeds():
     """Test that get provider succeeds.
 
     ReqID: N/A"""
-    with patch.object(ProviderFactory, 'create_provider') as mock_create:
+    with patch.object(ProviderFactory, "create_provider") as mock_create:
         mock_create.return_value = MagicMock(spec=OpenAIProvider)
-        provider = provider_system.get_provider(provider_type='openai', fallback=True)
+        provider = provider_system.get_provider(provider_type="openai", fallback=True)
         assert isinstance(provider, FallbackProvider)
-        provider = provider_system.get_provider(provider_type='openai', fallback=False)
+        provider = provider_system.get_provider(provider_type="openai", fallback=False)
         assert not isinstance(provider, FallbackProvider)
-        mock_create.assert_called_with('openai')
+        mock_create.assert_called_with("openai")
+
 
 @pytest.mark.medium
 def test_base_provider_methods_succeeds():
@@ -160,16 +244,23 @@ def test_base_provider_methods_succeeds():
     ReqID: N/A"""
     provider = BaseProvider()
     with pytest.raises(NotImplementedError):
-        provider.complete('test')
+        provider.complete("test")
     with pytest.raises(NotImplementedError):
-        provider.embed('test')
+        provider.embed("test")
     with pytest.raises(NotImplementedError):
-        asyncio.run(provider.acomplete('test'))
+        asyncio.run(provider.acomplete("test"))
     with pytest.raises(NotImplementedError):
-        asyncio.run(provider.aembed('test'))
+        asyncio.run(provider.aembed("test"))
+
 
 @pytest.mark.medium
-@pytest.mark.parametrize('provider_class,config', [(OpenAIProvider, {'api_key': 'test_key', 'model': 'gpt-4'}), (LMStudioProvider, {'endpoint': 'http://test-endpoint'})])
+@pytest.mark.parametrize(
+    "provider_class,config",
+    [
+        (OpenAIProvider, {"api_key": "test_key", "model": "gpt-4"}),
+        (LMStudioProvider, {"endpoint": "http://test-endpoint"}),
+    ],
+)
 def test_provider_initialization_succeeds(provider_class, config):
     """Test that provider initialization succeeds.
 
@@ -179,6 +270,7 @@ def test_provider_initialization_succeeds(provider_class, config):
     retry_decorator = provider.get_retry_decorator()
     assert callable(retry_decorator)
 
+
 @pytest.mark.medium
 def test_fallback_provider_succeeds():
     """Test that fallback provider succeeds.
@@ -186,29 +278,30 @@ def test_fallback_provider_succeeds():
     ReqID: N/A"""
     provider1 = MagicMock(spec=BaseProvider)
     provider2 = MagicMock(spec=BaseProvider)
-    provider1.complete.side_effect = ProviderError('Provider 1 failed')
-    provider2.complete.return_value = 'Success from provider 2'
+    provider1.complete.side_effect = ProviderError("Provider 1 failed")
+    provider2.complete.return_value = "Success from provider 2"
     fallback = FallbackProvider(providers=[provider1, provider2])
-    result = fallback.complete('test prompt')
-    assert result == 'Success from provider 2'
+    result = fallback.complete("test prompt")
+    assert result == "Success from provider 2"
     provider1.complete.assert_called_once()
     provider2.complete.assert_called_once()
-    provider2.complete.side_effect = ProviderError('Provider 2 failed')
+    provider2.complete.side_effect = ProviderError("Provider 2 failed")
     with pytest.raises(ProviderError):
-        fallback.complete('test prompt')
+        fallback.complete("test prompt")
 
-@pytest.mark.slow
+
 @pytest.mark.medium
 def test_get_env_or_default_succeeds():
     """Test the get_env_or_default function.
 
     ReqID: N/A"""
-    with patch.dict('os.environ', {'TEST_VAR': 'test_value'}):
-        assert get_env_or_default('TEST_VAR', 'default') == 'test_value'
-    with patch.dict('os.environ', {}, clear=True):
-        assert get_env_or_default('TEST_VAR', 'default') == 'default'
-    with patch.dict('os.environ', {}, clear=True):
-        assert get_env_or_default('TEST_VAR') is None
+    with patch.dict("os.environ", {"TEST_VAR": "test_value"}):
+        assert get_env_or_default("TEST_VAR", "default") == "test_value"
+    with patch.dict("os.environ", {}, clear=True):
+        assert get_env_or_default("TEST_VAR", "default") == "default"
+    with patch.dict("os.environ", {}, clear=True):
+        assert get_env_or_default("TEST_VAR") is None
+
 
 @pytest.mark.medium
 def test_get_provider_config_has_expected():
@@ -216,59 +309,68 @@ def test_get_provider_config_has_expected():
 
     ReqID: N/A"""
     get_provider_config.cache_clear()
-    env_vars = {'DEVSYNTH_PROVIDER': 'openai', 'OPENAI_API_KEY': 'test_key', 'OPENAI_MODEL': 'gpt-4', 'LM_STUDIO_ENDPOINT': 'http://test-endpoint'}
-    with patch.dict('os.environ', env_vars, clear=True):
+    env_vars = {
+        "DEVSYNTH_PROVIDER": "openai",
+        "OPENAI_API_KEY": "test_key",
+        "OPENAI_MODEL": "gpt-4",
+        "LM_STUDIO_ENDPOINT": "http://test-endpoint",
+    }
+    with patch.dict("os.environ", env_vars, clear=True):
         config = get_provider_config()
-        assert config['default_provider'] == 'openai'
-        assert config['openai']['api_key'] == 'test_key'
-        assert config['openai']['model'] == 'gpt-4'
-        assert config['lmstudio']['endpoint'] == 'http://test-endpoint'
+        assert config["default_provider"] == "openai"
+        assert config["openai"]["api_key"] == "test_key"
+        assert config["openai"]["model"] == "gpt-4"
+        assert config["lmstudio"]["endpoint"] == "http://test-endpoint"
     get_provider_config.cache_clear()
-    with patch.dict('os.environ', {'OPENAI_API_KEY': 'test_key'}, clear=True):
+    with patch.dict("os.environ", {"OPENAI_API_KEY": "test_key"}, clear=True):
         config = get_provider_config()
-        assert config['default_provider'] == 'openai'
-        assert config['openai']['api_key'] == 'test_key'
-        assert 'model' in config['openai']
+        assert config["default_provider"] == "openai"
+        assert config["openai"]["api_key"] == "test_key"
+        assert "model" in config["openai"]
+
 
 @pytest.mark.medium
-@patch('requests.post')
+@patch("requests.post")
 def test_openai_provider_complete_has_expected(mock_post):
     """Test the complete method of OpenAIProvider.
 
     ReqID: N/A"""
     mock_response = MagicMock()
     mock_response.status_code = 200
-    mock_response.json.return_value = {'choices': [{'message': {'content': 'Test completion'}}]}
+    mock_response.json.return_value = {
+        "choices": [{"message": {"content": "Test completion"}}]
+    }
     mock_post.return_value = mock_response
-    provider = OpenAIProvider(api_key='test_key', model='gpt-4')
-    result = provider.complete('Test prompt', system_prompt='System prompt')
-    assert result == 'Test completion'
+    provider = OpenAIProvider(api_key="test_key", model="gpt-4")
+    result = provider.complete("Test prompt", system_prompt="System prompt")
+    assert result == "Test completion"
     mock_post.assert_called_once()
     args, kwargs = mock_post.call_args
-    assert args[0] == 'https://api.openai.com/v1/chat/completions'
-    assert kwargs['headers']['Authorization'] == 'Bearer test_key'
-    assert kwargs['json']['model'] == 'gpt-4'
-    assert kwargs['json']['messages'][0]['content'] == 'System prompt'
-    assert kwargs['json']['messages'][1]['content'] == 'Test prompt'
+    assert args[0] == "https://api.openai.com/v1/chat/completions"
+    assert kwargs["headers"]["Authorization"] == "Bearer test_key"
+    assert kwargs["json"]["model"] == "gpt-4"
+    assert kwargs["json"]["messages"][0]["content"] == "System prompt"
+    assert kwargs["json"]["messages"][1]["content"] == "Test prompt"
 
-@pytest.mark.slow
+
 @pytest.mark.medium
-@patch('requests.post')
+@patch("requests.post")
 def test_openai_provider_complete_error_raises_error(mock_post):
     """Test error handling in the complete method of OpenAIProvider.
 
     ReqID: N/A"""
     mock_response = MagicMock()
     mock_response.status_code = 400
-    mock_response.json.return_value = {'error': {'message': 'Bad request'}}
+    mock_response.json.return_value = {"error": {"message": "Bad request"}}
     mock_post.return_value = mock_response
-    provider = OpenAIProvider(api_key='test_key', model='gpt-4')
+    provider = OpenAIProvider(api_key="test_key", model="gpt-4")
     with pytest.raises(ProviderError) as excinfo:
-        provider.complete('Test prompt')
-    assert 'Bad request' in str(excinfo.value)
+        provider.complete("Test prompt")
+    assert "Bad request" in str(excinfo.value)
+
 
 @pytest.mark.medium
-@patch('requests.post')
+@patch("requests.post")
 def test_openai_provider_complete_retry_has_expected(mock_post):
     """Test retry mechanism in the complete method of OpenAIProvider.
 
@@ -278,88 +380,110 @@ def test_openai_provider_complete_retry_has_expected(mock_post):
 
         def wrapper(func):
             return func
+
         return wrapper
-    with patch('devsynth.adapters.provider_system.retry_with_exponential_backoff', side_effect=mock_decorator) as mock_retry:
+
+    with patch(
+        "devsynth.adapters.provider_system.retry_with_exponential_backoff",
+        side_effect=mock_decorator,
+    ) as mock_retry:
         error_response = MagicMock()
         error_response.status_code = 429
-        error_response.json.return_value = {'error': {'message': 'Rate limit exceeded'}}
-        error_response.raise_for_status.side_effect = requests.exceptions.HTTPError('429 Client Error')
+        error_response.json.return_value = {"error": {"message": "Rate limit exceeded"}}
+        error_response.raise_for_status.side_effect = requests.exceptions.HTTPError(
+            "429 Client Error"
+        )
         success_response = MagicMock()
         success_response.status_code = 200
-        success_response.json.return_value = {'choices': [{'message': {'content': 'Test completion'}}]}
+        success_response.json.return_value = {
+            "choices": [{"message": {"content": "Test completion"}}]
+        }
         mock_post.side_effect = [error_response, success_response]
-        provider = OpenAIProvider(api_key='test_key', model='gpt-4')
+        provider = OpenAIProvider(api_key="test_key", model="gpt-4")
         with pytest.raises(ProviderError):
-            provider.complete('Test prompt')
+            provider.complete("Test prompt")
         mock_post.side_effect = [success_response]
-        result = provider.complete('Test prompt')
-        assert result == 'Test completion'
+        result = provider.complete("Test prompt")
+        assert result == "Test completion"
         assert mock_retry.call_count >= 1
-        retry_calls_with_correct_params = [call for call in mock_retry.call_args_list if call[1].get('retryable_exceptions') == (requests.exceptions.RequestException,)]
+        retry_calls_with_correct_params = [
+            call
+            for call in mock_retry.call_args_list
+            if call[1].get("retryable_exceptions")
+            == (requests.exceptions.RequestException,)
+        ]
         assert len(retry_calls_with_correct_params) >= 1
 
+
 @pytest.mark.medium
-@patch('httpx.AsyncClient.post')
+@patch("httpx.AsyncClient.post")
 def test_openai_provider_acomplete_has_expected(mock_post):
     """Test the acomplete method of OpenAIProvider.
 
     ReqID: N/A"""
     mock_response = MagicMock()
     mock_response.status_code = 200
-    mock_response.json.return_value = {'choices': [{'message': {'content': 'Async test completion'}}]}
+    mock_response.json.return_value = {
+        "choices": [{"message": {"content": "Async test completion"}}]
+    }
     mock_post.return_value = mock_response
-    provider = OpenAIProvider(api_key='test_key', model='gpt-4')
+    provider = OpenAIProvider(api_key="test_key", model="gpt-4")
 
     async def run_test():
-        result = await provider.acomplete('Test prompt', system_prompt='System prompt')
-        assert result == 'Async test completion'
+        result = await provider.acomplete("Test prompt", system_prompt="System prompt")
+        assert result == "Async test completion"
         mock_post.assert_called_once()
         args, kwargs = mock_post.call_args
-        assert args[0] == 'https://api.openai.com/v1/chat/completions'
-        assert kwargs['headers']['Authorization'] == 'Bearer test_key'
-        assert kwargs['json']['model'] == 'gpt-4'
-        assert kwargs['json']['messages'][0]['content'] == 'System prompt'
-        assert kwargs['json']['messages'][1]['content'] == 'Test prompt'
+        assert args[0] == "https://api.openai.com/v1/chat/completions"
+        assert kwargs["headers"]["Authorization"] == "Bearer test_key"
+        assert kwargs["json"]["model"] == "gpt-4"
+        assert kwargs["json"]["messages"][0]["content"] == "System prompt"
+        assert kwargs["json"]["messages"][1]["content"] == "Test prompt"
+
     asyncio.run(run_test())
 
-@pytest.mark.slow
+
 @pytest.mark.medium
-@patch('requests.post')
+@patch("requests.post")
 def test_openai_provider_embed_has_expected(mock_post):
     """Test the embed method of OpenAIProvider.
 
     ReqID: N/A"""
     mock_response = MagicMock()
     mock_response.status_code = 200
-    mock_response.json.return_value = {'data': [{'embedding': [0.1, 0.2, 0.3]}]}
+    mock_response.json.return_value = {"data": [{"embedding": [0.1, 0.2, 0.3]}]}
     mock_post.return_value = mock_response
-    provider = OpenAIProvider(api_key='test_key', model='gpt-4')
-    result = provider.embed('Test text')
+    provider = OpenAIProvider(api_key="test_key", model="gpt-4")
+    result = provider.embed("Test text")
     assert result == [[0.1, 0.2, 0.3]]
     mock_post.assert_called_once()
     args, kwargs = mock_post.call_args
-    assert args[0] == 'https://api.openai.com/v1/embeddings'
-    assert kwargs['headers']['Authorization'] == 'Bearer test_key'
-    assert kwargs['json']['input'] == ['Test text']
+    assert args[0] == "https://api.openai.com/v1/embeddings"
+    assert kwargs["headers"]["Authorization"] == "Bearer test_key"
+    assert kwargs["json"]["input"] == ["Test text"]
+
 
 @pytest.mark.medium
-@patch('requests.post')
+@patch("requests.post")
 def test_lmstudio_provider_complete_has_expected(mock_post):
     """Test the complete method of LMStudioProvider.
 
     ReqID: N/A"""
     mock_response = MagicMock()
     mock_response.status_code = 200
-    mock_response.json.return_value = {'choices': [{'message': {'content': 'LM Studio completion'}}]}
+    mock_response.json.return_value = {
+        "choices": [{"message": {"content": "LM Studio completion"}}]
+    }
     mock_post.return_value = mock_response
-    provider = LMStudioProvider(endpoint='http://test-endpoint')
-    result = provider.complete('Test prompt', system_prompt='System prompt')
-    assert result == 'LM Studio completion'
+    provider = LMStudioProvider(endpoint="http://test-endpoint")
+    result = provider.complete("Test prompt", system_prompt="System prompt")
+    assert result == "LM Studio completion"
     mock_post.assert_called_once()
     args, kwargs = mock_post.call_args
-    assert args[0] == 'http://test-endpoint/v1/chat/completions'
-    assert kwargs['json']['messages'][0]['content'] == 'System prompt'
-    assert kwargs['json']['messages'][1]['content'] == 'Test prompt'
+    assert args[0] == "http://test-endpoint/v1/chat/completions"
+    assert kwargs["json"]["messages"][0]["content"] == "System prompt"
+    assert kwargs["json"]["messages"][1]["content"] == "Test prompt"
+
 
 @pytest.mark.medium
 def test_fallback_provider_async_methods_has_expected():
@@ -368,61 +492,79 @@ def test_fallback_provider_async_methods_has_expected():
     ReqID: N/A"""
     provider1 = MagicMock(spec=BaseProvider)
     provider2 = MagicMock(spec=BaseProvider)
-    provider1.acomplete = AsyncMock(side_effect=ProviderError('Provider 1 failed'))
-    provider2.acomplete = AsyncMock(return_value='Async success from provider 2')
-    provider1.aembed = AsyncMock(side_effect=ProviderError('Provider 1 failed'))
+    provider1.acomplete = AsyncMock(side_effect=ProviderError("Provider 1 failed"))
+    provider2.acomplete = AsyncMock(return_value="Async success from provider 2")
+    provider1.aembed = AsyncMock(side_effect=ProviderError("Provider 1 failed"))
     provider2.aembed = AsyncMock(return_value=[[0.1, 0.2, 0.3]])
     fallback = FallbackProvider(providers=[provider1, provider2])
 
     async def run_test():
-        result = await fallback.acomplete('test prompt')
-        assert result == 'Async success from provider 2'
+        result = await fallback.acomplete("test prompt")
+        assert result == "Async success from provider 2"
         provider1.acomplete.assert_awaited_once()
         provider2.acomplete.assert_awaited_once()
-        result = await fallback.aembed('test text')
+        result = await fallback.aembed("test text")
         assert result == [[0.1, 0.2, 0.3]]
         provider1.aembed.assert_awaited_once()
         provider2.aembed.assert_awaited_once()
-        provider2.acomplete.side_effect = ProviderError('Provider 2 failed')
+        provider2.acomplete.side_effect = ProviderError("Provider 2 failed")
         with pytest.raises(ProviderError):
-            await fallback.acomplete('test prompt')
+            await fallback.acomplete("test prompt")
+
     asyncio.run(run_test())
+
 
 @pytest.mark.medium
 def test_provider_with_empty_inputs_has_expected():
     """Test providers with empty inputs.
 
     ReqID: N/A"""
-    with patch('requests.post') as mock_post:
+    with patch("requests.post") as mock_post:
         mock_response = MagicMock()
         mock_response.status_code = 200
-        mock_response.json.return_value = {'choices': [{'message': {'content': 'Empty prompt response'}}]}
+        mock_response.json.return_value = {
+            "choices": [{"message": {"content": "Empty prompt response"}}]
+        }
         mock_post.return_value = mock_response
-        provider = OpenAIProvider(api_key='test_key')
-        result = provider.complete('')
-        assert result == 'Empty prompt response'
+        provider = OpenAIProvider(api_key="test_key")
+        result = provider.complete("")
+        assert result == "Empty prompt response"
         args, kwargs = mock_post.call_args
-        assert kwargs['json']['messages'][0]['content'] == ''
-    with patch('requests.post') as mock_post:
+        assert kwargs["json"]["messages"][0]["content"] == ""
+    with patch("requests.post") as mock_post:
         mock_response = MagicMock()
         mock_response.status_code = 200
-        mock_response.json.return_value = {'choices': [{'message': {'content': 'Empty prompt response'}}]}
+        mock_response.json.return_value = {
+            "choices": [{"message": {"content": "Empty prompt response"}}]
+        }
         mock_post.return_value = mock_response
         provider = LMStudioProvider()
-        result = provider.complete('')
-        assert result == 'Empty prompt response'
+        result = provider.complete("")
+        assert result == "Empty prompt response"
 
-@pytest.mark.slow
+
 @pytest.mark.medium
 def test_provider_factory_injected_config_selects_provider():
     """ProviderFactory should respect injected configuration."""
-    custom_config = {'default_provider': 'openai', 'openai': {'api_key': 'x', 'model': 'gpt-4', 'base_url': 'http://api'}, 'lmstudio': {'endpoint': 'http://lm', 'model': 'default'}, 'retry': {'max_retries': 1, 'initial_delay': 0, 'exponential_base': 2, 'max_delay': 1, 'jitter': False}}
-    provider = ProviderFactory.create_provider('openai', config=custom_config)
+    custom_config = {
+        "default_provider": "openai",
+        "openai": {"api_key": "x", "model": "gpt-4", "base_url": "http://api"},
+        "lmstudio": {"endpoint": "http://lm", "model": "default"},
+        "retry": {
+            "max_retries": 1,
+            "initial_delay": 0,
+            "exponential_base": 2,
+            "max_delay": 1,
+            "jitter": False,
+        },
+    }
+    provider = ProviderFactory.create_provider("openai", config=custom_config)
     assert isinstance(provider, OpenAIProvider)
-    provider = ProviderFactory.create_provider('lmstudio', config=custom_config)
+    provider = ProviderFactory.create_provider("lmstudio", config=custom_config)
     assert isinstance(provider, LMStudioProvider)
     provider = ProviderFactory.create_provider(config=custom_config)
     assert isinstance(provider, OpenAIProvider)
+
 
 @pytest.mark.medium
 def test_fallback_provider_respects_order(monkeypatch):
@@ -435,7 +577,18 @@ def test_fallback_provider_respects_order(monkeypatch):
         def create_provider(provider_type: str, **kwargs):
             created.append(provider_type)
             return MagicMock(spec=BaseProvider)
-    config = {'fallback': {'enabled': True, 'order': ['openai', 'lmstudio']}, 'circuit_breaker': {'enabled': False}, 'retry': {'max_retries': 1, 'initial_delay': 0, 'exponential_base': 2, 'max_delay': 1, 'jitter': False}}
+
+    config = {
+        "fallback": {"enabled": True, "order": ["openai", "lmstudio"]},
+        "circuit_breaker": {"enabled": False},
+        "retry": {
+            "max_retries": 1,
+            "initial_delay": 0,
+            "exponential_base": 2,
+            "max_delay": 1,
+            "jitter": False,
+        },
+    }
     fallback = FallbackProvider(config=config, provider_factory=FakeFactory)
-    assert created == ['openai', 'lmstudio']
+    assert created == ["openai", "lmstudio"]
     assert len(fallback.providers) == 2

--- a/tests/unit/application/code_analysis/test_transformer.py
+++ b/tests/unit/application/code_analysis/test_transformer.py
@@ -5,292 +5,455 @@ This module contains tests for the various transformer classes in the
 transformer.py module, including the CodeTransformer class and its methods
 for transforming code, files, and directories.
 """
+
+import ast
 import os
 import tempfile
-import pytest
-import ast
-import astor
 from pathlib import Path
-from unittest.mock import patch, MagicMock
-from devsynth.application.code_analysis.transformer import AstTransformer, UnusedImportRemover, RedundantAssignmentRemover, UnusedVariableRemover, StringLiteralOptimizer, CodeStyleTransformer, CodeTransformer, SymbolUsageCounter
+from unittest.mock import MagicMock, patch
+
+import astor
+import pytest
+
+from devsynth.application.code_analysis.transformer import (
+    AstTransformer,
+    CodeStyleTransformer,
+    CodeTransformer,
+    RedundantAssignmentRemover,
+    StringLiteralOptimizer,
+    SymbolUsageCounter,
+    UnusedImportRemover,
+    UnusedVariableRemover,
+)
+
 
 @pytest.fixture
 def sample_code():
     """Return sample Python code for testing transformations."""
     return '\nimport os\nimport sys\nimport re  # This import is unused\n\ndef calculate_sum(a, b):\n    # Redundant assignment\n    result = a + b\n    return result\n\ndef main():\n    x = 5\n    y = 10\n    z = 15  # This variable is unused\n\n    # String concatenation that could be optimized\n    greeting = "Hello, " + "world!"\n\n    total = calculate_sum(x, y)\n    print(f"The sum is {total}")\n'
 
-@pytest.mark.medium
+
 @pytest.fixture
 def test_file_path_succeeds():
     """Create a temporary file with sample code for testing.
 
-ReqID: N/A"""
-    with tempfile.NamedTemporaryFile(suffix='.py', delete=False) as temp_file:
-        temp_file.write('\nimport os\nimport sys\nimport re  # This import is unused\n\ndef calculate_sum(a, b):\n    # Redundant assignment\n    result = a + b\n    return result\n\ndef main():\n    x = 5\n    y = 10\n    z = 15  # This variable is unused\n\n    # String concatenation that could be optimized\n    greeting = "Hello, " + "world!"\n\n    total = calculate_sum(x, y)\n    print(f"The sum is {total}")\n'.encode('utf-8'))
+    ReqID: N/A"""
+    with tempfile.NamedTemporaryFile(suffix=".py", delete=False) as temp_file:
+        temp_file.write(
+            '\nimport os\nimport sys\nimport re  # This import is unused\n\ndef calculate_sum(a, b):\n    # Redundant assignment\n    result = a + b\n    return result\n\ndef main():\n    x = 5\n    y = 10\n    z = 15  # This variable is unused\n\n    # String concatenation that could be optimized\n    greeting = "Hello, " + "world!"\n\n    total = calculate_sum(x, y)\n    print(f"The sum is {total}")\n'.encode(
+                "utf-8"
+            )
+        )
         temp_path = temp_file.name
     yield temp_path
     if os.path.exists(temp_path):
         os.unlink(temp_path)
 
-@pytest.mark.medium
+
 @pytest.fixture
 def test_directory_succeeds():
     """Create a temporary directory with Python files for testing.
 
-ReqID: N/A"""
+    ReqID: N/A"""
     with tempfile.TemporaryDirectory() as temp_dir:
         dir_path = Path(temp_dir)
-        (dir_path / 'unused_imports.py').write_text('\nimport os\nimport sys\nimport re  # This import is unused\n\ndef main():\n    print(os.path.join("a", "b"))\n')
-        (dir_path / 'unused_variables.py').write_text('\ndef process_data(data):\n    result = []\n    count = 0  # This variable is unused\n\n    for item in data:\n        result.append(item * 2)\n\n    return result\n')
-        subdir = dir_path / 'subdir'
+        (dir_path / "unused_imports.py").write_text(
+            '\nimport os\nimport sys\nimport re  # This import is unused\n\ndef main():\n    print(os.path.join("a", "b"))\n'
+        )
+        (dir_path / "unused_variables.py").write_text(
+            "\ndef process_data(data):\n    result = []\n    count = 0  # This variable is unused\n\n    for item in data:\n        result.append(item * 2)\n\n    return result\n"
+        )
+        subdir = dir_path / "subdir"
         subdir.mkdir()
-        (subdir / 'nested_file.py').write_text('\ndef nested_function():\n    x = 10\n    y = 20  # This variable is unused\n    return x\n')
+        (subdir / "nested_file.py").write_text(
+            "\ndef nested_function():\n    x = 10\n    y = 20  # This variable is unused\n    return x\n"
+        )
         yield str(dir_path)
+
 
 class TestAstTransformer:
     """Test the base AstTransformer class.
 
-ReqID: N/A"""
+    ReqID: N/A"""
 
     @pytest.mark.medium
     def test_record_change_succeeds(self):
         """Test that changes are recorded correctly.
 
-ReqID: N/A"""
+        ReqID: N/A"""
         transformer = AstTransformer()
         node = MagicMock()
         node.lineno = 10
         node.col_offset = 5
-        transformer.record_change(node, 'Test change')
+        transformer.record_change(node, "Test change")
         assert len(transformer.changes) == 1
-        assert transformer.changes[0]['description'] == 'Test change'
-        assert transformer.changes[0]['line'] == 10
-        assert transformer.changes[0]['col'] == 5
+        assert transformer.changes[0]["description"] == "Test change"
+        assert transformer.changes[0]["line"] == 10
+        assert transformer.changes[0]["col"] == 5
+
 
 class TestUnusedImportRemover:
     """Test the UnusedImportRemover class.
 
-ReqID: N/A"""
+    ReqID: N/A"""
 
     @pytest.mark.medium
     def test_remove_unused_imports_succeeds(self, sample_code):
         """Test that unused imports are removed.
 
-ReqID: N/A"""
+        ReqID: N/A"""
         tree = ast.parse(sample_code)
-        symbol_usage = {'os': 1, 'sys': 1, 're': 0}
+        symbol_usage = {"os": 1, "sys": 1, "re": 0}
         transformer = UnusedImportRemover(symbol_usage)
         transformed_tree = transformer.visit(tree)
         transformed_code = astor.to_source(transformed_tree)
-        assert 'import re' not in transformed_code
-        assert 'import os' in transformed_code
-        assert 'import sys' in transformed_code
-        assert any(('Removed unused import' in change['description'] for change in transformer.changes))
+        assert "import re" not in transformed_code
+        assert "import os" in transformed_code
+        assert "import sys" in transformed_code
+        assert any(
+            (
+                "Removed unused import" in change["description"]
+                for change in transformer.changes
+            )
+        )
+
 
 class TestRedundantAssignmentRemover:
     """Test the RedundantAssignmentRemover class.
 
-ReqID: N/A"""
+    ReqID: N/A"""
 
     @pytest.mark.medium
     def test_remove_redundant_assignments_succeeds(self, sample_code):
         """Test that redundant assignments are removed.
 
-ReqID: N/A"""
+        ReqID: N/A"""
         transformer = CodeTransformer()
-        result = transformer.transform_code(sample_code, ['remove_redundant_assignments'])
-        assert 'return a + b' in result.get_transformed_code()
-        assert 'result = a + b' not in result.get_transformed_code()
-        assert any(('Simplified redundant assignment' in change['description'] for change in result.get_changes()))
+        result = transformer.transform_code(
+            sample_code, ["remove_redundant_assignments"]
+        )
+        assert "return a + b" in result.get_transformed_code()
+        assert "result = a + b" not in result.get_transformed_code()
+        assert any(
+            (
+                "Simplified redundant assignment" in change["description"]
+                for change in result.get_changes()
+            )
+        )
+
 
 class TestUnusedVariableRemover:
     """Test the UnusedVariableRemover class.
 
-ReqID: N/A"""
+    ReqID: N/A"""
 
     @pytest.mark.medium
     def test_remove_unused_variables_succeeds(self, sample_code):
         """Test that unused variables are removed.
 
-ReqID: N/A"""
+        ReqID: N/A"""
         tree = ast.parse(sample_code)
-        symbol_usage = {'x': 1, 'y': 1, 'z': 0, 'calculate_sum': 1, 'total': 1, 'greeting': 0}
+        symbol_usage = {
+            "x": 1,
+            "y": 1,
+            "z": 0,
+            "calculate_sum": 1,
+            "total": 1,
+            "greeting": 0,
+        }
         transformer = UnusedVariableRemover(symbol_usage)
         transformed_tree = transformer.visit(tree)
         transformed_code = astor.to_source(transformed_tree)
-        assert 'z = 15' not in transformed_code
-        assert 'x = 5' in transformed_code
-        assert 'y = 10' in transformed_code
-        assert any(('Removed unused variable' in change['description'] for change in transformer.changes))
+        assert "z = 15" not in transformed_code
+        assert "x = 5" in transformed_code
+        assert "y = 10" in transformed_code
+        assert any(
+            (
+                "Removed unused variable" in change["description"]
+                for change in transformer.changes
+            )
+        )
+
 
 class TestStringLiteralOptimizer:
     """Test the StringLiteralOptimizer class.
 
-ReqID: N/A"""
+    ReqID: N/A"""
 
     @pytest.mark.medium
     def test_optimize_string_literals_succeeds(self, sample_code):
         """Test that string literals are optimized.
 
-ReqID: N/A"""
+        ReqID: N/A"""
         modified_code = '\ndef test_function():\n    # String with extra whitespace that should be optimized\n    greeting = "Hello,    world!"\n    return greeting\n'
         tree = ast.parse(modified_code)
         transformer = StringLiteralOptimizer()
         transformed_tree = transformer.visit(tree)
         transformed_code = astor.to_source(transformed_tree)
-        transformer.record_change(ast.parse('greeting = "Hello, world!"').body[0], 'Optimized string literal: removed extra whitespace')
-        assert any(('Optimized string literal' in change['description'] for change in transformer.changes))
+        transformer.record_change(
+            ast.parse('greeting = "Hello, world!"').body[0],
+            "Optimized string literal: removed extra whitespace",
+        )
+        assert any(
+            (
+                "Optimized string literal" in change["description"]
+                for change in transformer.changes
+            )
+        )
+
 
 class TestCodeStyleTransformer:
     """Test the CodeStyleTransformer class.
 
-ReqID: N/A"""
+    ReqID: N/A"""
 
     @pytest.mark.medium
     def test_improve_code_style_succeeds(self):
         """Test that code style is improved.
 
-ReqID: N/A"""
-        code = '\ndef function_without_docstring(a, b):\n    return a + b\n\nclass ClassWithoutDocstring:\n    def method_without_docstring(self):\n        pass\n'
+        ReqID: N/A"""
+        code = "\ndef function_without_docstring(a, b):\n    return a + b\n\nclass ClassWithoutDocstring:\n    def method_without_docstring(self):\n        pass\n"
         transformer = CodeTransformer()
-        result = transformer.transform_code(code, ['improve_code_style'])
+        result = transformer.transform_code(code, ["improve_code_style"])
         assert '"""' in result.get_transformed_code()
-        assert any(('Added missing docstring' in change['description'] for change in result.get_changes()))
+        assert any(
+            (
+                "Added missing docstring" in change["description"]
+                for change in result.get_changes()
+            )
+        )
+
 
 class TestCodeTransformer:
     """Test the CodeTransformer class.
 
-ReqID: N/A"""
+    ReqID: N/A"""
 
     @pytest.mark.medium
     def test_transform_code_succeeds(self, sample_code):
         """Test transforming code with multiple transformations.
 
-ReqID: N/A"""
+        ReqID: N/A"""
         mock_unused_import_remover = MagicMock()
-        mock_unused_import_remover.visit.return_value = ast.parse(sample_code.replace('import re', ''))
-        mock_unused_import_remover.changes = [{'description': 'Removed unused import: re'}]
+        mock_unused_import_remover.visit.return_value = ast.parse(
+            sample_code.replace("import re", "")
+        )
+        mock_unused_import_remover.changes = [
+            {"description": "Removed unused import: re"}
+        ]
         mock_unused_variable_remover = MagicMock()
-        mock_unused_variable_remover.visit.return_value = ast.parse(sample_code.replace('z = 15', ''))
-        mock_unused_variable_remover.changes = [{'description': 'Removed unused variable: z'}]
+        mock_unused_variable_remover.visit.return_value = ast.parse(
+            sample_code.replace("z = 15", "")
+        )
+        mock_unused_variable_remover.changes = [
+            {"description": "Removed unused variable: z"}
+        ]
         mock_string_optimizer = MagicMock()
         modified_code = sample_code.replace('"Hello, " + "world!"', '"Hello, world!"')
         mock_string_optimizer.visit.return_value = ast.parse(modified_code)
-        mock_string_optimizer.changes = [{'description': 'Optimized string literal'}]
+        mock_string_optimizer.changes = [{"description": "Optimized string literal"}]
         transformer = CodeTransformer()
-        with patch.dict(transformer.transformers, {'remove_unused_imports': lambda *args: mock_unused_import_remover, 'remove_unused_variables': lambda *args: mock_unused_variable_remover, 'optimize_string_literals': lambda *args: mock_string_optimizer}):
-            result = transformer.transform_code(sample_code, ['remove_unused_imports', 'remove_unused_variables', 'optimize_string_literals'])
-            assert hasattr(result, 'get_original_code')
-            assert hasattr(result, 'get_transformed_code')
-            assert hasattr(result, 'get_changes')
+        with patch.dict(
+            transformer.transformers,
+            {
+                "remove_unused_imports": lambda *args: mock_unused_import_remover,
+                "remove_unused_variables": lambda *args: mock_unused_variable_remover,
+                "optimize_string_literals": lambda *args: mock_string_optimizer,
+            },
+        ):
+            result = transformer.transform_code(
+                sample_code,
+                [
+                    "remove_unused_imports",
+                    "remove_unused_variables",
+                    "optimize_string_literals",
+                ],
+            )
+            assert hasattr(result, "get_original_code")
+            assert hasattr(result, "get_transformed_code")
+            assert hasattr(result, "get_changes")
             assert len(result.get_changes()) == 3
-            assert any(('Removed unused import' in change['description'] for change in result.get_changes()))
-            assert any(('Removed unused variable' in change['description'] for change in result.get_changes()))
-            assert any(('Optimized string literal' in change['description'] for change in result.get_changes()))
+            assert any(
+                (
+                    "Removed unused import" in change["description"]
+                    for change in result.get_changes()
+                )
+            )
+            assert any(
+                (
+                    "Removed unused variable" in change["description"]
+                    for change in result.get_changes()
+                )
+            )
+            assert any(
+                (
+                    "Optimized string literal" in change["description"]
+                    for change in result.get_changes()
+                )
+            )
 
     @pytest.mark.medium
     def test_transform_file_succeeds(self, test_file_path_succeeds):
         """Test transforming a file.
 
-ReqID: N/A"""
-        with open(test_file_path_succeeds, 'r', encoding='utf-8') as f:
+        ReqID: N/A"""
+        with open(test_file_path_succeeds, "r", encoding="utf-8") as f:
             file_content = f.read()
-        transformed_code = file_content.replace('import re', '').replace('z = 15', '')
+        transformed_code = file_content.replace("import re", "").replace("z = 15", "")
         mock_result = MagicMock()
         mock_result.get_original_code.return_value = file_content
         mock_result.get_transformed_code.return_value = transformed_code
-        mock_result.get_changes.return_value = [{'description': 'Removed unused import: re'}, {'description': 'Removed unused variable: z'}]
+        mock_result.get_changes.return_value = [
+            {"description": "Removed unused import: re"},
+            {"description": "Removed unused variable: z"},
+        ]
         transformer = CodeTransformer()
-        with patch.object(transformer, 'transform_code', return_value=mock_result) as mock_transform_code:
-            result = transformer.transform_file(test_file_path_succeeds, ['remove_unused_imports', 'remove_unused_variables'])
-            mock_transform_code.assert_called_once_with(file_content, ['remove_unused_imports', 'remove_unused_variables'])
-            assert hasattr(result, 'get_original_code')
-            assert hasattr(result, 'get_transformed_code')
-            assert hasattr(result, 'get_changes')
+        with patch.object(
+            transformer, "transform_code", return_value=mock_result
+        ) as mock_transform_code:
+            result = transformer.transform_file(
+                test_file_path_succeeds,
+                ["remove_unused_imports", "remove_unused_variables"],
+            )
+            mock_transform_code.assert_called_once_with(
+                file_content, ["remove_unused_imports", "remove_unused_variables"]
+            )
+            assert hasattr(result, "get_original_code")
+            assert hasattr(result, "get_transformed_code")
+            assert hasattr(result, "get_changes")
             assert len(result.get_changes()) == 2
-            assert any(('Removed unused import' in change['description'] for change in result.get_changes()))
-            assert any(('Removed unused variable' in change['description'] for change in result.get_changes()))
+            assert any(
+                (
+                    "Removed unused import" in change["description"]
+                    for change in result.get_changes()
+                )
+            )
+            assert any(
+                (
+                    "Removed unused variable" in change["description"]
+                    for change in result.get_changes()
+                )
+            )
 
     @pytest.mark.medium
     def test_transform_directory_succeeds(self, test_directory_succeeds):
         """Test transforming a directory.
 
-ReqID: N/A"""
-        python_files = [os.path.join(test_directory_succeeds, 'unused_imports.py'), os.path.join(test_directory_succeeds, 'unused_variables.py'), os.path.join(test_directory_succeeds, 'subdir', 'nested_file.py')]
+        ReqID: N/A"""
+        python_files = [
+            os.path.join(test_directory_succeeds, "unused_imports.py"),
+            os.path.join(test_directory_succeeds, "unused_variables.py"),
+            os.path.join(test_directory_succeeds, "subdir", "nested_file.py"),
+        ]
 
         def mock_transform_file(file_path, transformations):
             mock_result = MagicMock()
-            if 'unused_imports.py' in file_path:
+            if "unused_imports.py" in file_path:
                 mock_result.get_original_code.return_value = 'import os\nimport sys\nimport re\n\ndef main():\n    print(os.path.join("a", "b"))'
                 mock_result.get_transformed_code.return_value = 'import os\nimport sys\n\ndef main():\n    print(os.path.join("a", "b"))'
-                mock_result.get_changes.return_value = [{'description': 'Removed unused import: re'}]
-            elif 'unused_variables.py' in file_path:
-                mock_result.get_original_code.return_value = 'def process_data(data):\n    result = []\n    count = 0\n\n    for item in data:\n        result.append(item * 2)\n\n    return result'
-                mock_result.get_transformed_code.return_value = 'def process_data(data):\n    result = []\n\n    for item in data:\n        result.append(item * 2)\n\n    return result'
-                mock_result.get_changes.return_value = [{'description': 'Removed unused variable: count'}]
-            elif 'nested_file.py' in file_path:
-                mock_result.get_original_code.return_value = 'def nested_function():\n    x = 10\n    y = 20\n    return x'
-                mock_result.get_transformed_code.return_value = 'def nested_function():\n    x = 10\n    return x'
-                mock_result.get_changes.return_value = [{'description': 'Removed unused variable: y'}]
+                mock_result.get_changes.return_value = [
+                    {"description": "Removed unused import: re"}
+                ]
+            elif "unused_variables.py" in file_path:
+                mock_result.get_original_code.return_value = "def process_data(data):\n    result = []\n    count = 0\n\n    for item in data:\n        result.append(item * 2)\n\n    return result"
+                mock_result.get_transformed_code.return_value = "def process_data(data):\n    result = []\n\n    for item in data:\n        result.append(item * 2)\n\n    return result"
+                mock_result.get_changes.return_value = [
+                    {"description": "Removed unused variable: count"}
+                ]
+            elif "nested_file.py" in file_path:
+                mock_result.get_original_code.return_value = (
+                    "def nested_function():\n    x = 10\n    y = 20\n    return x"
+                )
+                mock_result.get_transformed_code.return_value = (
+                    "def nested_function():\n    x = 10\n    return x"
+                )
+                mock_result.get_changes.return_value = [
+                    {"description": "Removed unused variable: y"}
+                ]
             return mock_result
+
         transformer = CodeTransformer()
-        with patch.object(transformer, '_find_python_files', return_value=python_files) as mock_find_files, patch.object(transformer, 'transform_file', side_effect=mock_transform_file) as mock_transform_file:
-            results = transformer.transform_directory(test_directory_succeeds, recursive=True, transformations=['remove_unused_imports', 'remove_unused_variables'])
+        with (
+            patch.object(
+                transformer, "_find_python_files", return_value=python_files
+            ) as mock_find_files,
+            patch.object(
+                transformer, "transform_file", side_effect=mock_transform_file
+            ) as mock_transform_file,
+        ):
+            results = transformer.transform_directory(
+                test_directory_succeeds,
+                recursive=True,
+                transformations=["remove_unused_imports", "remove_unused_variables"],
+            )
             mock_find_files.assert_called_once_with(test_directory_succeeds, True)
             assert mock_transform_file.call_count == 3
-            mock_transform_file.assert_any_call(python_files[0], ['remove_unused_imports', 'remove_unused_variables'])
-            mock_transform_file.assert_any_call(python_files[1], ['remove_unused_imports', 'remove_unused_variables'])
-            mock_transform_file.assert_any_call(python_files[2], ['remove_unused_imports', 'remove_unused_variables'])
+            mock_transform_file.assert_any_call(
+                python_files[0], ["remove_unused_imports", "remove_unused_variables"]
+            )
+            mock_transform_file.assert_any_call(
+                python_files[1], ["remove_unused_imports", "remove_unused_variables"]
+            )
+            mock_transform_file.assert_any_call(
+                python_files[2], ["remove_unused_imports", "remove_unused_variables"]
+            )
             assert len(results) == 3
             for file_path, result in results.items():
-                assert hasattr(result, 'get_original_code')
-                assert hasattr(result, 'get_transformed_code')
-                assert hasattr(result, 'get_changes')
-            unused_imports_path = next((path for path in results.keys() if 'unused_imports.py' in path))
+                assert hasattr(result, "get_original_code")
+                assert hasattr(result, "get_transformed_code")
+                assert hasattr(result, "get_changes")
+            unused_imports_path = next(
+                (path for path in results.keys() if "unused_imports.py" in path)
+            )
             unused_imports_result = results[unused_imports_path]
-            assert 'import re' not in unused_imports_result.get_transformed_code()
-            unused_variables_path = next((path for path in results.keys() if 'unused_variables.py' in path))
+            assert "import re" not in unused_imports_result.get_transformed_code()
+            unused_variables_path = next(
+                (path for path in results.keys() if "unused_variables.py" in path)
+            )
             unused_variables_result = results[unused_variables_path]
-            assert 'count = 0' not in unused_variables_result.get_transformed_code()
-            nested_file_path = next((path for path in results.keys() if 'nested_file.py' in path))
+            assert "count = 0" not in unused_variables_result.get_transformed_code()
+            nested_file_path = next(
+                (path for path in results.keys() if "nested_file.py" in path)
+            )
             nested_file_result = results[nested_file_path]
-            assert 'y = 20' not in nested_file_result.get_transformed_code()
+            assert "y = 20" not in nested_file_result.get_transformed_code()
 
     @pytest.mark.medium
     def test_find_python_files_succeeds(self, test_directory_succeeds):
         """Test finding Python files in a directory.
 
-ReqID: N/A"""
+        ReqID: N/A"""
         transformer = CodeTransformer()
         files = transformer._find_python_files(test_directory_succeeds, recursive=True)
         assert len(files) == 3
-        assert any(('unused_imports.py' in f for f in files))
-        assert any(('unused_variables.py' in f for f in files))
-        assert any(('nested_file.py' in f for f in files))
+        assert any(("unused_imports.py" in f for f in files))
+        assert any(("unused_variables.py" in f for f in files))
+        assert any(("nested_file.py" in f for f in files))
         files = transformer._find_python_files(test_directory_succeeds, recursive=False)
         assert len(files) == 2
-        assert any(('unused_imports.py' in f for f in files))
-        assert any(('unused_variables.py' in f for f in files))
-        assert not any(('nested_file.py' in f for f in files))
+        assert any(("unused_imports.py" in f for f in files))
+        assert any(("unused_variables.py" in f for f in files))
+        assert not any(("nested_file.py" in f for f in files))
+
 
 class TestSymbolUsageCounter:
     """Test the SymbolUsageCounter class.
 
-ReqID: N/A"""
+    ReqID: N/A"""
 
     @pytest.mark.medium
     def test_count_symbol_usage_succeeds(self):
         """Test counting symbol usage in code.
 
-ReqID: N/A"""
+        ReqID: N/A"""
         code = '\nimport os\nimport sys\n\ndef main():\n    path = os.path.join("a", "b")\n    print(path)\n'
-        symbol_usage = {'os': 0, 'sys': 0, 'path': 0, 'main': 0}
+        symbol_usage = {"os": 0, "sys": 0, "path": 0, "main": 0}
         tree = ast.parse(code)
         counter = SymbolUsageCounter(symbol_usage)
         counter.visit(tree)
-        assert 'os' in symbol_usage
-        assert symbol_usage['os'] > 0
-        assert 'path' in symbol_usage
-        assert symbol_usage['path'] > 0
-        assert 'sys' in symbol_usage
-        assert symbol_usage['sys'] == 0
+        assert "os" in symbol_usage
+        assert symbol_usage["os"] > 0
+        assert "path" in symbol_usage
+        assert symbol_usage["path"] > 0
+        assert "sys" in symbol_usage
+        assert symbol_usage["sys"] == 0


### PR DESCRIPTION
## Summary
- add cleanup and proper speed markers to resource-intensive memory adapter tests
- normalize provider system test markers to single `medium`
- introduce stability check options to `fix_flaky_tests.py`

## Testing
- `poetry run pre-commit run --files scripts/fix_flaky_tests.py tests/conftest.py tests/unit/adapters/memory/test_memory_adapter.py tests/unit/adapters/test_provider_system.py tests/unit/application/code_analysis/test_transformer.py`
- `poetry run devsynth run-tests --speed=medium` *(fails: command interrupted)*
- `poetry run python tests/verify_test_organization.py`
- `poetry run python scripts/verify_test_markers.py` *(fails: KeyboardInterrupt)*
- `poetry run python scripts/verify_requirements_traceability.py`
- `poetry run python scripts/verify_version_sync.py`


------
https://chatgpt.com/codex/tasks/task_e_689c22bffa90833381b09d868361ef8e