### PR TITLE
feat: persist reasoning results to memory

### DIFF
--- a/docs/specifications/dialectical_reasoning_memory_persistence.md
+++ b/docs/specifications/dialectical_reasoning_memory_persistence.md
@@ -1,0 +1,30 @@
+---
+author: DevSynth Team
+date: '2025-08-15'
+last_reviewed: '2025-08-15'
+status: draft
+tags:
+- specification
+- dialectical-reasoning
+- memory
+title: Dialectical Reasoning Persists Results to Memory
+version: '0.1.0-alpha.1'
+---
+<div class="breadcrumbs">
+<a href="../index.md">Documentation</a> &gt; <a href="index.md">Specifications</a> &gt; Dialectical Reasoning Persists Results to Memory
+</div>
+
+# Dialectical Reasoning Persists Results to Memory
+
+## Problem
+
+Dialectical reasoning results were not consistently persisted, limiting retrospective analysis and reuse across EDRR phases.
+
+## Solution
+
+The dialectical reasoner stores generated reasoning in the memory system with the associated EDRR phase. When consensus evaluation fails, reasoning is still persisted for later inspection.
+
+## Verification
+
+- Behavior test: evaluating a requirement change stores the reasoning with phase `REFINE`.
+- Behavior test: an invalid consensus response raises an error and stores the reasoning with phase `RETROSPECT`.

--- a/docs/specifications/index.md
+++ b/docs/specifications/index.md
@@ -26,6 +26,7 @@ This section contains the official specifications for the DevSynth project, outl
 ## Core Specifications
 
 - **[DevSynth Specification MVP Updated](devsynth_specification_mvp_updated.md)**: The current authoritative specification for DevSynth.
+- **[Dialectical Reasoning Persists Results to Memory](dialectical_reasoning_memory_persistence.md)**: Dialectical reasoning results stored with EDRR phases.
 - **[EDRR Specification](edrr_cycle_specification.md)**: Specification for the EDRR cycle.
 - **[WSDE Interaction Specification](wsde_interaction_specification.md)**: Specification for the Wide Sweep, Deep Exploration interaction model.
 - **[WSDE-EDRR Collaboration Specification](wsde_edrr_collaboration.md)**: Expected phase progression, memory flush behavior, and peer-review mapping.

--- a/issues/105.md
+++ b/issues/105.md
@@ -5,8 +5,10 @@ This issue tracks tasks needed to finish the dialectical reasoning framework.
 
 - Integrate dialectical reasoning loop into EDRR workflow
 - Add consensus failure handling and logging
+- Ensure reasoning results persist to memory
 - Expand unit tests for reasoning modules
 
 ## Progress
 
+- Behavior tests confirm reasoning results persist to memory
 - Status: open

--- a/tests/behavior/features/general/dialectical_reasoning_memory_persistence.feature
+++ b/tests/behavior/features/general/dialectical_reasoning_memory_persistence.feature
@@ -1,0 +1,19 @@
+Feature: Dialectical reasoning persists results to memory
+  As a requirements engineer
+  I want dialectical reasoning results stored in memory
+  So that they can be reviewed later
+
+  @fast
+  Scenario: Successful evaluation stores reasoning
+    Given a dialectical reasoner with memory
+    And a requirement change
+    When the change is evaluated
+    Then the reasoning result should be stored in memory with phase "REFINE"
+
+  @fast
+  Scenario: Invalid consensus response stores reasoning for retrospection
+    Given a dialectical reasoner with memory
+    And a requirement change
+    When the change is evaluated with invalid consensus output
+    Then the reasoning result should be stored in memory with phase "RETROSPECT"
+    And a consensus error is raised

--- a/tests/behavior/features/index.md
+++ b/tests/behavior/features/index.md
@@ -27,6 +27,7 @@ This index lists all feature files for easy navigation.
 - [general/dbschema_generation.feature](./general/dbschema_generation.feature)
 - [general/delegate_task.feature](./general/delegate_task.feature)
 - [general/delegate_task_consensus.feature](./general/delegate_task_consensus.feature)
+- [general/dialectical_reasoning_memory_persistence.feature](./general/dialectical_reasoning_memory_persistence.feature)
 - [general/devsynth_doctor.feature](./general/devsynth_doctor.feature)
 - [general/docs_fetch.feature](./general/docs_fetch.feature)
 - [general/doctor.feature](./general/doctor.feature)

--- a/tests/behavior/steps/test_dialectical_reasoning_memory_persistence_steps.py
+++ b/tests/behavior/steps/test_dialectical_reasoning_memory_persistence_steps.py
@@ -1,0 +1,120 @@
+from unittest.mock import MagicMock
+from uuid import uuid4
+
+import pytest
+from pytest_bdd import given, parsers, then, when
+
+from devsynth.application.requirements.dialectical_reasoner import (
+    ConsensusError,
+    DialecticalReasonerService,
+)
+from devsynth.domain.models.memory import MemoryType
+from devsynth.domain.models.requirement import (
+    ChangeType,
+    Requirement,
+    RequirementChange,
+)
+
+
+class DummyMemoryManager:
+    """Simple in-memory store for reasoning results."""
+
+    def __init__(self):
+        self.calls = []
+
+    def store_with_edrr_phase(self, item, memory_type, edrr_phase, metadata):
+        self.calls.append((item, memory_type, edrr_phase, metadata))
+        return uuid4()
+
+
+@pytest.fixture
+def context():
+    class Context:
+        pass
+
+    return Context()
+
+
+@pytest.mark.fast
+@given("a dialectical reasoner with memory")
+def reasoner_with_memory(context):
+    memory_manager = DummyMemoryManager()
+    reasoning_repo = MagicMock()
+    reasoning_repo.get_reasoning_for_change.return_value = None
+    reasoning_repo.save_reasoning.side_effect = lambda r: r
+
+    llm_service = MagicMock()
+    llm_service.query.return_value = "yes"
+
+    reasoner = DialecticalReasonerService(
+        requirement_repository=MagicMock(),
+        reasoning_repository=reasoning_repo,
+        impact_repository=MagicMock(),
+        chat_repository=MagicMock(),
+        notification_service=MagicMock(),
+        llm_service=llm_service,
+        memory_manager=memory_manager,
+    )
+
+    # Stub generation methods to avoid LLM calls
+    reasoner._generate_thesis = MagicMock(return_value="thesis")
+    reasoner._generate_antithesis = MagicMock(return_value="antithesis")
+    reasoner._generate_arguments = MagicMock(
+        return_value=[{"position": "pro", "content": "arg"}]
+    )
+    reasoner._generate_synthesis = MagicMock(return_value="synthesis")
+    reasoner._generate_conclusion_and_recommendation = MagicMock(
+        return_value=("conclusion", "recommendation")
+    )
+
+    context.reasoner = reasoner
+    context.memory_manager = memory_manager
+    context.reasoning_repo = reasoning_repo
+
+
+@pytest.mark.fast
+@given("a requirement change")
+def requirement_change(context):
+    req = Requirement(title="Test", description="Desc", created_by="user")
+    context.change = RequirementChange(
+        requirement_id=req.id,
+        change_type=ChangeType.ADD,
+        new_state=req,
+        reason="new feature",
+        created_by="user",
+    )
+
+
+@pytest.mark.fast
+@when("the change is evaluated")
+def evaluate_change(context):
+    context.reasoning = context.reasoner.evaluate_change(context.change)
+
+
+@pytest.mark.fast
+@when("the change is evaluated with invalid consensus output")
+def evaluate_change_invalid(context):
+    context.reasoner.llm_service.query.return_value = "maybe"
+    with pytest.raises(ConsensusError) as err:
+        context.reasoner.evaluate_change(context.change)
+    context.consensus_error = err.value
+
+
+@pytest.mark.fast
+@then(
+    parsers.parse(
+        'the reasoning result should be stored in memory with phase "{phase}"'
+    )
+)
+def reasoning_stored_with_phase(context, phase):
+    assert context.memory_manager.calls, "No reasoning stored"
+    item, memory_type, edrr_phase, metadata = context.memory_manager.calls[-1]
+    assert edrr_phase == phase
+    assert memory_type == MemoryType.DIALECTICAL_REASONING
+    assert metadata["change_id"] == str(context.change.id)
+
+
+@pytest.mark.fast
+@then("a consensus error is raised")
+def consensus_error_raised(context):
+    assert isinstance(context.consensus_error, ConsensusError)

--- a/tests/behavior/test_dialectical_reasoning_memory_persistence.py
+++ b/tests/behavior/test_dialectical_reasoning_memory_persistence.py
@@ -1,0 +1,5 @@
+from pytest_bdd import scenarios
+
+from .steps.test_dialectical_reasoning_memory_persistence_steps import *  # noqa: F401,F403
+
+scenarios("general/dialectical_reasoning_memory_persistence.feature")


### PR DESCRIPTION
## Summary
- strengthen consensus evaluation with explicit response validation
- persist reasoning results to memory and cover with BDD scenarios
- document reasoning persistence requirements and update issue tracking

## Testing
- `poetry run pre-commit run --files docs/specifications/index.md docs/specifications/dialectical_reasoning_memory_persistence.md issues/105.md src/devsynth/application/requirements/dialectical_reasoner.py tests/behavior/features/index.md tests/behavior/features/general/dialectical_reasoning_memory_persistence.feature tests/behavior/steps/test_dialectical_reasoning_memory_persistence_steps.py tests/behavior/test_dialectical_reasoning_memory_persistence.py`
- `poetry run devsynth run-tests --speed=fast` *(fails: AssertionError in unrelated requirements_wizard test)*
- `poetry run pytest tests/behavior/test_dialectical_reasoning_memory_persistence.py -m fast -q`
- `poetry run python tests/verify_test_organization.py`
- `poetry run python scripts/verify_test_markers.py` *(interrupted after extended runtime)*
- `poetry run python scripts/verify_requirements_traceability.py`
- `poetry run python scripts/verify_version_sync.py`


------
https://chatgpt.com/codex/tasks/task_e_689eabaacfd0833398595f7234e3a67b