### PR TITLE
refactor webui progress tests

### DIFF
--- a/tests/unit/interface/test_webui_progress.py
+++ b/tests/unit/interface/test_webui_progress.py
@@ -1,192 +1,166 @@
+import importlib
 import sys
-from types import ModuleType
-from unittest.mock import MagicMock, patch, call
+
 import pytest
+
 from tests.unit.interface.test_webui_enhanced import _mock_streamlit
 
 
 @pytest.fixture
 def mock_streamlit(monkeypatch):
-    """Fixture to mock streamlit for testing."""
+    """Provide a mocked ``streamlit`` module."""
     st = _mock_streamlit()
-    monkeypatch.setitem(sys.modules, 'streamlit', st)
+    monkeypatch.setitem(sys.modules, "streamlit", st)
     return st
 
 
-@pytest.mark.medium
-
 @pytest.fixture
 def clean_state():
-    # Set up clean state
+    """Provide a clean state for each test."""
     yield
-    # Clean up state
 
+
+@pytest.mark.medium
 def test_ui_progress_init_succeeds(mock_streamlit, clean_state):
-    """Test the initialization of _UIProgress.
+    """Test the initialization of ``_UIProgress``.
 
     ReqID: N/A"""
-    import importlib
     import devsynth.interface.webui as webui
+
     importlib.reload(webui)
     from devsynth.interface.webui import WebUI
+
     bridge = WebUI()
-    progress = bridge.create_progress('Test Progress', total=100)
-    assert progress._description == 'Test Progress'
+    progress = bridge.create_progress("Test Progress", total=100)
+
+    assert progress._description == "Test Progress"
     assert progress._total == 100
     assert progress._current == 0
     assert progress._subtasks == {}
     assert mock_streamlit.empty.called
     assert mock_streamlit.progress.called
     status_container = mock_streamlit.empty.return_value
-    status_container.markdown.assert_called_with('**Test Progress** - 0%')
-
-
+    status_container.markdown.assert_called_with("**Test Progress** - 0%")
 
 
 @pytest.mark.medium
-
-@pytest.fixture
-def clean_state():
-    # Set up clean state
-    yield
-    # Clean up state
-
 def test_ui_progress_update_succeeds(mock_streamlit, clean_state):
-    """Test the update method of _UIProgress.
+    """Test the update method of ``_UIProgress``.
 
     ReqID: N/A"""
-    import importlib
     import devsynth.interface.webui as webui
+
     importlib.reload(webui)
     from devsynth.interface.webui import WebUI
+
     bridge = WebUI()
-    progress = bridge.create_progress('Test Progress', total=100)
+    progress = bridge.create_progress("Test Progress", total=100)
+
     status_container = mock_streamlit.empty.return_value
     status_container.markdown.reset_mock()
     progress_bar = mock_streamlit.progress.return_value
     progress_bar.progress.reset_mock()
-    progress.update(advance=25, description='Updated Progress')
+
+    progress.update(advance=25, description="Updated Progress")
+
     assert progress._current == 25
-    assert progress._description == 'Updated Progress'
-    status_container.markdown.assert_called_with('**Updated Progress** - 25%')
+    assert progress._description == "Updated Progress"
+    status_container.markdown.assert_called_with("**Updated Progress** - 25%")
     progress_bar.progress.assert_called_with(0.25)
 
 
-
 @pytest.mark.medium
-
-@pytest.fixture
-def clean_state():
-    # Set up clean state
-    yield
-    # Clean up state
-
 def test_ui_progress_complete_succeeds(mock_streamlit, clean_state):
-    """Test the complete method of _UIProgress.
+    """Test the complete method of ``_UIProgress``.
 
     ReqID: N/A"""
-    import importlib
     import devsynth.interface.webui as webui
+
     importlib.reload(webui)
     from devsynth.interface.webui import WebUI
+
     bridge = WebUI()
-    progress = bridge.create_progress('Test Progress', total=100)
+    progress = bridge.create_progress("Test Progress", total=100)
     progress.complete()
+
     assert progress._current == 100
-    mock_streamlit.success.assert_called_with('Completed: Test Progress')
+    mock_streamlit.success.assert_called_with("Completed: Test Progress")
 
 
 @pytest.mark.medium
-
-@pytest.fixture
-def clean_state():
-    # Set up clean state
-    yield
-    # Clean up state
-
 def test_ui_progress_add_subtask_succeeds(mock_streamlit, clean_state):
-    """Test the add_subtask method of _UIProgress.
+    """Test the ``add_subtask`` method of ``_UIProgress``.
 
     ReqID: N/A"""
-    import importlib
     import devsynth.interface.webui as webui
+
     importlib.reload(webui)
     from devsynth.interface.webui import WebUI
-    bridge = WebUI()
-    progress = bridge.create_progress('Test Progress', total=100)
-    subtask_id = progress.add_subtask('Subtask 1', total=50)
-    assert subtask_id in progress._subtasks
-    assert progress._subtasks[subtask_id]['description'] == 'Subtask 1'
-    assert progress._subtasks[subtask_id]['total'] == 50
-    assert progress._subtasks[subtask_id]['current'] == 0
-    assert mock_streamlit.container.called
-    subtask_container = (mock_streamlit.container.return_value.__enter__.
-        return_value)
-    subtask_container.markdown.assert_called_with(
-        '&nbsp;&nbsp;&nbsp;&nbsp;**Subtask 1** - 0%')
 
+    bridge = WebUI()
+    progress = bridge.create_progress("Test Progress", total=100)
+    subtask_id = progress.add_subtask("Subtask 1", total=50)
+
+    assert subtask_id in progress._subtasks
+    assert progress._subtasks[subtask_id]["description"] == "Subtask 1"
+    assert progress._subtasks[subtask_id]["total"] == 50
+    assert progress._subtasks[subtask_id]["current"] == 0
+    assert mock_streamlit.container.called
+    subtask_container = mock_streamlit.container.return_value.__enter__.return_value
+    subtask_container.markdown.assert_called_with(
+        "&nbsp;&nbsp;&nbsp;&nbsp;**Subtask 1** - 0%"
+    )
 
 
 @pytest.mark.medium
-
-@pytest.fixture
-def clean_state():
-    # Set up clean state
-    yield
-    # Clean up state
-
 def test_ui_progress_update_subtask_succeeds(mock_streamlit, clean_state):
-    """Test the update_subtask method of _UIProgress.
-
+    """Test the ``update_subtask`` method of ``_UIProgress``.
 
     ReqID: N/A"""
-    import importlib
     import devsynth.interface.webui as webui
+
     importlib.reload(webui)
     from devsynth.interface.webui import WebUI
+
     bridge = WebUI()
-    progress = bridge.create_progress('Test Progress', total=100)
-    subtask_id = progress.add_subtask('Subtask 1', total=50)
-    subtask_container = (mock_streamlit.container.return_value.__enter__.
-        return_value)
+    progress = bridge.create_progress("Test Progress", total=100)
+    subtask_id = progress.add_subtask("Subtask 1", total=50)
+
+    subtask_container = mock_streamlit.container.return_value.__enter__.return_value
     subtask_container.markdown.reset_mock()
     subtask_progress_bar = subtask_container.progress.return_value
     subtask_progress_bar.progress.reset_mock()
-    progress.update_subtask(subtask_id, advance=25, description=
-        'Updated Subtask')
-    assert progress._subtasks[subtask_id]['current'] == 25
-    assert progress._subtasks[subtask_id]['description'] == 'Updated Subtask'
+
+    progress.update_subtask(subtask_id, advance=25, description="Updated Subtask")
+
+    assert progress._subtasks[subtask_id]["current"] == 25
+    assert progress._subtasks[subtask_id]["description"] == "Updated Subtask"
     subtask_container.markdown.assert_called_with(
-        '&nbsp;&nbsp;&nbsp;&nbsp;**Updated Subtask** - 50%')
+        "&nbsp;&nbsp;&nbsp;&nbsp;**Updated Subtask** - 50%"
+    )
     subtask_progress_bar.progress.assert_called_with(0.5)
 
 
-
 @pytest.mark.medium
-
-@pytest.fixture
-def clean_state():
-    # Set up clean state
-    yield
-    # Clean up state
-
 def test_ui_progress_complete_subtask_succeeds(mock_streamlit, clean_state):
-    """Test the complete_subtask method of _UIProgress.
+    """Test the ``complete_subtask`` method of ``_UIProgress``.
 
     ReqID: N/A"""
-    import importlib
     import devsynth.interface.webui as webui
+
     importlib.reload(webui)
     from devsynth.interface.webui import WebUI
+
     bridge = WebUI()
-    progress = bridge.create_progress('Test Progress', total=100)
-    subtask_id = progress.add_subtask('Subtask 1', total=50)
+    progress = bridge.create_progress("Test Progress", total=100)
+    subtask_id = progress.add_subtask("Subtask 1", total=50)
     progress.complete_subtask(subtask_id)
-    assert progress._subtasks[subtask_id]['current'] == 50
-    subtask_container = (mock_streamlit.container.return_value.__enter__.
-        return_value)
+
+    assert progress._subtasks[subtask_id]["current"] == 50
+    subtask_container = mock_streamlit.container.return_value.__enter__.return_value
     subtask_container.markdown.assert_called_with(
-        '&nbsp;&nbsp;&nbsp;&nbsp;**Subtask 1** - 100%')
+        "&nbsp;&nbsp;&nbsp;&nbsp;**Subtask 1** - 100%"
+    )
     subtask_progress_bar = subtask_container.progress.return_value
     subtask_progress_bar.progress.assert_called_with(1.0)
-    subtask_container.success.assert_called_with('Completed: Subtask 1')
+    subtask_container.success.assert_called_with("Completed: Subtask 1")


### PR DESCRIPTION
## Summary
- consolidate clean_state fixture for web UI progress tests
- add explicit imports and use shared _mock_streamlit helper
- ensure progress tests assert streamlit progress and empty mocks

## Testing
- `poetry run pre-commit run --files tests/unit/interface/test_webui_progress.py`
- `poetry run devsynth run-tests --speed=fast`
- `poetry run python tests/verify_test_organization.py`
- `poetry run python scripts/verify_test_markers.py` *(fails: KeyboardInterrupt)*
- `poetry run python scripts/verify_requirements_traceability.py`
- `poetry run python scripts/verify_version_sync.py`


------
https://chatgpt.com/codex/tasks/task_e_68a10054bfa0833386f1eb97f106edd2