### PR TITLE
Add speed markers for CLI tests and update testing policy

### DIFF
--- a/docs/policies/testing.md
+++ b/docs/policies/testing.md
@@ -72,6 +72,13 @@ This document defines the testing policy for the DevSynth project, establishing 
    - Should verify properties across a range of inputs
 
 
+### Test Categorization and Markers
+
+1. **Speed Markers**: Each test must include exactly one of `fast`, `medium`, or `slow`.
+   - Unmarked tests default to `medium` but should still be explicitly marked.
+2. **Isolation Marker**: Add the `isolation` marker when a test requires dedicated resources or cleans up global state.
+
+
 ### Test Isolation and Cleanliness
 
 1. **Temporary Resources**: Tests must use temporary directories for all artifacts.

--- a/tests/unit/cli/test_cli_entry.py
+++ b/tests/unit/cli/test_cli_entry.py
@@ -1,9 +1,11 @@
 import runpy
 from unittest.mock import patch
+
 import click
+import pytest
 import typer
 import typer.main
-import pytest
+
 from devsynth.interface.ux_bridge import UXBridge
 
 
@@ -22,6 +24,7 @@ def patch_typer_types(monkeypatch):
     monkeypatch.setattr(typer.main, "get_click_type", patched_get_click_type)
 
 
+@pytest.mark.fast
 def test_cli_entry_invokes_run_cli():
     """Ensure the CLI module calls run_cli when executed as __main__."""
     with patch("devsynth.adapters.cli.typer_adapter.run_cli") as mock_run:

--- a/tests/unit/cli/test_command_module_loading.py
+++ b/tests/unit/cli/test_command_module_loading.py
@@ -1,6 +1,8 @@
 import importlib
 import sys
 
+import pytest
+
 # Import MVU modules to satisfy coverage requirements.
 import devsynth.core.mvu.api  # noqa: F401
 import devsynth.core.mvu.atomic_rewrite  # noqa: F401
@@ -52,10 +54,11 @@ _EXPECTED_COMMANDS = {
 }
 
 
-def test_command_modules_register_commands_and_build_app():
+@pytest.mark.fast
+def test_command_modules_register_commands_and_build_app(monkeypatch):
     """Each command module registers its commands and build_app loads them."""
-    registry.COMMAND_REGISTRY.clear()
-    modules = getattr(registry, "MODULES", list(_EXPECTED_COMMANDS))
+    monkeypatch.setattr(registry, "COMMAND_REGISTRY", {})
+    modules = list(_EXPECTED_COMMANDS)
     for module_path in modules:
         if module_path in sys.modules:
             importlib.reload(sys.modules[module_path])

--- a/tests/unit/cli/test_command_registry.py
+++ b/tests/unit/cli/test_command_registry.py
@@ -1,9 +1,11 @@
+import pytest
 import typer
 from typer.testing import CliRunner
 
 import devsynth.adapters.cli.typer_adapter as adapter
 
 
+@pytest.mark.fast
 def test_build_app_registers_commands_from_registry(monkeypatch):
     """Commands in COMMAND_REGISTRY should be registered with the CLI."""
     called = {}
@@ -22,6 +24,7 @@ def test_build_app_registers_commands_from_registry(monkeypatch):
     assert called.get("ran")
 
 
+@pytest.mark.fast
 def test_enable_feature_not_top_level():
     """The enable-feature command is managed under config and not at top level."""
     app = adapter.build_app()

--- a/tests/unit/cli/test_completion_progress.py
+++ b/tests/unit/cli/test_completion_progress.py
@@ -1,8 +1,12 @@
 import io
-from devsynth.interface.cli import CLIUXBridge
+
+import pytest
+
 from devsynth.application.cli.cli_commands import completion_cmd
+from devsynth.interface.cli import CLIUXBridge
 
 
+@pytest.mark.fast
 def test_completion_cmd_outputs_script_and_progress(capsys):
     """completion_cmd should print progress and the script."""
     bridge = CLIUXBridge()

--- a/tests/unit/cli/test_init_features_option.py
+++ b/tests/unit/cli/test_init_features_option.py
@@ -1,6 +1,8 @@
+import pytest
+
 from devsynth.application.cli.cli_commands import init_cmd
-from devsynth.interface.cli import CLIUXBridge
 from devsynth.config.unified_loader import UnifiedConfigLoader
+from devsynth.interface.cli import CLIUXBridge
 
 
 def _run_init(tmp_path, features, monkeypatch):
@@ -22,12 +24,14 @@ def _run_init(tmp_path, features, monkeypatch):
     return UnifiedConfigLoader.load(tmp_path).config
 
 
+@pytest.mark.fast
 def test_init_cmd_accepts_feature_list(tmp_path, monkeypatch):
     cfg = _run_init(tmp_path, ["code_generation", "test_generation"], monkeypatch)
     assert cfg.features["code_generation"] is True
     assert cfg.features["test_generation"] is True
 
 
+@pytest.mark.fast
 def test_init_cmd_accepts_feature_json(tmp_path, monkeypatch):
     cfg = _run_init(
         tmp_path,


### PR DESCRIPTION
## Summary
- mark CLI unit tests with `fast`
- stabilize CLI registry test by patching global state
- clarify test marker requirements in policy docs

## Testing
- `poetry run pre-commit run --files tests/unit/cli/test_cli_entry.py tests/unit/cli/test_completion_progress.py tests/unit/cli/test_command_registry.py tests/unit/cli/test_command_module_loading.py tests/unit/cli/test_init_features_option.py`
- `poetry run devsynth run-tests --speed=fast` *(fails: mkdocs missing)*
- `poetry run python tests/verify_test_organization.py`
- `poetry run python scripts/verify_requirements_traceability.py`
- `poetry run python scripts/verify_version_sync.py`
- `poetry run python scripts/verify_test_markers.py --module tests/unit/cli` *(hangs)*

------
https://chatgpt.com/codex/tasks/task_e_68a20e3f59708333b11e8ce6cadd4c2c