### PR TITLE
test: mock lmstudio endpoints

### DIFF
--- a/tests/fixtures/lmstudio_mock.py
+++ b/tests/fixtures/lmstudio_mock.py
@@ -1,0 +1,137 @@
+from __future__ import annotations
+
+import sys
+import types
+from dataclasses import dataclass
+from typing import Any, Dict, List
+
+import pytest
+from fastapi import FastAPI
+from fastapi.responses import JSONResponse
+from fastapi.testclient import TestClient
+
+
+@dataclass
+class LMStudioMockServer:
+    """Container for the LM Studio mock server state."""
+
+    base_url: str
+    fail: bool = False
+    status_code: int = 500
+
+    def trigger_error(self, status_code: int = 500) -> None:
+        """Make subsequent requests return an HTTP error."""
+        self.fail = True
+        self.status_code = status_code
+
+    def reset(self) -> None:
+        """Reset error state."""
+        self.fail = False
+        self.status_code = 500
+
+
+@pytest.fixture
+def lmstudio_mock() -> LMStudioMockServer:
+    """Provide a mocked LM Studio HTTP API and SDK."""
+
+    app = FastAPI()
+    server = LMStudioMockServer(base_url="")
+
+    @app.get("/v1/models")
+    def list_models() -> Dict[str, Any]:
+        if server.fail:
+            return JSONResponse(
+                status_code=server.status_code, content={"error": "Internal error"}
+            )
+        return {"data": [{"id": "test-model", "object": "model"}]}
+
+    @app.post("/v1/chat/completions")
+    def chat_completions(payload: Dict[str, Any]) -> Any:
+        if server.fail:
+            return JSONResponse(
+                status_code=server.status_code, content={"error": "Internal error"}
+            )
+        return {
+            "choices": [
+                {"message": {"content": "This is a test response"}},
+            ]
+        }
+
+    @app.post("/v1/embeddings")
+    def embeddings(payload: Dict[str, Any]) -> Any:
+        if server.fail:
+            return JSONResponse(
+                status_code=server.status_code, content={"error": "Internal error"}
+            )
+        return {"data": [{"embedding": [0.1, 0.2, 0.3, 0.4, 0.5]}]}
+
+    client = TestClient(app)
+    server.base_url = str(client.base_url)
+
+    def _post(path: str, json_payload: Dict[str, Any]) -> Dict[str, Any]:
+        response = client.post(path, json=json_payload)
+        if response.status_code >= 400:
+            raise Exception(response.json().get("error", "error"))
+        return response.json()
+
+    class MockLLM:
+        def __init__(self, model: str):
+            self.model = model
+
+        def complete(self, prompt: str, config: Dict[str, Any] | None = None) -> Any:
+            data = _post(
+                "/v1/chat/completions",
+                {
+                    "model": self.model,
+                    "messages": [{"role": "user", "content": prompt}],
+                },
+            )
+            return types.SimpleNamespace(
+                content=data["choices"][0]["message"]["content"]
+            )
+
+        def respond(
+            self, payload: Dict[str, Any], config: Dict[str, Any] | None = None
+        ) -> Any:
+            data = _post(
+                "/v1/chat/completions",
+                {"model": self.model, "messages": payload["messages"]},
+            )
+            return types.SimpleNamespace(
+                content=data["choices"][0]["message"]["content"]
+            )
+
+    class MockEmbeddingModel:
+        def __init__(self, model: str):
+            self.model = model
+
+        def embed(self, text: str) -> List[float]:
+            data = _post("/v1/embeddings", {"model": self.model, "input": text})
+            return data["data"][0]["embedding"]
+
+    class MockSyncAPI:
+        def configure_default_client(
+            self, host: str
+        ) -> None:  # pragma: no cover - noop
+            return None
+
+        def list_downloaded_models(self, kind: str) -> List[Any]:
+            return [
+                types.SimpleNamespace(model_key="test-model", display_name="Test Model")
+            ]
+
+        def _reset_default_client(self) -> None:  # pragma: no cover - noop
+            return None
+
+    mock_module = types.SimpleNamespace(
+        llm=lambda model: MockLLM(model),
+        embedding_model=lambda model: MockEmbeddingModel(model),
+        sync_api=MockSyncAPI(),
+    )
+    sys.modules["lmstudio"] = mock_module
+
+    try:
+        yield server
+    finally:
+        sys.modules.pop("lmstudio", None)
+        server.reset()

--- a/tests/unit/general/test_lmstudio_provider_unit.py
+++ b/tests/unit/general/test_lmstudio_provider_unit.py
@@ -1,138 +1,115 @@
-import json
-import os
-import unittest
+from contextlib import contextmanager
 from unittest.mock import MagicMock, patch
 
 import pytest
 
-pytest.importorskip("lmstudio")
-
-# Unit tests leveraging the LMStudio provider are medium speed
 pytestmark = [pytest.mark.requires_resource("lmstudio"), pytest.mark.medium]
-import requests
-
-from devsynth.application.llm.lmstudio_provider import LMStudioProvider
-from devsynth.application.utils.token_tracker import (
-    TokenLimitExceededError,
-    TokenTracker,
-)
 
 
-class TestLMStudioProvider(unittest.TestCase):
-    """Test cases for the LMStudio LLM provider.
+@pytest.fixture()
+def provider(lmstudio_mock):
+    from devsynth.application.llm.lmstudio_provider import LMStudioProvider
 
-    ReqID: N/A"""
+    return LMStudioProvider(
+        {
+            "api_base": f"{lmstudio_mock.base_url}/v1",
+            "model": "test-model",
+            "auto_select_model": False,
+        }
+    )
 
-    def setUp(self):
-        """Set up test environment."""
-        patcher = patch(
-            "devsynth.application.utils.token_tracker.TIKTOKEN_AVAILABLE", False
+
+@contextmanager
+def tracker_patches():
+    with (
+        patch(
+            "devsynth.application.utils.token_tracker.TokenTracker.__init__",
+            return_value=None,
+        ),
+        patch(
+            "devsynth.application.utils.token_tracker.TokenTracker.count_tokens",
+            return_value=1,
+        ),
+        patch(
+            "devsynth.application.utils.token_tracker.TokenTracker.ensure_token_limit",
+            return_value=None,
+        ),
+        patch(
+            "devsynth.application.utils.token_tracker.TokenTracker.count_conversation_tokens",
+            return_value=1,
+        ),
+        patch(
+            "devsynth.application.utils.token_tracker.TokenTracker.prune_conversation",
+            side_effect=lambda messages, max_tokens: messages,
+        ),
+    ):
+        yield
+
+
+def test_generate_succeeds(provider):
+    with tracker_patches():
+        result = provider.generate("Test prompt")
+    assert result == "This is a test response"
+
+
+def test_generate_with_context_succeeds(provider):
+    context = [
+        {"role": "system", "content": "You are a helpful assistant."},
+        {"role": "user", "content": "Hello"},
+        {"role": "assistant", "content": "Hi there!"},
+    ]
+    with tracker_patches():
+        result = provider.generate_with_context("How are you?", context)
+    assert result == "This is a test response"
+
+
+def test_get_embedding_succeeds(provider):
+    with patch(
+        "devsynth.application.utils.token_tracker.TokenTracker.__init__",
+        return_value=None,
+    ):
+        result = provider.get_embedding("Test text")
+    assert result == [0.1, 0.2, 0.3, 0.4, 0.5]
+
+
+def test_api_error_handling_raises_error(provider, lmstudio_mock):
+    lmstudio_mock.trigger_error()
+    with tracker_patches(), pytest.raises(Exception):
+        provider.generate("Test prompt")
+
+
+def test_circuit_breaker_opens_after_failures_fails(lmstudio_mock):
+    from devsynth.application.llm.lmstudio_provider import (
+        LMStudioConnectionError,
+        LMStudioProvider,
+    )
+
+    with (
+        patch("devsynth.application.llm.lmstudio_provider.lmstudio.llm") as mock_llm,
+        patch(
+            "devsynth.application.llm.lmstudio_provider.TokenTracker"
+        ) as mock_tracker,
+    ):
+        mock_model = MagicMock()
+        mock_model.complete.side_effect = Exception("fail")
+        mock_llm.return_value = mock_model
+        mock_tracker.return_value.count_tokens.return_value = 1
+        mock_tracker.return_value.ensure_token_limit.return_value = None
+
+        provider = LMStudioProvider(
+            {
+                "api_base": f"{lmstudio_mock.base_url}/v1",
+                "model": "test-model",
+                "auto_select_model": False,
+                "max_retries": 2,
+                "failure_threshold": 2,
+                "recovery_timeout": 60,
+            }
         )
-        self.addCleanup(patcher.stop)
-        patcher.start()
-        self.config = {"api_base": "http://localhost:1234/v1", "model": "local_model"}
-        self.provider = LMStudioProvider(self.config)
 
-    @patch("requests.post")
-    def test_generate_succeeds(self, mock_post):
-        """Test the generate method.
-
-        ReqID: N/A"""
-        mock_response = MagicMock()
-        mock_response.status_code = 200
-        mock_response.json.return_value = {
-            "choices": [{"message": {"content": "This is a test response"}}]
-        }
-        mock_post.return_value = mock_response
-        result = self.provider.generate("Test prompt")
-        self.assertEqual(result, "This is a test response")
-        mock_post.assert_called_once()
-        args, kwargs = mock_post.call_args
-        self.assertEqual(args[0], "http://localhost:1234/v1/chat/completions")
-        payload = json.loads(kwargs["data"])
-        self.assertEqual(payload["model"], "local_model")
-        self.assertEqual(len(payload["messages"]), 1)
-        self.assertEqual(payload["messages"][0]["role"], "user")
-        self.assertEqual(payload["messages"][0]["content"], "Test prompt")
-
-    @patch("requests.post")
-    def test_generate_with_context_succeeds(self, mock_post):
-        """Test the generate_with_context method.
-
-        ReqID: N/A"""
-        mock_response = MagicMock()
-        mock_response.status_code = 200
-        mock_response.json.return_value = {
-            "choices": [
-                {"message": {"content": "This is a test response with context"}}
-            ]
-        }
-        mock_post.return_value = mock_response
-        context = [
-            {"role": "system", "content": "You are a helpful assistant."},
-            {"role": "user", "content": "Hello"},
-            {"role": "assistant", "content": "Hi there!"},
-        ]
-        result = self.provider.generate_with_context("How are you?", context)
-        self.assertEqual(result, "This is a test response with context")
-        mock_post.assert_called_once()
-        args, kwargs = mock_post.call_args
-        self.assertEqual(args[0], "http://localhost:1234/v1/chat/completions")
-        payload = json.loads(kwargs["data"])
-        self.assertEqual(payload["model"], "local_model")
-        self.assertEqual(len(payload["messages"]), 4)
-        self.assertEqual(payload["messages"][0]["role"], "system")
-        self.assertEqual(payload["messages"][1]["role"], "user")
-        self.assertEqual(payload["messages"][2]["role"], "assistant")
-        self.assertEqual(payload["messages"][3]["role"], "user")
-        self.assertEqual(payload["messages"][3]["content"], "How are you?")
-
-    @patch("requests.post")
-    def test_get_embedding_succeeds(self, mock_post):
-        """Test the get_embedding method.
-
-        ReqID: N/A"""
-        mock_response = MagicMock()
-        mock_response.status_code = 200
-        mock_response.json.return_value = {
-            "data": [{"embedding": [0.1, 0.2, 0.3, 0.4, 0.5]}]
-        }
-        mock_post.return_value = mock_response
-        result = self.provider.get_embedding("Test text")
-        self.assertEqual(result, [0.1, 0.2, 0.3, 0.4, 0.5])
-        mock_post.assert_called_once()
-        args, kwargs = mock_post.call_args
-        self.assertEqual(args[0], "http://localhost:1234/v1/embeddings")
-        payload = json.loads(kwargs["data"])
-        self.assertEqual(payload["model"], "local_model")
-        self.assertEqual(payload["input"], "Test text")
-
-    @patch("requests.post")
-    def test_api_error_handling_raises_error(self, mock_post):
-        """Test error handling for API calls.
-
-        ReqID: N/A"""
-        mock_response = MagicMock()
-        mock_response.status_code = 500
-        mock_response.json.return_value = {"error": "Internal server error"}
-        mock_post.return_value = mock_response
-        with self.assertRaises(Exception):
-            self.provider.generate("Test prompt")
-
-    @patch("requests.post")
-    def test_circuit_breaker_opens_after_failures_fails(self, mock_post):
-        """Ensure circuit breaker prevents repeated failing calls.
-
-        ReqID: N/A"""
-        mock_post.side_effect = requests.RequestException("fail")
-        with self.assertRaises(Exception):
-            self.provider.generate("Test prompt")
-        self.assertEqual(mock_post.call_count, self.provider.max_retries)
-        mock_post.reset_mock()
-        with self.assertRaises(Exception):
-            self.provider.generate("Test prompt")
-        mock_post.assert_not_called()
-
-
-if __name__ == "__main__":
-    unittest.main()
+        with pytest.raises(LMStudioConnectionError):
+            provider.generate("Test prompt")
+        call_count = mock_model.complete.call_count
+        with pytest.raises(LMStudioConnectionError):
+            provider.generate("Test prompt")
+        assert mock_model.complete.call_count == call_count


### PR DESCRIPTION
## Summary
- add FastAPI-based LM Studio mock fixture
- replace direct LM Studio imports in unit tests with fixture
- mark LM Studio tests with requires_resource

## Testing
- `poetry run pre-commit run --files tests/fixtures/lmstudio_mock.py tests/unit/general/test_provider_logging.py tests/unit/general/test_lmstudio_provider_unit.py`
- `poetry run devsynth run-tests --speed=fast`
- `poetry run pytest tests/unit/general/test_lmstudio_provider_unit.py -m medium --no-cov`
- `poetry run python tests/verify_test_organization.py` *(fails: test_generation.feature naming)*
- `poetry run python scripts/verify_test_markers.py` *(command interrupted)*
- `poetry run python scripts/verify_requirements_traceability.py` *(command interrupted)*
- `poetry run python scripts/verify_version_sync.py`

------
https://chatgpt.com/codex/tasks/task_e_68a0d4c3abbc83338c7b4fe35217bcd1