### PR TITLE
Sanitize CLI progress status updates

### DIFF
--- a/src/devsynth/interface/cli.py
+++ b/src/devsynth/interface/cli.py
@@ -217,8 +217,7 @@ class CLIProgressIndicator(ProgressIndicator):
         # Handle status safely
         if status is not None:
             try:
-                status_str = str(status)
-                status_msg = sanitize_output(status_str)
+                status_msg = str(status)
             except (TypeError, ValueError) as exc:
                 logger.warning(
                     "Failed to sanitize task status",
@@ -241,6 +240,17 @@ class CLIProgressIndicator(ProgressIndicator):
                 status_msg = "Processing..."
             else:
                 status_msg = "Starting..."
+
+        # Sanitize the status message regardless of source
+        try:
+            status_msg = sanitize_output(status_msg)
+        except (TypeError, ValueError) as exc:
+            logger.warning(
+                "Failed to sanitize task status",
+                exc_info=exc,
+                extra={"status": status_msg},
+            )
+            status_msg = "In progress..."
 
         self._progress.update(
             self._task, advance=advance, description=desc, status=status_msg


### PR DESCRIPTION
## Summary
- sanitize status text in CLI progress indicator updates
- extend CLI progress tests for sanitized status and default values

## Testing
- `poetry run pytest tests/unit/interface/test_cli_components.py::test_CLIProgressIndicator_update_succeeds -q`
- `poetry run pytest tests/unit/interface/test_cli_components.py::test_cliprogressindicator_sanitize_output_succeeds -q`
- `SKIP=fix-code-blocks poetry run pre-commit run --files src/devsynth/interface/cli.py tests/unit/interface/test_cli_components.py`
- `poetry run devsynth run-tests --speed=fast`
- `poetry run python tests/verify_test_organization.py` *(fails: file naming)*
- `poetry run python scripts/verify_test_markers.py` *(terminated: KeyboardInterrupt)*
- `poetry run python scripts/verify_requirements_traceability.py`
- `poetry run python tests/verify_version_sync.py` *(missing file)*

------
https://chatgpt.com/codex/tasks/task_e_68a0d4add9408333852ebb7d3e65cb4a