### PR TITLE
feat: transactional consensus with shared memory

### DIFF
--- a/docs/specifications/consensus_transactional_memory.md
+++ b/docs/specifications/consensus_transactional_memory.md
@@ -1,0 +1,30 @@
+---
+author: ChatGPT
+date: 2025-08-16
+last_reviewed: 2025-08-16
+status: draft
+tags:
+  - specification
+title: Transactional consensus memory
+version: 0.1.0-alpha.1
+---
+
+# Summary
+
+## Socratic Checklist
+- What is the problem?
+- What proofs confirm the solution?
+
+## Motivation
+Consensus decisions must be written consistently across core memory stores. Prior implementations stored team decisions in a single backend, risking divergence between LMDB, FAISS, and Kuzu layers.
+
+## Specification
+- Wrap consensus voting in a transaction spanning LMDB, FAISS, and Kuzu stores.
+- Persist consensus decisions and summaries to all three stores.
+- Store a vector representation of the decision in the FAISS index during the same transaction.
+
+## Acceptance Criteria
+- Consensus voting operates within a multi-store transaction including LMDB, FAISS, and Kuzu.
+- Decision records and summaries appear in LMDB and Kuzu after consensus voting.
+- A corresponding vector entry exists in FAISS for each consensus decision.
+- Integration tests illustrate role reassignment where consensus data is shared across all stores.

--- a/tests/behavior/features/wsde/role_reassignment_shared_memory.feature
+++ b/tests/behavior/features/wsde/role_reassignment_shared_memory.feature
@@ -1,0 +1,7 @@
+Feature: Role reassignment uses shared memory
+  Reassigning roles and reaching consensus should commit decisions to all core stores.
+
+  Scenario: reassigning roles persists consensus decision
+    Given a collaborative WSDE team with LMDB, FAISS, and Kuzu stores
+    When the team reassigns roles and reaches consensus on a task
+    Then the consensus decision is persisted across LMDB, FAISS, and Kuzu

--- a/tests/behavior/steps/test_wsde_role_reassignment_shared_memory_steps.py
+++ b/tests/behavior/steps/test_wsde_role_reassignment_shared_memory_steps.py
@@ -1,0 +1,145 @@
+import logging
+from datetime import datetime
+
+import pytest
+from pytest_bdd import given, scenarios, then, when
+
+from devsynth.application.collaboration.collaborative_wsde_team import (
+    CollaborativeWSDETeam,
+)
+from devsynth.application.memory.faiss_store import FAISSStore
+from devsynth.application.memory.kuzu_store import KuzuStore
+from devsynth.application.memory.lmdb_store import LMDBStore
+from devsynth.application.memory.memory_manager import MemoryManager
+
+lmdb_mod = pytest.importorskip("lmdb")
+pytest.importorskip("faiss")
+if not hasattr(lmdb_mod, "open"):
+    pytest.skip("lmdb unavailable", allow_module_level=True)
+
+pytestmark = pytest.mark.fast
+scenarios("../features/wsde/role_reassignment_shared_memory.feature")
+
+
+class DummyAgent:
+    def __init__(self, name: str):
+        self.name = name
+        self.expertise = ["general"]
+        self.current_role = None
+
+
+class RoleTeam(CollaborativeWSDETeam):
+    def __init__(self, memory_manager: MemoryManager):
+        super().__init__("bdd-team", memory_manager=memory_manager)
+        self.agents = [DummyAgent("a1"), DummyAgent("a2")]
+        self.messages = {}
+        self.logger = logging.getLogger("bdd")
+
+    def dynamic_role_reassignment(
+        self, task
+    ):  # pragma: no cover - exercised in feature
+        self.agents[0].current_role = "Primus"
+        self.agents[1].current_role = "Scribe"
+
+    def get_primus(self):  # pragma: no cover - simple selection
+        for agent in self.agents:
+            if agent.current_role == "Primus":
+                return agent
+        return None
+
+    def get_messages(
+        self, agent=None, filters=None
+    ):  # pragma: no cover - basic opinions
+        now = datetime.now()
+        return [{"timestamp": now, "content": {"opinion": "approve", "rationale": "r"}}]
+
+    def _generate_agent_opinions(self, task):  # pragma: no cover - not needed
+        pass
+
+    def _identify_conflicts(self, task):  # pragma: no cover - no conflicts
+        return []
+
+    def _identify_weighted_majority_opinion(
+        self, opinions, keywords
+    ):  # pragma: no cover - simple
+        return "approve"
+
+    def _generate_stakeholder_explanation(
+        self, task, result
+    ):  # pragma: no cover - simple
+        return "because"
+
+    def vote_on_critical_decision(
+        self, task
+    ):  # pragma: no cover - delegate to consensus
+        return self.build_consensus(task)
+
+
+@pytest.fixture
+def context(tmp_path):
+    class Context:
+        pass
+
+    class LMDBTestStore(LMDBStore):
+        def is_transaction_active(
+            self, transaction_id: str
+        ) -> bool:  # pragma: no cover - simple
+            return False
+
+    class KuzuTestStore(KuzuStore):
+        def begin_transaction(
+            self, transaction_id: str | None = None
+        ):  # pragma: no cover - simple
+            return transaction_id or "0"
+
+        def commit_transaction(
+            self, transaction_id: str
+        ) -> bool:  # pragma: no cover - simple
+            return True
+
+        def rollback_transaction(
+            self, transaction_id: str
+        ) -> bool:  # pragma: no cover - simple
+            return True
+
+        def is_transaction_active(
+            self, transaction_id: str
+        ) -> bool:  # pragma: no cover - simple
+            return False
+
+    lmdb_store = LMDBTestStore(str(tmp_path / "lmdb"))
+    faiss_store = FAISSStore(str(tmp_path / "faiss"))
+    kuzu_store = KuzuTestStore(str(tmp_path / "kuzu"))
+    mm = MemoryManager(
+        adapters={"lmdb": lmdb_store, "faiss": faiss_store, "kuzu": kuzu_store}
+    )
+    ctx = Context()
+    ctx.team = RoleTeam(mm)
+    ctx.mm = mm
+    return ctx
+
+
+@given("a collaborative WSDE team with LMDB, FAISS, and Kuzu stores")
+def given_team(context):
+    assert context.team
+
+
+@when("the team reassigns roles and reaches consensus on a task")
+def when_reassign_and_consensus(context):
+    context.team.vote_with_role_reassignment(
+        {"id": "t1", "title": "Test", "options": ["approve", "reject"]}
+    )
+
+
+@then("the consensus decision is persisted across LMDB, FAISS, and Kuzu")
+def then_persisted(context):
+    mm = context.mm
+    for name, store in mm.adapters.items():
+        if name == "faiss":
+            assert any(
+                m.get("metadata", {}).get("type") == "CONSENSUS_VECTOR"
+                for m in store.metadata.values()
+            )
+        else:
+            results = store.search({"metadata.type": "CONSENSUS_DECISION"})
+            assert results

--- a/tests/integration/collaboration/test_role_reassignment_shared_memory.py
+++ b/tests/integration/collaboration/test_role_reassignment_shared_memory.py
@@ -1,0 +1,103 @@
+import logging
+from datetime import datetime
+
+import pytest
+
+from devsynth.application.collaboration.collaborative_wsde_team import (
+    CollaborativeWSDETeam,
+)
+from devsynth.application.memory.faiss_store import FAISSStore
+from devsynth.application.memory.kuzu_store import KuzuStore
+from devsynth.application.memory.lmdb_store import LMDBStore
+from devsynth.application.memory.memory_manager import MemoryManager
+
+lmdb_mod = pytest.importorskip("lmdb")
+pytest.importorskip("faiss")
+if not hasattr(lmdb_mod, "open"):
+    pytest.skip("lmdb unavailable", allow_module_level=True)
+
+
+class DummyAgent:
+    def __init__(self, name: str):
+        self.name = name
+        self.expertise = ["general"]
+        self.current_role = None
+
+
+class RoleTeam(CollaborativeWSDETeam):
+    def __init__(self, memory_manager: MemoryManager):
+        super().__init__("team", memory_manager=memory_manager)
+        self.agents = [DummyAgent("a1"), DummyAgent("a2")]
+        self.logger = logging.getLogger("test")
+
+    def dynamic_role_reassignment(self, task):
+        self.agents[0].current_role = "Primus"
+        self.agents[1].current_role = "Scribe"
+
+    def get_primus(self):
+        for agent in self.agents:
+            if agent.current_role == "Primus":
+                return agent
+        return None
+
+    def get_messages(self, agent=None, filters=None):
+        now = datetime.now()
+        return [{"timestamp": now, "content": {"opinion": "approve", "rationale": "r"}}]
+
+    def _generate_agent_opinions(self, task):
+        pass
+
+    def _identify_conflicts(self, task):
+        return []
+
+    def _identify_weighted_majority_opinion(self, opinions, keywords):
+        return "approve"
+
+    def _generate_stakeholder_explanation(self, task, result):
+        return "because"
+
+    def vote_on_critical_decision(self, task):
+        return self.build_consensus(task)
+
+
+@pytest.mark.requires_resource("lmdb")
+@pytest.mark.requires_resource("faiss")
+@pytest.mark.fast
+def test_role_reassignment_shared_memory(tmp_path):
+    class LMDBTestStore(LMDBStore):
+        def is_transaction_active(self, transaction_id: str) -> bool:
+            return False
+
+    class KuzuTestStore(KuzuStore):
+        def begin_transaction(self, transaction_id: str | None = None):
+            return transaction_id or "0"
+
+        def commit_transaction(self, transaction_id: str) -> bool:
+            return True
+
+        def rollback_transaction(self, transaction_id: str) -> bool:
+            return True
+
+        def is_transaction_active(self, transaction_id: str) -> bool:
+            return False
+
+    lmdb_store = LMDBTestStore(str(tmp_path / "lmdb"))
+    faiss_store = FAISSStore(str(tmp_path / "faiss"))
+    kuzu_store = KuzuTestStore(str(tmp_path / "kuzu"))
+    mm = MemoryManager(
+        adapters={"lmdb": lmdb_store, "faiss": faiss_store, "kuzu": kuzu_store}
+    )
+    team = RoleTeam(mm)
+    task = {"id": "t1", "title": "Test", "options": ["approve", "reject"]}
+
+    team.vote_with_role_reassignment(task)
+
+    for name, store in mm.adapters.items():
+        if name == "faiss":
+            assert any(
+                m.get("metadata", {}).get("type") == "CONSENSUS_VECTOR"
+                for m in store.metadata.values()
+            )
+        else:
+            results = store.search({"metadata.type": "CONSENSUS_DECISION"})
+            assert results


### PR DESCRIPTION
## Summary
- document transactional consensus requirements for cross-store memory
- ensure consensus voting uses LMDB, FAISS, and Kuzu in a single transaction
- add role reassignment integration test verifying shared memory

## Testing
- `poetry run pre-commit run --files docs/specifications/consensus_transactional_memory.md tests/behavior/features/wsde/role_reassignment_shared_memory.feature tests/behavior/steps/test_wsde_role_reassignment_shared_memory_steps.py`
- `poetry run devsynth run-tests --speed=fast`
- `poetry run python tests/verify_test_organization.py`
- `poetry run python scripts/verify_test_markers.py` *(fails: KeyboardInterrupt)*
- `poetry run python scripts/verify_requirements_traceability.py`
- `poetry run python scripts/verify_version_sync.py`


------
https://chatgpt.com/codex/tasks/task_e_68a10084639c83338b097ae18d28e4d1