### PR TITLE
feat: scaffold integration tests from context

### DIFF
--- a/docs/testing/auto_generated_tests.md
+++ b/docs/testing/auto_generated_tests.md
@@ -1,13 +1,20 @@
 # Auto-generated integration tests
 
-DevSynth can scaffold integration tests to highlight missing coverage while teams iterate on APIs.
+DevSynth can scaffold integration tests to highlight missing coverage while teams
+iterate on APIs. When the testing agent receives project context it derives
+likely integration targets and scaffolds placeholder modules for them
+automatically.
 
 ## Workflow
 
-1. Use `scaffold_integration_tests` or `write_scaffolded_tests` in `src/devsynth/testing/generation.py` to create placeholder tests. The generated modules are marked with `pytest.mark.skip` so the suite stays green.
+1. Use `scaffold_integration_tests` or `write_scaffolded_tests` in
+   `src/devsynth/testing/generation.py` to create placeholder tests. The
+   `TestAgent` also invokes these helpers, deriving file names from project
+   descriptions when explicit names are absent.
 2. Review each scaffolded file:
    - Replace the placeholder body with real assertions.
-   - Remove the `pytest.mark.skip` marker when the test is complete.
+   - Add `pytest.mark.skip` if temporary suppression of failures is needed and
+     remove the marker once the test is implemented.
 3. Use the prompt in `src/devsynth/testing/prompts.py` as guidance when authoring tests or when generating them automatically. The prompt emphasizes edge cases such as empty inputs, extreme values, permission errors, and network failures.
 4. Run `poetry run devsynth run-tests --speed=fast` and `poetry run pre-commit run --files ...` before submitting changes.
 

--- a/tests/unit/application/agents/test_test_agent_integration.py
+++ b/tests/unit/application/agents/test_test_agent_integration.py
@@ -1,0 +1,33 @@
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from devsynth.application.agents.test import TestAgent
+from devsynth.domain.models.agent import AgentConfig, AgentType
+
+
+@pytest.mark.fast
+def test_process_scaffolds_tests_from_context(tmp_path: Path) -> None:
+    """TestAgent derives integration tests from project context.
+
+    ReqID: N/A"""
+
+    agent = TestAgent()
+    agent.generate_text = MagicMock(return_value="tests")
+    agent.create_wsde = MagicMock(return_value="wsde")
+    config = AgentConfig(
+        name="TestAgent",
+        agent_type=AgentType.ORCHESTRATOR,
+        description="Test agent",
+        capabilities=[],
+    )
+    agent.initialize(config)
+
+    context = "The payment service communicates with the inventory module."
+    result = agent.process({"context": context, "integration_output_dir": tmp_path})
+
+    assert "test_payment.py" in result["integration_tests"]
+    assert "test_inventory.py" in result["integration_tests"]
+    assert (tmp_path / "test_payment.py").exists()
+    assert (tmp_path / "test_inventory.py").exists()


### PR DESCRIPTION
## Summary
- derive integration test names from project context when processing test requests
- verify context-based scaffolding via new unit tests
- document automated integration test scaffolding workflow

## Testing
- `poetry run pre-commit run --files src/devsynth/application/agents/test.py tests/unit/application/agents/test_test_agent_integration.py docs/testing/auto_generated_tests.md`
- `poetry run pytest tests/unit/application/agents/test_test_agent_integration.py -m fast -q`
- `poetry run python tests/verify_test_organization.py`
- `poetry run python scripts/verify_test_markers.py` *(fails: KeyboardInterrupt)*
- `poetry run python scripts/verify_requirements_traceability.py`
- `poetry run python scripts/verify_version_sync.py`

------
https://chatgpt.com/codex/tasks/task_e_68a126c7e2548333982977f1107b524d