### PR TITLE
Run dialectical audit in CI with tests

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -20,3 +20,11 @@ jobs:
         env:
           DEVSYNTH_PRE_DEPLOY_APPROVED: "true"
         run: poetry run task policy:gate
+      - name: Run dialectical audit
+        run: |
+          poetry run python scripts/dialectical_audit.py || true
+      - name: Upload dialectical audit log
+        uses: actions/upload-artifact@v4
+        with:
+          name: dialectical_audit
+          path: dialectical_audit.log

--- a/docs/policies/dialectical_audit.md
+++ b/docs/policies/dialectical_audit.md
@@ -30,6 +30,11 @@ This policy defines how Socratic dialogues support audits that seek consensus be
 - Use automated tools to surface inconsistencies among docs, code, and tests.
 - Convert inconsistencies into open questions that challenge assumptions.
 
+## Continuous Integration
+
+- The dialectical audit script runs in continuous integration.
+- Its output is written to `dialectical_audit.log` and archived with CI artifacts.
+
 ## Dialogue Procedure
 
 1. Present each question to all relevant contributors.

--- a/tests/unit/docs/test_dialectical_audit.py
+++ b/tests/unit/docs/test_dialectical_audit.py
@@ -1,0 +1,80 @@
+import json
+from pathlib import Path
+
+import pytest
+
+from scripts import dialectical_audit as da
+
+
+@pytest.mark.fast
+def test_fails_when_feature_in_tests_but_not_docs(tmp_path, monkeypatch):
+    monkeypatch.setenv("DEVSYNTH_NO_FILE_LOGGING", "0")
+    root = tmp_path
+    docs = root / "docs"
+    tests_dir = root / "tests"
+    src = root / "src"
+    docs.mkdir()
+    tests_dir.mkdir()
+    src.mkdir()
+
+    (tests_dir / "feature.feature").write_text(
+        "Feature: Undocumented Feature\n",
+        encoding="utf-8",
+    )
+    (src / "impl.py").write_text(
+        "# Feature: Undocumented Feature\n",
+        encoding="utf-8",
+    )
+
+    monkeypatch.setattr(da, "ROOT", root)
+    monkeypatch.setattr(da, "DOCS", docs)
+    monkeypatch.setattr(da, "TESTS", tests_dir)
+    monkeypatch.setattr(da, "SRC", src)
+    log_path = root / "dialectical_audit.log"
+    monkeypatch.setattr(da, "LOG_PATH", log_path)
+
+    exit_code = da.main()
+    assert exit_code == 1
+
+    data = json.loads(log_path.read_text())
+    assert (
+        "Feature 'Undocumented Feature' has tests but is not documented."
+        in data["questions"]
+    )
+
+
+@pytest.mark.fast
+def test_fails_when_feature_in_docs_but_not_tests(tmp_path, monkeypatch):
+    monkeypatch.setenv("DEVSYNTH_NO_FILE_LOGGING", "0")
+    root = tmp_path
+    docs = root / "docs"
+    tests_dir = root / "tests"
+    src = root / "src"
+    docs.mkdir()
+    tests_dir.mkdir()
+    src.mkdir()
+
+    (docs / "feature.md").write_text(
+        "Feature: Untested Feature\n",
+        encoding="utf-8",
+    )
+    (src / "impl.py").write_text(
+        "# Feature: Untested Feature\n",
+        encoding="utf-8",
+    )
+
+    monkeypatch.setattr(da, "ROOT", root)
+    monkeypatch.setattr(da, "DOCS", docs)
+    monkeypatch.setattr(da, "TESTS", tests_dir)
+    monkeypatch.setattr(da, "SRC", src)
+    log_path = root / "dialectical_audit.log"
+    monkeypatch.setattr(da, "LOG_PATH", log_path)
+
+    exit_code = da.main()
+    assert exit_code == 1
+
+    data = json.loads(log_path.read_text())
+    assert (
+        "Feature 'Untested Feature' is documented but has no corresponding tests."
+        in data["questions"]
+    )


### PR DESCRIPTION
## Summary
- ensure dialectical audit script runs in CI and publishes its log
- cover missing doc/test scenarios in the dialectical audit tests
- document continuous integration expectations for dialectical audits

## Testing
- `scripts/install_dev.sh`
- `poetry run pre-commit run --files tests/unit/docs/test_dialectical_audit.py .github/workflows/security.yml docs/policies/dialectical_audit.md`
- `poetry run devsynth run-tests --speed=fast`
- `poetry run python tests/verify_test_organization.py`
- `poetry run python scripts/verify_test_markers.py`
- `poetry run python scripts/verify_requirements_traceability.py`
- `poetry run python scripts/verify_version_sync.py`


------
https://chatgpt.com/codex/tasks/task_e_68a20e46177c8333a11534d8c70c76ea