### PR TITLE
feat: scaffold tests for multiple modules

### DIFF
--- a/docs/specifications/test_generation_multi_module.md
+++ b/docs/specifications/test_generation_multi_module.md
@@ -1,0 +1,31 @@
+---
+author: DevSynth Team
+date: '2025-08-17'
+last_reviewed: '2025-08-17'
+status: draft
+tags:
+- specification
+- testing
+title: Multi-Module Test Generation Specification
+version: "0.1.0-alpha.1"
+---
+<div class="breadcrumbs">
+<a href="../index.md">Documentation</a> &gt; <a href="index.md">Specifications</a> &gt; Multi-Module Test Generation Specification
+</div>
+
+# Multi-Module Test Generation Specification
+
+## Problem
+Existing test scaffolding creates placeholder tests in a single directory and
+cannot organize generated tests for projects that contain multiple modules.
+
+## Solution
+Accept a list of module paths and scaffold a placeholder integration test within
+an output directory for each module. Module paths using dot notation are
+converted to nested folders. The resulting map of generated tests includes the
+relative path to each file so callers can easily locate the scaffolds.
+
+## Proof
+Running the scaffolding on a project with modules `core` and `utils.parser`
+produces `core/test_core.py` and `utils/parser/test_parser.py` which execute
+successfully using `pytest`.

--- a/docs/user_guides/test_generation.md
+++ b/docs/user_guides/test_generation.md
@@ -1,0 +1,41 @@
+---
+title: "Test Generation"
+date: "2025-08-17"
+version: "0.1.0-alpha.1"
+tags:
+  - testing
+  - user-guide
+status: "draft"
+author: "DevSynth Team"
+last_reviewed: "2025-08-17"
+---
+<div class="breadcrumbs">
+<a href="../index.md">Documentation</a> &gt; <a href="index.md">User Guides</a> &gt; Test Generation
+</div>
+
+# Test Generation
+
+The Test agent can scaffold integration tests for single- or multi-module
+projects. Provide a list of module paths to create a placeholder test within an
+output directory for each module.
+
+```python
+from devsynth.application.agents.test import TestAgent
+
+agent = TestAgent()
+result = agent.process(
+    {
+        "modules": ["core", "utils.parsers"],
+        "integration_output_dir": "tests/integration/generated",
+    }
+)
+print(result["integration_tests"].keys())
+# dict_keys(['core/test_core.py', 'utils/parsers/test_parsers.py'])
+```
+
+The generated files contain a simple assertion so they pass immediately. Use
+`run_generated_tests` to execute them:
+
+```python
+agent.run_generated_tests(Path("tests/integration/generated"))
+```

--- a/src/devsynth/application/agents/test.py
+++ b/src/devsynth/application/agents/test.py
@@ -192,6 +192,19 @@ class TestAgent(BaseAgent):
         )
         output_dir = Path(output_dir_input)
         integration_tests: Dict[str, str] = {}
+
+        # Handle multi-module projects by creating a scaffolded test for each module.
+        modules = inputs.get("modules", [])
+        for module in modules:
+            module_path = Path(str(module).replace(".", "/"))
+            module_dir = output_dir / module_path
+            written = self.scaffold_integration_tests(
+                [module_path.name], output_dir=module_dir
+            )
+            integration_tests.update(
+                {str(module_path / name): content for name, content in written.items()}
+            )
+
         if integration_names:
             integration_tests.update(
                 self.scaffold_integration_tests(

--- a/tests/behavior/features/test_generation/multi_module.feature
+++ b/tests/behavior/features/test_generation/multi_module.feature
@@ -1,0 +1,6 @@
+Feature: Multi-module test generation
+
+  Scenario: Generate integration tests for multiple modules
+    Given a project with multiple modules
+    When the TestAgent generates integration tests
+    Then tests are scaffolded for each module

--- a/tests/behavior/test_test_generation.py
+++ b/tests/behavior/test_test_generation.py
@@ -1,0 +1,44 @@
+"""End-to-end tests for TestAgent integration test generation."""
+
+from pathlib import Path
+
+import pytest
+from pytest_bdd import given, scenarios, then, when
+
+from devsynth.application.agents.test import TestAgent
+
+pytestmark = pytest.mark.fast
+
+FEATURE_FILE = (
+    Path(__file__).parent / "features" / "test_generation" / "multi_module.feature"
+)
+scenarios(FEATURE_FILE)
+
+
+@given("a project with multiple modules", target_fixture="project")
+def setup_project(tmp_path):
+    return {"output_dir": tmp_path, "modules": ["pkg1", "pkg2.utils"]}
+
+
+@when("the TestAgent generates integration tests")
+def generate_tests(project):
+    agent = TestAgent()
+    inputs = {
+        "modules": project["modules"],
+        "integration_output_dir": project["output_dir"],
+    }
+    project["result"] = agent.process(inputs)
+    project["agent"] = agent
+
+
+@then("tests are scaffolded for each module")
+def check_scaffolded(project):
+    output_dir = project["output_dir"]
+    agent = project["agent"]
+    result = project["result"]
+    assert (output_dir / "pkg1" / "test_pkg1.py").exists()
+    assert (output_dir / "pkg2" / "utils" / "test_utils.py").exists()
+    assert "pkg1/test_pkg1.py" in result["integration_tests"]
+    assert "pkg2/utils/test_utils.py" in result["integration_tests"]
+    run_output = agent.run_generated_tests(output_dir)
+    assert "2 passed" in run_output


### PR DESCRIPTION
## Summary
- extend TestAgent to scaffold integration tests per module
- add end-to-end BDD test for multi-module projects
- document test generation workflow and multi-module usage

## Testing
- `poetry run pre-commit run --files src/devsynth/application/agents/test.py docs/specifications/test_generation_multi_module.md docs/user_guides/test_generation.md tests/behavior/features/test_generation/__init__.py tests/behavior/features/test_generation/multi_module.feature tests/behavior/test_test_generation.py`
- `poetry run devsynth run-tests --speed=fast`
- `poetry run python tests/verify_test_organization.py`
- `poetry run python scripts/verify_test_markers.py` *(fails: KeyboardInterrupt)*
- `poetry run python scripts/verify_requirements_traceability.py`
- `poetry run python scripts/verify_version_sync.py`
- `PIP_NO_INDEX=1 poetry run pip check`


------
https://chatgpt.com/codex/tasks/task_e_68a20e2c78748333a7138841ed5397ba