### PR TITLE
feat: add maxfail option to test runner

### DIFF
--- a/README.md
+++ b/README.md
@@ -372,6 +372,7 @@ Run the full test suite with:
 
 ```bash
 poetry run devsynth run-tests
+poetry run devsynth run-tests --maxfail 1  # optional early exit
 ```
 
 The legacy `scripts/run_all_tests.py` wrapper remains for backward compatibility but will be removed in a future release.

--- a/docs/developer_guides/testing.md
+++ b/docs/developer_guides/testing.md
@@ -286,11 +286,12 @@ poetry run pytest -q
 # pip commands are for installing from PyPI only
 
 ```text
-Always run tests with `poetry run devsynth run-tests --speed=<cat>`. If `pytest` reports missing packages, run `poetry install` to restore them.
+Always run tests with `poetry run devsynth run-tests --speed=<cat>`. Use `--maxfail <n>` to exit after a set number of failures. If `pytest` reports missing packages, run `poetry install` to restore them.
 
 Skip resource-heavy tests during routine development by running only fast tests:
 
 ```bash
+
 poetry run devsynth run-tests --speed=fast
 
 ```text

--- a/docs/specifications/index.md
+++ b/docs/specifications/index.md
@@ -37,6 +37,7 @@ This section contains the official specifications for the DevSynth project, outl
 - **[Interactive Requirements Gathering](interactive_requirements_gathering.md)**: Wizard for capturing project goals and constraints.
 - **[Requirements Wizard](requirements_wizard.md)**: Logging and priority persistence for the requirements wizard.
 - **[Requirements Wizard Logging](requirements_wizard_logging.md)**: Expected log structure and persistence rules for the requirements wizard.
+- **[Run Tests Maxfail Option](run_tests_maxfail_option.md)**: CLI flag to limit failures during test runs.
 
 ## Implementation Plans
 

--- a/docs/specifications/run_tests_maxfail_option.md
+++ b/docs/specifications/run_tests_maxfail_option.md
@@ -1,0 +1,35 @@
+---
+title: "Run Tests Maxfail Option"
+author: "DevSynth Team"
+date: "2025-07-14"
+last_reviewed: "2025-07-14"
+status: draft
+version: "0.1.0-alpha.1"
+tags:
+  - specification
+  - testing
+---
+<div class="breadcrumbs">
+<a href="../index.md">Documentation</a> &gt; <a href="index.md">Specifications</a> &gt; Run Tests Maxfail Option
+</div>
+
+# Run Tests Maxfail Option
+
+## Summary
+Adds a `--maxfail` flag to `devsynth run-tests` allowing early termination after a set number of test failures.
+
+## Socratic Checklist
+- What is the problem?
+- What proofs confirm the solution?
+
+## Motivation
+Quick feedback loops benefit from stopping test execution after the first few failures, but the DevSynth CLI lacked this control.
+
+## Specification
+- The `devsynth run-tests` command accepts `--maxfail <n>`.
+- The value is forwarded to pytest's `--maxfail` option.
+- When omitted, behavior matches previous releases.
+
+## Acceptance Criteria
+- `devsynth run-tests --maxfail 1` stops after a single failing test.
+- Invocations without `--maxfail` run all selected tests.

--- a/issues/122.md
+++ b/issues/122.md
@@ -13,3 +13,5 @@ Expose a `--maxfail` flag on `devsynth run-tests` that forwards to `pytest` to a
 
 ## Progress
 - Reproduced the error when passing `--maxfail=1` to `devsynth run-tests`.
+- Added `--maxfail` option to `devsynth run-tests` and updated docs and tests.
+- All tasks complete. Issue closed.

--- a/src/devsynth/application/cli/commands/run_tests_cmd.py
+++ b/src/devsynth/application/cli/commands/run_tests_cmd.py
@@ -66,6 +66,9 @@ def run_tests_cmd(
     segment_size: int = typer.Option(
         50, "--segment-size", help="Number of tests per batch when segmenting"
     ),
+    maxfail: Optional[int] = typer.Option(
+        None, "--maxfail", help="Exit after this many failures"
+    ),
     features: List[str] = typer.Option(
         [],
         "--feature",
@@ -91,6 +94,7 @@ def run_tests_cmd(
         not no_parallel,
         segment,
         segment_size,
+        maxfail,
     )
 
     if output:

--- a/src/devsynth/testing/run_tests.py
+++ b/src/devsynth/testing/run_tests.py
@@ -131,6 +131,7 @@ def run_tests(
     parallel: bool = True,
     segment: bool = False,
     segment_size: int = 50,
+    maxfail: Optional[int] = None,
 ) -> Tuple[bool, str]:
     """Execute pytest for the specified target.
 
@@ -144,6 +145,7 @@ def run_tests(
         parallel: Run tests in parallel using ``pytest-xdist``.
         segment: Run tests in smaller batches for large suites.
         segment_size: Number of tests per batch when ``segment`` is ``True``.
+        maxfail: Stop after this many failures.
 
     Returns:
         A tuple of ``(success, output)`` where ``success`` indicates whether all
@@ -154,6 +156,8 @@ def run_tests(
     print(f"{'=' * 80}")
 
     base_cmd = [sys.executable, "-m", "pytest"]
+    if maxfail is not None:
+        base_cmd.append(f"--maxfail={maxfail}")
     test_path = TARGET_PATHS.get(target, TARGET_PATHS["all-tests"])
     base_cmd.append(test_path)
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -354,6 +354,7 @@ Invoke the command from the Poetry environment to run the full suite or selected
 poetry run devsynth run-tests                     # run all tests
 poetry run devsynth run-tests --target unit-tests  # run only unit tests
 poetry run devsynth run-tests --report             # generate HTML report under test_reports/
+poetry run devsynth run-tests --maxfail 1          # stop after the first failure
 ```
 
 For additional utilities like flaky-test fixes and incremental categorization, see [Test Stabilization Tools](../docs/developer_guides/test_stabilization_tools.md).

--- a/tests/behavior/features/general/run_tests.feature
+++ b/tests/behavior/features/general/run_tests.feature
@@ -18,3 +18,8 @@ Feature: devsynth run-tests command
     Given the environment variable "PYTEST_ADDOPTS" is "-k test_provider_logging"
     When I invoke "devsynth run-tests --target unit-tests --speed=fast --no-parallel"
     Then the command should fail
+
+  Scenario: Maxfail option exits after first failure
+    Given the environment variable "PYTEST_ADDOPTS" is "-k test_provider_logging"
+    When I invoke "devsynth run-tests --target unit-tests --speed=fast --no-parallel --maxfail=1"
+    Then the command should fail

--- a/tests/behavior/steps/test_run_tests_steps.py
+++ b/tests/behavior/steps/test_run_tests_steps.py
@@ -40,6 +40,29 @@ def invoke_run_tests(command_result: Dict[str, str]) -> None:
     command_result["output"] = result.stdout + result.stderr
 
 
+@when(
+    'I invoke "devsynth run-tests --target unit-tests --speed=fast --no-parallel --maxfail=1"'
+)
+def invoke_run_tests_maxfail(command_result: Dict[str, str]) -> None:
+    env = os.environ.copy()
+    env.setdefault("DEVSYNTH_NO_FILE_LOGGING", "1")
+    env.setdefault("DEVSYNTH_RESOURCE_LMSTUDIO_AVAILABLE", "false")
+    cmd = [
+        "poetry",
+        "run",
+        "devsynth",
+        "run-tests",
+        "--target",
+        "unit-tests",
+        "--speed=fast",
+        "--no-parallel",
+        "--maxfail=1",
+    ]
+    result = subprocess.run(cmd, capture_output=True, text=True, env=env)
+    command_result["exit_code"] = result.returncode
+    command_result["output"] = result.stdout + result.stderr
+
+
 @then("the command should succeed")
 def command_succeeds(command_result: Dict[str, str]) -> None:
     assert command_result.get("exit_code") == 0

--- a/tests/unit/application/cli/commands/test_run_tests_cmd.py
+++ b/tests/unit/application/cli/commands/test_run_tests_cmd.py
@@ -79,6 +79,7 @@ def test_run_tests_cli_full_invocation() -> None:
             True,  # parallel
             False,  # segment
             50,  # segment_size
+            None,  # maxfail
         )
         assert "Tests completed successfully" in result.output
 
@@ -93,3 +94,30 @@ def test_run_tests_cli_help() -> None:
 
     assert result.exit_code == 0
     assert "Run DevSynth test suites." in result.output
+
+
+def test_run_tests_cli_maxfail_option() -> None:
+    """``--maxfail`` forwards the value to the runner."""
+
+    runner = CliRunner()
+    with patch(
+        "devsynth.application.cli.commands.run_tests_cmd.run_tests",
+        return_value=(True, ""),
+    ) as mock_run:
+        app = build_app()
+        result = runner.invoke(
+            app,
+            ["run-tests", "--target", "unit-tests", "--maxfail", "2"],
+        )
+
+        assert result.exit_code == 0
+        mock_run.assert_called_once_with(
+            "unit-tests",
+            None,
+            False,
+            False,
+            True,
+            False,
+            50,
+            2,
+        )


### PR DESCRIPTION
## Summary
- allow `devsynth run-tests` to forward `--maxfail` to pytest
- document and specify the new max-fail behavior
- close issue 122 and expand tests for the CLI

## Testing
- `poetry run pre-commit run --files src/devsynth/application/cli/commands/run_tests_cmd.py src/devsynth/testing/run_tests.py tests/unit/application/cli/commands/test_run_tests_cmd.py tests/behavior/steps/test_run_tests_steps.py tests/behavior/features/general/run_tests.feature tests/README.md docs/developer_guides/testing.md README.md docs/specifications/index.md docs/specifications/run_tests_maxfail_option.md issues/122.md`
- `poetry run devsynth run-tests --speed=fast` *(fails: AttributeError in test_provider_logging, FileNotFoundError in test_simple_standalone)*
- `poetry run python tests/verify_test_organization.py`
- `poetry run python scripts/verify_test_markers.py` *(interrupted)*
- `poetry run python scripts/verify_requirements_traceability.py`
- `poetry run python scripts/verify_version_sync.py`
- `PIP_NO_INDEX=1 poetry run pip check`


------
https://chatgpt.com/codex/tasks/task_e_689d471f0744833397c8e41c780f36a9