### PR TITLE
Align sprint ceremonies with EDRR phases

### DIFF
--- a/docs/developer_guides/index.md
+++ b/docs/developer_guides/index.md
@@ -34,6 +34,7 @@ This section is for developers contributing to the DevSynth project or those loo
 - **[Dependency Strategy](dependencies.md)**: Overview of optional extras and CI checks.
 - **[Repository Structure](../repo_structure.md)**: An overview of how the DevSynth repository is organized.
 - **[Requirements Wizard Structure](requirements_wizard_structure.md)**: Overview of the requirements wizard helpers.
+- **[Sprint–EDRR Ceremony Alignment](sprint_edrr_ceremony_alignment.md)**: Map sprint ceremonies to EDRR phases.
 - **[Agent Tools](agent_tools.md)**: Overview of the tool registry and how to add new tools.
 - **[Code Analysis Guide](code_analysis.md)**: Overview of repository analysis and AST transformation utilities.
 

--- a/docs/developer_guides/sprint_edrr_ceremony_alignment.md
+++ b/docs/developer_guides/sprint_edrr_ceremony_alignment.md
@@ -1,0 +1,21 @@
+# Sprint–EDRR Ceremony Alignment
+
+This guide explains how sprint ceremonies map to the Expand, Differentiate,
+Refine, and Retrospect (EDRR) phases.
+
+## Ceremony Mapping
+
+- **Planning → Expand**
+- **Standups → Differentiate**
+- **Review → Refine**
+- **Retrospective → Retrospect**
+
+## Integration Steps
+
+1. Instantiate `SprintAdapter` with optional `settings` and ceremony mapping.
+2. Call `get_ceremony_phase` to resolve the EDRR phase for a ceremony such as
+   `planning`, `dailyStandup`, `review`, or `retrospective`.
+3. Use `align_sprint_planning` to associate planning sections with their
+   phases.
+4. Run the sprint cycle; metrics and reports reflect the phase-aligned
+   ceremonies.

--- a/src/devsynth/methodology/sprint_adapter.py
+++ b/src/devsynth/methodology/sprint_adapter.py
@@ -2,9 +2,9 @@
 
 This module provides utilities for working with Agile sprint ceremonies
 within DevSynth's EDRR methodology. The primary helper maps common
-ceremonies such as planning or review to their corresponding EDRR
-:class:`~devsynth.methodology.base.Phase` values so that sprint adapters
-can automatically link ceremonies with EDRR phases.
+ceremonies such as planning, standups, review, or retrospective to their
+corresponding EDRR :class:`~devsynth.methodology.base.Phase` values so
+that sprint adapters can automatically link ceremonies with EDRR phases.
 """
 
 from __future__ import annotations
@@ -19,10 +19,12 @@ CEREMONY_PHASE_MAP: Dict[str, Optional[Phase]] = {
     # Sprint planning occurs before the Expand phase and prepares the scope
     # for the upcoming cycle.
     "planning": Phase.EXPAND,
+    # Daily standups surface blockers and progress checks during the
+    # Differentiate phase.
+    "dailystandup": Phase.DIFFERENTIATE,
+    "standup": Phase.DIFFERENTIATE,
     "review": Phase.REFINE,
     "retrospective": Phase.RETROSPECT,
-    # Daily standups track progress but are not tied to a specific phase.
-    "dailystandup": None,
 }
 
 

--- a/tests/behavior/features/index.md
+++ b/tests/behavior/features/index.md
@@ -139,3 +139,4 @@ This index lists all feature files for easy navigation.
 - [webui/validate_metadata.feature](./webui/validate_metadata.feature)
 - [webui/webapp.feature](./webui/webapp.feature)
 - [wsde/peer_review.feature](./wsde/peer_review.feature)
+- [sprint_edrr/ceremony_alignment.feature](./sprint_edrr/ceremony_alignment.feature)

--- a/tests/behavior/features/sprint_edrr/ceremony_alignment.feature
+++ b/tests/behavior/features/sprint_edrr/ceremony_alignment.feature
@@ -1,0 +1,11 @@
+Feature: Sprint ceremonies align with EDRR phases
+  The SprintAdapter maps common Agile ceremonies to the corresponding EDRR
+  phases so teams can track progress through Expand, Differentiate, Refine,
+  and Retrospect.
+
+  Scenario: Mapping ceremonies to phases
+    Given a sprint adapter
+    Then the "planning" ceremony maps to "expand"
+    And the "dailyStandup" ceremony maps to "differentiate"
+    And the "review" ceremony maps to "refine"
+    And the "retrospective" ceremony maps to "retrospect"

--- a/tests/integration/sprint_edrr/test_ceremony_phase_alignment.py
+++ b/tests/integration/sprint_edrr/test_ceremony_phase_alignment.py
@@ -1,8 +1,13 @@
+import pytest
+
 from devsynth.methodology.base import Phase
 from devsynth.methodology.sprint import SprintAdapter
 
 
+@pytest.mark.medium
 def test_default_ceremony_mapping_aligns_with_edrr():
     adapter = SprintAdapter(config={})
     assert adapter.get_ceremony_phase("planning") is Phase.EXPAND
+    assert adapter.get_ceremony_phase("dailyStandup") is Phase.DIFFERENTIATE
+    assert adapter.get_ceremony_phase("review") is Phase.REFINE
     assert adapter.get_ceremony_phase("retrospective") is Phase.RETROSPECT


### PR DESCRIPTION
## Summary
- map sprint standups and reviews to EDRR phases
- add sprint ceremony behavior spec and docs
- expand integration test coverage for ceremony mapping

## Testing
- `poetry run pre-commit run --files src/devsynth/methodology/sprint_adapter.py tests/integration/sprint_edrr/test_ceremony_phase_alignment.py tests/behavior/features/index.md tests/behavior/features/sprint_edrr/ceremony_alignment.feature tests/behavior/features/sprint_edrr/__init__.py docs/developer_guides/sprint_edrr_ceremony_alignment.md docs/developer_guides/index.md`
- `poetry run devsynth run-tests --speed=fast`
- `poetry run pytest tests/integration/sprint_edrr/test_ceremony_phase_alignment.py tests/integration/sprint_edrr/test_sprint_edrr_integration.py -q`
- `poetry run python tests/verify_test_organization.py`
- `poetry run python scripts/verify_test_markers.py` *(fails: KeyboardInterrupt)*
- `poetry run python scripts/verify_requirements_traceability.py`
- `poetry run python scripts/verify_version_sync.py`


------
https://chatgpt.com/codex/tasks/task_e_68a24e4a9f188333a8ece9ed2b9d5b40