### PR TITLE
fix: correct streamlit mock import

### DIFF
--- a/issues/archived/Fix-failing-test-tests-unit-interface-test-webui-cli-imports-py-test-function.md
+++ b/issues/archived/Fix-failing-test-tests-unit-interface-test-webui-cli-imports-py-test-function.md
@@ -1,0 +1,12 @@
+# Issue 140: Fix failing test tests/unit/interface/test_webui_cli_imports.py::test_webui_import_without_cli_commands_succeeds
+Milestone: 0.1.0-alpha.1 (completed 2025-08-17)
+Priority: low
+Dependencies: none
+
+## Progress
+- Adjusted import to use existing streamlit mocks fixture.
+- Confirmed test passes after running `poetry run devsynth run-tests --speed=fast`.
+- Status: closed
+
+## References
+- [tests/unit/interface/test_webui_cli_imports.py](../../tests/unit/interface/test_webui_cli_imports.py)

--- a/tests/unit/interface/test_webui_cli_imports.py
+++ b/tests/unit/interface/test_webui_cli_imports.py
@@ -4,7 +4,7 @@ from types import ModuleType
 
 import pytest
 
-from tests.unit.interface.test_streamlit_mocks import make_streamlit_mock
+from tests.fixtures.streamlit_mocks import make_streamlit_mock
 
 
 @pytest.fixture(autouse=True)


### PR DESCRIPTION
## Summary
- fix WebUI CLI import test to use existing streamlit mock fixture
- document resolution in archived issue tracker

## Testing
- `poetry run devsynth run-tests --speed=fast`
- `poetry run python tests/verify_test_organization.py`
- `poetry run python scripts/verify_test_markers.py` *(fails: hangs after ~50/688 files, requires manual interruption)*
- `poetry run python scripts/verify_requirements_traceability.py`
- `poetry run python scripts/verify_version_sync.py`


------
https://chatgpt.com/codex/tasks/task_e_68a13a1581ac8333b73a0b96d9a4392f