### PR TITLE
test: cover core subsystems

### DIFF
--- a/tests/unit/application/llm/test_provider_selection.py
+++ b/tests/unit/application/llm/test_provider_selection.py
@@ -1,0 +1,52 @@
+import types
+
+import pytest
+
+from devsynth.application.llm import providers
+
+
+class DummyFactory:
+    def __init__(self):
+        self.calls = []
+
+    def create_provider(self, provider_type, config):
+        self.calls.append((provider_type, config))
+        return provider_type
+
+
+@pytest.mark.fast
+def test_get_llm_provider_offline(monkeypatch):
+    """Selects offline provider when offline mode is enabled.
+
+    ReqID: FR-85"""
+    dummy = DummyFactory()
+    monkeypatch.setattr(providers, "factory", dummy)
+    monkeypatch.setattr(
+        providers,
+        "load_config",
+        lambda: types.SimpleNamespace(
+            as_dict=lambda: {"offline_mode": True, "offline_provider": "local"}
+        ),
+    )
+    monkeypatch.setattr(providers, "get_llm_settings", lambda: {"provider": "openai"})
+    provider = providers.get_llm_provider()
+    assert provider == "offline"
+    assert dummy.calls == [
+        ("offline", {"provider": "openai", "offline_provider": "local"})
+    ]
+
+
+@pytest.mark.fast
+def test_get_llm_provider_default(monkeypatch):
+    """Uses configured provider when offline mode is disabled.
+
+    ReqID: FR-85"""
+    dummy = DummyFactory()
+    monkeypatch.setattr(providers, "factory", dummy)
+    monkeypatch.setattr(
+        providers, "load_config", lambda: types.SimpleNamespace(as_dict=lambda: {})
+    )
+    monkeypatch.setattr(providers, "get_llm_settings", lambda: {"provider": "local"})
+    provider = providers.get_llm_provider()
+    assert provider == "local"
+    assert dummy.calls == [("local", {"provider": "local"})]

--- a/tests/unit/application/memory/test_memory_manager.py
+++ b/tests/unit/application/memory/test_memory_manager.py
@@ -1,26 +1,35 @@
 import importlib.util
 import pathlib
-import types
 import sys
+import types
 from unittest.mock import MagicMock, patch
+
 import pytest
-SRC_ROOT = pathlib.Path(__file__).resolve().parents[4] / 'src'
+
+SRC_ROOT = pathlib.Path(__file__).resolve().parents[4] / "src"
+
 
 def _load_module(path: pathlib.Path, name: str):
     spec = importlib.util.spec_from_file_location(name, path)
     module = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(module)
     return module
-PACKAGE_PATH = SRC_ROOT / 'devsynth/application/memory'
-memory_manager_module = _load_module(PACKAGE_PATH / 'memory_manager.py', 'devsynth.application.memory.memory_manager')
+
+
+PACKAGE_PATH = SRC_ROOT / "devsynth/application/memory"
+memory_manager_module = _load_module(
+    PACKAGE_PATH / "memory_manager.py", "devsynth.application.memory.memory_manager"
+)
 MemoryManager = memory_manager_module.MemoryManager
-from devsynth.domain.models.memory import MemoryType, MemoryItem
+from devsynth.domain.models.memory import MemoryItem, MemoryType
+
 
 @pytest.fixture(autouse=True)
 def _patch_memory_module(monkeypatch):
-    pkg = types.ModuleType('devsynth.application.memory')
+    pkg = types.ModuleType("devsynth.application.memory")
     pkg.__path__ = [str(PACKAGE_PATH)]
-    monkeypatch.setitem(sys.modules, 'devsynth.application.memory', pkg)
+    monkeypatch.setitem(sys.modules, "devsynth.application.memory", pkg)
+
 
 class DummyVectorStore:
 
@@ -29,7 +38,8 @@ class DummyVectorStore:
 
     def store(self, item):
         self.stored.append(item)
-        return 'vector-id'
+        return "vector-id"
+
 
 class DummyGraphStore:
 
@@ -39,16 +49,17 @@ class DummyGraphStore:
 
     def store(self, item):
         self.stored.append(item)
-        return 'graph-id'
+        return "graph-id"
 
     def retrieve_with_edrr_phase(self, item_type, edrr_phase, metadata=None):
-        key = f'{item_type}_{edrr_phase}'
+        key = f"{item_type}_{edrr_phase}"
         return self.edrr_items.get(key)
 
     def store_with_edrr_phase(self, content, memory_type, edrr_phase, metadata=None):
-        key = f'{memory_type}_{edrr_phase}'
+        key = f"{memory_type}_{edrr_phase}"
         self.edrr_items[key] = content
-        return 'graph-edrr-id'
+        return "graph-edrr-id"
+
 
 class TestMemoryManagerStore:
     """Tests for the MemoryManagerStore component.
@@ -59,13 +70,13 @@ class TestMemoryManagerStore:
     def adapters(self):
         tinydb = MagicMock()
         vector = DummyVectorStore()
-        return {'tinydb': tinydb, 'vector': vector}
+        return {"tinydb": tinydb, "vector": vector}
 
     @pytest.fixture
     def graph_adapters(self):
         graph = DummyGraphStore()
         tinydb = MagicMock()
-        return {'graph': graph, 'tinydb': tinydb}
+        return {"graph": graph, "tinydb": tinydb}
 
     @pytest.mark.medium
     def test_store_prefers_graph_for_edrr_succeeds(self, graph_adapters):
@@ -73,9 +84,9 @@ class TestMemoryManagerStore:
 
         ReqID: N/A"""
         manager = MemoryManager(adapters=graph_adapters)
-        manager.store_with_edrr_phase('x', MemoryType.CODE, 'EXPAND')
-        assert len(graph_adapters['graph'].stored) == 1
-        graph_adapters['tinydb'].store.assert_not_called()
+        manager.store_with_edrr_phase("x", MemoryType.CODE, "EXPAND")
+        assert len(graph_adapters["graph"].stored) == 1
+        graph_adapters["tinydb"].store.assert_not_called()
 
     @pytest.mark.medium
     def test_store_falls_back_to_tinydb_succeeds(self):
@@ -83,8 +94,8 @@ class TestMemoryManagerStore:
 
         ReqID: N/A"""
         tinydb = MagicMock()
-        manager = MemoryManager(adapters={'tinydb': tinydb})
-        manager.store_with_edrr_phase('x', MemoryType.CODE, 'EXPAND')
+        manager = MemoryManager(adapters={"tinydb": tinydb})
+        manager.store_with_edrr_phase("x", MemoryType.CODE, "EXPAND")
         tinydb.store.assert_called_once()
 
     @pytest.mark.medium
@@ -93,9 +104,10 @@ class TestMemoryManagerStore:
 
         ReqID: N/A"""
         vector = DummyVectorStore()
-        manager = MemoryManager(adapters={'vector': vector})
-        manager.store_with_edrr_phase('x', MemoryType.CODE, 'EXPAND')
+        manager = MemoryManager(adapters={"vector": vector})
+        manager.store_with_edrr_phase("x", MemoryType.CODE, "EXPAND")
         assert vector.stored
+
 
 class TestMemoryManagerRetrieve:
     """Tests for the MemoryManagerRetrieve component.
@@ -108,16 +120,16 @@ class TestMemoryManagerRetrieve:
 
     @pytest.fixture
     def manager_with_graph(self, graph_adapter):
-        return MemoryManager(adapters={'graph': graph_adapter})
+        return MemoryManager(adapters={"graph": graph_adapter})
 
     @pytest.mark.medium
     def test_retrieve_with_edrr_phase_succeeds(self, manager_with_graph, graph_adapter):
         """Test that retrieve with edrr phase succeeds.
 
         ReqID: N/A"""
-        test_content = {'key': 'value'}
-        graph_adapter.edrr_items['CODE_EXPAND'] = test_content
-        result = manager_with_graph.retrieve_with_edrr_phase('CODE', 'EXPAND')
+        test_content = {"key": "value"}
+        graph_adapter.edrr_items["CODE_EXPAND"] = test_content
+        result = manager_with_graph.retrieve_with_edrr_phase("CODE", "EXPAND")
         assert result == test_content
 
     @pytest.mark.medium
@@ -125,18 +137,23 @@ class TestMemoryManagerRetrieve:
         """Test that retrieve with edrr phase not found succeeds.
 
         ReqID: N/A"""
-        result = manager_with_graph.retrieve_with_edrr_phase('CODE', 'NONEXISTENT')
+        result = manager_with_graph.retrieve_with_edrr_phase("CODE", "NONEXISTENT")
         assert result == {}
 
     @pytest.mark.medium
-    def test_retrieve_with_edrr_phase_with_metadata_succeeds(self, manager_with_graph, graph_adapter):
+    def test_retrieve_with_edrr_phase_with_metadata_succeeds(
+        self, manager_with_graph, graph_adapter
+    ):
         """Test that retrieve with edrr phase with metadata succeeds.
 
         ReqID: N/A"""
-        test_content = {'key': 'value'}
-        graph_adapter.edrr_items['CODE_EXPAND'] = test_content
-        result = manager_with_graph.retrieve_with_edrr_phase('CODE', 'EXPAND', {'cycle_id': '123'})
+        test_content = {"key": "value"}
+        graph_adapter.edrr_items["CODE_EXPAND"] = test_content
+        result = manager_with_graph.retrieve_with_edrr_phase(
+            "CODE", "EXPAND", {"cycle_id": "123"}
+        )
         assert result == test_content
+
 
 class TestEmbedText:
     """Tests for the EmbedText component.
@@ -148,13 +165,49 @@ class TestEmbedText:
         """Test that fallback and provider succeeds.
 
         ReqID: N/A"""
-        manager = MemoryManager()
-        default = manager._embed_text('abc', dimension=5)
+        manager = MemoryManager(adapters={})
+        default = manager._embed_text("abc", dimension=5)
         provider = MagicMock()
-        provider.embed.side_effect = Exception('boom')
+        provider.embed.side_effect = Exception("boom")
         manager_fail = MemoryManager(embedding_provider=provider)
-        assert manager_fail._embed_text('abc', dimension=5) == default
+        assert manager_fail._embed_text("abc", dimension=5) == default
         provider.embed.side_effect = None
         provider.embed.return_value = [1.0, 2.0]
         manager_ok = MemoryManager(embedding_provider=provider)
-        assert manager_ok._embed_text('hi') == [1.0, 2.0]
+        assert manager_ok._embed_text("hi") == [1.0, 2.0]
+
+
+class TestSyncHooks:
+    """Tests for synchronization hooks.
+
+    ReqID: FR-60"""
+
+    @pytest.mark.fast
+    def test_register_and_notify_sync_hook_succeeds(self):
+        """Ensure sync hooks are invoked.
+
+        ReqID: FR-60"""
+        manager = MemoryManager(adapters={})
+        called = []
+
+        def hook(item):
+            called.append(item)
+
+        manager.register_sync_hook(hook)
+        dummy_item = object()
+        manager._notify_sync_hooks(dummy_item)
+        assert called == [dummy_item]
+
+    @pytest.mark.fast
+    def test_sync_hook_errors_are_logged(self, monkeypatch):
+        """Errors raised by sync hooks are caught and logged.
+
+        ReqID: FR-60"""
+        manager = MemoryManager(adapters={})
+
+        def bad_hook(item):
+            raise RuntimeError("boom")
+
+        manager.register_sync_hook(bad_hook)
+        manager._notify_sync_hooks(None)
+        assert True

--- a/tests/unit/general/test_api.py
+++ b/tests/unit/general/test_api.py
@@ -1,0 +1,29 @@
+import types
+
+import pytest
+from fastapi import HTTPException
+from fastapi.testclient import TestClient
+
+from devsynth import api
+
+
+@pytest.mark.fast
+def test_verify_token_rejects_invalid_token(monkeypatch):
+    """Verify incorrect token triggers unauthorized error.
+
+    ReqID: FR-74"""
+    monkeypatch.setattr(api, "settings", types.SimpleNamespace(access_token="s3cr3t"))
+    with pytest.raises(HTTPException):
+        api.verify_token("Bearer wrong")
+
+
+@pytest.mark.fast
+def test_health_endpoint_accepts_valid_token(monkeypatch):
+    """Health endpoint returns ok when authorized.
+
+    ReqID: FR-74"""
+    monkeypatch.setattr(api, "settings", types.SimpleNamespace(access_token="s3cr3t"))
+    client = TestClient(api.app)
+    response = client.get("/health", headers={"Authorization": "Bearer s3cr3t"})
+    assert response.status_code == 200
+    assert response.json() == {"status": "ok"}


### PR DESCRIPTION
## Summary
- improve sync hook coverage in memory manager
- add API token and health endpoint tests
- exercise LLM provider selection logic

## Testing
- `poetry run pre-commit run --files tests/unit/application/memory/test_memory_manager.py tests/unit/application/llm/test_provider_selection.py tests/unit/general/test_api.py`
- `poetry run devsynth run-tests --speed=fast`
- `poetry run python tests/verify_test_organization.py` *(fails: Behavior feature file misnamed)*
- `poetry run python scripts/verify_test_markers.py --module tests/unit/application` *(timeout)*
- `poetry run python scripts/verify_requirements_traceability.py`
- `poetry run python scripts/verify_version_sync.py`

------
https://chatgpt.com/codex/tasks/task_e_68a0d4bc98c88333ba0c5a573dee2e68