### PR TITLE
Improve CLI help examples and error handling tests

### DIFF
--- a/docs/user_guides/cli_usage.md
+++ b/docs/user_guides/cli_usage.md
@@ -13,21 +13,33 @@ last_reviewed: "2025-06-19"
 <a href="../index.md">Documentation</a> &gt; <a href="index.md">User Guides</a> &gt; CLI Usage
 </div>
 
-<div class="breadcrumbs">
-<a href="../index.md">Documentation</a> &gt; <a href="index.md">User Guides</a> &gt; CLI Usage
-</div>
-
 # CLI Usage
 
-This short reference outlines the most common DevSynth commands. Recent releases renamed some commands for clarity:
+The table below outlines the most common DevSynth commands with brief
+descriptions and example usage. Invoke ``devsynth <command> --help`` for full
+option details.
 
-- `init` – initialize a project directory
-- `inspect` – inspect requirements interactively or from a file
-- `run-pipeline` – execute generated code or tests
-- `refactor` – suggest the next workflow steps
-
+| Command      | Description                                              | Example                                               |
+|--------------|----------------------------------------------------------|-------------------------------------------------------|
+| init         | Initialize a new project                                 | `devsynth init`                                       |
+| spec         | Generate specifications from requirements                | `devsynth spec`                                       |
+| test         | Generate tests from specifications                       | `devsynth test`                                       |
+| code         | Generate code from tests                                 | `devsynth code`                                       |
+| run-pipeline | Run the generated code or a specific target              | `devsynth run-pipeline --target unit-tests`           |
+| config       | View or set configuration options                        | `devsynth config --list-models`                       |
+| gather       | Interactively gather project goals, constraints and priority | `devsynth gather`                                 |
+| inspect      | Inspect requirements from a file or interactively        | `devsynth inspect --input requirements.txt`           |
+| refactor     | Execute a refactor workflow based on the current project state | `devsynth refactor`                              |
+| webapp       | Generate a web application with the specified framework  | `devsynth webapp`                                     |
+| serve        | Run the DevSynth API server                              | `devsynth serve`                                      |
+| dbschema     | Generate a database schema for the specified database type | `devsynth dbschema`                                |
+| doctor       | Run diagnostics on the current environment               | `devsynth doctor`                                     |
+| check        | Alias for doctor command                                 | `devsynth check --quick`                             |
+| edrr-cycle   | Run an EDRR cycle                                        | `devsynth edrr-cycle`                                 |
+| webui        | Launch the Streamlit WebUI                               | `devsynth webui`                                      |
+| completion   | Generate or install shell completion scripts             | `devsynth completion --install`                      |
 
 Use `devsynth --help` for the full list of available commands and options.
 ## Implementation Status
 
-.
+This guide reflects the current CLI capabilities.

--- a/src/devsynth/application/cli/autocomplete.py
+++ b/src/devsynth/application/cli/autocomplete.py
@@ -106,6 +106,10 @@ COMMAND_EXAMPLES = {
         "devsynth doctor",
         "devsynth doctor --config-dir custom_config",
     ],
+    "check": [
+        "devsynth check",
+        "devsynth check --quick",
+    ],
     "edrr-cycle": [
         "devsynth edrr-cycle",
         "devsynth edrr-cycle --manifest manifest.yaml --auto",

--- a/src/devsynth/cli.py
+++ b/src/devsynth/cli.py
@@ -26,9 +26,17 @@ def main(argv: list[str] | None = None) -> None:
     If ``--analyze-repo`` is supplied, the repository at the provided path is
     analysed and the resulting data is printed as JSON.  Otherwise the standard
     Typer CLI is executed.
+
+    Examples:
+        Analyze the current repository::
+
+            devsynth --analyze-repo .
     """
 
-    parser = argparse.ArgumentParser(add_help=False)
+    parser = argparse.ArgumentParser(
+        add_help=False,
+        description="DevSynth command line interface",
+    )
     parser.add_argument(
         "--analyze-repo",
         metavar="PATH",

--- a/tests/unit/cli/test_cli_error_handling.py
+++ b/tests/unit/cli/test_cli_error_handling.py
@@ -1,0 +1,44 @@
+import click
+import pytest
+import typer
+import typer.main
+
+from devsynth.interface.ux_bridge import UXBridge
+
+
+@pytest.fixture(autouse=True)
+def patch_typer_types(monkeypatch):
+    orig = typer.main.get_click_type
+
+    def patched_get_click_type(*, annotation, parameter_info):
+        if annotation in {UXBridge, typer.models.Context}:
+            return click.STRING
+        origin = getattr(annotation, "__origin__", None)
+        if origin in {UXBridge, typer.models.Context}:
+            return click.STRING
+        return orig(annotation=annotation, parameter_info=parameter_info)
+
+    monkeypatch.setattr(typer.main, "get_click_type", patched_get_click_type)
+
+
+@pytest.mark.fast
+def test_main_handles_run_cli_errors(monkeypatch):
+    def failing_run_cli():
+        raise RuntimeError("boom")
+
+    handled = {}
+
+    def fake_handle_error(_bridge, err):
+        handled["error"] = err
+
+    monkeypatch.setattr("devsynth.adapters.cli.typer_adapter.run_cli", failing_run_cli)
+    monkeypatch.setattr(
+        "devsynth.application.cli.errors.handle_error", fake_handle_error
+    )
+
+    from devsynth.cli import main
+
+    with pytest.raises(SystemExit) as excinfo:
+        main([])
+    assert excinfo.value.code == 1
+    assert isinstance(handled["error"], RuntimeError)

--- a/tests/unit/cli/test_help_examples.py
+++ b/tests/unit/cli/test_help_examples.py
@@ -1,0 +1,38 @@
+import click
+import pytest
+import typer
+import typer.main
+
+from devsynth.interface.ux_bridge import UXBridge
+
+
+@pytest.fixture(autouse=True)
+def patch_typer_types(monkeypatch):
+    orig = typer.main.get_click_type
+
+    def patched_get_click_type(*, annotation, parameter_info):
+        if annotation in {UXBridge, typer.models.Context}:
+            return click.STRING
+        origin = getattr(annotation, "__origin__", None)
+        if origin in {UXBridge, typer.models.Context}:
+            return click.STRING
+        return orig(annotation=annotation, parameter_info=parameter_info)
+
+    monkeypatch.setattr(typer.main, "get_click_type", patched_get_click_type)
+
+
+@pytest.mark.fast
+def test_get_command_help_includes_examples():
+    from devsynth.application.cli.help import get_command_help
+
+    text = get_command_help("check")
+    assert "devsynth check" in text
+
+
+@pytest.mark.fast
+def test_get_command_help_unknown_command():
+    from devsynth.application.cli.help import get_command_help
+
+    text = get_command_help("unknown")
+    assert "Command: unknown" in text
+    assert "Command not found" in text


### PR DESCRIPTION
## Summary
- document `--analyze-repo` usage and provide parser description
- add missing `check` command examples to CLI help
- cover CLI help examples and error handling in unit tests

## Testing
- `poetry run pre-commit run --files docs/user_guides/cli_usage.md src/devsynth/application/cli/autocomplete.py src/devsynth/cli.py tests/unit/cli/test_cli_error_handling.py tests/unit/cli/test_help_examples.py`
- `poetry run devsynth run-tests --speed=fast`
- `poetry run python tests/verify_test_organization.py`
- `poetry run python scripts/verify_test_markers.py` *(fails: KeyboardInterrupt)*
- `poetry run python scripts/verify_requirements_traceability.py`
- `poetry run python scripts/verify_version_sync.py`


------
https://chatgpt.com/codex/tasks/task_e_68a20e300ca0833386861019ed915cb7