### PR TITLE
refactor: tighten exception handling

### DIFF
--- a/src/devsynth/config/__init__.py
+++ b/src/devsynth/config/__init__.py
@@ -2,11 +2,13 @@
 Configuration module for DevSynth.
 """
 
+import json
 import os
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Union
 
+import jsonschema
 import toml
 import yaml
 
@@ -104,10 +106,6 @@ class ProjectUnifiedConfig(UnifiedConfig):
             Path(__file__).resolve().parent.parent / "schemas" / "project_schema.json"
         )
         try:
-            import json
-
-            import jsonschema
-
             with open(schema_file, "r", encoding="utf-8") as sf:
                 schema = json.load(sf)
 
@@ -119,7 +117,11 @@ class ProjectUnifiedConfig(UnifiedConfig):
             raise DevSynthError(
                 "Configuration issues detected. Run 'devsynth init' to generate defaults."
             ) from err
-        except Exception as exc:  # pragma: no cover - defensive
+        except (
+            OSError,
+            json.JSONDecodeError,
+            jsonschema.exceptions.SchemaError,
+        ) as exc:  # pragma: no cover - defensive
             logger.warning("Could not validate project config: %s", exc)
 
         cfg = ConfigModel(project_root=str(root))

--- a/src/devsynth/config/unified_loader.py
+++ b/src/devsynth/config/unified_loader.py
@@ -23,7 +23,7 @@ class UnifiedConfig:
                 return False
             try:
                 data = toml.load(self.path)
-            except Exception:
+            except (OSError, toml.TomlDecodeError):
                 return False
             return "devsynth" in data.get("tool", {})
         return self.path.exists()

--- a/tests/unit/config/test_exception_handling.py
+++ b/tests/unit/config/test_exception_handling.py
@@ -1,0 +1,74 @@
+import os
+from pathlib import Path
+
+import pytest
+
+from devsynth.config.loader import ConfigModel, load_config
+from devsynth.config.settings import Settings, is_devsynth_managed_project
+from devsynth.config.unified_loader import UnifiedConfig
+from devsynth.exceptions import ConfigurationError
+
+
+@pytest.mark.fast
+def test_is_devsynth_managed_project_invalid_toml_returns_false(tmp_path: Path) -> None:
+    """Invalid pyproject files are ignored.
+
+    ReqID: N/A"""
+    pyproject = tmp_path / "pyproject.toml"
+    pyproject.write_text("[tool.devsynth\ninvalid")
+    assert not is_devsynth_managed_project(str(tmp_path))
+
+
+@pytest.mark.fast
+def test_unified_config_exists_returns_false_on_invalid_toml(tmp_path: Path) -> None:
+    """Unified config existence check handles bad TOML.
+
+    ReqID: N/A"""
+    pyproject = tmp_path / "pyproject.toml"
+    pyproject.write_text("[tool.devsynth\ninvalid")
+    cfg = ConfigModel(project_root=str(tmp_path))
+    unified = UnifiedConfig(cfg, pyproject, use_pyproject=True)
+    assert not unified.exists()
+
+
+@pytest.mark.fast
+def test_load_config_malformed_toml_raises_configuration_error(tmp_path: Path) -> None:
+    """Malformed TOML raises a ConfigurationError.
+
+    ReqID: N/A"""
+    pyproject = tmp_path / "pyproject.toml"
+    pyproject.write_text("[tool.devsynth\ninvalid")
+    with pytest.raises(ConfigurationError):
+        load_config(tmp_path)
+
+
+@pytest.mark.fast
+def test_load_config_invalid_values_raises_configuration_error(tmp_path: Path) -> None:
+    """Invalid configuration values surface as ConfigurationError.
+
+    ReqID: N/A"""
+    cfg_dir = tmp_path / ".devsynth"
+    cfg_dir.mkdir()
+    yaml_file = cfg_dir / "project.yaml"
+    yaml_file.write_text("kuzu_embedded: 'not_bool'\n")
+    with pytest.raises(ConfigurationError):
+        load_config(tmp_path)
+
+
+@pytest.mark.fast
+def test_set_default_memory_dir_handles_configuration_error(
+    monkeypatch, tmp_path: Path
+) -> None:
+    """Configuration errors fall back to default memory path.
+
+    ReqID: N/A"""
+    (tmp_path / "pyproject.toml").write_text("[tool.devsynth]\n")
+    monkeypatch.setenv("DEVSYNTH_PROJECT_DIR", str(tmp_path))
+
+    def boom(_path: str) -> ConfigModel:  # type: ignore[override]
+        raise ConfigurationError("boom")
+
+    monkeypatch.setattr("devsynth.config.settings.load_config", boom)
+    settings = Settings()
+    expected = os.path.join(tmp_path, ".devsynth", "memory")
+    assert settings.memory_file_path == expected


### PR DESCRIPTION
## Summary
- narrow catch-all exception blocks in configuration utilities
- add unit tests for configuration error paths

## Testing
- `poetry run pre-commit run --files src/devsynth/config/unified_loader.py src/devsynth/config/settings.py src/devsynth/config/loader.py src/devsynth/config/__init__.py tests/unit/config/test_exception_handling.py`
- `poetry run devsynth run-tests --speed=fast`
- `poetry run python tests/verify_test_organization.py`
- `poetry run python scripts/verify_test_markers.py` *(fails: KeyboardInterrupt)*
- `poetry run python scripts/verify_requirements_traceability.py`
- `poetry run python scripts/verify_version_sync.py`

------
https://chatgpt.com/codex/tasks/task_e_68a111b38f5c8333962a9bbe01d8d8b2