### PR TITLE
chore: refresh issue progress after environment checks

### DIFF
--- a/issues/120.md
+++ b/issues/120.md
@@ -12,6 +12,7 @@ failing tests, particularly in the code analysis pipeline.
 
 ## Progress
 - Environment provisioning completed without errors.
-- Test run reached roughly 48% before manual interruption.
-- Failures observed in `test_repo_analyzer` and `test_transformer`.
-- Recent fast test sweep shows additional failures in provider logging (missing `lmstudio`) and missing files for `test_simple_standalone`.
+- `devsynth run-tests --speed=fast` reports two failures in `tests/unit/general/test_provider_logging.py` due to missing `lmstudio`.
+- `tests/behavior/test_simple_standalone.py` raises `FileNotFoundError` for required sample files.
+- Previous runs also reported failures in `test_repo_analyzer` and `test_transformer`.
+- `pip check` confirms no broken requirements.

--- a/issues/128.md
+++ b/issues/128.md
@@ -22,3 +22,4 @@ The test suite must ensure each test file contains exactly one speed marker (`fa
 ## Status
 
 - Initial verification attempt timed out; needs further investigation.
+- A second run after provisioning also hung and required manual interruption.


### PR DESCRIPTION
## Summary
- note fast-test failures after provisioning
- record repeated verify_test_markers hang

## Testing
- `poetry run pre-commit run --files issues/120.md issues/128.md`
- `poetry run devsynth run-tests --speed=fast`
- `poetry run python tests/verify_test_organization.py`
- `poetry run python scripts/verify_test_markers.py` *(fails: KeyboardInterrupt)*
- `poetry run python scripts/verify_requirements_traceability.py`
- `poetry run python scripts/verify_version_sync.py`
- `PIP_NO_INDEX=1 poetry run pip check`


------
https://chatgpt.com/codex/tasks/task_e_689d471f0744833397c8e41c780f36a9