### PR TITLE
Refine environment provisioning and document test marker issues

### DIFF
--- a/issues/128.md
+++ b/issues/128.md
@@ -23,3 +23,4 @@ The test suite must ensure each test file contains exactly one speed marker (`fa
 
 - Initial verification attempt timed out; needs further investigation.
 - A second run after provisioning also hung and required manual interruption.
+- Third attempt after refining the environment provisioning to avoid heavy GPU extras still hung, indicating an internal issue with `verify_test_markers.py`.

--- a/issues/129.md
+++ b/issues/129.md
@@ -1,0 +1,12 @@
+# Issue 129: Refine environment provisioning to skip heavy GPU packages
+
+Repeated executions of the environment provisioning script attempted to install NVIDIA GPU packages, resulting in endless `Installing nvidia/__init__.py over existing file` messages and a hung process.
+
+## Plan
+- Adjust dependency installation to include only required extras.
+- Verify the script completes without repeated NVIDIA installation messages.
+- Document the expected environment footprint.
+
+## Status
+- Environment provisioning script updated to install `tests`, `retrieval`, `chromadb`, and `api` extras only.
+- Verification pending.

--- a/scripts/install_dev.sh
+++ b/scripts/install_dev.sh
@@ -1,3 +1,5 @@
 #!/usr/bin/env bash
-# Install DevSynth with all optional extras and development dependencies using Poetry
-poetry install --with dev --all-extras
+set -euo pipefail
+
+# Install DevSynth with development dependencies and required extras
+poetry install --with dev --extras tests retrieval chromadb api


### PR DESCRIPTION
## Summary
- Limit environment provisioning to required extras and enforce strict bash error handling
- Note repeated hangs when verifying test markers
- Record ongoing provisioning concerns in issue tracker

## Testing
- `poetry run pre-commit run --files scripts/install_dev.sh issues/128.md issues/129.md`
- `poetry run python tests/verify_test_organization.py`
- `poetry run python scripts/verify_test_markers.py` *(fails: hangs)*
- `poetry run python scripts/verify_requirements_traceability.py`
- `poetry run python scripts/verify_version_sync.py`
- `poetry run devsynth run-tests --speed=fast` *(fails: hangs)*
- `PIP_NO_INDEX=1 poetry run pip check`


------
https://chatgpt.com/codex/tasks/task_e_689d53bab3f88333aa2976e3232da33e