### PR TITLE
feat: expose test agent integration hooks

### DIFF
--- a/tests/integration/agents/test_test_agent_generation.py
+++ b/tests/integration/agents/test_test_agent_generation.py
@@ -1,0 +1,53 @@
+from pathlib import Path
+
+import pytest
+
+from devsynth.application.agents import test as test_agent_module
+from devsynth.application.agents.test import TestAgent
+
+
+@pytest.mark.fast
+def test_scaffold_hook_creates_placeholder(tmp_path: Path) -> None:
+    """Module-level hook writes placeholder integration tests.
+
+    ReqID: N/A"""
+    written = test_agent_module.write_scaffolded_tests(tmp_path, ["sample"])
+    file_path = tmp_path / "test_sample.py"
+    assert file_path in written
+    content = file_path.read_text()
+    assert "pytestmark = pytest.mark.skip" in content
+    assert content == written[file_path]
+
+
+@pytest.mark.fast
+def test_process_generates_tests_and_scaffolds(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """TestAgent.process generates tests and scaffolds integration files.
+
+    ReqID: N/A"""
+    agent = TestAgent()
+    monkeypatch.setattr(agent, "generate_text", lambda prompt: "generated tests")
+
+    wsde_sentinel = object()
+    monkeypatch.setattr(
+        agent,
+        "create_wsde",
+        lambda content, content_type, metadata: wsde_sentinel,
+    )
+
+    result = agent.process(
+        {
+            "context": "ctx",
+            "specifications": "spec",
+            "integration_test_names": ["alpha"],
+            "integration_output_dir": tmp_path,
+        }
+    )
+
+    assert result["tests"] == "generated tests"
+    assert result["wsde"] is wsde_sentinel
+    assert "test_alpha.py" in result["integration_tests"]
+    scaffold = tmp_path / "test_alpha.py"
+    assert scaffold.exists()
+    assert "pytestmark = pytest.mark.skip" in scaffold.read_text()


### PR DESCRIPTION
## Summary
- expose scaffold hooks for integration tests in test agent
- exercise end-to-end test generation via new integration scenarios

## Testing
- `poetry run pre-commit run --files src/devsynth/application/agents/test.py tests/integration/agents/__init__.py tests/integration/agents/test_test_agent_generation.py`
- `poetry run devsynth run-tests --target integration-tests --speed=fast`
- `poetry run python tests/verify_test_organization.py`
- `poetry run python scripts/verify_test_markers.py` *(fails: KeyboardInterrupt)*
- `poetry run python scripts/verify_requirements_traceability.py`
- `poetry run python scripts/verify_version_sync.py`

refs #108

------
https://chatgpt.com/codex/tasks/task_e_689eabc7c0948333854a4e67b697c558