### PR TITLE
Improve LMDB optional dependency handling

### DIFF
--- a/issues/106.md
+++ b/issues/106.md
@@ -5,3 +5,4 @@ The memory subsystem supports multiple backends but remains unstable.
 - Finalize sync manager for LMDB, FAISS, and Kuzu stores
 - Harden ChromaDB adapter and transactional semantics
 - Expand integration tests covering persistence and retrieval
+- Handle missing LMDB dependency more gracefully


### PR DESCRIPTION
## Summary
- guard LMDB import so missing optional package doesn't break module import
- note LMDB fallback handling in memory integration issue

## Testing
- `poetry run pre-commit run --files src/devsynth/application/memory/lmdb_store.py issues/106.md`
- `poetry run python tests/verify_test_organization.py`
- `poetry run python scripts/verify_test_markers.py` *(failed: KeyboardInterrupt)*
- `poetry run python scripts/verify_requirements_traceability.py`
- `poetry run python scripts/verify_version_sync.py`
- `poetry run pytest tests/unit/application/memory/test_lmdb_store.py::TestLMDBStore::test_init_succeeds --speed=medium -m medium -vv --no-cov` *(fails: abstract methods missing)*

------
https://chatgpt.com/codex/tasks/task_e_689d4339cec483339385434cf4d4e59a