### PR TITLE
feat: make streamlit optional

### DIFF
--- a/src/devsynth/interface/webui_bridge.py
+++ b/src/devsynth/interface/webui_bridge.py
@@ -3,7 +3,10 @@ from __future__ import annotations
 import time
 from typing import Any, Dict, List, Optional, Sequence
 
-import streamlit as st
+try:  # pragma: no cover - optional dependency
+    import streamlit as st
+except ModuleNotFoundError:  # pragma: no cover - streamlit is optional
+    st = None  # type: ignore[assignment]
 
 from devsynth.interface.state_access import get_session_value as _get_session_value
 from devsynth.interface.state_access import set_session_value as _set_session_value
@@ -15,6 +18,19 @@ from .ux_bridge import ProgressIndicator, UXBridge, sanitize_output
 
 # Module level logger
 logger = DevSynthLogger(__name__)
+
+
+def _require_streamlit() -> None:
+    """Ensure the ``streamlit`` package is available.
+
+    Raises:
+        RuntimeError: If ``streamlit`` is not installed.
+    """
+    if st is None:  # pragma: no cover - error path
+        raise RuntimeError(
+            "The 'streamlit' package is required for WebUI functionality."
+            " Please install it to use the WebUI interface."
+        )
 
 
 class WebUIProgressIndicator(ProgressIndicator):
@@ -450,6 +466,7 @@ class WebUIBridge(SharedBridgeMixin, UXBridge):
         self, message: str, *, highlight: bool = False, message_type: str = None
     ) -> None:
         """Display a message to the user with Streamlit styling."""
+        _require_streamlit()
 
         if message_type == "error":
             logger.error(f"WebUI displaying error: {message}")

--- a/tests/behavior/steps/test_requirements_wizard_navigation_steps.py
+++ b/tests/behavior/steps/test_requirements_wizard_navigation_steps.py
@@ -1,11 +1,12 @@
+import importlib
+import sys
 from types import ModuleType
 from unittest.mock import MagicMock
-import sys
-import importlib
 
 import pytest
-from pytest_bdd import given, when, then, scenarios
+from pytest_bdd import given, scenarios, then, when
 
+pytest.importorskip("streamlit")
 from devsynth.interface.webui import WebUI
 
 scenarios("../features/general/requirements_wizard_navigation.feature")

--- a/tests/behavior/steps/test_webui_integration_steps.py
+++ b/tests/behavior/steps/test_webui_integration_steps.py
@@ -3,8 +3,9 @@ from types import ModuleType
 from unittest.mock import MagicMock, patch
 
 import pytest
-from pytest_bdd import given, when, then, scenarios, parsers
-import streamlit as st
+from pytest_bdd import given, parsers, scenarios, then, when
+
+pytest.importorskip("streamlit")
 
 # Register the feature scenarios to ensure step discovery
 scenarios("../features/general/webui_integration.feature")

--- a/tests/integration/general/test_cli_webui_agentapi_pipeline.py
+++ b/tests/integration/general/test_cli_webui_agentapi_pipeline.py
@@ -14,6 +14,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 pytest.importorskip("fastapi")
+pytest.importorskip("streamlit")
 from fastapi.testclient import TestClient
 
 from devsynth.interface.agentapi import WorkflowResponse

--- a/tests/integration/interface/test_mvuu_dashboard_report.py
+++ b/tests/integration/interface/test_mvuu_dashboard_report.py
@@ -1,7 +1,10 @@
 import json
-from pathlib import Path
 import subprocess
+from pathlib import Path
 
+import pytest
+
+pytest.importorskip("streamlit")
 from streamlit.testing.v1 import AppTest
 
 


### PR DESCRIPTION
## Summary
- handle optional `streamlit` dependency in WebUI bridge
- skip WebUI tests when `streamlit` isn't installed

## Testing
- `poetry run pre-commit run --files src/devsynth/interface/webui_bridge.py tests/behavior/steps/test_requirements_wizard_navigation_steps.py tests/behavior/steps/test_webui_integration_steps.py tests/integration/general/test_cli_webui_agentapi_pipeline.py tests/integration/interface/test_mvuu_dashboard_report.py`
- `poetry run devsynth run-tests --speed=fast`
- `poetry run python tests/verify_test_organization.py`
- `poetry run python scripts/verify_test_markers.py` *(failed: KeyboardInterrupt)*
- `poetry run python scripts/verify_requirements_traceability.py`
- `poetry run python scripts/verify_version_sync.py`


------
https://chatgpt.com/codex/tasks/task_e_68a1005ebd4083339b50a8cb188e0754