### PR TITLE
feat: add policy audit script

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -49,6 +49,12 @@ repos:
       language: system
       pass_filenames: false
       stages: [post-commit]
+    - id: policy-audit
+      name: policy audit
+      entry: python scripts/policy_audit.py
+      language: system
+      pass_filenames: false
+      stages: [push]
     - id: commit-message-lint
       name: commit message lint
       description: lint commit messages for MVUU compliance

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -53,3 +53,9 @@
   entry: python scripts/update_traceability.py
   language: system
   pass_filenames: false
+- id: policy-audit
+  name: policy audit
+  description: "Scan configs and code for policy violations"
+  entry: python scripts/policy_audit.py
+  language: system
+  pass_filenames: false

--- a/docs/policies/security.md
+++ b/docs/policies/security.md
@@ -63,6 +63,12 @@ DevSynth automates routine security checks to prevent regressions:
 
 - A GitHub Actions workflow can be manually dispatched to run Bandit static
   analysis and Safety dependency scans via pre-commit.
+- The `policy_audit` script scans configuration and source files for hardcoded
+  secrets or debug flags and is run as part of pre-commit checks:
+
+  ```bash
+  poetry run python scripts/policy_audit.py
+  ```
 - The `security-audit` CLI command validates required security configuration
   flags using `scripts/verify_security_policy.py` before performing dependency
   vulnerability scans and Bandit static analysis. Deployment pipelines must set

--- a/docs/specifications/index.md
+++ b/docs/specifications/index.md
@@ -45,6 +45,7 @@ This section contains the official specifications for the DevSynth project, outl
 - **[Retry Predicates Specification](retry_predicates.md)**: Support conditional retry logic and metrics.
 - **[Generated Test Execution Failure](generated_test_execution_failure.md)**: Scaffolded tests fail until implemented.
 - **[Security Audit Reporting Specification](security_audit_reporting.md)**: JSON reporting for security audits.
+- **[Policy Audit Script](policy_audit.md)**: Scans configs and code for policy violations.
 
 ## Implementation Plans
 

--- a/docs/specifications/policy_audit.md
+++ b/docs/specifications/policy_audit.md
@@ -1,0 +1,30 @@
+---
+author: DevSynth Team
+date: 2025-09-16
+last_reviewed: 2025-09-16
+status: draft
+tags:
+- specification
+title: Policy Audit Script
+version: 0.1.0-alpha.1
+---
+
+# Summary
+
+## Socratic Checklist
+- What is the problem?
+- What proofs confirm the solution?
+
+## Motivation
+
+Manual reviews miss configuration mistakes and hardcoded secrets. An automated scan helps enforce security policies before changes merge.
+
+## Specification
+
+The `policy_audit` script scans configuration and source files for patterns that violate security policy. Forbidden constructs include hardcoded passwords, secret keys, API tokens and debug flags. The script exits with status `1` and reports offending files when violations are found.
+
+## Acceptance Criteria
+
+- Running `python scripts/policy_audit.py` without violations reports success and exits with `0`.
+- Running the script on a file containing `password=` reports the file and exits with `1`.
+- The script supports scanning specific paths or the entire repository by default.

--- a/scripts/policy_audit.py
+++ b/scripts/policy_audit.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python3
+"""Scan configs and source code for basic security policy violations.
+
+The script searches for hardcoded secrets and debug flags in common configuration
+and Python files. It exits with status ``1`` if any violations are detected.
+"""
+from __future__ import annotations
+
+import argparse
+import re
+from pathlib import Path
+from typing import Iterable, List, Tuple
+
+FORBIDDEN_PATTERNS = {
+    re.compile(r"password\s*=", re.IGNORECASE): "Hardcoded password",
+    re.compile(r"secret[_-]?key\s*=", re.IGNORECASE): "Hardcoded secret",
+    re.compile(r"api[_-]?key\s*=", re.IGNORECASE): "Hardcoded API key",
+    re.compile(r"access[_-]?token\s*=", re.IGNORECASE): "Hardcoded access token",
+    re.compile(r"debug\s*=\s*true", re.IGNORECASE): "Debug enabled",
+}
+
+SCAN_EXTENSIONS = {".py", ".yaml", ".yml", ".env", ".ini", ".cfg"}
+
+
+def scan_file(path: Path) -> List[Tuple[int, str, str]]:
+    """Return a list of violations found in a single file."""
+    try:
+        text = path.read_text()
+    except UnicodeDecodeError:
+        return []
+    violations: List[Tuple[int, str, str]] = []
+    for lineno, line in enumerate(text.splitlines(), start=1):
+        for pattern, message in FORBIDDEN_PATTERNS.items():
+            if pattern.search(line):
+                violations.append((lineno, line.strip(), message))
+    return violations
+
+
+def audit(paths: Iterable[Path]) -> List[Tuple[Path, int, str, str]]:
+    """Scan provided paths for policy violations."""
+    results: List[Tuple[Path, int, str, str]] = []
+    for target in paths:
+        if target.is_dir():
+            for file in target.rglob("*"):
+                if file.is_file() and file.suffix in SCAN_EXTENSIONS:
+                    for lineno, snippet, message in scan_file(file):
+                        results.append((file, lineno, snippet, message))
+        elif target.is_file() and target.suffix in SCAN_EXTENSIONS:
+            for lineno, snippet, message in scan_file(target):
+                results.append((target, lineno, snippet, message))
+    return results
+
+
+def main(argv: List[str] | None = None) -> int:
+    """CLI entry point for policy audit."""
+    parser = argparse.ArgumentParser(
+        description="Scan for policy violations in configuration and source files."
+    )
+    parser.add_argument(
+        "paths",
+        nargs="*",
+        type=Path,
+        default=[Path.cwd()],
+        help="Paths to scan (default: repository root)",
+    )
+    args = parser.parse_args(argv)
+    findings = audit(args.paths)
+    if findings:
+        print("Policy violations found:")
+        for file, lineno, snippet, message in findings:
+            print(f"{file}:{lineno}: {message}: {snippet}")
+        return 1
+    print("No policy violations found.")
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry point
+    raise SystemExit(main())

--- a/tests/behavior/features/security/policy_audit.feature
+++ b/tests/behavior/features/security/policy_audit.feature
@@ -1,0 +1,9 @@
+Feature: Policy audit
+  As a developer
+  I want to detect policy violations in configs and code
+  So that insecure settings are caught early
+
+  Scenario: Detect hardcoded password
+    Given a config file "unsafe.cfg" containing "password=123"
+    When I run the policy audit on that file
+    Then the audit should report a violation

--- a/tests/unit/security/test_policy_audit.py
+++ b/tests/unit/security/test_policy_audit.py
@@ -1,0 +1,27 @@
+"""Tests for the policy audit script."""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.append("scripts")
+
+import policy_audit  # type: ignore
+
+
+@pytest.mark.fast
+def test_audit_detects_violation(tmp_path: Path) -> None:
+    """A file with forbidden patterns should be reported."""
+    config = tmp_path / "unsafe.cfg"
+    config.write_text("password=secret")
+    results = policy_audit.audit([config])
+    assert results and results[0][0] == config
+
+
+@pytest.mark.fast
+def test_audit_passes_clean_file(tmp_path: Path) -> None:
+    """A clean file should yield no findings."""
+    config = tmp_path / "safe.cfg"
+    config.write_text("value=1")
+    assert policy_audit.audit([config]) == []


### PR DESCRIPTION
## Summary
- add policy audit script to detect hardcoded secrets and debug flags
- document policy audit usage and add related specification
- cover policy audit with unit tests and pre-commit hook

## Testing
- `SKIP=fix-code-blocks poetry run pre-commit run --files .pre-commit-config.yaml .pre-commit-hooks.yaml docs/policies/security.md docs/specifications/index.md docs/specifications/policy_audit.md scripts/policy_audit.py tests/behavior/features/security/policy_audit.feature tests/unit/security/test_policy_audit.py`
- `poetry run devsynth run-tests --speed=fast`
- `poetry run python tests/verify_test_organization.py`
- `poetry run python scripts/verify_version_sync.py`
- `poetry run python scripts/verify_test_markers.py` *(fails: KeyboardInterrupt)*
- `poetry run python scripts/verify_requirements_traceability.py`

------
https://chatgpt.com/codex/tasks/task_e_68a149fa947883339dce47fe7ac5f277