### PR TITLE
Handle offline pipx install in environment script

### DIFF
--- a/issues/120.md
+++ b/issues/120.md
@@ -14,3 +14,4 @@ failing tests, particularly in the code analysis pipeline.
 - Environment provisioning completed without errors.
 - Test run reached roughly 48% before manual interruption.
 - Failures observed in `test_repo_analyzer` and `test_transformer`.
+- Recent fast test sweep shows additional failures in provider logging (missing `lmstudio`) and missing files for `test_simple_standalone`.


### PR DESCRIPTION
## Summary
- Handle offline execution in the environment provisioning script by skipping pipx install when package indexes are unavailable and by tolerating missing `devsynth` CLI
- Note additional failing tests in issue 120 for tracking

## Testing
- `SKIP=devsynth-align,check-frontmatter,check-internal-links,fix-code-blocks,find-syntax-errors,verify-mvuu-references,verify-requirements-traceability,spec-or-test-updates,update-traceability poetry run pre-commit run --files scripts/codex_setup.sh issues/120.md`
- `poetry run python tests/verify_test_organization.py`
- `poetry run python scripts/verify_test_markers.py -d tests/behavior/steps` *(fails: KeyboardInterrupt)*
- `poetry run python scripts/verify_requirements_traceability.py`
- `poetry run python scripts/verify_version_sync.py`
- `poetry run pytest tests/behavior/test_simple_standalone.py -q` *(fails: FileNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_689d4339cec483339385434cf4d4e59a