### PR TITLE
Gracefully handle missing openai dependency

### DIFF
--- a/tests/unit/application/llm/test_import_without_openai.py
+++ b/tests/unit/application/llm/test_import_without_openai.py
@@ -1,0 +1,33 @@
+import builtins
+import importlib
+import sys
+
+import pytest
+
+
+@pytest.mark.fast
+def test_import_openai_provider_without_openai_succeeds(monkeypatch):
+    """Importing OpenAI provider should succeed without openai installed."""
+    sys.modules.pop("devsynth.application.llm.openai_provider", None)
+    sys.modules.pop("openai", None)
+    real_import = builtins.__import__
+
+    def fake_import(name, globals=None, locals=None, fromlist=(), level=0):
+        if name.startswith("openai"):
+            raise ImportError("No module named 'openai'")
+        return real_import(name, globals, locals, fromlist, level)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+    module = importlib.import_module("devsynth.application.llm.openai_provider")
+    assert module.OpenAI is object
+
+
+@pytest.mark.fast
+def test_openai_provider_requires_api_key(monkeypatch):
+    """Missing API key should raise a clear error."""
+    sys.modules.pop("devsynth.application.llm.openai_provider", None)
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    module = importlib.import_module("devsynth.application.llm.openai_provider")
+    with pytest.raises(module.OpenAIConnectionError) as exc:
+        module.OpenAIProvider({})
+    assert "OpenAI API key is required" in str(exc.value)


### PR DESCRIPTION
## Summary
- allow OpenAI provider module to load even if `openai` package is absent by guarding imports and providing fallbacks
- add tests ensuring the provider imports without `openai` and that a missing API key yields a clear error

## Testing
- `poetry run pre-commit run --files src/devsynth/application/llm/openai_provider.py tests/unit/application/llm/test_import_without_openai.py`
- `PYTEST_ADDOPTS="tests/unit/application/llm/test_import_without_openai.py" poetry run devsynth run-tests --target unit-tests --speed=fast`
- `poetry run python tests/verify_test_organization.py`
- `poetry run python scripts/verify_test_markers.py` *(fails: KeyboardInterrupt)*
- `poetry run python scripts/verify_requirements_traceability.py`
- `poetry run python scripts/verify_version_sync.py`


------
https://chatgpt.com/codex/tasks/task_e_689f7d980718833389ad81f3573669bc