### PR TITLE
chore: gate high memory tests and normalize speed markers

### DIFF
--- a/issues/116.md
+++ b/issues/116.md
@@ -23,5 +23,6 @@ Investigate these failing tests and determine why the suite is being killed mid-
 ## Current Status
 
 - Each module listed above now runs individually without failures or memory issues.
-- Marker verification and full suite run are pending; `scripts/verify_test_markers.py` and `devsynth run-tests --speed=fast` require further optimization to complete without timeouts.
-- Follow-up on test marker normalization is tracked in Issue 128.
+- High-memory modules such as `tests/unit/adapters/test_provider_system.py` are gated with `@pytest.mark.memory_intensive`, and missing speed markers were added to several issue-related tests.
+- `devsynth run-tests` executes for fast, medium, and slow categories but still reports internal xdist assertion errors outside the listed modules.
+- Full-suite stability depends on resolving remaining marker inconsistencies tracked in Issue 128.

--- a/tests/unit/adapters/issues/test_github_adapter.py
+++ b/tests/unit/adapters/issues/test_github_adapter.py
@@ -1,8 +1,11 @@
 """Tests for the GitHubIssueAdapter."""
 
+import pytest
 import responses
 
 from devsynth.adapters.issues import GitHubIssueAdapter
+
+pytestmark = [pytest.mark.fast]
 
 
 @responses.activate

--- a/tests/unit/adapters/issues/test_jira_adapter.py
+++ b/tests/unit/adapters/issues/test_jira_adapter.py
@@ -1,8 +1,11 @@
 """Tests for the JiraIssueAdapter."""
 
+import pytest
 import responses
 
 from devsynth.adapters.issues import JiraIssueAdapter
+
+pytestmark = [pytest.mark.fast]
 
 
 @responses.activate

--- a/tests/unit/adapters/issues/test_mvu_enrichment.py
+++ b/tests/unit/adapters/issues/test_mvu_enrichment.py
@@ -5,9 +5,12 @@ from __future__ import annotations
 import subprocess
 from pathlib import Path
 
+import pytest
 import responses
 
 from devsynth.core import mvu
+
+pytestmark = [pytest.mark.medium]
 
 
 def _init_repo(path: Path) -> None:

--- a/tests/unit/adapters/memory/test_memory_adapter_factory.py
+++ b/tests/unit/adapters/memory/test_memory_adapter_factory.py
@@ -2,13 +2,17 @@ import pytest
 
 from devsynth.adapters.kuzu_memory_store import KuzuMemoryStore
 from devsynth.adapters.memory.memory_adapter import MemorySystemAdapter
-from devsynth.application.memory.context_manager import InMemoryStore, SimpleContextManager
+from devsynth.application.memory.context_manager import (
+    InMemoryStore,
+    SimpleContextManager,
+)
 from devsynth.application.memory.kuzu_store import KuzuStore
 
 pytestmark = [
     pytest.mark.requires_resource("memory"),
     pytest.mark.memory_intensive,
     pytest.mark.isolation,
+    pytest.mark.medium,
 ]
 
 

--- a/tests/unit/adapters/memory/test_memory_adapter_transactions.py
+++ b/tests/unit/adapters/memory/test_memory_adapter_transactions.py
@@ -5,7 +5,7 @@ import types
 
 import pytest
 
-pytestmark = [pytest.mark.memory_intensive, pytest.mark.isolation]
+pytestmark = [pytest.mark.memory_intensive, pytest.mark.isolation, pytest.mark.medium]
 
 
 def _import_adapter():

--- a/tests/unit/adapters/memory/test_vector_store_provider_factory.py
+++ b/tests/unit/adapters/memory/test_vector_store_provider_factory.py
@@ -6,7 +6,7 @@ from devsynth.application.memory.vector_providers import (
 from devsynth.domain.interfaces.memory import MemoryVector, VectorStore
 from devsynth.exceptions import ValidationError
 
-pytestmark = [pytest.mark.memory_intensive, pytest.mark.isolation]
+pytestmark = [pytest.mark.memory_intensive, pytest.mark.isolation, pytest.mark.medium]
 
 
 class StubStore(VectorStore):

--- a/tests/unit/adapters/providers/test_embeddings.py
+++ b/tests/unit/adapters/providers/test_embeddings.py
@@ -1,8 +1,17 @@
 from unittest.mock import AsyncMock, MagicMock, patch
+
 import httpx
 import pytest
 import requests
-from devsynth.adapters.provider_system import LMStudioProvider, OpenAIProvider, ProviderError, aembed, embed
+
+from devsynth.adapters.provider_system import (
+    LMStudioProvider,
+    OpenAIProvider,
+    ProviderError,
+    aembed,
+    embed,
+)
+
 
 @pytest.mark.medium
 def test_openai_provider_embed_calls_api_succeeds():
@@ -10,28 +19,35 @@ def test_openai_provider_embed_calls_api_succeeds():
 
     ReqID: N/A"""
     mock_response = MagicMock()
-    mock_response.json.return_value = {'data': [{'embedding': [0.1, 0.2]}]}
+    mock_response.json.return_value = {"data": [{"embedding": [0.1, 0.2]}]}
     mock_response.raise_for_status.return_value = None
-    with patch('devsynth.adapters.provider_system.requests.post', return_value=mock_response) as mock_post:
-        provider = OpenAIProvider(api_key='key')
-        result = provider.embed('hello')
+    with patch(
+        "devsynth.adapters.provider_system.requests.post", return_value=mock_response
+    ) as mock_post:
+        provider = OpenAIProvider(api_key="key")
+        result = provider.embed("hello")
         assert result == [[0.1, 0.2]]
         mock_post.assert_called_once()
 
+
 @pytest.mark.anyio
+@pytest.mark.medium
 async def test_openai_provider_aembed_calls_api():
     mock_response = MagicMock()
-    mock_response.json.return_value = {'data': [{'embedding': [0.3, 0.4]}]}
+    mock_response.json.return_value = {"data": [{"embedding": [0.3, 0.4]}]}
     mock_response.raise_for_status.return_value = None
     async_client = AsyncMock()
     async_client.__aenter__.return_value = async_client
     async_client.__aexit__.return_value = None
     async_client.post.return_value = mock_response
-    with patch('devsynth.adapters.provider_system.httpx.AsyncClient', return_value=async_client):
-        provider = OpenAIProvider(api_key='key')
-        result = await provider.aembed('world')
+    with patch(
+        "devsynth.adapters.provider_system.httpx.AsyncClient", return_value=async_client
+    ):
+        provider = OpenAIProvider(api_key="key")
+        result = await provider.aembed("world")
         assert result == [[0.3, 0.4]]
         async_client.post.assert_called_once()
+
 
 @pytest.mark.medium
 def test_lmstudio_provider_embed_calls_api_succeeds():
@@ -39,61 +55,87 @@ def test_lmstudio_provider_embed_calls_api_succeeds():
 
     ReqID: N/A"""
     mock_response = MagicMock()
-    mock_response.json.return_value = {'data': [{'embedding': [0.5, 0.6]}]}
+    mock_response.json.return_value = {"data": [{"embedding": [0.5, 0.6]}]}
     mock_response.raise_for_status.return_value = None
-    with patch('devsynth.adapters.provider_system.requests.post', return_value=mock_response) as mock_post:
-        provider = LMStudioProvider(endpoint='http://localhost:1234')
-        result = provider.embed('text')
+    with patch(
+        "devsynth.adapters.provider_system.requests.post", return_value=mock_response
+    ) as mock_post:
+        provider = LMStudioProvider(endpoint="http://localhost:1234")
+        result = provider.embed("text")
         assert result == [[0.5, 0.6]]
         mock_post.assert_called_once()
+
 
 @pytest.mark.medium
 def test_embed_function_success_with_lmstudio_succeeds():
     """Test that embed function success with lmstudio succeeds.
 
     ReqID: N/A"""
-    provider = LMStudioProvider(endpoint='http://localhost:1234')
-    with patch('devsynth.adapters.provider_system.get_provider', return_value=provider), patch('devsynth.adapters.provider_system.requests.post') as mock_post:
+    provider = LMStudioProvider(endpoint="http://localhost:1234")
+    with (
+        patch("devsynth.adapters.provider_system.get_provider", return_value=provider),
+        patch("devsynth.adapters.provider_system.requests.post") as mock_post,
+    ):
         mock_resp = MagicMock()
-        mock_resp.json.return_value = {'data': [{'embedding': [0.7, 0.8]}]}
+        mock_resp.json.return_value = {"data": [{"embedding": [0.7, 0.8]}]}
         mock_resp.raise_for_status.return_value = None
         mock_post.return_value = mock_resp
-        result = embed('text', provider_type='lmstudio', fallback=False)
+        result = embed("text", provider_type="lmstudio", fallback=False)
         assert result == [[0.7, 0.8]]
         mock_post.assert_called_once()
 
+
 @pytest.mark.anyio
+@pytest.mark.medium
 async def test_aembed_function_success_with_lmstudio():
-    provider = LMStudioProvider(endpoint='http://localhost:1234')
+    provider = LMStudioProvider(endpoint="http://localhost:1234")
     async_client = AsyncMock()
     async_client.__aenter__.return_value = async_client
     async_client.__aexit__.return_value = None
     mock_resp = MagicMock()
-    mock_resp.json.return_value = {'data': [{'embedding': [0.9, 1.0]}]}
+    mock_resp.json.return_value = {"data": [{"embedding": [0.9, 1.0]}]}
     mock_resp.raise_for_status.return_value = None
     async_client.post.return_value = mock_resp
-    with patch('devsynth.adapters.provider_system.get_provider', return_value=provider), patch('devsynth.adapters.provider_system.httpx.AsyncClient', return_value=async_client):
-        result = await aembed('text', provider_type='lmstudio', fallback=False)
+    with (
+        patch("devsynth.adapters.provider_system.get_provider", return_value=provider),
+        patch(
+            "devsynth.adapters.provider_system.httpx.AsyncClient",
+            return_value=async_client,
+        ),
+    ):
+        result = await aembed("text", provider_type="lmstudio", fallback=False)
         assert result == [[0.9, 1.0]]
         async_client.post.assert_called_once()
+
 
 @pytest.mark.slow
 def test_lmstudio_provider_embed_error_succeeds():
     """Test that lmstudio provider embed error succeeds.
 
     ReqID: N/A"""
-    with patch('devsynth.adapters.provider_system.requests.post', side_effect=requests.exceptions.RequestException('boom')):
-        provider = LMStudioProvider(endpoint='http://localhost:1234')
+    with patch(
+        "devsynth.adapters.provider_system.requests.post",
+        side_effect=requests.exceptions.RequestException("boom"),
+    ):
+        provider = LMStudioProvider(endpoint="http://localhost:1234")
         with pytest.raises(ProviderError):
-            provider.embed('text')
+            provider.embed("text")
+
 
 @pytest.mark.anyio
+@pytest.mark.medium
 async def test_aembed_function_error_propagation():
-    provider = LMStudioProvider(endpoint='http://localhost:1234')
+    provider = LMStudioProvider(endpoint="http://localhost:1234")
     async_client = AsyncMock()
     async_client.__aenter__.return_value = async_client
     async_client.__aexit__.return_value = None
-    async_client.post.side_effect = httpx.HTTPError('fail')
-    with patch('devsynth.adapters.provider_system.get_provider', return_value=provider), patch('devsynth.adapters.provider_system.httpx.AsyncClient', return_value=async_client):
+    async_client.post.side_effect = httpx.HTTPError("fail")
+    with (
+        patch("devsynth.adapters.provider_system.get_provider", return_value=provider),
+        patch(
+            "devsynth.adapters.provider_system.httpx.AsyncClient",
+            return_value=async_client,
+        ),
+    ):
         with pytest.raises(ProviderError):
-            await aembed('text', provider_type='lmstudio', fallback=False)
+            await aembed("text", provider_type="lmstudio", fallback=False)

--- a/tests/unit/adapters/providers/test_provider_factory.py
+++ b/tests/unit/adapters/providers/test_provider_factory.py
@@ -1,6 +1,6 @@
 import pytest
 
-pytestmark = [pytest.mark.memory_intensive]
+pytestmark = [pytest.mark.memory_intensive, pytest.mark.medium]
 
 from devsynth.adapters.providers.provider_factory import (
     LMStudioProvider,

--- a/tests/unit/adapters/test_chromadb_memory_store.py
+++ b/tests/unit/adapters/test_chromadb_memory_store.py
@@ -27,6 +27,7 @@ from chromadb.api.models.Collection import Collection
 pytestmark = [
     pytest.mark.requires_resource("chromadb"),
     pytest.mark.memory_intensive,
+    pytest.mark.medium,
 ]
 
 

--- a/tests/unit/adapters/test_chromadb_vector_adapter.py
+++ b/tests/unit/adapters/test_chromadb_vector_adapter.py
@@ -19,6 +19,7 @@ pytestmark = [
     pytest.mark.requires_resource("chromadb"),
     pytest.mark.requires_resource("memory"),
     pytest.mark.memory_intensive,
+    pytest.mark.medium,
 ]
 
 

--- a/tests/unit/adapters/test_provider_system.py
+++ b/tests/unit/adapters/test_provider_system.py
@@ -19,6 +19,8 @@ from devsynth.adapters.provider_system import (
 )
 from devsynth.fallback import retry_with_exponential_backoff
 
+pytestmark = [pytest.mark.memory_intensive]
+
 
 @pytest.mark.medium
 def test_embed_success_succeeds():

--- a/tests/unit/agents/test_alignment_metrics_tool.py
+++ b/tests/unit/agents/test_alignment_metrics_tool.py
@@ -3,7 +3,11 @@
 from types import ModuleType
 from unittest.mock import patch
 
+import pytest
+
 from devsynth.agents.tools import alignment_metrics_tool, get_tool_registry
+
+pytestmark = [pytest.mark.fast]
 
 
 def test_alignment_metrics_tool_returns_structure() -> None:

--- a/tests/unit/application/cli/test_doctor_cmd.py
+++ b/tests/unit/application/cli/test_doctor_cmd.py
@@ -10,7 +10,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-pytestmark = [pytest.mark.memory_intensive]
+pytestmark = [pytest.mark.memory_intensive, pytest.mark.medium]
 
 # Create minimal stubs to avoid importing heavy dependencies when loading doctor_cmd
 devsynth_pkg = ModuleType("devsynth")


### PR DESCRIPTION
## Summary
- mark GitHub and Jira issue adapter tests as fast
- add speed markers and memory gating for memory and provider system tests
- note remaining marker inconsistencies in Issue 116

## Testing
- `poetry run pre-commit run --files tests/unit/adapters/issues/test_github_adapter.py tests/unit/adapters/issues/test_jira_adapter.py tests/unit/adapters/issues/test_mvu_enrichment.py tests/unit/adapters/memory/test_memory_adapter_factory.py tests/unit/adapters/memory/test_memory_adapter_transactions.py tests/unit/adapters/memory/test_vector_store_provider_factory.py tests/unit/adapters/providers/test_embeddings.py tests/unit/adapters/providers/test_provider_factory.py tests/unit/adapters/test_chromadb_memory_store.py tests/unit/adapters/test_chromadb_vector_adapter.py tests/unit/adapters/test_provider_system.py tests/unit/agents/test_alignment_metrics_tool.py tests/unit/application/cli/test_doctor_cmd.py`
- `poetry run pre-commit run --files issues/116.md`
- `poetry run python tests/verify_test_organization.py`
- `poetry run python scripts/verify_requirements_traceability.py`
- `poetry run python scripts/verify_version_sync.py`
- `poetry run devsynth run-tests --speed=fast`
- `poetry run devsynth run-tests --speed=medium`
- `poetry run devsynth run-tests --speed=slow`


------
https://chatgpt.com/codex/tasks/task_e_689e50e9fff08333be5ad2c06eb2164a