### PR TITLE
feat: enforce spec or test updates

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -41,6 +41,12 @@
   language: system
   pass_filenames: false
   files: ^docs/requirements_traceability.md$
+- id: spec-or-test-updates
+  name: warn on missing spec or test updates
+  description: "Ensure code changes include specification or test updates"
+  entry: python scripts/check_spec_or_test_updates.py
+  language: system
+  pass_filenames: false
 - id: update-traceability
   name: update traceability
   description: "Update traceability data"

--- a/docs/developer_guides/tdd_bdd_approach.md
+++ b/docs/developer_guides/tdd_bdd_approach.md
@@ -224,13 +224,13 @@ def agent_creates_promise(context, agent_id, capability, table):
     agent = context.agents[agent_id]
     parameters = {row['parameter']: row['value'] for row in table}
     promise_type = getattr(PromiseType, capability)
-    
+
     promise = agent.create_promise(
         type=promise_type,
         parameters=parameters,
         context_id="test_context"
     )
-    
+
     context.promises[f"{agent_id}:{capability}"] = promise
 
 @then("a new promise should be created")
@@ -253,6 +253,17 @@ def promise_has_parameters(context):
     assert "language" in promise.parameters, "Promise parameters should include language"
     assert "description" in promise.parameters, "Promise parameters should include description"
 ```
+
+## 5. Specification and Test Traceability
+
+DevSynth follows a specification-first workflow to maintain strong links between requirements, tests, and implementation:
+
+1. Draft or update a specification in `docs/specifications/` using `spec_template.md`. Fill in all required metadata (`author`, `date`, `last_reviewed`, `status`, `tags`, `title`, `version`) and address the Socratic questions:
+   - What is the problem?
+   - What proofs confirm the solution?
+2. Add or update tests in `tests/` that initially fail and validate the desired behavior.
+
+A pre-commit hook (`scripts/check_spec_or_test_updates.py`) enforces this policy by rejecting commits that modify code in `src/` or `scripts/` without accompanying specification or test changes.
 
 ## 6. Dialectical Reasoning in Testing
 

--- a/docs/specifications/spec_template.md
+++ b/docs/specifications/spec_template.md
@@ -1,9 +1,26 @@
 ---
-title: SPEC_TITLE
 author: AUTHOR_NAME
 date: YYYY-MM-DD
+last_reviewed: YYYY-MM-DD
 status: draft
+tags:
+
+- specification
+
+title: SPEC_TITLE
+version: 0.1.0-alpha.1
 ---
+
+<!--
+Required metadata fields:
+- author: document author
+- date: creation date
+- last_reviewed: last review date
+- status: draft | review | published
+- tags: search keywords
+- title: short descriptive name
+- version: specification version
+-->
 
 # Summary
 

--- a/scripts/check_spec_or_test_updates.py
+++ b/scripts/check_spec_or_test_updates.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import subprocess
 import sys
-from pathlib import Path
 
 
 def get_staged_files() -> list[str]:
@@ -20,7 +19,12 @@ def get_staged_files() -> list[str]:
 
 def main() -> int:
     staged = get_staged_files()
-    code_changes = [f for f in staged if f.startswith("src/") and f.endswith(".py")]
+    code_dirs = ("src/", "scripts/")
+    code_changes = [
+        f
+        for f in staged
+        if f.endswith(".py") and any(f.startswith(d) for d in code_dirs)
+    ]
     if not code_changes:
         return 0
     spec_or_test = [


### PR DESCRIPTION
## Summary
- expand specification template with required metadata and Socratic checklist
- add pre-commit hook to flag code changes without spec or test updates
- document spec-first workflow and hook usage

## Testing
- `SKIP=devsynth-align,fix-code-blocks,check-frontmatter,check-internal-links poetry run pre-commit run --files .pre-commit-hooks.yaml docs/specifications/spec_template.md scripts/check_spec_or_test_updates.py docs/developer_guides/tdd_bdd_approach.md`
- `poetry run python tests/verify_test_organization.py`
- `poetry run python scripts/verify_requirements_traceability.py`
- `poetry run python scripts/verify_version_sync.py`
- `poetry run devsynth run-tests --speed=fast` *(failed: coverage warnings)*
- `poetry run python scripts/verify_test_markers.py` *(failed: script hung)*

------
https://chatgpt.com/codex/tasks/task_e_689d37479ddc8333be921eb223d28a01