### PR TITLE
Refactor verify_test_markers to use bounded search and package utilities

### DIFF
--- a/scripts/__init__.py
+++ b/scripts/__init__.py
@@ -1,0 +1,1 @@
+"""Helper package for project scripts."""

--- a/scripts/test_utils.py
+++ b/scripts/test_utils.py
@@ -17,8 +17,7 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional, Set, Tuple
 
 # Import common test collector
-sys.path.append(os.path.dirname(os.path.abspath(__file__)))
-import common_test_collector
+from . import common_test_collector
 
 # Cache directories
 TEST_CACHE_DIR = ".test_cache"

--- a/scripts/test_utils_extended.py
+++ b/scripts/test_utils_extended.py
@@ -7,28 +7,26 @@ features for test collection, marker verification, and synchronization
 between test categorization tracking files.
 """
 
-import os
-import sys
-import json
-import re
-import time
 import argparse
+import json
+import os
+import re
 import subprocess
+import sys
+import time
 from datetime import datetime
 from pathlib import Path
-from typing import Dict, List, Set, Tuple, Any, Optional, Union
+from typing import Any, Dict, List, Optional, Set, Tuple, Union
 
 # Import original test_utils and common test collector
-sys.path.append(os.path.dirname(os.path.abspath(__file__)))
-import test_utils
-import common_test_collector
+from . import common_test_collector, test_utils
 
 # Constants
 PROGRESS_FILE = ".test_categorization_progress.json"
 SCHEDULE_FILE = ".test_categorization_schedule.json"
-MARKER_PATTERN = re.compile(r'@pytest\.mark\.(fast|medium|slow|isolation)')
-FUNCTION_PATTERN = re.compile(r'def (test_\w+)\(')
-CLASS_PATTERN = re.compile(r'class (Test\w+)\(')
+MARKER_PATTERN = re.compile(r"@pytest\.mark\.(fast|medium|slow|isolation)")
+FUNCTION_PATTERN = re.compile(r"def (test_\w+)\(")
+CLASS_PATTERN = re.compile(r"class (Test\w+)\(")
 
 # Test categories
 TEST_CATEGORIES = {
@@ -39,19 +37,20 @@ TEST_CATEGORIES = {
     "property": "tests/property",
 }
 
+
 def load_progress_file(file_path: str = PROGRESS_FILE) -> Dict[str, Any]:
     """
     Load the test categorization progress file.
-    
+
     Args:
         file_path: Path to the progress file
-        
+
     Returns:
         Dictionary containing categorization progress
     """
     if os.path.exists(file_path):
         try:
-            with open(file_path, 'r') as f:
+            with open(file_path, "r") as f:
                 return json.load(f)
         except json.JSONDecodeError:
             print(f"Error loading progress file {file_path}, creating new progress")
@@ -63,8 +62,8 @@ def load_progress_file(file_path: str = PROGRESS_FILE) -> Dict[str, Any]:
                     "fast": 0,
                     "medium": 0,
                     "slow": 0,
-                    "total": 0
-                }
+                    "total": 0,
+                },
             }
     else:
         print(f"Progress file {file_path} not found, creating new progress")
@@ -72,27 +71,23 @@ def load_progress_file(file_path: str = PROGRESS_FILE) -> Dict[str, Any]:
             "timestamp": datetime.now().isoformat(),
             "categorized_tests": {},
             "categorized_files": [],
-            "categorization_counts": {
-                "fast": 0,
-                "medium": 0,
-                "slow": 0,
-                "total": 0
-            }
+            "categorization_counts": {"fast": 0, "medium": 0, "slow": 0, "total": 0},
         }
+
 
 def load_schedule_file(file_path: str = SCHEDULE_FILE) -> Dict[str, Any]:
     """
     Load the test categorization schedule file.
-    
+
     Args:
         file_path: Path to the schedule file
-        
+
     Returns:
         Dictionary containing categorization schedule
     """
     if os.path.exists(file_path):
         try:
-            with open(file_path, 'r') as f:
+            with open(file_path, "r") as f:
                 return json.load(f)
         except json.JSONDecodeError:
             print(f"Error loading schedule file {file_path}")
@@ -101,26 +96,32 @@ def load_schedule_file(file_path: str = SCHEDULE_FILE) -> Dict[str, Any]:
         print(f"Schedule file {file_path} not found")
         return {}
 
-def save_progress_file(progress: Dict[str, Any], file_path: str = PROGRESS_FILE) -> None:
+
+def save_progress_file(
+    progress: Dict[str, Any], file_path: str = PROGRESS_FILE
+) -> None:
     """
     Save the test categorization progress file.
-    
+
     Args:
         progress: Dictionary containing categorization progress
         file_path: Path to the progress file
     """
     # Update timestamp
     progress["timestamp"] = datetime.now().isoformat()
-    
-    with open(file_path, 'w') as f:
+
+    with open(file_path, "w") as f:
         json.dump(progress, f, indent=2)
-    
+
     print(f"Progress saved to {file_path}")
 
-def save_schedule_file(schedule: Dict[str, Any], file_path: str = SCHEDULE_FILE) -> None:
+
+def save_schedule_file(
+    schedule: Dict[str, Any], file_path: str = SCHEDULE_FILE
+) -> None:
     """
     Save the test categorization schedule file.
-    
+
     Args:
         schedule: Dictionary containing categorization schedule
         file_path: Path to the schedule file
@@ -128,95 +129,111 @@ def save_schedule_file(schedule: Dict[str, Any], file_path: str = SCHEDULE_FILE)
     # Update timestamp
     if "generated_at" not in schedule:
         schedule["generated_at"] = datetime.now().isoformat()
-    
+
     schedule["updated_at"] = datetime.now().isoformat()
-    
-    with open(file_path, 'w') as f:
+
+    with open(file_path, "w") as f:
         json.dump(schedule, f, indent=2)
-    
+
     print(f"Schedule saved to {file_path}")
 
-def collect_behavior_tests(test_dir: str = "tests/behavior", use_cache: bool = True) -> List[str]:
+
+def collect_behavior_tests(
+    test_dir: str = "tests/behavior", use_cache: bool = True
+) -> List[str]:
     """
     Collect behavior tests using a specialized approach.
-    
+
     Args:
         test_dir: Directory containing behavior tests
         use_cache: Whether to use cached test collection results
-        
+
     Returns:
         List of behavior test paths
     """
     print(f"Collecting behavior tests in {test_dir}...")
-    
+
     # Use common_test_collector to collect behavior tests
-    return common_test_collector.collect_tests_by_category("behavior", use_cache=use_cache)
+    return common_test_collector.collect_tests_by_category(
+        "behavior", use_cache=use_cache
+    )
+
 
 def collect_all_tests(use_cache: bool = True) -> Dict[str, List[str]]:
     """
     Collect all tests in the project, organized by category.
-    
+
     Args:
         use_cache: Whether to use cached test collection results
-        
+
     Returns:
         Dictionary mapping test categories to lists of test paths
     """
     all_tests = {}
-    
+
     # Collect tests for each category using common_test_collector
     for category in common_test_collector.TEST_CATEGORIES:
-        all_tests[category] = common_test_collector.collect_tests_by_category(category, use_cache=use_cache)
-    
+        all_tests[category] = common_test_collector.collect_tests_by_category(
+            category, use_cache=use_cache
+        )
+
     return all_tests
 
-def check_test_has_marker(test_path: str, marker_type: Optional[str] = None) -> Tuple[bool, Optional[str]]:
+
+def check_test_has_marker(
+    test_path: str, marker_type: Optional[str] = None
+) -> Tuple[bool, Optional[str]]:
     """
     Check if a test has a speed marker without running pytest.
-    
+
     Args:
         test_path: Path to the test
         marker_type: Specific marker type to check for (fast, medium, slow, isolation)
-        
+
     Returns:
         Tuple of (has_marker, marker_type)
     """
     # Use common_test_collector to check for markers
     if marker_type:
         # Check for a specific marker type
-        has_marker, found_marker = common_test_collector.check_test_has_marker(test_path, [marker_type])
+        has_marker, found_marker = common_test_collector.check_test_has_marker(
+            test_path, [marker_type]
+        )
         return has_marker, found_marker
     else:
         # Check for any speed marker
-        return common_test_collector.check_test_has_marker(test_path, ["fast", "medium", "slow", "isolation"])
+        return common_test_collector.check_test_has_marker(
+            test_path, ["fast", "medium", "slow", "isolation"]
+        )
+
 
 def get_test_markers_from_file(file_path: str) -> Dict[str, str]:
     """
     Extract all test markers from a file.
-    
+
     Args:
         file_path: Path to the test file
-        
+
     Returns:
         Dictionary mapping test names to marker types
     """
     # Check if the file exists
     if not os.path.exists(file_path):
         return {}
-    
+
     # Read the file content
-    with open(file_path, 'r') as f:
+    with open(file_path, "r") as f:
         lines = f.readlines()
-    
+
     markers = {}
     current_markers = []
-    
+
     for i, line in enumerate(lines):
         # Check for markers
         marker_match = MARKER_PATTERN.search(line)
         if marker_match:
             current_markers.append(marker_match.group(1))
-        
+
         # Check for test functions
         func_match = FUNCTION_PATTERN.search(line)
         if func_match:
@@ -225,16 +242,19 @@ def get_test_markers_from_file(file_path: str) -> Dict[str, str]:
                 # Use the last marker if there are multiple
                 markers[test_name] = current_markers[-1]
             current_markers = []
-    
+
     return markers
 
-def count_categorized_tests_accurately(module_path: str) -> Tuple[int, int, Dict[str, int]]:
+
+def count_categorized_tests_accurately(
+    module_path: str,
+) -> Tuple[int, int, Dict[str, int]]:
     """
     Count the number of tests in a module that have speed markers, using a more accurate approach.
-    
+
     Args:
         module_path: Path to the test module
-        
+
     Returns:
         Tuple of (total_tests, categorized_tests, marker_counts)
     """
@@ -244,28 +264,30 @@ def count_categorized_tests_accurately(module_path: str) -> Tuple[int, int, Dict
         if module_path.startswith(path):
             category = cat
             break
-    
+
     if not category:
         return 0, 0, {"fast": 0, "medium": 0, "slow": 0}
-    
+
     # Collect all tests in the category using common_test_collector
     all_tests = common_test_collector.collect_tests_by_category(category)
-    
+
     # Filter tests that belong to this module
     module_tests = [test for test in all_tests if test.startswith(module_path)]
     total_tests = len(module_tests)
-    
+
     # Count tests with speed markers
     categorized_count = 0
     marker_counts = {"fast": 0, "medium": 0, "slow": 0}
-    
+
     # Get tests with markers using common_test_collector
-    tests_with_markers = common_test_collector.get_tests_with_markers(["fast", "medium", "slow"])
-    
+    tests_with_markers = common_test_collector.get_tests_with_markers(
+        ["fast", "medium", "slow"]
+    )
+
     # Load progress file for more accurate tracking
     progress = load_progress_file()
     categorized_tests = progress.get("categorized_tests", {})
-    
+
     for test_path in module_tests:
         # First check if the test is in the progress file
         if test_path in categorized_tests:
@@ -274,121 +296,123 @@ def count_categorized_tests_accurately(module_path: str) -> Tuple[int, int, Dict
             if marker in marker_counts:
                 marker_counts[marker] += 1
             continue
-        
+
         # If not in progress file, check if it's in the tests_with_markers
         for marker_type in ["fast", "medium", "slow"]:
-            if category in tests_with_markers and test_path in tests_with_markers[category][marker_type]:
+            if (
+                category in tests_with_markers
+                and test_path in tests_with_markers[category][marker_type]
+            ):
                 categorized_count += 1
                 marker_counts[marker_type] += 1
                 break
-    
+
     return total_tests, categorized_count, marker_counts
+
 
 def synchronize_test_categorization() -> Dict[str, Any]:
     """
     Synchronize the test categorization tracking between progress file and schedule file.
-    
+
     Returns:
         Dictionary containing synchronization results
     """
     print("Synchronizing test categorization tracking...")
-    
+
     # Load progress and schedule files
     progress = load_progress_file()
     schedule = load_schedule_file()
-    
+
     if not progress or not schedule:
         print("Cannot synchronize: missing progress or schedule file")
-        return {
-            "success": False,
-            "error": "Missing progress or schedule file"
-        }
-    
+        return {"success": False, "error": "Missing progress or schedule file"}
+
     # Extract categorized tests from progress file
     progress_categorized = progress.get("categorized_tests", {})
-    progress_counts = progress.get("categorization_counts", {
-        "fast": 0,
-        "medium": 0,
-        "slow": 0,
-        "total": 0
-    })
-    
+    progress_counts = progress.get(
+        "categorization_counts", {"fast": 0, "medium": 0, "slow": 0, "total": 0}
+    )
+
     # Extract module test counts from schedule file
     schedule_module_counts = schedule.get("module_test_counts", {})
-    
+
     # Collect all tests by module using common_test_collector
     all_tests_by_module = {}
     for category in common_test_collector.TEST_CATEGORIES:
         category_tests = common_test_collector.collect_tests_by_category(category)
-        
+
         for test_path in category_tests:
             # Extract the module path from the test path
-            if '::' in test_path:
-                module_path = test_path.split('::')[0]
+            if "::" in test_path:
+                module_path = test_path.split("::")[0]
                 # Get the directory containing the file
                 module_path = os.path.dirname(module_path)
             else:
                 module_path = os.path.dirname(test_path)
-            
+
             if module_path not in all_tests_by_module:
                 all_tests_by_module[module_path] = []
             all_tests_by_module[module_path].append(test_path)
-    
+
     # Update module test counts in schedule file
     for module_path, tests in all_tests_by_module.items():
         total_tests = len(tests)
         categorized_count = sum(1 for test in tests if test in progress_categorized)
         uncategorized_count = total_tests - categorized_count
-        
+
         if module_path in schedule_module_counts:
             schedule_module_counts[module_path] = {
                 "total": total_tests,
                 "categorized": categorized_count,
-                "uncategorized": uncategorized_count
+                "uncategorized": uncategorized_count,
             }
         elif uncategorized_count > 0:
             # Add new module to schedule
             schedule_module_counts[module_path] = {
                 "total": total_tests,
                 "categorized": categorized_count,
-                "uncategorized": uncategorized_count
+                "uncategorized": uncategorized_count,
             }
-    
+
     # Update total counts in schedule file
     total_tests = sum(len(tests) for tests in all_tests_by_module.values())
     total_categorized = len(progress_categorized)
     total_uncategorized = total_tests - total_categorized
-    
+
     schedule["total_tests"] = total_tests
     schedule["total_categorized"] = total_categorized
     schedule["total_uncategorized"] = total_uncategorized
     schedule["module_test_counts"] = schedule_module_counts
-    
+
     # Save updated schedule file
     save_schedule_file(schedule)
-    
+
     # Verify progress file counts
     actual_fast = sum(1 for marker in progress_categorized.values() if marker == "fast")
-    actual_medium = sum(1 for marker in progress_categorized.values() if marker == "medium")
+    actual_medium = sum(
+        1 for marker in progress_categorized.values() if marker == "medium"
+    )
     actual_slow = sum(1 for marker in progress_categorized.values() if marker == "slow")
     actual_total = len(progress_categorized)
-    
+
     # Update progress file counts if needed
-    if (actual_fast != progress_counts.get("fast", 0) or
-        actual_medium != progress_counts.get("medium", 0) or
-        actual_slow != progress_counts.get("slow", 0) or
-        actual_total != progress_counts.get("total", 0)):
-        
+    if (
+        actual_fast != progress_counts.get("fast", 0)
+        or actual_medium != progress_counts.get("medium", 0)
+        or actual_slow != progress_counts.get("slow", 0)
+        or actual_total != progress_counts.get("total", 0)
+    ):
+
         progress["categorization_counts"] = {
             "fast": actual_fast,
             "medium": actual_medium,
             "slow": actual_slow,
-            "total": actual_total
+            "total": actual_total,
         }
-        
+
         # Save updated progress file
         save_progress_file(progress)
-    
+
     return {
         "success": True,
         "total_tests": total_tests,
@@ -396,68 +420,74 @@ def synchronize_test_categorization() -> Dict[str, Any]:
         "total_uncategorized": total_uncategorized,
         "fast_tests": actual_fast,
         "medium_tests": actual_medium,
-        "slow_tests": actual_slow
+        "slow_tests": actual_slow,
     }
+
 
 def verify_test_markers(test_dir: str = "tests") -> Dict[str, Any]:
     """
     Verify that test markers are correctly applied and recognized by pytest.
-    
+
     Args:
         test_dir: Directory containing tests to verify
-        
+
     Returns:
         Dictionary containing verification results
     """
     print(f"Verifying test markers in {test_dir}...")
-    
+
     # Use common_test_collector to collect all tests
     all_tests = []
     for category in common_test_collector.TEST_CATEGORIES:
         if common_test_collector.TEST_CATEGORIES[category].startswith(test_dir):
             all_tests.extend(common_test_collector.collect_tests_by_category(category))
-    
+
     # Get tests with markers using common_test_collector
-    tests_with_markers = common_test_collector.get_tests_with_markers(["fast", "medium", "slow", "isolation"])
-    
+    tests_with_markers = common_test_collector.get_tests_with_markers(
+        ["fast", "medium", "slow", "isolation"]
+    )
+
     # Get marker counts using common_test_collector
     marker_counts = common_test_collector.get_marker_counts()
-    
+
     # Collect all test files for file-level analysis
     test_files = []
     for root, _, files in os.walk(test_dir):
         for file in files:
-            if file.startswith('test_') and file.endswith('.py'):
+            if file.startswith("test_") and file.endswith(".py"):
                 test_files.append(os.path.join(root, file))
-    
+
     # Initialize results
     results = {
         "total_files": len(test_files),
         "files_with_markers": 0,
         "total_tests": len(all_tests),
-        "tests_with_markers": sum(sum(len(tests) for tests in markers.values()) for markers in tests_with_markers.values()),
+        "tests_with_markers": sum(
+            sum(len(tests) for tests in markers.values())
+            for markers in tests_with_markers.values()
+        ),
         "marker_counts": {
             "fast": marker_counts["total"]["fast"],
             "medium": marker_counts["total"]["medium"],
             "slow": marker_counts["total"]["slow"],
-            "isolation": 0  # Not tracked in marker_counts
+            "isolation": 0,  # Not tracked in marker_counts
         },
-        "files_with_issues": []
+        "files_with_issues": [],
     }
-    
+
     # Analyze files for issues
     for file_path in test_files:
         # Count tests in the file
-        with open(file_path, 'r') as f:
+        with open(file_path, "r") as f:
             content = f.read()
-        
+
         test_matches = FUNCTION_PATTERN.findall(content)
         file_test_count = len(test_matches)
-        
+
         # Check if file has any markers
         has_markers = False
         file_tests_with_markers = 0
-        
+
         # Count tests with markers in this file
         for category in tests_with_markers:
             for marker_type in tests_with_markers[category]:
@@ -465,91 +495,98 @@ def verify_test_markers(test_dir: str = "tests") -> Dict[str, Any]:
                     if test_path.startswith(file_path):
                         has_markers = True
                         file_tests_with_markers += 1
-        
+
         if has_markers:
             results["files_with_markers"] += 1
-        
+
         # Check for issues
         if file_test_count > 0 and file_tests_with_markers < file_test_count:
-            results["files_with_issues"].append({
-                "file": file_path,
-                "total_tests": file_test_count,
-                "tests_with_markers": file_tests_with_markers,
-                "missing_markers": file_test_count - file_tests_with_markers
-            })
-    
+            results["files_with_issues"].append(
+                {
+                    "file": file_path,
+                    "total_tests": file_test_count,
+                    "tests_with_markers": file_tests_with_markers,
+                    "missing_markers": file_test_count - file_tests_with_markers,
+                }
+            )
+
     # Verify markers are recognized by pytest
     for marker_type in ["fast", "medium", "slow"]:
         cmd = [
-            sys.executable, '-m', 'pytest',
+            sys.executable,
+            "-m",
+            "pytest",
             test_dir,
-            f'-m={marker_type}',
-            '--collect-only',
-            '-q'
+            f"-m={marker_type}",
+            "--collect-only",
+            "-q",
         ]
-        
+
         try:
-            collect_result = subprocess.run(cmd, check=False, capture_output=True, text=True)
-            
+            collect_result = subprocess.run(
+                cmd, check=False, capture_output=True, text=True
+            )
+
             # Count tests collected with this marker
             test_count = 0
-            for line in collect_result.stdout.split('\n'):
+            for line in collect_result.stdout.split("\n"):
                 if line.startswith(test_dir):
                     test_count += 1
-            
+
             # Compare with our count
             if test_count != results["marker_counts"][marker_type]:
-                print(f"Warning: {marker_type} marker count mismatch - {test_count} tests collected by pytest, {results['marker_counts'][marker_type]} found in files")
+                print(
+                    f"Warning: {marker_type} marker count mismatch - {test_count} tests collected by pytest, {results['marker_counts'][marker_type]} found in files"
+                )
                 results[f"{marker_type}_marker_mismatch"] = {
                     "pytest_count": test_count,
-                    "file_count": results["marker_counts"][marker_type]
+                    "file_count": results["marker_counts"][marker_type],
                 }
         except Exception as e:
             print(f"Error verifying {marker_type} markers: {e}")
-    
+
     return results
+
 
 if __name__ == "__main__":
     # Example usage
-    parser = argparse.ArgumentParser(
-        description='Enhanced utilities for test scripts.'
-    )
+    parser = argparse.ArgumentParser(description="Enhanced utilities for test scripts.")
     parser.add_argument(
-        '--sync',
-        action='store_true',
-        help='Synchronize test categorization tracking'
+        "--sync", action="store_true", help="Synchronize test categorization tracking"
     )
+    parser.add_argument("--verify", action="store_true", help="Verify test markers")
     parser.add_argument(
-        '--verify',
-        action='store_true',
-        help='Verify test markers'
+        "--test-dir", default="tests", help="Directory containing tests to verify"
     )
-    parser.add_argument(
-        '--test-dir',
-        default='tests',
-        help='Directory containing tests to verify'
-    )
-    
+
     args = parser.parse_args()
-    
+
     if args.sync:
         results = synchronize_test_categorization()
         print(f"Synchronization {'successful' if results['success'] else 'failed'}")
-        if results['success']:
+        if results["success"]:
             print(f"Total tests: {results['total_tests']}")
-            print(f"Categorized: {results['total_categorized']} ({results['total_categorized']/results['total_tests']*100:.1f}%)")
-            print(f"Uncategorized: {results['total_uncategorized']} ({results['total_uncategorized']/results['total_tests']*100:.1f}%)")
+            print(
+                f"Categorized: {results['total_categorized']} ({results['total_categorized']/results['total_tests']*100:.1f}%)"
+            )
+            print(
+                f"Uncategorized: {results['total_uncategorized']} ({results['total_uncategorized']/results['total_tests']*100:.1f}%)"
+            )
             print(f"Fast tests: {results['fast_tests']}")
             print(f"Medium tests: {results['medium_tests']}")
             print(f"Slow tests: {results['slow_tests']}")
-    
+
     if args.verify:
         results = verify_test_markers(args.test_dir)
         print(f"Verification results:")
         print(f"Total files: {results['total_files']}")
-        print(f"Files with markers: {results['files_with_markers']} ({results['files_with_markers']/results['total_files']*100:.1f}%)")
+        print(
+            f"Files with markers: {results['files_with_markers']} ({results['files_with_markers']/results['total_files']*100:.1f}%)"
+        )
         print(f"Total tests: {results['total_tests']}")
-        print(f"Tests with markers: {results['tests_with_markers']} ({results['tests_with_markers']/results['total_tests']*100:.1f}%)")
+        print(
+            f"Tests with markers: {results['tests_with_markers']} ({results['tests_with_markers']/results['total_tests']*100:.1f}%)"
+        )
         print(f"Fast tests: {results['marker_counts']['fast']}")
         print(f"Medium tests: {results['marker_counts']['medium']}")
         print(f"Slow tests: {results['marker_counts']['slow']}")

--- a/scripts/verify_test_markers.py
+++ b/scripts/verify_test_markers.py
@@ -7,7 +7,7 @@ and recognized by pytest. It provides detailed reporting of marker issues and ca
 fix common issues automatically.
 
 Usage:
-    python scripts/verify_test_markers.py [options]
+    python -m scripts.verify_test_markers [options]
 
 Options:
     --directory DIR       Directory containing tests to verify (default: tests)
@@ -19,118 +19,122 @@ Options:
     --report-file FILE    File to save the report to (default: test_markers_report.json)
 """
 
-import os
-import sys
-import json
-import re
 import argparse
+import json
+import os
+import re
 import subprocess
-from pathlib import Path
+import sys
+import time
 from datetime import datetime
-from typing import Dict, List, Set, Tuple, Any, Optional
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Set, Tuple
 
 # Import enhanced test utilities
-sys.path.append(os.path.dirname(os.path.abspath(__file__)))
-import test_utils_extended as test_utils_ext
+from . import test_utils_extended as test_utils_ext
 
 # Regex patterns for finding and updating markers
-MARKER_PATTERN = re.compile(r'@pytest\.mark\.(fast|medium|slow|isolation)')
-FUNCTION_PATTERN = re.compile(r'def (test_\w+)\(')
-CLASS_PATTERN = re.compile(r'class (Test\w+)\(')
-PYTEST_IMPORT_PATTERN = re.compile(r'import\s+pytest|from\s+pytest\s+import')
+MARKER_PATTERN = re.compile(r"@pytest\.mark\.(fast|medium|slow|isolation)")
+FUNCTION_PATTERN = re.compile(r"def (test_\w+)\(")
+CLASS_PATTERN = re.compile(r"class (Test\w+)\(")
+PYTEST_IMPORT_PATTERN = re.compile(r"import\s+pytest|from\s+pytest\s+import")
+
 
 def parse_args():
     """Parse command line arguments."""
     parser = argparse.ArgumentParser(
-        description='Verify that test markers are correctly applied and recognized by pytest.'
+        description="Verify that test markers are correctly applied and recognized by pytest."
     )
     parser.add_argument(
-        '-d', '--directory',
-        default='tests',
-        help='Directory containing tests to verify (default: tests)'
+        "-d",
+        "--directory",
+        default="tests",
+        help="Directory containing tests to verify (default: tests)",
     )
     parser.add_argument(
-        '-m', '--module',
-        help='Specific module to verify (e.g., tests/unit/interface)'
+        "-m", "--module", help="Specific module to verify (e.g., tests/unit/interface)"
     )
     parser.add_argument(
-        '--dry-run',
-        action='store_true',
-        help='Show changes without modifying files'
+        "--dry-run", action="store_true", help="Show changes without modifying files"
     )
     parser.add_argument(
-        '-v', '--verbose',
-        action='store_true',
-        help='Show detailed information about verification'
+        "-v",
+        "--verbose",
+        action="store_true",
+        help="Show detailed information about verification",
     )
     parser.add_argument(
-        '--fix',
-        action='store_true',
-        help='Fix marker issues automatically'
+        "--fix", action="store_true", help="Fix marker issues automatically"
     )
     parser.add_argument(
-        '--report',
-        action='store_true',
-        help='Generate a report of marker issues'
+        "--report", action="store_true", help="Generate a report of marker issues"
     )
     parser.add_argument(
-        '--report-file',
-        default='test_markers_report.json',
-        help='File to save the report to (default: test_markers_report.json)'
+        "--report-file",
+        default="test_markers_report.json",
+        help="File to save the report to (default: test_markers_report.json)",
     )
     return parser.parse_args()
 
-def find_test_files(directory: str) -> List[Path]:
-    """Find all test files in the given directory."""
-    test_files = []
-    for root, _, files in os.walk(directory):
-        for file in files:
-            if file.startswith('test_') and file.endswith('.py'):
-                test_files.append(Path(os.path.join(root, file)))
+
+def find_test_files(directory: str, max_depth: int = 5) -> List[Path]:
+    """Find all test files in the given directory without unbounded traversal."""
+    base_path = Path(directory).resolve()
+    if base_path.is_file():
+        return [base_path]
+
+    test_files: List[Path] = []
+    for path in base_path.rglob("test_*.py"):
+        try:
+            relative = path.relative_to(base_path)
+        except ValueError:
+            continue
+        if len(relative.parts) <= max_depth:
+            test_files.append(path)
     return test_files
 
-def verify_file_markers(file_path: Path, verbose: bool = False) -> Dict[str, Any]:
+
+def verify_file_markers(
+    file_path: Path, verbose: bool = False, timeout: Optional[int] = 30
+) -> Dict[str, Any]:
     """
     Verify markers in a test file.
-    
+
     Args:
         file_path: Path to the test file
         verbose: Whether to show detailed information about verification
-        
+
     Returns:
         Dictionary containing verification results
     """
     if verbose:
         print(f"Verifying markers in {file_path}...")
-    
+
     # Check if the file exists
     if not os.path.exists(file_path):
-        return {
-            "success": False,
-            "error": f"File not found: {file_path}"
-        }
-    
+        return {"success": False, "error": f"File not found: {file_path}"}
+
     # Read the file content
-    with open(file_path, 'r') as f:
+    with open(file_path, "r") as f:
         content = f.read()
-        lines = content.split('\n')
-    
+        lines = content.split("\n")
+
     # Check if pytest is imported
     has_pytest_import = bool(PYTEST_IMPORT_PATTERN.search(content))
-    
+
     # Extract test functions
     test_functions = FUNCTION_PATTERN.findall(content)
-    
+
     # Extract markers
     markers = {}
     current_markers = []
-    
+
     for i, line in enumerate(lines):
         # Check for markers
         marker_match = MARKER_PATTERN.search(line)
         if marker_match:
             current_markers.append(marker_match.group(1))
-        
+
         # Check for test functions
         func_match = FUNCTION_PATTERN.search(line)
         if func_match:
@@ -139,29 +143,27 @@ def verify_file_markers(file_path: Path, verbose: bool = False) -> Dict[str, Any
                 # Use the last marker if there are multiple
                 markers[test_name] = current_markers[-1]
             current_markers = []
-    
+
     # Check for misaligned markers
     misaligned_markers = []
     for i, line in enumerate(lines):
         marker_match = MARKER_PATTERN.search(line)
         if marker_match:
             marker_type = marker_match.group(1)
-            
+
             # Check if this marker is associated with a test function
             is_associated = False
-            for j in range(i+1, min(i+10, len(lines))):
-                func_match = FUNCTION_PATTERN.search(lines[j] if j < len(lines) else '')
+            for j in range(i + 1, min(i + 10, len(lines))):
+                func_match = FUNCTION_PATTERN.search(lines[j] if j < len(lines) else "")
                 if func_match:
                     is_associated = True
                     break
-            
+
             if not is_associated:
-                misaligned_markers.append({
-                    "line": i,
-                    "marker": marker_type,
-                    "text": line.strip()
-                })
-    
+                misaligned_markers.append(
+                    {"line": i, "marker": marker_type, "text": line.strip()}
+                )
+
     # Check for duplicate markers
     duplicate_markers = []
     for test_name in test_functions:
@@ -169,65 +171,74 @@ def verify_file_markers(file_path: Path, verbose: bool = False) -> Dict[str, Any
         for i, line in enumerate(lines):
             if f"def {test_name}(" in line:
                 # Check for markers before this function
-                for j in range(i-1, max(0, i-10), -1):
+                for j in range(i - 1, max(0, i - 10), -1):
                     marker_match = MARKER_PATTERN.search(lines[j])
                     if marker_match:
                         marker_count += 1
-        
+
         if marker_count > 1:
-            duplicate_markers.append({
-                "test_name": test_name,
-                "marker_count": marker_count
-            })
-    
+            duplicate_markers.append(
+                {"test_name": test_name, "marker_count": marker_count}
+            )
+
     # Check if markers are recognized by pytest
     recognized_markers = {}
-    
+
     # First, check if pytest.ini has the markers registered
-    pytest_ini_path = Path(os.path.join(os.path.dirname(file_path), 'pytest.ini'))
+    pytest_ini_path = Path(os.path.join(os.path.dirname(file_path), "pytest.ini"))
     repo_root = None
-    
+
     # Try to find pytest.ini by traversing up the directory tree
     current_dir = os.path.dirname(file_path)
-    while current_dir and current_dir != '/':
-        potential_ini = os.path.join(current_dir, 'pytest.ini')
+    while current_dir and current_dir != "/":
+        potential_ini = os.path.join(current_dir, "pytest.ini")
         if os.path.exists(potential_ini):
             pytest_ini_path = Path(potential_ini)
             repo_root = current_dir
             break
         current_dir = os.path.dirname(current_dir)
-    
+
     markers_registered = {}
     if os.path.exists(pytest_ini_path):
-        with open(pytest_ini_path, 'r') as f:
+        with open(pytest_ini_path, "r") as f:
             pytest_ini_content = f.read()
             for marker_type in ["fast", "medium", "slow"]:
-                markers_registered[marker_type] = f"{marker_type}:" in pytest_ini_content
-    
+                markers_registered[marker_type] = (
+                    f"{marker_type}:" in pytest_ini_content
+                )
+
     # Check each marker type
     for marker_type in ["fast", "medium", "slow"]:
         # Count markers of this type in the file
         marker_count = sum(1 for m in markers.values() if m == marker_type)
-        
+
         if marker_count > 0:
             # Check if pytest recognizes these markers
             cmd = [
-                sys.executable, '-m', 'pytest',
+                sys.executable,
+                "-m",
+                "pytest",
                 str(file_path),
-                f'-m={marker_type}',
-                '--collect-only',
-                '-v'  # Use verbose output for better parsing
+                f"-m={marker_type}",
+                "--collect-only",
+                "-v",  # Use verbose output for better parsing
             ]
-            
+
             try:
-                collect_result = subprocess.run(cmd, check=False, capture_output=True, text=True)
-                
+                collect_result = subprocess.run(
+                    cmd,
+                    check=False,
+                    capture_output=True,
+                    text=True,
+                    timeout=timeout,
+                )
+
                 # Count tests collected with this marker
                 collected_count = 0
                 collected_tests = []
-                
+
                 # Parse the output to count collected tests and identify which tests were collected
-                for line in collect_result.stdout.split('\n'):
+                for line in collect_result.stdout.split("\n"):
                     if str(file_path) in line:
                         collected_count += 1
                         # Extract the test name from the output
@@ -237,30 +248,34 @@ def verify_file_markers(file_path: Path, verbose: bool = False) -> Dict[str, Any
                             if "(" in test_name:  # Handle parameterized tests
                                 test_name = test_name.split("(")[0]
                             collected_tests.append(test_name)
-                
+
                 # Identify which tests have the marker but weren't collected
                 uncollected_tests = []
                 for test_name, marker in markers.items():
                     if marker == marker_type and test_name not in collected_tests:
                         uncollected_tests.append(test_name)
-                
+
                 recognized_markers[marker_type] = {
                     "file_count": marker_count,
                     "pytest_count": collected_count,
                     "recognized": collected_count == marker_count,
-                    "registered_in_pytest_ini": markers_registered.get(marker_type, False),
-                    "uncollected_tests": uncollected_tests
+                    "registered_in_pytest_ini": markers_registered.get(
+                        marker_type, False
+                    ),
+                    "uncollected_tests": uncollected_tests,
                 }
             except Exception as e:
                 recognized_markers[marker_type] = {
                     "file_count": marker_count,
                     "pytest_count": 0,
                     "recognized": False,
-                    "registered_in_pytest_ini": markers_registered.get(marker_type, False),
+                    "registered_in_pytest_ini": markers_registered.get(
+                        marker_type, False
+                    ),
                     "error": str(e),
-                    "uncollected_tests": []
+                    "uncollected_tests": [],
                 }
-    
+
     # Prepare verification results
     results = {
         "file_path": str(file_path),
@@ -272,131 +287,145 @@ def verify_file_markers(file_path: Path, verbose: bool = False) -> Dict[str, Any
         "misaligned_markers": misaligned_markers,
         "duplicate_markers": duplicate_markers,
         "recognized_markers": recognized_markers,
-        "issues": []
+        "issues": [],
     }
-    
+
     # Identify issues
     if not has_pytest_import and len(markers) > 0:
-        results["issues"].append({
-            "type": "missing_pytest_import",
-            "message": "File has markers but no pytest import"
-        })
-    
+        results["issues"].append(
+            {
+                "type": "missing_pytest_import",
+                "message": "File has markers but no pytest import",
+            }
+        )
+
     if len(misaligned_markers) > 0:
-        results["issues"].append({
-            "type": "misaligned_markers",
-            "message": f"File has {len(misaligned_markers)} misaligned markers"
-        })
-    
+        results["issues"].append(
+            {
+                "type": "misaligned_markers",
+                "message": f"File has {len(misaligned_markers)} misaligned markers",
+            }
+        )
+
     if len(duplicate_markers) > 0:
-        results["issues"].append({
-            "type": "duplicate_markers",
-            "message": f"File has {len(duplicate_markers)} tests with duplicate markers"
-        })
-    
+        results["issues"].append(
+            {
+                "type": "duplicate_markers",
+                "message": f"File has {len(duplicate_markers)} tests with duplicate markers",
+            }
+        )
+
     for marker_type, info in recognized_markers.items():
         if not info.get("recognized", False):
-            results["issues"].append({
-                "type": "unrecognized_markers",
-                "message": f"{marker_type} markers are not recognized by pytest ({info['file_count']} in file, {info['pytest_count']} recognized)"
-            })
-    
+            results["issues"].append(
+                {
+                    "type": "unrecognized_markers",
+                    "message": f"{marker_type} markers are not recognized by pytest ({info['file_count']} in file, {info['pytest_count']} recognized)",
+                }
+            )
+
     if verbose and results["issues"]:
         print(f"  Issues found in {file_path}:")
         for issue in results["issues"]:
             print(f"    - {issue['message']}")
-    
+
     return results
 
-def fix_marker_issues(file_path: Path, verification_results: Dict[str, Any], dry_run: bool = False, verbose: bool = False) -> Dict[str, Any]:
+
+def fix_marker_issues(
+    file_path: Path,
+    verification_results: Dict[str, Any],
+    dry_run: bool = False,
+    verbose: bool = False,
+) -> Dict[str, Any]:
     """
     Fix marker issues in a test file.
-    
+
     Args:
         file_path: Path to the test file
         verification_results: Dictionary containing verification results
         dry_run: Whether to show changes without modifying files
         verbose: Whether to show detailed information about fixes
-        
+
     Returns:
         Dictionary containing fix results
     """
     if verbose:
         print(f"Fixing marker issues in {file_path}...")
-    
+
     # Check if the file exists
     if not os.path.exists(file_path):
-        return {
-            "success": False,
-            "error": f"File not found: {file_path}"
-        }
-    
+        return {"success": False, "error": f"File not found: {file_path}"}
+
     # Read the file content
-    with open(file_path, 'r') as f:
+    with open(file_path, "r") as f:
         lines = f.readlines()
-    
+
     # Track changes
     changes = {
         "added_pytest_import": False,
         "fixed_misaligned_markers": 0,
         "fixed_duplicate_markers": 0,
-        "total_changes": 0
+        "total_changes": 0,
     }
-    
+
     # Fix missing pytest import
-    if not verification_results["has_pytest_import"] and len(verification_results["markers"]) > 0:
+    if (
+        not verification_results["has_pytest_import"]
+        and len(verification_results["markers"]) > 0
+    ):
         # Find the best place to add the import
         import_line = -1
         for i, line in enumerate(lines):
-            if line.startswith('import ') or line.startswith('from '):
+            if line.startswith("import ") or line.startswith("from "):
                 import_line = i
-        
+
         if import_line >= 0:
             # Add import after the last import
             if verbose:
                 print(f"  Adding pytest import after line {import_line+1}")
-            
+
             if not dry_run:
-                lines.insert(import_line + 1, 'import pytest\n')
-                
+                lines.insert(import_line + 1, "import pytest\n")
+
                 # Update line numbers for subsequent issues
                 for marker in verification_results.get("misaligned_markers", []):
                     if marker["line"] > import_line:
                         marker["line"] += 1
-            
+
             changes["added_pytest_import"] = True
             changes["total_changes"] += 1
         else:
             # Add import at the beginning of the file
             if verbose:
                 print(f"  Adding pytest import at the beginning of the file")
-            
+
             if not dry_run:
-                lines.insert(0, 'import pytest\n\n')
-                
+                lines.insert(0, "import pytest\n\n")
+
                 # Update line numbers for subsequent issues
                 for marker in verification_results.get("misaligned_markers", []):
                     marker["line"] += 2
-            
+
             changes["added_pytest_import"] = True
             changes["total_changes"] += 1
-    
+
     # Fix misaligned markers
     for marker in verification_results.get("misaligned_markers", []):
         line_num = marker["line"]
         marker_type = marker["marker"]
-        
+
         # Find the next test function after this marker
         next_func_line = None
         next_func_name = None
-        
+
         for i in range(line_num + 1, min(line_num + 20, len(lines))):
-            func_match = FUNCTION_PATTERN.search(lines[i] if i < len(lines) else '')
+            func_match = FUNCTION_PATTERN.search(lines[i] if i < len(lines) else "")
             if func_match:
                 next_func_line = i
                 next_func_name = func_match.group(1)
                 break
-        
+
         if next_func_line is not None:
             # Check if the function already has a speed marker
             has_speed_marker = False
@@ -404,64 +433,74 @@ def fix_marker_issues(file_path: Path, verification_results: Dict[str, Any], dry
                 if MARKER_PATTERN.search(lines[i]):
                     has_speed_marker = True
                     break
-            
+
             if has_speed_marker:
                 # Function already has a speed marker, remove the misaligned one
                 if verbose:
-                    print(f"  Removing misaligned marker at line {line_num+1}: {marker['text']}")
-                
+                    print(
+                        f"  Removing misaligned marker at line {line_num+1}: {marker['text']}"
+                    )
+
                 if not dry_run:
-                    lines[line_num] = ''
-                
+                    lines[line_num] = ""
+
                 changes["fixed_misaligned_markers"] += 1
                 changes["total_changes"] += 1
             else:
                 # Move the marker to just before the function
                 if verbose:
-                    print(f"  Moving marker from line {line_num+1} to line {next_func_line+1}")
-                
+                    print(
+                        f"  Moving marker from line {line_num+1} to line {next_func_line+1}"
+                    )
+
                 if not dry_run:
                     # Remove the original marker
-                    lines[line_num] = ''
-                    
+                    lines[line_num] = ""
+
                     # Add the marker before the function
-                    indent = re.match(r'(\s*)', lines[next_func_line]).group(1)
-                    lines.insert(next_func_line, f"{indent}@pytest.mark.{marker_type}\n")
-                    
+                    indent = re.match(r"(\s*)", lines[next_func_line]).group(1)
+                    lines.insert(
+                        next_func_line, f"{indent}@pytest.mark.{marker_type}\n"
+                    )
+
                     # Update line numbers for subsequent markers
-                    for other_marker in verification_results.get("misaligned_markers", []):
+                    for other_marker in verification_results.get(
+                        "misaligned_markers", []
+                    ):
                         if other_marker["line"] > line_num:
                             other_marker["line"] += 1
-                
+
                 changes["fixed_misaligned_markers"] += 1
                 changes["total_changes"] += 1
         else:
             # No function found after this marker, remove it
             if verbose:
-                print(f"  Removing orphaned marker at line {line_num+1}: {marker['text']}")
-            
+                print(
+                    f"  Removing orphaned marker at line {line_num+1}: {marker['text']}"
+                )
+
             if not dry_run:
-                lines[line_num] = ''
-            
+                lines[line_num] = ""
+
             changes["fixed_misaligned_markers"] += 1
             changes["total_changes"] += 1
-    
+
     # Fix duplicate markers
     for duplicate in verification_results.get("duplicate_markers", []):
         test_name = duplicate["test_name"]
-        
+
         # Find the test function
         func_line = None
         for i, line in enumerate(lines):
             if f"def {test_name}(" in line:
                 func_line = i
                 break
-        
+
         if func_line is not None:
             # Find all markers for this function
             markers_to_remove = []
             kept_marker = None
-            
+
             for i in range(func_line - 1, max(0, func_line - 10), -1):
                 marker_match = MARKER_PATTERN.search(lines[i])
                 if marker_match:
@@ -469,48 +508,53 @@ def fix_marker_issues(file_path: Path, verification_results: Dict[str, Any], dry
                         kept_marker = marker_match.group(1)
                     else:
                         markers_to_remove.append(i)
-            
+
             # Remove duplicate markers
             for i in sorted(markers_to_remove, reverse=True):
                 if verbose:
-                    print(f"  Removing duplicate marker at line {i+1}: {lines[i].strip()}")
-                
+                    print(
+                        f"  Removing duplicate marker at line {i+1}: {lines[i].strip()}"
+                    )
+
                 if not dry_run:
-                    lines[i] = ''
-                
+                    lines[i] = ""
+
                 changes["fixed_duplicate_markers"] += 1
                 changes["total_changes"] += 1
-    
+
     # Write changes back to the file
     if not dry_run and changes["total_changes"] > 0:
-        with open(file_path, 'w') as f:
+        with open(file_path, "w") as f:
             f.writelines(lines)
-    
+
     return changes
 
-def verify_directory_markers(directory: str, verbose: bool = False) -> Dict[str, Any]:
+
+def verify_directory_markers(
+    directory: str,
+    verbose: bool = False,
+    progress_interval: int = 50,
+    timeout: Optional[int] = 30,
+) -> Dict[str, Any]:
     """
     Verify markers in all test files in a directory.
-    
+
     Args:
         directory: Directory containing test files
         verbose: Whether to show detailed information about verification
-        
+
     Returns:
         Dictionary containing verification results
     """
     print(f"Verifying markers in {directory}...")
-    
+
     # Find all test files
     test_files = find_test_files(directory)
-    
+
     if not test_files:
         print(f"No test files found in {directory}")
-        return {
-            "success": False,
-            "error": f"No test files found in {directory}"
-        }
-    
+        return {"success": False, "error": f"No test files found in {directory}"}
+
     # Verify markers in each file
     results = {
         "directory": directory,
@@ -521,52 +565,61 @@ def verify_directory_markers(directory: str, verbose: bool = False) -> Dict[str,
         "total_misaligned_markers": 0,
         "total_duplicate_markers": 0,
         "total_unrecognized_markers": 0,
-        "marker_counts": {
-            "fast": 0,
-            "medium": 0,
-            "slow": 0,
-            "isolation": 0
-        },
-        "files": {}
+        "marker_counts": {"fast": 0, "medium": 0, "slow": 0, "isolation": 0},
+        "files": {},
     }
-    
-    for file_path in test_files:
-        file_results = verify_file_markers(file_path, verbose)
-        
+
+    start = time.time()
+    for idx, file_path in enumerate(test_files, 1):
+        file_results = verify_file_markers(file_path, verbose, timeout=timeout)
+
         # Update overall results
         results["total_test_functions"] += file_results["test_functions"]
         results["total_markers"] += file_results["tests_with_markers"]
         results["total_misaligned_markers"] += len(file_results["misaligned_markers"])
         results["total_duplicate_markers"] += len(file_results["duplicate_markers"])
-        
+
         # Update marker counts
         for marker_type, count in file_results.get("recognized_markers", {}).items():
-            results["marker_counts"][marker_type] = results["marker_counts"].get(marker_type, 0) + count["file_count"]
+            results["marker_counts"][marker_type] = (
+                results["marker_counts"].get(marker_type, 0) + count["file_count"]
+            )
             if not count.get("recognized", False):
                 results["total_unrecognized_markers"] += count["file_count"]
-        
+
         # Check if file has issues
         if file_results["issues"]:
             results["files_with_issues"] += 1
             results["files"][str(file_path)] = file_results
-    
+
+        if idx % progress_interval == 0:
+            elapsed = time.time() - start
+            print(f"Processed {idx}/{len(test_files)} files ({elapsed:.1f}s elapsed)")
+            start = time.time()
+
     return results
 
-def fix_directory_markers(directory: str, verification_results: Dict[str, Any], dry_run: bool = False, verbose: bool = False) -> Dict[str, Any]:
+
+def fix_directory_markers(
+    directory: str,
+    verification_results: Dict[str, Any],
+    dry_run: bool = False,
+    verbose: bool = False,
+) -> Dict[str, Any]:
     """
     Fix marker issues in all test files in a directory.
-    
+
     Args:
         directory: Directory containing test files
         verification_results: Dictionary containing verification results
         dry_run: Whether to show changes without modifying files
         verbose: Whether to show detailed information about fixes
-        
+
     Returns:
         Dictionary containing fix results
     """
     print(f"Fixing marker issues in {directory}...")
-    
+
     # Track changes
     changes = {
         "total_files_fixed": 0,
@@ -574,96 +627,121 @@ def fix_directory_markers(directory: str, verification_results: Dict[str, Any], 
         "total_misaligned_markers_fixed": 0,
         "total_duplicate_markers_fixed": 0,
         "total_changes": 0,
-        "files": {}
+        "files": {},
     }
-    
+
     # Fix issues in each file
     for file_path_str, file_results in verification_results.get("files", {}).items():
         file_path = Path(file_path_str)
-        
+
         if file_results["issues"]:
             file_changes = fix_marker_issues(file_path, file_results, dry_run, verbose)
-            
+
             if file_changes["total_changes"] > 0:
                 changes["total_files_fixed"] += 1
-                changes["total_pytest_imports_added"] += 1 if file_changes["added_pytest_import"] else 0
-                changes["total_misaligned_markers_fixed"] += file_changes["fixed_misaligned_markers"]
-                changes["total_duplicate_markers_fixed"] += file_changes["fixed_duplicate_markers"]
+                changes["total_pytest_imports_added"] += (
+                    1 if file_changes["added_pytest_import"] else 0
+                )
+                changes["total_misaligned_markers_fixed"] += file_changes[
+                    "fixed_misaligned_markers"
+                ]
+                changes["total_duplicate_markers_fixed"] += file_changes[
+                    "fixed_duplicate_markers"
+                ]
                 changes["total_changes"] += file_changes["total_changes"]
                 changes["files"][file_path_str] = file_changes
-    
+
     return changes
 
-def generate_report(verification_results: Dict[str, Any], fix_results: Optional[Dict[str, Any]] = None, report_file: str = "test_markers_report.json") -> None:
+
+def generate_report(
+    verification_results: Dict[str, Any],
+    fix_results: Optional[Dict[str, Any]] = None,
+    report_file: str = "test_markers_report.json",
+) -> None:
     """
     Generate a report of marker issues.
-    
+
     Args:
         verification_results: Dictionary containing verification results
         fix_results: Dictionary containing fix results (optional)
         report_file: File to save the report to
     """
     print(f"Generating report to {report_file}...")
-    
+
     # Prepare report
     report = {
         "timestamp": datetime.now().isoformat(),
-        "verification": verification_results
+        "verification": verification_results,
     }
-    
+
     if fix_results:
         report["fixes"] = fix_results
-    
+
     # Save report
-    with open(report_file, 'w') as f:
+    with open(report_file, "w") as f:
         json.dump(report, f, indent=2)
-    
+
     print(f"Report saved to {report_file}")
+
 
 def main():
     """Main function."""
     args = parse_args()
-    
+
     # Determine the directory to verify
     directory = args.module if args.module else args.directory
-    
+
     # Verify markers
     verification_results = verify_directory_markers(directory, args.verbose)
-    
+
     # Print verification summary
     print("\nVerification Summary:")
     print(f"  Total files: {verification_results['total_files']}")
     print(f"  Files with issues: {verification_results['files_with_issues']}")
     print(f"  Total test functions: {verification_results['total_test_functions']}")
-    print(f"  Functions with markers: {verification_results['total_markers']} ({verification_results['total_markers']/verification_results['total_test_functions']*100:.1f}%)")
+    print(
+        f"  Functions with markers: {verification_results['total_markers']} ({verification_results['total_markers']/verification_results['total_test_functions']*100:.1f}%)"
+    )
     print(f"  Misaligned markers: {verification_results['total_misaligned_markers']}")
     print(f"  Duplicate markers: {verification_results['total_duplicate_markers']}")
-    print(f"  Unrecognized markers: {verification_results['total_unrecognized_markers']}")
+    print(
+        f"  Unrecognized markers: {verification_results['total_unrecognized_markers']}"
+    )
     print(f"  Marker counts:")
     print(f"    - Fast: {verification_results['marker_counts'].get('fast', 0)}")
     print(f"    - Medium: {verification_results['marker_counts'].get('medium', 0)}")
     print(f"    - Slow: {verification_results['marker_counts'].get('slow', 0)}")
-    print(f"    - Isolation: {verification_results['marker_counts'].get('isolation', 0)}")
-    
+    print(
+        f"    - Isolation: {verification_results['marker_counts'].get('isolation', 0)}"
+    )
+
     # Fix issues if requested
     fix_results = None
     if args.fix:
-        fix_results = fix_directory_markers(directory, verification_results, args.dry_run, args.verbose)
-        
+        fix_results = fix_directory_markers(
+            directory, verification_results, args.dry_run, args.verbose
+        )
+
         # Print fix summary
         action = "Would fix" if args.dry_run else "Fixed"
         print(f"\n{action} Issues Summary:")
         print(f"  Files fixed: {fix_results['total_files_fixed']}")
         print(f"  Pytest imports added: {fix_results['total_pytest_imports_added']}")
-        print(f"  Misaligned markers fixed: {fix_results['total_misaligned_markers_fixed']}")
-        print(f"  Duplicate markers fixed: {fix_results['total_duplicate_markers_fixed']}")
+        print(
+            f"  Misaligned markers fixed: {fix_results['total_misaligned_markers_fixed']}"
+        )
+        print(
+            f"  Duplicate markers fixed: {fix_results['total_duplicate_markers_fixed']}"
+        )
         print(f"  Total changes: {fix_results['total_changes']}")
-    
+
     # Generate report if requested
     if args.report:
         generate_report(verification_results, fix_results, args.report_file)
-    
+
     return 0
+
 
 if __name__ == "__main__":
     sys.exit(main())


### PR DESCRIPTION
## Summary
- restrict test discovery in `verify_test_markers` with depth-limited `Path.rglob`
- package `scripts` and switch to relative imports for test utilities
- add per-file timeouts and progress logging to marker verification

## Testing
- `poetry run pre-commit run --files scripts/verify_test_markers.py scripts/test_utils_extended.py scripts/test_utils.py scripts/__init__.py`
- `poetry run devsynth run-tests --speed=fast` *(fails: INTERNALERROR: AssertionError)*
- `poetry run python tests/verify_test_organization.py`
- `poetry run python -m scripts.verify_test_markers --module tests/unit/application/cli/test_serve_cmd.py --report --report-file tmp_markers_report.json`
- `poetry run python scripts/verify_requirements_traceability.py`
- `poetry run python scripts/verify_version_sync.py`

------
https://chatgpt.com/codex/tasks/task_e_689e2f5cd63c8333b70f9428e0a3ec88