### PR TITLE
feat: strengthen memory synchronization and fallbacks

### DIFF
--- a/src/devsynth/adapters/memory/chroma_db_adapter.py
+++ b/src/devsynth/adapters/memory/chroma_db_adapter.py
@@ -223,6 +223,7 @@ class ChromaDBAdapter(VectorStore):
             self.rollback_transaction(tx_id)
             raise
         else:
+            self.prepare_commit(tx_id)
             self.commit_transaction(tx_id)
 
     def _serialize_metadata(self, vector: MemoryVector) -> Dict[str, Any]:

--- a/src/devsynth/adapters/memory/sync_manager.py
+++ b/src/devsynth/adapters/memory/sync_manager.py
@@ -36,6 +36,11 @@ except Exception as exc:  # pragma: no cover - graceful fallback
     LMDBStore = None  # type: ignore[assignment]
     _LMDB_ERROR = exc
 
+try:  # pragma: no cover - optional dependency
+    from ...application.memory.kuzu_store import KuzuStore
+except Exception:  # pragma: no cover - graceful fallback
+    KuzuStore = None  # type: ignore[assignment]
+
 from ...application.memory.memory_manager import MemoryManager
 from ...application.memory.sync_manager import SyncManager
 
@@ -84,7 +89,9 @@ class MultiStoreSyncManager:
         # Some of the backend stores declare abstract methods which can
         # interfere with instantiation in tests.  Clear the abstract method
         # sets so they behave like concrete classes.
-        for cls in (LMDBStore, FAISSStore, KuzuMemoryStore):
+        for cls in (LMDBStore, FAISSStore, KuzuMemoryStore, KuzuStore):
+            if cls is None:
+                continue
             try:  # pragma: no cover - defensive
                 cls.__abstractmethods__ = frozenset()
             except Exception:

--- a/src/devsynth/application/memory/sync_manager.py
+++ b/src/devsynth/application/memory/sync_manager.py
@@ -578,8 +578,10 @@ class SyncManager:
             adapter = self.memory_manager.adapters.get(name)
             if not adapter:
                 continue
-            if name == "vector" and hasattr(adapter, "similarity_search"):
-                embedding = self.memory_manager._embed_text(query)
+            if hasattr(adapter, "similarity_search"):
+                embedding = self.memory_manager._embed_text(
+                    query, getattr(adapter, "dimension", 5)
+                )
                 results[name] = adapter.similarity_search(embedding, top_k=5)
             elif hasattr(adapter, "search"):
                 results[name] = adapter.search({"content": query})
@@ -604,8 +606,10 @@ class SyncManager:
             adapter = self.memory_manager.adapters.get(name)
             if not adapter:
                 return name, []
-            if name == "vector" and hasattr(adapter, "similarity_search"):
-                embedding = self.memory_manager._embed_text(query)
+            if hasattr(adapter, "similarity_search"):
+                embedding = self.memory_manager._embed_text(
+                    query, getattr(adapter, "dimension", 5)
+                )
                 result = await asyncio.to_thread(
                     adapter.similarity_search, embedding, top_k=5
                 )

--- a/tests/integration/memory/test_cross_store_query.py
+++ b/tests/integration/memory/test_cross_store_query.py
@@ -1,0 +1,39 @@
+import pytest
+
+pytest.importorskip("chromadb")
+
+MultiStoreSyncManager = pytest.importorskip(
+    "devsynth.adapters.memory.sync_manager"
+).MultiStoreSyncManager
+from devsynth.domain.models.memory import MemoryItem, MemoryType, MemoryVector
+
+pytestmark = [
+    pytest.mark.requires_resource("lmdb"),
+    pytest.mark.requires_resource("faiss"),
+    pytest.mark.requires_resource("kuzu"),
+]
+
+
+@pytest.mark.medium
+def test_cross_store_query_returns_results(tmp_path, monkeypatch):
+    """Cross-store queries should return results from all stores. ReqID: FR-60"""
+    ef = pytest.importorskip("chromadb.utils.embedding_functions")
+    monkeypatch.setattr(ef, "DefaultEmbeddingFunction", lambda: (lambda x: [0.0] * 5))
+    manager = MultiStoreSyncManager(str(tmp_path))
+
+    item = MemoryItem(id="q1", content="alpha", memory_type=MemoryType.CODE)
+    vector = MemoryVector(
+        id="q1",
+        content="alpha",
+        embedding=[0.1] * manager.faiss.dimension,
+        metadata={},
+    )
+
+    manager.lmdb.store(item)
+    manager.faiss.store_vector(vector)
+    manager.synchronize_all()
+
+    results = manager.cross_store_query("alpha")
+    assert any(m.id == "q1" for m in results.get("lmdb", []))
+    assert any(m.id == "q1" for m in results.get("kuzu", []))
+    assert any(v.id == "q1" for v in results.get("faiss", []))


### PR DESCRIPTION
## Summary
- guard LMDB imports with graceful fallbacks in memory adapter
- expand sync manager querying across LMDB, FAISS, and Kuzu
- add transactional commit checks in ChromaDB adapter and broaden tests

## Testing
- `poetry run pytest tests/integration/memory/test_chromadb_adapter_transactions.py tests/integration/memory/test_cross_store_query.py -q`
- `poetry run python tests/verify_test_organization.py`
- `poetry run python scripts/verify_version_sync.py`
- `poetry run python scripts/verify_test_markers.py` *(failed: KeyboardInterrupt)*
- `poetry run devsynth run-tests --speed=medium` *(failed: process killed)*


------
https://chatgpt.com/codex/tasks/task_e_68a24e5020d08333887e692199f76e2a