### PR TITLE
Sync phase recovery hooks to micro cycles

### DIFF
--- a/docs/implementation/edrr_assessment.md
+++ b/docs/implementation/edrr_assessment.md
@@ -158,9 +158,11 @@ helpers ensure phase and micro-cycle limits respect safe defaults. See the
 ## Current Limitations
 
 The EDRR framework now includes recursion handling and automatic phase
-transitions in the coordinator. Micro-cycle utilities and error recovery hooks are now implemented. Advanced optimization algorithms and rich
-monitoring tools are still in development. Visualization dashboards and detailed
-metrics remain on the roadmap along with improved manual override workflows.
+transitions in the coordinator. Micro-cycle utilities, phase recovery hooks,
+and threshold helpers are implemented and validated by unit tests. Advanced
+optimization algorithms and rich monitoring tools are still in development.
+Visualization dashboards and detailed metrics remain on the roadmap along with
+improved manual override workflows.
 
 ## Implementation Plan
 

--- a/src/devsynth/application/edrr/edrr_coordinator_enhanced.py
+++ b/src/devsynth/application/edrr/edrr_coordinator_enhanced.py
@@ -5,6 +5,7 @@ This module extends the EDRRCoordinator class with enhanced phase transition
 logic, quality scoring, and metrics collection.
 """
 
+from copy import deepcopy
 from datetime import datetime
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple, Union
@@ -367,6 +368,16 @@ class EnhancedEDRRCoordinator(EDRRCoordinator):
             parent_phase=parent_phase,
             config=self.config,
         )
+        # Sync phase metrics configuration with parent
+        micro_cycle.phase_metrics.thresholds = deepcopy(self.phase_metrics.thresholds)
+        micro_cycle.phase_metrics.recovery_hooks = {
+            phase: list(hooks)
+            for phase, hooks in self.phase_metrics.recovery_hooks.items()
+        }
+        micro_cycle.phase_metrics.failure_hooks = {
+            phase: list(hooks)
+            for phase, hooks in self.phase_metrics.failure_hooks.items()
+        }
 
         # Start the micro cycle
         micro_cycle.start_cycle(task)


### PR DESCRIPTION
## Summary
- ensure EnhancedEDRRCoordinator copies phase metrics hooks and thresholds to new micro-cycles
- cover phase configuration sync with unit tests
- document recovery hooks and threshold helpers in EDRR assessment

## Testing
- `poetry run pre-commit run --files src/devsynth/application/edrr/edrr_coordinator_enhanced.py tests/unit/application/edrr/test_phase_recovery_helpers.py docs/implementation/edrr_assessment.md`
- `poetry run pytest tests/unit/application/edrr/test_phase_recovery_helpers.py tests/unit/application/edrr/test_recovery_hooks.py -m medium -q`
- `poetry run python tests/verify_test_organization.py`
- `poetry run python scripts/verify_test_markers.py`
- `poetry run python scripts/verify_requirements_traceability.py`
- `poetry run python scripts/verify_version_sync.py`


------
https://chatgpt.com/codex/tasks/task_e_68a20e162a788333bea4d9947173b2b8