### PR TITLE
Add EDRR recovery hooks and configurable thresholds

### DIFF
--- a/docs/implementation/edrr_assessment.md
+++ b/docs/implementation/edrr_assessment.md
@@ -110,7 +110,8 @@ The EDRR framework is now feature complete. Phase transition logic, context
 persistence, and recursion limits are implemented in the coordinator. Advanced
 collaboration features can be toggled with feature flags, but the base workflow
 is stable and ready for production use. Configuration values for recursion are
-sanitized to prevent misconfiguration attacks. See the
+sanitized to prevent misconfiguration attacks. Configuration-driven threshold
+helpers ensure phase and micro-cycle limits respect safe defaults. See the
 [Feature Status Matrix](feature_status_matrix.md) for ongoing enhancements.
 
 ## Critical Gaps and Priorities

--- a/tests/unit/application/edrr/test_recovery_hooks.py
+++ b/tests/unit/application/edrr/test_recovery_hooks.py
@@ -1,0 +1,64 @@
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from devsynth.application.code_analysis.analyzer import CodeAnalyzer
+from devsynth.application.code_analysis.ast_transformer import AstTransformer
+from devsynth.application.documentation.documentation_manager import (
+    DocumentationManager,
+)
+from devsynth.application.edrr.coordinator import EDRRCoordinator
+from devsynth.application.memory.memory_manager import MemoryManager
+from devsynth.application.prompts.prompt_manager import PromptManager
+from devsynth.domain.models.wsde_facade import WSDETeam
+from devsynth.methodology.base import Phase
+
+
+@pytest.fixture
+def coordinator():
+    mm = MagicMock(spec=MemoryManager)
+    team = MagicMock(spec=WSDETeam)
+    ca = MagicMock(spec=CodeAnalyzer)
+    ast = MagicMock(spec=AstTransformer)
+    pm = MagicMock(spec=PromptManager)
+    dm = MagicMock(spec=DocumentationManager)
+    coord = EDRRCoordinator(mm, team, ca, ast, pm, dm)
+    coord.cycle_id = "cid"
+    coord.current_phase = Phase.EXPAND
+    coord.task = {}
+    return coord
+
+
+@pytest.mark.medium
+def test_recovery_hook_handles_error(coordinator):
+    """Recovery hooks can intercept phase errors and provide results."""
+
+    def hook(error, phase, coordinator):
+        assert phase == Phase.EXPAND
+        return {"recovered": True, "results": {"handled": True}}
+
+    coordinator.register_recovery_hook(Phase.EXPAND, hook)
+
+    with patch.object(EDRRCoordinator, "_execute_phase", side_effect=Exception("boom")):
+        results = coordinator.execute_current_phase({})
+
+    assert results["recovery_info"]["recovered"] is True
+    assert results["handled"] is True
+
+
+@pytest.mark.medium
+def test_recovery_hook_fallback_retry(coordinator):
+    """If hooks do not recover, coordinator retries the phase."""
+    coordinator.register_recovery_hook(Phase.EXPAND, lambda **_: {"recovered": False})
+
+    with patch.object(
+        EDRRCoordinator,
+        "_execute_expand_phase",
+        side_effect=[Exception("boom"), {"value": 1}],
+    ) as exec_mock:
+        results = coordinator.execute_current_phase({})
+
+    # First call fails, second call succeeds via retry
+    assert exec_mock.call_count == 2
+    assert results["recovery_info"]["recovered"] is True
+    assert results["value"] == 1

--- a/tests/unit/application/edrr/test_threshold_helpers.py
+++ b/tests/unit/application/edrr/test_threshold_helpers.py
@@ -1,0 +1,47 @@
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from devsynth.application.code_analysis.analyzer import CodeAnalyzer
+from devsynth.application.code_analysis.ast_transformer import AstTransformer
+from devsynth.application.documentation.documentation_manager import (
+    DocumentationManager,
+)
+from devsynth.application.edrr.coordinator import EDRRCoordinator
+from devsynth.application.memory.memory_manager import MemoryManager
+from devsynth.application.prompts.prompt_manager import PromptManager
+from devsynth.domain.models.wsde_facade import WSDETeam
+from devsynth.methodology.base import Phase
+
+
+@pytest.fixture
+def base_dependencies():
+    mm = MagicMock(spec=MemoryManager)
+    team = MagicMock(spec=WSDETeam)
+    ca = MagicMock(spec=CodeAnalyzer)
+    ast = MagicMock(spec=AstTransformer)
+    pm = MagicMock(spec=PromptManager)
+    dm = MagicMock(spec=DocumentationManager)
+    return mm, team, ca, ast, pm, dm
+
+
+@pytest.mark.medium
+def test_assess_phase_quality_uses_config_threshold(base_dependencies):
+    mm, team, ca, ast, pm, dm = base_dependencies
+    cfg = {"edrr": {"phase_transitions": {"quality_thresholds": {"expand": 0.6}}}}
+    coord = EDRRCoordinator(mm, team, ca, ast, pm, dm, config=cfg)
+    coord.results[Phase.EXPAND.name] = {}
+    with patch.object(EDRRCoordinator, "_assess_result_quality", return_value=0.5):
+        assessment = coord._assess_phase_quality(Phase.EXPAND)
+    assert assessment["can_progress"] is False
+
+
+@pytest.mark.medium
+def test_micro_cycle_config_sanitization(base_dependencies):
+    mm, team, ca, ast, pm, dm = base_dependencies
+    cfg = {"edrr": {"micro_cycles": {"max_iterations": 100, "quality_threshold": 2.0}}}
+    coord = EDRRCoordinator(mm, team, ca, ast, pm, dm, config=cfg)
+    with patch.object(EDRRCoordinator, "_assess_result_quality", return_value=0.1):
+        # iteration 0 allowed, iteration 1 stops due to sanitized max_iterations=1
+        assert coord._should_continue_micro_cycles(Phase.EXPAND, 0, {}) is True
+        assert coord._should_continue_micro_cycles(Phase.EXPAND, 1, {}) is False


### PR DESCRIPTION
## Summary
- implement phase-specific recovery hooks in EDRR coordinator
- introduce config-driven threshold helpers for phase quality and micro-cycles
- document threshold helpers in EDRR assessment and add unit tests

## Testing
- `poetry run pre-commit run --files src/devsynth/application/edrr/coordinator.py docs/implementation/edrr_assessment.md tests/unit/application/edrr/test_recovery_hooks.py tests/unit/application/edrr/test_threshold_helpers.py`
- `poetry run pytest tests/unit/application/edrr/test_recovery_hooks.py tests/unit/application/edrr/test_threshold_helpers.py -q`
- `poetry run python tests/verify_test_organization.py`
- `poetry run python scripts/verify_version_sync.py`
- `poetry run devsynth run-tests --speed fast` *(fails: process interrupted)*
- `poetry run python scripts/verify_test_markers.py` *(fails: process interrupted)*


------
https://chatgpt.com/codex/tasks/task_e_68a0c65dfa4c83339e532ce01e631644