### PR TITLE
test: mock add_text in dpg bridge conformance

### DIFF
--- a/tests/unit/interface/test_bridge_conformance.py
+++ b/tests/unit/interface/test_bridge_conformance.py
@@ -88,6 +88,7 @@ def _make_dpg(monkeypatch):
     dpg_mod.is_viewport_created = MagicMock(return_value=True)
     dpg_mod.window = lambda *a, **k: DummyCtx()
     dpg_mod.add_progress_bar = MagicMock(return_value=MagicMock())
+    dpg_mod.add_text = MagicMock()
     dpg_mod.set_item_label = MagicMock()
     dpg_mod.set_value = MagicMock()
     dpg_mod.render_dearpygui_frame = MagicMock()


### PR DESCRIPTION
## Summary
- mock `add_text` in `_make_dpg` to complete DearPyGUI bridge stub

## Testing
- `poetry run pre-commit run --files tests/unit/interface/test_bridge_conformance.py`
- `poetry run devsynth run-tests --target unit-tests --speed=slow --no-parallel --maxfail=1` *(fails: ModuleNotFoundError: No module named 'astor')*
- `poetry run pytest tests/unit/interface/test_bridge_conformance.py::test_bridge_implements_methods_succeeds[_make_dpg] -q`
- `poetry run python tests/verify_test_organization.py`
- `poetry run python scripts/verify_test_markers.py`
- `poetry run python scripts/verify_requirements_traceability.py`
- `poetry run python scripts/verify_version_sync.py`


------
https://chatgpt.com/codex/tasks/task_e_68a1005ab6708333a101222dc2d1f8d8