### PR TITLE
test: link requirements gathering to FR-81

### DIFF
--- a/tests/integration/general/test_requirements_gathering.py
+++ b/tests/integration/general/test_requirements_gathering.py
@@ -22,7 +22,7 @@ from devsynth.logging_setup import configure_logging
 def test_gather_updates_config_succeeds(tmp_path, monkeypatch):
     """Test that gather updates config succeeds.
 
-    ReqID: N/A"""
+    ReqID: FR-81"""
     os.chdir(tmp_path)
     monkeypatch.setenv("DEVSYNTH_PROJECT_DIR", str(tmp_path))
     os.makedirs(".devsynth", exist_ok=True)


### PR DESCRIPTION
## Summary
- ensure requirements gathering integration test references requirement FR-81

## Testing
- `SKIP=fix-code-blocks poetry run pre-commit run --files tests/integration/general/test_requirements_gathering.py`
- `poetry run python tests/verify_test_organization.py`
- `poetry run python scripts/verify_test_markers.py --module tests/integration/general/test_requirements_gathering.py` *(fails: KeyError: 'total_files')*
- `poetry run python scripts/verify_requirements_traceability.py`
- `poetry run python scripts/verify_version_sync.py`
- `poetry run pytest tests/integration/general/test_requirements_gathering.py`
- `poetry run devsynth run-tests --speed=fast` *(fails: 18 errors)*

------
https://chatgpt.com/codex/tasks/task_e_689d5cb6445c8333a58a9b060c7ba34a