### PR TITLE
Fix API authentication and validation

### DIFF
--- a/src/devsynth/api.py
+++ b/src/devsynth/api.py
@@ -3,6 +3,8 @@ import uuid
 from fastapi import Depends, FastAPI, Header, HTTPException, status
 from fastapi.responses import Response
 
+from devsynth.interface.agentapi import router as agent_router
+
 # Prometheus metrics are optional; fall back to lightweight stubs when the
 # dependency isn't available.  This keeps the API usable in stripped-down test
 # environments where the monitoring stack is absent.
@@ -65,6 +67,9 @@ REQUEST_LATENCY = Histogram(
 )
 
 app = FastAPI(title="DevSynth API")
+
+# Expose workflow endpoints under the `/api` namespace.
+app.include_router(agent_router, prefix="/api")
 
 
 @app.middleware("http")


### PR DESCRIPTION
## Summary
- include agent router in FastAPI app
- add lazy token verification and parameter validation to agent API endpoints

## Testing
- `poetry run pytest tests/unit/interface/test_api_advanced.py tests/unit/interface/test_api_endpoints.py -q`
- `poetry run pre-commit run --files src/devsynth/api.py src/devsynth/interface/agentapi.py`
- `poetry run python tests/verify_test_organization.py` *(fails: tests/behavior/features/test_generation.feature naming)*
- `poetry run python scripts/verify_test_markers.py --module tests/unit/interface` *(terminated due to runtime)*
- `poetry run python scripts/verify_requirements_traceability.py`
- `poetry run python scripts/verify_version_sync.py`


------
https://chatgpt.com/codex/tasks/task_e_68a0d4aae5e48333af280222537bfc16