### PR TITLE
feat: enhance memory sync manager with robust dependencies

### DIFF
--- a/src/devsynth/application/memory/sync_manager.py
+++ b/src/devsynth/application/memory/sync_manager.py
@@ -776,3 +776,9 @@ class SyncManager:
         except Exception:
             logger.debug("Adapter flush after rollback failed", exc_info=True)
         self.clear_cache()
+
+    # ------------------------------------------------------------------
+    def is_transaction_active(self, transaction_id: str) -> bool:
+        """Return ``True`` if ``transaction_id`` is currently active."""
+
+        return transaction_id in self._active_transactions

--- a/tests/integration/memory/test_reverse_sync_retrieval.py
+++ b/tests/integration/memory/test_reverse_sync_retrieval.py
@@ -1,0 +1,63 @@
+import pytest
+
+pytest.importorskip("chromadb")
+
+MultiStoreSyncManager = pytest.importorskip(
+    "devsynth.adapters.memory.sync_manager"
+).MultiStoreSyncManager
+from devsynth.domain.models.memory import MemoryItem, MemoryType, MemoryVector
+
+pytestmark = [
+    pytest.mark.requires_resource("lmdb"),
+    pytest.mark.requires_resource("faiss"),
+    pytest.mark.requires_resource("kuzu"),
+]
+
+
+@pytest.mark.medium
+def test_bidirectional_persistence_and_retrieval(tmp_path, monkeypatch):
+    """Synchronizes data both ways between stores. ReqID: FR-60"""
+
+    monkeypatch.setenv("DEVSYNTH_NO_FILE_LOGGING", "1")
+    ef = pytest.importorskip("chromadb.utils.embedding_functions")
+    monkeypatch.setattr(ef, "DefaultEmbeddingFunction", lambda: (lambda x: [0.0] * 5))
+    manager = MultiStoreSyncManager(str(tmp_path))
+
+    item_a = MemoryItem(id="a", content="alpha", memory_type=MemoryType.CODE)
+    vector_a = MemoryVector(
+        id="a",
+        content="alpha",
+        embedding=[0.1] * manager.faiss.dimension,
+        metadata={},
+    )
+    manager.lmdb.store(item_a)
+    manager.faiss.store_vector(vector_a)
+    manager.synchronize_all()
+    assert manager.kuzu.retrieve("a") is not None
+    assert manager.kuzu.vector.retrieve_vector("a") is not None
+
+    item_b = MemoryItem(id="b", content="beta", memory_type=MemoryType.CODE)
+    vector_b = MemoryVector(
+        id="b",
+        content="beta",
+        embedding=[0.2] * manager.faiss.dimension,
+        metadata={},
+    )
+    manager.kuzu.store(item_b)
+    manager.kuzu.vector.store_vector(vector_b)
+    manager.manager.synchronize("kuzu", "lmdb")
+    manager.manager.synchronize("kuzu", "faiss")
+
+    assert manager.lmdb.retrieve("b") is not None
+    assert manager.faiss.retrieve_vector("b") is not None
+
+    manager2 = MultiStoreSyncManager(str(tmp_path))
+    assert manager2.lmdb.retrieve("a") is not None
+    assert manager2.lmdb.retrieve("b") is not None
+    assert manager2.faiss.retrieve_vector("a") is not None
+    assert manager2.faiss.retrieve_vector("b") is not None
+    manager2.synchronize_all()
+    assert manager2.kuzu.retrieve("a") is not None
+    assert manager2.kuzu.vector.retrieve_vector("a") is not None
+    assert manager2.kuzu.retrieve("b") is not None
+    assert manager2.kuzu.vector.retrieve_vector("b") is not None


### PR DESCRIPTION
## Summary
- improve optional dependency handling in multi-store sync manager
- add `is_transaction_active` API and expose through wrapper
- integration test for bidirectional persistence across memory backends

## Testing
- `poetry run pre-commit run --files src/devsynth/adapters/memory/sync_manager.py src/devsynth/application/memory/sync_manager.py tests/integration/memory/test_reverse_sync_retrieval.py`
- `poetry run devsynth run-tests --speed=medium` *(fails: INTERNALERROR WorkerController gw2)*
- `poetry run python tests/verify_test_organization.py`
- `poetry run python scripts/verify_test_markers.py` *(failed: KeyboardInterrupt)*
- `poetry run python scripts/verify_requirements_traceability.py` *(inconclusive: no output)*
- `poetry run python scripts/verify_version_sync.py` *(inconclusive: no output)*

------
https://chatgpt.com/codex/tasks/task_e_68a111a5064c83339153578846840f1a