### PR TITLE
feat: mock LM Studio streaming responses

### DIFF
--- a/issues/LM-Studio-mock-service-for-deterministic-tests.md
+++ b/issues/LM-Studio-mock-service-for-deterministic-tests.md
@@ -28,6 +28,7 @@ it.
   `docs/developer_guides/testing.md`.
 - Running `tests/integration/general/test_lmstudio_provider.py` with `lmstudio` absent skips all tests and triggers coverage failure (`FAIL Required test coverage of 8% not reached`).
 - Mock service will support [Expand test generation capabilities](Expand-test-generation-capabilities.md).
+- Implemented a streaming LM Studio mock and updated integration tests to use it.
 
 ## References
 

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -85,5 +85,6 @@ pytest_plugins = [
     "tests.fixtures.state_access_fixture",
     "tests.fixtures.webui_wizard_state_fixture",
     "tests.fixtures.optional_deps",
+    "tests.fixtures.lmstudio_mock",
     "tests.unit.fakes.test_lmstudio_stub",
 ]

--- a/tests/fixtures/lmstudio_mock.py
+++ b/tests/fixtures/lmstudio_mock.py
@@ -1,0 +1,150 @@
+from __future__ import annotations
+
+import json
+import types
+from dataclasses import dataclass
+from typing import Any, Dict, List
+
+import pytest
+from fastapi import FastAPI
+from fastapi.responses import JSONResponse, StreamingResponse
+from fastapi.testclient import TestClient
+
+
+@dataclass
+class LMStudioMockServer:
+    """In-memory FastAPI server emulating the LM Studio HTTP API."""
+
+    base_url: str
+    fail: bool = False
+    status_code: int = 500
+
+    def trigger_error(self, status_code: int = 500) -> None:
+        """Make subsequent requests return an HTTP error."""
+        self.fail = True
+        self.status_code = status_code
+
+    def reset(self) -> None:
+        """Reset error state."""
+        self.fail = False
+        self.status_code = 500
+
+
+@pytest.fixture
+def lmstudio_mock(monkeypatch) -> LMStudioMockServer:
+    """Provide a mocked LM Studio HTTP API with streaming responses."""
+
+    lmstudio = pytest.importorskip("lmstudio")
+
+    app = FastAPI()
+    server = LMStudioMockServer(base_url="")
+
+    @app.get("/v1/models")
+    async def list_models() -> Dict[str, Any]:
+        if server.fail:
+            return JSONResponse(
+                status_code=server.status_code, content={"error": "Internal error"}
+            )
+        return {"data": [{"id": "test-model", "object": "model"}]}
+
+    @app.post("/v1/chat/completions")
+    async def chat_completions(payload: Dict[str, Any]):
+        if server.fail:
+            return JSONResponse(
+                status_code=server.status_code, content={"error": "Internal error"}
+            )
+
+        tokens = ["This", " is", " a", " test"]
+
+        async def event_stream():
+            for token in tokens:
+                data = {"choices": [{"delta": {"content": token}}]}
+                yield f"data: {json.dumps(data)}\n\n"
+            yield "data: [DONE]\n\n"
+
+        return StreamingResponse(event_stream(), media_type="text/event-stream")
+
+    @app.post("/v1/embeddings")
+    async def embeddings(payload: Dict[str, Any]):
+        if server.fail:
+            return JSONResponse(
+                status_code=server.status_code, content={"error": "Internal error"}
+            )
+        return {"data": [{"embedding": [0.1, 0.2, 0.3, 0.4, 0.5]}]}
+
+    client = TestClient(app)
+    server.base_url = str(client.base_url)
+
+    def _post_stream(path: str, json_payload: Dict[str, Any]) -> str:
+        with client.stream("POST", path, json=json_payload) as response:
+            if response.status_code >= 400:
+                raise Exception(response.json().get("error", "error"))
+            content = ""
+            for line in response.iter_lines():
+                if not line:
+                    continue
+                if line.startswith("data: "):
+                    data = line[6:]
+                    if data == "[DONE]":
+                        break
+                    token = json.loads(data)["choices"][0]["delta"].get("content", "")
+                    content += token
+            return content
+
+    class MockLLM:
+        def __init__(self, model: str):
+            self.model = model
+
+        def complete(self, prompt: str, config: Dict[str, Any] | None = None):
+            text = _post_stream(
+                "/v1/chat/completions",
+                {
+                    "model": self.model,
+                    "messages": [{"role": "user", "content": prompt}],
+                },
+            )
+            return types.SimpleNamespace(content=text)
+
+        def respond(
+            self, payload: Dict[str, Any], config: Dict[str, Any] | None = None
+        ):
+            text = _post_stream(
+                "/v1/chat/completions",
+                {"model": self.model, "messages": payload["messages"]},
+            )
+            return types.SimpleNamespace(content=text)
+
+    class MockEmbeddingModel:
+        def __init__(self, model: str):
+            self.model = model
+
+        def embed(self, text: str) -> List[float]:
+            response = client.post(
+                "/v1/embeddings", json={"model": self.model, "input": text}
+            )
+            if response.status_code >= 400:
+                raise Exception(response.json().get("error", "error"))
+            return response.json()["data"][0]["embedding"]
+
+    class MockSyncAPI:
+        def configure_default_client(self, host: str) -> None:  # pragma: no cover
+            return None
+
+        def list_downloaded_models(self, kind: str) -> List[Any]:
+            return [
+                types.SimpleNamespace(model_key="test-model", display_name="Test Model")
+            ]
+
+        def _reset_default_client(self) -> None:  # pragma: no cover
+            return None
+
+    monkeypatch.setattr(lmstudio, "llm", lambda model: MockLLM(model))
+    monkeypatch.setattr(
+        lmstudio, "embedding_model", lambda model: MockEmbeddingModel(model)
+    )
+    monkeypatch.setattr(lmstudio, "sync_api", MockSyncAPI())
+
+    try:
+        yield server
+    finally:
+        server.reset()

--- a/tests/integration/llm/test_lmstudio_streaming.py
+++ b/tests/integration/llm/test_lmstudio_streaming.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+pytest.importorskip("lmstudio")
+
+# LM Studio streaming tests run at medium speed
+pytestmark = [pytest.mark.medium]
+
+
+def _import_provider():
+    from devsynth.application.llm.lmstudio_provider import LMStudioProvider
+
+    return LMStudioProvider
+
+
+class TestLMStudioStreaming:
+    """Tests for LMStudioProvider using the streaming mock."""
+
+    def test_generate_streaming_returns_expected(self, lmstudio_mock):
+        """Ensure generate handles streaming responses."""
+        LMStudioProvider = _import_provider()
+        with patch(
+            "devsynth.application.llm.lmstudio_provider.get_llm_settings"
+        ) as mock_settings:
+            mock_settings.return_value = {
+                "api_base": f"{lmstudio_mock.base_url}/v1",
+                "model": "test-model",
+                "max_tokens": 1024,
+                "temperature": 0.7,
+                "auto_select_model": False,
+            }
+            provider = LMStudioProvider()
+        result = provider.generate("Hello")
+        assert result == "This is a test"
+
+    def test_generate_with_context_streaming_returns_expected(self, lmstudio_mock):
+        """Ensure generate_with_context handles streaming responses."""
+        LMStudioProvider = _import_provider()
+        with patch(
+            "devsynth.application.llm.lmstudio_provider.get_llm_settings"
+        ) as mock_settings:
+            mock_settings.return_value = {
+                "api_base": f"{lmstudio_mock.base_url}/v1",
+                "model": "test-model",
+                "max_tokens": 1024,
+                "temperature": 0.7,
+                "auto_select_model": False,
+            }
+            provider = LMStudioProvider()
+        context = [{"role": "system", "content": "You are helpful."}]
+        result = provider.generate_with_context("Hi", context)
+        assert result == "This is a test"


### PR DESCRIPTION
## Summary
- add FastAPI-based LM Studio mock that streams response chunks
- test LMStudioProvider against streaming mock under `tests/integration/llm`
- log progress for LM Studio mock service issue

## Testing
- `poetry run pre-commit run --files tests/fixtures/lmstudio_mock.py tests/integration/llm/test_lmstudio_streaming.py tests/__init__.py issues/LM-Studio-mock-service-for-deterministic-tests.md tests/integration/llm/__init__.py`
- `poetry run devsynth run-tests --speed=fast`
- `poetry run pytest tests/integration/llm/test_lmstudio_streaming.py -m medium`
- `poetry run python tests/verify_test_organization.py`
- `poetry run python scripts/verify_test_markers.py`
- `poetry run python scripts/verify_requirements_traceability.py`
- `poetry run python scripts/verify_version_sync.py`


------
https://chatgpt.com/codex/tasks/task_e_68a155c0c3ec833392a3416d83850976