### PR TITLE
chore: update test marker and xdist issues

### DIFF
--- a/issues/Normalize-and-verify-test-markers.md
+++ b/issues/Normalize-and-verify-test-markers.md
@@ -35,6 +35,7 @@ The test suite must ensure each test file contains exactly one speed marker (`fa
 - Marker normalization blocks [Resolve pytest-xdist assertion errors](Resolve-pytest-xdist-assertion-errors.md).
 - Reproduced the hang on a minimal test set by running `poetry run python scripts/verify_test_markers.py --workers 1 tests/unit/interface/test_bridge_conformance.py`; logging revealed blocking during the `pytest --collect-only` subprocess call, so the script now logs subprocess start/end and exits non-zero when issues persist.
 - 2025-08-16: Re-running `poetry run python scripts/verify_test_markers.py` after executing the environment provisioning script still hangs and requires manual interruption.
+- 2025-08-16: Latest attempt processed 150 of 679 files (~18s) before hanging, confirming persistent blocking in `pytest --collect-only`.
 
 ## References
 

--- a/issues/Resolve-pytest-xdist-assertion-errors.md
+++ b/issues/Resolve-pytest-xdist-assertion-errors.md
@@ -19,6 +19,7 @@ Running `devsynth run-tests` across speed categories triggers internal pytest-xd
 
 - Attempted `devsynth run-tests --speed=fast`; after initial output the process hung and required manual interruption, indicating ongoing runner issues.
 - Blocked by [Normalize and verify test markers](Normalize-and-verify-test-markers.md).
+- 2025-08-16: `poetry run devsynth run-tests --speed=fast` completed with 36 passed and 19 skipped tests, no xdist assertion errors observed; medium and slow categories remain unverified.
 
 ## References
 


### PR DESCRIPTION
## Summary
- document latest hang in verify_test_markers after ~150 files
- note passing fast test run in xdist assertion issue

## Testing
- `poetry run pre-commit run --files issues/Normalize-and-verify-test-markers.md issues/Resolve-pytest-xdist-assertion-errors.md`
- `poetry run python tests/verify_test_organization.py`
- `poetry run python scripts/verify_test_markers.py` *(failed: hung after ~150 files)*
- `poetry run python scripts/verify_requirements_traceability.py`
- `poetry run python scripts/verify_version_sync.py`
- `poetry run devsynth run-tests --speed=fast`


------
https://chatgpt.com/codex/tasks/task_e_68a10c87024083338f179eaea27e70b0