### PR TITLE
test: verify webui setup wizard run

### DIFF
--- a/tests/unit/interface/test_webui_setup.py
+++ b/tests/unit/interface/test_webui_setup.py
@@ -10,30 +10,9 @@ pytestmark = pytest.mark.requires_resource("webui")
 
 
 @pytest.mark.medium
-@pytest.fixture
-def clean_state():
-    # Set up clean state
-    yield
-    # Clean up state
-
-
-@pytest.mark.slow
-def test_function(clean_state):
-    # Test with clean state
+def test_webui_setup_wizard_runs(monkeypatch):
     bridge = MagicMock(spec=UXBridge)
-    run_called = {}
-
-    def fake_run(self):
-        run_called["called"] = True
-
-    original = module_name
-    try:
-        monkeypatch.setattr(target_module, mock_function)
-        # Test code here
-    finally:
-        # Restore original if needed for cleanup
-        pass
-
-        wizard = WebUISetupWizard(bridge)
-        wizard.run()
-        assert run_called.get("called") is True
+    run_mock = MagicMock()
+    monkeypatch.setattr(SetupWizard, "run", run_mock)
+    WebUISetupWizard(bridge).run()
+    run_mock.assert_called_once()


### PR DESCRIPTION
## Summary
- verify that WebUISetupWizard.run triggers SetupWizard.run via monkeypatch

## Testing
- `poetry run pre-commit run --files tests/unit/interface/test_webui_setup.py`
- `poetry run devsynth run-tests --speed=fast`
- `DEVSYNTH_RESOURCE_WEBUI_AVAILABLE=true poetry run pytest tests/unit/interface/test_webui_setup.py -m medium`
- `poetry run python tests/verify_test_organization.py`
- `poetry run python scripts/verify_test_markers.py` *(fails: KeyboardInterrupt)*
- `poetry run python scripts/verify_requirements_traceability.py`
- `poetry run python scripts/verify_version_sync.py`


------
https://chatgpt.com/codex/tasks/task_e_68a10051a08483338b549c4b60027132