### PR TITLE
docs: clarify test marker guidelines

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,6 +33,7 @@ Thank you for your interest in contributing to DevSynth! This document provides 
 - Adhere to our [coding standards](docs/developer_guides/code_style.md)
 - Update documentation for any changes
 - Ensure all tests pass before submitting a pull request
+- Mark every test with exactly one of `@pytest.mark.fast`, `@pytest.mark.medium`, or `@pytest.mark.slow`; gate high-memory tests with `@pytest.mark.memory_intensive`.
 
 ## Specification and BDD Features
 
@@ -103,6 +104,7 @@ Before opening a pull request, run:
 poetry run pre-commit run --files <changed>
 poetry run devsynth run-tests --speed=<cat>
 poetry run python tests/verify_test_organization.py
+poetry run python scripts/verify_test_markers.py
 poetry run python scripts/verify_requirements_traceability.py
 poetry run python scripts/verify_version_sync.py
 poetry run python scripts/dialectical_audit.py

--- a/docs/developer_guides/contributing.md
+++ b/docs/developer_guides/contributing.md
@@ -218,6 +218,11 @@ poetry run pytest --cov=src --cov-report=term-missing
 - New features must include appropriate tests (unit tests and BDD tests for user-facing features)
 - Bug fixes should include tests that reproduce the bug
 - No significant decrease in code coverage
+- Mark each test with exactly one speed marker:
+  - `@pytest.mark.fast` – under 1 second
+  - `@pytest.mark.medium` – under 5 seconds
+  - `@pytest.mark.slow` – 5 seconds or more
+- Gate high-memory tests with `@pytest.mark.memory_intensive`
 - Pre-commit hooks will enforce the test-first approach by checking for test files
 
 

--- a/issues/Normalize-and-verify-test-markers.md
+++ b/issues/Normalize-and-verify-test-markers.md
@@ -38,6 +38,7 @@ The test suite must ensure each test file contains exactly one speed marker (`fa
 - 2025-08-16: Re-running `poetry run python scripts/verify_test_markers.py` after executing the environment provisioning script still hangs and requires manual interruption.
 - 2025-08-16: Latest attempt processed 150 of 679 files (~18s) before hanging, confirming persistent blocking in `pytest --collect-only`.
 - 2025-08-17: Running `poetry run python scripts/verify_test_markers.py --workers 1` processed 50 of 700 files (~76s) before hanging and required manual interruption.
+- 2025-08-17: Executed `standardize_marker_placement.py`, which updated hundreds of files but introduced syntax errors, so changes were reverted; marker verification still hangs.
 
 ## References
 


### PR DESCRIPTION
## Summary
- document speed-marker and memory-intensive requirements in contributing guides
- record standardization attempt and ongoing verification hangs in marker cleanup issue

## Testing
- `poetry run pre-commit run --files CONTRIBUTING.md docs/developer_guides/contributing.md issues/Normalize-and-verify-test-markers.md`
- `poetry run python tests/verify_test_organization.py`
- `poetry run python scripts/verify_test_markers.py --workers 1` *(fails: KeyboardInterrupt)*
- `poetry run python scripts/verify_requirements_traceability.py`
- `poetry run python scripts/verify_version_sync.py`
- `poetry run devsynth run-tests --speed=fast` *(fails: interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_68a24e18ae888333ae399b90b3f62a76