### PR TITLE
docs: add kuzu memory and wizard logging docs

### DIFF
--- a/dialectical_audit.log
+++ b/dialectical_audit.log
@@ -43,13 +43,13 @@
     "Feature 'Interactive Requirements Flow WebUI' has tests but is not documented.",
     "Feature 'Interactive Requirements Wizard' has tests but is not documented.",
     "Feature 'Invalid configuration handling' has tests but is not documented.",
-    "Feature 'Kuzu memory integration' has tests but is not documented.",
     "Feature 'MVU Command Execution' has tests but is not documented.",
     "Feature 'Memory Adapter Integration' has tests but is not documented.",
     "Feature 'Memory Backend Integration' has tests but is not documented.",
     "Feature 'Memory Manager and Adapters' has tests but is not documented.",
     "Feature 'Memory adapter read and write operations' has tests but is not documented.",
     "Feature 'Memory and Context System' has tests but is not documented.",
+    "Feature 'Memory module handles missing TinyDB dependency' has tests but is not documented.",
     "Feature 'Micro EDRR Cycle' has tests but is not documented.",
     "Feature 'Multi-Layered Memory System and Tiered Cache Strategy' has tests but is not documented.",
     "Feature 'Multi-agent task delegation' has tests but is not documented.",
@@ -67,8 +67,8 @@
     "Feature 'Requirements Gathering Wizard' has tests but is not documented.",
     "Feature 'Requirements Management' has tests but is not documented.",
     "Feature 'Requirements Wizard' has tests but is not documented.",
-    "Feature 'Requirements Wizard Logging' has tests but is not documented.",
     "Feature 'Requirements Wizard Navigation' has tests but is not documented.",
+    "Feature 'Requirements wizard logging and priority persistence' has tests but is not documented.",
     "Feature 'Retry Mechanism with Exponential Backoff' has tests but is not documented.",
     "Feature 'Run Pipeline Command' has tests but is not documented.",
     "Feature 'Run tests from the CLI' has tests but is not documented.",
@@ -94,6 +94,7 @@
     "Feature 'WSDE Peer Review Workflow' has tests but is not documented.",
     "Feature 'WSDE Voting Mechanisms for Critical Decisions' has tests but is not documented.",
     "Feature 'WSDE and EDRR collaboration' has tests but is not documented.",
+    "Feature 'WSDE collaboration flow' has tests but is not documented.",
     "Feature 'WSDE-EDRR Integration' has tests but is not documented.",
     "Feature 'Web Application Generation' has tests but is not documented.",
     "Feature 'WebUI APISpec Page' has tests but is not documented.",
@@ -180,6 +181,7 @@
     "Feature 'Memory Manager and Adapters' is referenced in docs or tests but not in code.",
     "Feature 'Memory adapter read and write operations' is referenced in docs or tests but not in code.",
     "Feature 'Memory and Context System' is referenced in docs or tests but not in code.",
+    "Feature 'Memory module handles missing TinyDB dependency' is referenced in docs or tests but not in code.",
     "Feature 'Methodology Adapters Integration' is referenced in docs or tests but not in code.",
     "Feature 'Micro EDRR Cycle' is referenced in docs or tests but not in code.",
     "Feature 'Multi-Agent Collaboration' is referenced in docs or tests but not in code.",
@@ -203,6 +205,7 @@
     "Feature 'Requirements Wizard' is referenced in docs or tests but not in code.",
     "Feature 'Requirements Wizard Logging' is referenced in docs or tests but not in code.",
     "Feature 'Requirements Wizard Navigation' is referenced in docs or tests but not in code.",
+    "Feature 'Requirements wizard logging and priority persistence' is referenced in docs or tests but not in code.",
     "Feature 'Retry Mechanism with Exponential Backoff' is referenced in docs or tests but not in code.",
     "Feature 'Run Pipeline Command' is referenced in docs or tests but not in code.",
     "Feature 'Run tests from the CLI' is referenced in docs or tests but not in code.",
@@ -229,6 +232,7 @@
     "Feature 'WSDE Peer Review Workflow' is referenced in docs or tests but not in code.",
     "Feature 'WSDE Voting Mechanisms for Critical Decisions' is referenced in docs or tests but not in code.",
     "Feature 'WSDE and EDRR collaboration' is referenced in docs or tests but not in code.",
+    "Feature 'WSDE collaboration flow' is referenced in docs or tests but not in code.",
     "Feature 'WSDE-EDRR Integration' is referenced in docs or tests but not in code.",
     "Feature 'Web Application Generation' is referenced in docs or tests but not in code.",
     "Feature 'WebUI APISpec Page' is referenced in docs or tests but not in code.",
@@ -259,9 +263,5 @@
     "Feature 'Workflow Execution' is referenced in docs or tests but not in code.",
     "Feature 'devsynth run-tests command' is referenced in docs or tests but not in code."
   ],
-  "resolved": [
-    "Simple Addition feature documented and implemented in code.",
-    "Doctor command features documented and annotated in tools module.",
-    "Template and duplicate features removed; rationale in docs/rationales/feature_pruning.md."
-  ]
+  "resolved": []
 }

--- a/docs/developer_guides/requirements_wizard_structure.md
+++ b/docs/developer_guides/requirements_wizard_structure.md
@@ -20,6 +20,8 @@ The WebUI requirements wizard has been refactored into smaller helper methods to
 maintainability and testing. The `WebUI` class now delegates specific tasks to the
 following private helpers:
 
+Logging behavior is covered in the [Requirements Wizard Logging feature](../features/requirements_wizard_logging.md).
+
 - `_validate_requirements_step` – ensures required fields are provided for each step.
 - `_handle_requirements_navigation` – manages navigation buttons and orchestrates saving.
 - `_save_requirements` – writes collected requirements to `requirements_wizard.json` and resets state.

--- a/docs/documentation_index.md
+++ b/docs/documentation_index.md
@@ -50,6 +50,8 @@ _This index lists all documentation files, their status, and release phase. It i
 | docs/architecture/wsde_agent_model.md | WSDE Agent Model: WSDE | active | foundation |
 | docs/architecture/wsde_edrr_integration.md | WSDE-EDRR Integration Architecture | published | foundation |
 | docs/developer_guides/* | Developer guides and code style | published | development |
+| docs/features/kuzu_memory_integration.md | Kuzu Memory Integration | draft | development |
+| docs/features/requirements_wizard_logging.md | Requirements Wizard Logging | draft | development |
 | docs/implementation/* | Implementation examples and pseudocode | draft | implementation |
 | docs/policies/* | SDLC and project policies | published | governance |
 | docs/roadmap/FINAL_SUMMARY.md | DevSynth Repository Harmonization Final Summary | published | roadmap |

--- a/docs/features/kuzu_memory_integration.md
+++ b/docs/features/kuzu_memory_integration.md
@@ -1,0 +1,25 @@
+---
+title: "Kuzu Memory Integration"
+date: "2025-08-13"
+version: "0.1.0-alpha.1"
+tags:
+  - "documentation"
+  - "feature"
+status: "draft"
+author: "DevSynth Team"
+last_reviewed: "2025-08-13"
+---
+<div class="breadcrumbs">
+<a href="../index.md">Documentation</a> &gt; <a href="index.md">Feature Documentation</a> &gt; Kuzu Memory Integration
+</div>
+
+# Kuzu Memory Integration
+
+Feature: Kuzu memory integration
+
+Integrates the Kuzu graph database as a memory store, providing persistent graph storage with automatic fallback to an in-memory implementation when the embedded engine is unavailable. The `DEVSYNTH_KUZU_EMBEDDED` environment variable controls use of the embedded engine.
+
+## Related Documentation
+
+- [Kuzu Memory Integration specification](../specifications/kuzu_memory_integration.md)
+- [Memory Integration Guide](../developer_guides/memory_integration_guide.md)

--- a/docs/features/requirements_wizard_logging.md
+++ b/docs/features/requirements_wizard_logging.md
@@ -1,0 +1,25 @@
+---
+title: "Requirements Wizard Logging"
+date: "2025-08-13"
+version: "0.1.0-alpha.1"
+tags:
+  - "documentation"
+  - "feature"
+status: "draft"
+author: "DevSynth Team"
+last_reviewed: "2025-08-13"
+---
+<div class="breadcrumbs">
+<a href="../index.md">Documentation</a> &gt; <a href="index.md">Feature Documentation</a> &gt; Requirements Wizard Logging
+</div>
+
+# Requirements Wizard Logging
+
+Feature: Requirements Wizard Logging
+
+The requirements wizard emits structured JSON logs, preserving navigation state and respecting the `DEVSYNTH_NO_FILE_LOGGING` flag to disable file output when set.
+
+## Related Documentation
+
+- [Requirements Wizard Logging specification](../specifications/requirements_wizard_logging.md)
+- [Requirements Wizard Structure guide](../developer_guides/requirements_wizard_structure.md)

--- a/docs/specifications/kuzu_memory_integration.md
+++ b/docs/specifications/kuzu_memory_integration.md
@@ -7,6 +7,8 @@ status: draft
 
 # Summary
 
+See [Kuzu Memory Integration feature](../features/kuzu_memory_integration.md) for usage overview.
+
 ## Socratic Checklist
 - What is the problem?
 - What proofs confirm the solution?

--- a/docs/specifications/requirements_wizard_logging.md
+++ b/docs/specifications/requirements_wizard_logging.md
@@ -9,6 +9,8 @@ status: draft
 
 Defines expected logging behaviour for the requirements wizard, including structured JSON fields and persistence rules.
 
+See [Requirements Wizard Logging feature](../features/requirements_wizard_logging.md) for an overview.
+
 ## Socratic Checklist
 - What is the problem?
 - What proofs confirm the solution?


### PR DESCRIPTION
## Summary
- add feature docs for Kuzu memory integration and Requirements Wizard Logging
- link new features from specs, developer guides, and documentation index
- rerun dialectical audit to record remaining unanswered items

## Testing
- `SKIP=fix-code-blocks poetry run pre-commit run --files dialectical_audit.log docs/developer_guides/memory_integration_guide.md docs/developer_guides/requirements_wizard_structure.md docs/documentation_index.md docs/specifications/kuzu_memory_integration.md docs/specifications/requirements_wizard_logging.md docs/features/kuzu_memory_integration.md docs/features/requirements_wizard_logging.md`
- `poetry run devsynth run-tests --speed=fast` *(fails: AttributeError in provider logging tests; FileNotFoundError in behavior tests)*
- `poetry run python tests/verify_test_organization.py`
- `poetry run python scripts/verify_test_markers.py` *(hangs, terminated)*
- `poetry run python scripts/verify_requirements_traceability.py`
- `poetry run python scripts/verify_version_sync.py`
- `poetry run python scripts/dialectical_audit.py`


------
https://chatgpt.com/codex/tasks/task_e_689cd3606d448333a213eb7aa09e0b2e