### PR TITLE
feat: extend sprint hooks and tests

### DIFF
--- a/docs/roadmap/CONSOLIDATED_ROADMAP.md
+++ b/docs/roadmap/CONSOLIDATED_ROADMAP.md
@@ -43,6 +43,10 @@ As of August 15, 2025, the project is finalizing Phase 1 (Foundation Stabilizati
   - Documented lessons learned and best practices in flaky_test_lessons.md
   - Created test stabilization tools and scripts
 
+- **Methodology Integration**:
+  - Extended sprint adapter to cover all EDRR phase hooks
+  - Added behavior tests for the sprint EDRR cycle
+
 The project will transition to Phase 2 (Production Readiness) after publishing `0.1.0-alpha.1`.
 
 ## Phased Roadmap

--- a/src/devsynth/methodology/sprint.py
+++ b/src/devsynth/methodology/sprint.py
@@ -67,6 +67,8 @@ class SprintAdapter(BaseMethodologyAdapter):
             "quality_metrics": {},
             "velocity": [],
             "retrospective_reviews": [],
+            "inconsistencies_detected": [],
+            "relationships_modeled": [],
         }
 
         # Map sprint ceremonies to their corresponding EDRR phases. Start with
@@ -256,6 +258,60 @@ class SprintAdapter(BaseMethodologyAdapter):
                 self.sprint_plan.get("planned_scope", [])
             )
         return results
+
+    def before_differentiate(self, context: Dict[str, Any]) -> Dict[str, Any]:
+        """Sprint-specific setup before the Differentiate phase.
+
+        Args:
+            context: The current context.
+
+        Returns:
+            Updated context with phase start timestamp.
+        """
+        context["phase_start_time"] = datetime.datetime.now()
+        return context
+
+    def after_differentiate(
+        self, context: Dict[str, Any], results: Dict[str, Any]
+    ) -> Dict[str, Any]:
+        """Record metrics after the Differentiate phase."""
+        inconsistencies = results.get("inconsistencies")
+        if inconsistencies is not None:
+            self.metrics["inconsistencies_detected"].append(inconsistencies)
+        return results
+
+    def before_refine(self, context: Dict[str, Any]) -> Dict[str, Any]:
+        """Sprint-specific setup before the Refine phase.
+
+        Args:
+            context: The current context.
+
+        Returns:
+            Updated context with phase start timestamp.
+        """
+        context["phase_start_time"] = datetime.datetime.now()
+        return context
+
+    def after_refine(
+        self, context: Dict[str, Any], results: Dict[str, Any]
+    ) -> Dict[str, Any]:
+        """Record metrics after the Refine phase."""
+        relationships = results.get("relationships")
+        if relationships is not None:
+            self.metrics["relationships_modeled"].append(relationships)
+        return results
+
+    def before_retrospect(self, context: Dict[str, Any]) -> Dict[str, Any]:
+        """Sprint-specific setup before the Retrospect phase.
+
+        Args:
+            context: The current context.
+
+        Returns:
+            Updated context with phase start timestamp.
+        """
+        context["phase_start_time"] = datetime.datetime.now()
+        return context
 
     def after_retrospect(
         self, context: Dict[str, Any], results: Dict[str, Any]

--- a/tests/behavior/test_sprint_edrr_cycle.py
+++ b/tests/behavior/test_sprint_edrr_cycle.py
@@ -1,0 +1,86 @@
+import pytest
+
+from devsynth.methodology.base import Phase
+from devsynth.methodology.sprint import SprintAdapter
+
+
+@pytest.mark.medium
+def test_sprint_adapter_phase_hooks():
+    """SprintAdapter processes EDRR cycle hooks for all phases.
+
+    ReqID: FR-88
+    """
+    adapter = SprintAdapter({"settings": {"sprintDuration": 1}})
+    context = adapter.before_cycle()
+
+    expand_ctx = adapter.before_phase(Phase.EXPAND, context)
+    expand_results = adapter.after_phase(
+        Phase.EXPAND,
+        expand_ctx,
+        {
+            "requirements_analysis": {},
+            "processed_artifacts": ["a"],
+            "completed_activities": [
+                "discovery_complete",
+                "classification_complete",
+                "extraction_complete",
+            ],
+        },
+    )
+
+    diff_ctx = adapter.before_phase(Phase.DIFFERENTIATE, context)
+    assert "phase_start_time" in diff_ctx
+    diff_results = adapter.after_phase(
+        Phase.DIFFERENTIATE,
+        diff_ctx,
+        {
+            "inconsistencies": ["gap"],
+            "completed_activities": ["validation_complete", "gap_analysis_complete"],
+        },
+    )
+    assert adapter.metrics["inconsistencies_detected"][-1] == ["gap"]
+
+    refine_ctx = adapter.before_phase(Phase.REFINE, context)
+    assert "phase_start_time" in refine_ctx
+    refine_results = adapter.after_phase(
+        Phase.REFINE,
+        refine_ctx,
+        {
+            "relationships": ["rel"],
+            "completed_activities": [
+                "context_merging_complete",
+                "relationship_modeling_complete",
+            ],
+        },
+    )
+    assert adapter.metrics["relationships_modeled"][-1] == ["rel"]
+
+    retro_ctx = adapter.before_phase(Phase.RETROSPECT, context)
+    assert "phase_start_time" in retro_ctx
+    retro_results = adapter.after_phase(
+        Phase.RETROSPECT,
+        retro_ctx,
+        {
+            "insights": ["improve"],
+            "evaluation": {"score": 1},
+            "next_cycle_recommendations": {
+                "scope": [],
+                "objectives": [],
+                "success_criteria": [],
+            },
+            "completed_activities": [
+                "evaluation_complete",
+                "insight_capture_complete",
+                "planning_complete",
+            ],
+        },
+    )
+
+    cycle_results = {
+        "expand": expand_results,
+        "differentiate": diff_results,
+        "refine": refine_results,
+        "retrospect": retro_results,
+    }
+    adapter.after_cycle(cycle_results)
+    assert adapter.metrics["velocity"][-1]["completed_items"] == 1


### PR DESCRIPTION
## Summary
- track differentiate and refine details in SprintAdapter
- exercise sprint EDRR cycle in behavior test
- note sprint hook coverage in roadmap

## Testing
- `poetry run pre-commit run --files docs/roadmap/CONSOLIDATED_ROADMAP.md src/devsynth/methodology/sprint.py tests/behavior/test_sprint_edrr_cycle.py`
- `poetry run devsynth run-tests --speed=medium --target changed` *(failed: timed out)*
- `poetry run pytest tests/behavior/test_sprint_edrr_cycle.py -q`
- `poetry run python tests/verify_test_organization.py`
- `poetry run python scripts/verify_test_markers.py` *(failed: KeyboardInterrupt)*
- `poetry run python scripts/verify_requirements_traceability.py`
- `poetry run python scripts/verify_version_sync.py`


------
https://chatgpt.com/codex/tasks/task_e_68a20e28d1708333a0aa429cf009dda9