### PR TITLE
Run verification scripts during environment provisioning

### DIFF
--- a/docs/developer_guides/development_setup.md
+++ b/docs/developer_guides/development_setup.md
@@ -70,7 +70,16 @@ Before setting up the development environment, ensure you have the following ins
 
 Ensure the development environment is fully bootstrapped before beginning work. Unless otherwise noted, prefix commands with `poetry run` to ensure they execute inside the project's virtual environment.
 
-Use the environment provisioning script in the `scripts/` directory to prepare the environment and cache optional extras for offline development. It installs development and test extras in one pass, caches those extras to a local wheel directory, and prompts two dialectical checkpoints: *What dependencies are truly required?* and *How do we verify the cache reproduces identical environments?* The script runs a non-interactive fast test sweep, performs a dialectical audit that writes `dialectical_audit.log`, and echoes any unanswered Socratic questions. After it completes, you can revalidate dependencies offline:
+Use the environment provisioning script in the `scripts/` directory to prepare the environment and cache optional extras for offline development. It installs development and test extras in one pass, caches those extras to a local wheel directory, and prompts two dialectical checkpoints: *What dependencies are truly required?* and *How do we verify the cache reproduces identical environments?* The script runs a non-interactive fast test sweep, performs a dialectical audit that writes `dialectical_audit.log`, and echoes any unanswered Socratic questions. It also executes several verification checks:
+
+```bash
+poetry run python tests/verify_test_organization.py
+poetry run python scripts/verify_test_markers.py
+poetry run python scripts/verify_requirements_traceability.py
+poetry run python scripts/verify_version_sync.py
+```
+
+After it completes, you can revalidate dependencies offline:
 
 ```bash
 PIP_NO_INDEX=1 poetry run pip check

--- a/scripts/codex_setup.sh
+++ b/scripts/codex_setup.sh
@@ -30,6 +30,16 @@ fi
 export PATH="$HOME/.local/bin:$PATH"
 pipx ensurepath
 
+# Run commands and exit with a clear message on failure
+run_check() {
+  local desc="$1"
+  shift
+  if ! "$@"; then
+    echo "$desc failed" >&2
+    exit 1
+  fi
+}
+
 # Use Python 3.12 if available, otherwise fall back to Python 3.11
 poetry env use "$(command -v python3.12 || command -v python3.11)"
 
@@ -203,6 +213,11 @@ if questions:
         print(f'- {q}')
 PY
 fi
+
+run_check "Test organization verification" poetry run python tests/verify_test_organization.py
+run_check "Test marker verification" poetry run python scripts/verify_test_markers.py
+run_check "Requirements traceability verification" poetry run python scripts/verify_requirements_traceability.py
+run_check "Version synchronization verification" poetry run python scripts/verify_version_sync.py
 
 # Cleanup any failure marker if the setup completes successfully
 [ -f CODEX_ENVIRONMENT_SETUP_FAILED ] && rm CODEX_ENVIRONMENT_SETUP_FAILED


### PR DESCRIPTION
## Summary
- Ensure the environment provisioning script runs four project verification scripts and fails fast on errors
- Document the new automatic checks in the development setup guide

## Testing
- `poetry run pre-commit run --files scripts/codex_setup.sh docs/developer_guides/development_setup.md`
- `poetry run python tests/verify_test_organization.py`
- `poetry run python scripts/verify_requirements_traceability.py`
- `poetry run python scripts/verify_version_sync.py`
- `timeout 300 bash scripts/codex_setup.sh` *(fails: Test marker verification exceeded time limit)*

------
https://chatgpt.com/codex/tasks/task_e_689d18e40f8c8333a1726115349ae8e6