### PR TITLE
Add WSDE workflow helpers and test markers

### DIFF
--- a/src/devsynth/domain/models/wsde_facade.py
+++ b/src/devsynth/domain/models/wsde_facade.py
@@ -18,6 +18,7 @@ from devsynth.domain.models.wsde_utils import (
     conduct_peer_review,
     get_messages,
     request_peer_review,
+    run_basic_workflow,
     send_message,
 )
 
@@ -30,6 +31,7 @@ WSDETeam.get_messages = get_messages
 WSDETeam.request_peer_review = request_peer_review
 WSDETeam.conduct_peer_review = conduct_peer_review
 WSDETeam.add_solution = add_solution
+WSDETeam.run_basic_workflow = run_basic_workflow
 
 # ---------------------------------------------------------------------------
 # Role management
@@ -40,6 +42,7 @@ WSDETeam.dynamic_role_reassignment = wsde_roles.dynamic_role_reassignment
 WSDETeam._validate_role_mapping = wsde_roles._validate_role_mapping
 WSDETeam._auto_assign_roles = wsde_roles._auto_assign_roles
 WSDETeam.get_role_map = wsde_roles.get_role_map
+WSDETeam.get_role_assignments = wsde_roles.get_role_assignments
 WSDETeam._calculate_expertise_score = wsde_roles._calculate_expertise_score
 WSDETeam._calculate_phase_expertise_score = wsde_roles._calculate_phase_expertise_score
 WSDETeam.select_primus_by_expertise = wsde_roles.select_primus_by_expertise

--- a/src/devsynth/domain/models/wsde_roles.py
+++ b/src/devsynth/domain/models/wsde_roles.py
@@ -370,6 +370,18 @@ def get_role_map(self: WSDETeam):
     return agent_to_role
 
 
+def get_role_assignments(self: WSDETeam) -> Dict[str, str]:
+    """Map agent IDs to their current role names."""
+
+    assignments: Dict[str, str] = {}
+    for role, agent in self.roles.items():
+        if agent is None:
+            continue
+        agent_id = getattr(agent, "id", None) or getattr(agent, "name", None)
+        assignments[agent_id] = role.capitalize()
+    return assignments
+
+
 def dynamic_role_reassignment(self: WSDETeam, task: Dict[str, Any]):
     """
     Dynamically reassign roles based on the current task.

--- a/tests/integration/general/test_wsde_edrr_component_interactions.py
+++ b/tests/integration/general/test_wsde_edrr_component_interactions.py
@@ -181,6 +181,7 @@ class TestWSDEEDRRComponentInteractions:
             config={"edrr": {"quality_based_transitions": True}},
         )
 
+    @pytest.mark.medium
     def test_wsde_team_role_assignment_in_edrr_phases_has_expected(self, coordinator):
         """Test that WSDE team roles are assigned appropriately for each EDRR phase.
 
@@ -207,6 +208,7 @@ class TestWSDEEDRRComponentInteractions:
         assert primus is not None
         assert primus in coordinator.wsde_team.agents
 
+    @pytest.mark.medium
     def test_wsde_method_calls_in_edrr_phases_has_expected(self, coordinator):
         """Test that appropriate WSDE methods are called in each EDRR phase.
 
@@ -233,6 +235,7 @@ class TestWSDEEDRRComponentInteractions:
         assert coordinator.wsde_team._team.perform_quality_assurance.call_count >= 1
         assert coordinator.wsde_team._team.extract_learnings.call_count >= 1
 
+    @pytest.mark.medium
     def test_memory_integration_in_edrr_wsde_workflow_succeeds(
         self, coordinator, memory_manager
     ):
@@ -278,6 +281,7 @@ class TestWSDEEDRRComponentInteractions:
         assert Phase.REFINE.name in report["phases"]
         assert Phase.RETROSPECT.name in report["phases"]
 
+    @pytest.mark.medium
     def test_error_handling_in_edrr_wsde_integration_raises_error(self, coordinator):
         """Test error handling in the EDRR-WSDE integration.
 
@@ -297,6 +301,7 @@ class TestWSDEEDRRComponentInteractions:
             coordinator.execute_current_phase()
         assert "Test error in evaluate_options" in str(exc_info.value)
 
+    @pytest.mark.medium
     def test_memory_sync_hook_receives_events(self, memory_manager):
         """Ensure memory sync hooks capture memory updates."""
 
@@ -316,6 +321,7 @@ class TestWSDEEDRRComponentInteractions:
 
         assert events == ["test-item", None]
 
+    @pytest.mark.medium
     def test_retrospective_flushes_pending_memory_without_record(self, memory_manager):
         """Ensure retrospective flushes memory even without record method.
 
@@ -342,6 +348,7 @@ class TestWSDEEDRRComponentInteractions:
 
         assert memory_manager.sync_manager._queue == []
 
+    @pytest.mark.medium
     def test_role_assignment_mapping_is_accessible(self, coordinator):
         """WSDE wrapper exposes current role assignments."""
 

--- a/tests/integration/general/test_wsde_edrr_integration_advanced.py
+++ b/tests/integration/general/test_wsde_edrr_integration_advanced.py
@@ -103,6 +103,7 @@ def enhanced_coordinator():
     return coordinator
 
 
+@pytest.mark.medium
 def test_phase_specific_role_assignment_has_expected(enhanced_coordinator):
     """Test that roles are assigned based on the current EDRR phase.
 
@@ -144,6 +145,7 @@ def test_phase_specific_role_assignment_has_expected(enhanced_coordinator):
     )
 
 
+@pytest.mark.medium
 def test_quality_based_phase_transitions_has_expected(enhanced_coordinator):
     """Test that phase transitions are based on quality metrics from the WSDE team.
 
@@ -170,6 +172,7 @@ def test_quality_based_phase_transitions_has_expected(enhanced_coordinator):
         assert enhanced_coordinator.current_phase in {Phase.EXPAND, Phase.DIFFERENTIATE}
 
 
+@pytest.mark.medium
 def test_micro_cycle_implementation_succeeds(enhanced_coordinator):
     """Test the micro-cycle implementation with the WSDE team.
 
@@ -193,6 +196,7 @@ def test_micro_cycle_implementation_succeeds(enhanced_coordinator):
     enhanced_coordinator._execute_micro_cycle = original_execute_micro_cycle
 
 
+@pytest.mark.medium
 def test_error_handling_and_recovery_raises_error(enhanced_coordinator):
     """Test error handling and recovery in WSDE-EDRR integration.
 
@@ -217,6 +221,7 @@ def test_error_handling_and_recovery_raises_error(enhanced_coordinator):
         enhanced_coordinator.wsde_team._team.process = original_process
 
 
+@pytest.mark.medium
 def test_performance_metrics_and_traceability_succeeds(enhanced_coordinator):
     """Test performance metrics and traceability in WSDE-EDRR integration.
 
@@ -234,6 +239,7 @@ def test_performance_metrics_and_traceability_succeeds(enhanced_coordinator):
     assert metrics is not None
 
 
+@pytest.mark.medium
 def test_memory_sync_hook_handles_wsde_events():
     """Verify memory sync hooks are invoked during updates."""
 

--- a/tests/integration/general/test_wsde_edrr_integration_end_to_end.py
+++ b/tests/integration/general/test_wsde_edrr_integration_end_to_end.py
@@ -98,6 +98,7 @@ def coordinator():
     )
 
 
+@pytest.mark.medium
 def test_wsde_edrr_integration_end_to_end_succeeds(coordinator):
     """Test the complete integration between WSDE and EDRR.
 
@@ -142,6 +143,7 @@ def test_wsde_edrr_integration_end_to_end_succeeds(coordinator):
     assert "phases" in report
 
 
+@pytest.mark.medium
 def test_multi_agent_collaboration_with_memory_succeeds(coordinator):
     """Test multi-agent collaboration with memory system.
 
@@ -168,6 +170,7 @@ def test_multi_agent_collaboration_with_memory_succeeds(coordinator):
     coordinator.memory_manager.retrieve_with_edrr_phase.assert_called()
 
 
+@pytest.mark.medium
 def test_dialectical_reasoning_in_full_workflow_succeeds(coordinator):
     """Test dialectical reasoning in a full workflow.
 
@@ -207,6 +210,7 @@ def test_dialectical_reasoning_in_full_workflow_succeeds(coordinator):
     )
 
 
+@pytest.mark.medium
 def test_peer_review_integration_in_edrr_workflow_succeeds(coordinator):
     """Test the integration of peer review in the EDRR workflow.
 
@@ -280,6 +284,7 @@ def test_peer_review_integration_in_edrr_workflow_succeeds(coordinator):
             mock_flush.assert_called()
 
 
+@pytest.mark.medium
 def test_retrospective_phase_synchronizes_memory(coordinator):
     """Ensure retrospective phase flushes memory updates."""
 
@@ -297,6 +302,7 @@ def test_retrospective_phase_synchronizes_memory(coordinator):
         mock_flush.assert_called()
 
 
+@pytest.mark.medium
 def test_memory_sync_hook_captures_events_during_team_sync():
     """Ensure memory synchronization hooks capture memory updates."""
 


### PR DESCRIPTION
## Summary
- add memory-flushing workflow utilities for WSDE teams
- expose WSDE role assignments by agent id
- mark WSDE/EDRR integration tests with speed category

## Testing
- `poetry run pre-commit run --files src/devsynth/domain/models/wsde_facade.py src/devsynth/domain/models/wsde_roles.py src/devsynth/domain/models/wsde_utils.py tests/integration/general/test_wsde_edrr_component_interactions.py tests/integration/general/test_wsde_edrr_integration_advanced.py tests/integration/general/test_wsde_edrr_integration_end_to_end.py`
- `poetry run pytest tests/integration/general/test_wsde_edrr_component_interactions.py tests/integration/general/test_wsde_edrr_integration_advanced.py tests/integration/general/test_wsde_edrr_integration_end_to_end.py`
- `poetry run python tests/verify_test_organization.py`
- `poetry run python scripts/verify_test_markers.py -m tests/integration/general/test_wsde_edrr_component_interactions.py` *(fails: KeyError: 'total_files')*
- `poetry run python scripts/verify_requirements_traceability.py`
- `poetry run python scripts/verify_version_sync.py`


------
https://chatgpt.com/codex/tasks/task_e_689e2f511a1c833383f122a22092258f