### PR TITLE
chore: mark unit tests with speed categories

### DIFF
--- a/tests/unit/core/test_config_loader.py
+++ b/tests/unit/core/test_config_loader.py
@@ -5,6 +5,7 @@ import pytest
 from devsynth.config import load_config, load_project_config
 
 
+@pytest.mark.medium
 def test_load_from_dev_synth_yaml_succeeds(tmp_path, monkeypatch):
     """Load configuration from .devsynth/project.yaml.
 

--- a/tests/unit/core/test_core_values.py
+++ b/tests/unit/core/test_core_values.py
@@ -1,14 +1,16 @@
-import pytest
-
 import importlib.util
 from pathlib import Path
 
+import pytest
+
 spec = importlib.util.spec_from_file_location(
-    'devsynth.core.values', Path(__file__).resolve().parents[3] / 'src' / 'devsynth' / 'core' / 'values.py'
+    "devsynth.core.values",
+    Path(__file__).resolve().parents[3] / "src" / "devsynth" / "core" / "values.py",
 )
 values_mod = importlib.util.module_from_spec(spec)
 assert spec.loader is not None
 import sys
+
 sys.modules[spec.name] = values_mod
 spec.loader.exec_module(values_mod)
 CoreValues = values_mod.CoreValues
@@ -16,30 +18,31 @@ find_value_conflicts = values_mod.find_value_conflicts
 check_report_for_value_conflicts = values_mod.check_report_for_value_conflicts
 
 
+pytestmark = pytest.mark.medium
+
+
 def test_load_core_values_succeeds(tmp_path):
     """Test loading core values from YAML."""
-    values_dir = tmp_path / '.devsynth'
+    values_dir = tmp_path / ".devsynth"
     values_dir.mkdir()
-    (values_dir / 'values.yml').write_text('- integrity\n- transparency\n')
+    (values_dir / "values.yml").write_text("- integrity\n- transparency\n")
     values = CoreValues.load(tmp_path)
-    assert values.statements == ['integrity', 'transparency']
+    assert values.statements == ["integrity", "transparency"]
 
 
-@pytest.mark.medium
 def test_find_value_conflicts_succeeds():
     """Test conflict detection within text."""
-    values = CoreValues(['integrity', 'transparency'])
-    text = 'This plan would violate integrity while remaining transparent.'
-    assert find_value_conflicts(text, values) == ['integrity']
+    values = CoreValues(["integrity", "transparency"])
+    text = "This plan would violate integrity while remaining transparent."
+    assert find_value_conflicts(text, values) == ["integrity"]
 
 
-@pytest.mark.medium
 def test_check_report_for_value_conflicts_succeeds(tmp_path):
     """Test conflict detection within a report structure."""
-    values_dir = tmp_path / '.devsynth'
+    values_dir = tmp_path / ".devsynth"
     values_dir.mkdir()
-    (values_dir / 'values.yml').write_text('- honesty\n')
+    (values_dir / "values.yml").write_text("- honesty\n")
     values = CoreValues.load(tmp_path)
-    report = {'notes': 'This approach may violate honesty in execution.'}
+    report = {"notes": "This approach may violate honesty in execution."}
     conflicts = check_report_for_value_conflicts(report, values)
-    assert conflicts == ['honesty']
+    assert conflicts == ["honesty"]

--- a/tests/unit/core/test_unified_config_loader.py
+++ b/tests/unit/core/test_unified_config_loader.py
@@ -1,16 +1,17 @@
 import pytest
-
-from devsynth.config.unified_loader import UnifiedConfigLoader
 import toml
 
+from devsynth.config.unified_loader import UnifiedConfigLoader
 
+
+@pytest.mark.medium
 def test_unified_loader_detects_yaml_succeeds(tmp_path):
     """use_pyproject is False when only YAML config exists.
 
-ReqID: N/A"""
-    cfg_dir = tmp_path / '.devsynth'
+    ReqID: N/A"""
+    cfg_dir = tmp_path / ".devsynth"
     cfg_dir.mkdir()
-    (cfg_dir / 'project.yaml').write_text('language: python\n')
+    (cfg_dir / "project.yaml").write_text("language: python\n")
     unified = UnifiedConfigLoader.load(tmp_path)
     assert not unified.use_pyproject
 
@@ -19,9 +20,8 @@ ReqID: N/A"""
 def test_unified_loader_detects_pyproject_succeeds(tmp_path):
     """use_pyproject is True when pyproject.toml exists.
 
-ReqID: N/A"""
-    (tmp_path / 'pyproject.toml').write_text(
-        "[tool.devsynth]\nlanguage = 'python'\n")
+    ReqID: N/A"""
+    (tmp_path / "pyproject.toml").write_text("[tool.devsynth]\nlanguage = 'python'\n")
     unified = UnifiedConfigLoader.load(tmp_path)
     assert unified.use_pyproject
 
@@ -30,41 +30,37 @@ ReqID: N/A"""
 def test_unified_loader_prefers_pyproject_succeeds(tmp_path):
     """pyproject.toml is used when both config files exist.
 
-ReqID: N/A"""
-    cfg_dir = tmp_path / '.devsynth'
+    ReqID: N/A"""
+    cfg_dir = tmp_path / ".devsynth"
     cfg_dir.mkdir()
-    (cfg_dir / 'project.yaml').write_text('language: python\n')
-    (tmp_path / 'pyproject.toml').write_text(
-        "[tool.devsynth]\nlanguage = 'python'\n")
+    (cfg_dir / "project.yaml").write_text("language: python\n")
+    (tmp_path / "pyproject.toml").write_text("[tool.devsynth]\nlanguage = 'python'\n")
     unified = UnifiedConfigLoader.load(tmp_path)
     assert unified.use_pyproject
-    assert unified.config.language == 'python'
+    assert unified.config.language == "python"
 
 
 @pytest.mark.medium
 def test_unified_config_save_updates_pyproject_succeeds(tmp_path):
     """Saving config with use_pyproject=True updates the TOML table.
 
-ReqID: N/A"""
-    (tmp_path / 'pyproject.toml').write_text(
-        "[tool.devsynth]\nlanguage='python'\n")
+    ReqID: N/A"""
+    (tmp_path / "pyproject.toml").write_text("[tool.devsynth]\nlanguage='python'\n")
     unified = UnifiedConfigLoader.load(tmp_path)
-    unified.set_language('python')
+    unified.set_language("python")
     unified.save()
-    data = toml.load(tmp_path / 'pyproject.toml')
-    assert data['tool']['devsynth']['language'] == 'python'
+    data = toml.load(tmp_path / "pyproject.toml")
+    assert data["tool"]["devsynth"]["language"] == "python"
 
 
 @pytest.mark.medium
-def test_unified_config_exists_for_both_formats_returns_expected_result(
-    tmp_path):
+def test_unified_config_exists_for_both_formats_returns_expected_result(tmp_path):
     """exists() returns True for YAML and TOML configurations.
 
-ReqID: N/A"""
-    cfg_dir = tmp_path / '.devsynth'
+    ReqID: N/A"""
+    cfg_dir = tmp_path / ".devsynth"
     cfg_dir.mkdir()
-    (cfg_dir / 'project.yaml').write_text('language: python\n')
+    (cfg_dir / "project.yaml").write_text("language: python\n")
     assert UnifiedConfigLoader.load(tmp_path).exists()
-    (tmp_path / 'pyproject.toml').write_text(
-        "[tool.devsynth]\nlanguage='python'\n")
+    (tmp_path / "pyproject.toml").write_text("[tool.devsynth]\nlanguage='python'\n")
     assert UnifiedConfigLoader.load(tmp_path).exists()

--- a/tests/unit/fallback/test_retry_conditions.py
+++ b/tests/unit/fallback/test_retry_conditions.py
@@ -6,6 +6,7 @@ import pytest
 from devsynth.fallback import retry_with_exponential_backoff
 
 
+@pytest.mark.medium
 def test_should_retry_prevents_retry():
     """Retry decorator should not retry when ``should_retry`` returns False.
 

--- a/tests/unit/general/test_agent_collaboration.py
+++ b/tests/unit/general/test_agent_collaboration.py
@@ -16,6 +16,8 @@ from devsynth.domain.models.agent import AgentConfig, AgentType
 from devsynth.domain.models.wsde_facade import WSDE, WSDETeam
 from devsynth.exceptions import ValidationError
 
+pytestmark = pytest.mark.medium
+
 
 class TestAgentCollaboration:
     """Tests for the AgentCollaboration component.
@@ -40,7 +42,6 @@ class TestAgentCollaboration:
         coordinator.add_agent(mock_agent)
         return coordinator
 
-    @pytest.mark.medium
     def test_coordinator_initialization_succeeds(self):
         """Test that the coordinator initializes correctly.
 
@@ -49,7 +50,6 @@ class TestAgentCollaboration:
         assert coordinator.teams == {}
         assert coordinator.current_team_id is None
 
-    @pytest.mark.medium
     def test_add_agent_succeeds(self, mock_agent):
         """Test adding an agent to the coordinator.
 
@@ -59,7 +59,6 @@ class TestAgentCollaboration:
         assert len(coordinator.teams["default_team"].agents) == 1
         assert coordinator.teams["default_team"].agents[0] == mock_agent
 
-    @pytest.mark.medium
     def test_delegate_task_succeeds(self, coordinator, mock_agent):
         """Test delegating a task to the agent.
 
@@ -69,7 +68,6 @@ class TestAgentCollaboration:
         assert result["result"] == "Success"
         mock_agent.process.assert_called_once_with(task)
 
-    @pytest.mark.medium
     def test_simplified_agent_factory_succeeds(self):
         """Test the simplified agent factory.
 
@@ -80,7 +78,6 @@ class TestAgentCollaboration:
         agent = factory.create_agent(AgentType.CODE.value)
         assert isinstance(agent, CodeAgent)
 
-    @pytest.mark.medium
     def test_team_task_phase_notifications_succeeds(self):
         """Test that team task phase notifications succeeds.
 
@@ -140,7 +137,6 @@ class TestAgentCollaboration:
         )
         assert result["result"] == "final"
 
-    @pytest.mark.medium
     def test_delegate_task_agent_type_not_found_succeeds(self):
         """Test that delegate task agent type not found succeeds.
 
@@ -153,7 +149,6 @@ class TestAgentCollaboration:
         with pytest.raises(ValidationError):
             coordinator.delegate_task({"agent_type": "nonexistent"})
 
-    @pytest.mark.medium
     def test_delegate_task_multi_agent_consensus_succeeds(self):
         """Test that delegate task multi agent consensus succeeds.
 
@@ -204,7 +199,6 @@ class TestAgentCollaboration:
         assert result["result"] == "final"
         assert "dialectical_analysis" in result
 
-    @pytest.mark.medium
     def test_delegate_task_dynamic_role_assignment_succeeds(self):
         """Test that delegate task dynamic role assignment succeeds.
 
@@ -252,7 +246,6 @@ class TestAgentCollaboration:
         team.select_primus_by_expertise.assert_called_once_with(task)
         assert result["contributors"] == ["a1", "a2"]
 
-    @pytest.mark.medium
     def test_delegate_task_voting_succeeds(self):
         """Test that delegate task voting succeeds.
 
@@ -279,7 +272,6 @@ class TestAgentCollaboration:
         team.vote_on_critical_decision.assert_called_once_with(task)
         assert result["voting_initiated"]
 
-    @pytest.mark.medium
     def test_agent_adapter_succeeds(self, mock_agent):
         """Test the agent adapter.
 

--- a/tests/unit/methodology/test_dialectical_reasoner.py
+++ b/tests/unit/methodology/test_dialectical_reasoner.py
@@ -1,17 +1,18 @@
-import pytest
 from uuid import uuid4
+
+import pytest
 
 from devsynth.application.requirements.dialectical_reasoner import (
     DialecticalReasonerService,
 )
 from devsynth.domain.interfaces.requirement import (
-    RequirementRepositoryInterface,
+    ChatRepositoryInterface,
     DialecticalReasoningRepositoryInterface,
     ImpactAssessmentRepositoryInterface,
-    ChatRepositoryInterface,
+    RequirementRepositoryInterface,
 )
-from devsynth.domain.models.requirement import RequirementChange
 from devsynth.domain.models.memory import MemoryType
+from devsynth.domain.models.requirement import RequirementChange
 
 
 class DummyNotification:
@@ -72,6 +73,7 @@ def test_evaluate_change_persists_reasoning_to_memory():
     assert memory.calls[0][1] == MemoryType.DIALECTICAL_REASONING
 
 
+@pytest.mark.medium
 def test_create_session_adds_welcome_message():
     service = DialecticalReasonerService(
         requirement_repository=RequirementRepositoryInterface(),
@@ -90,6 +92,7 @@ def test_create_session_adds_welcome_message():
     assert session.messages[0].sender == "system"
 
 
+@pytest.mark.medium
 def test_process_message_records_conversation():
     chat_repo = ChatRepositoryInterface()
     service = DialecticalReasonerService(

--- a/tests/unit/security/test_authorization.py
+++ b/tests/unit/security/test_authorization.py
@@ -7,8 +7,9 @@ ACL = {"admin": ["read", "write"], "user": ["read"], "superuser": ["*"]}
 EMPTY_ACL = {}
 CASE_SENSITIVE_ACL = {"Admin": ["Read", "Write"], "user": ["read"]}
 
+pytestmark = pytest.mark.medium
 
-@pytest.mark.medium
+
 def test_is_authorized_true_returns_expected_result():
     """Test that is_authorized returns True when the user has the required role.
 


### PR DESCRIPTION
## Summary
- categorize unmarked core configuration tests with `@pytest.mark.medium`
- add module-level markers for agent collaboration and security tests
- ensure retry and dialectical reasoner tests declare speed markers

## Testing
- `poetry run pre-commit run --files tests/unit/core/test_config_loader.py tests/unit/core/test_core_values.py tests/unit/core/test_unified_config_loader.py tests/unit/fallback/test_retry_conditions.py tests/unit/general/test_agent_collaboration.py tests/unit/methodology/test_dialectical_reasoner.py tests/unit/security/test_authorization.py`
- `poetry run python scripts/verify_test_markers.py --report`

------
https://chatgpt.com/codex/tasks/task_e_68a149d8e7f88333a1c4310953a7eebe