### PR TITLE
chore: streamline feature matrix front matter

### DIFF
--- a/docs/implementation/feature_status_matrix.md
+++ b/docs/implementation/feature_status_matrix.md
@@ -3,13 +3,7 @@ author: DevSynth Team
 date: '2025-06-01'
 last_reviewed: "2025-07-27"
 status: active
-tags:
-
-- implementation
-- status
-- audit
-- foundation-stabilization
-
+tags: [implementation, status, audit, foundation-stabilization]
 title: DevSynth Feature Status Matrix
 version: "0.1.0-alpha.1"
 ---


### PR DESCRIPTION
## Summary
- simplify `feature_status_matrix` front matter by removing bullet-style tags

## Testing
- `SKIP=fix-code-blocks poetry run pre-commit run --files docs/implementation/feature_status_matrix.md`
- `poetry run devsynth run-tests --speed=fast` *(fails: AssertionError in requirements wizard tests)*
- `poetry run python tests/verify_test_organization.py`
- `poetry run python scripts/verify_test_markers.py` *(hangs, interrupted)*
- `poetry run python scripts/verify_requirements_traceability.py`
- `poetry run python scripts/verify_version_sync.py`
- `poetry run mkdocs build` *(fails: ValueError: Empty strings are not supported)*

------
https://chatgpt.com/codex/tasks/task_e_689d77adfbc883339266bf9f12cbc338