### PR TITLE
feat(security): enforce static analysis policy gate

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -16,7 +16,7 @@ jobs:
           python -m pip install --upgrade pip
           pip install poetry
           poetry install --with dev --all-extras
-      - name: Run security audit
+      - name: Run policy gate
         env:
           DEVSYNTH_PRE_DEPLOY_APPROVED: "true"
-        run: poetry run python scripts/security_audit.py
+        run: poetry run task policy:gate

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -210,10 +210,24 @@ tasks:
     cmds:
       - scripts/deployment/publish_image.sh {{.TAG}}
 
+  security:bandit:
+    desc: Run Bandit static analysis
+    cmds:
+      - poetry run bandit -q -r src
+
+  security:safety:
+    desc: Run Safety dependency scan
+    cmds:
+      - poetry export --without-hashes -f requirements.txt -o /tmp/requirements.txt
+      - poetry run safety check --file /tmp/requirements.txt --full-report
+      - rm /tmp/requirements.txt
+
   security:audit:
     desc: Run security audit checks
     cmds:
-      - poetry run python scripts/security_audit.py
+      - task: security:bandit
+      - task: security:safety
+      - poetry run python scripts/security_audit.py --skip-bandit --skip-safety
 
   policy:gate:
     desc: Enforce security policy checks before deployment

--- a/docs/security/audit_process.md
+++ b/docs/security/audit_process.md
@@ -1,0 +1,29 @@
+# Security Audit Process
+
+DevSynth uses automated static analysis to detect security issues before deployment.
+
+## Automated Checks
+
+The `policy:gate` task runs the full audit:
+
+```bash
+poetry run task policy:gate
+```
+
+This invokes the following tools:
+
+- **Bandit** – scans source code for common security flaws.
+- **Safety** – checks project dependencies for known vulnerabilities.
+
+The task fails if either tool reports a problem, preventing insecure builds from progressing in CI.
+
+## Manual Execution
+
+Developers can run the checks locally:
+
+```bash
+poetry run task security:bandit
+poetry run task security:safety
+```
+
+Approve pre-deployment checks as needed and re-run `policy:gate` to verify compliance.


### PR DESCRIPTION
## Summary
- integrate policy gate into security workflow
- add bandit and safety tasks to Taskfile with audit docs

## Testing
- `poetry run pre-commit run --files .github/workflows/security.yml Taskfile.yml docs/security/audit_process.md`
- `poetry run devsynth run-tests --speed=fast`
- `poetry run python tests/verify_test_organization.py`
- `poetry run python scripts/verify_test_markers.py` *(fails: KeyboardInterrupt)*
- `poetry run python scripts/verify_requirements_traceability.py`
- `poetry run python scripts/verify_version_sync.py`


------
https://chatgpt.com/codex/tasks/task_e_68a111b84bd083339be64a07f9ef6c69