### PR TITLE
Document verify_test_markers hangs

### DIFF
--- a/issues/Investigate-xdist-worker-timeouts.md
+++ b/issues/Investigate-xdist-worker-timeouts.md
@@ -8,6 +8,7 @@ Running `poetry run devsynth run-tests` occasionally hangs with xdist workers ti
 
 ## Progress
 - 2025-02-19: timeout reproduced during `scripts/verify_test_markers.py` run; root cause undetermined.
+- 2025-08-17: `poetry run python scripts/verify_test_markers.py --workers 1` still hung after processing 50 of 700 files (~76s), indicating worker timeouts remain unresolved.
 
 ## References
 - [scripts/verify_test_markers.py](../scripts/verify_test_markers.py)

--- a/issues/Normalize-and-verify-test-markers.md
+++ b/issues/Normalize-and-verify-test-markers.md
@@ -37,6 +37,7 @@ The test suite must ensure each test file contains exactly one speed marker (`fa
 - Reproduced the hang on a minimal test set by running `poetry run python scripts/verify_test_markers.py --workers 1 tests/unit/interface/test_bridge_conformance.py`; logging revealed blocking during the `pytest --collect-only` subprocess call, so the script now logs subprocess start/end and exits non-zero when issues persist.
 - 2025-08-16: Re-running `poetry run python scripts/verify_test_markers.py` after executing the environment provisioning script still hangs and requires manual interruption.
 - 2025-08-16: Latest attempt processed 150 of 679 files (~18s) before hanging, confirming persistent blocking in `pytest --collect-only`.
+- 2025-08-17: Running `poetry run python scripts/verify_test_markers.py --workers 1` processed 50 of 700 files (~76s) before hanging and required manual interruption.
 
 ## References
 


### PR DESCRIPTION
## Summary
- note progress on test marker normalization showing verify_test_markers still stalls after 50/700 files
- update xdist worker timeout issue with latest hang details

## Testing
- `poetry run devsynth run-tests --speed=fast`
- `poetry run python tests/verify_test_organization.py`
- `poetry run python scripts/verify_test_markers.py --workers 1` *(fails: hang after 50/700 files)*
- `poetry run python scripts/verify_requirements_traceability.py`
- `poetry run python scripts/verify_version_sync.py`


------
https://chatgpt.com/codex/tasks/task_e_68a2046a793083338b1129cf0eec8982