### PR TITLE
feat: add deployment script with environment checks

### DIFF
--- a/docs/specifications/end_to_end_deployment.md
+++ b/docs/specifications/end_to_end_deployment.md
@@ -1,0 +1,39 @@
+---
+author: DevSynth Team
+date: 2025-07-14
+last_reviewed: 2025-07-14
+status: draft
+tags:
+  - specification
+  - deployment
+title: End-to-End Deployment Script
+version: 0.1.0-alpha.1
+---
+<div class="breadcrumbs">
+<a href="../index.md">Documentation</a> &gt; <a href="index.md">Specifications</a> &gt; End-to-End Deployment Script
+</div>
+
+# End-to-End Deployment Script
+
+## Summary
+Provides a single command to deploy the DevSynth stack with environment validation.
+
+## Socratic Checklist
+- What is the problem?
+- What proofs confirm the solution?
+
+## Motivation
+Existing deployment utilities are fragmented and do not expose one clear entry point with pre-flight validation. A unified script reduces operational risk and standardizes checks.
+
+## Specification
+- A `deploy.sh` script resides under `scripts/deployment/`.
+- The script refuses to run as the root user.
+- Required commands `docker` and `docker compose` must be available.
+- Environment file `.env.<environment>` must exist with `600` permissions.
+- Allowed environments: `development`, `staging`, `production`, `testing`.
+- On success the script builds images, starts the stack, and performs a health check.
+
+## Acceptance Criteria
+- Running the script as root exits with an error.
+- Invoking the script inside a container lacking Docker reports that Docker is required.
+- Providing an environment file with incorrect permissions results in a failure message.

--- a/docs/specifications/index.md
+++ b/docs/specifications/index.md
@@ -51,6 +51,7 @@ This section contains the official specifications for the DevSynth project, outl
 - **[Delimiting Recursion Algorithms](delimiting_recursion_algorithms.md)**: Heuristics for ending recursive cycles.
 - **[Documentation Plan](documentation_plan.md)**: Comprehensive plan for DevSynth's documentation structure and organization.
 - **[Testing Infrastructure](testing_infrastructure.md)**: Specification for DevSynth's testing infrastructure.
+- **[End-to-End Deployment Script](end_to_end_deployment.md)**: Unified deployment with environment validation.
 
 ## Historical and Planning Documents
 

--- a/scripts/deployment/deploy.sh
+++ b/scripts/deployment/deploy.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# End-to-end deployment of the DevSynth stack.
+# Usage: deploy.sh [environment]
+#   environment: development (default), staging, production, testing
+
+ENVIRONMENT=${1:-development}
+
+# Refuse to run as root
+if [[ "$EUID" -eq 0 ]]; then
+  echo "Please run this script as a non-root user." >&2
+  exit 1
+fi
+
+# Allow only known environments
+ALLOWED_ENVIRONMENTS=(development staging production testing)
+if [[ ! " ${ALLOWED_ENVIRONMENTS[*]} " =~ " ${ENVIRONMENT} " ]]; then
+  echo "Invalid environment: ${ENVIRONMENT}" >&2
+  exit 1
+fi
+
+# Ensure Docker is available
+if ! command -v docker >/dev/null 2>&1; then
+  echo "Docker is required but could not be found in PATH." >&2
+  exit 1
+fi
+if ! docker compose version >/dev/null 2>&1; then
+  echo "docker compose is required but unavailable." >&2
+  exit 1
+fi
+
+ENV_FILE=".env.${ENVIRONMENT}"
+if [[ ! -f "$ENV_FILE" ]]; then
+  echo "Missing environment file: $ENV_FILE" >&2
+  exit 1
+fi
+if [[ $(stat -c %a "$ENV_FILE") != "600" ]]; then
+  echo "Environment file $ENV_FILE must have 600 permissions" >&2
+  exit 1
+fi
+
+# Pull latest images and build the compose configuration
+docker compose pull
+docker compose build
+
+# Start the stack and verify health
+"$(dirname "$0")/start_stack.sh" "$ENVIRONMENT"
+"$(dirname "$0")/health_check.sh"

--- a/tests/behavior/features/index.md
+++ b/tests/behavior/features/index.md
@@ -5,6 +5,7 @@ This index lists all feature files for easy navigation.
 - [examples/simple_addition.feature](./examples/simple_addition.feature)
 - [integration/generated_tests_fail.feature](./integration/generated_tests_fail.feature)
 - [integration/test_scaffolding.feature](./integration/test_scaffolding.feature)
+- [integration/deployment_environment_validation.feature](./integration/deployment_environment_validation.feature)
 - [general/additional_storage_backends.feature](./general/additional_storage_backends.feature)
 - [general/advanced_graph_memory_features.feature](./general/advanced_graph_memory_features.feature)
 - [general/agent_api_health_metrics.feature](./general/agent_api_health_metrics.feature)

--- a/tests/behavior/features/integration/deployment_environment_validation.feature
+++ b/tests/behavior/features/integration/deployment_environment_validation.feature
@@ -1,0 +1,9 @@
+Feature: Deployment environment validation
+  As a developer
+  I want the deployment script to verify prerequisites
+  So that misconfigured environments are detected early
+
+  Scenario: Docker missing in containerized environment
+    Given Docker is not installed
+    When the deployment script is executed
+    Then an error is reported about Docker being required

--- a/tests/integration/deployment/test_end_to_end_deploy.py
+++ b/tests/integration/deployment/test_end_to_end_deploy.py
@@ -1,0 +1,40 @@
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+
+@pytest.mark.slow
+@pytest.mark.docker
+def test_deploy_script_requires_docker(tmp_path):
+    if shutil.which("docker") is None:
+        pytest.skip("Docker not available")
+
+    repo_root = Path(__file__).resolve().parents[3]
+    env_file = tmp_path / ".env.development"
+    env_file.write_text("DEVSYNTH_ENV=development\n")
+    env_file.chmod(0o600)
+
+    result = subprocess.run(
+        [
+            "docker",
+            "run",
+            "--rm",
+            "--user",
+            "1000:1000",
+            "-v",
+            f"{repo_root}:/repo",
+            "-v",
+            f"{env_file}:/repo/.env.development",
+            "python:3.11",
+            "bash",
+            "-lc",
+            "cd /repo && scripts/deployment/deploy.sh development",
+        ],
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode != 0
+    assert "Docker is required but could not be found in PATH." in result.stderr


### PR DESCRIPTION
## Summary
- specify end-to-end deployment script and document in specification index
- add `deploy.sh` with non-root and permission validation
- include BDD and integration tests for missing Docker

## Testing
- `poetry run pre-commit run --files docs/specifications/index.md docs/specifications/end_to_end_deployment.md tests/behavior/features/index.md tests/behavior/features/integration/deployment_environment_validation.feature scripts/deployment/deploy.sh tests/integration/deployment/test_end_to_end_deploy.py`
- `poetry run devsynth run-tests --speed=fast`
- `poetry run python tests/verify_test_organization.py`
- `poetry run python scripts/verify_test_markers.py`
- `poetry run python scripts/verify_requirements_traceability.py`
- `poetry run python scripts/verify_version_sync.py`


------
https://chatgpt.com/codex/tasks/task_e_68a126cb3cd48333a2245ddca14f5912