### PR TITLE
docs: document API reference generation commands

### DIFF
--- a/docs/user_guides/api_reference_generation.md
+++ b/docs/user_guides/api_reference_generation.md
@@ -16,9 +16,22 @@ last_reviewed: "2025-08-08"
 
 # API Reference Generation
 
-This guide explains how to generate API reference pages for DevSynth using the `scripts/gen_ref_pages.py` command. The script scans project source directories, creates a navigation tree, and writes Markdown files under `docs/api_reference/` for inclusion in the documentation site.
+DevSynth can generate API reference pages using the `devsynth generate-docs` command or the underlying `scripts/gen_ref_pages.py` script. Both approaches scan project source directories, create a navigation tree, and write Markdown files under `docs/api_reference/` for inclusion in the documentation site.
 
-## Usage
+## CLI Command
+
+Run the CLI to generate documentation from the current project:
+
+```bash
+poetry run devsynth generate-docs [--path PATH] [--output-dir DIR]
+```
+
+- `--path PATH`: Project directory to analyze (defaults to the current directory).
+- `--output-dir DIR`: Output directory for the generated documentation (defaults to `docs/api_reference`).
+
+See the [CLI Reference](cli_reference.md#generate-docs) for additional options.
+
+## Script Usage
 
 1. Ensure the environment provisioning script has been run and dependencies are installed.
 2. From the repository root, generate API reference pages:

--- a/docs/user_guides/cli_reference.md
+++ b/docs/user_guides/cli_reference.md
@@ -642,6 +642,21 @@ completion
 mvu
 ```
 
+### generate-docs
+
+Generate API reference documentation for the current project.
+
+```bash
+devsynth generate-docs [--path PATH] [--output-dir DIR]
+```
+
+**Options:**
+
+- `--path PATH`: Project directory to analyze (defaults to the current directory).
+- `--output-dir DIR`: Directory for generated documentation (defaults to `docs/api_reference`).
+
+See the [API Reference Generation Guide](api_reference_generation.md) for usage and examples.
+
 ### ingest
 
 Run the Expand, Differentiate, Refine, Retrospect pipeline for a project.

--- a/issues/archived/Document-API-reference-generation-feature.md
+++ b/issues/archived/Document-API-reference-generation-feature.md
@@ -1,7 +1,7 @@
-# Document API reference generation feature
+# Issue 148: Document API reference generation feature
 
-Milestone: 0.1.0-alpha.1
-Status: blocked
+Milestone: 0.1.0-alpha.1 (completed 2025-08-17)
+Status: closed
 
 Priority: medium
 Dependencies: [Resolve remaining dialectical audit questions](Resolve-remaining-dialectical-audit-questions.md)
@@ -20,6 +20,7 @@ Add a user guide or section describing how to generate API reference documentati
 - 2025-02-19: documentation still missing; blocked on audit questions.
 - Confirmed presence of behavior tests for API reference documentation generation without corresponding documentation.
 - Linked with [Resolve remaining dialectical audit questions](Resolve-remaining-dialectical-audit-questions.md).
+- 2025-08-17: API reference generation guide added. Issue resolved.
 
 ## References
 

--- a/tests/behavior/features/general/generate_docs.feature
+++ b/tests/behavior/features/general/generate_docs.feature
@@ -1,3 +1,4 @@
+# Reference: docs/user_guides/api_reference_generation.md
 Feature: API Reference Documentation Generation
   As a developer using DevSynth
   I want to generate API reference documentation


### PR DESCRIPTION
## Summary
- document `devsynth generate-docs` usage and script-based API reference generation
- link CLI reference to API reference generation guide
- archive ticket for API reference generation docs

## Testing
- `poetry run pre-commit run --files docs/user_guides/api_reference_generation.md docs/user_guides/cli_reference.md issues/archived/Document-API-reference-generation-feature.md tests/behavior/features/general/generate_docs.feature`
- `poetry run devsynth run-tests --speed=fast`
- `poetry run python tests/verify_test_organization.py`
- `poetry run python scripts/verify_test_markers.py`
- `poetry run python scripts/verify_requirements_traceability.py`
- `poetry run python scripts/verify_version_sync.py`


------
https://chatgpt.com/codex/tasks/task_e_68a2663f2c8c8333beea6bd98e14dd58