### PR TITLE
test: ensure providers import without lmstudio

### DIFF
--- a/tests/unit/application/llm/test_import_without_lmstudio.py
+++ b/tests/unit/application/llm/test_import_without_lmstudio.py
@@ -1,25 +1,24 @@
-import pytest
 import builtins
 import importlib
 import sys
 
+import pytest
+
+
 @pytest.mark.medium
 def test_import_lmstudio_provider_without_lmstudio_succeeds(monkeypatch):
     """Importing providers should succeed without lmstudio installed."""
-    sys.modules.pop('devsynth.application.llm.providers', None)
-    sys.modules.pop('devsynth.application.llm.lmstudio_provider', None)
-    sys.modules.pop('lmstudio', None)
+    sys.modules.pop("devsynth.application.llm.providers", None)
+    sys.modules.pop("devsynth.application.llm.lmstudio_provider", None)
+    sys.modules.pop("lmstudio", None)
     real_import = builtins.__import__
 
     def fake_import(name, globals=None, locals=None, fromlist=(), level=0):
-        if name.startswith('lmstudio'):
+        if name.startswith("lmstudio"):
             raise ImportError("No module named 'lmstudio'")
         return real_import(name, globals, locals, fromlist, level)
-    original = module_name
-    try:
-        monkeypatch.setattr(target_module, mock_function)
-    finally:
-        pass
-        providers = importlib.import_module('devsynth.application.llm.providers')
-        assert providers.LMStudioProvider is None
-        assert 'lmstudio' not in providers.factory.provider_types
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+    providers = importlib.import_module("devsynth.application.llm.providers")
+    assert providers.LMStudioProvider is None
+    assert "lmstudio" not in providers.factory.provider_types


### PR DESCRIPTION
## Summary
- add unit test verifying providers import without lmstudio installed

## Testing
- `poetry run pre-commit run --files tests/unit/application/llm/test_import_without_lmstudio.py`
- `poetry run pytest tests/unit/application/llm/test_import_without_lmstudio.py`
- `poetry run devsynth run-tests --speed=fast` *(fails: command produced no output)*
- `poetry run python tests/verify_test_organization.py`
- `poetry run python scripts/verify_test_markers.py --module tests/unit/application/llm/test_import_without_lmstudio.py`
- `poetry run python scripts/verify_requirements_traceability.py`
- `poetry run python scripts/verify_version_sync.py`


------
https://chatgpt.com/codex/tasks/task_e_68a10057b4648333ba61fe1998fedee6