### PR TITLE
Enforce non-root execution and env file security for deployment scripts

### DIFF
--- a/docs/gap-matrix.md
+++ b/docs/gap-matrix.md
@@ -23,7 +23,7 @@ This matrix tracks the state of major DevSynth features. Update entries as featu
 | WSDE Agent Collaboration (`src/devsynth/application/collaboration/`) | Y | Partial | Partial | Voting logic exercised in `tests/unit/domain/test_wsde_voting_logic.py` |
 | Memory System (`src/devsynth/application/memory/`) | Y | Y | Y | Managed via `MemoryManager`; validated by `tests/unit/application/memory/test_memory_manager.py` |
 | CLI Interface (`src/devsynth/cli.py`, `src/devsynth/application/cli/`) | Y | Partial | Partial | Command loading tested in `tests/unit/cli/test_command_module_loading.py` |
-| Deployment Automation (`docker-compose.yml`, `scripts/deployment/`) | Y | Partial | Partial | Deployment scripts checked by `tests/integration/deployment/test_deployment_scripts.py` |
+| Deployment Automation (`docker-compose.yml`, `scripts/deployment/`) | Y | Partial | Partial | Deployment scripts enforce non-root execution and secure `.env` handling; verified by `tests/integration/deployment/test_deployment_scripts.py` |
 | Security Framework (`src/devsynth/security/`) | Y | Y | Y | Encryption and policy enforcement verified by `tests/unit/security/test_encryption.py` |
 | Retry Mechanism (`src/devsynth/fallback.py`) | Y | Partial | Partial | Retry logic covered in `tests/unit/fallback/test_retry.py` |
 

--- a/issues/109.md
+++ b/issues/109.md
@@ -5,3 +5,4 @@ Current Docker Compose workflows require manual steps.
 - Add scripts for environment bootstrapping and health checks
 - Integrate Docker image publishing into CI pipeline
 - Provide rollback instructions and test coverage
+- Enforce non-root execution and strict `.env` permissions in deployment scripts with smoke tests

--- a/scripts/deployment/prometheus_exporter.py
+++ b/scripts/deployment/prometheus_exporter.py
@@ -2,15 +2,35 @@
 
 import logging
 import os
+import sys
 import time
+from pathlib import Path
 
+from dotenv import load_dotenv
 from prometheus_client import Counter, start_http_server
 
 logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
 
+
+def _ensure_non_root() -> None:
+    if os.geteuid() == 0:
+        sys.stderr.write("Please run this script as a non-root user.\n")
+        raise SystemExit(1)
+
+
+def _load_env() -> None:
+    env_path = Path(".env")
+    if env_path.exists():
+        if env_path.stat().st_mode & 0o777 != 0o600:
+            raise RuntimeError(f"Environment file {env_path} must have 600 permissions")
+        load_dotenv(env_path)
+
+
 REQUESTS = Counter("devsynth_exporter_requests_total", "Exporter request count")
 
 if __name__ == "__main__":
+    _ensure_non_root()
+    _load_env()
     port = int(os.getenv("EXPORTER_PORT", "9200"))
     start_http_server(port)
     logging.info("Prometheus exporter running on port %s", port)

--- a/scripts/deployment/publish_image.sh
+++ b/scripts/deployment/publish_image.sh
@@ -29,10 +29,19 @@ fi
 
 export DEVSYNTH_IMAGE_TAG="$TAG"
 
-# Build the image with the specified tag
+# Ensure environment file permissions
+ENV_FILE=".env.production"
+ENV_ARGS=()
+if [[ -f "$ENV_FILE" ]]; then
+  if [[ $(stat -c %a "$ENV_FILE") != "600" ]]; then
+    echo "Environment file $ENV_FILE must have 600 permissions" >&2
+    exit 1
+  fi
+  ENV_ARGS=(--env-file "$ENV_FILE")
+fi
 
-docker compose -f docker-compose.production.yml build "$SERVICE"
+# Build the image with the specified tag
+docker compose "${ENV_ARGS[@]}" -f docker-compose.production.yml build "$SERVICE"
 
 # Push the image to the configured registry
-
-docker compose -f docker-compose.production.yml push "$SERVICE"
+docker compose "${ENV_ARGS[@]}" -f docker-compose.production.yml push "$SERVICE"

--- a/tests/integration/deployment/test_deployment_scripts.py
+++ b/tests/integration/deployment/test_deployment_scripts.py
@@ -26,3 +26,46 @@ def test_health_check_validates_url():
     )
     assert result.returncode != 0
     assert "Invalid URL" in result.stderr
+
+
+def test_prometheus_exporter_refuses_root():
+    result = subprocess.run(
+        ["python", str(SCRIPTS_DIR / "prometheus_exporter.py")],
+        capture_output=True,
+        text=True,
+        cwd=ROOT,
+        timeout=5,
+    )
+    assert result.returncode != 0
+    assert "Please run this script as a non-root user." in result.stderr
+
+
+def test_prometheus_exporter_env_permissions(tmp_path):
+    env_file = tmp_path / ".env"
+    env_file.write_text("EXPORTER_PORT=9300")
+    env_file.chmod(0o644)
+    cmd = f"python {SCRIPTS_DIR / 'prometheus_exporter.py'}"
+    result = subprocess.run(
+        ["su", "nobody", "-s", "/bin/bash", "-c", cmd],
+        capture_output=True,
+        text=True,
+        cwd=tmp_path,
+        timeout=5,
+    )
+    assert result.returncode != 0
+    assert "Environment file" in result.stderr
+
+
+def test_publish_image_env_permissions(tmp_path):
+    env_file = tmp_path / ".env.production"
+    env_file.write_text("DEVSYNTH_IMAGE_TAG=test")
+    env_file.chmod(0o644)
+    cmd = f"{SCRIPTS_DIR / 'publish_image.sh'}"
+    result = subprocess.run(
+        ["su", "nobody", "-s", "/bin/bash", "-c", cmd],
+        capture_output=True,
+        text=True,
+        cwd=tmp_path,
+    )
+    assert result.returncode != 0
+    assert "Environment file .env.production must have 600 permissions" in result.stderr


### PR DESCRIPTION
## Summary
- ensure `prometheus_exporter.py` refuses root execution and loads `.env` only with 600 permissions
- validate `.env.production` in `publish_image.sh` and pass through to Docker Compose
- expand deployment smoke tests and documentation

## Testing
- `poetry run pre-commit run --files docs/gap-matrix.md issues/109.md scripts/deployment/prometheus_exporter.py scripts/deployment/publish_image.sh tests/integration/deployment/test_deployment_scripts.py`
- `poetry run devsynth run-tests --speed=medium --target tests/integration/deployment/test_deployment_scripts.py`
- `poetry run python tests/verify_test_organization.py`
- `poetry run python scripts/verify_test_markers.py -m tests/integration/deployment/test_deployment_scripts.py`
- `poetry run python scripts/verify_requirements_traceability.py`
- `poetry run python scripts/verify_version_sync.py`


------
https://chatgpt.com/codex/tasks/task_e_689eb349f7808333ad4b84aa26591f36