### PR TITLE
feat: add per-error retry policies and metrics

### DIFF
--- a/docs/specifications/per_error_retry_policies.md
+++ b/docs/specifications/per_error_retry_policies.md
@@ -1,0 +1,29 @@
+---
+author: DevSynth Team
+date: '2025-07-30'
+last_reviewed: '2025-07-30'
+status: draft
+tags:
+- specification
+- retry
+- error-handling
+title: Per-Error Retry Policies
+version: "0.1.0-alpha.1"
+---
+<div class="breadcrumbs">
+<a href="../index.md">Documentation</a> &gt; <a href="index.md">Specifications</a> &gt; Per-Error Retry Policies
+</div>
+
+# Per-Error Retry Policies
+
+## Problem
+
+Global retry settings cannot accommodate exceptions that require custom retry
+limits or disabling retries altogether.
+
+## Proof
+
+Implement a mapping of exception types to per-error policies consumed by
+``retry_with_exponential_backoff``. Policies may specify ``max_retries`` and a
+``retry`` flag that overrides the global behaviour. Metrics should record when
+named conditions permit or suppress retries for observability.

--- a/tests/behavior/features/general/per_error_retry_policies.feature
+++ b/tests/behavior/features/general/per_error_retry_policies.feature
@@ -1,0 +1,9 @@
+Feature: Per-error retry policies
+  As a developer
+  I want retries to honour per-error policies
+  So that transient and fatal errors are handled appropriately
+
+  Scenario: policy prevents retry
+    Given a function with a retry policy disabling retries
+    When the function raises a disallowed error
+    Then the retry loop aborts immediately

--- a/tests/unit/fallback/test_condition_callbacks_prometheus.py
+++ b/tests/unit/fallback/test_condition_callbacks_prometheus.py
@@ -102,8 +102,11 @@ def test_condition_callback_records_metrics():
     with pytest.raises(Exception):
         wrapped()
 
-    assert metrics.get_retry_condition_metrics() == {cb.__name__: 1}
-    assert retry_condition_counter.labels(condition=cb.__name__)._value.get() == 1
+    assert metrics.get_retry_condition_metrics() == {f"{cb.__name__}:suppress": 1}
+    assert (
+        retry_condition_counter.labels(condition=f"{cb.__name__}:suppress")._value.get()
+        == 1
+    )
 
 
 @pytest.mark.medium
@@ -126,7 +129,10 @@ def test_memory_condition_callback_records_metrics():
         wrapped()
 
     assert (
-        memory_retry_condition_counter.labels(condition=cb.__name__)._value.get() == 1
+        memory_retry_condition_counter.labels(
+            condition=f"{cb.__name__}:suppress"
+        )._value.get()
+        == 1
     )
 
 
@@ -146,5 +152,8 @@ def test_memory_retry_condition_records_metrics() -> None:
         wrapped()
 
     assert (
-        memory_retry_condition_counter.labels(condition="needs_retry")._value.get() == 1
+        memory_retry_condition_counter.labels(
+            condition="needs_retry:suppress"
+        )._value.get()
+        == 1
     )

--- a/tests/unit/fallback/test_retry.py
+++ b/tests/unit/fallback/test_retry.py
@@ -46,7 +46,7 @@ def test_anonymous_retry_condition_records_metrics() -> None:
     assert retry_metrics.get("abort") == 1
 
     condition_metrics = get_retry_condition_metrics()
-    assert condition_metrics.get(ANONYMOUS_CONDITION) == 1
+    assert condition_metrics.get(f"{ANONYMOUS_CONDITION}:suppress") == 1
     assert (
         circuit_breaker_state_counter.labels(
             function="func", state=CircuitBreaker.OPEN

--- a/tests/unit/fallback/test_retry_condition_metrics.py
+++ b/tests/unit/fallback/test_retry_condition_metrics.py
@@ -27,8 +27,11 @@ def test_named_retry_condition_records_metrics_on_abort() -> None:
         wrapped()
 
     assert func.call_count == 1
-    assert metrics.get_retry_condition_metrics() == {"needs_retry": 1}
-    assert retry_condition_counter.labels(condition="needs_retry")._value.get() == 1
+    assert metrics.get_retry_condition_metrics() == {"needs_retry:suppress": 1}
+    assert (
+        retry_condition_counter.labels(condition="needs_retry:suppress")._value.get()
+        == 1
+    )
 
 
 @pytest.mark.medium
@@ -51,4 +54,4 @@ def test_named_retry_condition_allows_retry() -> None:
 
     assert result == "ok"
     assert func.call_count == 2
-    assert metrics.get_retry_condition_metrics() == {}
+    assert metrics.get_retry_condition_metrics() == {"needs_retry:trigger": 1}

--- a/tests/unit/fallback/test_retry_with_conditions.py
+++ b/tests/unit/fallback/test_retry_with_conditions.py
@@ -1,0 +1,76 @@
+from unittest.mock import Mock
+
+import pytest
+
+from devsynth import metrics
+from devsynth.fallback import reset_prometheus_metrics, retry_with_exponential_backoff
+
+
+@pytest.mark.medium
+def test_error_policy_overrides_max_retries() -> None:
+    """Per-error policies override global max retries."""
+    metrics.reset_metrics()
+    reset_prometheus_metrics()
+
+    func = Mock(side_effect=[ValueError("bad"), ValueError("bad"), "ok"])
+    func.__name__ = "func"
+
+    wrapped = retry_with_exponential_backoff(
+        max_retries=5,
+        initial_delay=0,
+        track_metrics=True,
+        error_retry_map={ValueError: {"max_retries": 1}},
+    )(func)
+
+    with pytest.raises(ValueError):
+        wrapped()
+
+    assert func.call_count == 2
+    assert metrics.get_retry_metrics()["failure"] == 1
+
+
+@pytest.mark.medium
+def test_error_policy_prevents_retry() -> None:
+    """Per-error policies can disable retries entirely."""
+    metrics.reset_metrics()
+    reset_prometheus_metrics()
+
+    func = Mock(side_effect=KeyError("nope"))
+    func.__name__ = "func"
+
+    wrapped = retry_with_exponential_backoff(
+        max_retries=5,
+        initial_delay=0,
+        track_metrics=True,
+        error_retry_map={KeyError: {"retry": False}},
+    )(func)
+
+    with pytest.raises(KeyError):
+        wrapped()
+
+    assert func.call_count == 1
+    assert metrics.get_retry_metrics()["abort"] == 1
+
+
+@pytest.mark.medium
+def test_condition_metrics_track_trigger_and_suppress() -> None:
+    """Condition metrics increment on trigger and suppress."""
+    metrics.reset_metrics()
+    reset_prometheus_metrics()
+
+    func = Mock(side_effect=[Exception("please retry"), Exception("boom")])
+    func.__name__ = "func"
+
+    wrapped = retry_with_exponential_backoff(
+        max_retries=1,
+        initial_delay=0,
+        retry_conditions={"needs_retry": "retry"},
+        track_metrics=True,
+    )(func)
+
+    with pytest.raises(Exception):
+        wrapped()
+
+    condition_stats = metrics.get_retry_condition_metrics()
+    assert condition_stats["needs_retry:trigger"] == 1
+    assert condition_stats["needs_retry:suppress"] == 1

--- a/tests/unit/general/test_retry_failure_scenarios.py
+++ b/tests/unit/general/test_retry_failure_scenarios.py
@@ -30,7 +30,7 @@ def test_named_retry_condition_aborts_and_records_metrics():
     stats = get_retry_stat_metrics()
     condition_stats = get_retry_condition_metrics()
     assert stats["always_fail:abort"] == 1
-    assert condition_stats["always_false"] == 1
+    assert condition_stats["always_false:suppress"] == 1
 
 
 def test_circuit_breaker_open_records_abort_metrics():


### PR DESCRIPTION
## Summary
- support per-error retry policies in retry_with_exponential_backoff
- record metrics when retry conditions trigger or suppress execution
- test retry condition metrics and per-error retry behaviors

## Testing
- `poetry run pre-commit run --files src/devsynth/application/memory/retry.py src/devsynth/fallback.py tests/unit/fallback/test_condition_callbacks_prometheus.py tests/unit/fallback/test_retry.py tests/unit/fallback/test_retry_condition_metrics.py tests/unit/general/test_retry_failure_scenarios.py docs/specifications/per_error_retry_policies.md tests/behavior/features/general/per_error_retry_policies.feature tests/unit/fallback/test_retry_with_conditions.py`
- `poetry run devsynth run-tests --speed=fast`
- `poetry run python tests/verify_test_organization.py`
- `poetry run python scripts/verify_test_markers.py` *(failed: KeyboardInterrupt)*
- `poetry run python scripts/verify_requirements_traceability.py`
- `poetry run python scripts/verify_version_sync.py`
- `PIP_NO_INDEX=1 poetry run pip check`


------
https://chatgpt.com/codex/tasks/task_e_68a0c6776ef88333bc2dad65551b38e8