### PR TITLE
Integrate voting summaries into EDRR coordination

### DIFF
--- a/docs/implementation/feature_status_matrix.md
+++ b/docs/implementation/feature_status_matrix.md
@@ -52,7 +52,7 @@ Each feature is scored on two dimensions:
 |---------|--------|---------|-------------------|--------------------------------|-------------|------|------|
 | **Core Framework** |
 | EDRR Framework | Partial | src/devsynth/application/EDRR | 5 | 4 | Agent Orchestration | | Phase transition logic, recursion handling, and CLI integration are stable. Recovery hooks and threshold helpers now validated by unit tests. Remaining tasks are tracked in [issue 104](../../issues/Critical-recommendations-follow-up.md).
-| WSDE Agent Collaboration | Partial | src/devsynth/application/collaboration | 4 | 5 | Memory System | | Consensus voting validated with dynamic role reassignment. Summary utilities for voting results implemented. Coordination with the EDRR cycle is still under review (see [issue 104](../../issues/Critical-recommendations-follow-up.md)).  |
+| WSDE Agent Collaboration | Partial | src/devsynth/application/collaboration | 4 | 5 | Memory System | | Consensus voting validated with dynamic role reassignment. Voting summaries now integrated across EDRR phases (see [issue 104](../../issues/Critical-recommendations-follow-up.md)). |
 | Dialectical Reasoning | Partial | src/devsynth/application/requirements/dialectical_reasoner.py | 4 | 3 | WSDE Model | | Hooks integrated in WSDETeam, framework largely implemented. Tracked in [issue 105](../../issues/Finalize-dialectical-reasoning.md) |
 | Message Passing Protocol | Complete | src/devsynth/application/collaboration/message_protocol.py | 4 | 2 | WSDE Model | | Enables structured agent communication |
 | Peer Review Mechanism | Complete | src/devsynth/application/collaboration/peer_review.py | 4 | 3 | WSDE Model | | Workflow implemented with revision cycles and integration tests |

--- a/src/devsynth/application/collaboration/coordinator.py
+++ b/src/devsynth/application/collaboration/coordinator.py
@@ -128,7 +128,23 @@ class AgentCoordinatorImpl(AgentCoordinator):
 
         # Critical decisions use the WSDE voting mechanism
         if task.get("type") == "critical_decision" and task.get("is_critical", False):
-            return self.team.vote_on_critical_decision(task)
+            voting_result = self.team.vote_on_critical_decision(task)
+            phase_name = task.get("phase")
+            if phase_name:
+                voting_result["phase"] = phase_name
+            summary_input = {
+                "status": voting_result.get("status"),
+                "result": {
+                    "method": voting_result.get("method"),
+                    "winner": voting_result.get("result"),
+                    "tie_broken": voting_result.get("tie_broken", False),
+                    "tie_breaker_method": voting_result.get("tie_breaker_method"),
+                },
+                "vote_counts": voting_result.get("vote_counts", {}),
+                "vote_weights": voting_result.get("vote_weights", {}),
+            }
+            voting_result["summary"] = self.team.summarize_voting_result(summary_input)
+            return voting_result
 
         # Assign roles to team members
         phase_name = task.get("phase")

--- a/tests/integration/collaboration/test_voting_summary_edrr.py
+++ b/tests/integration/collaboration/test_voting_summary_edrr.py
@@ -1,0 +1,41 @@
+import pytest
+
+from devsynth.application.collaboration.coordinator import AgentCoordinatorImpl
+from devsynth.methodology.base import Phase
+
+
+class DummyAgent:
+    def __init__(self, name: str):
+        self.name = name
+        self.agent_type = "general"
+        self.expertise = ["option_a"]
+
+    def process(self, task):  # pragma: no cover - not used in voting
+        return {}
+
+
+@pytest.fixture
+def coordinator():
+    cfg = {"features": {"wsde_collaboration": True}}
+    coord = AgentCoordinatorImpl(config=cfg)
+    coord.add_agent(DummyAgent("a1"))
+    coord.add_agent(DummyAgent("a2"))
+    return coord
+
+
+@pytest.mark.medium
+@pytest.mark.parametrize(
+    "phase",
+    [Phase.EXPAND, Phase.DIFFERENTIATE, Phase.REFINE, Phase.RETROSPECT],
+)
+def test_voting_summary_in_edrr_phases(coordinator, phase):
+    task = {
+        "type": "critical_decision",
+        "is_critical": True,
+        "options": ["option_a", "option_b"],
+        "phase": phase.value,
+        "team_task": True,
+    }
+    result = coordinator.delegate_task(task)
+    assert result["phase"] == phase.value
+    assert "Voting was completed" in result["summary"]


### PR DESCRIPTION
## Summary
- propagate EDRR phase context and human-readable voting summaries in agent coordination
- cover voting summary propagation across EDRR phases with integration tests
- document collaboration progress in feature status matrix

## Testing
- `poetry run pre-commit run --files src/devsynth/application/collaboration/coordinator.py tests/integration/collaboration/test_voting_summary_edrr.py`
- `poetry run devsynth run-tests --speed=fast`
- `poetry run pytest tests/integration/collaboration/test_voting_summary_edrr.py -m medium`
- `poetry run python tests/verify_test_organization.py`
- `poetry run python scripts/verify_test_markers.py` *(fails: KeyboardInterrupt)*
- `poetry run python scripts/verify_requirements_traceability.py`
- `poetry run python scripts/verify_version_sync.py`


------
https://chatgpt.com/codex/tasks/task_e_68a0c663e88c83339e861a442ce18804