### PR TITLE
Guard optional WebUI setup wizard and enable webui tests

### DIFF
--- a/src/devsynth/interface/webui_setup.py
+++ b/src/devsynth/interface/webui_setup.py
@@ -4,9 +4,13 @@ from __future__ import annotations
 
 from typing import Optional
 
-from devsynth.application.cli.setup_wizard import SetupWizard
 from devsynth.interface.ux_bridge import UXBridge
 from devsynth.interface.webui_bridge import WebUIBridge
+
+try:  # pragma: no cover - optional dependency
+    from devsynth.application.cli.setup_wizard import SetupWizard
+except Exception:  # pragma: no cover - setup wizard is optional
+    SetupWizard = None  # type: ignore[assignment]
 
 
 class WebUISetupWizard:
@@ -17,6 +21,10 @@ class WebUISetupWizard:
 
     def run(self) -> None:
         """Launch the guided setup wizard."""
+        if SetupWizard is None:  # pragma: no cover - error path
+            raise RuntimeError(
+                "The SetupWizard dependency is missing; ensure CLI components are installed."
+            )
         SetupWizard(self.bridge).run()
 
 

--- a/tests/unit/interface/test_webui_progress_time.py
+++ b/tests/unit/interface/test_webui_progress_time.py
@@ -5,7 +5,7 @@ from pytest import MonkeyPatch
 
 from devsynth.interface.webui_bridge import WebUIProgressIndicator
 
-pytestmark = [pytest.mark.requires_resource("webui"), pytest.mark.fast]
+pytestmark = pytest.mark.fast
 
 
 def test_update_records_time(monkeypatch: MonkeyPatch) -> None:

--- a/tests/unit/interface/test_webui_setup.py
+++ b/tests/unit/interface/test_webui_setup.py
@@ -6,8 +6,6 @@ from devsynth.application.cli.setup_wizard import SetupWizard
 from devsynth.interface.ux_bridge import UXBridge
 from devsynth.interface.webui_setup import WebUISetupWizard
 
-pytestmark = pytest.mark.requires_resource("webui")
-
 
 @pytest.mark.medium
 def test_webui_setup_wizard_runs(monkeypatch):


### PR DESCRIPTION
## Summary
- guard `WebUISetupWizard` against missing CLI setup dependencies
- allow `WebUIProgressIndicator` and setup wizard tests to run without webui resource gate

## Testing
- `poetry run devsynth run-tests --speed=fast`
- `poetry run python tests/verify_test_organization.py`
- `poetry run python scripts/verify_test_markers.py` *(fails: KeyboardInterrupt)*
- `poetry run python scripts/verify_requirements_traceability.py`
- `poetry run python scripts/verify_version_sync.py`


------
https://chatgpt.com/codex/tasks/task_e_68a11179b360833382285420d6bd3584