### PR TITLE
Handle memory flush without flush_updates implementation

### DIFF
--- a/src/devsynth/application/collaboration/collaboration_memory_utils.py
+++ b/src/devsynth/application/collaboration/collaboration_memory_utils.py
@@ -54,7 +54,14 @@ def flush_memory_queue(memory_manager: Any) -> List[tuple[str, MemoryItem]]:
     try:
         if hasattr(memory_manager, "flush_updates"):
             memory_manager.flush_updates()
+        else:
+            flush = getattr(sync_manager, "flush_queue", None)
+            if callable(flush):
+                flush()
+
         wait = getattr(memory_manager, "wait_for_sync", None)
+        if not callable(wait):
+            wait = getattr(sync_manager, "wait_for_async", None)
         if callable(wait):
             import asyncio
             import inspect

--- a/tests/unit/application/collaboration/test_memory_utils_fallback.py
+++ b/tests/unit/application/collaboration/test_memory_utils_fallback.py
@@ -1,0 +1,29 @@
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from devsynth.application.collaboration.collaboration_memory_utils import (
+    flush_memory_queue,
+)
+from devsynth.domain.models.memory import MemoryItem, MemoryType
+
+
+@pytest.mark.medium
+def test_flush_memory_queue_falls_back_to_sync_manager() -> None:
+    """Uses sync manager flush when memory manager lacks flush_updates."""
+
+    item = MemoryItem(id="x", content={}, memory_type=MemoryType.TEAM_STATE)
+    sync_manager = SimpleNamespace(
+        _queue=[("default", item)],
+        flush_queue=MagicMock(),
+        wait_for_async=MagicMock(return_value=asyncio.sleep(0)),
+    )
+    mm = SimpleNamespace(sync_manager=sync_manager)
+
+    flushed = flush_memory_queue(mm)
+
+    sync_manager.flush_queue.assert_called_once()
+    sync_manager.wait_for_async.assert_called_once()
+    assert flushed == [("default", item)]


### PR DESCRIPTION
## Summary
- ensure `flush_memory_queue` falls back to the sync manager when `flush_updates` is unavailable
- add unit test covering the sync-manager flush and wait-for-async path

## Testing
- `poetry run pre-commit run --files src/devsynth/application/collaboration/collaboration_memory_utils.py tests/unit/application/collaboration/test_memory_utils_fallback.py`
- `poetry run pytest tests/unit/application/collaboration/test_memory_utils_edge_cases.py tests/unit/application/collaboration/test_wsde_phase_transition_and_memory_flush.py tests/unit/application/collaboration/test_memory_utils_fallback.py -m "not memory_intensive" --maxfail=1`
- `poetry run pytest tests/integration/general/test_wsde_edrr_component_interactions.py tests/integration/general/test_wsde_edrr_integration_advanced.py tests/integration/general/test_wsde_edrr_integration_end_to_end.py tests/integration/general/test_wsde_memory_edrr_integration.py tests/integration/general/test_wsde_peer_review_memory_integration.py tests/integration/general/test_wsde_peer_review_workflow.py -m "not memory_intensive" --maxfail=1`
- `poetry run python tests/verify_test_organization.py`
- `poetry run python scripts/verify_test_markers.py`
- `poetry run python scripts/verify_requirements_traceability.py`
- `poetry run python scripts/verify_version_sync.py`


------
https://chatgpt.com/codex/tasks/task_e_68a24e4273e083339ffb551bb7e5c9ac