### PR TITLE
Ensure WSDE workflows flush and sync memory

### DIFF
--- a/src/devsynth/agents/wsde_team_coordinator.py
+++ b/src/devsynth/agents/wsde_team_coordinator.py
@@ -52,6 +52,14 @@ class WSDETeamCoordinatorAgent:
         if memory_manager and hasattr(memory_manager, "flush_updates"):
             try:
                 memory_manager.flush_updates()
+                wait = getattr(memory_manager, "wait_for_sync", None)
+                if callable(wait):
+                    import asyncio
+                    import inspect
+
+                    result = wait()
+                    if inspect.isawaitable(result):  # pragma: no cover - requires loop
+                        asyncio.run(result)
             except (RuntimeError, OSError):  # pragma: no cover - defensive
                 logger.debug(
                     "Memory synchronization failed during retrospective",

--- a/src/devsynth/application/collaboration/collaboration_memory_utils.py
+++ b/src/devsynth/application/collaboration/collaboration_memory_utils.py
@@ -43,6 +43,14 @@ def flush_memory_queue(memory_manager: Any) -> List[tuple[str, MemoryItem]]:
     try:
         if hasattr(memory_manager, "flush_updates"):
             memory_manager.flush_updates()
+        wait = getattr(memory_manager, "wait_for_sync", None)
+        if callable(wait):
+            import asyncio
+            import inspect
+
+            result = wait()
+            if inspect.isawaitable(result):  # pragma: no cover - depends on event loop
+                asyncio.run(result)
     except Exception:  # pragma: no cover - defensive
         logger.debug("Flush failed", exc_info=True)
     finally:

--- a/tests/unit/application/collaboration/test_wsde_phase_transition_and_memory_flush.py
+++ b/tests/unit/application/collaboration/test_wsde_phase_transition_and_memory_flush.py
@@ -1,0 +1,53 @@
+import asyncio
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from devsynth.application.collaboration.collaboration_memory_utils import (
+    flush_memory_queue,
+)
+from devsynth.application.collaboration.WSDE import WSDE
+from devsynth.application.memory.memory_manager import MemoryManager
+from devsynth.domain.models.memory import MemoryItem, MemoryType
+from devsynth.methodology.base import Phase
+
+
+@pytest.mark.medium
+def test_progress_roles_triggers_memory_flush():
+    """Progressing roles should flush pending memory updates."""
+
+    mm = MemoryManager(adapters={"default": MagicMock(flush=MagicMock())})
+    team = WSDE(name="RoleTeam")
+    agent = MagicMock()
+    agent.id = "agent-1"
+    agent.name = "Agent One"
+    team.add_agent(agent)
+
+    def assign_roles_for_phase(self, phase, _context=None):
+        self.roles = {"explorer": agent}
+
+    team.assign_roles_for_phase = assign_roles_for_phase.__get__(team, WSDE)
+
+    with patch("devsynth.domain.wsde.workflow.flush_memory_queue") as flush_mock:
+        flush_mock.return_value = []
+        assignments = team.progress_roles(Phase.EXPAND, memory_manager=mm)
+
+    assert assignments == {"agent-1": "Explorer"}
+    flush_mock.assert_called_once_with(mm)
+
+
+@pytest.mark.medium
+def test_flush_memory_queue_waits_for_sync():
+    """Flushing memory queue should await async sync if available."""
+
+    adapter = MagicMock(flush=MagicMock())
+    mm = MemoryManager(adapters={"default": adapter})
+    mm.wait_for_sync = MagicMock(return_value=asyncio.sleep(0))
+
+    item = MemoryItem(id="m1", content={}, memory_type=MemoryType.TEAM_STATE)
+    mm.queue_update("default", item)
+    flushed = flush_memory_queue(mm)
+
+    assert flushed == [("default", item)]
+    mm.wait_for_sync.assert_called_once()
+    assert mm.sync_manager._queue == []


### PR DESCRIPTION
## Summary
- flush queued memory updates and await sync completion
- ensure retrospective summaries wait for pending memory writes
- add unit tests for role progression and memory flush sequencing

## Testing
- `poetry run pre-commit run --files src/devsynth/application/collaboration/collaboration_memory_utils.py src/devsynth/agents/wsde_team_coordinator.py tests/unit/application/collaboration/test_wsde_phase_transition_and_memory_flush.py`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 poetry run python -c "import httpx, pytest; raise SystemExit(pytest.main(['-p','pytest_cov','tests/unit/application/collaboration/test_wsde_phase_transition_and_memory_flush.py','-q']))"`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 poetry run python -c "import httpx, pytest; raise SystemExit(pytest.main(['-p','pytest_cov','tests/integration/general/test_wsde_edrr_component_interactions.py','-q']))"`


------
https://chatgpt.com/codex/tasks/task_e_68a149e5940483338a642012a34fbe8e