### PR TITLE
feat: add security policy verification

### DIFF
--- a/docs/policies/security.md
+++ b/docs/policies/security.md
@@ -2,7 +2,7 @@
 
 author: DevSynth Team
 date: '2025-07-07'
-last_reviewed: "2025-08-07"
+last_reviewed: "2025-08-15"
 status: published
 tags:
 
@@ -72,6 +72,23 @@ DevSynth automates routine security checks to prevent regressions:
   pipelines and deployment.
 - Developers should run `devsynth security-audit` locally before committing
   changes to catch issues early.
+
+### Enforceable Audit Criteria
+
+The following settings must be configured for deployments and are verified by
+`scripts/verify_security_policy.py`:
+
+- `DEVSYNTH_AUTHENTICATION_ENABLED` is set to `true`.
+- `DEVSYNTH_AUTHORIZATION_ENABLED` is set to `true`.
+- `DEVSYNTH_SANITIZATION_ENABLED` is set to `true`.
+- `DEVSYNTH_ENCRYPTION_AT_REST` is set to `true`.
+- `DEVSYNTH_ENCRYPTION_IN_TRANSIT` is set to `true`.
+- `DEVSYNTH_TLS_VERIFY` is set to `true`.
+- `DEVSYNTH_ACCESS_TOKEN` is non-empty.
+- `DEVSYNTH_PRE_DEPLOY_APPROVED` is set to `true`.
+
+Run `poetry run python scripts/verify_security_policy.py` to enforce these
+criteria; the script exits with status `1` if any requirement is unmet.
 
 ## Periodic Security Reviews
 

--- a/scripts/verify_security_policy.py
+++ b/scripts/verify_security_policy.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python3
+"""Verify security policy compliance by checking required environment variables.
+
+The script enforces audit criteria defined in ``docs/policies/security.md``. It
+ensures critical security controls are enabled before deployment and exits with
+status ``1`` if any requirement is unmet.
+"""
+from __future__ import annotations
+
+import os
+from typing import List
+
+REQUIRED_TRUE = [
+    "DEVSYNTH_AUTHENTICATION_ENABLED",
+    "DEVSYNTH_AUTHORIZATION_ENABLED",
+    "DEVSYNTH_SANITIZATION_ENABLED",
+    "DEVSYNTH_ENCRYPTION_AT_REST",
+    "DEVSYNTH_ENCRYPTION_IN_TRANSIT",
+    "DEVSYNTH_TLS_VERIFY",
+    "DEVSYNTH_PRE_DEPLOY_APPROVED",
+]
+
+REQUIRED_NONEMPTY = ["DEVSYNTH_ACCESS_TOKEN"]
+
+
+def main() -> int:
+    """Check environment variables and report any violations."""
+    failures: List[str] = []
+    for name in REQUIRED_TRUE:
+        if os.getenv(name, "").lower() != "true":
+            failures.append(f"{name} must be set to 'true'")
+    for name in REQUIRED_NONEMPTY:
+        if not os.getenv(name):
+            failures.append(f"{name} must be set")
+    if failures:
+        print("Security policy violations:")
+        for failure in failures:
+            print(f"- {failure}")
+        return 1
+    print("Security policy checks passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/unit/policies/__init__.py
+++ b/tests/unit/policies/__init__.py
@@ -1,0 +1,1 @@
+"""Unit tests for policy utilities."""

--- a/tests/unit/policies/test_verify_security_policy.py
+++ b/tests/unit/policies/test_verify_security_policy.py
@@ -1,0 +1,35 @@
+"""Tests for ``scripts/verify_security_policy.py``."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[3] / "scripts"))
+
+import verify_security_policy as vsp  # type: ignore
+
+
+@pytest.mark.fast
+def test_passes_when_all_variables_set(monkeypatch, capsys) -> None:
+    """Script returns 0 when all required variables are set correctly."""
+    for name in vsp.REQUIRED_TRUE:
+        monkeypatch.setenv(name, "true")
+    for name in vsp.REQUIRED_NONEMPTY:
+        monkeypatch.setenv(name, "token")
+    assert vsp.main() == 0
+    captured = capsys.readouterr()
+    assert "Security policy checks passed." in captured.out
+
+
+@pytest.mark.fast
+def test_fails_when_variable_missing(monkeypatch, capsys) -> None:
+    """Script returns 1 and lists violations when variables are missing."""
+    for name in vsp.REQUIRED_TRUE + vsp.REQUIRED_NONEMPTY:
+        monkeypatch.delenv(name, raising=False)
+    assert vsp.main() == 1
+    captured = capsys.readouterr()
+    assert "Security policy violations:" in captured.out
+    assert "DEVSYNTH_AUTHENTICATION_ENABLED" in captured.out


### PR DESCRIPTION
## Summary
- define enforceable audit criteria in security policy
- add `scripts/verify_security_policy.py` to check critical env vars
- test security policy verification

## Testing
- `poetry run pre-commit run --files docs/policies/security.md scripts/verify_security_policy.py tests/unit/policies/__init__.py tests/unit/policies/test_verify_security_policy.py`
- `poetry run devsynth run-tests --speed=fast` *(fails: AssertionError in requirements_wizard test)*
- `poetry run pytest tests/unit/policies/test_verify_security_policy.py -m fast`
- `poetry run python tests/verify_test_organization.py`
- `poetry run python scripts/verify_test_markers.py` *(timeout after 100s)*
- `poetry run python scripts/verify_requirements_traceability.py`
- `poetry run python scripts/verify_version_sync.py`

Refs #111

------
https://chatgpt.com/codex/tasks/task_e_689eb7185afc83339c34c157a0828f82