### PR TITLE
Add recovery and threshold helpers for EDRR

### DIFF
--- a/docs/specifications/edrr_phase_recovery_threshold_helpers.md
+++ b/docs/specifications/edrr_phase_recovery_threshold_helpers.md
@@ -1,0 +1,29 @@
+---
+author: AutoDev
+date: 2025-02-13
+last_reviewed: 2025-02-13
+status: draft
+tags:
+- specification
+- edrr
+title: EDRR phase recovery and threshold helpers
+version: 0.1.0-alpha.1
+---
+
+# Summary
+
+## Socratic Checklist
+- What is the problem?
+- What proofs confirm the solution?
+
+## Motivation
+The Enhanced EDRR coordinator lacks public helpers to register recovery hooks and adjust phase thresholds, limiting recursive recovery flows and observability.
+
+## Specification
+- Expose `register_phase_recovery_hook` and `configure_phase_thresholds` on `EnhancedEDRRCoordinator` to delegate to `PhaseTransitionMetrics`.
+- Add `get_thresholds` to `PhaseTransitionMetrics` for retrieving active thresholds.
+- Recovery hooks receive phase metrics and may mutate them; returning `{"recovered": True}` stops further hooks and re-evaluates thresholds.
+
+## Acceptance Criteria
+- Unit tests cover registering recovery hooks and configuring thresholds.
+- Integration tests demonstrate recursive phase transitions using recovery hooks.

--- a/docs/specifications/index.md
+++ b/docs/specifications/index.md
@@ -32,6 +32,7 @@ This section contains the official specifications for the DevSynth project, outl
 - **[WSDE Interaction Specification](wsde_interaction_specification.md)**: Specification for the Wide Sweep, Deep Exploration interaction model.
 - **[WSDE-EDRR Collaboration Specification](wsde_edrr_collaboration.md)**: Expected phase progression, memory flush behavior, and peer-review mapping.
 - **[WSDE Role Progression and Memory Semantics](wsde_role_progression_memory.md)**: Identifier-based role mapping and queue flush guarantees.
+- **[EDRR Phase Recovery and Threshold Helpers](edrr_phase_recovery_threshold_helpers.md)**: Coordinator helpers for recovery hooks and threshold configuration.
 - **[Hybrid Memory Architecture](hybrid_memory_architecture.md)**: Specification for DevSynth's hybrid memory architecture.
 - **[Kuzu Memory Integration](kuzu_memory_integration.md)**: Environment-variable overrides and fallback behaviour for the Kuzu-backed memory store.
 - **[Memory Module Handles Missing TinyDB Dependency](memory_optional_tinydb_dependency.md)**: Import behavior when `tinydb` is absent.

--- a/issues/Critical-recommendations-follow-up.md
+++ b/issues/Critical-recommendations-follow-up.md
@@ -16,6 +16,7 @@ This issue captures remaining work from the critical recommendations report.
 
 - [x] Implemented phase transition helpers and recovery hooks with unit tests ([21c6da3a](../commit/21c6da3a)).
 - [x] Linked WSDE team consensus with EDRR phase transitions and added cross-store memory sync integration tests ([797e9976](../commit/797e9976)).
+- [x] Added coordinator helpers for recovery hooks and threshold overrides with recursive recovery tests.
 - Pending [Implement SDLC security audits](Implement-SDLC-security-audits.md) and [Resolve remaining dialectical audit questions](Resolve-remaining-dialectical-audit-questions.md).
 
 ## References

--- a/src/devsynth/application/edrr/edrr_coordinator_enhanced.py
+++ b/src/devsynth/application/edrr/edrr_coordinator_enhanced.py
@@ -113,6 +113,16 @@ class EnhancedEDRRCoordinator(EDRRCoordinator):
         """Register a hook for phase transition failures."""
         self.phase_metrics.register_failure_hook(phase, hook)
 
+    def register_phase_recovery_hook(self, phase: Phase, hook: Any) -> None:
+        """Register a recovery hook for phase transition metrics."""
+        self.phase_metrics.register_recovery_hook(phase, hook)
+
+    def configure_phase_thresholds(
+        self, phase: Phase, thresholds: Dict[str, float]
+    ) -> None:
+        """Configure threshold overrides for ``phase``."""
+        self.phase_metrics.configure_thresholds(phase, thresholds)
+
     def progress_to_phase(self, phase: Phase) -> None:
         """
         Progress to the specified phase with enhanced metrics collection.

--- a/src/devsynth/application/edrr/edrr_phase_transitions.py
+++ b/src/devsynth/application/edrr/edrr_phase_transitions.py
@@ -106,6 +106,10 @@ class PhaseTransitionMetrics:
         """Override thresholds for ``phase``."""
         self.thresholds.setdefault(phase.name, {}).update(thresholds)
 
+    def get_thresholds(self, phase: Phase) -> Dict[str, float]:
+        """Return configured thresholds for ``phase``."""
+        return self.thresholds.get(phase.name, {})
+
     def register_failure_hook(self, phase: Phase, hook: Any) -> None:
         """Register a hook executed when a phase fails to meet thresholds."""
         self.failure_hooks.setdefault(phase.name, []).append(hook)

--- a/tests/behavior/features/general/edrr_recursive_recovery.feature
+++ b/tests/behavior/features/general/edrr_recursive_recovery.feature
@@ -1,0 +1,5 @@
+Feature: Recursive EDRR phase recovery
+  Scenario: Recovery hook enables recursive phase transition
+    Given an enhanced coordinator with a micro cycle and failing metrics
+    When recovery hooks adjust metrics
+    Then the micro cycle transitions to the next phase

--- a/tests/behavior/steps/test_edrr_recursive_recovery_steps.py
+++ b/tests/behavior/steps/test_edrr_recursive_recovery_steps.py
@@ -1,0 +1,80 @@
+import pytest
+from pytest_bdd import given, scenarios, then, when
+
+from devsynth.application.code_analysis.analyzer import CodeAnalyzer
+from devsynth.application.code_analysis.ast_transformer import AstTransformer
+from devsynth.application.documentation.documentation_manager import (
+    DocumentationManager,
+)
+from devsynth.application.edrr.edrr_coordinator_enhanced import EnhancedEDRRCoordinator
+from devsynth.application.edrr.edrr_phase_transitions import MetricType
+from devsynth.application.memory.memory_manager import MemoryManager
+from devsynth.application.requirements.prompt_manager import PromptManager
+from devsynth.domain.models.wsde_facade import WSDETeam
+from devsynth.methodology.base import Phase
+
+scenarios("../features/general/edrr_recursive_recovery.feature")
+
+
+class SimpleAgent:
+    def __init__(self, name):
+        self.name = name
+        self.expertise = []
+        self.current_role = None
+
+    def process(self, task):
+        return {"processed_by": self.name}
+
+
+@pytest.fixture
+def context():
+    class Ctx:
+        pass
+
+    return Ctx()
+
+
+@pytest.mark.medium
+@given("an enhanced coordinator with a micro cycle and failing metrics")
+def enhanced_coordinator_with_micro_cycle(context):
+    mm = MemoryManager(adapters={})
+    team = WSDETeam(name="BDDRecoveryTeam")
+    team.add_agent(SimpleAgent("agent1"))
+    coord = EnhancedEDRRCoordinator(
+        memory_manager=mm,
+        wsde_team=team,
+        code_analyzer=CodeAnalyzer(),
+        ast_transformer=AstTransformer(),
+        prompt_manager=PromptManager(),
+        documentation_manager=DocumentationManager(
+            mm, storage_path="tests/fixtures/docs"
+        ),
+    )
+    coord.start_cycle({"description": "macro"})
+    micro = coord.create_micro_cycle({"description": "micro"}, Phase.EXPAND)
+    metrics = {
+        MetricType.QUALITY.value: 0.2,
+        MetricType.COMPLETENESS.value: 1.0,
+        MetricType.CONSISTENCY.value: 1.0,
+        MetricType.CONFLICTS.value: 0,
+    }
+    micro.phase_metrics.end_phase(Phase.EXPAND, metrics)
+
+    def hook(m):
+        m[MetricType.QUALITY.value] = 1.0
+        return {"recovered": True}
+
+    micro.register_phase_recovery_hook(Phase.EXPAND, hook)
+    context.micro = micro
+
+
+@pytest.mark.medium
+@when("recovery hooks adjust metrics")
+def recovery_hooks_adjust_metrics(context):
+    context.micro._enhanced_maybe_auto_progress()
+
+
+@pytest.mark.medium
+@then("the micro cycle transitions to the next phase")
+def micro_cycle_transitions(context):
+    assert context.micro.current_phase == Phase.DIFFERENTIATE

--- a/tests/integration/general/test_recursive_recovery_flow.py
+++ b/tests/integration/general/test_recursive_recovery_flow.py
@@ -1,0 +1,82 @@
+from unittest.mock import MagicMock
+
+import pytest
+
+from devsynth.application.code_analysis.analyzer import CodeAnalyzer
+from devsynth.application.code_analysis.ast_transformer import AstTransformer
+from devsynth.application.documentation.documentation_manager import (
+    DocumentationManager,
+)
+from devsynth.application.edrr.edrr_coordinator_enhanced import EnhancedEDRRCoordinator
+from devsynth.application.edrr.edrr_phase_transitions import MetricType
+from devsynth.application.memory.memory_manager import MemoryManager
+from devsynth.application.requirements.prompt_manager import PromptManager
+from devsynth.domain.models.wsde_facade import WSDETeam
+from devsynth.methodology.base import Phase
+
+
+class SimpleAgent:
+    def __init__(self, name):
+        self.name = name
+        self.expertise = []
+        self.current_role = None
+
+    def process(self, task):
+        return {"processed_by": self.name}
+
+
+@pytest.fixture
+def enhanced_coordinator():
+    team = WSDETeam(name="RecursiveRecoveryTeam")
+    team.add_agent(SimpleAgent("agent1"))
+    team.generate_diverse_ideas = MagicMock(return_value=["idea"])
+    team.create_comparison_matrix = MagicMock(return_value={})
+    team.evaluate_options = MagicMock(return_value=[])
+    team.analyze_trade_offs = MagicMock(return_value=[])
+    team.formulate_decision_criteria = MagicMock(return_value={})
+    team.select_best_option = MagicMock(return_value={})
+    team.elaborate_details = MagicMock(return_value=[])
+    team.create_implementation_plan = MagicMock(return_value=[])
+    team.optimize_implementation = MagicMock(return_value={})
+    team.perform_quality_assurance = MagicMock(return_value={})
+    team.extract_learnings = MagicMock(return_value=[])
+    team.recognize_patterns = MagicMock(return_value=[])
+    team.integrate_knowledge = MagicMock(return_value={})
+    team.generate_improvement_suggestions = MagicMock(return_value=[])
+    mm = MemoryManager()
+    analyzer = MagicMock(spec=CodeAnalyzer)
+    analyzer.analyze_project_structure.return_value = []
+    coord = EnhancedEDRRCoordinator(
+        memory_manager=mm,
+        wsde_team=team,
+        code_analyzer=analyzer,
+        ast_transformer=MagicMock(spec=AstTransformer),
+        prompt_manager=MagicMock(spec=PromptManager),
+        documentation_manager=MagicMock(spec=DocumentationManager),
+    )
+    coord.start_cycle({"description": "macro"})
+    return coord
+
+
+@pytest.mark.medium
+def test_recursive_recovery_flow(enhanced_coordinator):
+    micro = enhanced_coordinator.create_micro_cycle(
+        {"description": "micro"}, Phase.EXPAND
+    )
+
+    def hook(metrics):
+        metrics[MetricType.QUALITY.value] = 1.0
+        return {"recovered": True}
+
+    micro.register_phase_recovery_hook(Phase.EXPAND, hook)
+    micro.phase_metrics.end_phase(
+        Phase.EXPAND,
+        {
+            MetricType.QUALITY.value: 0.2,
+            MetricType.COMPLETENESS.value: 1.0,
+            MetricType.CONSISTENCY.value: 1.0,
+            MetricType.CONFLICTS.value: 0,
+        },
+    )
+    micro._enhanced_maybe_auto_progress()
+    assert micro.current_phase == Phase.DIFFERENTIATE

--- a/tests/unit/application/edrr/test_phase_recovery_helpers.py
+++ b/tests/unit/application/edrr/test_phase_recovery_helpers.py
@@ -1,0 +1,81 @@
+from unittest.mock import MagicMock
+
+import pytest
+
+from devsynth.application.code_analysis.analyzer import CodeAnalyzer
+from devsynth.application.code_analysis.ast_transformer import AstTransformer
+from devsynth.application.documentation.documentation_manager import (
+    DocumentationManager,
+)
+from devsynth.application.edrr.edrr_coordinator_enhanced import EnhancedEDRRCoordinator
+from devsynth.application.edrr.edrr_phase_transitions import MetricType
+from devsynth.application.memory.memory_manager import MemoryManager
+from devsynth.application.requirements.prompt_manager import PromptManager
+from devsynth.domain.models.wsde_facade import WSDETeam
+from devsynth.methodology.base import Phase
+
+
+@pytest.fixture
+def base_dependencies():
+    mm = MagicMock(spec=MemoryManager)
+    team = MagicMock(spec=WSDETeam)
+    ca = MagicMock(spec=CodeAnalyzer)
+    ast = MagicMock(spec=AstTransformer)
+    pm = MagicMock(spec=PromptManager)
+    dm = MagicMock(spec=DocumentationManager)
+    return mm, team, ca, ast, pm, dm
+
+
+@pytest.mark.medium
+def test_recovery_registration_and_threshold_config(base_dependencies):
+    mm, team, ca, ast, pm, dm = base_dependencies
+    coord = EnhancedEDRRCoordinator(mm, team, ca, ast, pm, dm)
+
+    def hook(metrics):
+        metrics[MetricType.QUALITY.value] = 1.0
+        return {"recovered": True}
+
+    coord.register_phase_recovery_hook(Phase.EXPAND, hook)
+    coord.configure_phase_thresholds(Phase.EXPAND, {MetricType.QUALITY.value: 0.9})
+    coord.phase_metrics.start_phase(Phase.EXPAND)
+    coord.phase_metrics.end_phase(
+        Phase.EXPAND,
+        {
+            MetricType.QUALITY.value: 0.2,
+            MetricType.COMPLETENESS.value: 1.0,
+            MetricType.CONSISTENCY.value: 1.0,
+            MetricType.CONFLICTS.value: 0,
+        },
+    )
+    should_transition, reasons = coord.phase_metrics.should_transition(Phase.EXPAND)
+    assert should_transition is True
+    assert reasons["recovery"] == "metrics recovered"
+    assert (
+        coord.phase_metrics.get_thresholds(Phase.EXPAND)[MetricType.QUALITY.value]
+        == 0.9
+    )
+
+
+@pytest.mark.medium
+def test_micro_cycle_recovery_auto_progress(base_dependencies):
+    mm, team, ca, ast, pm, dm = base_dependencies
+    coord = EnhancedEDRRCoordinator(mm, team, ca, ast, pm, dm)
+    coord.start_cycle({"description": "macro"})
+    micro = coord.create_micro_cycle({"description": "micro"}, Phase.EXPAND)
+
+    def hook(metrics):
+        metrics[MetricType.QUALITY.value] = 1.0
+        return {"recovered": True}
+
+    micro.register_phase_recovery_hook(Phase.EXPAND, hook)
+    micro.phase_metrics.end_phase(
+        Phase.EXPAND,
+        {
+            MetricType.QUALITY.value: 0.2,
+            MetricType.COMPLETENESS.value: 1.0,
+            MetricType.CONSISTENCY.value: 1.0,
+            MetricType.CONFLICTS.value: 0,
+        },
+    )
+    micro._enhanced_maybe_auto_progress()
+    assert micro.current_phase == Phase.DIFFERENTIATE


### PR DESCRIPTION
## Summary
- expose recovery hook and threshold configuration helpers on Enhanced EDRR coordinator
- add threshold accessor to phase metrics
- cover recursive phase recovery with unit, integration, and BDD tests

## Testing
- `poetry run devsynth run-tests --speed=fast`
- `poetry run pytest tests/unit/application/edrr/test_phase_recovery_helpers.py tests/integration/general/test_recursive_recovery_flow.py tests/behavior/steps/test_edrr_recursive_recovery_steps.py -m medium`
- `poetry run python tests/verify_test_organization.py`
- `poetry run python scripts/verify_test_markers.py` *(failed: hung, interrupted)*
- `poetry run python scripts/verify_requirements_traceability.py` *(failed: hung, interrupted)*
- `poetry run python scripts/verify_version_sync.py`


------
https://chatgpt.com/codex/tasks/task_e_68a126bebbb88333b6ae6c044febb8d5