### PR TITLE
Enforce explicit test speed markers

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -105,7 +105,8 @@ Tests are grouped by runtime using pytest markers:
 - `@pytest.mark.medium` – completes in under **5 seconds**
 - `@pytest.mark.slow` – takes **5 seconds or more**
 
-`tests/conftest_extensions.py` automatically applies these markers and adds a
+Each test **must include exactly one** of these markers. The
+`tests/conftest_extensions.py` plugin enforces this requirement and provides a
 `--speed` option so you can filter tests by runtime:
 
 ```bash

--- a/tests/conftest_extensions.py
+++ b/tests/conftest_extensions.py
@@ -1,28 +1,31 @@
 """
 Extensions to pytest configuration for test categorization and organization.
 """
-import pytest
+
 import time
-from typing import Dict, Any, Optional, List, Callable
 from pathlib import Path
+from typing import Any, Callable, Dict, List, Optional
+
+import pytest
+
 test_times: Dict[str, float] = {}
 
 
 def pytest_configure(config):
     """Configure pytest with custom markers."""
-    config.addinivalue_line('markers',
-        'fast: mark test as fast (execution time < 1s)')
-    config.addinivalue_line('markers',
-        'medium: mark test as medium speed (execution time between 1s and 5s)')
-    config.addinivalue_line('markers',
-        'slow: mark test as slow (execution time > 5s)')
-    config.pluginmanager.register(TestCategorization(), 'test_categorization')
+    config.addinivalue_line("markers", "fast: mark test as fast (execution time < 1s)")
+    config.addinivalue_line(
+        "markers",
+        "medium: mark test as medium speed (execution time between 1s and 5s)",
+    )
+    config.addinivalue_line("markers", "slow: mark test as slow (execution time > 5s)")
+    config.pluginmanager.register(TestCategorization(), "test_categorization")
 
 
 class TestCategorization:
     """Plugin for test categorization and organization.
 
-ReqID: N/A"""
+    ReqID: N/A"""
 
     @pytest.hookimpl(tryfirst=True)
     def pytest_runtest_setup(self, item):
@@ -32,15 +35,9 @@ ReqID: N/A"""
     @pytest.hookimpl(trylast=True)
     def pytest_runtest_teardown(self, item):
         """Record test execution time."""
-        if hasattr(item, '_start_time'):
+        if hasattr(item, "_start_time"):
             item._duration = time.time() - item._start_time
             test_times[item.nodeid] = item._duration
-            if item._duration < 1.0:
-                item.add_marker(pytest.mark.fast)
-            elif item._duration < 5.0:
-                item.add_marker(pytest.mark.medium)
-            else:
-                item.add_marker(pytest.mark.slow)
 
     @pytest.hookimpl(trylast=True)
     def pytest_terminal_summary(self, terminalreporter):
@@ -48,70 +45,78 @@ ReqID: N/A"""
         tr = terminalreporter
         if not tr.stats:
             return
-        tr.write_sep('=', 'Test Categorization Summary')
-        categories = {'unit': 0, 'integration': 0, 'behavior': 0, 'fast': 0,
-            'medium': 0, 'slow': 0}
-        for item in (tr.stats.get('passed', []) + tr.stats.get('failed', []
-            ) + tr.stats.get('skipped', [])):
-            if 'unit' in item.nodeid:
-                categories['unit'] += 1
-            elif 'integration' in item.nodeid:
-                categories['integration'] += 1
-            elif 'behavior' in item.nodeid:
-                categories['behavior'] += 1
+        tr.write_sep("=", "Test Categorization Summary")
+        categories = {
+            "unit": 0,
+            "integration": 0,
+            "behavior": 0,
+            "fast": 0,
+            "medium": 0,
+            "slow": 0,
+        }
+        for item in (
+            tr.stats.get("passed", [])
+            + tr.stats.get("failed", [])
+            + tr.stats.get("skipped", [])
+        ):
+            if "unit" in item.nodeid:
+                categories["unit"] += 1
+            elif "integration" in item.nodeid:
+                categories["integration"] += 1
+            elif "behavior" in item.nodeid:
+                categories["behavior"] += 1
             nodeid = item.nodeid
             duration = test_times.get(nodeid, 0)
             if duration < 1.0:
-                categories['fast'] += 1
+                categories["fast"] += 1
             elif duration < 5.0:
-                categories['medium'] += 1
+                categories["medium"] += 1
             else:
-                categories['slow'] += 1
-        tr.write_line('Test Type Distribution:')
+                categories["slow"] += 1
+        tr.write_line("Test Type Distribution:")
         tr.write_line(f"  Unit Tests: {categories['unit']}")
         tr.write_line(f"  Integration Tests: {categories['integration']}")
         tr.write_line(f"  Behavior Tests: {categories['behavior']}")
-        tr.write_line('')
-        tr.write_line('Test Speed Distribution:')
+        tr.write_line("")
+        tr.write_line("Test Speed Distribution:")
         tr.write_line(f"  Fast Tests (< 1s): {categories['fast']}")
         tr.write_line(f"  Medium Tests (1-5s): {categories['medium']}")
         tr.write_line(f"  Slow Tests (> 5s): {categories['slow']}")
         if test_times:
-            tr.write_sep('=', 'Top 10 Slowest Tests')
-            sorted_times = sorted(test_times.items(), key=lambda x: x[1],
-                reverse=True)
+            tr.write_sep("=", "Top 10 Slowest Tests")
+            sorted_times = sorted(test_times.items(), key=lambda x: x[1], reverse=True)
             for i, (nodeid, duration) in enumerate(sorted_times[:10]):
-                tr.write_line(f'{i + 1}. {nodeid}: {duration:.2f}s')
+                tr.write_line(f"{i + 1}. {nodeid}: {duration:.2f}s")
 
 
 def pytest_addoption(parser):
     """Add command-line options for test categorization."""
-    group = parser.getgroup('test_categorization')
-    group.addoption('--speed', action='store', choices=['fast', 'medium',
-        'slow', 'all'], default='all', help=
-        'Run tests based on execution speed (fast, medium, slow, or all)')
+    group = parser.getgroup("test_categorization")
+    group.addoption(
+        "--speed",
+        action="store",
+        choices=["fast", "medium", "slow", "all"],
+        default="all",
+        help="Run tests based on execution speed (fast, medium, slow, or all)",
+    )
 
 
 def pytest_collection_modifyitems(config, items):
-    """Modify test collection based on categorization options."""
-    speed = config.getoption('--speed')
-    if speed != 'all':
-        skip_other_speeds = pytest.mark.skip(reason=
-            f"Test speed doesn't match --speed={speed}")
-        for item in items:
-            nodeid = item.nodeid
-            duration = getattr(item, '_duration', None)
-            if duration is None:
-                if speed == 'fast' and not item.get_closest_marker('fast'):
-                    item.add_marker(skip_other_speeds)
-                elif speed == 'medium' and not item.get_closest_marker('medium'
-                    ):
-                    item.add_marker(skip_other_speeds)
-                elif speed == 'slow' and not item.get_closest_marker('slow'):
-                    item.add_marker(skip_other_speeds)
-            elif speed == 'fast' and duration >= 1.0:
-                item.add_marker(skip_other_speeds)
-            elif speed == 'medium' and (duration < 1.0 or duration >= 5.0):
-                item.add_marker(skip_other_speeds)
-            elif speed == 'slow' and duration < 5.0:
-                item.add_marker(skip_other_speeds)
+    """Validate test speed markers and apply filtering."""
+    speed = config.getoption("--speed")
+    skip_other_speeds = None
+    if speed != "all":
+        skip_other_speeds = pytest.mark.skip(
+            reason=f"Test speed doesn't match --speed={speed}"
+        )
+    for item in items:
+        speed_markers = [
+            name for name in ("fast", "medium", "slow") if item.get_closest_marker(name)
+        ]
+        if len(speed_markers) != 1:
+            raise pytest.UsageError(
+                f"{item.nodeid} must have exactly one of fast, medium, or slow markers"
+            )
+        marker = speed_markers[0]
+        if skip_other_speeds and marker != speed:
+            item.add_marker(skip_other_speeds)


### PR DESCRIPTION
## Summary
- remove automatic speed marker assignment
- ensure each test declares exactly one of `fast`, `medium`, or `slow`

## Testing
- `poetry run pre-commit run --files tests/conftest_extensions.py tests/README.md`
- `poetry run python scripts/verify_test_markers.py --report` *(timeout after extended runtime)*

------
https://chatgpt.com/codex/tasks/task_e_689d687c5f848333a2e344849358402c