### PR TITLE
Add memory synchronization hooks for EDRR and WSDE modules

### DIFF
--- a/src/devsynth/agents/wsde_team_coordinator.py
+++ b/src/devsynth/agents/wsde_team_coordinator.py
@@ -4,6 +4,9 @@ from __future__ import annotations
 
 from typing import Any, Dict, List
 
+from devsynth.application.collaboration.collaboration_memory_utils import (
+    flush_memory_queue,
+)
 from devsynth.application.sprint.retrospective import map_retrospective_to_summary
 from devsynth.logging_setup import DevSynthLogger
 
@@ -49,18 +52,10 @@ class WSDETeamCoordinatorAgent:
             logger.debug("Team object lacks 'record_retrospective' method")
 
         memory_manager = getattr(self._team, "memory_manager", None)
-        if memory_manager and hasattr(memory_manager, "flush_updates"):
+        if memory_manager:
             try:
-                memory_manager.flush_updates()
-                wait = getattr(memory_manager, "wait_for_sync", None)
-                if callable(wait):
-                    import asyncio
-                    import inspect
-
-                    result = wait()
-                    if inspect.isawaitable(result):  # pragma: no cover - requires loop
-                        asyncio.run(result)
-            except (RuntimeError, OSError):  # pragma: no cover - defensive
+                flush_memory_queue(memory_manager)
+            except Exception:  # pragma: no cover - defensive
                 logger.debug(
                     "Memory synchronization failed during retrospective",
                     exc_info=True,

--- a/src/devsynth/application/collaboration/collaborative_wsde_team.py
+++ b/src/devsynth/application/collaboration/collaborative_wsde_team.py
@@ -8,19 +8,22 @@ This is part of an effort to break up the monolithic wsde_team_extended.py
 into smaller, more focused modules.
 """
 
-from typing import Any, Dict, List, Optional, Union
-from datetime import datetime
 import uuid
+from datetime import datetime
+from typing import Any, Dict, List, Optional, Union
 
-from devsynth.domain.models.wsde_facade import WSDETeam
-from devsynth.application.collaboration.wsde_team_task_management import (
-    TaskManagementMixin,
+from devsynth.application.collaboration.collaboration_memory_utils import (
+    flush_memory_queue,
 )
 from devsynth.application.collaboration.wsde_team_consensus import (
     ConsensusBuildingMixin,
 )
+from devsynth.application.collaboration.wsde_team_task_management import (
+    TaskManagementMixin,
+)
 from devsynth.application.memory.memory_manager import MemoryManager
 from devsynth.domain.models.memory import MemoryItem, MemoryType
+from devsynth.domain.models.wsde_facade import WSDETeam
 
 
 class CollaborativeWSDETeam(TaskManagementMixin, ConsensusBuildingMixin, WSDETeam):
@@ -190,7 +193,7 @@ class CollaborativeWSDETeam(TaskManagementMixin, ConsensusBuildingMixin, WSDETea
         )
         self.memory_manager.update_item(primary, item)
         try:  # Ensure the update is persisted
-            self.memory_manager.flush_updates()
+            flush_memory_queue(self.memory_manager)
         except Exception:
             pass
         return item.id

--- a/tests/unit/application/collaboration/test_memory_utils_edge_cases.py
+++ b/tests/unit/application/collaboration/test_memory_utils_edge_cases.py
@@ -1,0 +1,40 @@
+from unittest.mock import MagicMock
+
+import pytest
+
+from devsynth.application.collaboration.collaboration_memory_utils import (
+    flush_memory_queue,
+    restore_memory_queue,
+)
+from devsynth.domain.models.memory import MemoryItem, MemoryType
+
+
+@pytest.mark.medium
+def test_flush_memory_queue_handles_missing_manager() -> None:
+    """Gracefully handles a missing memory manager."""
+
+    assert flush_memory_queue(None) == []
+
+
+@pytest.mark.medium
+def test_flush_memory_queue_without_sync_manager() -> None:
+    """Returns empty list when sync manager is absent."""
+
+    class Dummy:
+        def __init__(self) -> None:
+            self.flush_updates = MagicMock()
+
+    mm = Dummy()
+    result = flush_memory_queue(mm)
+    assert result == []
+    mm.flush_updates.assert_not_called()
+
+
+@pytest.mark.medium
+def test_restore_memory_queue_requeues_items_in_order() -> None:
+    """Items are requeued without raising errors."""
+
+    mm = MagicMock()
+    item = MemoryItem(id="1", content={}, memory_type=MemoryType.TEAM_STATE)
+    restore_memory_queue(mm, [("default", item)])
+    mm.queue_update.assert_called_once_with("default", item)


### PR DESCRIPTION
## Summary
- flush memory queues before EDRR phase transitions and expose sync hooks
- use memory queue flushing in WSDE team coordination and collaborative team state sync
- add edge case tests for memory utilities

## Testing
- `poetry run pre-commit run --files src/devsynth/agents/wsde_team_coordinator.py src/devsynth/application/collaboration/collaborative_wsde_team.py src/devsynth/application/edrr/coordinator.py tests/unit/application/collaboration/test_memory_utils_edge_cases.py` (fails: devsynth-align modified files; check-internal-links found broken links)
- `poetry run pytest tests/unit/application/collaboration/test_memory_utils_edge_cases.py tests/integration/general/test_wsde_edrr_component_interactions.py`
- `poetry run python tests/verify_test_organization.py`
- `poetry run python scripts/verify_test_markers.py` (fails: flake8 reported many style errors)
- `poetry run python scripts/verify_requirements_traceability.py`
- `poetry run python scripts/verify_version_sync.py`


------
https://chatgpt.com/codex/tasks/task_e_68a1e79384ac8333b6c174749820717e