### PR TITLE
Link consensus metrics to EDRR transitions

### DIFF
--- a/docs/roadmap/development_status.md
+++ b/docs/roadmap/development_status.md
@@ -197,6 +197,7 @@ This phase focuses on stabilizing the foundation of the DevSynth project by addr
    - Created consensus-building mechanisms
    - Added conflict resolution capabilities
    - Developed collaborative memory implementation
+   - Linked consensus metrics to EDRR phase transitions and verified cross-store memory syncing through integration tests
 
 
 #### Week 7-8: WSDE Agent Collaboration

--- a/issues/104.md
+++ b/issues/104.md
@@ -11,3 +11,4 @@ This issue captures remaining work from the critical recommendations report.
 
 - Status: open
 - [x] Implemented phase transition helpers and recovery hooks with unit tests.
+- [x] Linked WSDE team consensus with EDRR phase transitions and added cross-store memory sync integration tests.

--- a/tests/integration/collaboration/test_cross_store_memory_sync.py
+++ b/tests/integration/collaboration/test_cross_store_memory_sync.py
@@ -1,0 +1,94 @@
+import logging
+from datetime import datetime
+
+import pytest
+
+from devsynth.application.collaboration.collaborative_wsde_team import (
+    CollaborativeWSDETeam,
+)
+from devsynth.application.memory.memory_manager import MemoryManager
+from devsynth.domain.interfaces.memory import MemoryStore
+from devsynth.domain.models.memory import MemoryItem
+
+
+class DummyAgent:
+    def __init__(self, name: str):
+        self.name = name
+        self.metadata = {"expertise": ["general"]}
+
+
+class SimpleStore(MemoryStore):
+    def __init__(self):
+        self.items = {}
+
+    def store(self, item: MemoryItem):
+        if not item.id:
+            item.id = str(len(self.items))
+        self.items[item.id] = item
+        return item.id
+
+    def retrieve(self, item_id: str):
+        return self.items.get(item_id)
+
+    def search(self, query):  # pragma: no cover - unused in tests
+        return list(self.items.values())
+
+    def delete(self, item_id: str):  # pragma: no cover - unused in tests
+        return self.items.pop(item_id, None) is not None
+
+    def begin_transaction(self, *args, **kwargs):  # pragma: no cover - unused
+        return None
+
+    def commit_transaction(self, *args, **kwargs):  # pragma: no cover - unused
+        return True
+
+    def rollback_transaction(self, *args, **kwargs):  # pragma: no cover - unused
+        return False
+
+    def is_transaction_active(self):  # pragma: no cover - unused
+        return False
+
+
+class DemoTeam(CollaborativeWSDETeam):
+    def __init__(self, memory_manager: MemoryManager):
+        super().__init__("team", memory_manager=memory_manager)
+        self.agents = [DummyAgent("a1"), DummyAgent("a2")]
+        now = datetime.now()
+        self.messages = {
+            "a1": [
+                {"timestamp": now, "content": {"opinion": "approve", "rationale": "r1"}}
+            ],
+            "a2": [
+                {"timestamp": now, "content": {"opinion": "approve", "rationale": "r2"}}
+            ],
+        }
+        self.logger = logging.getLogger("test")
+
+    def get_messages(self, agent=None, filters=None):  # type: ignore[override]
+        return self.messages.get(agent, [])
+
+    def _generate_agent_opinions(self, task):  # pragma: no cover - not used
+        pass
+
+    def _identify_conflicts(self, task):  # type: ignore[override]
+        return []
+
+    def _identify_weighted_majority_opinion(self, opinions, keywords):
+        return "approve"
+
+    def _generate_stakeholder_explanation(self, task, consensus_result):
+        return "because we agree"
+
+
+@pytest.mark.medium
+def test_consensus_syncs_across_stores():
+    memory_manager = MemoryManager(adapters={"s1": SimpleStore(), "s2": SimpleStore()})
+    team = DemoTeam(memory_manager)
+    task = {"id": "t1", "title": "Test"}
+
+    team.build_consensus(task)
+
+    for store in memory_manager.adapters.values():
+        types = [item.metadata.get("type") for item in store.items.values()]
+        assert "CONSENSUS_DECISION" in types
+        assert "CONSENSUS_SUMMARY" in types


### PR DESCRIPTION
## Summary
- feed WSDE team consensus data into EDRR phase metrics
- test cross-store memory syncing during consensus building
- document progress and log updates in issue 104

## Testing
- `poetry run pre-commit run --files docs/roadmap/development_status.md issues/104.md src/devsynth/application/collaboration/wsde_team_consensus.py tests/integration/collaboration/__init__.py tests/integration/collaboration/test_cross_store_memory_sync.py`
- `poetry run devsynth run-tests --speed=medium` *(internal xdist assertion logged but run completed)*
- `poetry run pytest tests/integration/collaboration/test_cross_store_memory_sync.py -m medium`
- `poetry run python tests/verify_test_organization.py`
- `poetry run python scripts/verify_test_markers.py` *(terminated without completion)*
- `poetry run python scripts/verify_requirements_traceability.py`
- `poetry run python scripts/verify_version_sync.py`


------
https://chatgpt.com/codex/tasks/task_e_689eb345f5048333a80e6b114700a595