### PR TITLE
Add security audit checklist and release integration

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -146,6 +146,7 @@ tasks:
       - task: build:wheel
       - task: build:sdist
       - task: test:smoke
+      - task: security:audit
       - poetry run python scripts/dialectical_audit.py
 
   # Development workflow tasks

--- a/docs/policies/security.md
+++ b/docs/policies/security.md
@@ -91,6 +91,16 @@ DEVSYNTH_PRE_DEPLOY_APPROVED=true poetry run python scripts/security_audit.py
 ```
 
 
+### Audit Checklist
+
+1. Verify required security flags:
+   `poetry run python scripts/verify_security_policy.py`.
+2. Run the combined Bandit and Safety scan:
+   `poetry run python scripts/security_audit.py --report security_audit.json`.
+3. Review the generated report and address any failures.
+4. Archive the report with release artifacts.
+
+
 ### Enforceable Audit Criteria
 
 The following settings must be configured for deployments and are verified by

--- a/scripts/security_audit.py
+++ b/scripts/security_audit.py
@@ -21,8 +21,12 @@ from devsynth.security.validation import require_pre_deploy_checks
 logger = setup_logging(__name__)
 
 
-def run(argv: list[str] | None = None) -> None:
-    """Validate security flags then execute Bandit and Safety checks."""
+def run(argv: list[str] | None = None) -> dict[str, str]:
+    """Validate security flags then execute Bandit and Safety checks.
+
+    Returns a mapping of each check to its status (`passed`, `failed`, or
+    `skipped`).
+    """
     parser = argparse.ArgumentParser(
         description="Run Bandit static analysis and Safety dependency scan.",
     )
@@ -69,6 +73,8 @@ def run(argv: list[str] | None = None) -> None:
     finally:
         if args.report:
             args.report.write_text(json.dumps(results, indent=2))
+
+    return results
 
 
 if __name__ == "__main__":

--- a/tests/unit/security/test_security_audit.py
+++ b/tests/unit/security/test_security_audit.py
@@ -25,11 +25,12 @@ def test_run_executes_checks(
     mock_bandit: MagicMock,
 ) -> None:
     """The script should validate flags and run Bandit and Safety."""
-    security_audit.run([])
+    results = security_audit.run([])
     mock_pre.assert_called_once_with()
     mock_policy.assert_called_once_with()
     mock_bandit.assert_called_once_with()
     mock_safety.assert_called_once_with()
+    assert results == {"bandit": "passed", "safety": "passed"}
 
 
 @patch("security_audit.audit.run_bandit")
@@ -62,8 +63,9 @@ def test_report_writes_results(
 ) -> None:
     """Running with --report should write a JSON summary."""
     report = tmp_path / "audit.json"
-    security_audit.run(["--report", str(report)])
+    results = security_audit.run(["--report", str(report)])
     data = json.loads(report.read_text())
+    assert results == {"bandit": "passed", "safety": "passed"}
     assert data == {"bandit": "passed", "safety": "passed"}
 
 


### PR DESCRIPTION
## Summary
- document a step-by-step security audit checklist
- return audit results from `security_audit` and cover with tests
- run security audit as part of release preparation

## Testing
- `poetry run pre-commit run --files Taskfile.yml docs/policies/security.md scripts/security_audit.py tests/unit/security/test_security_audit.py`
- `poetry run devsynth run-tests --speed=fast`
- `poetry run python tests/verify_test_organization.py`
- `poetry run python scripts/verify_test_markers.py` *(fails: KeyboardInterrupt)*
- `poetry run python scripts/verify_requirements_traceability.py`
- `poetry run python scripts/verify_version_sync.py`


------
https://chatgpt.com/codex/tasks/task_e_68a20e3c0ab483339eba4c81dfe6a581