### PR TITLE
Add retry predicates with Prometheus metrics

### DIFF
--- a/docs/specifications/index.md
+++ b/docs/specifications/index.md
@@ -41,6 +41,7 @@ This section contains the official specifications for the DevSynth project, outl
 - **[Requirements Wizard Logging](requirements_wizard_logging.md)**: Expected log structure and persistence rules for the requirements wizard.
 - **[Run Tests Maxfail Option](run_tests_maxfail_option.md)**: CLI flag to limit failures during test runs.
 - **[Integration Test Scenario Generation](integration_test_generation.md)**: Scenario-based scaffolding for integration tests.
+- **[Retry Predicates Specification](retry_predicates.md)**: Support conditional retry logic and metrics.
 
 ## Implementation Plans
 

--- a/docs/specifications/retry_predicates.md
+++ b/docs/specifications/retry_predicates.md
@@ -1,0 +1,25 @@
+---
+author: DevSynth Team
+date: '2025-07-24'
+last_reviewed: '2025-07-24'
+status: draft
+tags:
+- specification
+- retry
+- reliability
+- metrics
+title: Retry Predicates Specification
+version: "0.1.0-alpha.1"
+---
+<div class="breadcrumbs">
+<a href="../index.md">Documentation</a> &gt; <a href="index.md">Specifications</a> &gt; Retry Predicates Specification
+</div>
+
+## Problem
+
+Transient HTTP failures are currently detected only through exceptions. Responses with error status codes are returned to callers without automatic retry, reducing resilience.
+
+## Proof
+
+- A unit test mocks an HTTP response returning status code 503 followed by 200 and verifies the retry predicate triggers a retry and increments Prometheus metrics.
+- A behavior-driven test demonstrates that functions using retry predicates eventually succeed after transient server errors.

--- a/tests/behavior/features/general/retry_predicates.feature
+++ b/tests/behavior/features/general/retry_predicates.feature
@@ -1,0 +1,11 @@
+Feature: Retry Predicates for HTTP status codes
+  As a developer
+  I want to retry operations based on result predicates
+  So that transient server errors are handled transparently
+
+  Scenario: Retry on HTTP 503 status code
+    Given an HTTP request function that returns status 503 then 200
+    When I apply the retry decorator with a predicate for status>=500 and jitter=False
+    And I call the decorated function
+    Then the function should be called 2 times
+    And the final result should be successful

--- a/tests/unit/fallback/test_retry_predicates.py
+++ b/tests/unit/fallback/test_retry_predicates.py
@@ -1,0 +1,36 @@
+from unittest.mock import Mock, patch
+
+import pytest
+
+from devsynth.fallback import reset_prometheus_metrics, retry_with_exponential_backoff
+from devsynth.metrics import get_retry_condition_metrics, get_retry_metrics
+
+
+class Response:
+    def __init__(self, status_code: int) -> None:
+        self.status_code = status_code
+
+
+@pytest.mark.fast
+def test_retry_predicate_triggers_retry() -> None:
+    reset_prometheus_metrics()
+    responses = [Response(503), Response(200)]
+    func = Mock(side_effect=lambda: responses.pop(0))
+    func.__name__ = "http_call"
+    decorated = retry_with_exponential_backoff(
+        max_retries=2,
+        initial_delay=1,
+        jitter=False,
+        retry_predicates={"server_error": lambda r: r.status_code >= 500},
+        track_metrics=True,
+    )(func)
+    with patch("time.sleep") as sleep_mock:
+        result = decorated()
+    assert result.status_code == 200
+    sleep_mock.assert_called_once_with(2)
+    retry_metrics = get_retry_metrics()
+    cond_metrics = get_retry_condition_metrics()
+    assert retry_metrics.get("predicate") == 1
+    assert retry_metrics.get("success") == 1
+    assert cond_metrics.get("predicate:server_error:trigger") == 1
+    assert cond_metrics.get("predicate:server_error:suppress") == 1


### PR DESCRIPTION
## Summary
- allow retry_with_exponential_backoff to evaluate result predicates and HTTP status codes
- record predicate outcomes through existing Prometheus metrics
- cover predicate logic with behavior spec and unit test

## Testing
- `poetry run pre-commit run --files docs/specifications/retry_predicates.md docs/specifications/index.md tests/behavior/features/general/retry_predicates.feature tests/unit/fallback/test_retry_predicates.py src/devsynth/fallback.py`
- `poetry run devsynth run-tests --speed=fast`
- `poetry run python tests/verify_test_organization.py`
- `poetry run python scripts/verify_test_markers.py` *(failed: KeyboardInterrupt)*
- `poetry run python scripts/verify_requirements_traceability.py`
- `poetry run python scripts/verify_version_sync.py`


------
https://chatgpt.com/codex/tasks/task_e_68a1008fbb5883339ef4275b7f0396f7