### PR TITLE
test: verify WebUIProgressIndicator update timestamps

### DIFF
--- a/tests/unit/interface/test_webui_progress_time.py
+++ b/tests/unit/interface/test_webui_progress_time.py
@@ -1,34 +1,20 @@
 import time
 
 import pytest
+from pytest import MonkeyPatch
 
 from devsynth.interface.webui_bridge import WebUIProgressIndicator
 
-pytestmark = pytest.mark.requires_resource("webui")
+pytestmark = [pytest.mark.requires_resource("webui"), pytest.mark.fast]
 
 
-@pytest.mark.medium
-@pytest.fixture
-def clean_state():
-    # Set up clean state
-    yield
-    # Clean up state
-
-
-@pytest.mark.slow
-def test_function(clean_state):
-    # Test with clean state
+def test_update_records_time(monkeypatch: MonkeyPatch) -> None:
+    """WebUIProgressIndicator.update stores deterministic timestamps."""
     times = iter([100.0, 101.0])
+    monkeypatch.setattr(time, "time", lambda: next(times))
 
-    original = module_name
-    try:
-        monkeypatch.setattr(target_module, mock_function)
-        # Test code here
-    finally:
-        # Restore original if needed for cleanup
-        pass
-        #     ) # Commented out unmatched parenthesis
-        indicator = WebUIProgressIndicator("Task", 10)
-        indicator.update()
-        indicator.update(advance=2)
-        assert indicator._update_times == [(100.0, 1), (101.0, 3)]
+    indicator = WebUIProgressIndicator("Task", 10)
+    indicator.update()
+    indicator.update(advance=2)
+
+    assert indicator._update_times == [(100.0, 1), (101.0, 3)]


### PR DESCRIPTION
## Summary
- ensure WebUIProgressIndicator.update records deterministic timestamps

## Testing
- `poetry run pre-commit run --files tests/unit/interface/test_webui_progress_time.py`
- `poetry run devsynth run-tests --speed=fast`
- `poetry run python tests/verify_test_organization.py`
- `poetry run python scripts/verify_test_markers.py`
- `poetry run python scripts/verify_requirements_traceability.py`
- `poetry run python scripts/verify_version_sync.py`


------
https://chatgpt.com/codex/tasks/task_e_68a1004eff4c8333b814e28107f7d01e