### PR TITLE
docs: add API reference generation guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ tags:
   - "readme"
 status: "draft"
 author: "DevSynth Team"
-last_reviewed: "2025-08-05"
+last_reviewed: "2025-08-08"
 ---
 
 > Special note: LLMs have synthesized this project, with minimal manual editing, using a dialectical HITL methodology.
@@ -62,6 +62,7 @@ Full documentation is available in the [docs/](docs/index.md) directory and onli
 - [User Guide](docs/user_guides/user_guide.md)
 - [Progressive Feature Setup](docs/user_guides/progressive_setup.md)
 - [CLI Reference](docs/user_guides/cli_reference.md)
+- [API Reference Generation](docs/user_guides/api_reference_generation.md)
 - [Dear PyGui Guide](docs/user_guides/dearpygui.md)
 - [Architecture Overview](docs/architecture/overview.md)
 - [Project Analysis](docs/analysis/executive_summary.md)

--- a/docs/documentation_index.md
+++ b/docs/documentation_index.md
@@ -7,7 +7,7 @@ tags:
 
 status: "published"
 author: "DevSynth Team"
-last_reviewed: "2025-08-02"
+last_reviewed: "2025-08-08"
 ---
 
 <div class="breadcrumbs">
@@ -68,5 +68,6 @@ _This index lists all documentation files, their status, and release phase. It i
 | docs/specifications/documentation_plan.md | DevSynth Documentation Plan | published | consolidation |
 | docs/specifications/metrics_system.md | DevSynth Metrics and Analytics System | published | v1 |
 | docs/testing/* | Behavior feature files index | draft | testing |
+| docs/user_guides/api_reference_generation.md | API Reference Generation | draft | usage |
 | docs/user_guides/* | User guides and CLI references | published | usage |
 > **Note:** Update this table to include any new documentation files. Automate via an indexing script for accuracy.

--- a/docs/user_guides/api_reference_generation.md
+++ b/docs/user_guides/api_reference_generation.md
@@ -1,0 +1,35 @@
+---
+title: "API Reference Generation"
+date: "2025-08-08"
+version: "0.1.0-alpha.1"
+tags:
+  - "user-guide"
+  - "documentation"
+  - "api"
+  - "reference"
+
+status: "draft"
+author: "DevSynth Team"
+last_reviewed: "2025-08-08"
+---
+<div class="breadcrumbs">
+<a href="../index.md">Documentation</a> &gt; <a href="index.md">User Guides</a> &gt; API Reference Generation
+</div>
+
+# API Reference Generation
+
+This guide explains how to generate API reference pages for DevSynth using the `scripts/gen_ref_pages.py` command. The script scans project source directories, creates a navigation tree, and writes Markdown files under `api_reference/` for inclusion in the documentation site.
+
+## Usage
+
+1. Ensure the environment provisioning script has been run and dependencies are installed.
+2. From the repository root, generate API reference pages:
+
+   ```bash
+   poetry run python scripts/gen_ref_pages.py
+   ```
+3. The script reads project structure from `manifest.yaml` if available. Generated pages appear under `docs/api_reference/` and are included in the MkDocs build.
+
+## Implementation Status
+
+.


### PR DESCRIPTION
## Summary
- document how to generate API reference pages
- link the guide from documentation index and README

## Testing
- ✅ `PIP_NO_INDEX=1 poetry run pip check`
- ✅ `poetry run pre-commit run --files README.md docs/documentation_index.md docs/user_guides/api_reference_generation.md`
- ✅ `poetry run devsynth run-tests --speed=fast`
- ✅ `poetry run python tests/verify_test_organization.py`
- ✅ `poetry run python scripts/verify_test_markers.py`
- ✅ `poetry run python scripts/verify_requirements_traceability.py`
- ✅ `poetry run python scripts/verify_version_sync.py`

------
https://chatgpt.com/codex/tasks/task_e_68a1119a15ec83338c6e2888c101c9e4