### PR TITLE
Refactor script imports to use package-relative helpers

### DIFF
--- a/scripts/identify_high_risk_tests.py
+++ b/scripts/identify_high_risk_tests.py
@@ -24,39 +24,38 @@ Options:
     --dependencies          Consider test dependencies for risk calculation
 """
 
+import argparse
+import json
 import os
 import re
-import json
-import time
-import argparse
 import subprocess
-from pathlib import Path
+import time
+from collections import Counter, defaultdict
 from datetime import datetime, timedelta
-from typing import Dict, List, Set, Tuple, Any, Optional
-from collections import defaultdict, Counter
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Set, Tuple
 
 # Import enhanced test utilities if available
-import sys
-sys.path.append(os.path.dirname(os.path.abspath(__file__)))
 try:
-    import test_utils_extended as test_utils_ext
-    from test_utils import setup_test_environment, get_cache_dir
+    from . import test_utils_extended as test_utils_ext
+    from .test_utils import get_cache_dir, setup_test_environment
 except ImportError:
     try:
-        from test_utils import setup_test_environment, get_cache_dir
+        from .test_utils import get_cache_dir, setup_test_environment
+
         test_utils_ext = None
     except ImportError:
         # Fallback implementation if test_utils.py is not available
         def setup_test_environment():
             """Set up the test environment."""
             os.environ["PYTHONPATH"] = os.getcwd()
-            
+
         def get_cache_dir():
             """Get the cache directory."""
             cache_dir = Path(".test_history_cache")
             cache_dir.mkdir(exist_ok=True)
             return cache_dir
-        
+
         test_utils_ext = None
 
 # Test categories
@@ -68,6 +67,7 @@ TEST_CATEGORIES = {
     "property": "tests/property",
 }
 
+
 def parse_args():
     """Parse command line arguments."""
     parser = argparse.ArgumentParser(
@@ -76,94 +76,82 @@ def parse_args():
     parser.add_argument(
         "--history-file",
         default="test_execution_history.json",
-        help="Test execution history file (default: test_execution_history.json)"
+        help="Test execution history file (default: test_execution_history.json)",
     )
     parser.add_argument(
         "--output",
         default="high_risk_tests.json",
-        help="Output file for high-risk tests (default: high_risk_tests.json)"
+        help="Output file for high-risk tests (default: high_risk_tests.json)",
     )
     parser.add_argument(
         "--risk-threshold",
         type=float,
         default=0.7,
-        help="Risk threshold for high-risk tests (default: 0.7)"
+        help="Risk threshold for high-risk tests (default: 0.7)",
     )
     parser.add_argument(
         "--max-tests",
         type=int,
         default=100,
-        help="Maximum number of high-risk tests to identify (default: 100)"
+        help="Maximum number of high-risk tests to identify (default: 100)",
     )
     parser.add_argument(
         "--consider-recent",
         type=int,
         default=10,
-        help="Number of recent executions to consider (default: 10)"
+        help="Number of recent executions to consider (default: 10)",
     )
     parser.add_argument(
         "--git-history",
         action="store_true",
-        help="Consider git history for risk calculation"
+        help="Consider git history for risk calculation",
     )
     parser.add_argument(
         "--complexity",
         action="store_true",
-        help="Consider test complexity for risk calculation"
+        help="Consider test complexity for risk calculation",
     )
     parser.add_argument(
         "--dependencies",
         action="store_true",
-        help="Consider test dependencies for risk calculation"
+        help="Consider test dependencies for risk calculation",
     )
     parser.add_argument(
         "--update-history",
         action="store_true",
-        help="Update test execution history with latest results"
+        help="Update test execution history with latest results",
     )
     parser.add_argument(
-        "--results-file",
-        help="Test results file to use for updating history"
+        "--results-file", help="Test results file to use for updating history"
     )
-    parser.add_argument(
-        "--html",
-        action="store_true",
-        help="Generate HTML report"
-    )
+    parser.add_argument("--html", action="store_true", help="Generate HTML report")
     parser.add_argument(
         "--html-file",
         default="high_risk_tests.html",
-        help="HTML report file (default: high_risk_tests.html)"
+        help="HTML report file (default: high_risk_tests.html)",
     )
     parser.add_argument(
         "--use-markers",
         action="store_true",
-        help="Use test markers for complexity estimation"
+        help="Use test markers for complexity estimation",
     )
     parser.add_argument(
-        "--cache",
-        action="store_true",
-        help="Use cached test collection results"
+        "--cache", action="store_true", help="Use cached test collection results"
     )
     parser.add_argument(
-        "--clear-cache",
-        action="store_true",
-        help="Clear cache before running"
+        "--clear-cache", action="store_true", help="Clear cache before running"
     )
-    parser.add_argument(
-        "--verbose",
-        action="store_true",
-        help="Verbose output"
-    )
+    parser.add_argument("--verbose", action="store_true", help="Verbose output")
     return parser.parse_args()
+
 
 def load_test_history(history_file: str) -> Dict[str, Any]:
     """
     Load test execution history from a file.
-    
+
     Args:
         history_file: Path to the history file
-        
+
     Returns:
         Test execution history
     """
@@ -174,7 +162,7 @@ def load_test_history(history_file: str) -> Dict[str, Any]:
             return history
         except json.JSONDecodeError:
             print(f"Error: {history_file} is not a valid JSON file")
-    
+
     # Create a new history file if it doesn't exist
     history = {
         "last_updated": datetime.now().isoformat(),
@@ -183,28 +171,29 @@ def load_test_history(history_file: str) -> Dict[str, Any]:
     }
     return history
 
+
 def update_test_history(history: Dict[str, Any], results_file: str) -> Dict[str, Any]:
     """
     Update test execution history with latest results.
-    
+
     Args:
         history: Test execution history
         results_file: Path to the test results file
-        
+
     Returns:
         Updated test execution history
     """
     if not os.path.exists(results_file):
         print(f"Error: {results_file} does not exist")
         return history
-    
+
     try:
         with open(results_file, "r") as f:
             results = json.load(f)
     except json.JSONDecodeError:
         print(f"Error: {results_file} is not a valid JSON file")
         return history
-    
+
     # Create a new execution record
     execution = {
         "timestamp": results.get("timestamp", datetime.now().isoformat()),
@@ -212,10 +201,10 @@ def update_test_history(history: Dict[str, Any], results_file: str) -> Dict[str,
         "failed": results.get("failed", []),
         "skipped": results.get("skipped", []),
     }
-    
+
     # Add the execution to the history
     history["executions"].append(execution)
-    
+
     # Update test records
     for test in execution["passed"] + execution["failed"] + execution["skipped"]:
         if test not in history["tests"]:
@@ -226,10 +215,10 @@ def update_test_history(history: Dict[str, Any], results_file: str) -> Dict[str,
                 "total_skipped": 0,
                 "recent_results": [],
             }
-        
+
         # Update test statistics
         history["tests"][test]["total_executions"] += 1
-        
+
         if test in execution["passed"]:
             history["tests"][test]["total_passed"] += 1
             result = "passed"
@@ -239,25 +228,30 @@ def update_test_history(history: Dict[str, Any], results_file: str) -> Dict[str,
         else:
             history["tests"][test]["total_skipped"] += 1
             result = "skipped"
-        
+
         # Add to recent results
-        history["tests"][test]["recent_results"].append({
-            "timestamp": execution["timestamp"],
-            "result": result,
-        })
-        
+        history["tests"][test]["recent_results"].append(
+            {
+                "timestamp": execution["timestamp"],
+                "result": result,
+            }
+        )
+
         # Keep only the most recent results
-        history["tests"][test]["recent_results"] = history["tests"][test]["recent_results"][-10:]
-    
+        history["tests"][test]["recent_results"] = history["tests"][test][
+            "recent_results"
+        ][-10:]
+
     # Update last updated timestamp
     history["last_updated"] = datetime.now().isoformat()
-    
+
     return history
+
 
 def save_test_history(history: Dict[str, Any], history_file: str):
     """
     Save test execution history to a file.
-    
+
     Args:
         history: Test execution history
         history_file: Path to the history file
@@ -266,14 +260,15 @@ def save_test_history(history: Dict[str, Any], history_file: str):
         json.dump(history, f, indent=2)
     print(f"Test execution history saved to {history_file}")
 
+
 def calculate_failure_risk(test_record: Dict[str, Any], consider_recent: int) -> float:
     """
     Calculate the failure risk for a test based on its execution history.
-    
+
     Args:
         test_record: Test execution record
         consider_recent: Number of recent executions to consider
-        
+
     Returns:
         Failure risk score (0.0 to 1.0)
     """
@@ -281,31 +276,34 @@ def calculate_failure_risk(test_record: Dict[str, Any], consider_recent: int) ->
     total_executions = test_record["total_executions"]
     if total_executions == 0:
         return 0.0
-    
+
     historical_failure_rate = test_record["total_failed"] / total_executions
-    
+
     # Calculate recent failure rate
     recent_results = test_record["recent_results"][-consider_recent:]
-    recent_failures = sum(1 for result in recent_results if result["result"] == "failed")
+    recent_failures = sum(
+        1 for result in recent_results if result["result"] == "failed"
+    )
     recent_executions = len(recent_results)
-    
+
     if recent_executions == 0:
         recent_failure_rate = 0.0
     else:
         recent_failure_rate = recent_failures / recent_executions
-    
+
     # Weight recent failures more heavily
     failure_risk = (historical_failure_rate * 0.4) + (recent_failure_rate * 0.6)
-    
+
     return failure_risk
+
 
 def collect_all_tests(use_cache: bool = False) -> List[str]:
     """
     Collect all tests in the project.
-    
+
     Args:
         use_cache: Whether to use cached test collection results
-        
+
     Returns:
         List of test paths
     """
@@ -317,13 +315,15 @@ def collect_all_tests(use_cache: bool = False) -> List[str]:
         for category, tests in tests_by_category.items():
             all_tests.extend(tests)
         return all_tests
-    
+
     # Fallback implementation
     print("Using fallback test collection method...")
     all_tests = []
     for category, test_dir in TEST_CATEGORIES.items():
         cmd = [
-            "python", "-m", "pytest",
+            "python",
+            "-m",
+            "pytest",
             test_dir,
             "--collect-only",
             "-q",
@@ -335,17 +335,18 @@ def collect_all_tests(use_cache: bool = False) -> List[str]:
                     all_tests.append(line.strip())
         except Exception as e:
             print(f"Error collecting tests for {category}: {e}")
-    
+
     return all_tests
+
 
 def get_test_complexity(test_path: str, use_markers: bool = False) -> float:
     """
     Calculate the complexity of a test based on various factors.
-    
+
     Args:
         test_path: Path to the test file
         use_markers: Whether to use test markers for complexity estimation
-        
+
     Returns:
         Complexity score (0.0 to 1.0)
     """
@@ -359,7 +360,7 @@ def get_test_complexity(test_path: str, use_markers: bool = False) -> float:
                 return 0.5
             elif marker_type == "fast":
                 return 0.2
-    
+
     # Estimate complexity based on test category
     if test_path.startswith("tests/behavior"):
         return 0.7  # Behavior tests are complex
@@ -367,49 +368,63 @@ def get_test_complexity(test_path: str, use_markers: bool = False) -> float:
         return 0.5  # Integration tests are moderately complex
     elif test_path.startswith("tests/performance"):
         return 0.8  # Performance tests are complex
-    
+
     # Fallback to code analysis
     if not os.path.exists(test_path):
         return 0.3  # Default complexity for unit tests
-    
+
     # Extract the test file path from the test path
     match = re.match(r"(.*?\.py)(?:::(.*))?", test_path)
     if not match:
         return 0.3
-    
+
     test_file = match.group(1)
-    
+
     try:
         # Count lines of code
         with open(test_file, "r") as f:
             lines = f.readlines()
-        
-        code_lines = len([line for line in lines if line.strip() and not line.strip().startswith("#")])
-        
+
+        code_lines = len(
+            [
+                line
+                for line in lines
+                if line.strip() and not line.strip().startswith("#")
+            ]
+        )
+
         # Count assertions
         assertion_count = sum(1 for line in lines if "assert" in line)
-        
+
         # Count fixtures
         fixture_count = sum(1 for line in lines if "@pytest.fixture" in line)
-        
+
         # Count parametrize decorators
-        parametrize_count = sum(1 for line in lines if "@pytest.mark.parametrize" in line)
-        
+        parametrize_count = sum(
+            1 for line in lines if "@pytest.mark.parametrize" in line
+        )
+
         # Calculate complexity score
-        complexity = min(1.0, (code_lines / 500) * 0.4 + (assertion_count / 20) * 0.3 + 
-                        (fixture_count / 5) * 0.2 + (parametrize_count / 3) * 0.1)
-        
+        complexity = min(
+            1.0,
+            (code_lines / 500) * 0.4
+            + (assertion_count / 20) * 0.3
+            + (fixture_count / 5) * 0.2
+            + (parametrize_count / 3) * 0.1,
+        )
+
         return complexity
     except Exception:
         return 0.3
 
+
 def get_git_churn(test_path: str) -> float:
     """
     Calculate the git churn for a test file.
-    
+
     Args:
         test_path: Path to the test file
-        
+
     Returns:
         Churn score (0.0 to 1.0)
     """
@@ -417,24 +432,28 @@ def get_git_churn(test_path: str) -> float:
     match = re.match(r"(.*?\.py)(?:::(.*))?", test_path)
     if not match:
         return 0.0
-    
+
     test_file = match.group(1)
-    
+
     try:
         # Get the number of commits in the last 30 days
-        cmd = [
-            "git", "log", "--since=30.days", "--pretty=format:%H", "--", test_file
-        ]
+        cmd = ["git", "log", "--since=30.days", "--pretty=format:%H", "--", test_file]
         result = subprocess.run(cmd, capture_output=True, text=True)
         commits = result.stdout.strip().split("\n")
         commit_count = len([c for c in commits if c])
-        
+
         # Get the number of lines changed in the last 30 days
         cmd = [
-            "git", "log", "--since=30.days", "--numstat", "--pretty=format:", "--", test_file
+            "git",
+            "log",
+            "--since=30.days",
+            "--numstat",
+            "--pretty=format:",
+            "--",
+            test_file,
         ]
         result = subprocess.run(cmd, capture_output=True, text=True)
-        
+
         lines_changed = 0
         for line in result.stdout.strip().split("\n"):
             if line.strip():
@@ -444,21 +463,22 @@ def get_git_churn(test_path: str) -> float:
                         lines_changed += int(parts[0]) + int(parts[1])
                     except ValueError:
                         pass
-        
+
         # Calculate churn score
         churn = min(1.0, (commit_count / 10) * 0.5 + (lines_changed / 100) * 0.5)
-        
+
         return churn
     except Exception:
         return 0.0
 
+
 def get_test_dependencies(test_path: str) -> List[str]:
     """
     Identify dependencies for a test.
-    
+
     Args:
         test_path: Path to the test file
-        
+
     Returns:
         List of dependent test paths
     """
@@ -466,20 +486,22 @@ def get_test_dependencies(test_path: str) -> List[str]:
     match = re.match(r"(.*?\.py)(?:::(.*))?", test_path)
     if not match:
         return []
-    
+
     test_file = match.group(1)
     test_name = match.group(2) if match.group(2) else ""
-    
+
     try:
         # Run pytest with --collect-only to get dependencies
         cmd = [
-            "python", "-m", "pytest",
+            "python",
+            "-m",
+            "pytest",
             test_path,
             "--collect-only",
             "-v",
         ]
         result = subprocess.run(cmd, capture_output=True, text=True)
-        
+
         # Parse the output to find dependencies
         dependencies = []
         for line in result.stdout.split("\n"):
@@ -488,32 +510,36 @@ def get_test_dependencies(test_path: str) -> List[str]:
                 if match:
                     dependency = match.group(1)
                     dependencies.append(dependency)
-        
+
         return dependencies
     except Exception:
         return []
 
+
 def calculate_dependency_risk(test_path: str, high_risk_tests: Set[str]) -> float:
     """
     Calculate the risk based on dependencies.
-    
+
     Args:
         test_path: Path to the test file
         high_risk_tests: Set of high-risk test paths
-        
+
     Returns:
         Dependency risk score (0.0 to 1.0)
     """
     dependencies = get_test_dependencies(test_path)
-    
+
     if not dependencies:
         return 0.0
-    
+
     # Calculate the percentage of dependencies that are high-risk
     high_risk_dependencies = sum(1 for dep in dependencies if dep in high_risk_tests)
-    dependency_risk = high_risk_dependencies / len(dependencies) if dependencies else 0.0
-    
+    dependency_risk = (
+        high_risk_dependencies / len(dependencies) if dependencies else 0.0
+    )
+
     return dependency_risk
+
 
 def identify_high_risk_tests(
     history: Dict[str, Any],
@@ -523,11 +549,11 @@ def identify_high_risk_tests(
     use_git_history: bool,
     use_complexity: bool,
     use_dependencies: bool,
-    verbose: bool
+    verbose: bool,
 ) -> List[Dict[str, Any]]:
     """
     Identify high-risk tests based on execution history and other factors.
-    
+
     Args:
         history: Test execution history
         risk_threshold: Risk threshold for high-risk tests
@@ -537,7 +563,7 @@ def identify_high_risk_tests(
         use_complexity: Whether to consider test complexity for risk calculation
         use_dependencies: Whether to consider test dependencies for risk calculation
         verbose: Whether to print verbose output
-        
+
     Returns:
         List of high-risk tests with risk scores
     """
@@ -553,53 +579,64 @@ def identify_high_risk_tests(
             "dependency_risk": 0.0,
             "total_risk": failure_risk,  # Initial risk is just the failure risk
         }
-    
+
     # Sort tests by initial risk score
-    sorted_tests = sorted(risk_scores.values(), key=lambda x: x["failure_risk"], reverse=True)
-    
+    sorted_tests = sorted(
+        risk_scores.values(), key=lambda x: x["failure_risk"], reverse=True
+    )
+
     # Get the top tests for further analysis
-    top_tests = sorted_tests[:max_tests * 2]  # Analyze twice as many tests as we need
-    high_risk_test_paths = {test["test_path"] for test in top_tests if test["failure_risk"] >= risk_threshold}
-    
+    top_tests = sorted_tests[: max_tests * 2]  # Analyze twice as many tests as we need
+    high_risk_test_paths = {
+        test["test_path"]
+        for test in top_tests
+        if test["failure_risk"] >= risk_threshold
+    }
+
     # Calculate additional risk factors for top tests
     for test in top_tests:
         test_path = test["test_path"]
-        
+
         if use_complexity:
             if verbose:
                 print(f"Calculating complexity for {test_path}")
             test["complexity"] = get_test_complexity(test_path)
-        
+
         if use_git_history:
             if verbose:
                 print(f"Calculating git churn for {test_path}")
             test["git_churn"] = get_git_churn(test_path)
-        
+
         if use_dependencies:
             if verbose:
                 print(f"Calculating dependency risk for {test_path}")
-            test["dependency_risk"] = calculate_dependency_risk(test_path, high_risk_test_paths)
-        
+            test["dependency_risk"] = calculate_dependency_risk(
+                test_path, high_risk_test_paths
+            )
+
         # Calculate total risk score with weights
         test["total_risk"] = (
-            test["failure_risk"] * 0.6 +
-            test["complexity"] * 0.1 +
-            test["git_churn"] * 0.2 +
-            test["dependency_risk"] * 0.1
+            test["failure_risk"] * 0.6
+            + test["complexity"] * 0.1
+            + test["git_churn"] * 0.2
+            + test["dependency_risk"] * 0.1
         )
-    
+
     # Sort tests by total risk score
     sorted_tests = sorted(top_tests, key=lambda x: x["total_risk"], reverse=True)
-    
+
     # Get the top high-risk tests
-    high_risk_tests = [test for test in sorted_tests if test["total_risk"] >= risk_threshold][:max_tests]
-    
+    high_risk_tests = [
+        test for test in sorted_tests if test["total_risk"] >= risk_threshold
+    ][:max_tests]
+
     return high_risk_tests
+
 
 def save_high_risk_tests(high_risk_tests: List[Dict[str, Any]], output_file: str):
     """
     Save high-risk tests to a file.
-    
+
     Args:
         high_risk_tests: List of high-risk tests with risk scores
         output_file: Path to the output file
@@ -608,15 +645,16 @@ def save_high_risk_tests(high_risk_tests: List[Dict[str, Any]], output_file: str
         "timestamp": datetime.now().isoformat(),
         "high_risk_tests": high_risk_tests,
     }
-    
+
     with open(output_file, "w") as f:
         json.dump(result, f, indent=2)
     print(f"High-risk tests saved to {output_file}")
 
+
 def generate_html_report(high_risk_tests: List[Dict[str, Any]], html_file: str):
     """
     Generate an HTML report for high-risk tests.
-    
+
     Args:
         high_risk_tests: List of high-risk tests with risk scores
         html_file: Path to the HTML file
@@ -644,12 +682,12 @@ def generate_html_report(high_risk_tests: List[Dict[str, Any]], html_file: str):
     </head>
     <body>
         <h1>High-Risk Test Analysis</h1>
-        
+
         <div class="summary">
             <h2>Summary</h2>
             <p>Identified {len(high_risk_tests)} high-risk tests.</p>
         </div>
-        
+
         <h2>High-Risk Tests</h2>
         <table>
             <tr>
@@ -661,10 +699,14 @@ def generate_html_report(high_risk_tests: List[Dict[str, Any]], html_file: str):
                 <th>Dependency Risk</th>
             </tr>
     """
-    
+
     for test in high_risk_tests:
-        risk_class = "risk-high" if test["total_risk"] > 0.7 else "risk-medium" if test["total_risk"] > 0.5 else "risk-low"
-        
+        risk_class = (
+            "risk-high"
+            if test["total_risk"] > 0.7
+            else "risk-medium" if test["total_risk"] > 0.5 else "risk-low"
+        )
+
         html += f"""
             <tr class="{risk_class}">
                 <td>{test["test_path"]}</td>
@@ -690,67 +732,69 @@ def generate_html_report(high_risk_tests: List[Dict[str, Any]], html_file: str):
                 </td>
             </tr>
         """
-    
+
     html += f"""
         </table>
-        
+
         <div class="timestamp">
             Generated on: {datetime.now().isoformat()}
         </div>
     </body>
     </html>
     """
-    
+
     with open(html_file, "w") as f:
         f.write(html)
     print(f"HTML report saved to {html_file}")
 
+
 def print_high_risk_tests(high_risk_tests: List[Dict[str, Any]]):
     """
     Print high-risk tests to the console.
-    
+
     Args:
         high_risk_tests: List of high-risk tests with risk scores
     """
-    print("\n" + "="*80)
+    print("\n" + "=" * 80)
     print("HIGH-RISK TESTS:")
-    print("="*80)
-    
+    print("=" * 80)
+
     for i, test in enumerate(high_risk_tests):
         print(f"{i+1}. {test['test_path']}")
         print(f"   Total Risk: {test['total_risk']:.2f}")
         print(f"   Failure Risk: {test['failure_risk']:.2f}")
-        
+
         if test["complexity"] > 0:
             print(f"   Complexity: {test['complexity']:.2f}")
-        
+
         if test["git_churn"] > 0:
             print(f"   Git Churn: {test['git_churn']:.2f}")
-        
+
         if test["dependency_risk"] > 0:
             print(f"   Dependency Risk: {test['dependency_risk']:.2f}")
-        
+
         print()
-    
+
     print(f"Total high-risk tests: {len(high_risk_tests)}")
-    print("="*80)
+    print("=" * 80)
+
 
 def main():
     """Main function."""
     start_time = time.time()
     args = parse_args()
-    
+
     # Set up the test environment
     setup_test_environment()
-    
+
     # Load test execution history
     history = load_test_history(args.history_file)
-    
+
     # Update history if requested
     if args.update_history and args.results_file:
         history = update_test_history(history, args.results_file)
         save_test_history(history, args.history_file)
-    
+
     # Identify high-risk tests
     high_risk_tests = identify_high_risk_tests(
         history,
@@ -760,18 +804,19 @@ def main():
         args.git_history,
         args.complexity,
         args.dependencies,
-        args.verbose
+        args.verbose,
     )
-    
+
     # Save high-risk tests
     save_high_risk_tests(high_risk_tests, args.output)
-    
+
     # Print high-risk tests
     print_high_risk_tests(high_risk_tests)
-    
+
     # Calculate execution time
     execution_time = time.time() - start_time
     print(f"\nExecution time: {execution_time:.2f} seconds")
+
 
 if __name__ == "__main__":
     main()

--- a/scripts/run_modified_tests_enhanced.py
+++ b/scripts/run_modified_tests_enhanced.py
@@ -37,17 +37,13 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional, Set, Tuple
 
 # Import test utilities
-sys.path.append(os.path.dirname(os.path.abspath(__file__)))
 try:
-    import common_test_collector
-    import test_utils
-    import test_utils_extended
+    from . import common_test_collector, test_utils, test_utils_extended
 
     EXTENDED_UTILS_AVAILABLE = True
 except ImportError:
     print("Warning: test_utils_extended.py not found. Using original implementation.")
-    import common_test_collector
-    import test_utils
+    from . import common_test_collector, test_utils
 
     EXTENDED_UTILS_AVAILABLE = False
 

--- a/scripts/run_unified_tests.py
+++ b/scripts/run_unified_tests.py
@@ -44,17 +44,13 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional, Set, Tuple
 
 # Import test utilities
-sys.path.append(os.path.dirname(os.path.abspath(__file__)))
 try:
-    import common_test_collector
-    import test_utils
-    import test_utils_extended
+    from . import common_test_collector, test_utils, test_utils_extended
 
     EXTENDED_UTILS_AVAILABLE = True
 except ImportError:
     print("Warning: test_utils_extended.py not found. Using original implementation.")
-    import common_test_collector
-    import test_utils
+    from . import common_test_collector, test_utils
 
     EXTENDED_UTILS_AVAILABLE = False
 

--- a/scripts/sync_test_categorization.py
+++ b/scripts/sync_test_categorization.py
@@ -18,114 +18,104 @@ Options:
     --report              Generate a report of discrepancies
 """
 
-import os
-import sys
-import json
 import argparse
+import json
+import os
 from datetime import datetime
-from typing import Dict, List, Set, Tuple, Any, Optional
+from typing import Any, Dict, List, Optional, Set, Tuple
 
 # Import common test collector and enhanced test utilities
-sys.path.append(os.path.dirname(os.path.abspath(__file__)))
-import test_utils_extended as test_utils_ext
-import common_test_collector as test_collector
+from . import common_test_collector as test_collector
+from . import test_utils_extended as test_utils_ext
+
 
 def parse_args():
     """Parse command line arguments."""
     parser = argparse.ArgumentParser(
-        description='Synchronize test categorization tracking between progress and schedule files.'
+        description="Synchronize test categorization tracking between progress and schedule files."
     )
     parser.add_argument(
-        '--dry-run',
-        action='store_true',
-        help='Show changes without modifying files'
+        "--dry-run", action="store_true", help="Show changes without modifying files"
     )
     parser.add_argument(
-        '--verbose',
-        action='store_true',
-        help='Show detailed information about changes'
+        "--verbose", action="store_true", help="Show detailed information about changes"
     )
     parser.add_argument(
-        '--update-schedule',
-        action='store_true',
-        help='Update schedule file based on progress file'
+        "--update-schedule",
+        action="store_true",
+        help="Update schedule file based on progress file",
     )
     parser.add_argument(
-        '--update-progress',
-        action='store_true',
-        help='Update progress file based on actual markers in code'
+        "--update-progress",
+        action="store_true",
+        help="Update progress file based on actual markers in code",
     )
     parser.add_argument(
-        '--verify',
-        action='store_true',
-        help='Verify consistency between progress file, schedule file, and actual markers'
+        "--verify",
+        action="store_true",
+        help="Verify consistency between progress file, schedule file, and actual markers",
     )
     parser.add_argument(
-        '--report',
-        action='store_true',
-        help='Generate a report of discrepancies'
+        "--report", action="store_true", help="Generate a report of discrepancies"
     )
     parser.add_argument(
-        '--report-file',
-        default='test_categorization_sync_report.json',
-        help='File to save the report to'
+        "--report-file",
+        default="test_categorization_sync_report.json",
+        help="File to save the report to",
     )
     return parser.parse_args()
 
-def update_schedule_from_progress(dry_run: bool = False, verbose: bool = False) -> Dict[str, Any]:
+
+def update_schedule_from_progress(
+    dry_run: bool = False, verbose: bool = False
+) -> Dict[str, Any]:
     """
     Update the schedule file based on the progress file.
-    
+
     Args:
         dry_run: Whether to show changes without modifying files
         verbose: Whether to show detailed information about changes
-        
+
     Returns:
         Dictionary containing update results
     """
     print("Updating schedule file from progress file...")
-    
+
     # Load progress and schedule files
     progress = test_utils_ext.load_progress_file()
     schedule = test_utils_ext.load_schedule_file()
-    
+
     if not progress or not schedule:
         print("Cannot update: missing progress or schedule file")
-        return {
-            "success": False,
-            "error": "Missing progress or schedule file"
-        }
-    
+        return {"success": False, "error": "Missing progress or schedule file"}
+
     # Extract categorized tests from progress file
     progress_categorized = progress.get("categorized_tests", {})
-    progress_counts = progress.get("categorization_counts", {
-        "fast": 0,
-        "medium": 0,
-        "slow": 0,
-        "total": 0
-    })
-    
+    progress_counts = progress.get(
+        "categorization_counts", {"fast": 0, "medium": 0, "slow": 0, "total": 0}
+    )
+
     # Extract module test counts from schedule file
     schedule_module_counts = schedule.get("module_test_counts", {})
-    
+
     # Collect all tests by module using the common test collector
     all_tests_by_module = {}
     for category in test_collector.TEST_CATEGORIES:
         category_tests = test_collector.collect_tests_by_category(category)
-        
+
         for test_path in category_tests:
             # Extract the module path from the test path
-            if '::' in test_path:
-                module_path = test_path.split('::')[0]
+            if "::" in test_path:
+                module_path = test_path.split("::")[0]
                 # Get the directory containing the file
                 module_path = os.path.dirname(module_path)
             else:
                 module_path = os.path.dirname(test_path)
-            
+
             if module_path not in all_tests_by_module:
                 all_tests_by_module[module_path] = []
             all_tests_by_module[module_path].append(test_path)
-    
+
     # Update module test counts in schedule file
     changes = {
         "modules_updated": 0,
@@ -133,33 +123,41 @@ def update_schedule_from_progress(dry_run: bool = False, verbose: bool = False) 
         "modules_unchanged": 0,
         "total_tests_before": schedule.get("total_tests", 0),
         "total_categorized_before": schedule.get("total_categorized", 0),
-        "total_uncategorized_before": schedule.get("total_uncategorized", 0)
+        "total_uncategorized_before": schedule.get("total_uncategorized", 0),
     }
-    
+
     for module_path, tests in all_tests_by_module.items():
         total_tests = len(tests)
         categorized_count = sum(1 for test in tests if test in progress_categorized)
         uncategorized_count = total_tests - categorized_count
-        
+
         if module_path in schedule_module_counts:
             old_counts = schedule_module_counts[module_path]
-            if (old_counts.get("total", 0) != total_tests or
-                old_counts.get("categorized", 0) != categorized_count or
-                old_counts.get("uncategorized", 0) != uncategorized_count):
-                
+            if (
+                old_counts.get("total", 0) != total_tests
+                or old_counts.get("categorized", 0) != categorized_count
+                or old_counts.get("uncategorized", 0) != uncategorized_count
+            ):
+
                 if verbose:
                     print(f"Updating module {module_path}:")
-                    print(f"  Total tests: {old_counts.get('total', 0)} -> {total_tests}")
-                    print(f"  Categorized: {old_counts.get('categorized', 0)} -> {categorized_count}")
-                    print(f"  Uncategorized: {old_counts.get('uncategorized', 0)} -> {uncategorized_count}")
-                
+                    print(
+                        f"  Total tests: {old_counts.get('total', 0)} -> {total_tests}"
+                    )
+                    print(
+                        f"  Categorized: {old_counts.get('categorized', 0)} -> {categorized_count}"
+                    )
+                    print(
+                        f"  Uncategorized: {old_counts.get('uncategorized', 0)} -> {uncategorized_count}"
+                    )
+
                 if not dry_run:
                     schedule_module_counts[module_path] = {
                         "total": total_tests,
                         "categorized": categorized_count,
-                        "uncategorized": uncategorized_count
+                        "uncategorized": uncategorized_count,
                     }
-                
+
                 changes["modules_updated"] += 1
             else:
                 changes["modules_unchanged"] += 1
@@ -170,81 +168,82 @@ def update_schedule_from_progress(dry_run: bool = False, verbose: bool = False) 
                 print(f"  Total tests: {total_tests}")
                 print(f"  Categorized: {categorized_count}")
                 print(f"  Uncategorized: {uncategorized_count}")
-            
+
             if not dry_run:
                 schedule_module_counts[module_path] = {
                     "total": total_tests,
                     "categorized": categorized_count,
-                    "uncategorized": uncategorized_count
+                    "uncategorized": uncategorized_count,
                 }
-            
+
             changes["modules_added"] += 1
-    
+
     # Update total counts in schedule file
     total_tests = sum(len(tests) for tests in all_tests_by_module.values())
     total_categorized = len(progress_categorized)
     total_uncategorized = total_tests - total_categorized
-    
+
     if verbose:
         print(f"Updating total counts:")
         print(f"  Total tests: {schedule.get('total_tests', 0)} -> {total_tests}")
-        print(f"  Categorized: {schedule.get('total_categorized', 0)} -> {total_categorized}")
-        print(f"  Uncategorized: {schedule.get('total_uncategorized', 0)} -> {total_uncategorized}")
-    
+        print(
+            f"  Categorized: {schedule.get('total_categorized', 0)} -> {total_categorized}"
+        )
+        print(
+            f"  Uncategorized: {schedule.get('total_uncategorized', 0)} -> {total_uncategorized}"
+        )
+
     if not dry_run:
         schedule["total_tests"] = total_tests
         schedule["total_categorized"] = total_categorized
         schedule["total_uncategorized"] = total_uncategorized
         schedule["module_test_counts"] = schedule_module_counts
-        
+
         # Save updated schedule file
         test_utils_ext.save_schedule_file(schedule)
-    
+
     changes["total_tests_after"] = total_tests
     changes["total_categorized_after"] = total_categorized
     changes["total_uncategorized_after"] = total_uncategorized
-    
-    return {
-        "success": True,
-        "changes": changes
-    }
 
-def update_progress_from_code(dry_run: bool = False, verbose: bool = False) -> Dict[str, Any]:
+    return {"success": True, "changes": changes}
+
+
+def update_progress_from_code(
+    dry_run: bool = False, verbose: bool = False
+) -> Dict[str, Any]:
     """
     Update the progress file based on actual markers in code.
-    
+
     Args:
         dry_run: Whether to show changes without modifying files
         verbose: Whether to show detailed information about changes
-        
+
     Returns:
         Dictionary containing update results
     """
     print("Updating progress file from actual markers in code...")
-    
+
     # Load progress file
     progress = test_utils_ext.load_progress_file()
-    
+
     if not progress:
         print("Cannot update: missing progress file")
-        return {
-            "success": False,
-            "error": "Missing progress file"
-        }
-    
+        return {"success": False, "error": "Missing progress file"}
+
     # Extract categorized tests from progress file
     progress_categorized = progress.get("categorized_tests", {})
-    
+
     # Collect all tests using the common test collector
     all_tests = test_collector.collect_tests()
-    
+
     # Check actual markers in code using the common test collector
     code_markers = {}
     for test_path in all_tests:
         has_marker, marker_type = test_collector.check_test_has_marker(test_path)
         if has_marker and marker_type in ["fast", "medium", "slow"]:
             code_markers[test_path] = marker_type
-    
+
     # Compare with progress file
     changes = {
         "tests_added": 0,
@@ -252,196 +251,245 @@ def update_progress_from_code(dry_run: bool = False, verbose: bool = False) -> D
         "tests_removed": 0,
         "tests_unchanged": 0,
         "total_before": len(progress_categorized),
-        "fast_before": sum(1 for marker in progress_categorized.values() if marker == "fast"),
-        "medium_before": sum(1 for marker in progress_categorized.values() if marker == "medium"),
-        "slow_before": sum(1 for marker in progress_categorized.values() if marker == "slow")
+        "fast_before": sum(
+            1 for marker in progress_categorized.values() if marker == "fast"
+        ),
+        "medium_before": sum(
+            1 for marker in progress_categorized.values() if marker == "medium"
+        ),
+        "slow_before": sum(
+            1 for marker in progress_categorized.values() if marker == "slow"
+        ),
     }
-    
+
     # Add or update tests with markers in code
     for test_path, marker in code_markers.items():
         if test_path not in progress_categorized:
             if verbose:
                 print(f"Adding test {test_path} with marker {marker}")
-            
+
             if not dry_run:
                 progress_categorized[test_path] = marker
-            
+
             changes["tests_added"] += 1
         elif progress_categorized[test_path] != marker:
             if verbose:
-                print(f"Updating test {test_path} from {progress_categorized[test_path]} to {marker}")
-            
+                print(
+                    f"Updating test {test_path} from {progress_categorized[test_path]} to {marker}"
+                )
+
             if not dry_run:
                 progress_categorized[test_path] = marker
-            
+
             changes["tests_updated"] += 1
         else:
             changes["tests_unchanged"] += 1
-    
+
     # Remove tests without markers in code
     tests_to_remove = []
     for test_path in progress_categorized:
         if test_path not in code_markers:
             if verbose:
-                print(f"Removing test {test_path} with marker {progress_categorized[test_path]}")
-            
+                print(
+                    f"Removing test {test_path} with marker {progress_categorized[test_path]}"
+                )
+
             tests_to_remove.append(test_path)
             changes["tests_removed"] += 1
-    
+
     if not dry_run:
         for test_path in tests_to_remove:
             del progress_categorized[test_path]
-    
+
     # Update progress file
     if not dry_run:
         progress["categorized_tests"] = progress_categorized
-        
+
         # Update counts
-        fast_count = sum(1 for marker in progress_categorized.values() if marker == "fast")
-        medium_count = sum(1 for marker in progress_categorized.values() if marker == "medium")
-        slow_count = sum(1 for marker in progress_categorized.values() if marker == "slow")
+        fast_count = sum(
+            1 for marker in progress_categorized.values() if marker == "fast"
+        )
+        medium_count = sum(
+            1 for marker in progress_categorized.values() if marker == "medium"
+        )
+        slow_count = sum(
+            1 for marker in progress_categorized.values() if marker == "slow"
+        )
         total_count = len(progress_categorized)
-        
+
         progress["categorization_counts"] = {
             "fast": fast_count,
             "medium": medium_count,
             "slow": slow_count,
-            "total": total_count
+            "total": total_count,
         }
-        
+
         # Save updated progress file
         test_utils_ext.save_progress_file(progress)
-    
+
     changes["total_after"] = len(progress_categorized)
-    changes["fast_after"] = sum(1 for marker in progress_categorized.values() if marker == "fast")
-    changes["medium_after"] = sum(1 for marker in progress_categorized.values() if marker == "medium")
-    changes["slow_after"] = sum(1 for marker in progress_categorized.values() if marker == "slow")
-    
-    return {
-        "success": True,
-        "changes": changes
-    }
+    changes["fast_after"] = sum(
+        1 for marker in progress_categorized.values() if marker == "fast"
+    )
+    changes["medium_after"] = sum(
+        1 for marker in progress_categorized.values() if marker == "medium"
+    )
+    changes["slow_after"] = sum(
+        1 for marker in progress_categorized.values() if marker == "slow"
+    )
+
+    return {"success": True, "changes": changes}
+
 
 def verify_consistency(verbose: bool = False) -> Dict[str, Any]:
     """
     Verify consistency between progress file, schedule file, and actual markers in code.
-    
+
     Args:
         verbose: Whether to show detailed information about discrepancies
-        
+
     Returns:
         Dictionary containing verification results
     """
-    print("Verifying consistency between progress file, schedule file, and actual markers in code...")
-    
+    print(
+        "Verifying consistency between progress file, schedule file, and actual markers in code..."
+    )
+
     # Load progress and schedule files
     progress = test_utils_ext.load_progress_file()
     schedule = test_utils_ext.load_schedule_file()
-    
+
     if not progress or not schedule:
         print("Cannot verify: missing progress or schedule file")
-        return {
-            "success": False,
-            "error": "Missing progress or schedule file"
-        }
-    
+        return {"success": False, "error": "Missing progress or schedule file"}
+
     # Extract categorized tests from progress file
     progress_categorized = progress.get("categorized_tests", {})
-    progress_counts = progress.get("categorization_counts", {
-        "fast": 0,
-        "medium": 0,
-        "slow": 0,
-        "total": 0
-    })
-    
+    progress_counts = progress.get(
+        "categorization_counts", {"fast": 0, "medium": 0, "slow": 0, "total": 0}
+    )
+
     # Extract total counts from schedule file
     schedule_total = schedule.get("total_tests", 0)
     schedule_categorized = schedule.get("total_categorized", 0)
     schedule_uncategorized = schedule.get("total_uncategorized", 0)
-    
+
     # Collect all tests using the common test collector
     all_tests = test_collector.collect_tests()
-    
+
     # Check actual markers in code using the common test collector
     code_markers = {}
     for test_path in all_tests:
         has_marker, marker_type = test_collector.check_test_has_marker(test_path)
         if has_marker and marker_type in ["fast", "medium", "slow"]:
             code_markers[test_path] = marker_type
-    
+
     # Calculate actual counts
     actual_total = len(all_tests)
     actual_categorized = len(code_markers)
     actual_uncategorized = actual_total - actual_categorized
-    
+
     # Verify progress file counts
-    progress_fast = sum(1 for marker in progress_categorized.values() if marker == "fast")
-    progress_medium = sum(1 for marker in progress_categorized.values() if marker == "medium")
-    progress_slow = sum(1 for marker in progress_categorized.values() if marker == "slow")
+    progress_fast = sum(
+        1 for marker in progress_categorized.values() if marker == "fast"
+    )
+    progress_medium = sum(
+        1 for marker in progress_categorized.values() if marker == "medium"
+    )
+    progress_slow = sum(
+        1 for marker in progress_categorized.values() if marker == "slow"
+    )
     progress_total = len(progress_categorized)
-    
+
     # Verify code marker counts
     code_fast = sum(1 for marker in code_markers.values() if marker == "fast")
     code_medium = sum(1 for marker in code_markers.values() if marker == "medium")
     code_slow = sum(1 for marker in code_markers.values() if marker == "slow")
-    
+
     # Check for discrepancies
     discrepancies = {
         "progress_vs_code": {
             "tests_in_progress_not_in_code": [],
             "tests_in_code_not_in_progress": [],
-            "tests_with_different_markers": []
+            "tests_with_different_markers": [],
         },
         "progress_vs_counts": {
             "fast": progress_counts.get("fast", 0) != progress_fast,
             "medium": progress_counts.get("medium", 0) != progress_medium,
             "slow": progress_counts.get("slow", 0) != progress_slow,
-            "total": progress_counts.get("total", 0) != progress_total
+            "total": progress_counts.get("total", 0) != progress_total,
         },
         "schedule_vs_actual": {
             "total": schedule_total != actual_total,
             "categorized": schedule_categorized != actual_categorized,
-            "uncategorized": schedule_uncategorized != actual_uncategorized
-        }
+            "uncategorized": schedule_uncategorized != actual_uncategorized,
+        },
     }
-    
+
     # Find tests in progress file but not in code
     for test_path in progress_categorized:
         if test_path not in code_markers:
-            discrepancies["progress_vs_code"]["tests_in_progress_not_in_code"].append(test_path)
-    
+            discrepancies["progress_vs_code"]["tests_in_progress_not_in_code"].append(
+                test_path
+            )
+
     # Find tests in code but not in progress file
     for test_path in code_markers:
         if test_path not in progress_categorized:
-            discrepancies["progress_vs_code"]["tests_in_code_not_in_progress"].append(test_path)
-    
+            discrepancies["progress_vs_code"]["tests_in_code_not_in_progress"].append(
+                test_path
+            )
+
     # Find tests with different markers
     for test_path in progress_categorized:
-        if test_path in code_markers and progress_categorized[test_path] != code_markers[test_path]:
-            discrepancies["progress_vs_code"]["tests_with_different_markers"].append({
-                "test_path": test_path,
-                "progress_marker": progress_categorized[test_path],
-                "code_marker": code_markers[test_path]
-            })
-    
+        if (
+            test_path in code_markers
+            and progress_categorized[test_path] != code_markers[test_path]
+        ):
+            discrepancies["progress_vs_code"]["tests_with_different_markers"].append(
+                {
+                    "test_path": test_path,
+                    "progress_marker": progress_categorized[test_path],
+                    "code_marker": code_markers[test_path],
+                }
+            )
+
     # Print discrepancies if verbose
     if verbose:
         print("\nDiscrepancies between progress file and code:")
-        print(f"  Tests in progress file but not in code: {len(discrepancies['progress_vs_code']['tests_in_progress_not_in_code'])}")
-        print(f"  Tests in code but not in progress file: {len(discrepancies['progress_vs_code']['tests_in_code_not_in_progress'])}")
-        print(f"  Tests with different markers: {len(discrepancies['progress_vs_code']['tests_with_different_markers'])}")
-        
+        print(
+            f"  Tests in progress file but not in code: {len(discrepancies['progress_vs_code']['tests_in_progress_not_in_code'])}"
+        )
+        print(
+            f"  Tests in code but not in progress file: {len(discrepancies['progress_vs_code']['tests_in_code_not_in_progress'])}"
+        )
+        print(
+            f"  Tests with different markers: {len(discrepancies['progress_vs_code']['tests_with_different_markers'])}"
+        )
+
         print("\nDiscrepancies in progress file counts:")
-        print(f"  Fast: {progress_counts.get('fast', 0)} (reported) vs {progress_fast} (actual)")
-        print(f"  Medium: {progress_counts.get('medium', 0)} (reported) vs {progress_medium} (actual)")
-        print(f"  Slow: {progress_counts.get('slow', 0)} (reported) vs {progress_slow} (actual)")
-        print(f"  Total: {progress_counts.get('total', 0)} (reported) vs {progress_total} (actual)")
-        
+        print(
+            f"  Fast: {progress_counts.get('fast', 0)} (reported) vs {progress_fast} (actual)"
+        )
+        print(
+            f"  Medium: {progress_counts.get('medium', 0)} (reported) vs {progress_medium} (actual)"
+        )
+        print(
+            f"  Slow: {progress_counts.get('slow', 0)} (reported) vs {progress_slow} (actual)"
+        )
+        print(
+            f"  Total: {progress_counts.get('total', 0)} (reported) vs {progress_total} (actual)"
+        )
+
         print("\nDiscrepancies in schedule file counts:")
         print(f"  Total: {schedule_total} (schedule) vs {actual_total} (actual)")
-        print(f"  Categorized: {schedule_categorized} (schedule) vs {actual_categorized} (actual)")
-        print(f"  Uncategorized: {schedule_uncategorized} (schedule) vs {actual_uncategorized} (actual)")
-    
+        print(
+            f"  Categorized: {schedule_categorized} (schedule) vs {actual_categorized} (actual)"
+        )
+        print(
+            f"  Uncategorized: {schedule_uncategorized} (schedule) vs {actual_uncategorized} (actual)"
+        )
+
     return {
         "success": True,
         "actual_counts": {
@@ -450,7 +498,7 @@ def verify_consistency(verbose: bool = False) -> Dict[str, Any]:
             "uncategorized": actual_uncategorized,
             "fast": code_fast,
             "medium": code_medium,
-            "slow": code_slow
+            "slow": code_slow,
         },
         "progress_counts": {
             "total": progress_total,
@@ -460,79 +508,103 @@ def verify_consistency(verbose: bool = False) -> Dict[str, Any]:
             "reported_total": progress_counts.get("total", 0),
             "reported_fast": progress_counts.get("fast", 0),
             "reported_medium": progress_counts.get("medium", 0),
-            "reported_slow": progress_counts.get("slow", 0)
+            "reported_slow": progress_counts.get("slow", 0),
         },
         "schedule_counts": {
             "total": schedule_total,
             "categorized": schedule_categorized,
-            "uncategorized": schedule_uncategorized
+            "uncategorized": schedule_uncategorized,
         },
-        "discrepancies": discrepancies
+        "discrepancies": discrepancies,
     }
+
 
 def generate_report(results: Dict[str, Any], report_file: str) -> None:
     """
     Generate a report of discrepancies.
-    
+
     Args:
         results: Dictionary containing verification results
         report_file: File to save the report to
     """
     print(f"Generating report to {report_file}...")
-    
+
     # Add timestamp to results
     results["timestamp"] = datetime.now().isoformat()
-    
+
     # Save report
-    with open(report_file, 'w') as f:
+    with open(report_file, "w") as f:
         json.dump(results, f, indent=2)
-    
+
     print(f"Report saved to {report_file}")
+
 
 def main():
     """Main function."""
     args = parse_args()
-    
+
     results = {}
-    
+
     if args.update_schedule:
-        results["update_schedule"] = update_schedule_from_progress(args.dry_run, args.verbose)
-    
+        results["update_schedule"] = update_schedule_from_progress(
+            args.dry_run, args.verbose
+        )
+
     if args.update_progress:
-        results["update_progress"] = update_progress_from_code(args.dry_run, args.verbose)
-    
+        results["update_progress"] = update_progress_from_code(
+            args.dry_run, args.verbose
+        )
+
     if args.verify or args.report:
         results["verify"] = verify_consistency(args.verbose)
-    
+
     if args.report:
         generate_report(results, args.report_file)
-    
+
     # Print summary
     print("\nSummary:")
-    
+
     if "update_schedule" in results:
         update_result = results["update_schedule"]
         if update_result["success"]:
             changes = update_result["changes"]
-            print(f"  Schedule file update: {changes['modules_updated']} modules updated, {changes['modules_added']} added")
-            print(f"  Total tests: {changes['total_tests_before']} -> {changes['total_tests_after']}")
-            print(f"  Categorized: {changes['total_categorized_before']} -> {changes['total_categorized_after']}")
-            print(f"  Uncategorized: {changes['total_uncategorized_before']} -> {changes['total_uncategorized_after']}")
+            print(
+                f"  Schedule file update: {changes['modules_updated']} modules updated, {changes['modules_added']} added"
+            )
+            print(
+                f"  Total tests: {changes['total_tests_before']} -> {changes['total_tests_after']}"
+            )
+            print(
+                f"  Categorized: {changes['total_categorized_before']} -> {changes['total_categorized_after']}"
+            )
+            print(
+                f"  Uncategorized: {changes['total_uncategorized_before']} -> {changes['total_uncategorized_after']}"
+            )
         else:
-            print(f"  Schedule file update failed: {update_result.get('error', 'Unknown error')}")
-    
+            print(
+                f"  Schedule file update failed: {update_result.get('error', 'Unknown error')}"
+            )
+
     if "update_progress" in results:
         update_result = results["update_progress"]
         if update_result["success"]:
             changes = update_result["changes"]
-            print(f"  Progress file update: {changes['tests_added']} tests added, {changes['tests_updated']} updated, {changes['tests_removed']} removed")
-            print(f"  Total tests: {changes['total_before']} -> {changes['total_after']}")
+            print(
+                f"  Progress file update: {changes['tests_added']} tests added, {changes['tests_updated']} updated, {changes['tests_removed']} removed"
+            )
+            print(
+                f"  Total tests: {changes['total_before']} -> {changes['total_after']}"
+            )
             print(f"  Fast tests: {changes['fast_before']} -> {changes['fast_after']}")
-            print(f"  Medium tests: {changes['medium_before']} -> {changes['medium_after']}")
+            print(
+                f"  Medium tests: {changes['medium_before']} -> {changes['medium_after']}"
+            )
             print(f"  Slow tests: {changes['slow_before']} -> {changes['slow_after']}")
         else:
-            print(f"  Progress file update failed: {update_result.get('error', 'Unknown error')}")
-    
+            print(
+                f"  Progress file update failed: {update_result.get('error', 'Unknown error')}"
+            )
+
     if "verify" in results:
         verify_result = results["verify"]
         if verify_result["success"]:
@@ -540,21 +612,36 @@ def main():
             progress = verify_result["progress_counts"]
             schedule = verify_result["schedule_counts"]
             discrepancies = verify_result["discrepancies"]
-            
+
             print(f"  Verification results:")
-            print(f"    Actual counts: {actual['total']} total, {actual['categorized']} categorized, {actual['uncategorized']} uncategorized")
-            print(f"    Progress counts: {progress['total']} total, {progress['fast']} fast, {progress['medium']} medium, {progress['slow']} slow")
-            print(f"    Schedule counts: {schedule['total']} total, {schedule['categorized']} categorized, {schedule['uncategorized']} uncategorized")
-            
+            print(
+                f"    Actual counts: {actual['total']} total, {actual['categorized']} categorized, {actual['uncategorized']} uncategorized"
+            )
+            print(
+                f"    Progress counts: {progress['total']} total, {progress['fast']} fast, {progress['medium']} medium, {progress['slow']} slow"
+            )
+            print(
+                f"    Schedule counts: {schedule['total']} total, {schedule['categorized']} categorized, {schedule['uncategorized']} uncategorized"
+            )
+
             print(f"    Discrepancies:")
-            print(f"      Tests in progress file but not in code: {len(discrepancies['progress_vs_code']['tests_in_progress_not_in_code'])}")
-            print(f"      Tests in code but not in progress file: {len(discrepancies['progress_vs_code']['tests_in_code_not_in_progress'])}")
-            print(f"      Tests with different markers: {len(discrepancies['progress_vs_code']['tests_with_different_markers'])}")
+            print(
+                f"      Tests in progress file but not in code: {len(discrepancies['progress_vs_code']['tests_in_progress_not_in_code'])}"
+            )
+            print(
+                f"      Tests in code but not in progress file: {len(discrepancies['progress_vs_code']['tests_in_code_not_in_progress'])}"
+            )
+            print(
+                f"      Tests with different markers: {len(discrepancies['progress_vs_code']['tests_with_different_markers'])}"
+            )
         else:
-            print(f"  Verification failed: {verify_result.get('error', 'Unknown error')}")
-    
+            print(
+                f"  Verification failed: {verify_result.get('error', 'Unknown error')}"
+            )
+
     if args.report:
         print(f"  Report generated: {args.report_file}")
+
 
 if __name__ == "__main__":
     main()

--- a/scripts/test_categorization_schedule_fixed.py
+++ b/scripts/test_categorization_schedule_fixed.py
@@ -25,18 +25,17 @@ Options:
     --verbose            Show detailed information about changes
 """
 
-import os
-import sys
-import json
 import argparse
 import datetime
+import json
+import os
 import subprocess
+import sys
 from pathlib import Path
-from typing import Dict, List, Set, Tuple, Any, Optional
+from typing import Any, Dict, List, Optional, Set, Tuple
 
 # Import enhanced test utilities
-sys.path.append(os.path.dirname(os.path.abspath(__file__)))
-import test_utils_extended as test_utils_ext
+from . import test_utils_extended as test_utils_ext
 
 # Schedule and progress files
 SCHEDULE_FILE = ".test_categorization_schedule.json"
@@ -46,10 +45,10 @@ PROGRESS_FILE = ".test_categorization_progress.json"
 HIGH_PRIORITY_MODULES = [
     "tests/unit/application/cli",  # CLI components
     "tests/unit/adapters/memory",  # Memory adapters
-    "tests/unit/adapters/llm",     # LLM adapters
-    "tests/integration/memory",    # Memory integration
-    "tests/unit/application/wsde", # WSDE components
-    "tests/unit/application/webui" # WebUI components
+    "tests/unit/adapters/llm",  # LLM adapters
+    "tests/integration/memory",  # Memory integration
+    "tests/unit/application/wsde",  # WSDE components
+    "tests/unit/application/webui",  # WebUI components
 ]
 
 # Test categories - ensure consistency with test_metrics_optimized.py
@@ -61,98 +60,100 @@ TEST_CATEGORIES = {
     "property": "tests/property",
 }
 
+
 def parse_args():
     """Parse command line arguments."""
     parser = argparse.ArgumentParser(
-        description='Implement a schedule for categorizing remaining tests.'
+        description="Implement a schedule for categorizing remaining tests."
     )
     parser.add_argument(
-        '--generate-schedule',
-        action='store_true',
-        help='Generate a new categorization schedule'
+        "--generate-schedule",
+        action="store_true",
+        help="Generate a new categorization schedule",
     )
     parser.add_argument(
-        '--update-progress',
-        action='store_true',
-        help='Update the progress of the categorization schedule'
+        "--update-progress",
+        action="store_true",
+        help="Update the progress of the categorization schedule",
     )
     parser.add_argument(
-        '--run-scheduled',
-        action='store_true',
-        help='Run the scheduled categorization for today'
+        "--run-scheduled",
+        action="store_true",
+        help="Run the scheduled categorization for today",
     )
     parser.add_argument(
-        '--list-schedule',
-        action='store_true',
-        help='List the current categorization schedule'
+        "--list-schedule",
+        action="store_true",
+        help="List the current categorization schedule",
     )
     parser.add_argument(
-        '--priority-only',
-        action='store_true',
-        help='Only include high-priority modules in the schedule'
+        "--priority-only",
+        action="store_true",
+        help="Only include high-priority modules in the schedule",
     )
     parser.add_argument(
-        '--days',
+        "--days",
         type=int,
         default=14,
-        help='Number of days to spread the categorization over (default: 14)'
+        help="Number of days to spread the categorization over (default: 14)",
     )
     parser.add_argument(
-        '--batch-size',
+        "--batch-size",
         type=int,
         default=100,
-        help='Number of tests to categorize in each batch (default: 100)'
+        help="Number of tests to categorize in each batch (default: 100)",
     )
     parser.add_argument(
-        '--dry-run',
-        action='store_true',
-        help='Show what would be done without making changes'
+        "--dry-run",
+        action="store_true",
+        help="Show what would be done without making changes",
     )
     parser.add_argument(
-        '--update-from-progress',
-        action='store_true',
-        help='Update schedule file based on progress file'
+        "--update-from-progress",
+        action="store_true",
+        help="Update schedule file based on progress file",
     )
     parser.add_argument(
-        '--verbose',
-        action='store_true',
-        help='Show detailed information about changes'
+        "--verbose", action="store_true", help="Show detailed information about changes"
     )
     return parser.parse_args()
+
 
 def collect_all_test_modules() -> List[str]:
     """
     Collect all test modules in the project.
-    
+
     Returns:
         List of test module paths
     """
     test_modules = []
-    
+
     # Walk the tests directory
-    for root, dirs, files in os.walk('tests'):
+    for root, dirs, files in os.walk("tests"):
         # Skip cache directories
-        if '.test_cache' in root or '.pytest_cache' in root:
+        if ".test_cache" in root or ".pytest_cache" in root:
             continue
-        
+
         # Check if this directory contains test files
-        has_test_files = any(f.startswith('test_') and f.endswith('.py') for f in files)
-        
+        has_test_files = any(f.startswith("test_") and f.endswith(".py") for f in files)
+
         if has_test_files:
             # Add this directory as a test module
             test_modules.append(root)
-    
+
     return test_modules
 
+
 # This function is replaced by test_utils.collect_tests
+
 
 def count_tests_in_module(module_path: str) -> int:
     """
     Count the number of tests in a module.
-    
+
     Args:
         module_path: Path to the test module
-        
+
     Returns:
         Number of tests in the module
     """
@@ -162,112 +163,124 @@ def count_tests_in_module(module_path: str) -> int:
         if module_path.startswith(path):
             category = cat
             break
-    
+
     if not category:
         return 0
-    
+
     # Get the test directory for this category
     test_dir = TEST_CATEGORIES[category]
-    
+
     # Collect all tests in the category
     if category == "behavior":
         all_tests = test_utils_ext.collect_behavior_tests(test_dir)
     else:
         all_tests = test_utils_ext.test_utils.collect_tests(test_dir)
-    
+
     # Count tests that belong to this module
     test_count = sum(1 for test in all_tests if test.startswith(module_path))
-    
+
     return test_count
+
 
 def count_categorized_tests_in_module(module_path: str) -> Tuple[int, Dict[str, int]]:
     """
     Count the number of tests in a module that have speed markers, using a more accurate approach.
-    
+
     Args:
         module_path: Path to the test module
-        
+
     Returns:
         Tuple of (categorized_count, marker_counts)
     """
     # Use the improved function from test_utils_extended
-    total_tests, categorized_count, marker_counts = test_utils_ext.count_categorized_tests_accurately(module_path)
-    
+    total_tests, categorized_count, marker_counts = (
+        test_utils_ext.count_categorized_tests_accurately(module_path)
+    )
+
     return categorized_count, marker_counts
+
 
 def generate_schedule(args) -> Dict[str, Any]:
     """
     Generate a schedule for categorizing remaining tests.
-    
+
     Args:
         args: Command-line arguments
-        
+
     Returns:
         Dictionary containing the schedule
     """
     print("Generating test categorization schedule...")
-    
+
     # Collect all test modules
     all_modules = collect_all_test_modules()
-    
+
     # Filter to high-priority modules if requested
     if args.priority_only:
-        modules = [m for m in all_modules if any(m.startswith(hp) for hp in HIGH_PRIORITY_MODULES)]
+        modules = [
+            m
+            for m in all_modules
+            if any(m.startswith(hp) for hp in HIGH_PRIORITY_MODULES)
+        ]
     else:
         # Start with high-priority modules, then add the rest
         modules = []
         for hp in HIGH_PRIORITY_MODULES:
             modules.extend([m for m in all_modules if m.startswith(hp)])
-        
+
         # Add remaining modules
         for m in all_modules:
             if not any(m.startswith(hp) for hp in HIGH_PRIORITY_MODULES):
                 modules.append(m)
-    
+
     # Count tests in each module
     module_test_counts = {}
     total_tests = 0
     total_categorized = 0
-    
+
     for module in modules:
         test_count = count_tests_in_module(module)
         categorized_count, marker_counts = count_categorized_tests_in_module(module)
         uncategorized_count = test_count - categorized_count
-        
+
         if uncategorized_count > 0:
             module_test_counts[module] = {
-                'total': test_count,
-                'categorized': categorized_count,
-                'uncategorized': uncategorized_count,
-                'marker_counts': marker_counts
+                "total": test_count,
+                "categorized": categorized_count,
+                "uncategorized": uncategorized_count,
+                "marker_counts": marker_counts,
             }
             total_tests += test_count
             total_categorized += categorized_count
-    
+
     # Calculate total uncategorized tests
     total_uncategorized = total_tests - total_categorized
-    
+
     # Calculate tests per day
     days = args.days
     tests_per_day = (total_uncategorized + days - 1) // days  # Ceiling division
-    
+
     # Create daily schedule
     daily_schedule = {}
     remaining_modules = list(module_test_counts.keys())
     remaining_tests = total_uncategorized
-    
+
     for day in range(1, days + 1):
         day_key = f"day_{day}"
-        day_date = (datetime.datetime.now() + datetime.timedelta(days=day-1)).date().isoformat()
-        
+        day_date = (
+            (datetime.datetime.now() + datetime.timedelta(days=day - 1))
+            .date()
+            .isoformat()
+        )
+
         # Allocate modules for this day
         day_modules = []
         day_tests = 0
-        
+
         while remaining_modules and day_tests < tests_per_day:
             module = remaining_modules[0]
-            module_tests = module_test_counts[module]['uncategorized']
-            
+            module_tests = module_test_counts[module]["uncategorized"]
+
             if day_tests + module_tests <= tests_per_day or not day_modules:
                 # Add this module to today's schedule
                 day_modules.append(module)
@@ -276,34 +289,35 @@ def generate_schedule(args) -> Dict[str, Any]:
             else:
                 # This module would exceed today's quota, try the next one
                 break
-        
+
         daily_schedule[day_key] = {
-            'date': day_date,
-            'modules': day_modules,
-            'total_tests': day_tests
+            "date": day_date,
+            "modules": day_modules,
+            "total_tests": day_tests,
         }
-        
+
         remaining_tests -= day_tests
-    
+
     # Create the schedule
     schedule = {
-        'generated_at': datetime.datetime.now().isoformat(),
-        'total_tests': total_tests,
-        'total_categorized': total_categorized,
-        'total_uncategorized': total_uncategorized,
-        'days': days,
-        'tests_per_day': tests_per_day,
-        'batch_size': args.batch_size,
-        'module_test_counts': module_test_counts,
-        'daily_schedule': daily_schedule
+        "generated_at": datetime.datetime.now().isoformat(),
+        "total_tests": total_tests,
+        "total_categorized": total_categorized,
+        "total_uncategorized": total_uncategorized,
+        "days": days,
+        "tests_per_day": tests_per_day,
+        "batch_size": args.batch_size,
+        "module_test_counts": module_test_counts,
+        "daily_schedule": daily_schedule,
     }
-    
+
     return schedule
+
 
 def save_schedule(schedule: Dict[str, Any], dry_run: bool = False) -> None:
     """
     Save the schedule to a file.
-    
+
     Args:
         schedule: Schedule to save
         dry_run: Whether to show changes without making them
@@ -311,138 +325,148 @@ def save_schedule(schedule: Dict[str, Any], dry_run: bool = False) -> None:
     if dry_run:
         print(f"Would save schedule to {SCHEDULE_FILE}")
         return
-    
+
     # Use the function from test_utils_extended
     test_utils_ext.save_schedule_file(schedule, SCHEDULE_FILE)
+
 
 def load_schedule() -> Dict[str, Any]:
     """
     Load the schedule from a file.
-    
+
     Returns:
         Dictionary containing the schedule
     """
     # Use the function from test_utils_extended
     return test_utils_ext.load_schedule_file(SCHEDULE_FILE)
 
+
 def update_progress(args) -> None:
     """
     Update the progress of the categorization schedule.
-    
+
     Args:
         args: Command-line arguments
     """
     print("Updating categorization progress...")
-    
+
     # Load the schedule
     schedule = load_schedule()
     if not schedule:
         print("No schedule found. Generate a schedule first.")
         return
-    
+
     # Count tests in each module
-    module_test_counts = schedule['module_test_counts']
+    module_test_counts = schedule["module_test_counts"]
     total_tests = 0
     total_categorized = 0
-    
+
     for module, counts in module_test_counts.items():
         test_count = count_tests_in_module(module)
         categorized_count, marker_counts = count_categorized_tests_in_module(module)
         uncategorized_count = test_count - categorized_count
-        
+
         module_test_counts[module] = {
-            'total': test_count,
-            'categorized': categorized_count,
-            'uncategorized': uncategorized_count,
-            'marker_counts': marker_counts
+            "total": test_count,
+            "categorized": categorized_count,
+            "uncategorized": uncategorized_count,
+            "marker_counts": marker_counts,
         }
-        
+
         total_tests += test_count
         total_categorized += categorized_count
-    
+
     # Calculate total uncategorized tests
     total_uncategorized = total_tests - total_categorized
-    
+
     # Update the schedule
-    schedule['total_tests'] = total_tests
-    schedule['total_categorized'] = total_categorized
-    schedule['total_uncategorized'] = total_uncategorized
-    schedule['updated_at'] = datetime.datetime.now().isoformat()
-    
+    schedule["total_tests"] = total_tests
+    schedule["total_categorized"] = total_categorized
+    schedule["total_uncategorized"] = total_uncategorized
+    schedule["updated_at"] = datetime.datetime.now().isoformat()
+
     # Save the updated schedule
     save_schedule(schedule, args.dry_run)
-    
+
     # Print progress
-    print(f"Progress: {total_categorized}/{total_tests} tests categorized ({total_categorized/total_tests*100:.1f}%)")
+    print(
+        f"Progress: {total_categorized}/{total_tests} tests categorized ({total_categorized/total_tests*100:.1f}%)"
+    )
     print(f"Remaining: {total_uncategorized} tests")
+
 
 def run_scheduled_categorization(args) -> None:
     """
     Run the scheduled categorization for today.
-    
+
     Args:
         args: Command-line arguments
     """
     print("Running scheduled categorization for today...")
-    
+
     # Load the schedule
     schedule = load_schedule()
     if not schedule:
         print("No schedule found. Generate a schedule first.")
         return
-    
+
     # Find today's schedule
     today = datetime.datetime.now().date()
     today_key = None
-    
-    for day_key, day_schedule in schedule['daily_schedule'].items():
-        day_date = datetime.datetime.fromisoformat(day_schedule['date']).date()
+
+    for day_key, day_schedule in schedule["daily_schedule"].items():
+        day_date = datetime.datetime.fromisoformat(day_schedule["date"]).date()
         if day_date == today:
             today_key = day_key
             break
-    
+
     if not today_key:
         print(f"No categorization scheduled for today ({today.isoformat()})")
         return
-    
+
     # Get the modules to categorize today
-    modules = schedule['daily_schedule'][today_key]['modules']
-    
+    modules = schedule["daily_schedule"][today_key]["modules"]
+
     if not modules:
         print("No modules to categorize today")
         return
-    
+
     print(f"Categorizing {len(modules)} modules today:")
     for module in modules:
         print(f"  - {module}")
-    
+
     # Run the categorization for each module
     for module in modules:
         print(f"\nCategorizing tests in {module}...")
-        
+
         # Build the command
         cmd = [
-            'python', 'scripts/incremental_test_categorization.py',
-            '--module', module,
-            '--batch-size', str(args.batch_size),
-            '--max-tests', str(schedule['tests_per_day']),
-            '--update'
+            "python",
+            "scripts/incremental_test_categorization.py",
+            "--module",
+            module,
+            "--batch-size",
+            str(args.batch_size),
+            "--max-tests",
+            str(schedule["tests_per_day"]),
+            "--update",
         ]
-        
+
         if args.dry_run:
             print(f"Would run: {' '.join(cmd)}")
         else:
             # Run the command
             subprocess.run(cmd)
-    
+
     # Update the progress
     if not args.dry_run:
         update_progress(args)
 
+
 def list_schedule(args) -> None:
     """
     List the current categorization schedule.
-    
+
     Args:
         args: Command-line arguments
     """
@@ -451,90 +475,104 @@ def list_schedule(args) -> None:
     if not schedule:
         print("No schedule found. Generate a schedule first.")
         return
-    
+
     # Print schedule information
     print("\nTest Categorization Schedule")
     print("===========================")
-    print(f"Generated: {datetime.datetime.fromisoformat(schedule['generated_at']).strftime('%Y-%m-%d %H:%M:%S')}")
-    
-    if 'updated_at' in schedule:
-        print(f"Last updated: {datetime.datetime.fromisoformat(schedule['updated_at']).strftime('%Y-%m-%d %H:%M:%S')}")
-    
+    print(
+        f"Generated: {datetime.datetime.fromisoformat(schedule['generated_at']).strftime('%Y-%m-%d %H:%M:%S')}"
+    )
+
+    if "updated_at" in schedule:
+        print(
+            f"Last updated: {datetime.datetime.fromisoformat(schedule['updated_at']).strftime('%Y-%m-%d %H:%M:%S')}"
+        )
+
     print(f"\nTotal tests: {schedule['total_tests']}")
-    print(f"Categorized: {schedule['total_categorized']} ({schedule['total_categorized']/schedule['total_tests']*100:.1f}%)")
-    print(f"Uncategorized: {schedule['total_uncategorized']} ({schedule['total_uncategorized']/schedule['total_tests']*100:.1f}%)")
-    
+    print(
+        f"Categorized: {schedule['total_categorized']} ({schedule['total_categorized']/schedule['total_tests']*100:.1f}%)"
+    )
+    print(
+        f"Uncategorized: {schedule['total_uncategorized']} ({schedule['total_uncategorized']/schedule['total_tests']*100:.1f}%)"
+    )
+
     # Calculate total marker counts
     total_marker_counts = {"fast": 0, "medium": 0, "slow": 0}
-    for module, counts in schedule['module_test_counts'].items():
-        if 'marker_counts' in counts:
-            for marker, count in counts['marker_counts'].items():
+    for module, counts in schedule["module_test_counts"].items():
+        if "marker_counts" in counts:
+            for marker, count in counts["marker_counts"].items():
                 total_marker_counts[marker] += count
-    
+
     # Print total marker counts
     print(f"Fast tests: {total_marker_counts['fast']}")
     print(f"Medium tests: {total_marker_counts['medium']}")
     print(f"Slow tests: {total_marker_counts['slow']}")
-    
+
     print(f"\nSchedule duration: {schedule['days']} days")
     print(f"Tests per day: ~{schedule['tests_per_day']}")
     print(f"Batch size: {schedule['batch_size']}")
-    
+
     # Print daily schedule
     print("\nDaily Schedule:")
-    for day_key, day_schedule in sorted(schedule['daily_schedule'].items()):
-        day_num = int(day_key.split('_')[1])
-        day_date = datetime.datetime.fromisoformat(day_schedule['date']).date()
+    for day_key, day_schedule in sorted(schedule["daily_schedule"].items()):
+        day_num = int(day_key.split("_")[1])
+        day_date = datetime.datetime.fromisoformat(day_schedule["date"]).date()
         today = datetime.datetime.now().date()
-        
+
         status = ""
         if day_date < today:
             status = " (past)"
         elif day_date == today:
             status = " (today)"
-        
+
         print(f"\nDay {day_num} - {day_date.isoformat()}{status}")
         print(f"Modules to categorize: {len(day_schedule['modules'])}")
         print(f"Total tests: {day_schedule['total_tests']}")
-        
-        for module in day_schedule['modules']:
-            counts = schedule['module_test_counts'][module]
+
+        for module in day_schedule["modules"]:
+            counts = schedule["module_test_counts"][module]
             print(f"  - {module}: {counts['uncategorized']} uncategorized tests")
-            
+
             # Print marker counts if available
-            if 'marker_counts' in counts and args.verbose:
-                marker_counts = counts['marker_counts']
+            if "marker_counts" in counts and args.verbose:
+                marker_counts = counts["marker_counts"]
                 print(f"    - Fast: {marker_counts.get('fast', 0)}")
                 print(f"    - Medium: {marker_counts.get('medium', 0)}")
                 print(f"    - Slow: {marker_counts.get('slow', 0)}")
 
+
 def update_from_progress(args) -> None:
     """
     Update the schedule file based on the progress file.
-    
+
     Args:
         args: Command-line arguments
     """
     print("Updating schedule file from progress file...")
-    
+
     # Use the synchronize_test_categorization function from test_utils_extended
     results = test_utils_ext.synchronize_test_categorization()
-    
+
     if results["success"]:
         print(f"Schedule updated successfully.")
         print(f"Total tests: {results['total_tests']}")
-        print(f"Categorized: {results['total_categorized']} ({results['total_categorized']/results['total_tests']*100:.1f}%)")
-        print(f"Uncategorized: {results['total_uncategorized']} ({results['total_uncategorized']/results['total_tests']*100:.1f}%)")
+        print(
+            f"Categorized: {results['total_categorized']} ({results['total_categorized']/results['total_tests']*100:.1f}%)"
+        )
+        print(
+            f"Uncategorized: {results['total_uncategorized']} ({results['total_uncategorized']/results['total_tests']*100:.1f}%)"
+        )
         print(f"Fast tests: {results['fast_tests']}")
         print(f"Medium tests: {results['medium_tests']}")
         print(f"Slow tests: {results['slow_tests']}")
     else:
         print(f"Failed to update schedule: {results.get('error', 'Unknown error')}")
 
+
 def main() -> None:
     """Main function."""
     args = parse_args()
-    
+
     if args.generate_schedule:
         schedule = generate_schedule(args)
         save_schedule(schedule, args.dry_run)
@@ -547,7 +585,10 @@ def main() -> None:
     elif args.update_from_progress:
         update_from_progress(args)
     else:
-        print("No action specified. Use --generate-schedule, --update-progress, --run-scheduled, --list-schedule, or --update-from-progress.")
+        print(
+            "No action specified. Use --generate-schedule, --update-progress, --run-scheduled, --list-schedule, or --update-from-progress."
+        )
+
 
 if __name__ == "__main__":
     main()

--- a/scripts/test_utils_bdd.py
+++ b/scripts/test_utils_bdd.py
@@ -7,184 +7,200 @@ particularly for test collection, marker verification, and marker application.
 It's designed to work with pytest-bdd tests that use @given, @when, @then decorators.
 """
 
-import os
-import sys
-import re
 import json
+import os
+import re
 from pathlib import Path
-from typing import Dict, List, Set, Tuple, Any, Optional, Union
+from typing import Any, Dict, List, Optional, Set, Tuple, Union
 
 # Import original test_utils and common test collector
-sys.path.append(os.path.dirname(os.path.abspath(__file__)))
-import test_utils
-import test_utils_extended
-import common_test_collector
+from . import common_test_collector, test_utils, test_utils_extended
 
 # Constants
 CACHE_DIR = ".test_timing_cache"
 
 # Enhanced patterns for BDD-style tests
-BDD_DECORATOR_PATTERN = re.compile(r'@(given|when|then|scenario|scenarios)')
-BDD_FUNCTION_PATTERN = re.compile(r'def (\w+)\(')
-MARKER_PATTERN = re.compile(r'@pytest\.mark\.(fast|medium|slow|isolation)')
+BDD_DECORATOR_PATTERN = re.compile(r"@(given|when|then|scenario|scenarios)")
+BDD_FUNCTION_PATTERN = re.compile(r"def (\w+)\(")
+MARKER_PATTERN = re.compile(r"@pytest\.mark\.(fast|medium|slow|isolation)")
+
 
 def find_bdd_step_files(test_dir: str = "tests/behavior/steps") -> List[str]:
     """
     Find all BDD step definition files.
-    
+
     Args:
         test_dir: Directory containing BDD step definitions
-        
+
     Returns:
         List of step definition file paths
     """
     step_files = []
-    
+
     for root, _, files in os.walk(test_dir):
         for file in files:
-            if file.endswith('.py') and file.startswith('test_'):
+            if file.endswith(".py") and file.startswith("test_"):
                 step_files.append(os.path.join(root, file))
-    
+
     return step_files
+
 
 def find_feature_files(test_dir: str = "tests/behavior/features") -> List[str]:
     """
     Find all feature files.
-    
+
     Args:
         test_dir: Directory containing feature files
-        
+
     Returns:
         List of feature file paths
     """
     feature_files = []
-    
+
     for root, _, files in os.walk(test_dir):
         for file in files:
-            if file.endswith('.feature'):
+            if file.endswith(".feature"):
                 feature_files.append(os.path.join(root, file))
-    
+
     return feature_files
+
 
 def extract_bdd_test_info(file_path: str) -> Dict[str, Any]:
     """
     Extract information about BDD tests from a step definition file.
-    
+
     Args:
         file_path: Path to the step definition file
-        
+
     Returns:
         Dictionary containing test information
     """
     if not os.path.exists(file_path):
         return {"file_path": file_path, "test_functions": [], "feature_files": []}
-    
-    with open(file_path, 'r') as f:
+
+    with open(file_path, "r") as f:
         content = f.read()
-    
+
     # Extract test functions
     test_functions = []
-    lines = content.split('\n')
-    
+    lines = content.split("\n")
+
     # Track decorators and functions
     current_decorators = []
-    
+
     for i, line in enumerate(lines):
         # Check for BDD decorators
         if BDD_DECORATOR_PATTERN.search(line):
             current_decorators.append((i, line.strip()))
-        
+
         # Check for function definitions
         func_match = BDD_FUNCTION_PATTERN.search(line)
         if func_match and current_decorators:
             func_name = func_match.group(1)
-            
+
             # Check if this is a test function (has BDD decorators)
-            if any(d[1].startswith('@given') or d[1].startswith('@when') or 
-                   d[1].startswith('@then') or d[1].startswith('@scenario') for d in current_decorators):
-                
+            if any(
+                d[1].startswith("@given")
+                or d[1].startswith("@when")
+                or d[1].startswith("@then")
+                or d[1].startswith("@scenario")
+                for d in current_decorators
+            ):
+
                 # Check for existing markers
-                has_marker = any(MARKER_PATTERN.search(lines[j]) for j in range(max(0, i-len(current_decorators)-3), i))
-                
-                test_functions.append({
-                    "name": func_name,
-                    "line": i,
-                    "decorators": current_decorators,
-                    "has_marker": has_marker
-                })
-            
+                has_marker = any(
+                    MARKER_PATTERN.search(lines[j])
+                    for j in range(max(0, i - len(current_decorators) - 3), i)
+                )
+
+                test_functions.append(
+                    {
+                        "name": func_name,
+                        "line": i,
+                        "decorators": current_decorators,
+                        "has_marker": has_marker,
+                    }
+                )
+
             current_decorators = []
-    
+
     # Extract feature files
     feature_files = []
     scenarios_match = re.search(r'scenarios\([\'"](.+?)[\'"]', content)
     if scenarios_match:
         feature_path = scenarios_match.group(1)
         feature_files.append(feature_path)
-    
-    scenario_matches = re.finditer(r'@scenario\([\'"](.+?)[\'"],\s*[\'"](.+?)[\'"]\)', content)
+
+    scenario_matches = re.finditer(
+        r'@scenario\([\'"](.+?)[\'"],\s*[\'"](.+?)[\'"]\)', content
+    )
     for match in scenario_matches:
         feature_path = match.group(1)
         if feature_path not in feature_files:
             feature_files.append(feature_path)
-    
+
     return {
         "file_path": file_path,
         "test_functions": test_functions,
-        "feature_files": feature_files
+        "feature_files": feature_files,
     }
 
+
 def update_bdd_test_file(
-    file_path: str, 
-    marker: str,
-    dry_run: bool = False
+    file_path: str, marker: str, dry_run: bool = False
 ) -> Tuple[int, int, int]:
     """
     Update a BDD test file with appropriate markers.
-    
+
     Args:
         file_path: Path to the test file
         marker: Marker to apply (fast, medium, slow)
         dry_run: Whether to show changes without modifying files
-        
+
     Returns:
         Tuple containing counts of (added, updated, unchanged) markers
     """
     added = 0
     updated = 0
     unchanged = 0
-    
+
     # Extract test information
     test_info = extract_bdd_test_info(file_path)
-    
+
     if not test_info["test_functions"]:
         return 0, 0, 0
-    
-    with open(file_path, 'r') as f:
+
+    with open(file_path, "r") as f:
         lines = f.readlines()
-    
+
     modified_lines = lines.copy()
     line_offset = 0  # Track line number changes due to insertions
-    
+
     for func in test_info["test_functions"]:
         # Skip functions that already have the correct marker
         if func["has_marker"]:
             # Check if it's the same marker
             for i in range(max(0, func["line"] - 10), func["line"]):
-                if i < len(lines) and f'@pytest.mark.{marker}' in lines[i]:
+                if i < len(lines) and f"@pytest.mark.{marker}" in lines[i]:
                     unchanged += 1
                     break
             else:
                 # Has a different marker, need to update
-                for i in range(max(0, func["line"] + line_offset - 10), func["line"] + line_offset):
-                    if i < len(modified_lines) and MARKER_PATTERN.search(modified_lines[i]):
+                for i in range(
+                    max(0, func["line"] + line_offset - 10), func["line"] + line_offset
+                ):
+                    if i < len(modified_lines) and MARKER_PATTERN.search(
+                        modified_lines[i]
+                    ):
                         old_line = modified_lines[i]
                         modified_lines[i] = old_line.replace(
-                            f'@pytest.mark.{MARKER_PATTERN.search(old_line).group(1)}',
-                            f'@pytest.mark.{marker}'
+                            f"@pytest.mark.{MARKER_PATTERN.search(old_line).group(1)}",
+                            f"@pytest.mark.{marker}",
                         )
                         if dry_run:
-                            print(f"Would update {file_path}:{i+1} - {old_line.strip()} -> {modified_lines[i].strip()}")
+                            print(
+                                f"Would update {file_path}:{i+1} - {old_line.strip()} -> {modified_lines[i].strip()}"
+                            )
                         updated += 1
                         break
         else:
@@ -192,69 +208,78 @@ def update_bdd_test_file(
             # Find the last decorator line
             if func["decorators"]:
                 last_decorator_line = func["decorators"][-1][0]
-                
+
                 # Insert marker after the last decorator
-                indent = re.match(r'(\s*)', modified_lines[last_decorator_line + line_offset]).group(1)
-                marker_line = f'{indent}@pytest.mark.{marker}\n'
-                modified_lines.insert(last_decorator_line + line_offset + 1, marker_line)
+                indent = re.match(
+                    r"(\s*)", modified_lines[last_decorator_line + line_offset]
+                ).group(1)
+                marker_line = f"{indent}@pytest.mark.{marker}\n"
+                modified_lines.insert(
+                    last_decorator_line + line_offset + 1, marker_line
+                )
                 line_offset += 1
-                
+
                 if dry_run:
-                    print(f"Would add to {file_path}:{last_decorator_line+2} - {marker_line.strip()}")
+                    print(
+                        f"Would add to {file_path}:{last_decorator_line+2} - {marker_line.strip()}"
+                    )
                 added += 1
-    
+
     # Write changes back to the file
     if not dry_run and (added > 0 or updated > 0):
-        with open(file_path, 'w') as f:
+        with open(file_path, "w") as f:
             f.writelines(modified_lines)
-    
+
     return added, updated, unchanged
+
 
 def categorize_bdd_tests(
     test_dir: str = "tests/behavior/steps",
     marker: str = "medium",
     dry_run: bool = False,
-    max_files: Optional[int] = None
+    max_files: Optional[int] = None,
 ) -> Dict[str, int]:
     """
     Categorize BDD tests with appropriate markers.
-    
+
     Args:
         test_dir: Directory containing BDD step definitions
         marker: Marker to apply (fast, medium, slow)
         dry_run: Whether to show changes without modifying files
         max_files: Maximum number of files to process
-        
+
     Returns:
         Dictionary containing counts of added, updated, and unchanged markers
     """
     step_files = find_bdd_step_files(test_dir)
-    
+
     if max_files:
         step_files = step_files[:max_files]
-    
+
     total_added = 0
     total_updated = 0
     total_unchanged = 0
     total_files_modified = 0
-    
+
     print(f"Found {len(step_files)} BDD step files")
     print(f"Applying {marker} marker to BDD tests...")
-    
+
     for file_path in step_files:
         added, updated, unchanged = update_bdd_test_file(file_path, marker, dry_run)
-        
+
         total_added += added
         total_updated += updated
         total_unchanged += unchanged
-        
+
         if added > 0 or updated > 0:
             total_files_modified += 1
-            
+
         if added > 0 or updated > 0 or unchanged > 0:
             status = "would be modified" if dry_run else "modified"
-            print(f"{file_path}: {added} added, {updated} updated, {unchanged} unchanged ({status})")
-    
+            print(
+                f"{file_path}: {added} added, {updated} updated, {unchanged} unchanged ({status})"
+            )
+
     # Invalidate cache after modifications
     if not dry_run and (total_added > 0 or total_updated > 0):
         try:
@@ -262,31 +287,49 @@ def categorize_bdd_tests(
             print("Cache invalidated for modified files")
         except Exception as e:
             print(f"Warning: Failed to invalidate cache: {e}")
-    
+
     return {
         "added": total_added,
         "updated": total_updated,
         "unchanged": total_unchanged,
         "files_modified": total_files_modified,
-        "total_files": len(step_files)
+        "total_files": len(step_files),
     }
+
 
 def main():
     """Main function."""
     import argparse
-    
-    parser = argparse.ArgumentParser(description='Utilities for BDD-style tests')
-    parser.add_argument('--categorize', action='store_true', help='Categorize BDD tests with markers')
-    parser.add_argument('--marker', choices=['fast', 'medium', 'slow'], default='medium', help='Marker to apply')
-    parser.add_argument('--dry-run', action='store_true', help='Show changes without modifying files')
-    parser.add_argument('--max-files', type=int, help='Maximum number of files to process')
-    parser.add_argument('--dir', default='tests/behavior/steps', help='Directory containing BDD step definitions')
-    
+
+    parser = argparse.ArgumentParser(description="Utilities for BDD-style tests")
+    parser.add_argument(
+        "--categorize", action="store_true", help="Categorize BDD tests with markers"
+    )
+    parser.add_argument(
+        "--marker",
+        choices=["fast", "medium", "slow"],
+        default="medium",
+        help="Marker to apply",
+    )
+    parser.add_argument(
+        "--dry-run", action="store_true", help="Show changes without modifying files"
+    )
+    parser.add_argument(
+        "--max-files", type=int, help="Maximum number of files to process"
+    )
+    parser.add_argument(
+        "--dir",
+        default="tests/behavior/steps",
+        help="Directory containing BDD step definitions",
+    )
+
     args = parser.parse_args()
-    
+
     if args.categorize:
-        results = categorize_bdd_tests(args.dir, args.marker, args.dry_run, args.max_files)
-        
+        results = categorize_bdd_tests(
+            args.dir, args.marker, args.dry_run, args.max_files
+        )
+
         print("\nSummary:")
         print(f"Total files: {results['total_files']}")
         print(f"Files modified: {results['files_modified']}")
@@ -295,6 +338,7 @@ def main():
         print(f"Markers unchanged: {results['unchanged']}")
     else:
         parser.print_help()
+
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
## Summary
- refactor helper scripts to import utilities via `scripts` package
- remove `sys.path` hacks and rely on package context

## Testing
- `poetry run pre-commit run --files scripts/distributed_test_runner_enhanced.py scripts/identify_high_risk_tests.py scripts/run_modified_tests_enhanced.py scripts/run_unified_tests.py scripts/sync_test_categorization.py scripts/test_categorization_schedule_fixed.py scripts/test_utils_bdd.py`
- `poetry run devsynth run-tests --speed=fast` *(fails: INTERNALERROR due to xdist worker assertion)*
- `poetry run python tests/verify_test_organization.py`
- `poetry run python -m scripts.verify_test_markers --dry-run --module tests/unit/application` *(terminated: KeyboardInterrupt after long runtime)*
- `poetry run python scripts/verify_requirements_traceability.py`
- `poetry run python scripts/verify_version_sync.py`


------
https://chatgpt.com/codex/tasks/task_e_689e5e64afe88333b8765d1f721996e8