### PR TITLE
chore: capture mock workflow manager

### DIFF
--- a/tests/behavior/steps/cli_commands_steps.py
+++ b/tests/behavior/steps/cli_commands_steps.py
@@ -72,6 +72,7 @@ def run_command(command, monkeypatch, mock_workflow_manager, command_context):
         args = args[1:]
 
     command_context["command"] = command
+    command_context["mock_manager"] = mock_workflow_manager
 
     runner = CliRunner()
 


### PR DESCRIPTION
## Summary
- preserve mock workflow manager in command context for later verification

## Testing
- `SKIP=fix-code-blocks poetry run pre-commit run --files tests/behavior/steps/cli_commands_steps.py`
- `poetry run devsynth run-tests --speed=fast --target tests/behavior/steps/test_code_generation_steps.py`
- `poetry run pytest tests/behavior/steps/test_code_generation_steps.py::tests_passed -vv` *(fails: 'NoneType' object has no attribute 'execute_command')*
- `poetry run python tests/verify_test_organization.py`
- `poetry run python scripts/verify_test_markers.py` *(marker issues found)*
- `poetry run python scripts/verify_requirements_traceability.py`
- `poetry run python scripts/verify_version_sync.py`
- `PIP_NO_INDEX=1 poetry run pip check`


------
https://chatgpt.com/codex/tasks/task_e_68a0c604bb548333a8949a829f477997