### PR TITLE
fix: improve sanitization escaping

### DIFF
--- a/src/devsynth/interface/cli.py
+++ b/src/devsynth/interface/cli.py
@@ -649,10 +649,9 @@ class CLIUXBridge(SharedBridgeMixin, UXBridge):
         else:
             logger.debug(f"Displaying message: {message}")
 
-        # Check if the message contains Rich markup
+        # Check if the message contains Rich markup. Sanitize while preserving markup
         if "[" in message and "]" in message:
-            # For Rich markup, pass the message directly with the highlight parameter
-            self.console.print(message, highlight=highlight)
+            self.console.print(sanitize_output(message), highlight=highlight)
             return
 
         # Format the message using the shared formatter

--- a/src/devsynth/interface/ux_bridge.py
+++ b/src/devsynth/interface/ux_bridge.py
@@ -11,6 +11,8 @@ import html
 from abc import ABC, abstractmethod
 from typing import Any, Dict, Optional, Sequence, Union
 
+from devsynth.security.validation import parse_bool_env
+
 try:  # pragma: no cover - import guarded for optional deps
     # Import directly from the sanitization module to avoid initializing the
     # entire security package, which may have optional dependencies.
@@ -23,8 +25,15 @@ except ImportError:  # pragma: no cover - graceful degradation
 
 
 def sanitize_output(text: str) -> str:
-    """Sanitize and escape user provided text for safe display."""
+    """Sanitize and escape user provided text for safe display.
+
+    Respects the ``DEVSYNTH_SANITIZATION_ENABLED`` environment variable so that
+    projects can disable all sanitization/escaping in trusted contexts.
+    """
+
     sanitized = sanitize_input(text)
+    if not parse_bool_env("DEVSYNTH_SANITIZATION_ENABLED", True):
+        return sanitized
     return html.escape(sanitized)
 
 

--- a/src/devsynth/security/sanitization.py
+++ b/src/devsynth/security/sanitization.py
@@ -1,10 +1,16 @@
 """Input sanitization helpers for DevSynth."""
 
 import re
+
 from devsynth.exceptions import InputSanitizationError
+
 from .validation import parse_bool_env
 
-_SCRIPT_TAG_RE = re.compile(r"<script.*?>.*?</script>", re.IGNORECASE | re.DOTALL)
+# Match both standard and self-closing script tags as well as stray closing tags
+_SCRIPT_TAG_RE = re.compile(
+    r"<script[^>]*>.*?</script>|<script[^>]*/>|</script>",
+    re.IGNORECASE | re.DOTALL,
+)
 _CONTROL_CHAR_RE = re.compile(r"[\x00-\x1f\x7f]")
 
 


### PR DESCRIPTION
## Summary
- respect `DEVSYNTH_SANITIZATION_ENABLED` and escape outputs accordingly
- broaden script tag detection to self-closing tags
- sanitize rich-markup messages and test edge cases

## Testing
- `poetry run pytest tests/unit/interface/test_output_sanitization.py`
- `poetry run pre-commit run --files src/devsynth/interface/cli.py src/devsynth/interface/ux_bridge.py src/devsynth/security/sanitization.py tests/unit/interface/test_output_sanitization.py`
- `poetry run python tests/verify_test_organization.py` *(fails: Behavior feature files naming)*
- `poetry run python scripts/verify_test_markers.py` *(interrupted: exceeded time)*
- `poetry run python scripts/verify_requirements_traceability.py`
- `poetry run python scripts/verify_version_sync.py`
- `poetry run devsynth run-tests --speed=fast`


------
https://chatgpt.com/codex/tasks/task_e_68a0d4b10ddc8333987d193cea69e99d