### PR TITLE
Ensure sync hooks fire without memory manager

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,7 @@ version has been published yet.
 
 ### Fixed
 - Improved error handling in the EDRR coordinator
+- EDRR coordinator emits sync hooks even when memory management is unavailable or flush operations fail
 - Optional tiktoken dependency no longer breaks Kuzu memory initialization
 - Added missing step definitions for enhanced memory scenarios
 - Linked remaining alpha tasks (WebUI, Kuzu memory, WSDE collaboration, CLI ingestion) to milestone `0.1.0-alpha.1` and updated development status.

--- a/docs/architecture/wsde_edrr_integration.md
+++ b/docs/architecture/wsde_edrr_integration.md
@@ -148,7 +148,9 @@ The EDRR Coordinator assigns different roles to the WSDE team members based on t
 Role assignments are keyed by agent identifiers rather than names. When the
 coordinator advances to a new phase, the `progress_roles` helper updates these
 mappings and calls `flush_memory_queue` so queued memory operations are written
-before the next phase begins.
+before the next phase begins. If no memory manager is configured the
+coordinator still emits a terminal sync event to keep downstream observers in
+step.
 
 ```python
 

--- a/docs/specifications/wsde_edrr_collaboration.md
+++ b/docs/specifications/wsde_edrr_collaboration.md
@@ -42,6 +42,8 @@ EDRR results.
    so callers may re-queue them to roll back the state if necessary.
 3. A companion **restore_memory_queue** function accepts the returned items and re-queues them in their original order.
 4. Retrospective phases MUST flush any remaining updates before reporting.
+5. If flushing fails or no memory manager is configured, the coordinator emits a final
+   sync hook with ``None`` so observers are not left waiting for state propagation.
 
 ## 4. Peer-Review Result Mapping
 

--- a/issues/ensure-edrr-coordinator-sync-hooks.md
+++ b/issues/ensure-edrr-coordinator-sync-hooks.md
@@ -1,0 +1,13 @@
+# Ensure EDRR coordinator sync hooks fire without memory manager
+Milestone: 0.1.0-alpha.1
+Status: open
+Priority: medium
+Dependencies: none
+
+## Progress
+- Identified that `_sync_memory` returned without notifying hooks when no memory manager was configured.
+- Added fallback to emit final sync hook on missing manager or flush failure.
+
+## References
+- src/devsynth/application/orchestration/edrr_coordinator.py
+- docs/specifications/wsde_edrr_collaboration.md

--- a/src/devsynth/application/orchestration/edrr_coordinator.py
+++ b/src/devsynth/application/orchestration/edrr_coordinator.py
@@ -39,11 +39,17 @@ class EDRRCoordinator:
         """Flush memory updates and notify hooks."""
 
         if self.memory_manager is None:
+            # Even without a memory manager, downstream hooks expect a sync
+            # notification so observers can advance their state.
+            self._invoke_sync_hooks(None)
             return
         try:
             self.memory_manager.flush_updates()
         except Exception:
             logger.debug("Memory flush failed", exc_info=True)
+            # On failure, still notify hooks so callers are not left waiting
+            # for a sync event that never occurs.
+            self._invoke_sync_hooks(None)
 
     def apply_dialectical_reasoning(
         self,


### PR DESCRIPTION
## Summary
- ensure orchestration coordinator emits sync hooks even when no memory manager is present
- document fallback sync behavior in WSDE-EDRR integration spec and architecture
- track missing sync hook issue

## Testing
- `poetry run pre-commit run --files src/devsynth/application/orchestration/edrr_coordinator.py docs/specifications/wsde_edrr_collaboration.md docs/architecture/wsde_edrr_integration.md CHANGELOG.md issues/ensure-edrr-coordinator-sync-hooks.md`
- `poetry run pytest tests/integration/general/test_wsde_edrr_component_interactions.py -q`
- `poetry run python tests/verify_test_organization.py`
- `poetry run python scripts/verify_test_markers.py` *(fails: KeyboardInterrupt)*
- `poetry run python scripts/verify_requirements_traceability.py`
- `poetry run python scripts/verify_version_sync.py`


------
https://chatgpt.com/codex/tasks/task_e_68a111ab9a848333b3a0c56687619bd9