### PR TITLE
Add evaluation hooks for dialectical reasoner

### DIFF
--- a/docs/specifications/dialectical_reasoning.md
+++ b/docs/specifications/dialectical_reasoning.md
@@ -1,0 +1,30 @@
+---
+author: DevSynth Team
+date: '2025-08-16'
+last_reviewed: '2025-08-16'
+status: draft
+tags:
+  - specification
+  - dialectical-reasoning
+title: Dialectical Reasoner Evaluation Hooks
+version: '0.1.0-alpha.1'
+---
+<div class="breadcrumbs">
+<a href="../index.md">Documentation</a> &gt; <a href="index.md">Specifications</a> &gt; Dialectical Reasoner Evaluation Hooks
+</div>
+
+# Dialectical Reasoner Evaluation Hooks
+
+## Problem
+
+External collaborators lacked a deterministic way to observe requirement evaluations, making it difficult to audit consensus decisions.
+
+## Solution
+
+The dialectical reasoner exposes evaluation hooks. Registered callbacks receive the ``DialecticalReasoning`` instance and a boolean indicating whether consensus was reached. Hooks execute after every evaluation, even when consensus fails. Exceptions raised by hooks are logged and suppressed so the evaluation workflow continues.
+
+## Verification
+
+- Unit test: a hook receives the reasoning and consensus flag when evaluation succeeds.
+- Unit test: hook exceptions are logged without interrupting evaluation.
+- Unit test: a hook runs when consensus is not reached and receives ``False``.

--- a/docs/specifications/index.md
+++ b/docs/specifications/index.md
@@ -27,6 +27,7 @@ This section contains the official specifications for the DevSynth project, outl
 
 - **[DevSynth Specification MVP Updated](devsynth_specification_mvp_updated.md)**: The current authoritative specification for DevSynth.
 - **[Dialectical Reasoning Persists Results to Memory](dialectical_reasoning_memory_persistence.md)**: Dialectical reasoning results stored with EDRR phases.
+- **[Dialectical Reasoner Evaluation Hooks](dialectical_reasoning.md)**: Callbacks observe reasoning outcomes.
 - **[Impact Assessment Persists Results to Memory](dialectical_reasoning_impact_memory_persistence.md)**: Impact assessments stored with EDRR phases.
 - **[EDRR Specification](edrr_cycle_specification.md)**: Specification for the EDRR cycle.
 - **[WSDE Interaction Specification](wsde_interaction_specification.md)**: Specification for the Wide Sweep, Deep Exploration interaction model.

--- a/src/devsynth/application/requirements/dialectical_reasoner.py
+++ b/src/devsynth/application/requirements/dialectical_reasoner.py
@@ -82,15 +82,19 @@ class DialecticalReasonerService(DialecticalReasonerPort):
     # ------------------------------------------------------------------
     # Hook registration
     # ------------------------------------------------------------------
-    def register_evaluation_hook(self, hook):
+    def register_evaluation_hook(
+        self, hook: Callable[[DialecticalReasoning, bool], None]
+    ) -> None:
         """Register a callback to run after evaluating a change.
 
         The signature mirrors ``WSDETeam.register_dialectical_hook`` so team
-        components can cross-reference requirement evaluations.  Hooks should
-        accept ``(reasoning, consensus)`` and should not raise, though any
-        exception will be logged and suppressed.
+        components can cross-reference requirement evaluations. Hooks must
+        accept ``(reasoning, consensus)`` and should not raise. Any exception
+        raised by a hook will later be logged and suppressed.
         """
 
+        if not callable(hook):
+            raise TypeError("hook must be callable")
         if not hasattr(self, "evaluation_hooks"):
             self.evaluation_hooks = []
         self.evaluation_hooks.append(hook)

--- a/tests/unit/methodology/test_dialectical_reasoner_hooks.py
+++ b/tests/unit/methodology/test_dialectical_reasoner_hooks.py
@@ -1,0 +1,103 @@
+from uuid import uuid4
+
+import pytest
+
+from devsynth.application.requirements.dialectical_reasoner import (
+    ConsensusError,
+    DialecticalReasonerService,
+)
+from devsynth.domain.interfaces.requirement import (
+    ChatRepositoryInterface,
+    DialecticalReasoningRepositoryInterface,
+    ImpactAssessmentRepositoryInterface,
+    RequirementRepositoryInterface,
+)
+from devsynth.domain.models.requirement import RequirementChange
+
+
+class DummyNotification:
+    def notify_change_proposed(self, change):
+        pass
+
+    def notify_change_approved(self, change):
+        pass
+
+    def notify_change_rejected(self, change):
+        pass
+
+    def notify_impact_assessment_completed(self, assessment):
+        pass
+
+
+class DummyLLM:
+    def __init__(self, response: str):
+        self.response = response
+
+    def query(self, prompt: str) -> str:
+        return self.response
+
+
+def _build_service(response: str) -> DialecticalReasonerService:
+    service = DialecticalReasonerService(
+        requirement_repository=RequirementRepositoryInterface(),
+        reasoning_repository=DialecticalReasoningRepositoryInterface(),
+        impact_repository=ImpactAssessmentRepositoryInterface(),
+        chat_repository=ChatRepositoryInterface(),
+        notification_service=DummyNotification(),
+        llm_service=DummyLLM(response),
+    )
+    service._generate_thesis = lambda change: "t"
+    service._generate_antithesis = lambda change: "a"
+    service._generate_arguments = lambda change, t, a: []
+    service._generate_synthesis = lambda change, args: "s"
+    service._generate_conclusion_and_recommendation = lambda change, syn: ("c", "r")
+    return service
+
+
+@pytest.mark.medium
+def test_hook_receives_consensus_flag():
+    service = _build_service("yes")
+    change = RequirementChange(requirement_id=uuid4(), created_by="user")
+    called = {}
+
+    def hook(reasoning, consensus):
+        called["id"] = reasoning.change_id
+        called["consensus"] = consensus
+
+    service.register_evaluation_hook(hook)
+    reasoning = service.evaluate_change(change)
+
+    assert called["consensus"] is True
+    assert called["id"] == change.id
+    assert reasoning.conclusion == "c"
+
+
+@pytest.mark.medium
+def test_hook_runs_on_failure():
+    service = _build_service("no")
+    change = RequirementChange(requirement_id=uuid4(), created_by="user")
+    called = {}
+
+    def hook(reasoning, consensus):
+        called["consensus"] = consensus
+
+    service.register_evaluation_hook(hook)
+    with pytest.raises(ConsensusError):
+        service.evaluate_change(change)
+
+    assert called["consensus"] is False
+
+
+@pytest.mark.medium
+def test_hook_exception_suppressed(caplog):
+    service = _build_service("yes")
+    change = RequirementChange(requirement_id=uuid4(), created_by="user")
+
+    def bad_hook(reasoning, consensus):
+        raise RuntimeError("boom")
+
+    service.register_evaluation_hook(bad_hook)
+    with caplog.at_level("WARNING"):
+        service.evaluate_change(change)
+
+    assert "Evaluation hook failed" in caplog.text


### PR DESCRIPTION
## Summary
- add type-checked evaluation hook registration
- document evaluation hook behavior
- test dialectical reasoner evaluation hooks

## Testing
- `poetry run pre-commit run --files docs/specifications/index.md docs/specifications/dialectical_reasoning.md src/devsynth/application/requirements/dialectical_reasoner.py tests/unit/methodology/test_dialectical_reasoner_hooks.py`
- `poetry run pytest tests/unit/methodology/test_dialectical_reasoner_hooks.py -m medium`
- `poetry run python tests/verify_test_organization.py`
- `poetry run python scripts/verify_test_markers.py`
- `poetry run python scripts/verify_requirements_traceability.py`
- `poetry run python scripts/verify_version_sync.py`


------
https://chatgpt.com/codex/tasks/task_e_68a20e1ddb908333a32b344046e7081b