### PR TITLE
ci: run dialectical audit and publish log

### DIFF
--- a/.github/workflows/ci.yml.disabled
+++ b/.github/workflows/ci.yml.disabled
@@ -20,6 +20,14 @@ jobs:
           poetry install --with dev --extras tests retrieval chromadb api
       - name: Run security checks
         run: poetry run pre-commit run --all-files bandit safety
+      - name: Run dialectical audit
+        run: poetry run python scripts/dialectical_audit.py
+      - name: Upload dialectical audit log
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: dialectical_audit
+          path: dialectical_audit.log
 
   publish-image:
     needs: security

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -105,7 +105,10 @@ poetry run devsynth run-tests --speed=<cat>
 poetry run python tests/verify_test_organization.py
 poetry run python scripts/verify_requirements_traceability.py
 poetry run python scripts/verify_version_sync.py
+poetry run python scripts/dialectical_audit.py
 ```
+
+The CI pipeline runs the same dialectical audit and fails if any questions remain unresolved. The generated `dialectical_audit.log` is uploaded as a workflow artifact for review.
 
 ## Pull Request Process
 


### PR DESCRIPTION
## Summary
- run dialectical audit during CI and upload the resulting log
- note audit step in contributing guide for local checks

## Testing
- `SKIP=fix-code-blocks poetry run pre-commit run --files .github/workflows/ci.yml.disabled CONTRIBUTING.md`
- `poetry run devsynth run-tests --speed=fast` *(hangs, no output)*
- `poetry run pytest -q` *(fails: ModuleNotFoundError: mkdocs_gen_files; Command not found: mkdocs)*
- `poetry run python tests/verify_test_organization.py`
- `poetry run python scripts/verify_test_markers.py` *(interrupted)*
- `poetry run python scripts/verify_requirements_traceability.py`
- `poetry run python scripts/verify_version_sync.py`


------
https://chatgpt.com/codex/tasks/task_e_68a24eac73a08333b6eb0dc2a0eaf858