### PR TITLE
feat: run generated tests via test agent

### DIFF
--- a/docs/specifications/index.md
+++ b/docs/specifications/index.md
@@ -41,6 +41,7 @@ This section contains the official specifications for the DevSynth project, outl
 - **[Requirements Wizard Logging](requirements_wizard_logging.md)**: Expected log structure and persistence rules for the requirements wizard.
 - **[Run Tests Maxfail Option](run_tests_maxfail_option.md)**: CLI flag to limit failures during test runs.
 - **[Integration Test Scenario Generation](integration_test_generation.md)**: Scenario-based scaffolding for integration tests.
+- **[Test Agent Executes Generated Tests](test_agent_executes_generated_tests.md)**: TestAgent runs test suites and raises on failures.
 
 ## Implementation Plans
 

--- a/docs/specifications/test_agent_executes_generated_tests.md
+++ b/docs/specifications/test_agent_executes_generated_tests.md
@@ -1,0 +1,34 @@
+title: "Test Agent Executes Generated Tests"
+author: "DevSynth Team"
+date: "2025-08-16"
+last_reviewed: "2025-08-16"
+status: draft
+version: "0.1.0-alpha.1"
+tags:
+  - specification
+  - testing
+---
+<div class="breadcrumbs">
+<a href="../index.md">Documentation</a> &gt; <a href="index.md">Specifications</a> &gt; Test Agent Executes Generated Tests
+</div>
+
+# Test Agent Executes Generated Tests
+
+## Summary
+TestAgent can execute generated tests and surfaces failures when requirements are not met.
+
+## Socratic Checklist
+- What is the problem?
+- What proofs confirm the solution?
+
+## Motivation
+Developers need immediate feedback that placeholder tests failing due to unmet requirements are executed.
+
+## Specification
+- `TestAgent.run_tests` delegates to `devsynth.testing.run_tests.run_tests` to execute a test target.
+- If any test fails, the method raises `DevSynthError`.
+- On success, the method returns combined output of the test run.
+
+## Acceptance Criteria
+- Running tests with at least one failing test raises `DevSynthError`.
+- Running tests where all pass returns the test output without raising.

--- a/src/devsynth/application/agents/test.py
+++ b/src/devsynth/application/agents/test.py
@@ -11,6 +11,7 @@ from devsynth.testing.generation import (
 from devsynth.testing.generation import (
     write_scaffolded_tests as _write_scaffolded_tests,
 )
+from devsynth.testing.run_tests import run_tests as _run_tests
 
 from .base import BaseAgent
 
@@ -160,6 +161,29 @@ class TestAgent(BaseAgent):
             "role": self.current_role,
             "integration_tests": integration_tests,
         }
+
+    def run_tests(self, target: str, speed: str | None = None) -> str:
+        """Execute tests and raise if they fail.
+
+        Args:
+            target: Test target to run, such as ``unit-tests`` or
+                ``integration-tests``.
+            speed: Optional speed marker (``fast``, ``medium``, ``slow``).
+
+        Returns:
+            Combined stdout and stderr from the test run.
+
+        Raises:
+            DevSynthError: If any tests fail.
+        """
+
+        speed_categories = [speed] if speed else None
+        success, output = _run_tests(
+            target, speed_categories=speed_categories, parallel=False
+        )
+        if not success:
+            raise DevSynthError("Generated tests failed")
+        return output
 
     def get_capabilities(self) -> List[str]:
         """Get the capabilities of this agent."""

--- a/tests/behavior/features/general/test_agent_executes_generated_tests.feature
+++ b/tests/behavior/features/general/test_agent_executes_generated_tests.feature
@@ -1,0 +1,9 @@
+Feature: Test Agent executes generated tests
+  As a developer
+  I want the TestAgent to run generated tests
+  So that unmet requirements cause test failures
+
+  Scenario: Run generated tests with unmet requirement
+    Given a generated test referencing an unmet requirement
+    When the TestAgent runs the test suite
+    Then the test run should fail

--- a/tests/integration/agents/test_generation/__init__.py
+++ b/tests/integration/agents/test_generation/__init__.py
@@ -1,0 +1,1 @@
+# Integration tests for test generation utilities.

--- a/tests/integration/agents/test_generation/test_run_generated_tests.py
+++ b/tests/integration/agents/test_generation/test_run_generated_tests.py
@@ -1,0 +1,51 @@
+from pathlib import Path
+
+import pytest
+
+from devsynth.application.agents.test import TestAgent
+from devsynth.exceptions import DevSynthError
+from devsynth.testing import run_tests as run_tests_module
+
+
+@pytest.mark.fast
+def test_run_tests_fails_when_tests_fail(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """TestAgent.run_tests raises DevSynthError on failing tests.
+
+    ReqID: N/A"""
+    (tmp_path / "test_fail.py").write_text(
+        "import pytest\npytestmark = pytest.mark.fast\n\n"
+        "def test_fail() -> None:\n    assert False\n"
+    )
+    monkeypatch.setitem(
+        run_tests_module.TARGET_PATHS, "integration-tests", str(tmp_path)
+    )
+    monkeypatch.setattr(
+        run_tests_module, "COLLECTION_CACHE_DIR", str(tmp_path / "cache")
+    )
+    agent = TestAgent()
+    with pytest.raises(DevSynthError):
+        agent.run_tests("integration-tests", speed="fast")
+
+
+@pytest.mark.fast
+def test_run_tests_succeeds_when_tests_pass(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """TestAgent.run_tests returns output when tests pass.
+
+    ReqID: N/A"""
+    (tmp_path / "test_pass.py").write_text(
+        "import pytest\npytestmark = pytest.mark.fast\n\n"
+        "def test_pass() -> None:\n    assert True\n"
+    )
+    monkeypatch.setitem(
+        run_tests_module.TARGET_PATHS, "integration-tests", str(tmp_path)
+    )
+    monkeypatch.setattr(
+        run_tests_module, "COLLECTION_CACHE_DIR", str(tmp_path / "cache")
+    )
+    agent = TestAgent()
+    output = agent.run_tests("integration-tests", speed="fast")
+    assert "1 passed" in output


### PR DESCRIPTION
## Summary
- document and specify test execution for TestAgent
- add `run_tests` method to TestAgent and integration tests for success/failure cases
- introduce BDD feature outlining desired behavior

## Testing
- `poetry run pre-commit run --files docs/specifications/index.md docs/specifications/test_agent_executes_generated_tests.md tests/behavior/features/general/test_agent_executes_generated_tests.feature`
- `poetry run pre-commit run --files src/devsynth/application/agents/test.py tests/integration/agents/test_generation/__init__.py tests/integration/agents/test_generation/test_run_generated_tests.py`
- `poetry run devsynth run-tests --speed=fast`
- `poetry run python tests/verify_test_organization.py`
- `poetry run python scripts/verify_test_markers.py` *(failed: KeyboardInterrupt)*
- `poetry run python scripts/verify_requirements_traceability.py`
- `poetry run python scripts/verify_version_sync.py`


------
https://chatgpt.com/codex/tasks/task_e_68a1008c1a8483339ca847bb04d30196