### PR TITLE
fix: stabilize memory import without tinydb

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,7 @@ version has been published yet.
 - Optional tiktoken dependency no longer breaks Kuzu memory initialization
 - Added missing step definitions for enhanced memory scenarios
 - Linked remaining alpha tasks (WebUI, Kuzu memory, WSDE collaboration, CLI ingestion) to milestone `0.1.0-alpha.1` and updated development status.
+- Memory module import no longer leaves residual TinyDB state when the dependency is absent
 
 ### Dialectical audit
 - Generated `dialectical_audit.log`; see Issue 125 for unresolved questions.

--- a/docs/specifications/index.md
+++ b/docs/specifications/index.md
@@ -31,6 +31,7 @@ This section contains the official specifications for the DevSynth project, outl
 - **[WSDE-EDRR Collaboration Specification](wsde_edrr_collaboration.md)**: Expected phase progression, memory flush behavior, and peer-review mapping.
 - **[Hybrid Memory Architecture](hybrid_memory_architecture.md)**: Specification for DevSynth's hybrid memory architecture.
 - **[Kuzu Memory Integration](kuzu_memory_integration.md)**: Environment-variable overrides and fallback behaviour for the Kuzu-backed memory store.
+- **[Memory Module Handles Missing TinyDB Dependency](memory_optional_tinydb_dependency.md)**: Import behavior when `tinydb` is absent.
 - **[Interactive Requirements Wizard](interactive_requirements_wizard.md)**: Guided collection of requirements via CLI and WebUI.
 - **[Interactive Requirements Gathering](interactive_requirements_gathering.md)**: Wizard for capturing project goals and constraints.
 - **[Requirements Wizard Logging](requirements_wizard_logging.md)**: Expected log structure and persistence rules for the requirements wizard.

--- a/docs/specifications/memory_optional_tinydb_dependency.md
+++ b/docs/specifications/memory_optional_tinydb_dependency.md
@@ -1,0 +1,45 @@
+---
+author: DevSynth Team
+date: '2025-08-15'
+last_reviewed: '2025-08-15'
+status: draft
+tags:
+- specification
+- memory
+- optional-dependencies
+title: Memory Module Handles Missing TinyDB Dependency
+version: '0.1.0-alpha.1'
+---
+<div class="breadcrumbs">
+<a href="../index.md">Documentation</a> &gt; <a href="index.md">Specifications</a> &gt; Memory Module Handles Missing TinyDB Dependency
+</div>
+
+# Memory Module Handles Missing TinyDB Dependency
+
+## Problem
+
+The memory subsystem exposes adapters for multiple backends. Importing the
+module when the optional `tinydb` package is absent should not raise
+`ImportError` or leave partially initialized modules in `sys.modules`.
+Previous tests mutated `sys.modules` without restoring state, causing flaky
+imports in subsequent tests.
+
+## Solution
+
+Wrap the TinyDB adapter import in a `try/except` block and ensure tests restore
+any mutated module state. When `tinydb` is unavailable the memory module should
+export no `TinyDBMemoryAdapter` symbol.
+
+```pseudocode
+try:
+    from .adapters.tinydb_memory_adapter import TinyDBMemoryAdapter
+except ImportError:
+    TinyDBMemoryAdapter = None
+```
+
+## Verification
+
+- Unit test simulates missing `tinydb` and asserts the adapter symbol is
+  omitted from `__all__`.
+- BDD scenario: Given TinyDB is not installed, when the memory module is
+  imported, then the TinyDB adapter is unavailable.

--- a/tests/behavior/features/index.md
+++ b/tests/behavior/features/index.md
@@ -111,6 +111,7 @@ This index lists all feature files for easy navigation.
 - [general/wsde_message_passing_peer_review.feature](./general/wsde_message_passing_peer_review.feature)
 - [general/wsde_voting_mechanisms.feature](./general/wsde_voting_mechanisms.feature)
 - [memory/memory_operations.feature](./memory/memory_operations.feature)
+- [memory/optional_tinydb_dependency.feature](./memory/optional_tinydb_dependency.feature)
 - [mvu/commands.feature](./mvu/commands.feature)
 - [template/feature_template.feature](./template/feature_template.feature)
 - [webui/alignment_metrics.feature](./webui/alignment_metrics.feature)

--- a/tests/behavior/features/memory/optional_tinydb_dependency.feature
+++ b/tests/behavior/features/memory/optional_tinydb_dependency.feature
@@ -1,0 +1,9 @@
+Feature: Memory module handles missing TinyDB dependency
+  In order to run DevSynth without TinyDB
+  As a developer
+  I want importing the memory module to succeed even when TinyDB is not installed
+
+  Scenario: Importing memory module without TinyDB installed
+    Given TinyDB is not installed
+    When the memory module is imported
+    Then the TinyDB adapter is unavailable

--- a/tests/behavior/steps/test_optional_tinydb_dependency_steps.py
+++ b/tests/behavior/steps/test_optional_tinydb_dependency_steps.py
@@ -1,0 +1,62 @@
+import builtins
+import importlib
+import sys
+
+import pytest
+from pytest_bdd import given, scenarios, then, when
+
+scenarios("../features/memory/optional_tinydb_dependency.feature")
+pytestmark = pytest.mark.medium
+
+
+@pytest.fixture
+def context():
+    class Context:
+        module = None
+
+    return Context()
+
+
+@pytest.fixture
+def simulate_missing_tinydb(monkeypatch):
+    original_memory = sys.modules.pop("devsynth.application.memory", None)
+    original_adapter = sys.modules.pop(
+        "devsynth.application.memory.adapters.tinydb_memory_adapter", None
+    )
+    real_import = builtins.__import__
+
+    def fake_import(name, globals=None, locals=None, fromlist=(), level=0):
+        if name.startswith("tinydb"):
+            raise ImportError("No module named 'tinydb'")
+        return real_import(name, globals, locals, fromlist, level)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+    yield
+    if original_memory is not None:
+        sys.modules["devsynth.application.memory"] = original_memory
+    else:
+        sys.modules.pop("devsynth.application.memory", None)
+    if original_adapter is not None:
+        sys.modules["devsynth.application.memory.adapters.tinydb_memory_adapter"] = (
+            original_adapter
+        )
+    else:
+        sys.modules.pop(
+            "devsynth.application.memory.adapters.tinydb_memory_adapter", None
+        )
+
+
+@given("TinyDB is not installed")
+def given_tinydb_not_installed(simulate_missing_tinydb):
+    pass
+
+
+@when("the memory module is imported")
+def when_import_memory(context):
+    context.module = importlib.import_module("devsynth.application.memory")
+
+
+@then("the TinyDB adapter is unavailable")
+def then_no_tinydb_adapter(context):
+    assert context.module.TinyDBMemoryAdapter is None
+    assert "TinyDBMemoryAdapter" not in context.module.__all__

--- a/tests/unit/application/memory/test_import_without_tinydb.py
+++ b/tests/unit/application/memory/test_import_without_tinydb.py
@@ -1,22 +1,42 @@
-import pytest
 import builtins
 import importlib
 import sys
+
+import pytest
+
 
 @pytest.mark.medium
 def test_import_memory_without_tinydb_succeeds(monkeypatch):
     """Importing memory module should succeed without tinydb installed.
 
-ReqID: N/A"""
-    sys.modules.pop('devsynth.application.memory', None)
-    sys.modules.pop('devsynth.application.memory.adapters.tinydb_memory_adapter', None)
+    ReqID: N/A"""
+
+    original_memory = sys.modules.pop("devsynth.application.memory", None)
+    original_adapter = sys.modules.pop(
+        "devsynth.application.memory.adapters.tinydb_memory_adapter", None
+    )
     real_import = builtins.__import__
 
     def fake_import(name, globals=None, locals=None, fromlist=(), level=0):
-        if name.startswith('tinydb'):
+        if name.startswith("tinydb"):
             raise ImportError("No module named 'tinydb'")
         return real_import(name, globals, locals, fromlist, level)
-    monkeypatch.setattr(builtins, '__import__', fake_import)
-    module = importlib.import_module('devsynth.application.memory')
-    assert module.TinyDBMemoryAdapter is None
-    assert 'TinyDBMemoryAdapter' not in module.__all__
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+    try:
+        module = importlib.import_module("devsynth.application.memory")
+        assert module.TinyDBMemoryAdapter is None
+        assert "TinyDBMemoryAdapter" not in module.__all__
+    finally:
+        if original_memory is not None:
+            sys.modules["devsynth.application.memory"] = original_memory
+        else:
+            sys.modules.pop("devsynth.application.memory", None)
+        if original_adapter is not None:
+            sys.modules[
+                "devsynth.application.memory.adapters.tinydb_memory_adapter"
+            ] = original_adapter
+        else:
+            sys.modules.pop(
+                "devsynth.application.memory.adapters.tinydb_memory_adapter", None
+            )


### PR DESCRIPTION
## Summary
- document memory module behavior when TinyDB is missing
- add BDD scenario for importing memory without TinyDB
- restore module state in tinydb import test

## Testing
- `poetry run pre-commit run --files CHANGELOG.md docs/specifications/index.md docs/specifications/memory_optional_tinydb_dependency.md tests/behavior/features/index.md tests/behavior/features/memory/optional_tinydb_dependency.feature tests/behavior/steps/test_optional_tinydb_dependency_steps.py tests/unit/application/memory/test_import_without_tinydb.py`
- `poetry run pytest tests/unit/application/memory/test_import_without_tinydb.py tests/behavior/steps/test_optional_tinydb_dependency_steps.py -m medium -q`
- `poetry run python tests/verify_test_organization.py`
- `poetry run python scripts/verify_test_markers.py` *(failed: KeyboardInterrupt)*
- `poetry run python scripts/verify_requirements_traceability.py`
- `poetry run python scripts/verify_version_sync.py`


------
https://chatgpt.com/codex/tasks/task_e_689ca4b97e1c83338afe30e9d1bd0f97