### PR TITLE
fix: allow marker utility scripts to run standalone

### DIFF
--- a/issues/128.md
+++ b/issues/128.md
@@ -25,5 +25,5 @@ The test suite must ensure each test file contains exactly one speed marker (`fa
 - Initial verification attempt timed out; needs further investigation.
 - A second run after provisioning also hung and required manual interruption.
 - Third attempt after refining the environment provisioning to avoid heavy GPU extras still hung, indicating an internal issue with `verify_test_markers.py`.
-- Latest run of `verify_test_markers.py` again hung and required manual interruption, producing no report.
+- Updated `verify_test_markers.py` and supporting utilities to handle direct script execution, but verification still hangs and requires manual interruption.
 - Status: open

--- a/scripts/test_utils.py
+++ b/scripts/test_utils.py
@@ -16,8 +16,16 @@ from datetime import datetime
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Set, Tuple
 
-# Import common test collector
-from . import common_test_collector
+# Import common test collector. Allow execution as a standalone script by
+# falling back to a direct import if relative imports fail.
+try:  # pragma: no cover - import resolution
+    from . import common_test_collector
+except ImportError:  # pragma: no cover - script execution
+    import pathlib
+    import sys
+
+    sys.path.append(str(pathlib.Path(__file__).resolve().parent))
+    import common_test_collector
 
 # Cache directories
 TEST_CACHE_DIR = ".test_cache"

--- a/scripts/test_utils_extended.py
+++ b/scripts/test_utils_extended.py
@@ -19,7 +19,17 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional, Set, Tuple, Union
 
 # Import original test_utils and common test collector
-from . import common_test_collector, test_utils
+# Import original test_utils and common test collector. When the module is
+# executed outside a package context, fall back to direct imports.
+try:  # pragma: no cover - import resolution
+    from . import common_test_collector, test_utils
+except ImportError:  # pragma: no cover - script execution
+    import pathlib
+    import sys
+
+    sys.path.append(str(pathlib.Path(__file__).resolve().parent))
+    import common_test_collector
+    import test_utils
 
 # Constants
 PROGRESS_FILE = ".test_categorization_progress.json"

--- a/scripts/verify_test_markers.py
+++ b/scripts/verify_test_markers.py
@@ -30,8 +30,16 @@ from datetime import datetime
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Set, Tuple
 
-# Import enhanced test utilities
-from . import test_utils_extended as test_utils_ext
+# Import enhanced test utilities. Allow running as a script by falling back to a
+# direct import when relative imports fail.
+try:  # pragma: no cover - import resolution
+    from . import test_utils_extended as test_utils_ext
+except ImportError:  # pragma: no cover - script execution
+    import pathlib
+    import sys
+
+    sys.path.append(str(pathlib.Path(__file__).resolve().parent))
+    import test_utils_extended as test_utils_ext
 
 # Regex patterns for finding and updating markers
 MARKER_PATTERN = re.compile(r"@pytest\.mark\.(fast|medium|slow|isolation)")


### PR DESCRIPTION
## Summary
- allow marker verification utilities to be executed directly without package context
- note ongoing marker verification hangs in issue tracker

## Testing
- `poetry run python tests/verify_test_organization.py`
- `poetry run python scripts/verify_requirements_traceability.py` *(no output)*
- `poetry run python scripts/verify_test_markers.py --directory tests/unit` *(terminated: KeyboardInterrupt)*
- `poetry run python scripts/verify_version_sync.py`
- `PIP_NO_INDEX=1 poetry run pip check`
- `poetry run pre-commit run --files scripts/test_utils.py scripts/test_utils_extended.py scripts/verify_test_markers.py` *(terminated: KeyboardInterrupt)*
- `poetry run devsynth run-tests --speed=fast` *(terminated: KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_689e8e2a01b883338e36fd6bf108fbf0