### PR TITLE
feat: add exception-based retry predicates

### DIFF
--- a/docs/specifications/retry_predicates.md
+++ b/docs/specifications/retry_predicates.md
@@ -23,3 +23,4 @@ Transient HTTP failures are currently detected only through exceptions. Response
 
 - A unit test mocks an HTTP response returning status code 503 followed by 200 and verifies the retry predicate triggers a retry and increments Prometheus metrics.
 - A behavior-driven test demonstrates that functions using retry predicates eventually succeed after transient server errors.
+- A unit test passes an exception type as a retry condition and confirms trigger and suppress metrics are recorded.


### PR DESCRIPTION
## Summary
- support exception classes as retry conditions in `retry_with_exponential_backoff`
- capture Prometheus metrics for exception-based conditions
- document and test exception-class retry conditions

## Testing
- `poetry run pre-commit run --files docs/specifications/retry_predicates.md src/devsynth/fallback.py tests/unit/fallback/test_retry_condition_metrics.py tests/unit/fallback/test_retry_conditions.py`
- `poetry run devsynth run-tests --speed=fast`
- `poetry run pytest tests/unit/fallback/test_retry_conditions.py::test_class_condition_allows_retry tests/unit/fallback/test_retry_conditions.py::test_class_condition_aborts_on_mismatch tests/unit/fallback/test_retry_condition_metrics.py::test_exception_class_condition_records_metrics`
- `poetry run python tests/verify_test_organization.py`
- `poetry run python scripts/verify_test_markers.py` *(partial output)*
- `poetry run python scripts/verify_requirements_traceability.py`
- `poetry run python scripts/verify_version_sync.py`


------
https://chatgpt.com/codex/tasks/task_e_68a149f4bd7883338493b2dc9f1b7d59