### PR TITLE
docs: simplify issue headers

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -89,9 +89,10 @@ Before implementing changes—especially when introducing new features—draft a
 ## Issue Tracking
 
 - Use the in-repo issue tracker under `issues/` (see [issues/README.md](issues/README.md)).
+- The first line of each ticket must be `# <title>`.
 - Create new tickets by copying `issues/TEMPLATE.md` and renaming it using a slug of its title.
 - Include `Priority` and `Dependencies` fields along with the standard sections.
-- When a ticket is resolved, move its file to `issues/archived/<slug>.md` and leave it immutable.
+- When a ticket is resolved, move its file to `issues/archived/<slug>.md` and leave it immutable. Archived tickets retain the legacy format `# Issue <number>: <title>`.
 
 ## Specification-First Workflow
 

--- a/issues/Complete-Sprint-EDRR-integration.md
+++ b/issues/Complete-Sprint-EDRR-integration.md
@@ -1,4 +1,4 @@
-# Issue 107: Complete Sprint-EDRR integration
+# Complete Sprint-EDRR integration
 Milestone: 0.2.0
 Status: open
 

--- a/issues/Complete-memory-system-integration.md
+++ b/issues/Complete-memory-system-integration.md
@@ -1,4 +1,4 @@
-# Issue 106: Complete memory system integration
+# Complete memory system integration
 Milestone: 0.1.0-alpha.1
 Status: open
 

--- a/issues/Critical-recommendations-follow-up.md
+++ b/issues/Critical-recommendations-follow-up.md
@@ -1,4 +1,4 @@
-# Issue 104: Critical recommendations follow-up
+# Critical recommendations follow-up
 Milestone: 0.1.0-alpha.1
 Status: open
 

--- a/issues/Dialectical-audit-reports-missing-WebUI-Diagnostics-Page.md
+++ b/issues/Dialectical-audit-reports-missing-WebUI-Diagnostics-Page.md
@@ -1,4 +1,4 @@
-# Issue 124: Dialectical audit reports missing WebUI Diagnostics Page
+# Dialectical audit reports missing WebUI Diagnostics Page
 
 Milestone: 0.1.0-alpha.1
 Status: open

--- a/issues/Dialectical-audit-reports-undocumented-features.md
+++ b/issues/Dialectical-audit-reports-undocumented-features.md
@@ -1,4 +1,4 @@
-# Issue 125: Dialectical audit reports undocumented features
+# Dialectical audit reports undocumented features
 
 Milestone: 0.1.0-alpha.1
 Status: open

--- a/issues/Document-API-reference-generation-feature.md
+++ b/issues/Document-API-reference-generation-feature.md
@@ -1,4 +1,4 @@
-# Issue 123: Document API reference generation feature
+# Document API reference generation feature
 
 Milestone: 0.1.0-alpha.1
 Status: open

--- a/issues/Enhance-retry-mechanism.md
+++ b/issues/Enhance-retry-mechanism.md
@@ -1,4 +1,4 @@
-# Issue 110: Enhance retry mechanism
+# Enhance retry mechanism
 Milestone: 0.2.0
 Status: open
 

--- a/issues/Expand-test-generation-capabilities.md
+++ b/issues/Expand-test-generation-capabilities.md
@@ -1,4 +1,4 @@
-# Issue 108: Expand test generation capabilities
+# Expand test generation capabilities
 Milestone: 0.2.0
 Status: open
 

--- a/issues/Finalize-WSDE-EDRR-workflow-logic.md
+++ b/issues/Finalize-WSDE-EDRR-workflow-logic.md
@@ -1,4 +1,4 @@
-# Issue 130: Finalize WSDE/EDRR workflow logic
+# Finalize WSDE/EDRR workflow logic
 Milestone: 0.1.0-alpha.1
 Status: open
 

--- a/issues/Finalize-dialectical-reasoning.md
+++ b/issues/Finalize-dialectical-reasoning.md
@@ -1,4 +1,4 @@
-# Issue 105: Finalize dialectical reasoning
+# Finalize dialectical reasoning
 Milestone: 0.1.0-alpha.1
 Status: open
 

--- a/issues/Fix-failing-test-tests-behavior-steps-test-code-generation-steps-py-tests-passed.md
+++ b/issues/Fix-failing-test-tests-behavior-steps-test-code-generation-steps-py-tests-passed.md
@@ -1,4 +1,4 @@
-# Issue 126: Fix failing test tests/behavior/steps/test_code_generation_steps.py::tests_passed
+# Fix failing test tests/behavior/steps/test_code_generation_steps.py::tests_passed
 
 Milestone: 0.1.0-alpha.1
 Status: open

--- a/issues/Implement-SDLC-security-audits.md
+++ b/issues/Implement-SDLC-security-audits.md
@@ -1,4 +1,4 @@
-# Issue 111: Implement SDLC security audits
+# Implement SDLC security audits
 Milestone: 0.3.0
 Status: open
 

--- a/issues/Improve-deployment-automation.md
+++ b/issues/Improve-deployment-automation.md
@@ -1,4 +1,4 @@
-# Issue 109: Improve deployment automation
+# Improve deployment automation
 Milestone: 0.2.0
 Status: open
 

--- a/issues/LM-Studio-mock-service-for-deterministic-tests.md
+++ b/issues/LM-Studio-mock-service-for-deterministic-tests.md
@@ -1,4 +1,4 @@
-# Issue 121: LM Studio mock service for deterministic tests
+# LM Studio mock service for deterministic tests
 
 Milestone: 0.1.0-alpha.1
 Status: open

--- a/issues/Normalize-and-verify-test-markers.md
+++ b/issues/Normalize-and-verify-test-markers.md
@@ -1,4 +1,4 @@
-# Issue 128: Normalize and verify test markers
+# Normalize and verify test markers
 Milestone: 0.1.0-alpha.1
 Status: open
 Priority: high

--- a/issues/README.md
+++ b/issues/README.md
@@ -5,14 +5,15 @@ This directory contains the active ticketing system for DevSynth. It does not in
 ## Naming Conventions
 
 - Each ticket filename is a slug of its title (e.g., `CLI-and-UI-improvements.md`).
-- The first line must follow `# Issue <number>: <title>`.
+- The first line must be `# <title>`.
 
 ## Ticket Template
 
 - Start new tickets by copying `TEMPLATE.md` and renaming it to a slug of its title.
-- Populate the Title, Milestone, Status, Priority, Dependencies, Progress, and References sections.
+- Populate the Milestone, Status, Priority, Dependencies, Progress, and References sections.
 
 ## Archive Policy
 
 - When a ticket is closed, move it to `archived/<slug>.md`.
 - Archived files are immutable; open new tickets for follow-up work.
+- Archived tickets use the legacy format `# Issue <number>: <title>`.

--- a/issues/Resolve-pytest-xdist-assertion-errors.md
+++ b/issues/Resolve-pytest-xdist-assertion-errors.md
@@ -1,4 +1,4 @@
-# Issue 131: Resolve pytest-xdist assertion errors
+# Resolve pytest-xdist assertion errors
 Milestone: 0.1.0-alpha.1
 Status: open
 

--- a/issues/Resolve-remaining-dialectical-audit-questions.md
+++ b/issues/Resolve-remaining-dialectical-audit-questions.md
@@ -1,4 +1,4 @@
-# Issue 127: Resolve remaining dialectical audit questions
+# Resolve remaining dialectical audit questions
 
 Milestone: 0.1.0-alpha.1
 Status: open

--- a/issues/TEMPLATE.md
+++ b/issues/TEMPLATE.md
@@ -1,4 +1,4 @@
-# Issue <number>: <title>
+# <title>
 Milestone: <milestone>
 Status: <status>
 Priority: <priority>

--- a/issues/WSDE-collaboration-test-failures.md
+++ b/issues/WSDE-collaboration-test-failures.md
@@ -1,4 +1,4 @@
-# Issue 112: WSDE collaboration test failures
+# WSDE collaboration test failures
 Milestone: 0.1.0-alpha.1
 Status: open
 


### PR DESCRIPTION
## Summary
- standardize ticket headers to `# <title>` and update template and docs
- adjust open tickets to remove issue numbers from header
- clarify legacy issue format in README and AGENTS guidance

## Testing
- `SKIP=fix-code-blocks poetry run pre-commit run --files $(git ls-files -m)`
- `poetry run devsynth run-tests --speed=fast`
- `poetry run python tests/verify_test_organization.py`
- `poetry run python scripts/verify_test_markers.py`
- `poetry run python scripts/verify_requirements_traceability.py`
- `poetry run python scripts/verify_version_sync.py`


------
https://chatgpt.com/codex/tasks/task_e_68a0c64eb0a0833397a6872f84af6e8b