### PR TITLE
Log consensus vote failures and add collaboration test

### DIFF
--- a/docs/specifications/consensus_failure_logging.md
+++ b/docs/specifications/consensus_failure_logging.md
@@ -1,0 +1,35 @@
+---
+author: AutoGPT
+date: 2024-11-05
+last_reviewed: 2024-11-05
+status: draft
+tags:
+  - specification
+title: Consensus failure logging
+version: 0.1.0-alpha.1
+---
+
+# Summary
+
+When WSDE teams attempt a consensus vote that does not yield a completed decision, the system should log the failure and fall back to the more robust consensus-building process.
+
+## Socratic Checklist
+- What is the problem?
+- What proofs confirm the solution?
+
+## Motivation
+
+Consensus votes may fail to produce a decision due to ties or incomplete participation. Without explicit logging, these failures are hard to diagnose, and downstream processes cannot distinguish between successful votes and silent fallbacks.
+
+## Specification
+
+- `WSDE.run_consensus` logs a consensus failure using `log_consensus_failure` when `consensus_vote` returns without a completed decision.
+- The logged error includes the task identifier.
+- After logging, `run_consensus` invokes `build_consensus` and attaches the result under the `consensus` key.
+
+## Acceptance Criteria
+
+- Given a WSDE team whose vote does not complete,
+  when `run_consensus` is called,
+  then the failure is logged via `log_consensus_failure`
+  and the returned dictionary contains a `consensus` result.

--- a/src/devsynth/application/collaboration/WSDE.py
+++ b/src/devsynth/application/collaboration/WSDE.py
@@ -4,6 +4,7 @@ from typing import Any, Dict
 
 from devsynth.domain.models.wsde_facade import WSDETeam
 from devsynth.domain.wsde.workflow import progress_roles as _progress_roles
+from devsynth.logger import log_consensus_failure
 from devsynth.methodology.base import Phase
 
 
@@ -19,6 +20,8 @@ class WSDE(WSDETeam):
         result = self.consensus_vote(task)
         decision = result.get("decision") or result.get("result")
         if not decision or result.get("status") != "completed":
+            error = RuntimeError("Consensus vote failed")
+            log_consensus_failure(self.logger, error, extra={"task_id": task.get("id")})
             result["consensus"] = self.build_consensus(task)
         return result
 

--- a/tests/behavior/features/wsde/consensus_failure_logging.feature
+++ b/tests/behavior/features/wsde/consensus_failure_logging.feature
@@ -1,0 +1,6 @@
+Feature: Consensus failure logging
+  Scenario: Consensus vote failure triggers logging and fallback
+    Given a WSDE team whose vote fails to reach a decision
+    When the team runs consensus on a task
+    Then a consensus failure is logged
+    And the result includes a fallback consensus

--- a/tests/behavior/steps/test_consensus_failure_logging_steps.py
+++ b/tests/behavior/steps/test_consensus_failure_logging_steps.py
@@ -1,0 +1,64 @@
+import logging
+from datetime import datetime
+
+import pytest
+from pytest_bdd import given, scenarios, then, when
+
+from devsynth.application.collaboration.WSDE import WSDE
+from devsynth.logger import DevSynthLogger
+
+pytestmark = pytest.mark.fast
+scenarios("../features/wsde/consensus_failure_logging.feature")
+
+
+class DummyAgent:
+    def __init__(self, name: str):
+        self.name = name
+        self.expertise = ["general"]
+        self.current_role = None
+
+
+@pytest.fixture
+def context():
+    class Context:
+        pass
+
+    ctx = Context()
+    ctx.task = {"id": "t1", "title": "Test"}
+    return ctx
+
+
+@given("a WSDE team whose vote fails to reach a decision")
+def given_team(context):
+    team = WSDE("bdd-team", agents=[DummyAgent("a1"), DummyAgent("a2")])
+    team.logger = DevSynthLogger("bdd")
+
+    def failing_vote(task):
+        return {"status": "failed"}
+
+    def fallback_consensus(task):
+        return {"method": "fallback"}
+
+    team.consensus_vote = failing_vote
+    team.build_consensus = fallback_consensus
+    context.team = team
+
+
+@when("the team runs consensus on a task")
+def when_run_consensus(context, caplog):
+    caplog.set_level(logging.ERROR)
+    context.result = context.team.run_consensus(context.task)
+    context.log_records = [
+        r for r in caplog.records if r.message == "Consensus failure"
+    ]
+
+
+@then("a consensus failure is logged")
+def then_logged(context):
+    assert context.log_records, "Consensus failure was not logged"
+
+
+@then("the result includes a fallback consensus")
+def then_fallback(context):
+    assert "consensus" in context.result
+    assert context.result["consensus"].get("method") == "fallback"


### PR DESCRIPTION
## Summary
- log consensus vote failures and fall back to full consensus building
- specify and test consensus failure logging in WSDE teams

## Testing
- `poetry run pre-commit run --files docs/specifications/consensus_failure_logging.md tests/behavior/features/wsde/consensus_failure_logging.feature tests/behavior/steps/test_consensus_failure_logging_steps.py src/devsynth/application/collaboration/WSDE.py`
- `poetry run devsynth run-tests --speed=fast`
- `poetry run python tests/verify_test_organization.py`
- `poetry run python scripts/verify_test_markers.py -d tests/behavior/steps`
- `poetry run python scripts/verify_requirements_traceability.py`
- `poetry run python scripts/verify_version_sync.py`


------
https://chatgpt.com/codex/tasks/task_e_68a126c1beec8333a9e23364ff768dae