### PR TITLE
Add scaffolding and edge-case prompts for generated integration tests

### DIFF
--- a/docs/developer_guides/testing.md
+++ b/docs/developer_guides/testing.md
@@ -419,6 +419,22 @@ All test changes should undergo a brief review cycle before merging:
    [cross_functional_review_process.md](cross_functional_review_process.md)
    for expectations.
 
+### Generated Tests
+
+Automatically produced tests require extra scrutiny before they become part of
+the suite:
+
+1. Scaffold missing integration coverage with
+   `devsynth.testing.generation.scaffold_integration_tests` or
+   `write_scaffolded_tests` to create placeholder modules under
+   `tests/integration/generated/`.
+2. Replace placeholder assertions and remove any `pytest.mark.skip` markers once
+   real behavior is verified.
+3. Apply edge-case prompt templates from `templates/test_generation/` to ensure
+   boundary values and error conditions are exercised.
+4. Re-run marker normalization scripts on the new files before executing
+   `poetry run pre-commit run --files` and the relevant test suites.
+
 ## Enabling Resource-Dependent Tests
 
 Some tests require external services such as LM Studio or the DevSynth CLI. By

--- a/src/devsynth/agents/test_generator.py
+++ b/src/devsynth/agents/test_generator.py
@@ -1,0 +1,77 @@
+"""Prompt utilities for generating edge-case aware tests.
+
+This module exposes helpers that load prompt templates used when requesting
+new tests from language models. The templates live under
+``application/prompts/templates/test_generation`` and cover boundary values
+and error conditions. Missing templates are logged so callers can diagnose
+configuration issues.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Dict
+
+from devsynth.logging_setup import DevSynthLogger
+
+logger = DevSynthLogger(__name__)
+
+_TEMPLATE_DIR = (
+    Path(__file__).resolve().parent
+    / ".."
+    / "application"
+    / "prompts"
+    / "templates"
+    / "test_generation"
+)
+
+
+def _load_template(name: str) -> str:
+    """Return the contents of ``name`` template or an empty string.
+
+    Args:
+        name: Base filename of the template without extension.
+
+    Returns:
+        The stripped template text. Logs a warning when the template is missing
+        so callers can surface configuration problems without raising.
+    """
+
+    path = _TEMPLATE_DIR / f"{name}.md"
+    try:
+        return path.read_text().strip()
+    except FileNotFoundError:
+        logger.warning("Edge case template %s missing at %s", name, path)
+        return ""
+
+
+BOUNDARY_VALUES_PROMPT = _load_template("boundary_values")
+"""Prompt encouraging tests that hit numeric and collection boundaries."""
+
+ERROR_CONDITIONS_PROMPT = _load_template("error_conditions")
+"""Prompt guiding generation of failure-path assertions."""
+
+
+def build_edge_case_prompts() -> Dict[str, str]:
+    """Return available edge-case prompt templates.
+
+    The mapping keys correspond to template names such as ``boundary_values``
+    or ``error_conditions``. Templates that cannot be located are omitted from
+    the result.
+    """
+
+    prompts: Dict[str, str] = {}
+    for key, content in {
+        "boundary_values": BOUNDARY_VALUES_PROMPT,
+        "error_conditions": ERROR_CONDITIONS_PROMPT,
+    }.items():
+        if content:
+            prompts[key] = content
+    return prompts
+
+
+__all__ = [
+    "BOUNDARY_VALUES_PROMPT",
+    "ERROR_CONDITIONS_PROMPT",
+    "build_edge_case_prompts",
+]

--- a/tests/integration/generated/test_generated_module.py
+++ b/tests/integration/generated/test_generated_module.py
@@ -1,0 +1,38 @@
+"""Scaffolded integration test for generated modules.
+
+This file originates from `tests/integration/templates/test_generated_module.py`
+and provides a placeholder example for verifying generated modules. Replace
+its contents with real assertions when implementing tests for actual
+modules.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+pytestmark = [
+    pytest.mark.fast,
+    pytest.mark.skip(reason="Scaffold for generated module integration tests"),
+]
+
+
+def process_data(value: int, output_path: Path) -> Path:
+    """Write a doubled value to ``output_path`` as JSON and return the path."""
+    result = {"doubled": value * 2}
+    output_path.write_text(json.dumps(result))
+    return output_path
+
+
+def test_generated_module_workflow(tmp_path: Path) -> None:
+    """Verify the generated module can create and read output files."""
+    output_file = tmp_path / "result.json"
+    returned_path = process_data(21, output_file)
+
+    assert returned_path == output_file
+    assert output_file.exists(), "process_data should create the file"
+
+    loaded = json.loads(output_file.read_text())
+    assert loaded["doubled"] == 42


### PR DESCRIPTION
## Summary
- scaffold placeholder integration test for generated modules
- introduce edge-case prompt utilities for test generation
- document review workflow for generated tests

## Testing
- `poetry run pre-commit run --files docs/developer_guides/testing.md src/devsynth/agents/test_generator.py tests/integration/generated/test_generated_module.py`
- `poetry run devsynth run-tests --speed=fast` *(fails: Command not found: mkdocs; tests/unit/scripts/test_gen_ref_pages.py::test_gen_ref_pages_matches_examples and tests/behavior/test_documentation_generation.py::test_docs_build)*
- `poetry run python tests/verify_test_organization.py`
- `poetry run python scripts/verify_test_markers.py` *(timeout)*
- `poetry run python scripts/verify_requirements_traceability.py`
- `poetry run python scripts/verify_version_sync.py`


------
https://chatgpt.com/codex/tasks/task_e_68a24e7cf3ac8333be5650f432f2fc60