### PR TITLE
Add WSDE-EDRR phase coordinator and docs

### DIFF
--- a/docs/implementation/index.md
+++ b/docs/implementation/index.md
@@ -25,6 +25,7 @@ This section provides documentation on the implementation details of DevSynth, i
 - **[Feature Status Matrix](feature_status_matrix.md)**: A matrix showing the status of various features in DevSynth.
 - **[Phase 1 Month 1 Summary](phase1_month1_summary.md)**: A summary of the first month of Phase 1 implementation.
 - **[WSDE Validation](wsde_validation.md)**: Validation of the Wide Sweep, Deep Exploration (WSDE) agent model implementation.
+- **[WSDE-EDRR Workflow](wsde_edrr_workflow.md)**: Finalized phase transition and memory synchronization behavior.
 - **[CLI Overhaul Pseudocode](../specifications/cli_overhaul_pseudocode.md)**: Pseudocode for the refactored `init` command and UXBridge abstraction.
 - **[Init Workflow](../architecture/init_workflow.md)**: Detailed sequence for project initialization.
 - **[UXBridge Interaction Flow](uxbridge_interaction_pseudocode.md)**: How the CLI and WebUI use the shared bridge.

--- a/docs/implementation/wsde_edrr_workflow.md
+++ b/docs/implementation/wsde_edrr_workflow.md
@@ -1,0 +1,36 @@
+---
+title: "WSDE-EDRR Workflow"
+date: "2025-08-01"
+version: "0.1.0-alpha.1"
+tags:
+  - implementation
+  - wsde
+  - edrr
+  - workflow
+status: active
+author: "DevSynth Team"
+last_reviewed: "2025-08-01"
+---
+<div class="breadcrumbs">
+<a href="../index.md">Documentation</a> &gt; <a href="index.md">Implementation</a> &gt; WSDE-EDRR Workflow
+</div>
+
+<div class="breadcrumbs">
+<a href="../index.md">Documentation</a> &gt; <a href="index.md">Implementation</a> &gt; WSDE-EDRR Workflow
+</div>
+
+# WSDE-EDRR Workflow
+
+The finalized WSDE-EDRR workflow links the Worker Self-Directed Enterprise team model with the Expand–Differentiate–Refine–Retrospect methodology.
+
+## Phase Progression
+
+Each transition invokes `progress_roles`, reassigning roles for the new phase and flushing queued memory updates through the provided memory manager. The coordinator retains the mapping so external consumers can inspect current responsibilities.
+
+## Memory Synchronization
+
+Queued updates collected during a phase are flushed on boundary crossing. This prevents collaboration utilities from stalling and keeps cross-store data in sync.
+
+## Role Accessibility
+
+Role assignments for the active phase are accessible via `get_role_assignments`, enabling downstream processes to understand which agent holds a given responsibility.

--- a/src/devsynth/methodology/wsde_edrr_coordinator.py
+++ b/src/devsynth/methodology/wsde_edrr_coordinator.py
@@ -1,0 +1,59 @@
+"""WSDE-aware EDRR phase coordination utilities.
+
+This module bridges the WSDE team model with the EDRR methodology by
+providing minimal helpers to progress through phases while ensuring role
+assignments are updated and queued memory operations are flushed.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Optional
+
+from devsynth.domain.models.wsde_facade import WSDETeam
+from devsynth.domain.wsde.workflow import progress_roles
+from devsynth.methodology.base import Phase
+
+
+class WSDEEDRRCoordinator:
+    """Coordinate EDRR phases for a WSDE team.
+
+    The coordinator keeps track of the current phase and delegates role
+    assignment and memory synchronization to :func:`progress_roles` on each
+    transition.  It stores the resulting assignments so callers can inspect
+    how roles evolve across phases.
+    """
+
+    def __init__(self, team: WSDETeam, memory_manager: Optional[Any] = None) -> None:
+        """Initialize the coordinator.
+
+        Args:
+            team: WSDE team whose roles will be managed.
+            memory_manager: Optional memory manager used for synchronization.
+        """
+
+        self.wsde_team = team
+        self.memory_manager = memory_manager
+        self.current_phase: Optional[Phase] = None
+        self.role_history: Dict[str, Dict[str, str]] = {}
+
+    def progress_to_phase(self, phase: Phase) -> Dict[str, str]:
+        """Advance to ``phase`` and flush queued memory operations.
+
+        Args:
+            phase: The EDRR phase being entered.
+
+        Returns:
+            Mapping of agent identifiers to their assigned roles for the phase.
+        """
+
+        assignments = progress_roles(self.wsde_team, phase, self.memory_manager)
+        self.current_phase = phase
+        self.role_history[phase.name] = assignments
+        return assignments
+
+    def get_role_assignments(self) -> Dict[str, str]:
+        """Return the most recent role assignments for the team."""
+
+        if self.current_phase is None:
+            return {}
+        return self.role_history.get(self.current_phase.name, {})


### PR DESCRIPTION
## Summary
- add WSDEEDRRCoordinator to handle role progression and memory flushes during phase changes
- document finalized WSDE-EDRR workflow and link from implementation index

## Testing
- `poetry run pytest tests/integration/general/test_wsde_edrr_component_interactions.py::TestWSDEEDRRComponentInteractions::test_phase_progression_flushes_memory_queue -q`
- `poetry run python tests/verify_test_organization.py`
- `poetry run python scripts/verify_test_markers.py` *(fails: KeyboardInterrupt)*
- `poetry run python scripts/verify_requirements_traceability.py`
- `poetry run python scripts/verify_version_sync.py`


------
https://chatgpt.com/codex/tasks/task_e_68a24e463ae88333988678401afa6df9