### PR TITLE
Add transactional support and tests for memory stores

### DIFF
--- a/tests/integration/memory/test_faiss_transactions.py
+++ b/tests/integration/memory/test_faiss_transactions.py
@@ -1,0 +1,34 @@
+import pytest
+
+FAISSStore = pytest.importorskip("devsynth.application.memory.faiss_store").FAISSStore
+from devsynth.domain.models.memory import MemoryVector
+
+pytestmark = [
+    pytest.mark.requires_resource("faiss"),
+]
+
+
+@pytest.mark.medium
+def test_faiss_transaction_commit_and_rollback(tmp_path):
+    """FAISSStore transactions should commit and rollback correctly."""
+    store = FAISSStore(str(tmp_path))
+
+    vec = MemoryVector(
+        id="v1", content="hello", embedding=[0.1] * store.dimension, metadata={}
+    )
+    with store.transaction():
+        store.store_vector(vec)
+    assert store.retrieve_vector("v1") is not None
+
+    vec2 = MemoryVector(
+        id="v2", content="boom", embedding=[0.2] * store.dimension, metadata={}
+    )
+    with pytest.raises(RuntimeError):
+        with store.transaction():
+            store.store_vector(vec2)
+            raise RuntimeError("boom")
+    assert store.retrieve_vector("v2") is None
+
+    # Verify persistence after reopening the store
+    reopened = FAISSStore(str(tmp_path))
+    assert reopened.retrieve_vector("v1") is not None

--- a/tests/integration/memory/test_transaction_failure_recovery.py
+++ b/tests/integration/memory/test_transaction_failure_recovery.py
@@ -1,0 +1,61 @@
+import sys
+
+import pytest
+
+LMDBStore = pytest.importorskip("devsynth.application.memory.lmdb_store").LMDBStore
+FAISSStore = pytest.importorskip("devsynth.application.memory.faiss_store").FAISSStore
+from devsynth.adapters.kuzu_memory_store import KuzuMemoryStore
+from devsynth.application.memory import sync_manager as sm_mod
+from devsynth.application.memory.kuzu_store import KuzuStore
+from devsynth.application.memory.memory_manager import MemoryManager
+from devsynth.application.memory.sync_manager import SyncManager
+from devsynth.domain.models.memory import MemoryItem, MemoryType, MemoryVector
+
+pytestmark = [
+    pytest.mark.requires_resource("lmdb"),
+    pytest.mark.requires_resource("faiss"),
+]
+
+
+@pytest.fixture(autouse=True)
+def no_kuzu(monkeypatch):
+    monkeypatch.delitem(sys.modules, "kuzu", raising=False)
+    for cls in (KuzuMemoryStore, KuzuStore, LMDBStore, FAISSStore):
+        monkeypatch.setattr(cls, "__abstractmethods__", frozenset())
+
+
+def _manager(lmdb, faiss, kuzu):
+    adapters = {"lmdb": lmdb, "faiss": faiss, "kuzu": kuzu}
+    manager = MemoryManager(adapters=adapters)
+    manager.sync_manager = SyncManager(manager)
+    return manager
+
+
+@pytest.mark.medium
+def test_commit_failure_triggers_rollback(tmp_path, monkeypatch):
+    """Commit failures should roll back all stores."""
+    monkeypatch.setenv("DEVSYNTH_NO_FILE_LOGGING", "1")
+    lmdb = LMDBStore(str(tmp_path / "lmdb"))
+    faiss = FAISSStore(str(tmp_path / "faiss"))
+    kuzu = KuzuMemoryStore.create_ephemeral(use_provider_system=False)
+    manager = _manager(lmdb, faiss, kuzu)
+
+    item = MemoryItem(id="3", content="fail", memory_type=MemoryType.CODE)
+    vector = MemoryVector(id="3", content="fail", embedding=[0.3] * 5, metadata={})
+
+    def fail_exit(self, exc_type, exc_val, exc_tb):
+        raise RuntimeError("commit failure")
+
+    monkeypatch.setattr(sm_mod.LMDBTransactionContext, "__exit__", fail_exit)
+
+    with pytest.raises(RuntimeError):
+        with manager.sync_manager.transaction(["lmdb", "faiss", "kuzu"]):
+            lmdb.store(item)
+            faiss.store_vector(vector)
+            kuzu.store(item)
+
+    assert lmdb.retrieve("3") is None
+    assert faiss.retrieve_vector("3") is None
+    assert kuzu.retrieve("3") is None
+    assert kuzu.retrieve_vector("3") is None
+    kuzu.cleanup()


### PR DESCRIPTION
## Summary
- add explicit transaction tracking to LMDBStore
- implement snapshot-based transactions for FAISSStore
- coordinate transactions in KuzuMemoryStore adapter and expose commit/rollback
- exercise FAISS transactions and commit failure rollback in integration tests

## Testing
- `poetry run pre-commit run --files src/devsynth/adapters/kuzu_memory_store.py src/devsynth/application/memory/faiss_store.py src/devsynth/application/memory/lmdb_store.py src/devsynth/application/memory/sync_manager.py tests/integration/memory/test_faiss_transactions.py tests/integration/memory/test_transaction_failure_recovery.py`
- `poetry run devsynth run-tests --speed=medium` *(failed: 889 failed, 1857 passed, 142 skipped, 101 errors)*
- `poetry run python tests/verify_test_organization.py` *(failed: Test organization verification failed)*
- `poetry run python scripts/verify_test_markers.py` *(interrupted: KeyboardInterrupt)*
- `poetry run python scripts/verify_requirements_traceability.py`
- `poetry run python scripts/verify_version_sync.py`

------
https://chatgpt.com/codex/tasks/task_e_68a0d4c0b0f4833391722ddaa35d0c6d