### PR TITLE
feat: add lmstudio test stub

### DIFF
--- a/docs/testing/auto_generated_tests.md
+++ b/docs/testing/auto_generated_tests.md
@@ -19,3 +19,12 @@ automatically.
 4. Run `poetry run devsynth run-tests --speed=fast` and `poetry run pre-commit run --files ...` before submitting changes.
 
 This process ensures that auto-generated tests receive human oversight and evolve into reliable integration coverage.
+
+## Mocking Optional Services
+
+Some providers, such as LM Studio, may be unavailable during local testing.  Use
+`pytest.importorskip("lmstudio")` to skip tests when the optional SDK is not
+installed and rely on the `lmstudio_stub` fixture to emulate the HTTP API.  The
+fixture lives under `tests/unit/fakes/` and returns deterministic responses for
+model listing, text generation, and embeddings so tests can run without a real
+LM Studio instance.

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -84,6 +84,6 @@ pytest_plugins = [
     "tests.fixtures.kuzu",
     "tests.fixtures.state_access_fixture",
     "tests.fixtures.webui_wizard_state_fixture",
-    "tests.fixtures.lmstudio_mock",
     "tests.fixtures.optional_deps",
+    "tests.unit.fakes.test_lmstudio_stub",
 ]

--- a/tests/integration/general/test_lmstudio_provider.py
+++ b/tests/integration/general/test_lmstudio_provider.py
@@ -4,6 +4,8 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+pytest.importorskip("lmstudio")
+
 # LMStudio provider integration tests run at medium speed
 pytestmark = [pytest.mark.medium]
 
@@ -24,7 +26,7 @@ class TestLMStudioProvider:
 
     ReqID: N/A"""
 
-    def test_init_with_default_config_succeeds(self, lmstudio_mock):
+    def test_init_with_default_config_succeeds(self, lmstudio_stub):
         """Test initialization with default configuration.
 
         ReqID: N/A"""
@@ -50,7 +52,7 @@ class TestLMStudioProvider:
             assert provider.api_base == "http://localhost:1234/v1"
             assert provider.max_tokens == 1024
 
-    def test_init_with_specified_model_succeeds(self, lmstudio_mock):
+    def test_init_with_specified_model_succeeds(self, lmstudio_stub):
         """Test initialization with a specified model.
 
         ReqID: N/A"""
@@ -58,7 +60,7 @@ class TestLMStudioProvider:
         provider = LMStudioProvider({"model": "specified_model"})
         assert provider.model == "specified_model"
 
-    def test_init_with_connection_error_succeeds(self, lmstudio_mock):
+    def test_init_with_connection_error_succeeds(self, lmstudio_stub):
         """Test initialization when LM Studio is not available.
 
         ReqID: N/A"""
@@ -82,7 +84,7 @@ class TestLMStudioProvider:
             provider = LMStudioProvider()
             assert provider.model == "local_model"
 
-    def test_list_available_models_error_fails(self, lmstudio_mock):
+    def test_list_available_models_error_fails(self, lmstudio_stub):
         """Test listing available models when the API call fails.
 
         ReqID: N/A"""
@@ -95,7 +97,7 @@ class TestLMStudioProvider:
             with pytest.raises(LMStudioConnectionError):
                 provider.list_available_models()
 
-    def test_list_available_models_integration_succeeds(self, lmstudio_mock):
+    def test_list_available_models_integration_succeeds(self, lmstudio_stub):
         """Integration test for listing available models from LM Studio.
 
         ReqID: N/A"""
@@ -105,7 +107,7 @@ class TestLMStudioProvider:
                 "devsynth.application.llm.lmstudio_provider.get_llm_settings"
             ) as mock_settings:
                 mock_settings.return_value = {
-                    "api_base": f"{lmstudio_mock.base_url}/v1",
+                    "api_base": f"{lmstudio_stub.base_url}/v1",
                     "model": "test-model",
                     "max_tokens": 1024,
                     "temperature": 0.7,
@@ -119,7 +121,7 @@ class TestLMStudioProvider:
         if models:
             assert "id" in models[0]
 
-    def test_generate_integration_succeeds(self, lmstudio_mock):
+    def test_generate_integration_succeeds(self, lmstudio_stub):
         """Integration test for generating text from LM Studio.
 
         ReqID: N/A"""
@@ -129,7 +131,7 @@ class TestLMStudioProvider:
                 "devsynth.application.llm.lmstudio_provider.get_llm_settings"
             ) as mock_settings:
                 mock_settings.return_value = {
-                    "api_base": f"{lmstudio_mock.base_url}/v1",
+                    "api_base": f"{lmstudio_stub.base_url}/v1",
                     "model": "test_model",
                     "max_tokens": 1024,
                     "temperature": 0.7,
@@ -142,7 +144,7 @@ class TestLMStudioProvider:
         assert isinstance(response, str)
         assert response == "This is a test response"
 
-    def test_generate_with_connection_error_succeeds(self, lmstudio_mock):
+    def test_generate_with_connection_error_succeeds(self, lmstudio_stub):
         """Test generating text when LM Studio is not available.
 
         ReqID: N/A"""
@@ -181,11 +183,15 @@ class TestLMStudioProvider:
             with pytest.raises(LMStudioConnectionError):
                 provider.generate("Hello, how are you?")
 
-    def test_generate_with_invalid_response_returns_expected_result(self, lmstudio_mock):
+    def test_generate_with_invalid_response_returns_expected_result(
+        self, lmstudio_stub
+    ):
         """Test generating text when LM Studio returns an invalid response.
 
         ReqID: N/A"""
-        LMStudioProvider, LMStudioConnectionError, LMStudioModelError = _import_provider()
+        LMStudioProvider, LMStudioConnectionError, LMStudioModelError = (
+            _import_provider()
+        )
         # Patch the TokenTracker.__init__ method to avoid using tiktoken
         with (
             patch(
@@ -220,7 +226,7 @@ class TestLMStudioProvider:
             with pytest.raises(LMStudioModelError):
                 provider.generate("Hello, how are you?")
 
-    def test_generate_with_context_integration_succeeds(self, lmstudio_mock):
+    def test_generate_with_context_integration_succeeds(self, lmstudio_stub):
         """Integration test for generating text with context from LM Studio.
 
         ReqID: N/A"""
@@ -230,7 +236,7 @@ class TestLMStudioProvider:
                 "devsynth.application.llm.lmstudio_provider.get_llm_settings"
             ) as mock_settings:
                 mock_settings.return_value = {
-                    "api_base": f"{lmstudio_mock.base_url}/v1",
+                    "api_base": f"{lmstudio_stub.base_url}/v1",
                     "model": "test_model",
                     "max_tokens": 1024,
                     "temperature": 0.7,

--- a/tests/unit/general/test_lmstudio_provider_unit.py
+++ b/tests/unit/general/test_lmstudio_provider_unit.py
@@ -3,16 +3,18 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+pytest.importorskip("lmstudio")
+
 pytestmark = [pytest.mark.requires_resource("lmstudio"), pytest.mark.medium]
 
 
 @pytest.fixture()
-def provider(lmstudio_mock):
+def provider(lmstudio_stub):
     from devsynth.application.llm.lmstudio_provider import LMStudioProvider
 
     return LMStudioProvider(
         {
-            "api_base": f"{lmstudio_mock.base_url}/v1",
+            "api_base": f"{lmstudio_stub.base_url}/v1",
             "model": "test-model",
             "auto_select_model": False,
         }
@@ -72,13 +74,13 @@ def test_get_embedding_succeeds(provider):
     assert result == [0.1, 0.2, 0.3, 0.4, 0.5]
 
 
-def test_api_error_handling_raises_error(provider, lmstudio_mock):
-    lmstudio_mock.trigger_error()
+def test_api_error_handling_raises_error(provider, lmstudio_stub):
+    lmstudio_stub.trigger_error()
     with tracker_patches(), pytest.raises(Exception):
         provider.generate("Test prompt")
 
 
-def test_circuit_breaker_opens_after_failures_fails(lmstudio_mock):
+def test_circuit_breaker_opens_after_failures_fails(lmstudio_stub):
     from devsynth.application.llm.lmstudio_provider import (
         LMStudioConnectionError,
         LMStudioProvider,
@@ -98,7 +100,7 @@ def test_circuit_breaker_opens_after_failures_fails(lmstudio_mock):
 
         provider = LMStudioProvider(
             {
-                "api_base": f"{lmstudio_mock.base_url}/v1",
+                "api_base": f"{lmstudio_stub.base_url}/v1",
                 "model": "test-model",
                 "auto_select_model": False,
                 "max_retries": 2,

--- a/tests/unit/general/test_provider_logging.py
+++ b/tests/unit/general/test_provider_logging.py
@@ -3,6 +3,8 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+pytest.importorskip("lmstudio")
+
 from devsynth.application.llm.offline_provider import OfflineProvider
 from devsynth.exceptions import DevSynthError
 from devsynth.metrics import get_retry_metrics, reset_metrics
@@ -11,7 +13,7 @@ from devsynth.metrics import get_retry_metrics, reset_metrics
 pytestmark = [pytest.mark.fast, pytest.mark.requires_resource("lmstudio")]
 
 
-def test_provider_logging_cleanup(lmstudio_mock, capsys):
+def test_provider_logging_cleanup(lmstudio_stub, capsys):
     """Providers should not log after logging.shutdown."""
     from devsynth.application.llm.lmstudio_provider import LMStudioProvider
 
@@ -37,7 +39,7 @@ def test_provider_logging_cleanup(lmstudio_mock, capsys):
     assert "I/O operation on closed file" not in capsys.readouterr().err
 
 
-def test_lmstudio_retry_metrics_and_circuit_breaker(lmstudio_mock):
+def test_lmstudio_retry_metrics_and_circuit_breaker(lmstudio_stub):
     """Failures increment retry metrics and open the circuit breaker."""
     from devsynth.application.llm.lmstudio_provider import (
         LMStudioConnectionError,


### PR DESCRIPTION
## Summary
- add FastAPI-based `lmstudio_stub` fixture for deterministic LM Studio responses
- ensure LM Studio provider tests use `pytest.importorskip` and the stub fixture
- document LM Studio mock usage in testing guide

## Testing
- `poetry run pre-commit run --files docs/testing/auto_generated_tests.md tests/__init__.py tests/integration/general/test_lmstudio_provider.py tests/unit/general/test_lmstudio_provider_unit.py tests/unit/general/test_provider_logging.py tests/unit/fakes/test_lmstudio_stub.py`
- `poetry run devsynth run-tests --speed=fast`
- `poetry run python tests/verify_test_organization.py`
- `poetry run python scripts/verify_test_markers.py` *(fails: KeyboardInterrupt)*
- `poetry run python scripts/verify_requirements_traceability.py`
- `poetry run python scripts/verify_version_sync.py`


------
https://chatgpt.com/codex/tasks/task_e_68a149feb8f48333850ae93bec68c0e8