### PR TITLE
chore: enforce deployment script security

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,6 +13,7 @@ services:
       - ./logs:/var/log/devsynth
     env_file:
       - .env
+    user: "${UID:-1000}:${GID:-1000}"
     ports:
       - "8000:8000"
     environment:
@@ -50,6 +51,7 @@ services:
     command: /bin/bash -c "tail -f /dev/null"
     env_file:
       - .env
+    user: "${UID:-1000}:${GID:-1000}"
     networks:
       - devsynth-network
     profiles:
@@ -77,6 +79,7 @@ services:
       - DEVSYNTH_ENV=testing
     env_file:
       - .env
+    user: "${UID:-1000}:${GID:-1000}"
     networks:
       - devsynth-network
     profiles:

--- a/docs/policies/deployment.md
+++ b/docs/policies/deployment.md
@@ -27,6 +27,8 @@ This policy defines best practices for deployment, CI/CD, and operational safety
 - Store deployment docs and scripts in `deployment/` and document the process in `deployment/README.md`.
 - Automate deployment via CI/CD; require all tests to pass and review/approval before production deploys.
 - Use environment variables or secrets management for credentials; never hardcode secrets.
+- Run deployment tooling as a non-root user; scripts fail fast if executed with elevated privileges.
+- Ensure required environment files exist with `600` permissions before starting services.
 - Document rollback and incident response procedures in deployment docs.
 - Require post-deployment verification (smoke tests, monitoring checks).
 - Limit production deployment permissions to authorized roles/agents.
@@ -34,6 +36,7 @@ This policy defines best practices for deployment, CI/CD, and operational safety
 - Provide Docker Compose files for local and production deployments in the
   `deployment/` directory. The monitoring compose file enables Prometheus metrics
   scraping and Grafana dashboards.
+- Containers run using the caller's UID/GID to avoid root inside services.
 
 ## Artifacts
 

--- a/scripts/deployment/bootstrap_env.sh
+++ b/scripts/deployment/bootstrap_env.sh
@@ -27,7 +27,11 @@ if ! command -v docker >/dev/null 2>&1; then
 fi
 
 ENV_FILE=".env.${ENVIRONMENT}"
-if [[ -f "$ENV_FILE" ]] && [[ $(stat -c %a "$ENV_FILE") != "600" ]]; then
+if [[ ! -f "$ENV_FILE" ]]; then
+  echo "Missing environment file: $ENV_FILE" >&2
+  exit 1
+fi
+if [[ $(stat -c %a "$ENV_FILE") != "600" ]]; then
   echo "Environment file $ENV_FILE must have 600 permissions" >&2
   exit 1
 fi

--- a/scripts/deployment/check_health.sh
+++ b/scripts/deployment/check_health.sh
@@ -21,7 +21,11 @@ if [[ ! " ${ALLOWED_ENVIRONMENTS[*]} " =~ " ${ENVIRONMENT} " ]]; then
 fi
 
 ENV_FILE=".env.${ENVIRONMENT}"
-if [[ -f "$ENV_FILE" ]] && [[ $(stat -c %a "$ENV_FILE") != "600" ]]; then
+if [[ ! -f "$ENV_FILE" ]]; then
+  echo "Missing environment file: $ENV_FILE" >&2
+  exit 1
+fi
+if [[ $(stat -c %a "$ENV_FILE") != "600" ]]; then
   echo "Environment file $ENV_FILE must have 600 permissions" >&2
   exit 1
 fi

--- a/scripts/deployment/publish_image.sh
+++ b/scripts/deployment/publish_image.sh
@@ -31,14 +31,15 @@ export DEVSYNTH_IMAGE_TAG="$TAG"
 
 # Ensure environment file permissions
 ENV_FILE=".env.production"
-ENV_ARGS=()
-if [[ -f "$ENV_FILE" ]]; then
-  if [[ $(stat -c %a "$ENV_FILE") != "600" ]]; then
-    echo "Environment file $ENV_FILE must have 600 permissions" >&2
-    exit 1
-  fi
-  ENV_ARGS=(--env-file "$ENV_FILE")
+if [[ ! -f "$ENV_FILE" ]]; then
+  echo "Missing environment file: $ENV_FILE" >&2
+  exit 1
 fi
+if [[ $(stat -c %a "$ENV_FILE") != "600" ]]; then
+  echo "Environment file $ENV_FILE must have 600 permissions" >&2
+  exit 1
+fi
+ENV_ARGS=(--env-file "$ENV_FILE")
 
 # Build the image with the specified tag
 docker compose "${ENV_ARGS[@]}" -f docker-compose.production.yml build "$SERVICE"

--- a/scripts/deployment/rollback.sh
+++ b/scripts/deployment/rollback.sh
@@ -34,7 +34,11 @@ if ! command -v docker >/dev/null 2>&1; then
 fi
 
 ENV_FILE=".env.${ENVIRONMENT}"
-if [[ -f "$ENV_FILE" ]] && [[ $(stat -c %a "$ENV_FILE") != "600" ]]; then
+if [[ ! -f "$ENV_FILE" ]]; then
+  echo "Missing environment file: $ENV_FILE" >&2
+  exit 1
+fi
+if [[ $(stat -c %a "$ENV_FILE") != "600" ]]; then
   echo "Environment file $ENV_FILE must have 600 permissions" >&2
   exit 1
 fi

--- a/scripts/deployment/stop_stack.sh
+++ b/scripts/deployment/stop_stack.sh
@@ -21,7 +21,11 @@ if [[ ! " ${ALLOWED_ENVIRONMENTS[*]} " =~ " ${ENVIRONMENT} " ]]; then
 fi
 
 ENV_FILE=".env.${ENVIRONMENT}"
-if [[ -f "$ENV_FILE" ]] && [[ $(stat -c %a "$ENV_FILE") != "600" ]]; then
+if [[ ! -f "$ENV_FILE" ]]; then
+  echo "Missing environment file: $ENV_FILE" >&2
+  exit 1
+fi
+if [[ $(stat -c %a "$ENV_FILE") != "600" ]]; then
   echo "Environment file $ENV_FILE must have 600 permissions" >&2
   exit 1
 fi


### PR DESCRIPTION
## Summary
- ensure deployment scripts fail for missing or insecure env files
- run compose services as the calling user to avoid root
- document non-root execution and env file permissions

## Testing
- `poetry run pre-commit run --files scripts/deployment/bootstrap_env.sh scripts/deployment/check_health.sh scripts/deployment/stop_stack.sh scripts/deployment/rollback.sh scripts/deployment/publish_image.sh docker-compose.yml docs/policies/deployment.md`
- `poetry run devsynth run-tests --speed=fast`
- `poetry run python tests/verify_test_organization.py`
- `poetry run python scripts/verify_test_markers.py` *(fails: KeyboardInterrupt)*
- `poetry run python scripts/verify_requirements_traceability.py` *(fails: KeyboardInterrupt)*
- `poetry run python scripts/verify_version_sync.py`


------
https://chatgpt.com/codex/tasks/task_e_68a0c672d0148333a3ff5be17e0b1d27