### PR TITLE
Add regression test for run-tests and refine test docs

### DIFF
--- a/docs/developer_guides/testing.md
+++ b/docs/developer_guides/testing.md
@@ -285,16 +285,23 @@ poetry run pytest -q
 
 # pip commands are for installing from PyPI only
 
-```text
 Always run tests with `poetry run devsynth run-tests --speed=<cat>`. Use `--maxfail <n>` to exit after a set number of failures. If `pytest` reports missing packages, run `poetry install` to restore them.
+
+Run each speed category separately to surface any parallel execution issues:
+
+```bash
+poetry run devsynth run-tests --speed=fast
+poetry run devsynth run-tests --speed=medium
+poetry run devsynth run-tests --speed=slow
+```
+
+The test runner automatically disables coverage collection and the `pytest-benchmark` plugin when running in parallel to avoid `pytest-xdist` assertion errors.
 
 Skip resource-heavy tests during routine development by running only fast tests:
 
 ```bash
-
 poetry run devsynth run-tests --speed=fast
-
-```text
+```
 
 Mark such tests with `@pytest.mark.memory_intensive`. For optional services, use resource markers such as `@pytest.mark.requires_resource("lmstudio")` and set `DEVSYNTH_RESOURCE_<NAME>_AVAILABLE=false` to skip them when unavailable.
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,7 +1,7 @@
 [pytest]
 # Run tests sequentially to avoid resource contention with heavy fixtures
-addopts = -p no:warnings --cov=src/devsynth --cov-report=term-missing --cov-fail-under=8
-norecursedirs = templates
+addopts = -p no:warnings -p no:benchmark --cov=src/devsynth --cov-report=term-missing --cov-fail-under=8
+norecursedirs = templates .hypothesis
 # Run tests from the tests directory only
 # This prevents template files from being collected as tests.
 testpaths = tests

--- a/tests/unit/testing/test_run_tests_no_xdist_assertions.py
+++ b/tests/unit/testing/test_run_tests_no_xdist_assertions.py
@@ -1,0 +1,15 @@
+import pytest
+
+from devsynth.testing.run_tests import TARGET_PATHS, run_tests
+
+
+@pytest.mark.fast
+def test_run_tests_completes_without_xdist_assertions(tmp_path, monkeypatch):
+    test_file = tmp_path / "test_dummy.py"
+    test_file.write_text(
+        "import pytest\n\n@pytest.mark.fast\ndef test_dummy():\n    assert True\n"
+    )
+    monkeypatch.setitem(TARGET_PATHS, "unit-tests", str(tmp_path))
+    success, output = run_tests("unit-tests", ["fast"], parallel=True)
+    assert success
+    assert "INTERNALERROR" not in output


### PR DESCRIPTION
## Summary
- Disable pytest-benchmark and ignore `.hypothesis` directories to reduce xdist noise
- Document running `devsynth run-tests` per speed category and note automatic coverage/benchmark disabling
- Add regression test ensuring `run_tests` completes without xdist assertions

## Testing
- `timeout 120s poetry run devsynth run-tests --speed=fast`
- `timeout 120s poetry run devsynth run-tests --speed=medium` *(timeout)*
- `timeout 120s poetry run devsynth run-tests --speed=slow`
- `poetry run python tests/verify_test_organization.py`
- `poetry run python scripts/verify_test_markers.py` *(interrupted)*
- `poetry run python scripts/verify_requirements_traceability.py`
- `poetry run python scripts/verify_version_sync.py`


------
https://chatgpt.com/codex/tasks/task_e_68a24e1e79e883338fe17c74f541fb8f