### PR TITLE
Add test marker for sprint planning

### DIFF
--- a/scripts/verify_test_markers.py
+++ b/scripts/verify_test_markers.py
@@ -221,7 +221,7 @@ def verify_file_markers(
                 str(file_path),
                 f"-m={marker_type}",
                 "--collect-only",
-                "-v",  # Use verbose output for better parsing
+                "-q",  # Use quiet output for reliable parsing
             ]
 
             try:
@@ -238,8 +238,9 @@ def verify_file_markers(
                 collected_tests = []
 
                 # Parse the output to count collected tests and identify which tests were collected
+                rel_path = os.path.relpath(file_path)
                 for line in collect_result.stdout.split("\n"):
-                    if str(file_path) in line:
+                    if str(file_path) in line or rel_path in line:
                         collected_count += 1
                         # Extract the test name from the output
                         test_parts = line.strip().split("::")

--- a/tests/unit/application/sprint/test_planning.py
+++ b/tests/unit/application/sprint/test_planning.py
@@ -1,8 +1,11 @@
 """Tests for sprint planning helpers."""
 
+import pytest
+
 from devsynth.application.sprint.planning import map_requirements_to_plan
 
 
+@pytest.mark.fast
 def test_map_requirements_to_plan_extracts_fields() -> None:
     """It maps requirement analysis results to a plan structure."""
     requirements = {


### PR DESCRIPTION
## Summary
- mark sprint planning test as fast
- improve verify_test_markers path parsing to prevent false positives

## Testing
- `poetry run pre-commit run --files tests/unit/application/sprint/test_planning.py scripts/verify_test_markers.py`
- `poetry run pytest tests/unit/application/sprint/test_planning.py -m fast -q`
- `poetry run python tests/verify_test_organization.py`
- `PYTEST_ADDOPTS="--no-cov --color=no" poetry run python -m scripts.verify_test_markers --report --module tests/unit/application/sprint/test_planning.py`
- `poetry run python scripts/verify_requirements_traceability.py`
- `poetry run python scripts/verify_version_sync.py`

------
https://chatgpt.com/codex/tasks/task_e_689e55e63cb4833393460045d526cead