### PR TITLE
Integrate reasoning loop with EDRR phases

### DIFF
--- a/docs/specifications/edrr_reasoning_loop_integration.md
+++ b/docs/specifications/edrr_reasoning_loop_integration.md
@@ -1,0 +1,34 @@
+---
+author: ChatGPT
+date: 2024-07-01
+last_reviewed: 2024-07-01
+status: draft
+tags:
+  - specification
+  - methodology
+  - edrr
+  - reasoning
+
+title: Integrate reasoning loop with EDRR phases
+version: 0.1.0-alpha.1
+---
+
+# Summary
+
+## Socratic Checklist
+- What is the problem?
+- What proofs confirm the solution?
+
+## Motivation
+The dialectical reasoning loop currently operates independently of EDRR phase tracking. Without explicit phase integration, reasoning results are not persisted consistently and consensus failures lack dedicated logging.
+
+## Specification
+- Expose a `phase` parameter on `reasoning_loop` allowing callers to specify the active EDRR phase.
+- When a coordinator with a memory manager is provided, persist each iteration's results with the given phase.
+- Delegate consensus failures to the coordinator so they are logged through standard mechanisms.
+- Application coordinators must instantiate a methodology `EDRRCoordinator` and pass it, along with the phase, to `reasoning_loop`.
+
+## Acceptance Criteria
+- Dialectical reasoning results are stored in the memory manager under the phase that invoked them.
+- Consensus failures during reasoning are logged via `log_consensus_failure`.
+- Unit tests cover successful persistence and failure handling.

--- a/src/devsynth/application/edrr/coordinator.py
+++ b/src/devsynth/application/edrr/coordinator.py
@@ -34,6 +34,9 @@ from devsynth.exceptions import DevSynthError
 from devsynth.logging_setup import DevSynthLogger
 from devsynth.methodology.base import Phase
 from devsynth.methodology.dialectical_reasoning import reasoning_loop
+from devsynth.methodology.edrr_coordinator import (
+    EDRRCoordinator as MethodologyEDRRCoordinator,
+)
 
 # Create a logger for this module
 logger = DevSynthLogger(__name__)
@@ -433,12 +436,15 @@ class EDRRCoordinator:
         """Apply the dialectical reasoning loop and handle consensus failures."""
 
         logger.info("EDRRCoordinator invoking dialectical reasoning")
-        results = reasoning_loop(self.wsde_team, task, critic_agent, memory_integration)
-        if self.memory_manager is not None:
-            try:
-                self.memory_manager.flush_updates()
-            except Exception:  # pragma: no cover - defensive
-                logger.debug("Memory flush failed", exc_info=True)
+        coordinator = MethodologyEDRRCoordinator(self.memory_manager)
+        results = reasoning_loop(
+            self.wsde_team,
+            task,
+            critic_agent,
+            memory_integration,
+            phase=Phase.REFINE,
+            coordinator=coordinator,
+        )
         if not results:
             logger.warning(
                 "Consensus failure during dialectical reasoning",

--- a/src/devsynth/application/orchestration/edrr_coordinator.py
+++ b/src/devsynth/application/orchestration/edrr_coordinator.py
@@ -3,7 +3,11 @@
 from typing import Any, Callable, Dict, List, Optional
 
 from devsynth.logging_setup import DevSynthLogger
+from devsynth.methodology.base import Phase
 from devsynth.methodology.dialectical_reasoning import reasoning_loop
+from devsynth.methodology.edrr_coordinator import (
+    EDRRCoordinator as MethodologyEDRRCoordinator,
+)
 
 logger = DevSynthLogger(__name__)
 
@@ -68,6 +72,14 @@ class EDRRCoordinator:
             Result from :func:`apply_dialectical_reasoning`.
         """
         logger.info("EDRRCoordinator invoking dialectical reasoning")
-        results = reasoning_loop(self.wsde_team, task, critic_agent, memory_integration)
+        coordinator = MethodologyEDRRCoordinator(self.memory_manager)
+        results = reasoning_loop(
+            self.wsde_team,
+            task,
+            critic_agent,
+            memory_integration,
+            phase=Phase.REFINE,
+            coordinator=coordinator,
+        )
         self._sync_memory()
         return results[-1] if results else {}

--- a/tests/behavior/features/dialectical_reasoning/edrr_phase_integration.feature
+++ b/tests/behavior/features/dialectical_reasoning/edrr_phase_integration.feature
@@ -1,0 +1,19 @@
+Feature: Reasoning loop integrates with EDRR phases
+  As a methodology developer
+  I want reasoning results persisted with phase context
+  So that EDRR history remains accessible
+
+  @fast
+  Scenario: Reasoning persistence via memory manager
+    Given a dialectical reasoner with memory
+    And a requirement change
+    When the change is evaluated
+    Then the reasoning result should be stored in memory with phase "REFINE"
+
+  @fast
+  Scenario: Consensus failure is recorded
+    Given a dialectical reasoner with memory
+    And a requirement change
+    When the change is evaluated with invalid consensus output
+    Then the reasoning result should be stored in memory with phase "RETROSPECT"
+    And a consensus error is raised

--- a/tests/unit/application/orchestration/test_dialectical_reasoner.py
+++ b/tests/unit/application/orchestration/test_dialectical_reasoner.py
@@ -5,6 +5,10 @@ import pytest
 from devsynth.application.collaboration.exceptions import ConsensusError
 from devsynth.application.orchestration.dialectical_reasoner import DialecticalReasoner
 from devsynth.application.orchestration.edrr_coordinator import EDRRCoordinator
+from devsynth.methodology.base import Phase
+from devsynth.methodology.edrr_coordinator import (
+    EDRRCoordinator as MethodologyEDRRCoordinator,
+)
 
 
 class DummyConsensusError(ConsensusError):
@@ -23,7 +27,11 @@ def test_edrr_coordinator_delegates_to_helper():
         return_value=[{"ok": True}],
     ) as helper:
         result = coordinator.apply_dialectical_reasoning(task, critic)
-    helper.assert_called_once_with(team, task, critic, None)
+    helper.assert_called_once()
+    args, kwargs = helper.call_args
+    assert args[:4] == (team, task, critic, None)
+    assert kwargs["phase"] == Phase.REFINE
+    assert isinstance(kwargs["coordinator"], MethodologyEDRRCoordinator)
     assert result == {"ok": True}
 
 

--- a/tests/unit/methodology/test_dialectical_reasoning.py
+++ b/tests/unit/methodology/test_dialectical_reasoning.py
@@ -1,6 +1,8 @@
 """Tests for the dialectical reasoning utilities."""
 
+from devsynth.domain.models.memory import MemoryType
 from devsynth.exceptions import ConsensusError
+from devsynth.methodology.base import Phase
 from devsynth.methodology.dialectical_reasoning import reasoning_loop
 from devsynth.methodology.edrr_coordinator import EDRRCoordinator
 
@@ -40,3 +42,21 @@ def test_reasoning_loop_logs_consensus_failure(mocker) -> None:
 
     assert output == []
     coordinator.record_consensus_failure.assert_called_once()
+
+
+def test_reasoning_loop_persists_phase_results(mocker) -> None:
+    """It stores results using the memory manager."""
+
+    memory_manager = mocker.Mock()
+    coordinator = EDRRCoordinator(memory_manager)
+    result = {"status": "completed"}
+    mocker.patch(
+        "devsynth.methodology.dialectical_reasoning._apply_dialectical_reasoning",
+        return_value=result,
+    )
+
+    reasoning_loop(None, {}, None, coordinator=coordinator, phase=Phase.DIFFERENTIATE)
+
+    memory_manager.store_with_edrr_phase.assert_called_once_with(
+        result, MemoryType.KNOWLEDGE, "DIFFERENTIATE"
+    )


### PR DESCRIPTION
## Summary
- allow specifying EDRR phase in `reasoning_loop` and record results for each phase
- route application coordinators through methodology coordinator so reasoning is persisted and failures logged
- test persistence via memory manager and consensus failure handling

## Testing
- `poetry run pre-commit run --files src/devsynth/application/edrr/coordinator.py src/devsynth/application/orchestration/edrr_coordinator.py src/devsynth/methodology/dialectical_reasoning.py tests/unit/application/orchestration/test_dialectical_reasoner.py tests/unit/methodology/test_dialectical_reasoning.py docs/specifications/edrr_reasoning_loop_integration.md tests/behavior/features/dialectical_reasoning/edrr_phase_integration.feature`
- `poetry run devsynth run-tests --speed=fast` *(fails: Config value 'plugins': The "literate-nav" plugin is not installed)*
- `poetry run python tests/verify_test_organization.py`
- `poetry run python scripts/verify_test_markers.py`
- `poetry run python scripts/verify_requirements_traceability.py`
- `poetry run python scripts/verify_version_sync.py`


------
https://chatgpt.com/codex/tasks/task_e_68a1685d564883338b7bc46cf9621084