### PR TITLE
Avoid xdist worker teardown errors in parallel test runs

### DIFF
--- a/src/devsynth/testing/run_tests.py
+++ b/src/devsynth/testing/run_tests.py
@@ -177,7 +177,11 @@ def run_tests(
     if verbose:
         base_cmd.append("-v")
     if parallel:
-        base_cmd += ["-n", "auto"]
+        # ``pytest-cov`` interacts poorly with ``pytest-xdist`` when workers
+        # terminate unexpectedly, leading to internal ``KeyError`` exceptions
+        # during teardown. Disabling coverage collection in parallel runs avoids
+        # these worker teardown issues.
+        base_cmd += ["-n", "auto", "--no-cov"]
 
     report_options: List[str] = []
     if report:


### PR DESCRIPTION
## Summary
- disable coverage when tests run in parallel to prevent pytest-xdist KeyError during teardown

## Testing
- `poetry run pre-commit run --files src/devsynth/testing/run_tests.py`
- `poetry run devsynth run-tests --speed=medium --maxfail 1`
- `poetry run python tests/verify_test_organization.py`
- `poetry run python scripts/verify_test_markers.py` *(partial; long-running, interrupted)*
- `poetry run python scripts/verify_requirements_traceability.py`
- `poetry run python scripts/verify_version_sync.py`


------
https://chatgpt.com/codex/tasks/task_e_68a1119464ac8333bfcf3aa75a5b3d96