### PR TITLE
docs: integrate API reference generator

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -70,7 +70,8 @@ tasks:
   docs:build:
     desc: Build documentation
     cmds:
-      - poetry run mkdocs build
+      - task: docs:gen-api
+      - poetry run mkdocs build --strict
 
   # Manifest validation and API doc generation
   manifest:validate:

--- a/docs/api_reference/SUMMARY.md
+++ b/docs/api_reference/SUMMARY.md
@@ -1,0 +1,2 @@
+* [devsynth](devsynth/index.md)
+    * [api](devsynth/api.md)

--- a/docs/api_reference/devsynth/api.md
+++ b/docs/api_reference/devsynth/api.md
@@ -1,0 +1,1 @@
+::: devsynth.api

--- a/docs/api_reference/devsynth/index.md
+++ b/docs/api_reference/devsynth/index.md
@@ -1,0 +1,1 @@
+::: devsynth

--- a/docs/user_guides/api_reference_generation.md
+++ b/docs/user_guides/api_reference_generation.md
@@ -7,8 +7,6 @@ tags:
   - "documentation"
   - "api"
   - "reference"
-
-status: "draft"
 author: "DevSynth Team"
 last_reviewed: "2025-08-08"
 ---
@@ -18,7 +16,7 @@ last_reviewed: "2025-08-08"
 
 # API Reference Generation
 
-This guide explains how to generate API reference pages for DevSynth using the `scripts/gen_ref_pages.py` command. The script scans project source directories, creates a navigation tree, and writes Markdown files under `api_reference/` for inclusion in the documentation site.
+This guide explains how to generate API reference pages for DevSynth using the `scripts/gen_ref_pages.py` command. The script scans project source directories, creates a navigation tree, and writes Markdown files under `docs/api_reference/` for inclusion in the documentation site.
 
 ## Usage
 
@@ -28,7 +26,7 @@ This guide explains how to generate API reference pages for DevSynth using the `
    ```bash
    poetry run python scripts/gen_ref_pages.py
    ```
-3. Build the documentation site to include the generated pages:
+3. Validate by building the documentation site, which reruns the generator via the MkDocs build pipeline:
 
    ```bash
    poetry run mkdocs build --strict
@@ -44,8 +42,8 @@ INFO     -  Building documentation...
 INFO     -  Documentation built in "site"
 ```
 
-Open `site/index.html` in a browser to browse the full reference. The script reads project structure from `manifest.yaml` if available and defaults to `src/` otherwise.
+Open `site/index.html` in a browser to browse the full reference. Example generated pages are provided under `docs/api_reference/`. The script reads project structure from `manifest.yaml` if available and defaults to `src/` otherwise.
 
 ## Implementation Status
 
-The generation script is integrated with MkDocs through the `gen-files` plugin, ensuring API pages regenerate during each build.
+The generation script is integrated with MkDocs through the `gen-files` plugin and invoked automatically during documentation builds, ensuring API pages regenerate during each build and are validated with the `--strict` flag.

--- a/scripts/install_dev.sh
+++ b/scripts/install_dev.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Install DevSynth with development dependencies and required extras
-poetry install --with dev --extras "tests retrieval chromadb api"
+# Install DevSynth with development and documentation dependencies and required extras
+poetry install --with dev,docs --extras "tests retrieval chromadb api"

--- a/tests/unit/scripts/test_gen_ref_pages.py
+++ b/tests/unit/scripts/test_gen_ref_pages.py
@@ -1,0 +1,43 @@
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+
+@pytest.mark.fast
+def test_gen_ref_pages_matches_examples(tmp_path: Path) -> None:
+    """gen_ref_pages should reproduce example output."""
+    # Setup minimal project structure
+    scripts_dir = tmp_path / "scripts"
+    scripts_dir.mkdir()
+    repo_root = Path(__file__).resolve().parents[3]
+    shutil.copy(repo_root / "scripts" / "gen_ref_pages.py", scripts_dir / "gen_ref_pages.py")
+
+    src_pkg = tmp_path / "src" / "devsynth"
+    src_pkg.mkdir(parents=True)
+    (src_pkg / "__init__.py").write_text("\n")
+    (src_pkg / "api.py").write_text("\n")
+
+    (tmp_path / "mkdocs.yml").write_text("site_name: example\n")
+    (tmp_path / "docs").mkdir()
+
+    subprocess.run(
+        [sys.executable, str(scripts_dir / "gen_ref_pages.py")],
+        cwd=tmp_path,
+        check=True,
+    )
+
+    generated = tmp_path / "docs" / "api_reference"
+    example = repo_root / "docs" / "api_reference"
+
+    assert (generated / "devsynth" / "index.md").read_text() == (
+        example / "devsynth" / "index.md"
+    ).read_text()
+    assert (generated / "devsynth" / "api.md").read_text() == (
+        example / "devsynth" / "api.md"
+    ).read_text()
+    assert (generated / "SUMMARY.md").read_text() == (
+        example / "SUMMARY.md"
+    ).read_text()


### PR DESCRIPTION
## Summary
- document API reference generation and remove draft status
- run API ref generator in docs build pipeline
- add example generated pages with tests

## Testing
- `poetry run pre-commit run --files scripts/install_dev.sh docs/api_reference/SUMMARY.md docs/api_reference/devsynth/index.md docs/api_reference/devsynth/api.md docs/user_guides/api_reference_generation.md Taskfile.yml tests/unit/scripts/test_gen_ref_pages.py`
- `poetry run devsynth run-tests --speed=fast`
- `poetry run python tests/verify_test_organization.py`
- `poetry run python scripts/verify_test_markers.py` *(failed: KeyboardInterrupt)*
- `poetry run python scripts/verify_requirements_traceability.py`
- `poetry run python scripts/verify_version_sync.py`


------
https://chatgpt.com/codex/tasks/task_e_68a16878763883338b446650166ed5c2