### PR TITLE
chore: add speed markers to memory type tests

### DIFF
--- a/test_markers_report.json
+++ b/test_markers_report.json
@@ -1,0 +1,53 @@
+{
+  "timestamp": "2025-08-17T04:40:30.779496",
+  "verification": {
+    "directory": "tests/unit/domain/test_memory_type.py",
+    "total_files": 1,
+    "files_with_issues": 1,
+    "total_test_functions": 4,
+    "total_markers": 3,
+    "total_misaligned_markers": 0,
+    "total_duplicate_markers": 0,
+    "total_unrecognized_markers": 3,
+    "marker_counts": {
+      "fast": 0,
+      "medium": 3,
+      "slow": 0,
+      "isolation": 0
+    },
+    "files": {
+      "/workspace/devsynth/tests/unit/domain/test_memory_type.py": {
+        "file_path": "/workspace/devsynth/tests/unit/domain/test_memory_type.py",
+        "has_pytest_import": true,
+        "test_functions": 4,
+        "markers": {
+          "test_memory_type_serialization_deserialization": "medium",
+          "test_memory_type_members_complete": "medium",
+          "test_memory_type_lookup_by_value": "medium"
+        },
+        "tests_with_markers": 3,
+        "tests_without_markers": 1,
+        "misaligned_markers": [],
+        "duplicate_markers": [],
+        "recognized_markers": {
+          "medium": {
+            "file_count": 3,
+            "pytest_count": 25,
+            "recognized": false,
+            "registered_in_pytest_ini": true,
+            "uncollected_tests": [
+              "test_memory_type_lookup_by_value"
+            ]
+          }
+        },
+        "issues": [
+          {
+            "type": "unrecognized_markers",
+            "message": "medium markers are not recognized by pytest (3 in file, 25 recognized)"
+          }
+        ]
+      }
+    },
+    "subprocess_timeouts": 0
+  }
+}

--- a/tests/unit/domain/test_memory_type.py
+++ b/tests/unit/domain/test_memory_type.py
@@ -1,8 +1,11 @@
 import json
+
 import pytest
+
 from devsynth.domain.models.memory import MemoryType
 
 
+@pytest.mark.medium
 def test_memory_type_serialization_deserialization():
     """Ensure all MemoryType members serialize and deserialize correctly."""
     for name, member in MemoryType.__members__.items():
@@ -17,6 +20,7 @@ def test_working_memory_alias():
     assert MemoryType.WORKING_MEMORY is MemoryType.WORKING
 
 
+@pytest.mark.medium
 def test_memory_type_members_complete():
     """Verify that all expected memory types are present."""
     expected = [


### PR DESCRIPTION
## Summary
- add medium markers to memory type tests
- include marker verification report

## Testing
- `poetry run devsynth run-tests --speed=fast`
- `poetry run python tests/verify_test_organization.py`
- `poetry run python scripts/verify_requirements_traceability.py`
- `poetry run python scripts/verify_version_sync.py`


------
https://chatgpt.com/codex/tasks/task_e_68a155bcb894833382805b1e0dab49ba