### PR TITLE
Expose audit logs on diagnostics page

### DIFF
--- a/docs/specifications/index.md
+++ b/docs/specifications/index.md
@@ -46,6 +46,7 @@ This section contains the official specifications for the DevSynth project, outl
 - **[Generated Test Execution Failure](generated_test_execution_failure.md)**: Scaffolded tests fail until implemented.
 - **[Security Audit Reporting Specification](security_audit_reporting.md)**: JSON reporting for security audits.
 - **[Policy Audit Script](policy_audit.md)**: Scans configs and code for policy violations.
+- **[WebUI Diagnostics Audit Logs](webui_diagnostics_audit_logs.md)**: Display dialectical audit logs on the diagnostics page.
 
 ## Implementation Plans
 

--- a/docs/specifications/webui_diagnostics_audit_logs.md
+++ b/docs/specifications/webui_diagnostics_audit_logs.md
@@ -1,0 +1,32 @@
+---
+author: DevSynth Team
+date: 2025-08-17
+last_reviewed: 2025-08-17
+status: draft
+tags:
+  - specification
+  - webui
+  - diagnostics
+  - audit
+  - logs
+title: WebUI Diagnostics Audit Logs
+version: 0.1.0-alpha.1
+---
+
+# Summary
+
+## Socratic Checklist
+- What is the problem?
+- What proofs confirm the solution?
+
+## Motivation
+The WebUI diagnostics page currently provides system checks but lacks visibility into dialectical audit logs. Developers need convenient access to audit information when diagnosing issues.
+
+## Specification
+The diagnostics page SHALL display the contents of the most recent `dialectical_audit.log` file. The log contents SHALL be presented within an expandable section labeled "Dialectical Audit Log". If the log file is absent, the page SHALL indicate that no audit logs are available.
+
+## Acceptance Criteria
+- The diagnostics page exposes the dialectical audit log in an expandable section.
+- When the log file exists, its contents are shown.
+- When the log file is missing, the page indicates that no audit logs are available.
+- Integration tests cover both log-present and log-absent scenarios.

--- a/issues/archived/Dialectical-audit-reports-missing-WebUI-Diagnostics-Page.md
+++ b/issues/archived/Dialectical-audit-reports-missing-WebUI-Diagnostics-Page.md
@@ -1,7 +1,7 @@
-# Dialectical audit reports missing WebUI Diagnostics Page
+# Issue 144: Dialectical audit reports missing WebUI Diagnostics Page
 
 Milestone: 0.1.0-alpha.1
-Status: open
+Status: closed
 
 Priority: medium
 Dependencies: None

--- a/src/devsynth/interface/webui.py
+++ b/src/devsynth/interface/webui.py
@@ -2135,6 +2135,12 @@ class WebUI(UXBridge):
     def diagnostics_page(self) -> None:
         """Run environment diagnostics via :func:`doctor_cmd`."""
         st.header("Diagnostics")
+        audit_log = Path("dialectical_audit.log")
+        with st.expander("Dialectical Audit Log"):
+            if audit_log.exists():
+                st.code(audit_log.read_text())
+            else:
+                st.write("No audit logs available.")
         with st.form("diagnostics"):
             config_dir = st.text_input("Config Directory", "config")
             submitted = st.form_submit_button("Run Diagnostics")

--- a/tests/behavior/features/index.md
+++ b/tests/behavior/features/index.md
@@ -125,6 +125,7 @@ This index lists all feature files for easy navigation.
 - [webui/config.feature](./webui/config.feature)
 - [webui/dbschema.feature](./webui/dbschema.feature)
 - [webui/diagnostics.feature](./webui/diagnostics.feature)
+- [webui/diagnostics_audit.feature](./webui/diagnostics_audit.feature)
 - [webui/docs_generation.feature](./webui/docs_generation.feature)
 - [webui/gather_wizard.feature](./webui/gather_wizard.feature)
 - [webui/ingestion.feature](./webui/ingestion.feature)

--- a/tests/behavior/features/webui/diagnostics_audit.feature
+++ b/tests/behavior/features/webui/diagnostics_audit.feature
@@ -1,0 +1,17 @@
+Feature: Diagnostics displays audit logs
+  As a developer
+  I want to view dialectical audit logs in the WebUI diagnostics page
+  So that I can diagnose issues using audit information
+
+  Background:
+    Given the WebUI is initialized
+
+  Scenario: View dialectical audit log
+    Given an audit log is present
+    When I navigate to "Diagnostics"
+    Then the dialectical audit log should be displayed
+
+  Scenario: Audit log missing
+    Given no audit log is present
+    When I navigate to "Diagnostics"
+    Then a message indicates no audit logs are available

--- a/tests/behavior/test_webui_diagnostics_audit.py
+++ b/tests/behavior/test_webui_diagnostics_audit.py
@@ -1,0 +1,45 @@
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from devsynth.interface import webui
+from devsynth.interface.webui import WebUI
+
+
+@pytest.mark.medium
+def test_view_dialectical_audit_log(monkeypatch, tmp_path):
+    log_path = tmp_path / "dialectical_audit.log"
+    log_path.write_text("log entry")
+    mock_st = MagicMock()
+    mock_st.expander.return_value.__enter__.return_value = mock_st.expander.return_value
+    monkeypatch.setattr(webui, "st", mock_st)
+
+    def mock_path(p):
+        return Path(tmp_path / p)
+
+    monkeypatch.setattr(webui, "Path", mock_path)
+
+    ui = WebUI()
+    ui.diagnostics_page()
+
+    mock_st.expander.assert_called_with("Dialectical Audit Log")
+    assert mock_st.code.called
+
+
+@pytest.mark.medium
+def test_audit_log_missing(monkeypatch, tmp_path):
+    mock_st = MagicMock()
+    mock_st.expander.return_value.__enter__.return_value = mock_st.expander.return_value
+    monkeypatch.setattr(webui, "st", mock_st)
+
+    def mock_path(p):
+        return Path(tmp_path / p)
+
+    monkeypatch.setattr(webui, "Path", mock_path)
+
+    ui = WebUI()
+    ui.diagnostics_page()
+
+    mock_st.expander.assert_called_with("Dialectical Audit Log")
+    mock_st.write.assert_called_with("No audit logs available.")


### PR DESCRIPTION
## Summary
- show dialectical audit log content on the WebUI diagnostics page
- cover audit log visibility with integration tests and documentation
- archive issue tracking missing audit log exposure

## Testing
- `poetry run pytest tests/behavior/test_webui_diagnostics_audit.py`
- `poetry run python tests/verify_test_organization.py`
- `poetry run python scripts/verify_version_sync.py`
- `poetry run python scripts/verify_test_markers.py` *(fails: KeyboardInterrupt)*
- `poetry run python scripts/verify_requirements_traceability.py` *(fails: KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_68a155d4b4a88333adc182c7cc2c3dcc