### PR TITLE
Harden deployment scripts and add Docker integration test

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -103,6 +103,7 @@ services:
       - chromadb-data:/chroma
     environment:
       - IS_PERSISTENT=TRUE
+    user: "${UID:-1000}:${GID:-1000}"
     ports:
       - "8001:8000"
     networks:
@@ -129,6 +130,7 @@ services:
       - ./config/prometheus.yml:/etc/prometheus/prometheus.yml:ro
     ports:
       - "9090:9090"
+    user: "${UID:-1000}:${GID:-1000}"
     networks:
       - devsynth-network
     healthcheck:
@@ -154,6 +156,7 @@ services:
       - grafana-data:/var/lib/grafana
     depends_on:
       - prometheus
+    user: "${UID:-1000}:${GID:-1000}"
     networks:
       - devsynth-network
     healthcheck:
@@ -175,6 +178,7 @@ services:
       context: .
       target: production
     entrypoint: ["/bin/bash", "scripts/deployment/publish_image.sh", "${DEVSYNTH_IMAGE_TAG:-latest}"]
+    user: "${UID:-1000}:${GID:-1000}"
     profiles:
       - ci
 
@@ -183,6 +187,7 @@ services:
       context: .
       target: production
     entrypoint: ["/bin/bash", "scripts/deployment/rollback.sh", "${DEVSYNTH_ROLLBACK_TAG:-latest}", "development"]
+    user: "${UID:-1000}:${GID:-1000}"
     profiles:
       - ci
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -25,6 +25,7 @@ markers =
     webapp-generation: mark test as related to web application generation
     memory_intensive: mark test as using significant memory
     no_network: mark test as not performing network access
+    docker: mark test as requiring Docker
 
 # Note on running isolation tests:
 # Tests marked with @pytest.mark.isolation should be run separately from other tests.

--- a/scripts/deployment/README.md
+++ b/scripts/deployment/README.md
@@ -1,0 +1,12 @@
+# Deployment Utilities
+
+This directory contains helper scripts for managing DevSynth deployments.
+
+## Rollback Procedure
+
+1. Identify the previous image tag to restore.
+2. Ensure the corresponding environment file (e.g. `.env.production`) exists with `600` permissions.
+3. Run `scripts/deployment/rollback.sh <previous_tag> [environment]` as a non-root user.
+4. The script stops the stack, pulls the specified tag, and verifies service health before completing.
+
+All scripts in this directory refuse to run as the root user and validate environment file permissions to promote least privilege and prevent misconfiguration.

--- a/scripts/deployment/bootstrap.sh
+++ b/scripts/deployment/bootstrap.sh
@@ -27,7 +27,11 @@ if ! command -v docker >/dev/null 2>&1; then
 fi
 
 ENV_FILE=".env.${ENVIRONMENT}"
-if [[ -f "$ENV_FILE" ]] && [[ $(stat -c %a "$ENV_FILE") != "600" ]]; then
+if [[ ! -f "$ENV_FILE" ]]; then
+  echo "Missing environment file: $ENV_FILE" >&2
+  exit 1
+fi
+if [[ $(stat -c %a "$ENV_FILE") != "600" ]]; then
   echo "Environment file $ENV_FILE must have 600 permissions" >&2
   exit 1
 fi

--- a/tests/integration/deployment/test_docker_non_root.py
+++ b/tests/integration/deployment/test_docker_non_root.py
@@ -1,0 +1,36 @@
+import shutil
+import subprocess
+
+import pytest
+
+
+@pytest.mark.slow
+@pytest.mark.docker
+def test_temporary_container_runs_as_non_root(tmp_path):
+    if shutil.which("docker") is None:
+        pytest.skip("Docker not available")
+
+    dockerfile = tmp_path / "Dockerfile"
+    dockerfile.write_text(
+        "FROM alpine:3.19\n"
+        "RUN adduser -D appuser\n"
+        "USER appuser\n"
+        "CMD ['id', '-u']\n"
+    )
+    image = "devsynth-temp-non-root"
+    try:
+        subprocess.run(
+            ["docker", "build", "-t", image, str(tmp_path)],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        result = subprocess.run(
+            ["docker", "run", "--rm", image],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        assert result.stdout.strip() != "0"
+    finally:
+        subprocess.run(["docker", "rmi", "-f", image], capture_output=True)


### PR DESCRIPTION
## Summary
- enforce host user in remaining docker-compose services
- require environment file presence in bootstrap script and document rollback
- add docker-marked integration test for non-root containers

## Testing
- `poetry run pre-commit run --files docker-compose.yml pytest.ini scripts/deployment/bootstrap.sh scripts/deployment/README.md tests/integration/deployment/test_docker_non_root.py`
- `poetry run devsynth run-tests --speed=fast`
- `poetry run python tests/verify_test_organization.py`
- `poetry run python scripts/verify_test_markers.py --workers 1` *(interrupted: KeyboardInterrupt)*
- `poetry run python scripts/verify_requirements_traceability.py`
- `poetry run python scripts/verify_version_sync.py`


------
https://chatgpt.com/codex/tasks/task_e_68a100930998833387f45e6f823fc38a