### PR TITLE
Add deployment enforcement tests and release guide step

### DIFF
--- a/docs/release/0.1.0-alpha.1.md
+++ b/docs/release/0.1.0-alpha.1.md
@@ -28,6 +28,10 @@ last_reviewed: "2025-08-16"
    poetry run python scripts/verify_requirements_traceability.py
    poetry run python scripts/verify_version_sync.py
    ```
+4. Validate deployment configuration:
+   ```bash
+   poetry run pytest tests/unit/deployment -m fast
+   ```
 
 ## Green Criteria
 

--- a/tests/unit/deployment/test_deployment_scripts.py
+++ b/tests/unit/deployment/test_deployment_scripts.py
@@ -1,7 +1,11 @@
 import os
 from pathlib import Path
 
+import pytest
+
 ROOT = Path(__file__).resolve().parents[3]
+
+pytestmark = pytest.mark.fast
 
 
 def test_bootstrap_script_exists():

--- a/tests/unit/deployment/test_enforcement.py
+++ b/tests/unit/deployment/test_enforcement.py
@@ -1,0 +1,36 @@
+from pathlib import Path
+
+import pytest
+import yaml
+
+ROOT = Path(__file__).resolve().parents[3]
+
+pytestmark = pytest.mark.fast
+
+
+def test_shell_scripts_enforce_non_root_and_env_validation():
+    """Deployment shell scripts enforce non-root execution and env file checks."""
+    scripts_dir = ROOT / "scripts/deployment"
+    for script in scripts_dir.glob("*.sh"):
+        content = script.read_text()
+        assert "$EUID" in content, f"{script} missing non-root enforcement"
+        if "ENV_FILE" in content:
+            assert "Missing environment file" in content
+            assert "Environment file $ENV_FILE must have 600 permissions" in content
+
+
+def test_docker_compose_enforces_user_and_env_file():
+    """docker-compose defines non-root users and required env files."""
+    compose = yaml.safe_load((ROOT / "docker-compose.yml").read_text())
+    services = compose.get("services", {})
+    required_env_file_services = {
+        "devsynth",
+        "dev-tools",
+        "test-runner",
+        "publish",
+        "rollback",
+    }
+    for name, config in services.items():
+        assert "user" in config, f"{name} missing user directive"
+    for name in required_env_file_services:
+        assert "env_file" in services.get(name, {}), f"{name} missing env_file"

--- a/tests/unit/deployment/test_scripts_dir.py
+++ b/tests/unit/deployment/test_scripts_dir.py
@@ -1,7 +1,11 @@
 import os
 from pathlib import Path
 
+import pytest
+
 ROOT = Path(__file__).resolve().parents[3]
+
+pytestmark = pytest.mark.fast
 
 
 def test_scripts_bootstrap_exists():


### PR DESCRIPTION
## Summary
- add unit tests verifying deployment scripts enforce non-root execution and env file validation
- ensure docker-compose services run as non-root via tests
- document deployment validation step in release guide

## Testing
- `poetry run pre-commit run --files docs/release/0.1.0-alpha.1.md tests/unit/deployment/test_deployment_scripts.py tests/unit/deployment/test_scripts_dir.py tests/unit/deployment/test_enforcement.py`
- `poetry run devsynth run-tests --speed=fast`
- `poetry run python tests/verify_test_organization.py`
- `poetry run python scripts/verify_test_markers.py -d tests/unit/deployment`
- `poetry run python scripts/verify_requirements_traceability.py`
- `poetry run python scripts/verify_version_sync.py`
- `PIP_NO_INDEX=1 poetry run pip check`


------
https://chatgpt.com/codex/tasks/task_e_68a20e34502c83338e80135a84c9c361