### PR TITLE
Clarify UXBridge aliases and fix UX bridge tests

### DIFF
--- a/src/devsynth/interface/ux_bridge.py
+++ b/src/devsynth/interface/ux_bridge.py
@@ -63,10 +63,11 @@ class ProgressIndicator(ABC):
 class UXBridge(ABC):
     """Protocol defining basic user interaction methods.
 
-    The original interface exposed ``prompt``, ``confirm`` and ``print``.  This
-    version adds the more descriptive ``ask_question``, ``confirm_choice`` and
-    ``display_result`` methods.  The legacy method names remain for backward
-    compatibility and simply delegate to the new ones.
+    The original interface exposed the terse ``prompt``, ``confirm`` and
+    ``print`` helpers.  The modern API uses the more explicit
+    ``ask_question``, ``confirm_choice`` and ``display_result`` methods.  The
+    old method names remain available as thin wrappers around the new API so
+    existing front‑ends continue to work during the transition.
     """
 
     # ------------------------------------------------------------------
@@ -149,7 +150,11 @@ class UXBridge(ABC):
         default: Optional[str] = None,
         show_default: bool = True,
     ) -> str:
-        """Alias for :meth:`ask_question`."""
+        """Backward compatible alias for :meth:`ask_question`.
+
+        Parameters mirror those of :meth:`ask_question` so callers using the
+        legacy name automatically benefit from the new behaviour.
+        """
         return self.ask_question(
             message,
             choices=choices,
@@ -158,12 +163,25 @@ class UXBridge(ABC):
         )
 
     def confirm(self, message: str, *, default: bool = False) -> bool:
-        """Alias for :meth:`confirm_choice`."""
+        """Backward compatible alias for :meth:`confirm_choice`."""
         return self.confirm_choice(message, default=default)
 
-    def print(self, message: str, *, highlight: bool = False) -> None:
-        """Alias for :meth:`display_result`."""
-        self.display_result(message, highlight=highlight)
+    def print(
+        self,
+        message: str,
+        *,
+        highlight: bool = False,
+        message_type: str | None = None,
+    ) -> None:
+        """Backward compatible alias for :meth:`display_result`.
+
+        Args:
+            message: Message to display to the user.
+            highlight: Whether to emphasise the message.
+            message_type: Optional semantic type forwarded to
+                :meth:`display_result`.
+        """
+        self.display_result(message, highlight=highlight, message_type=message_type)
 
 
 __all__ = ["UXBridge", "ProgressIndicator", "sanitize_output"]

--- a/tests/unit/interface/test_ux_bridge.py
+++ b/tests/unit/interface/test_ux_bridge.py
@@ -1,8 +1,10 @@
 import importlib
 import sys
-import pytest
 from types import ModuleType
 from unittest.mock import MagicMock, patch
+
+import pytest
+
 from devsynth.interface.agentapi import APIBridge
 from devsynth.interface.cli import CLIUXBridge
 
@@ -37,7 +39,7 @@ def clean_state():
 
 
 @pytest.mark.slow
-def test_function(clean_state):
+def test_function(clean_state, monkeypatch):
     # Test with clean state
     """Test that bridge methods succeeds.
 
@@ -61,12 +63,9 @@ def test_function(clean_state):
     api_prog.complete()
     _stub_streamlit(monkeypatch)
 
-    import importlib
     from devsynth.interface import webui
 
     # Reload the module to ensure clean state
-    importlib.reload(module_2)
-
     importlib.reload(webui)
     from devsynth.interface.webui import WebUI
 


### PR DESCRIPTION
## Summary
- expand UXBridge documentation for legacy aliases
- ensure `print` alias forwards `message_type`
- fix UX bridge unit test to use `monkeypatch` and reload WebUI cleanly

## Testing
- `poetry run pytest tests/unit/interface/test_ux_bridge.py`
- `poetry run python tests/verify_test_organization.py` *(fails: tests/behavior/features/test_generation.feature)*
- `poetry run python scripts/verify_test_markers.py` *(terminated: long runtime)*
- `poetry run python scripts/verify_requirements_traceability.py`
- `poetry run python scripts/verify_version_sync.py`


------
https://chatgpt.com/codex/tasks/task_e_68a0d4b582dc8333bf4b31773063fab8