### PR TITLE
Integrate security audit script into setup and CI

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -16,9 +16,7 @@ jobs:
           python -m pip install --upgrade pip
           pip install poetry
           poetry install --with dev --all-extras
-      - name: Run static analysis
-        run: poetry run pre-commit run --hook-stage push --all-files bandit safety
-      - name: Enforce security policy
+      - name: Run security audit
         env:
           DEVSYNTH_PRE_DEPLOY_APPROVED: "true"
         run: poetry run python scripts/security_audit.py

--- a/docs/policies/security.md
+++ b/docs/policies/security.md
@@ -73,6 +73,11 @@ DevSynth automates routine security checks to prevent regressions:
 - Developers should run `devsynth security-audit` locally before committing
   changes to catch issues early.
 
+```bash
+DEVSYNTH_PRE_DEPLOY_APPROVED=true poetry run python scripts/security_audit.py
+```
+
+
 ### Enforceable Audit Criteria
 
 The following settings must be configured for deployments and are verified by

--- a/scripts/codex_setup.sh
+++ b/scripts/codex_setup.sh
@@ -227,6 +227,7 @@ run_check "Test organization verification" poetry run python tests/verify_test_o
 run_check "Test marker verification" poetry run python scripts/verify_test_markers.py
 run_check "Requirements traceability verification" poetry run python scripts/verify_requirements_traceability.py
 run_check "Version synchronization verification" poetry run python scripts/verify_version_sync.py
+run_check "Security audit" DEVSYNTH_PRE_DEPLOY_APPROVED=true poetry run python scripts/security_audit.py
 
 # Cleanup any failure marker if the setup completes successfully
 [ -f CODEX_ENVIRONMENT_SETUP_FAILED ] && rm CODEX_ENVIRONMENT_SETUP_FAILED

--- a/scripts/security_audit.py
+++ b/scripts/security_audit.py
@@ -16,11 +16,10 @@ from devsynth.security.validation import require_pre_deploy_checks
 logger = setup_logging(__name__)
 
 
-def run() -> None:
+def run(argv: list[str] | None = None) -> None:
     """Execute Bandit and Safety security checks."""
     require_pre_deploy_checks()
-    audit.run_bandit()
-    audit.run_safety()
+    audit.main(argv)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- hook security audit script into environment provisioning and dedicated security workflow
- allow audit script to delegate to internal Bandit and Safety runner
- document how to invoke the audit script from the security policy

## Testing
- `poetry run pre-commit run --files .github/workflows/security.yml docs/policies/security.md scripts/codex_setup.sh scripts/security_audit.py`
- `poetry run devsynth run-tests --speed=fast`
- `poetry run python tests/verify_test_organization.py`
- `poetry run python scripts/verify_test_markers.py` *(fails: KeyboardInterrupt)*
- `poetry run python scripts/verify_requirements_traceability.py`
- `poetry run python scripts/verify_version_sync.py`
- `DEVSYNTH_PRE_DEPLOY_APPROVED=true poetry run python scripts/security_audit.py` *(fails: Command '['poetry', 'run', 'bandit', '-q', '-r', 'src']' returned non-zero exit status 1)*

------
https://chatgpt.com/codex/tasks/task_e_68a0c67c52fc8333b6f2d3873b78828f