### PR TITLE
feat: log requirements priority

### DIFF
--- a/docs/specifications/index.md
+++ b/docs/specifications/index.md
@@ -34,6 +34,7 @@ This section contains the official specifications for the DevSynth project, outl
 - **[Memory Module Handles Missing TinyDB Dependency](memory_optional_tinydb_dependency.md)**: Import behavior when `tinydb` is absent.
 - **[Interactive Requirements Wizard](interactive_requirements_wizard.md)**: Guided collection of requirements via CLI and WebUI.
 - **[Interactive Requirements Gathering](interactive_requirements_gathering.md)**: Wizard for capturing project goals and constraints.
+- **[Requirements Wizard](requirements_wizard.md)**: Logging and priority persistence for the requirements wizard.
 - **[Requirements Wizard Logging](requirements_wizard_logging.md)**: Expected log structure and persistence rules for the requirements wizard.
 
 ## Implementation Plans

--- a/docs/specifications/requirements_wizard.md
+++ b/docs/specifications/requirements_wizard.md
@@ -1,0 +1,24 @@
+title: "Requirements Wizard"
+author: "DevSynth Team"
+date: "2025-09-05"
+status: "draft"
+---
+
+# Summary
+
+## Socratic Checklist
+- What is the problem?
+- What proofs confirm the solution?
+
+## Motivation
+The interactive requirements wizard should provide an auditable record of each user interaction and persist the selected priority so subsequent tools can reference it.
+
+## Specification
+- The wizard records each step with `DevSynthLogger`, including the step name and chosen value.
+- `DevSynthLogger` accepts exception objects via `exc_info` and renders full stack traces without crashing.
+- The final priority selection is written to `.devsynth/project.yaml` via the configuration loader.
+
+## Acceptance Criteria
+- Running the wizard produces log entries for each step.
+- The saved configuration contains the selected priority value.
+- Supplying `exc_info` to `DevSynthLogger` does not raise errors.

--- a/docs/user_guides/requirements_wizard.md
+++ b/docs/user_guides/requirements_wizard.md
@@ -1,0 +1,32 @@
+title: "Requirements Wizard"
+date: "2025-09-05"
+version: "0.1.0-alpha.1"
+tags:
+  - "requirements"
+  - "cli"
+status: "draft"
+author: "DevSynth Team"
+last_reviewed: "2025-09-05"
+---
+
+<div class="breadcrumbs">
+<a href="../index.md">Documentation</a> &gt; <a href="index.md">User Guides</a> &gt; Requirements Wizard
+</div>
+
+# Requirements Wizard
+
+The requirements wizard interactively gathers title, description, type, priority, and constraints. Each step is logged using `DevSynthLogger` so sessions can be audited.
+
+When the wizard completes, the selected priority is persisted to `.devsynth/project.yaml` allowing subsequent commands to reference the user's choice.
+
+Example log entry:
+
+```json
+{"logger": "devsynth.application.requirements.wizard", "step": "priority", "value": "high"}
+```
+
+After running, the configuration file includes:
+
+```yaml
+priority: high
+```

--- a/src/devsynth/utils/__init__.py
+++ b/src/devsynth/utils/__init__.py
@@ -1,0 +1,17 @@
+"""Utility helpers for DevSynth."""
+
+from .logging import (
+    DevSynthLogger,
+    configure_logging,
+    get_logger,
+    log_consensus_failure,
+    setup_logging,
+)
+
+__all__ = [
+    "DevSynthLogger",
+    "configure_logging",
+    "get_logger",
+    "log_consensus_failure",
+    "setup_logging",
+]

--- a/src/devsynth/utils/logging.py
+++ b/src/devsynth/utils/logging.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+import sys
+
+from devsynth.logger import configure_logging, log_consensus_failure  # re-export
+from devsynth.logging_setup import DevSynthLogger as _BaseLogger
+
+
+class DevSynthLogger(_BaseLogger):
+    """Project-level logger that normalizes ``exc_info`` values."""
+
+    def _log(self, level: int, msg: str, *args, **kwargs) -> None:  # type: ignore[override]
+        exc = kwargs.pop("exc_info", None)
+        if isinstance(exc, BaseException):
+            exc = (exc.__class__, exc, exc.__traceback__)
+        elif exc is True:
+            exc = sys.exc_info()
+        elif exc not in (None, False) and not (
+            isinstance(exc, tuple) and len(exc) == 3
+        ):
+            exc = None
+        super()._log(level, msg, *args, exc_info=exc, **kwargs)
+
+
+def get_logger(name: str) -> DevSynthLogger:
+    """Return a :class:`DevSynthLogger` for ``name``."""
+    return DevSynthLogger(name)
+
+
+def setup_logging(name: str, log_level: int | str | None = None) -> DevSynthLogger:
+    """Configure logging and return a logger for ``name``."""
+    configure_logging(log_level)
+    return DevSynthLogger(name)
+
+
+__all__ = [
+    "DevSynthLogger",
+    "get_logger",
+    "setup_logging",
+    "configure_logging",
+    "log_consensus_failure",
+]

--- a/tests/behavior/requirements_wizard/__init__.py
+++ b/tests/behavior/requirements_wizard/__init__.py
@@ -1,0 +1,1 @@
+# BDD scenarios for requirements wizard logging and priority persistence

--- a/tests/behavior/requirements_wizard/logging_and_priority.feature
+++ b/tests/behavior/requirements_wizard/logging_and_priority.feature
@@ -1,0 +1,10 @@
+Feature: Requirements wizard logging and priority persistence
+  As a developer
+  I want the wizard to log user choices and store the selected priority
+  So that sessions are auditable and configuration reflects decisions
+
+  Scenario: Logging includes priority and configuration saves it
+    Given logging is configured for the requirements wizard
+    When I run the requirements wizard with priority "high"
+    Then the log should include the priority "high"
+    And the configuration file should record priority "high"

--- a/tests/behavior/requirements_wizard/test_logging_and_priority_steps.py
+++ b/tests/behavior/requirements_wizard/test_logging_and_priority_steps.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+import pytest
+import yaml
+from pytest_bdd import given, scenarios, then, when
+
+from devsynth.application.requirements.wizard import requirements_wizard
+from devsynth.interface.ux_bridge import UXBridge
+from devsynth.utils.logging import configure_logging
+
+pytestmark = pytest.mark.fast
+
+
+class DummyBridge(UXBridge):
+    def __init__(self, answers):
+        self.answers = list(answers)
+
+    def ask_question(
+        self, message: str, *, choices=None, default=None, show_default=True
+    ):
+        return self.answers.pop(0)
+
+    def confirm_choice(self, message: str, *, default: bool = False) -> bool:
+        return True
+
+    def display_result(self, message: str, *, highlight: bool = False) -> None:
+        pass
+
+
+scenarios(str(Path(__file__).with_name("logging_and_priority.feature")))
+
+
+@pytest.mark.fast
+@given("logging is configured for the requirements wizard")
+def logging_configured(tmp_path, monkeypatch):
+    import os
+
+    os.chdir(tmp_path)
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    configure_logging("INFO")
+
+
+@pytest.mark.fast
+@when('I run the requirements wizard with priority "high"')
+def run_wizard(caplog):
+    answers = ["Title", "Desc", "functional", "high", ""]
+    bridge = DummyBridge(answers)
+    with caplog.at_level(logging.INFO):
+        requirements_wizard(bridge, output_file="req.json")
+
+
+@pytest.mark.fast
+@then('the log should include the priority "high"')
+def log_contains_priority(caplog):
+    assert any(
+        getattr(rec, "step", None) == "priority"
+        and getattr(rec, "value", None) == "high"
+        for rec in caplog.records
+    )
+
+
+@pytest.mark.fast
+@then('the configuration file should record priority "high"')
+def config_has_priority(tmp_path):
+    cfg = yaml.safe_load((tmp_path / ".devsynth" / "project.yaml").read_text())
+    assert cfg["priority"] == "high"


### PR DESCRIPTION
## Summary
- specify logging and priority persistence for requirements wizard
- record wizard steps and saved priority
- add DevSynthLogger with exc_info normalization

## Testing
- `poetry run pre-commit run --files docs/specifications/index.md docs/specifications/requirements_wizard.md docs/user_guides/requirements_wizard.md src/devsynth/application/requirements/wizard.py src/devsynth/utils/__init__.py src/devsynth/utils/logging.py tests/behavior/requirements_wizard/__init__.py tests/behavior/requirements_wizard/logging_and_priority.feature tests/behavior/requirements_wizard/test_logging_and_priority_steps.py`
- `poetry run pytest tests/behavior/requirements_wizard/test_logging_and_priority_steps.py -m fast -q`
- `poetry run python tests/verify_test_organization.py`
- `poetry run python scripts/verify_test_markers.py` *(fails: KeyboardInterrupt)*
- `poetry run python scripts/verify_requirements_traceability.py`
- `poetry run python scripts/verify_version_sync.py`


------
https://chatgpt.com/codex/tasks/task_e_689cb9acdfc08333a1e30a5488e62acc