### PR TITLE
feat: add conditional retry metrics

### DIFF
--- a/tests/unit/fallback/test_condition_callbacks_prometheus.py
+++ b/tests/unit/fallback/test_condition_callbacks_prometheus.py
@@ -2,16 +2,19 @@ from unittest.mock import Mock
 
 import pytest
 
+from devsynth import metrics
 from devsynth.application.memory import retry as memory_retry
 from devsynth.fallback import (
     reset_prometheus_metrics,
     retry_event_counter,
     retry_with_exponential_backoff,
 )
+from devsynth.metrics import retry_condition_counter
 
 retry_with_backoff = memory_retry.retry_with_backoff
 memory_retry_event_counter = memory_retry.retry_event_counter
 reset_memory_retry_metrics = memory_retry.reset_memory_retry_metrics
+memory_retry_condition_counter = memory_retry.retry_condition_counter
 
 
 @pytest.mark.medium
@@ -79,3 +82,69 @@ def test_memory_retry_metrics_and_callback():
     assert cb_called is True
     assert memory_retry_event_counter.labels(status="attempt")._value.get() == 1
     assert memory_retry_event_counter.labels(status="success")._value.get() == 1
+
+
+@pytest.mark.medium
+def test_condition_callback_records_metrics():
+    metrics.reset_metrics()
+    reset_prometheus_metrics()
+
+    def cb(exc: Exception, attempt: int) -> bool:
+        return False
+
+    func = Mock(side_effect=Exception("boom"))
+    func.__name__ = "func"
+
+    wrapped = retry_with_exponential_backoff(
+        max_retries=2, initial_delay=0, condition_callbacks=[cb], track_metrics=True
+    )(func)
+
+    with pytest.raises(Exception):
+        wrapped()
+
+    assert metrics.get_retry_condition_metrics() == {cb.__name__: 1}
+    assert retry_condition_counter.labels(condition=cb.__name__)._value.get() == 1
+
+
+@pytest.mark.medium
+def test_memory_condition_callback_records_metrics():
+    reset_memory_retry_metrics()
+
+    def cb(exc: Exception, attempt: int) -> bool:
+        return False
+
+    func = Mock(side_effect=Exception("boom"))
+    func.__name__ = "mem_func"
+
+    wrapped = retry_with_backoff(
+        max_retries=2,
+        initial_backoff=0,
+        condition_callbacks=[cb],
+    )(func)
+
+    with pytest.raises(Exception):
+        wrapped()
+
+    assert (
+        memory_retry_condition_counter.labels(condition=cb.__name__)._value.get() == 1
+    )
+
+
+@pytest.mark.medium
+def test_memory_retry_condition_records_metrics() -> None:
+    reset_memory_retry_metrics()
+    func = Mock(side_effect=Exception("boom"))
+    func.__name__ = "mem_func"
+
+    wrapped = retry_with_backoff(
+        max_retries=2,
+        initial_backoff=0,
+        retry_conditions={"needs_retry": "retry"},
+    )(func)
+
+    with pytest.raises(Exception):
+        wrapped()
+
+    assert (
+        memory_retry_condition_counter.labels(condition="needs_retry")._value.get() == 1
+    )


### PR DESCRIPTION
## Summary
- add condition callback metrics for retry fallback
- extend memory retry with conditional hooks and Prometheus counters
- cover callback and condition metrics with unit tests

## Testing
- `poetry run pre-commit run --files src/devsynth/fallback.py src/devsynth/application/memory/retry.py tests/unit/fallback/test_condition_callbacks_prometheus.py`
- `poetry run devsynth run-tests --speed=medium` *(fails: INTERNALERROR)*
- `poetry run pytest tests/unit/fallback/test_condition_callbacks_prometheus.py`
- `poetry run python tests/verify_test_organization.py`
- `poetry run python scripts/verify_test_markers.py` *(interrupt: KeyboardInterrupt)*
- `poetry run python scripts/verify_requirements_traceability.py`
- `poetry run python scripts/verify_version_sync.py`

Closes #110

------
https://chatgpt.com/codex/tasks/task_e_689eb70e850c8333b3559cb291d05961