### PR TITLE
chore: reset coverage state between tests

### DIFF
--- a/issues/Resolve-medium-test-suite-xdist-KeyError.md
+++ b/issues/Resolve-medium-test-suite-xdist-KeyError.md
@@ -6,6 +6,8 @@ Dependencies: None
 
 ## Progress
 - `poetry run devsynth run-tests --speed=medium` raised KeyError `<WorkerController gw2>` with 889 failing tests and 104 errors.
+- 2025-02-14: `poetry run pytest -n auto --dist load` reproduced the failure; investigation identified leaked coverage collectors causing worker shutdowns.
+- Patched `tests/conftest.py` to clean coverage state and integrate global-state reset.
 
 ## References
 - [scripts/run_tests.sh](../scripts/run_tests.sh)

--- a/issues/Resolve-pytest-xdist-assertion-errors.md
+++ b/issues/Resolve-pytest-xdist-assertion-errors.md
@@ -20,6 +20,7 @@ Running `devsynth run-tests` across speed categories triggers internal pytest-xd
 - Attempted `devsynth run-tests --speed=fast`; after initial output the process hung and required manual interruption, indicating ongoing runner issues.
 - Blocked by [Normalize and verify test markers](Normalize-and-verify-test-markers.md).
 - 2025-08-16: `poetry run devsynth run-tests --speed=fast` completed with 36 passed and 19 skipped tests, no xdist assertion errors observed; medium and slow categories remain unverified.
+- 2025-02-14: `poetry run pytest -n auto --dist load` exposed a coverage collector assertion; updated test fixtures to reset coverage state between runs.
 
 ## References
 


### PR DESCRIPTION
## Summary
- avoid sys.modules churn and wire reset_global_state into global isolation fixture
- clear leftover coverage collectors to reduce pytest-xdist KeyErrors
- document progress on xdist KeyError and assertion error issues

## Testing
- `poetry run pre-commit run --files tests/conftest.py issues/Resolve-medium-test-suite-xdist-KeyError.md issues/Resolve-pytest-xdist-assertion-errors.md`
- `poetry run python tests/verify_test_organization.py`
- `poetry run python scripts/verify_test_markers.py` *(fails: KeyboardInterrupt)*
- `poetry run python scripts/verify_requirements_traceability.py`
- `poetry run python scripts/verify_version_sync.py`
- `poetry run pytest -n auto --dist load` *(fails: AssertionError from coverage collector)*

------
https://chatgpt.com/codex/tasks/task_e_68a155d9e5388333acc04dc1de69b61b