### PR TITLE
Add security audit CLI wrapper

### DIFF
--- a/src/devsynth/application/cli/commands/extra_cmds.py
+++ b/src/devsynth/application/cli/commands/extra_cmds.py
@@ -6,12 +6,14 @@ from .completion_cmd import completion_cmd
 from .edrr_cycle_cmd import edrr_cycle_cmd
 from .init_cmd import init_cmd
 from .run_tests_cmd import run_tests_cmd
+from .security_audit_cmd import security_audit_cmd
 
 register("align", align_cmd)
 register("completion", completion_cmd)
 register("init", init_cmd)
 register("run-tests", run_tests_cmd)
 register("edrr-cycle", edrr_cycle_cmd)
+register("security-audit", security_audit_cmd)
 
 __all__ = [
     "align_cmd",
@@ -19,4 +21,5 @@ __all__ = [
     "init_cmd",
     "run_tests_cmd",
     "edrr_cycle_cmd",
+    "security_audit_cmd",
 ]

--- a/src/devsynth/application/cli/commands/security_audit_cmd.py
+++ b/src/devsynth/application/cli/commands/security_audit_cmd.py
@@ -15,21 +15,12 @@ from typing import Optional
 from devsynth.interface.cli import CLIUXBridge
 from devsynth.interface.ux_bridge import UXBridge
 from devsynth.logging_setup import DevSynthLogger
+from devsynth.security import audit
 
 logger = DevSynthLogger(__name__)
 bridge: UXBridge = CLIUXBridge()
 
 REQUIRED_ENV_VARS = ["DEVSYNTH_ACCESS_TOKEN"]
-
-
-def run_safety() -> None:
-    """Run dependency vulnerability scan using safety."""
-    subprocess.check_call(["python", "scripts/dependency_safety_check.py"])
-
-
-def run_bandit() -> None:
-    """Run Bandit static analysis over the src directory."""
-    subprocess.check_call(["bandit", "-r", "src", "-ll"])
 
 
 def run_secrets_scan() -> None:
@@ -109,9 +100,9 @@ def security_audit_cmd(
     bridge.display_result("[blue]Running security audit checks...[/blue]")
     check_required_env()
     if not skip_safety:
-        run_safety()
+        audit.run_safety()
     if not skip_static:
-        run_bandit()
+        audit.run_bandit()
     if not skip_secrets:
         run_secrets_scan()
     if not skip_owasp:

--- a/tests/unit/security/test_security_audit_cmd.py
+++ b/tests/unit/security/test_security_audit_cmd.py
@@ -1,0 +1,58 @@
+import pytest
+
+from devsynth.application.cli.commands import security_audit_cmd as cmd
+
+
+class DummyBridge:
+    def display_result(self, *_args, **_kwargs) -> None:  # pragma: no cover - trivial
+        pass
+
+
+@pytest.mark.fast
+def test_security_audit_cmd_runs_checks(monkeypatch):
+    """Command should invoke bandit and dependency scans."""
+    monkeypatch.setenv("DEVSYNTH_ACCESS_TOKEN", "token")
+    called = {}
+    monkeypatch.setattr(
+        cmd.audit, "run_bandit", lambda: called.setdefault("bandit", True)
+    )
+    monkeypatch.setattr(
+        cmd.audit, "run_safety", lambda: called.setdefault("safety", True)
+    )
+
+    cmd.security_audit_cmd(skip_secrets=True, skip_owasp=True, bridge=DummyBridge())
+
+    assert called == {"bandit": True, "safety": True}
+
+
+@pytest.mark.fast
+def test_security_audit_cmd_respects_skip_flags(monkeypatch):
+    """Skipping flags should avoid running checks."""
+    monkeypatch.setenv("DEVSYNTH_ACCESS_TOKEN", "token")
+    called = {}
+    monkeypatch.setattr(
+        cmd.audit, "run_bandit", lambda: called.setdefault("bandit", True)
+    )
+    monkeypatch.setattr(
+        cmd.audit, "run_safety", lambda: called.setdefault("safety", True)
+    )
+
+    cmd.security_audit_cmd(
+        skip_static=True,
+        skip_safety=True,
+        skip_secrets=True,
+        skip_owasp=True,
+        bridge=DummyBridge(),
+    )
+
+    assert called == {}
+
+
+@pytest.mark.fast
+def test_security_audit_cmd_registered():
+    """The security-audit command should be available via the CLI registry."""
+    # Import extra_cmds to ensure registration side effects run
+    import devsynth.application.cli.commands.extra_cmds  # noqa: F401
+    from devsynth.application.cli.registry import COMMAND_REGISTRY
+
+    assert COMMAND_REGISTRY.get("security-audit") is cmd.security_audit_cmd


### PR DESCRIPTION
## Summary
- wire up security-audit command in CLI registry
- implement CLI security audit using shared bandit and safety helpers
- test security-audit command and registration

## Testing
- `poetry run pre-commit run --files src/devsynth/application/cli/commands/extra_cmds.py src/devsynth/application/cli/commands/security_audit_cmd.py tests/unit/security/test_security_audit_cmd.py`
- `poetry run devsynth run-tests --speed=fast`
- `poetry run python tests/verify_test_organization.py`
- `poetry run python scripts/verify_test_markers.py`
- `poetry run python scripts/verify_requirements_traceability.py`
- `poetry run python scripts/verify_version_sync.py`


------
https://chatgpt.com/codex/tasks/task_e_68a155cc6f0483339c2273acb0432fe2