### PR TITLE
feat: execute scaffolded tests and surface failures

### DIFF
--- a/docs/specifications/generated_test_execution_failure.md
+++ b/docs/specifications/generated_test_execution_failure.md
@@ -1,0 +1,34 @@
+title: "Generated Test Execution Failure"
+author: "DevSynth Team"
+date: "2025-07-26"
+last_reviewed: "2025-07-26"
+status: draft
+version: "0.1.0-alpha.1"
+tags:
+  - specification
+  - testing
+---
+<div class="breadcrumbs">
+<a href="../index.md">Documentation</a> &gt; <a href="index.md">Specifications</a> &gt; Generated Test Execution Failure
+</div>
+
+# Generated Test Execution Failure
+
+## Summary
+Scaffolded tests execute and fail when underlying requirements are unimplemented.
+
+## Socratic Checklist
+- What is the problem?
+- What proofs confirm the solution?
+
+## Motivation
+Developers need immediate feedback when requirements are unmet, so scaffolded tests should fail until implemented.
+
+## Specification
+- Placeholder tests produced by `devsynth.testing.generation.scaffold_integration_tests` omit skip markers.
+- Running the generated tests raises `NotImplementedError` until real tests replace them.
+- `TestAgent` exposes `run_generated_tests` to execute tests in a directory and surface failures.
+
+## Acceptance Criteria
+- Generated placeholder tests fail when executed.
+- `TestAgent.run_generated_tests` raises `DevSynthError` if test execution succeeds unexpectedly.

--- a/docs/specifications/index.md
+++ b/docs/specifications/index.md
@@ -42,6 +42,7 @@ This section contains the official specifications for the DevSynth project, outl
 - **[Run Tests Maxfail Option](run_tests_maxfail_option.md)**: CLI flag to limit failures during test runs.
 - **[Integration Test Scenario Generation](integration_test_generation.md)**: Scenario-based scaffolding for integration tests.
 - **[Retry Predicates Specification](retry_predicates.md)**: Support conditional retry logic and metrics.
+- **[Generated Test Execution Failure](generated_test_execution_failure.md)**: Scaffolded tests fail until implemented.
 
 ## Implementation Plans
 

--- a/src/devsynth/application/agents/test.py
+++ b/src/devsynth/application/agents/test.py
@@ -1,5 +1,7 @@
 """Test agent for the DevSynth system."""
 
+import subprocess
+import sys
 from pathlib import Path
 from typing import Any, Dict, List
 
@@ -86,6 +88,32 @@ class TestAgent(BaseAgent):
             else:
                 names.append(str(scenario))
         return self.scaffold_integration_tests(names, output_dir=output_dir)
+
+    def run_generated_tests(self, directory: Path) -> str:
+        """Run tests in ``directory`` and raise on failures.
+
+        This helper executes the scaffolded tests so unmet requirements
+        surface as errors.
+
+        Args:
+            directory: Location of the tests to run.
+
+        Returns:
+            Combined stdout and stderr from the test run.
+
+        Raises:
+            DevSynthError: If the tests fail.
+        """
+
+        result = subprocess.run(
+            [sys.executable, "-m", "pytest", str(directory)],
+            capture_output=True,
+            text=True,
+        )
+        output = result.stdout + result.stderr
+        if result.returncode != 0:
+            raise DevSynthError(output)
+        return output
 
     def process(self, inputs: Dict[str, Any]) -> Dict[str, Any]:
         """Process inputs and produce tests."""

--- a/src/devsynth/testing/generation.py
+++ b/src/devsynth/testing/generation.py
@@ -1,8 +1,8 @@
 """Integration test scaffolding utilities.
 
 This module provides helpers for creating placeholder integration test
-modules. Generated tests include ``pytest`` skip markers so missing
-coverage is highlighted during review without breaking the suite.
+modules. Generated tests raise ``NotImplementedError`` so missing coverage
+causes visible failures until real tests are added.
 """
 
 from __future__ import annotations
@@ -12,9 +12,7 @@ from typing import Dict, Iterable
 
 PLACEHOLDER_TEMPLATE = (
     '"""Scaffolded integration test for {name}.\n\n'
-    'Replace this file with real tests and remove the skip marker.\n"""\n'
-    "import pytest\n\n"
-    'pytestmark = pytest.mark.skip(reason="scaffold placeholder for {name}")\n\n'
+    'Replace this file with real tests.\n"""\n\n'
     "def test_{name}() -> None:\n"
     '    """Integration test placeholder for {name}."""\n'
     '    raise NotImplementedError("Add integration test for {name}")\n'

--- a/tests/behavior/features/index.md
+++ b/tests/behavior/features/index.md
@@ -3,6 +3,7 @@
 This index lists all feature files for easy navigation.
 
 - [examples/simple_addition.feature](./examples/simple_addition.feature)
+- [integration/generated_tests_fail.feature](./integration/generated_tests_fail.feature)
 - [integration/test_scaffolding.feature](./integration/test_scaffolding.feature)
 - [general/additional_storage_backends.feature](./general/additional_storage_backends.feature)
 - [general/advanced_graph_memory_features.feature](./general/advanced_graph_memory_features.feature)

--- a/tests/behavior/features/integration/generated_tests_fail.feature
+++ b/tests/behavior/features/integration/generated_tests_fail.feature
@@ -1,0 +1,9 @@
+Feature: Generated tests fail when requirements are unmet
+  As a developer
+  I want scaffolded tests to execute and fail until implemented
+  So that unmet requirements are visible early
+
+  Scenario: Run scaffolded tests without implementations
+    Given integration scenarios are defined
+    When the generated tests are executed
+    Then the test run reports missing implementation failures

--- a/tests/integration/agents/test_generation/test_run_generated_tests.py
+++ b/tests/integration/agents/test_generation/test_run_generated_tests.py
@@ -1,0 +1,18 @@
+from pathlib import Path
+
+import pytest
+
+from devsynth.application.agents.test import TestAgent
+from devsynth.exceptions import DevSynthError
+
+
+@pytest.mark.fast
+def test_run_generated_tests_fails(tmp_path: Path) -> None:
+    """Generated tests execute and fail when unimplemented.
+
+    ReqID: N/A"""
+    agent = TestAgent()
+    agent.scaffold_integration_tests(["beta"], output_dir=tmp_path)
+    with pytest.raises(DevSynthError) as exc:
+        agent.run_generated_tests(tmp_path)
+    assert "NotImplementedError" in str(exc.value)

--- a/tests/integration/agents/test_generation/test_scaffold_generation.py
+++ b/tests/integration/agents/test_generation/test_scaffold_generation.py
@@ -15,7 +15,7 @@ def test_scaffold_hook_creates_placeholder(tmp_path: Path) -> None:
     file_path = tmp_path / "test_sample.py"
     assert file_path in written
     content = file_path.read_text()
-    assert "pytestmark = pytest.mark.skip" in content
+    assert "NotImplementedError" in content
     assert content == written[file_path]
 
 
@@ -50,4 +50,4 @@ def test_process_generates_tests_and_scaffolds(
     assert "test_alpha.py" in result["integration_tests"]
     scaffold = tmp_path / "test_alpha.py"
     assert scaffold.exists()
-    assert "pytestmark = pytest.mark.skip" in scaffold.read_text()
+    assert "NotImplementedError" in scaffold.read_text()


### PR DESCRIPTION
## Summary
- add helper to run generated tests and raise when they fail
- scaffolded tests drop skip markers and raise `NotImplementedError`
- add integration coverage and BDD feature for failing scaffolds

## Testing
- `poetry run pre-commit run --files docs/specifications/index.md src/devsynth/application/agents/test.py src/devsynth/testing/generation.py tests/behavior/features/index.md tests/integration/agents/test_generation/test_scaffold_generation.py docs/specifications/generated_test_execution_failure.md tests/behavior/features/integration/generated_tests_fail.feature tests/integration/agents/test_generation/__init__.py tests/integration/agents/test_generation/test_run_generated_tests.py --hook-stage=manual --show-diff-on-failure`
- `poetry run devsynth run-tests --speed=fast`
- `poetry run python tests/verify_test_organization.py`
- `poetry run python scripts/verify_version_sync.py`
- `poetry run python scripts/verify_test_markers.py` *(fails: interrupted after long runtime)*
- `poetry run python scripts/verify_requirements_traceability.py` *(fails: interrupted after long runtime)*

------
https://chatgpt.com/codex/tasks/task_e_68a107a24b9c8333a362f7a873f05ab6