### PR TITLE
Add security audit policy validation

### DIFF
--- a/docs/policies/security.md
+++ b/docs/policies/security.md
@@ -63,9 +63,9 @@ DevSynth automates routine security checks to prevent regressions:
 
 - A GitHub Actions workflow can be manually dispatched to run Bandit static
   analysis and Safety dependency scans via pre-commit.
-- The `security-audit` CLI command performs dependency vulnerability scans,
-  Bandit static analysis, and verifies required security environment variables
-  such as `DEVSYNTH_ACCESS_TOKEN`. Deployment pipelines must set
+- The `security-audit` CLI command validates required security configuration
+  flags using `scripts/verify_security_policy.py` before performing dependency
+  vulnerability scans and Bandit static analysis. Deployment pipelines must set
   `DEVSYNTH_PRE_DEPLOY_APPROVED=true` before invoking this command to enforce
   policy compliance prior to publishing artifacts.
 - The command exits with a non‑zero status if any check fails, which blocks CI

--- a/scripts/security_audit.py
+++ b/scripts/security_audit.py
@@ -9,6 +9,8 @@ from __future__ import annotations
 import subprocess
 import sys
 
+import verify_security_policy
+
 from devsynth.logger import setup_logging
 from devsynth.security import audit
 from devsynth.security.validation import require_pre_deploy_checks
@@ -17,8 +19,10 @@ logger = setup_logging(__name__)
 
 
 def run(argv: list[str] | None = None) -> None:
-    """Execute Bandit and Safety security checks."""
+    """Validate security flags then execute Bandit and Safety checks."""
     require_pre_deploy_checks()
+    if verify_security_policy.main() != 0:
+        raise subprocess.CalledProcessError(1, "verify_security_policy")
     audit.main(argv)
 
 


### PR DESCRIPTION
## Summary
- ensure security-audit script checks required config flags before running dependency scans
- document security-audit flag validation in security policy
- test security-audit script behavior

## Testing
- `poetry run pre-commit run --files docs/policies/security.md scripts/security_audit.py tests/unit/security/test_security_audit.py`
- `poetry run devsynth run-tests --speed=fast`
- `poetry run python tests/verify_test_organization.py`
- `poetry run python scripts/verify_test_markers.py --workers 4` *(failed: KeyboardInterrupt)*
- `poetry run python scripts/verify_requirements_traceability.py`
- `poetry run python scripts/verify_version_sync.py`


------
https://chatgpt.com/codex/tasks/task_e_68a1009735ac83338156679bdb38b79b