### PR TITLE
Ensure memory sync hooks and add edge-case tests

### DIFF
--- a/src/devsynth/application/collaboration/collaboration_memory_utils.py
+++ b/src/devsynth/application/collaboration/collaboration_memory_utils.py
@@ -39,6 +39,12 @@ def flush_memory_queue(memory_manager: Any) -> List[tuple[str, MemoryItem]]:
     """
 
     if not memory_manager or not hasattr(memory_manager, "sync_manager"):
+        notify = getattr(memory_manager, "_notify_sync_hooks", None)
+        if callable(notify):
+            try:
+                notify(None)
+            except Exception:  # pragma: no cover - defensive
+                logger.debug("Sync hook notification failed", exc_info=True)
         return []
 
     sync_manager = memory_manager.sync_manager
@@ -64,6 +70,12 @@ def flush_memory_queue(memory_manager: Any) -> List[tuple[str, MemoryItem]]:
                 asyncio.run(result)
     except Exception:  # pragma: no cover - defensive
         logger.debug("Flush failed", exc_info=True)
+        notify = getattr(memory_manager, "_notify_sync_hooks", None)
+        if callable(notify):
+            try:
+                notify(None)
+            except Exception:  # pragma: no cover - defensive
+                logger.debug("Sync hook notification failed", exc_info=True)
 
     return queue
 

--- a/tests/unit/application/collaboration/test_wsde_phase_transition_and_memory_flush.py
+++ b/tests/unit/application/collaboration/test_wsde_phase_transition_and_memory_flush.py
@@ -5,6 +5,7 @@ import pytest
 
 from devsynth.application.collaboration.collaboration_memory_utils import (
     flush_memory_queue,
+    restore_memory_queue,
 )
 from devsynth.application.collaboration.WSDE import WSDE
 from devsynth.application.memory.memory_manager import MemoryManager
@@ -51,3 +52,33 @@ def test_flush_memory_queue_waits_for_sync():
     assert flushed == [("default", item)]
     mm.wait_for_sync.assert_called_once()
     assert mm.sync_manager._queue == []
+
+
+@pytest.mark.medium
+def test_flush_memory_queue_notifies_hooks_on_failure():
+    """Even if flushing fails, hooks receive a final None event."""
+
+    adapter = MagicMock(flush=MagicMock())
+    mm = MemoryManager(adapters={"default": adapter})
+    mm.flush_updates = MagicMock(side_effect=RuntimeError("boom"))
+    events: list[object | None] = []
+    mm.register_sync_hook(lambda item: events.append(item))
+
+    flushed = flush_memory_queue(mm)
+
+    assert flushed == []
+    assert events == [None]
+
+
+@pytest.mark.medium
+def test_restore_memory_queue_preserves_order():
+    """Items are requeued in their original order."""
+
+    adapter = MagicMock(flush=MagicMock())
+    mm = MemoryManager(adapters={"default": adapter})
+    item1 = MemoryItem(id="m1", content={}, memory_type=MemoryType.TEAM_STATE)
+    item2 = MemoryItem(id="m2", content={}, memory_type=MemoryType.TEAM_STATE)
+
+    restore_memory_queue(mm, [("default", item1), ("default", item2)])
+
+    assert mm.sync_manager._queue == [("default", item1), ("default", item2)]


### PR DESCRIPTION
## Summary
- ensure memory queue flushes notify sync hooks on failure
- expose synchronization hooks in WSDE coordinator and EDRR coordinator
- cover memory utilities with edge-case tests

## Testing
- `poetry run pre-commit run --files src/devsynth/agents/wsde_team_coordinator.py src/devsynth/application/collaboration/collaboration_memory_utils.py src/devsynth/application/edrr/coordinator.py tests/unit/application/collaboration/test_wsde_phase_transition_and_memory_flush.py`
- `poetry run pytest tests/integration/general/test_wsde_edrr_component_interactions.py::TestWSDEEDRRComponentInteractions::test_phase_progression_flushes_memory_queue tests/unit/application/collaboration/test_wsde_phase_transition_and_memory_flush.py::test_flush_memory_queue_notifies_hooks_on_failure tests/unit/application/collaboration/test_wsde_phase_transition_and_memory_flush.py::test_restore_memory_queue_preserves_order`
- `poetry run python tests/verify_test_organization.py`
- `poetry run python scripts/verify_requirements_traceability.py`
- `poetry run python scripts/verify_version_sync.py`
- `poetry run devsynth run-tests --speed=fast` *(fails: Config value 'plugins': The "literate-nav" plugin is not installed)*
- `poetry run python scripts/verify_test_markers.py` *(fails: KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_68a1685962f0833388b622eeea433b93