### PR TITLE
feat: improve CLI error handling

### DIFF
--- a/src/devsynth/interface/cli.py
+++ b/src/devsynth/interface/cli.py
@@ -171,8 +171,12 @@ class CLIProgressIndicator(ProgressIndicator):
         try:
             desc_str = str(description)
             desc = sanitize_output(desc_str)
-        except Exception:
-            # Fallback for objects that can't be safely converted to string
+        except (TypeError, ValueError) as exc:
+            logger.warning(
+                "Failed to sanitize main task description",
+                exc_info=exc,
+                extra={"description": description},
+            )
             desc = "<main task>"
 
         self._task = self._progress.add_task(desc, total=total, status="Starting...")
@@ -200,8 +204,12 @@ class CLIProgressIndicator(ProgressIndicator):
             try:
                 desc_str = str(description)
                 desc = sanitize_output(desc_str)
-            except Exception:
-                # Fallback for objects that can't be safely converted to string
+            except (TypeError, ValueError) as exc:
+                logger.warning(
+                    "Failed to sanitize task description",
+                    exc_info=exc,
+                    extra={"description": description},
+                )
                 desc = "<description>"
         else:
             desc = None
@@ -211,8 +219,12 @@ class CLIProgressIndicator(ProgressIndicator):
             try:
                 status_str = str(status)
                 status_msg = sanitize_output(status_str)
-            except Exception:
-                # Fallback for objects that can't be safely converted to string
+            except (TypeError, ValueError) as exc:
+                logger.warning(
+                    "Failed to sanitize task status",
+                    exc_info=exc,
+                    extra={"status": status},
+                )
                 status_msg = "In progress..."
         else:
             # If no status is provided, use a default based on progress
@@ -267,8 +279,12 @@ class CLIProgressIndicator(ProgressIndicator):
             desc_str = str(description)
             desc = sanitize_output(desc_str)
             formatted_desc = f"  ↳ {desc}"
-        except Exception:
-            # Fallback for objects that can't be safely converted to string
+        except (TypeError, ValueError) as exc:
+            logger.warning(
+                "Failed to sanitize subtask description",
+                exc_info=exc,
+                extra={"description": description},
+            )
             formatted_desc = "  ↳ <subtask>"
 
         # Add the task without the status parameter to be compatible with the test mock
@@ -314,8 +330,12 @@ class CLIProgressIndicator(ProgressIndicator):
                 desc_str = str(description)
                 desc = sanitize_output(desc_str)
                 formatted_desc = f"  ↳ {desc}"
-            except Exception:
-                # Fallback for objects that can't be safely converted to string
+            except (TypeError, ValueError) as exc:
+                logger.warning(
+                    "Failed to sanitize subtask update description",
+                    exc_info=exc,
+                    extra={"description": description},
+                )
                 formatted_desc = "  ↳ <description>"
         else:
             formatted_desc = None
@@ -325,8 +345,12 @@ class CLIProgressIndicator(ProgressIndicator):
             try:
                 status_str = str(status)
                 status_msg = sanitize_output(status_str)
-            except Exception:
-                # Fallback for objects that can't be safely converted to string
+            except (TypeError, ValueError) as exc:
+                logger.warning(
+                    "Failed to sanitize subtask status",
+                    exc_info=exc,
+                    extra={"status": status},
+                )
                 status_msg = "In progress..."
         else:
             # If no status is provided, use a default based on progress
@@ -402,8 +426,12 @@ class CLIProgressIndicator(ProgressIndicator):
             desc_str = str(description)
             desc = sanitize_output(desc_str)
             formatted_desc = f"    ↳ {desc}"
-        except Exception:
-            # Fallback for objects that can't be safely converted to string
+        except (TypeError, ValueError) as exc:
+            logger.warning(
+                "Failed to sanitize nested subtask description",
+                exc_info=exc,
+                extra={"description": description},
+            )
             formatted_desc = "    ↳ <nested subtask>"
 
         task_id = self._progress.add_task(formatted_desc, total=total, status=status)
@@ -439,8 +467,12 @@ class CLIProgressIndicator(ProgressIndicator):
                 desc_str = str(description)
                 desc = sanitize_output(desc_str)
                 formatted_desc = f"    ↳ {desc}"
-            except Exception:
-                # Fallback for objects that can't be safely converted to string
+            except (TypeError, ValueError) as exc:
+                logger.warning(
+                    "Failed to sanitize nested subtask update description",
+                    exc_info=exc,
+                    extra={"description": description},
+                )
                 formatted_desc = "    ↳ <description>"
         else:
             formatted_desc = None
@@ -450,8 +482,12 @@ class CLIProgressIndicator(ProgressIndicator):
             try:
                 status_str = str(status)
                 status_msg = sanitize_output(status_str)
-            except Exception:
-                # Fallback for objects that can't be safely converted to string
+            except (TypeError, ValueError) as exc:
+                logger.warning(
+                    "Failed to sanitize nested subtask status",
+                    exc_info=exc,
+                    extra={"status": status},
+                )
                 status_msg = "In progress..."
         else:
             # If no status is provided, use a default based on progress

--- a/tests/unit/interface/test_cli_progress_indicator.py
+++ b/tests/unit/interface/test_cli_progress_indicator.py
@@ -1,0 +1,102 @@
+import types
+
+import pytest
+from rich.console import Console
+
+from devsynth.interface.cli import CLIProgressIndicator
+
+
+class BadStr:
+    def __str__(self) -> str:  # pragma: no cover - deliberately bad
+        raise TypeError("bad string")
+
+
+@pytest.mark.fast
+def test_progress_indicator_init_with_bad_description_uses_fallback(caplog):
+    """Ensure CLIProgressIndicator falls back when description conversion fails.
+
+    ReqID: N/A"""
+    console = Console()
+    with caplog.at_level("WARNING"):
+        indicator = CLIProgressIndicator(console, BadStr(), total=1)
+    task = indicator._progress.tasks[indicator._task]
+    assert task.description == "<main task>"
+    assert any(
+        "Failed to sanitize main task description" in rec.message
+        for rec in caplog.records
+    )
+
+
+@pytest.mark.fast
+def test_progress_indicator_update_with_bad_inputs_uses_fallback(caplog):
+    """Ensure update handles bad description and status.
+
+    ReqID: N/A"""
+    indicator = CLIProgressIndicator(Console(), "task", total=1)
+    with caplog.at_level("WARNING"):
+        indicator.update(description=BadStr())
+    task = indicator._progress.tasks[indicator._task]
+    assert task.description == "<description>"
+    assert any(
+        "Failed to sanitize task description" in rec.message for rec in caplog.records
+    )
+    caplog.clear()
+    with caplog.at_level("WARNING"):
+        indicator.update(status=BadStr())
+    task = indicator._progress.tasks[indicator._task]
+    assert task.fields["status"] == "In progress..."
+    assert any(
+        "Failed to sanitize task status" in rec.message for rec in caplog.records
+    )
+
+
+@pytest.mark.fast
+def test_progress_indicator_subtasks_with_bad_inputs_use_fallbacks(caplog):
+    """Ensure subtask helpers handle malformed inputs gracefully.
+
+    ReqID: N/A"""
+    indicator = CLIProgressIndicator(Console(), "task", total=1)
+    indicator._progress.live = types.SimpleNamespace(
+        refresh=lambda *args, **kwargs: None, is_started=False
+    )
+    caplog.set_level("WARNING")
+    sub_id = indicator.add_subtask(BadStr())
+    assert indicator._progress.tasks[sub_id].description == "  ↳ <subtask>"
+    assert any(
+        "Failed to sanitize subtask description" in rec.message
+        for rec in caplog.records
+    )
+    caplog.clear()
+    indicator.update_subtask(sub_id, description=BadStr())
+    assert indicator._progress.tasks[sub_id].description == "  ↳ <description>"
+    assert any(
+        "Failed to sanitize subtask update description" in rec.message
+        for rec in caplog.records
+    )
+    caplog.clear()
+    indicator.update_subtask(sub_id, status=BadStr())
+    assert indicator._progress.tasks[sub_id].fields["status"] == "In progress..."
+    assert any(
+        "Failed to sanitize subtask status" in rec.message for rec in caplog.records
+    )
+    caplog.clear()
+    nested_id = indicator.add_nested_subtask(sub_id, BadStr())
+    assert indicator._progress.tasks[nested_id].description == "    ↳ <nested subtask>"
+    assert any(
+        "Failed to sanitize nested subtask description" in rec.message
+        for rec in caplog.records
+    )
+    caplog.clear()
+    indicator.update_nested_subtask(sub_id, nested_id, description=BadStr())
+    assert indicator._progress.tasks[nested_id].description == "    ↳ <description>"
+    assert any(
+        "Failed to sanitize nested subtask update description" in rec.message
+        for rec in caplog.records
+    )
+    caplog.clear()
+    indicator.update_nested_subtask(sub_id, nested_id, status=BadStr())
+    assert indicator._progress.tasks[nested_id].fields["status"] == "In progress..."
+    assert any(
+        "Failed to sanitize nested subtask status" in rec.message
+        for rec in caplog.records
+    )


### PR DESCRIPTION
## Summary
- log specific TypeError/ValueError cases in CLI progress indicator
- test CLI progress indicator resilience to malformed inputs

## Testing
- `poetry run pre-commit run --files src/devsynth/interface/cli.py tests/unit/interface/test_cli_progress_indicator.py`
- `poetry run devsynth run-tests --speed=fast`
- `poetry run python tests/verify_test_organization.py`
- `poetry run python scripts/verify_test_markers.py --workers 1` *(fails: KeyboardInterrupt)*
- `poetry run python scripts/verify_requirements_traceability.py`
- `poetry run python scripts/verify_version_sync.py`


------
https://chatgpt.com/codex/tasks/task_e_68a0c654d7a88333bd91ae00aac1285e