### PR TITLE
Add security audit reporting

### DIFF
--- a/docs/developer_guides/index.md
+++ b/docs/developer_guides/index.md
@@ -60,6 +60,7 @@ This section is for developers contributing to the DevSynth project or those loo
 
 - **[Cross-Functional Review Process](cross_functional_review_process.md)**: Information about the cross-functional review process.
 - **[Secure Coding](secure_coding.md)**: Guidelines for secure coding practices.
+- **[Security Audit Guide](security_audits.md)**: How to run and interpret automated security audits.
 
 ## Overview
 

--- a/docs/developer_guides/security_audits.md
+++ b/docs/developer_guides/security_audits.md
@@ -1,0 +1,41 @@
+---
+author: DevSynth Team
+date: '2025-08-29'
+last_reviewed: '2025-08-29'
+status: published
+tags:
+- developer-guide
+- security
+
+title: Security Audit Guide
+version: '0.1.0-alpha.1'
+---
+<div class="breadcrumbs">
+<a href="../index.md">Documentation</a> &gt; <a href="index.md">Developer Guides</a> &gt; Security Audit Guide
+</div>
+
+# Security Audit Guide
+
+Use the security audit command to validate required security settings and run
+static analysis and dependency checks.
+
+## Running the Audit
+
+```bash
+DEVSYNTH_PRE_DEPLOY_APPROVED=true poetry run python scripts/security_audit.py --report audit.json
+```
+
+The command performs the following routines:
+
+- verifies mandatory security flags
+- runs Bandit static analysis
+- runs Safety dependency scanning
+- writes a JSON summary to the path provided by `--report`
+
+The JSON file contains `bandit` and `safety` fields with values `passed`,
+`failed`, or `skipped`.
+
+## Troubleshooting
+
+- Ensure all required environment variables are set before running the audit.
+- A non-zero exit code indicates a failed check; inspect the report for details.

--- a/docs/policies/security.md
+++ b/docs/policies/security.md
@@ -73,6 +73,13 @@ DevSynth automates routine security checks to prevent regressions:
 - Developers should run `devsynth security-audit` locally before committing
   changes to catch issues early.
 
+### Audit Reporting
+
+The `security-audit` command records the outcome of each check and can write a
+machine-readable summary. Passing `--report <file>` generates a JSON document
+with `bandit` and `safety` fields set to `passed`, `failed`, or `skipped`.
+Deployment pipelines can archive this report for traceability.
+
 ```bash
 DEVSYNTH_PRE_DEPLOY_APPROVED=true poetry run python scripts/security_audit.py
 ```

--- a/docs/specifications/index.md
+++ b/docs/specifications/index.md
@@ -43,6 +43,7 @@ This section contains the official specifications for the DevSynth project, outl
 - **[Integration Test Scenario Generation](integration_test_generation.md)**: Scenario-based scaffolding for integration tests.
 - **[Retry Predicates Specification](retry_predicates.md)**: Support conditional retry logic and metrics.
 - **[Generated Test Execution Failure](generated_test_execution_failure.md)**: Scaffolded tests fail until implemented.
+- **[Security Audit Reporting Specification](security_audit_reporting.md)**: JSON reporting for security audits.
 
 ## Implementation Plans
 

--- a/docs/specifications/security_audit_reporting.md
+++ b/docs/specifications/security_audit_reporting.md
@@ -1,0 +1,40 @@
+---
+author: DevSynth Team
+date: '2025-08-29'
+last_reviewed: '2025-08-29'
+status: draft
+tags:
+- specification
+- security
+
+title: Security Audit Reporting Specification
+version: '0.1.0-alpha.1'
+---
+
+# Summary
+
+DevSynth should produce a structured report summarizing security audit checks.
+
+## Socratic Checklist
+- What is the problem?
+- What proofs confirm the solution?
+
+## Motivation
+
+Security audits currently run Bandit and Safety but do not emit a consolidated report.
+Providing a machine-readable summary helps developers and CI pipelines verify compliance.
+
+## Specification
+
+- The `security-audit` command accepts a `--report <path>` option.
+- The command validates pre-deployment checks and mandatory security flags.
+- When audits run, the command records the result of Bandit and Safety checks.
+- Results are written as JSON with keys for each check and values of `passed`, `failed`, or `skipped`.
+- The command exits with a non-zero status if any required check fails.
+
+## Acceptance Criteria
+
+- Running `security-audit --report audit.json` writes a JSON file containing
+  `bandit` and `safety` result fields.
+- Failing a check sets the corresponding field to `failed` and the process exits
+  with a non-zero status.

--- a/scripts/security_audit.py
+++ b/scripts/security_audit.py
@@ -6,8 +6,11 @@ executing the audits.
 
 from __future__ import annotations
 
+import argparse
+import json
 import subprocess
 import sys
+from pathlib import Path
 
 import verify_security_policy
 
@@ -20,10 +23,52 @@ logger = setup_logging(__name__)
 
 def run(argv: list[str] | None = None) -> None:
     """Validate security flags then execute Bandit and Safety checks."""
+    parser = argparse.ArgumentParser(
+        description="Run Bandit static analysis and Safety dependency scan.",
+    )
+    parser.add_argument(
+        "--report",
+        type=Path,
+        help="Write JSON report of audit results",
+    )
+    parser.add_argument(
+        "--skip-bandit",
+        action="store_true",
+        help="Skip running Bandit static analysis",
+    )
+    parser.add_argument(
+        "--skip-safety",
+        action="store_true",
+        help="Skip dependency vulnerability scan",
+    )
+    args = parser.parse_args(argv)
+
     require_pre_deploy_checks()
     if verify_security_policy.main() != 0:
         raise subprocess.CalledProcessError(1, "verify_security_policy")
-    audit.main(argv)
+
+    results: dict[str, str] = {}
+    try:
+        if args.skip_bandit:
+            results["bandit"] = "skipped"
+        else:
+            audit.run_bandit()
+            results["bandit"] = "passed"
+        if args.skip_safety:
+            results["safety"] = "skipped"
+        else:
+            audit.run_safety()
+            results["safety"] = "passed"
+    except subprocess.CalledProcessError as exc:
+        if "bandit" not in results:
+            results["bandit"] = "failed"
+            results["safety"] = "skipped"
+        else:
+            results["safety"] = "failed"
+        raise
+    finally:
+        if args.report:
+            args.report.write_text(json.dumps(results, indent=2))
 
 
 if __name__ == "__main__":

--- a/tests/behavior/features/security/__init__.py
+++ b/tests/behavior/features/security/__init__.py
@@ -1,0 +1,1 @@
+# placeholder for security features

--- a/tests/behavior/features/security/security_audit_reporting.feature
+++ b/tests/behavior/features/security/security_audit_reporting.feature
@@ -1,0 +1,10 @@
+Feature: Security audit reporting
+  As a developer
+  I want the security audit command to produce a summary report
+  So that I can verify compliance results
+
+  Scenario: Generate audit report
+    Given the security audit pre-deployment checks are approved
+    When I run the command "devsynth security-audit --report audit.json"
+    Then the audit report "audit.json" should contain "bandit" and "safety" results
+    And the workflow should execute successfully

--- a/tests/unit/security/test_security_audit.py
+++ b/tests/unit/security/test_security_audit.py
@@ -1,7 +1,9 @@
 """Tests for the security audit script."""
 
+import json
 import subprocess
 import sys
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -11,27 +13,76 @@ sys.path.append("scripts")
 import security_audit  # type: ignore
 
 
-@patch("security_audit.audit.main")
+@patch("security_audit.audit.run_bandit")
+@patch("security_audit.audit.run_safety")
 @patch("security_audit.verify_security_policy.main", return_value=0)
 @patch("security_audit.require_pre_deploy_checks")
 @pytest.mark.fast
-def test_run_executes_policy_and_audit(
-    mock_pre: MagicMock, mock_policy: MagicMock, mock_audit: MagicMock
+def test_run_executes_checks(
+    mock_pre: MagicMock,
+    mock_policy: MagicMock,
+    mock_safety: MagicMock,
+    mock_bandit: MagicMock,
 ) -> None:
-    """The script should validate flags and run dependency checks."""
+    """The script should validate flags and run Bandit and Safety."""
     security_audit.run([])
     mock_pre.assert_called_once_with()
     mock_policy.assert_called_once_with()
-    mock_audit.assert_called_once_with([])
+    mock_bandit.assert_called_once_with()
+    mock_safety.assert_called_once_with()
 
 
-@patch("security_audit.audit.main")
+@patch("security_audit.audit.run_bandit")
+@patch("security_audit.audit.run_safety")
 @patch("security_audit.verify_security_policy.main", return_value=1)
 @patch("security_audit.require_pre_deploy_checks")
 @pytest.mark.fast
 def test_run_raises_on_policy_failure(
-    mock_pre: MagicMock, mock_policy: MagicMock, mock_audit: MagicMock
+    mock_pre: MagicMock,
+    mock_policy: MagicMock,
+    mock_safety: MagicMock,
+    mock_bandit: MagicMock,
 ) -> None:
     """A non-zero policy result should raise an error."""
     with pytest.raises(subprocess.CalledProcessError):
         security_audit.run([])
+
+
+@patch("security_audit.audit.run_bandit")
+@patch("security_audit.audit.run_safety")
+@patch("security_audit.verify_security_policy.main", return_value=0)
+@patch("security_audit.require_pre_deploy_checks")
+@pytest.mark.fast
+def test_report_writes_results(
+    mock_pre: MagicMock,
+    mock_policy: MagicMock,
+    mock_safety: MagicMock,
+    mock_bandit: MagicMock,
+    tmp_path: Path,
+) -> None:
+    """Running with --report should write a JSON summary."""
+    report = tmp_path / "audit.json"
+    security_audit.run(["--report", str(report)])
+    data = json.loads(report.read_text())
+    assert data == {"bandit": "passed", "safety": "passed"}
+
+
+@patch(
+    "security_audit.audit.run_bandit",
+    side_effect=subprocess.CalledProcessError(1, "bandit"),
+)
+@patch("security_audit.verify_security_policy.main", return_value=0)
+@patch("security_audit.require_pre_deploy_checks")
+@pytest.mark.fast
+def test_report_records_failure(
+    mock_pre: MagicMock,
+    mock_policy: MagicMock,
+    mock_bandit: MagicMock,
+    tmp_path: Path,
+) -> None:
+    """Failed checks should be noted in the report."""
+    report = tmp_path / "audit.json"
+    with pytest.raises(subprocess.CalledProcessError):
+        security_audit.run(["--report", str(report)])
+    data = json.loads(report.read_text())
+    assert data == {"bandit": "failed", "safety": "skipped"}


### PR DESCRIPTION
## Summary
- document security audit reporting workflow
- generate JSON reports from security audit script
- test audit triggers and report generation

## Testing
- `poetry run pre-commit run --files docs/developer_guides/index.md docs/developer_guides/security_audits.md docs/policies/security.md docs/specifications/index.md docs/specifications/security_audit_reporting.md scripts/security_audit.py tests/unit/security/test_security_audit.py tests/behavior/features/security/__init__.py tests/behavior/features/security/security_audit_reporting.feature`
- `poetry run devsynth run-tests --speed=fast`
- `poetry run python tests/verify_test_organization.py`
- `poetry run python scripts/verify_test_markers.py --directory tests/unit/security`
- `poetry run python scripts/verify_requirements_traceability.py`
- `poetry run python scripts/verify_version_sync.py`


------
https://chatgpt.com/codex/tasks/task_e_68a126d1e6288333ba1acd678a9e17a6