### PR TITLE
Refine exception handling

### DIFF
--- a/src/devsynth/agents/tools.py
+++ b/src/devsynth/agents/tools.py
@@ -171,7 +171,7 @@ def alignment_metrics_tool(
 
         return {"success": True, "metrics": metrics}
 
-    except Exception as exc:  # pragma: no cover - defensive programming
+    except (ImportError, OSError, ValueError) as exc:  # pragma: no cover - defensive
         logger.error("Error collecting alignment metrics: %s", exc)
         return {"success": False, "error": str(exc)}
 
@@ -244,7 +244,7 @@ def security_audit_tool(
             bridge=bridge,
         )
         return {"success": True, "output": "\n".join(bridge.messages)}
-    except Exception as exc:  # pragma: no cover - defensive programming
+    except (ImportError, RuntimeError) as exc:  # pragma: no cover - defensive
         logger.error("Security audit failed: %s", exc)
         return {
             "success": False,
@@ -273,7 +273,7 @@ def doctor_tool(config_dir: str = "config", quick: bool = False) -> Dict[str, An
             "error": str(exc),
             "output": "\n".join(bridge.messages),
         }
-    except Exception as exc:  # pragma: no cover - defensive programming
+    except (ImportError, RuntimeError) as exc:  # pragma: no cover - defensive
         logger.error("Doctor command failed: %s", exc)
         return {
             "success": False,

--- a/src/devsynth/agents/wsde_team_coordinator.py
+++ b/src/devsynth/agents/wsde_team_coordinator.py
@@ -52,7 +52,7 @@ class WSDETeamCoordinatorAgent:
         if memory_manager and hasattr(memory_manager, "flush_updates"):
             try:
                 memory_manager.flush_updates()
-            except Exception:  # pragma: no cover - defensive
+            except (RuntimeError, OSError):  # pragma: no cover - defensive
                 logger.debug(
                     "Memory synchronization failed during retrospective",
                     exc_info=True,

--- a/src/devsynth/api.py
+++ b/src/devsynth/api.py
@@ -13,7 +13,7 @@ try:  # pragma: no cover - import guarded for optional dependency
         Histogram,
         generate_latest,
     )
-except Exception:  # pragma: no cover - fallback for minimal environments
+except ImportError:  # pragma: no cover - fallback for minimal environments
 
     class _NoopMetric:  # type: ignore[override]
         def __init__(self, *args: object, **kwargs: object) -> None:  # noqa: D401

--- a/src/devsynth/interface/ux_bridge.py
+++ b/src/devsynth/interface/ux_bridge.py
@@ -15,7 +15,7 @@ try:  # pragma: no cover - import guarded for optional deps
     # Import directly from the sanitization module to avoid initializing the
     # entire security package, which may have optional dependencies.
     from devsynth.security.sanitization import sanitize_input
-except Exception:  # pragma: no cover - graceful degradation
+except ImportError:  # pragma: no cover - graceful degradation
 
     def sanitize_input(text: str) -> str:  # type: ignore[override]
         """Fallback sanitizer used when security helpers are unavailable."""


### PR DESCRIPTION
## Summary
- replace broad `except Exception` with `ImportError` and `ProviderError` in agent graph
- narrow exception handling in agent tools and team coordinator
- tighten optional dependency guards in API and UX bridge

## Testing
- `poetry run pre-commit run --files src/devsynth/agents/base_agent_graph.py src/devsynth/agents/tools.py src/devsynth/agents/wsde_team_coordinator.py src/devsynth/api.py src/devsynth/interface/ux_bridge.py`
- `poetry run devsynth run-tests --speed=fast`
- `poetry run python tests/verify_test_organization.py`
- `poetry run python scripts/verify_test_markers.py` *(failed: KeyboardInterrupt)*
- `poetry run python scripts/verify_requirements_traceability.py`
- `poetry run python scripts/verify_version_sync.py`


------
https://chatgpt.com/codex/tasks/task_e_689fec9596608333b422fff2cee70d90