### PR TITLE
chore: update issue progress after test runs

### DIFF
--- a/issues/Failing-unit-tests-after-environment-setup.md
+++ b/issues/Failing-unit-tests-after-environment-setup.md
@@ -22,6 +22,7 @@ failing tests, particularly in the code analysis pipeline.
 - `pip check` confirms no broken requirements.
 - Latest `devsynth run-tests --speed=fast` run produced five errors, including a failure in `tests/behavior/requirements_wizard/test_logging_and_priority_steps.py`.
 - Current fast test run reports a single failure in `tests/unit/interface/test_nicegui_bridge.py::test_session_storage_roundtrip` due to missing session initialization.
+- After running the environment provisioning script, `devsynth run-tests --speed=fast` still fails: `tests/unit/interface/test_nicegui_bridge.py::test_session_storage_roundtrip` raises `RuntimeError: app.storage.user can only be used with page builder functions`.
 
 ## References
 

--- a/issues/Fix-failing-test-tests-behavior-steps-test-code-generation-steps-py-tests-passed.md
+++ b/issues/Fix-failing-test-tests-behavior-steps-test-code-generation-steps-py-tests-passed.md
@@ -11,6 +11,7 @@ The test `tests/behavior/steps/test_code_generation_steps.py::tests_passed` fail
 
 ## Progress
 - Test re-run still fails with `AttributeError: 'NoneType' object has no attribute 'execute_command'`.
+- Running the environment provisioning script followed by the same test run continues to raise the `AttributeError` with `mock_manager` being `None`.
 
 ## References
 


### PR DESCRIPTION
## Summary
- record latest fast test failure in failing-unit-tests tracker
- note environment provisioning run for ongoing code-generation test failure

## Testing
- `poetry run pre-commit run --files issues/Failing-unit-tests-after-environment-setup.md issues/Fix-failing-test-tests-behavior-steps-test-code-generation-steps-py-tests-passed.md`
- `poetry run python tests/verify_test_organization.py`
- `poetry run python scripts/verify_test_markers.py` *(fails: KeyboardInterrupt)*
- `poetry run python scripts/verify_requirements_traceability.py`
- `poetry run python scripts/verify_version_sync.py`
- `poetry run devsynth run-tests --speed=fast` *(fails: tests/unit/interface/test_nicegui_bridge.py::test_session_storage_roundtrip)*

------
https://chatgpt.com/codex/tasks/task_e_68a0a5d383c883339123c22ec6798d44