### PR TITLE
feat: add retry conditions and circuit breaker hooks

### DIFF
--- a/docs/developer_guides/reliability.md
+++ b/docs/developer_guides/reliability.md
@@ -1,0 +1,75 @@
+---
+author: DevSynth Team
+date: '2025-02-19'
+last_reviewed: '2025-02-19'
+status: draft
+tags:
+  - reliability
+  - retries
+  - circuit-breaker
+
+title: Reliability Patterns
+version: "0.1.0-alpha.1"
+---
+<div class="breadcrumbs">
+<a href="../index.md">Documentation</a> &gt; <a href="index.md">Developer Guides</a> &gt; Reliability Patterns
+</div>
+
+<div class="breadcrumbs">
+<a href="../index.md">Documentation</a> &gt; <a href="index.md">Developer Guides</a> &gt; Reliability Patterns
+</div>
+
+# Reliability Patterns
+
+DevSynth provides helpers for implementing resilient services. This guide
+covers two core utilities from `devsynth.fallback`.
+
+## Configurable Retry Conditions
+
+`retry_with_exponential_backoff` accepts a `condition_callbacks` mapping that
+allows custom logic to veto retries. Each callback receives the raised
+exception and the current attempt number:
+
+```python
+from devsynth.fallback import retry_with_exponential_backoff
+from devsynth.metrics import get_retry_condition_metrics
+
+policy = {"stop": lambda exc, attempt: attempt < 1}
+
+@retry_with_exponential_backoff(condition_callbacks=policy, max_retries=3)
+def unstable():
+    raise RuntimeError("boom")
+
+try:
+    unstable()
+except RuntimeError:
+    pass
+
+print(get_retry_condition_metrics())
+```
+
+Metrics record whether each callback triggered or suppressed further retries.
+
+## Circuit Breaker Hooks
+
+`CircuitBreaker` emits hooks on state transitions. Hooks receive the protected
+function's name so callers can update dashboards or trigger alerts.
+
+```python
+from devsynth.fallback import CircuitBreaker
+
+events = []
+cb = CircuitBreaker(on_open=lambda name: events.append(f"open:{name}"))
+
+@cb
+def flaky():
+    raise ValueError("oops")
+
+try:
+    flaky()
+except ValueError:
+    pass
+```
+
+`events` now contains `['open:flaky']` and circuit breaker metrics are updated via
+`devsynth.metrics`.

--- a/tests/unit/devsynth/test_fallback_reliability.py
+++ b/tests/unit/devsynth/test_fallback_reliability.py
@@ -1,0 +1,53 @@
+import time
+
+import pytest
+
+from devsynth import metrics
+from devsynth.fallback import (
+    CircuitBreaker,
+    reset_prometheus_metrics,
+    retry_with_exponential_backoff,
+)
+
+
+@pytest.mark.fast
+def test_named_condition_callbacks_record_metrics():
+    reset_prometheus_metrics()
+    calls = []
+
+    def stop(exc: Exception, attempt: int) -> bool:  # pragma: no cover - simple
+        calls.append(attempt)
+        return False
+
+    @retry_with_exponential_backoff(max_retries=1, condition_callbacks={"stop": stop})
+    def boom() -> None:
+        raise ValueError("boom")
+
+    with pytest.raises(ValueError):
+        boom()
+
+    assert calls == [0]
+    metrics_dict = metrics.get_retry_condition_metrics()
+    assert metrics_dict.get("stop:suppress") == 1
+
+
+@pytest.mark.fast
+def test_circuit_breaker_open_hook_and_metrics():
+    reset_prometheus_metrics()
+    events: list[str] = []
+
+    cb = CircuitBreaker(
+        failure_threshold=1,
+        on_open=lambda name: events.append(f"open:{name}"),
+    )
+
+    @cb
+    def flaky() -> None:
+        raise ValueError("boom")
+
+    with pytest.raises(ValueError):
+        flaky()
+
+    assert events == ["open:flaky"]
+    cb_metrics = metrics.get_circuit_breaker_state_metrics()
+    assert cb_metrics["flaky:OPEN"] == 1


### PR DESCRIPTION
## Summary
- allow named retry condition callbacks and record metrics
- emit circuit breaker hooks on state transitions
- document reliability patterns and add regression tests

## Testing
- `poetry run pre-commit run --files src/devsynth/fallback.py docs/developer_guides/reliability.md tests/unit/devsynth/test_fallback_reliability.py`
- `poetry run pre-commit run --files tests/unit/devsynth/test_fallback_reliability.py`
- `poetry run devsynth run-tests --speed=fast`
- `poetry run python tests/verify_test_organization.py`
- `poetry run python scripts/verify_test_markers.py` *(failed: keyboard interrupt)*
- `poetry run python scripts/verify_requirements_traceability.py`
- `poetry run python scripts/verify_version_sync.py`


------
https://chatgpt.com/codex/tasks/task_e_68a24e648f50833388b0850b81199e14