### PR TITLE
Add deployment workflow scripts and tests

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -179,6 +179,11 @@ services:
       target: production
     entrypoint: ["/bin/bash", "scripts/deployment/publish_image.sh", "${DEVSYNTH_IMAGE_TAG:-latest}"]
     user: "${UID:-1000}:${GID:-1000}"
+    env_file:
+      - .env.production
+    volumes:
+      - .:/opt/pysetup
+      - ./.env.production:/opt/pysetup/.env.production:ro
     profiles:
       - ci
 
@@ -188,6 +193,11 @@ services:
       target: production
     entrypoint: ["/bin/bash", "scripts/deployment/rollback.sh", "${DEVSYNTH_ROLLBACK_TAG:-latest}", "development"]
     user: "${UID:-1000}:${GID:-1000}"
+    env_file:
+      - .env.development
+    volumes:
+      - .:/opt/pysetup
+      - ./.env.development:/opt/pysetup/.env.development:ro
     profiles:
       - ci
 

--- a/tests/integration/deployment/test_compose_workflow.py
+++ b/tests/integration/deployment/test_compose_workflow.py
@@ -1,0 +1,48 @@
+import subprocess
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[3]
+SCRIPTS_DIR = ROOT / "scripts" / "deployment"
+
+
+@pytest.mark.fast
+def test_setup_env_refuses_root():
+    result = subprocess.run(
+        ["bash", str(SCRIPTS_DIR / "setup_env.sh")],
+        capture_output=True,
+        text=True,
+        cwd=ROOT,
+    )
+    assert result.returncode != 0
+    assert "Please run this script as a non-root user." in result.stderr
+
+
+@pytest.mark.fast
+def test_check_health_env_permissions(tmp_path):
+    env_file = tmp_path / ".env.development"
+    env_file.write_text("DEVSYNTH_ENV=development\n")
+    env_file.chmod(0o644)
+    cmd = f"{SCRIPTS_DIR / 'check_health.sh'} development"
+    result = subprocess.run(
+        ["su", "nobody", "-s", "/bin/bash", "-c", cmd],
+        capture_output=True,
+        text=True,
+        cwd=tmp_path,
+    )
+    assert result.returncode != 0
+    assert "environment file" in result.stderr.lower()
+
+
+@pytest.mark.fast
+def test_rollback_requires_tag():
+    cmd = f"{SCRIPTS_DIR / 'rollback.sh'}"
+    result = subprocess.run(
+        ["su", "nobody", "-s", "/bin/bash", "-c", cmd],
+        capture_output=True,
+        text=True,
+        cwd=ROOT,
+    )
+    assert result.returncode != 0
+    assert "Usage: rollback.sh" in result.stderr


### PR DESCRIPTION
## Summary
- add setup script for Docker-based environments
- mount environment files in CI services to enforce permissions
- cover deployment helper scripts with integration smoke tests

## Testing
- `poetry run pre-commit run --files docker-compose.yml scripts/deployment/setup_env.sh scripts/deployment/rollback.sh tests/integration/deployment/test_compose_workflow.py`
- `poetry run devsynth run-tests --speed=fast`
- `poetry run python tests/verify_test_organization.py`
- `poetry run python scripts/verify_test_markers.py` *(timeout)*
- `poetry run python scripts/verify_requirements_traceability.py`
- `poetry run python scripts/verify_version_sync.py`


------
https://chatgpt.com/codex/tasks/task_e_68a155c8a6148333891a5a4bb5f7912a