### PR TITLE
feat: add failure hooks and configurable thresholds

### DIFF
--- a/src/devsynth/application/edrr/edrr_coordinator_enhanced.py
+++ b/src/devsynth/application/edrr/edrr_coordinator_enhanced.py
@@ -83,7 +83,10 @@ class EnhancedEDRRCoordinator(EDRRCoordinator):
         )
 
         # Initialize phase transition metrics
-        self.phase_metrics = PhaseTransitionMetrics()
+        thresholds_cfg = (
+            (config or {}).get("phase_transitions", {}).get("thresholds", {})
+        )
+        self.phase_metrics = PhaseTransitionMetrics(thresholds=thresholds_cfg)
 
         # Enhanced configuration
         self.config = config or {}
@@ -105,6 +108,10 @@ class EnhancedEDRRCoordinator(EDRRCoordinator):
             "quality_threshold", 0.7
         )
         self.max_revision_cycles = peer_review_config.get("max_revision_cycles", 2)
+
+    def register_phase_failure_hook(self, phase: Phase, hook: Any) -> None:
+        """Register a hook for phase transition failures."""
+        self.phase_metrics.register_failure_hook(phase, hook)
 
     def progress_to_phase(self, phase: Phase) -> None:
         """


### PR DESCRIPTION
## Summary
- allow phase transition metrics to accept configurable thresholds
- add failure hooks for unresolved phase transitions
- test new hooks and threshold overrides

## Testing
- `poetry run pre-commit run --files src/devsynth/application/edrr/edrr_coordinator_enhanced.py src/devsynth/application/edrr/edrr_phase_transitions.py tests/unit/application/edrr/test_edrr_coordinator_enhanced.py tests/unit/application/edrr/test_edrr_phase_transitions.py`
- `poetry run devsynth run-tests --speed=medium` *(fails: 888 failed, 1872 passed, 118 skipped, 95 errors)*
- `poetry run pytest tests/unit/application/edrr/test_edrr_phase_transitions.py::TestPhaseTransitionMetrics::test_configure_thresholds_override tests/unit/application/edrr/test_edrr_phase_transitions.py::TestPhaseTransitionMetrics::test_failure_hook_invoked_on_unrecovered_failure tests/unit/application/edrr/test_edrr_coordinator_enhanced.py::TestEnhancedEDRRCoordinator::test_phase_failure_hook_called -m medium`
- `poetry run python tests/verify_test_organization.py`
- `poetry run python scripts/verify_test_markers.py -d tests/unit/application/edrr`
- `poetry run python scripts/verify_requirements_traceability.py`
- `poetry run python scripts/verify_version_sync.py`


------
https://chatgpt.com/codex/tasks/task_e_68a10080b5288333ac85b26d676b8a88