### PR TITLE
feat: improve memory sync and chromadb resilience

### DIFF
--- a/tests/integration/memory/test_chromadb_fallback.py
+++ b/tests/integration/memory/test_chromadb_fallback.py
@@ -1,0 +1,38 @@
+import pytest
+
+pytest.importorskip("chromadb")
+
+ChromaDBAdapter = pytest.importorskip(
+    "devsynth.adapters.memory.chroma_db_adapter"
+).ChromaDBAdapter
+from devsynth.domain.models.memory import MemoryVector
+
+pytestmark = [pytest.mark.requires_resource("chromadb")]
+
+
+def test_chromadb_falls_back_to_ephemeral_client(tmp_path, monkeypatch):
+    """Adapter should fall back to an in-memory client when LMDB is missing. ReqID: FR-60"""
+    ef = pytest.importorskip("chromadb.utils.embedding_functions")
+    monkeypatch.setattr(ef, "DefaultEmbeddingFunction", lambda: (lambda x: [0.0] * 5))
+
+    import chromadb
+
+    def raise_module_error(*args, **kwargs):
+        raise ModuleNotFoundError("lmdb")
+
+    monkeypatch.setattr(chromadb, "PersistentClient", raise_module_error)
+
+    used = {}
+    original_ephemeral = chromadb.EphemeralClient
+
+    def spy_ephemeral(*args, **kwargs):
+        used["called"] = True
+        return original_ephemeral(*args, **kwargs)
+
+    monkeypatch.setattr(chromadb, "EphemeralClient", spy_ephemeral)
+
+    adapter = ChromaDBAdapter(str(tmp_path))
+    vec = MemoryVector(id="v1", content="hi", embedding=[0.1] * 5, metadata={})
+    adapter.store_vector(vec)
+    assert adapter.retrieve_vector("v1") is not None
+    assert used.get("called")

--- a/tests/integration/memory/test_multistore_transaction_wrapper.py
+++ b/tests/integration/memory/test_multistore_transaction_wrapper.py
@@ -1,0 +1,62 @@
+import pytest
+
+pytest.importorskip("chromadb")
+
+MultiStoreSyncManager = pytest.importorskip(
+    "devsynth.adapters.memory.sync_manager"
+).MultiStoreSyncManager
+from devsynth.domain.models.memory import MemoryItem, MemoryType, MemoryVector
+
+pytestmark = [
+    pytest.mark.requires_resource("lmdb"),
+    pytest.mark.requires_resource("faiss"),
+    pytest.mark.requires_resource("kuzu"),
+]
+
+
+@pytest.mark.medium
+def test_transaction_context_commit_and_rollback(tmp_path, monkeypatch):
+    """MultiStoreSyncManager transaction wrapper commits and rolls back."""
+    ef = pytest.importorskip("chromadb.utils.embedding_functions")
+    monkeypatch.setattr(ef, "DefaultEmbeddingFunction", lambda: (lambda x: [0.0] * 5))
+    manager = MultiStoreSyncManager(str(tmp_path))
+
+    item = MemoryItem(id="1", content="hello", memory_type=MemoryType.CODE)
+    vector = MemoryVector(
+        id="1",
+        content="hello",
+        embedding=[0.1] * manager.faiss.dimension,
+        metadata={},
+    )
+    with manager.transaction():
+        manager.lmdb.store(item)
+        manager.faiss.store_vector(vector)
+        manager.kuzu.store(item)
+        manager.kuzu.vector.store_vector(vector)
+
+    assert manager.lmdb.retrieve("1") is not None
+    assert manager.faiss.retrieve_vector("1") is not None
+    assert manager.kuzu.retrieve("1") is not None
+    assert manager.kuzu.vector.retrieve_vector("1") is not None
+
+    with pytest.raises(RuntimeError):
+        with manager.transaction():
+            bad_item = MemoryItem(id="2", content="bad", memory_type=MemoryType.CODE)
+            bad_vec = MemoryVector(
+                id="2",
+                content="bad",
+                embedding=[0.2] * manager.faiss.dimension,
+                metadata={},
+            )
+            manager.lmdb.store(bad_item)
+            manager.faiss.store_vector(bad_vec)
+            manager.kuzu.store(bad_item)
+            manager.kuzu.vector.store_vector(bad_vec)
+            raise RuntimeError("boom")
+
+    assert manager.lmdb.retrieve("2") is None
+    assert manager.faiss.retrieve_vector("2") is None
+    assert manager.kuzu.retrieve("2") is None
+    assert manager.kuzu.vector.retrieve_vector("2") is None
+
+    manager.cleanup()


### PR DESCRIPTION
## Summary
- add cross-store query and validation to multi-store SyncManager
- fall back to in-memory ChromaDB client when LMDB backend is unavailable
- cover transaction wrapper and ChromaDB fallback with integration tests

## Testing
- `SKIP=devsynth-align,fix-code-blocks poetry run pre-commit run --files src/devsynth/adapters/memory/chroma_db_adapter.py src/devsynth/adapters/memory/sync_manager.py tests/integration/memory/test_chromadb_fallback.py tests/integration/memory/test_multistore_transaction_wrapper.py`
- `DEVSYNTH_RESOURCE_MKDOCS_AVAILABLE=false poetry run pytest -k 'test_chromadb_falls_back_to_ephemeral_client or test_transaction_context_commit_and_rollback' tests/integration/memory/test_chromadb_fallback.py tests/integration/memory/test_multistore_transaction_wrapper.py --no-cov -q`
- `poetry run python tests/verify_test_organization.py`
- `poetry run python scripts/verify_version_sync.py`
- `poetry run python scripts/verify_requirements_traceability.py`


------
https://chatgpt.com/codex/tasks/task_e_68a16854a0248333a9d6419092a5ad08