### PR TITLE
docs: add feature cross-references

### DIFF
--- a/dialectical_audit.log
+++ b/dialectical_audit.log
@@ -1,8 +1,10 @@
 {
   "questions": [
+    "Feature 'ChromaDB memory store' has tests but is not documented.",
     "Feature 'MVU shell command execution' has tests but is not documented.",
     "Feature 'Multi-disciplinary dialectical reasoning' has tests but is not documented.",
-    "Feature 'Simple addition input validation' has tests but is not documented."
+    "Feature 'Simple addition input validation' has tests but is not documented.",
+    "Feature 'ChromaDB memory store' is referenced in docs or tests but not in code."
   ],
   "resolved": []
 }

--- a/docs/user_guides/multi_disciplinary_dialectical_reasoning.md
+++ b/docs/user_guides/multi_disciplinary_dialectical_reasoning.md
@@ -1,0 +1,28 @@
+---
+title: "Multi-disciplinary Dialectical Reasoning"
+date: "2025-08-20"
+version: "0.1.0-alpha.1"
+tags:
+  - "dialectical-reasoning"
+  - "wsde"
+status: "draft"
+author: "DevSynth Team"
+last_reviewed: "2025-08-20"
+---
+
+<div class="breadcrumbs">
+<a href="../index.md">Documentation</a> &gt; <a href="index.md">User Guides</a> &gt; Multi-disciplinary Dialectical Reasoning
+</div>
+
+# Multi-disciplinary Dialectical Reasoning
+
+Multi-disciplinary dialectical reasoning gathers perspectives from diverse disciplines to synthesize well-rounded solutions. Use it when problems benefit from inputs across fields.
+
+1. Configure a reasoner with agents representing distinct disciplines.
+2. Pose a complex problem to the reasoner.
+3. Review the synthesized evaluation that cites each discipline.
+
+## References
+
+- [Specification: Multi-disciplinary Dialectical Reasoning](../specifications/multi-disciplinary-dialectical-reasoning.md)
+- [BDD Feature: Multi-disciplinary dialectical reasoning](../../tests/behavior/features/dialectical_reasoning/multi_disciplinary_dialectical_reasoning.feature)

--- a/docs/user_guides/mvu_exec.md
+++ b/docs/user_guides/mvu_exec.md
@@ -23,3 +23,8 @@ devsynth mvu exec echo hello
 ```
 
 The above command prints `hello` and exits with code `0`. Errors from the executed command propagate their non-zero exit codes and error messages.
+
+## References
+
+- [Specification: MVU Command Execution](../specifications/mvu-command-execution.md)
+- [BDD Feature: MVU shell command execution](../../tests/behavior/features/mvu/command_execution.feature)

--- a/docs/user_guides/simple_addition_input_validation.md
+++ b/docs/user_guides/simple_addition_input_validation.md
@@ -1,0 +1,30 @@
+---
+title: "Simple Addition Input Validation"
+date: "2025-08-20"
+version: "0.1.0-alpha.1"
+tags:
+  - "simple-addition"
+  - "validation"
+status: "draft"
+author: "DevSynth Team"
+last_reviewed: "2025-08-20"
+---
+
+<div class="breadcrumbs">
+<a href="../index.md">Documentation</a> &gt; <a href="index.md">User Guides</a> &gt; Simple Addition Input Validation
+</div>
+
+# Simple Addition Input Validation
+
+The `add` function accepts only numeric inputs. Passing non-numeric values raises a `TypeError` to prevent accidental string concatenation or other unintended behavior.
+
+```python
+from devsynth.simple_addition import add
+add(1, 2)        # returns 3
+add("1", "2")   # raises TypeError
+```
+
+## References
+
+- [Specification: Simple Addition Input Validation](../specifications/simple_addition_input_validation.md)
+- [BDD Feature: Simple addition input validation](../../tests/behavior/features/general/simple_addition_input_validation.feature)


### PR DESCRIPTION
## Summary
- expand MVU command execution guide with spec and BDD references
- add multi-disciplinary dialectical reasoning user guide with cross-references
- document simple addition input validation and link to tests/spec

## Testing
- `poetry run pre-commit run --files docs/user_guides/mvu_exec.md docs/user_guides/multi_disciplinary_dialectical_reasoning.md docs/user_guides/simple_addition_input_validation.md dialectical_audit.log` *(fails: find syntax errors in unrelated tests)*
- `poetry run devsynth run-tests --speed=fast` *(fails: LMStudioProvider not available)*
- `poetry run python tests/verify_test_organization.py`
- `poetry run python scripts/verify_test_markers.py` *(fails: collection errors and KeyboardInterrupt)*
- `poetry run python scripts/verify_requirements_traceability.py`
- `poetry run python scripts/verify_version_sync.py`


------
https://chatgpt.com/codex/tasks/task_e_68a3bb7a4a788333b04d50151f51d8dd