### PR TITLE
chore: align xdist KeyError issue with template

### DIFF
--- a/issues/Resolve-medium-test-suite-xdist-KeyError.md
+++ b/issues/Resolve-medium-test-suite-xdist-KeyError.md
@@ -1,7 +1,6 @@
 # Resolve medium test suite xdist KeyError
 Milestone: 0.1.0-alpha.1
 Status: open
-
 Priority: high
 Dependencies: None
 


### PR DESCRIPTION
## Summary
- ensure Resolve medium test suite xdist KeyError issue begins with the required title line and metadata fields

## Testing
- `SKIP=fix-code-blocks poetry run pre-commit run --files issues/Resolve-medium-test-suite-xdist-KeyError.md`
- `poetry run devsynth run-tests --speed=fast`
- `poetry run python tests/verify_test_organization.py`
- `poetry run python scripts/verify_test_markers.py`
- `poetry run python scripts/verify_requirements_traceability.py`
- `poetry run python scripts/verify_version_sync.py`


------
https://chatgpt.com/codex/tasks/task_e_68a1006c4d348333b026315133fa04d4