### PR TITLE
feat: add deployment health checks and publishing workflow

### DIFF
--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -1,7 +1,9 @@
-# This workflow is disabled by default. Rename the file to publish-image.yml to enable it.
 name: Publish Docker Image
 
 on:
+  push:
+    tags:
+      - 'v*'
   workflow_dispatch:
 
 jobs:
@@ -11,7 +13,7 @@ jobs:
       contents: read
       packages: write
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
       - name: Log in to GHCR

--- a/docs/deployment/rollback.md
+++ b/docs/deployment/rollback.md
@@ -51,7 +51,7 @@ If you prefer to perform the steps manually, follow the process below.
 4. Verify service health:
 
    ```bash
-   deployment/health_check.sh
+   scripts/deployment/health_check.sh
    ```
 
 ## Tests
@@ -59,8 +59,8 @@ If you prefer to perform the steps manually, follow the process below.
 After performing a rollback, validate the environment:
 
 ```bash
-poetry run pytest tests/unit/deployment
-deployment/health_check.sh
+scripts/deployment/health_check.sh
+poetry run pytest tests/unit/deployment/test_health_check_smoke.py
 ```
 
-These checks confirm that the core services and deployment scripts operate as expected.
+These smoke tests confirm that the core services and deployment scripts operate as expected.

--- a/scripts/deployment/bootstrap.sh
+++ b/scripts/deployment/bootstrap.sh
@@ -20,9 +20,13 @@ if [[ ! " ${ALLOWED_ENVIRONMENTS[*]} " =~ " ${ENVIRONMENT} " ]]; then
   exit 1
 fi
 
-# Ensure Docker is available before continuing
+# Ensure Docker and docker compose are available before continuing
 if ! command -v docker >/dev/null 2>&1; then
   echo "Docker is required but could not be found in PATH." >&2
+  exit 1
+fi
+if ! docker compose version >/dev/null 2>&1; then
+  echo "docker compose is required but unavailable." >&2
   exit 1
 fi
 

--- a/scripts/deployment/health_check.sh
+++ b/scripts/deployment/health_check.sh
@@ -14,6 +14,17 @@ if [[ "$EUID" -eq 0 ]]; then
   exit 1
 fi
 
+# Require a local environment file and enforce strict permissions
+ENV_FILE=${ENV_FILE:-.env}
+if [[ ! -f "$ENV_FILE" ]]; then
+  echo "Missing environment file: $ENV_FILE" >&2
+  exit 1
+fi
+if [[ $(stat -c %a "$ENV_FILE") != "600" ]]; then
+  echo "Environment file $ENV_FILE must have 600 permissions" >&2
+  exit 1
+fi
+
 if ! command -v curl >/dev/null 2>&1; then
   echo "curl is required but could not be found in PATH." >&2
   exit 1

--- a/tests/unit/deployment/test_health_check_smoke.py
+++ b/tests/unit/deployment/test_health_check_smoke.py
@@ -1,0 +1,47 @@
+import shutil
+import subprocess
+import tempfile
+import threading
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[3]
+SCRIPTS_DIR = ROOT / "scripts" / "deployment"
+
+pytestmark = pytest.mark.fast
+
+
+class _Handler(BaseHTTPRequestHandler):
+    def do_GET(self):
+        self.send_response(200)
+        self.end_headers()
+
+
+def test_health_check_script_reports_healthy():
+    """health_check.sh should succeed when endpoints return 200."""
+    server = HTTPServer(("127.0.0.1", 0), _Handler)
+    port = server.server_address[1]
+    thread = threading.Thread(target=server.serve_forever)
+    thread.daemon = True
+    thread.start()
+    workdir = Path(tempfile.mkdtemp())
+    workdir.chmod(0o755)
+    try:
+        env_file = workdir / ".env"
+        env_file.write_text("DEVSYNTH_ENV=testing\n")
+        env_file.chmod(0o600)
+        url = f"http://127.0.0.1:{port}"
+        cmd = f"cd '{workdir}' && {SCRIPTS_DIR / 'health_check.sh'} {url} {url} {url}"
+        result = subprocess.run(
+            ["su", "nobody", "-s", "/bin/bash", "-c", cmd],
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode == 0
+        assert "All services are healthy" in result.stdout
+    finally:
+        server.shutdown()
+        thread.join()
+        shutil.rmtree(workdir)


### PR DESCRIPTION
## Summary
- expand bootstrap checks for docker compose and env permissions
- enforce env file permissions in health check script
- add Docker image publishing workflow and smoke tests

## Testing
- `poetry run pre-commit run --files docs/deployment/rollback.md scripts/deployment/bootstrap.sh scripts/deployment/health_check.sh .github/workflows/publish-image.yml tests/unit/deployment/test_health_check_smoke.py tests/integration/deployment/test_deployment_scripts.py`
- `poetry run devsynth run-tests --speed=fast`
- `poetry run python tests/verify_test_organization.py`
- `poetry run python scripts/verify_test_markers.py` *(fails: KeyboardInterrupt)*
- `poetry run python scripts/verify_requirements_traceability.py` *(fails: KeyboardInterrupt)*
- `poetry run python scripts/verify_version_sync.py`


------
https://chatgpt.com/codex/tasks/task_e_68a24e8c07f883339c2b64c9d4296ea0