### PR TITLE
docs: add post alpha roadmap

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ last_reviewed: "2025-08-05"
 
 DevSynth is an agentic software engineering platform that leverages LLMs, advanced memory systems, and dialectical reasoning to automate and enhance the software development lifecycle. The system is designed for extensibility, resilience, and traceability, supporting both autonomous and collaborative workflows.
 
-**Pre-release notice:** DevSynth is still pre-0.1.0 and no package has been published on PyPI. All versions should be considered experimental. Version labels follow our [Semantic Versioning+ policy](docs/policies/semantic_versioning.md), and release milestones are tracked in [docs/roadmap/CONSOLIDATED_ROADMAP.md](docs/roadmap/CONSOLIDATED_ROADMAP.md).
+**Pre-release notice:** DevSynth is still pre-0.1.0 and no package has been published on PyPI. All versions should be considered experimental. Version labels follow our [Semantic Versioning+ policy](docs/policies/semantic_versioning.md). Release milestones and targeted features post-`0.1.0-alpha.1` are documented in [docs/release/roadmap.md](docs/release/roadmap.md); see [docs/roadmap/CONSOLIDATED_ROADMAP.md](docs/roadmap/CONSOLIDATED_ROADMAP.md) for the broader project plan.
 ## Key Features
 - Modular, hexagonal architecture for extensibility and testability
 - Unified memory system with Kuzu, TinyDB, RDFLib, and JSON backends

--- a/docs/release/0.1.0-alpha.1.md
+++ b/docs/release/0.1.0-alpha.1.md
@@ -41,3 +41,7 @@ last_reviewed: "2025-08-12"
 - Kuzu-backed memory store fails to initialise during tests ([Issue 113](../../issues/113.md)).
 - Requirements wizard logging and persistence errors break integration tests ([Issue 114](../../issues/114.md)).
 - Full test suite terminates early with multiple unit failures ([Issue 116](../../issues/116.md)).
+
+## Looking Ahead
+
+For milestones and targeted features planned after this release, see the [DevSynth Release Roadmap](roadmap.md).

--- a/docs/release/roadmap.md
+++ b/docs/release/roadmap.md
@@ -1,0 +1,35 @@
+---
+title: "DevSynth Release Roadmap"
+date: "2025-08-15"
+version: "0.1.0-alpha.1"
+tags:
+  - "devsynth"
+  - "roadmap"
+  - "release"
+status: "draft"
+author: "DevSynth Team"
+last_reviewed: "2025-08-15"
+---
+
+# DevSynth Release Roadmap
+
+This roadmap outlines planned milestones and targeted features following the `0.1.0-alpha.1` release.
+
+## Upcoming Milestones
+
+### 0.1.0-alpha.2
+- Stabilize CI workflows and increase unit test coverage.
+- Implement basic plugin interface for memory backends.
+- Improve documentation automation and review tooling.
+
+### 0.1.0-beta.1
+- Provide authenticated API layer and token management.
+- Ship web UI prototype powered by the CLI/WebUI bridge.
+- Integrate Kuzu-backed memory store for default operations.
+
+### 0.1.0
+- Deliver fully tested release with reproducible builds.
+- Harden security policies and release automation.
+- Conduct full dialectical audit and cross-functional review.
+
+For a comprehensive project roadmap and historical context, see [CONSOLIDATED_ROADMAP.md](../roadmap/CONSOLIDATED_ROADMAP.md).


### PR DESCRIPTION
## Summary
- document post-`0.1.0-alpha.1` milestones in new release roadmap
- reference roadmap from README and `0.1.0-alpha.1` release notes

## Testing
- `poetry run pre-commit run --files README.md docs/release/0.1.0-alpha.1.md docs/release/roadmap.md`
- `poetry run devsynth run-tests --speed=fast` *(failed: INTERNALERROR with 5 errors)*
- `poetry run python tests/verify_test_organization.py`
- `poetry run python scripts/verify_test_markers.py` *(execution interrupted)*
- `poetry run python scripts/verify_requirements_traceability.py`
- `poetry run python scripts/verify_version_sync.py`


------
https://chatgpt.com/codex/tasks/task_e_689f7db639d883339f109537b3e492ca