### PR TITLE
Document unresolved test marker issues

### DIFF
--- a/docs/implementation/feature_status_matrix.md
+++ b/docs/implementation/feature_status_matrix.md
@@ -85,7 +85,7 @@ Each feature is scored on two dimensions:
 | SDLC Security Policy | Partial | docs/policies/security.md | 3 | 2 | Security Framework | | Configuration flags exist, automated audits planned. Tracked in [issue 111](../../issues/Implement-SDLC-security-audits.md) |
 | Documentation Policies | Complete | docs/policies/documentation_policies.md | 2 | 1 | None | | Policies implemented across documentation |
 | Test Import Performance | Partial | tests/ | 2 | 2 | Testing Infrastructure | | Slow module imports under investigation in [issue](../../issues/Investigate-slow-test-imports.md) |
-| Test Marker Verification | Partial | scripts/verify_test_markers.py, tests/ | 2 | 3 | Testing Infrastructure | | Enforce single speed marker per test. Work tracked in [issue](../../issues/Normalize-and-verify-test-markers.md) |
+| Test Marker Verification | Partial | scripts/verify_test_markers.py, tests/ | 2 | 3 | Testing Infrastructure | | Enforce single speed marker per test. `verify_test_markers.py` still flags misaligned markers in behavior step modules (see [Expand test generation capabilities](../../issues/Expand-test-generation-capabilities.md)). |
 | Test Runner Stability | Partial | scripts/run_tests.sh | 3 | 3 | Testing Infrastructure | | xdist errors tracked in [issue](../../issues/Resolve-medium-test-suite-xdist-KeyError.md) and [issue](../../issues/Resolve-pytest-xdist-assertion-errors.md) |
 | Dialectical Audit Coverage | Partial | scripts/dialectical_audit.py | 3 | 3 | Documentation Policies | | Audit inconsistencies tracked in [issue](../../issues/Dialectical-audit-reports-undocumented-features.md) and [issue](../../issues/Resolve-remaining-dialectical-audit-questions.md) |
 | **Planned/Unimplemented Features** |

--- a/docs/implementation/project_status.md
+++ b/docs/implementation/project_status.md
@@ -69,6 +69,7 @@ Recent fast test runs report **0** failing tests, **51** passing tests, and **30
 ### Test Categorization Progress
 
 - Speed markers applied to **1,362** of **2,459** test functions (55.4%)
+- `verify_test_markers.py` reports misaligned markers in `tests/behavior/steps` (e.g., `test_agent_api_steps.py`), indicating normalization is incomplete.
 - Tests categorized by speed:
   - Fast: 43 tests
   - Medium: 1,265 tests

--- a/issues/Expand-test-generation-capabilities.md
+++ b/issues/Expand-test-generation-capabilities.md
@@ -23,7 +23,7 @@ Automated unit test generation works but integration coverage is lacking.
 - 2025-02-19: LM Studio mock service completed; awaiting marker normalization.
 - Tracked by [c07240c1](../commit/c07240c1).
 - Expanded scenario scaffolding [ce68098d](../commit/ce68098d).
-- 2025-08-20: Marker normalization completed; still awaiting LM Studio mock service.
+- 2025-08-19: Speed marker normalization remains unresolved; `verify_test_markers.py` reports misaligned markers in `tests/behavior/steps` (e.g., `test_agent_api_steps.py`).
 - Further expansion depends on [LM Studio mock service for deterministic tests](archived/LM-Studio-mock-service-for-deterministic-tests.md).
 
 ## References

--- a/test_markers_report.json
+++ b/test_markers_report.json
@@ -1,9967 +1,23 @@
 {
-  "timestamp": "2025-08-18T05:29:52.514132",
+  "timestamp": "2025-08-19T00:05:09.297147",
   "verification": {
-    "directory": "tests",
-    "total_files": 716,
-    "files_with_issues": 423,
-    "total_test_functions": 2515,
-    "total_markers": 1561,
-    "total_misaligned_markers": 2301,
-    "total_duplicate_markers": 115,
-    "total_unrecognized_markers": 1559,
+    "directory": "tests/behavior/steps",
+    "total_files": 152,
+    "files_with_issues": 136,
+    "total_test_functions": 42,
+    "total_markers": 18,
+    "total_misaligned_markers": 1822,
+    "total_duplicate_markers": 29,
+    "total_unrecognized_markers": 18,
     "marker_counts": {
-      "fast": 78,
-      "medium": 1429,
-      "slow": 52,
+      "fast": 0,
+      "medium": 18,
+      "slow": 0,
       "isolation": 0
     },
     "files": {
-      "/workspace/devsynth/tests/performance/test_api_benchmarks.py": {
-        "file_path": "/workspace/devsynth/tests/performance/test_api_benchmarks.py",
-        "has_pytest_import": true,
-        "test_functions": 1,
-        "markers": {
-          "test_health_endpoint_benchmark": "slow"
-        },
-        "tests_with_markers": 1,
-        "tests_without_markers": 0,
-        "misaligned_markers": [],
-        "duplicate_markers": [],
-        "recognized_markers": {
-          "slow": {
-            "file_count": 1,
-            "pytest_count": 0,
-            "recognized": false,
-            "registered_in_pytest_ini": true,
-            "error": "subprocess error: 4",
-            "uncollected_tests": []
-          }
-        },
-        "issues": [
-          {
-            "type": "unrecognized_markers",
-            "message": "slow markers are not recognized by pytest (1 in file, 0 recognized)"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/performance/test_cache_benchmarks.py": {
-        "file_path": "/workspace/devsynth/tests/performance/test_cache_benchmarks.py",
-        "has_pytest_import": true,
-        "test_functions": 2,
-        "markers": {
-          "test_cache_put_benchmark": "slow",
-          "test_cache_get_benchmark": "slow"
-        },
-        "tests_with_markers": 2,
-        "tests_without_markers": 0,
-        "misaligned_markers": [],
-        "duplicate_markers": [],
-        "recognized_markers": {
-          "slow": {
-            "file_count": 2,
-            "pytest_count": 0,
-            "recognized": false,
-            "registered_in_pytest_ini": true,
-            "error": "subprocess error: 4",
-            "uncollected_tests": []
-          }
-        },
-        "issues": [
-          {
-            "type": "unrecognized_markers",
-            "message": "slow markers are not recognized by pytest (2 in file, 0 recognized)"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/property/test_core_values_properties.py": {
-        "file_path": "/workspace/devsynth/tests/property/test_core_values_properties.py",
-        "has_pytest_import": true,
-        "test_functions": 2,
-        "markers": {
-          "test_update_values_deduplicates": "medium",
-          "test_find_value_conflicts_no_negation": "medium"
-        },
-        "tests_with_markers": 2,
-        "tests_without_markers": 0,
-        "misaligned_markers": [],
-        "duplicate_markers": [],
-        "recognized_markers": {
-          "medium": {
-            "file_count": 2,
-            "pytest_count": 0,
-            "recognized": false,
-            "registered_in_pytest_ini": true,
-            "error": "subprocess error: 4",
-            "uncollected_tests": []
-          }
-        },
-        "issues": [
-          {
-            "type": "unrecognized_markers",
-            "message": "medium markers are not recognized by pytest (2 in file, 0 recognized)"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/performance/test_provider_benchmarks.py": {
-        "file_path": "/workspace/devsynth/tests/performance/test_provider_benchmarks.py",
-        "has_pytest_import": true,
-        "test_functions": 2,
-        "markers": {
-          "test_offline_generate_benchmark": "slow",
-          "test_offline_embedding_benchmark": "slow"
-        },
-        "tests_with_markers": 2,
-        "tests_without_markers": 0,
-        "misaligned_markers": [],
-        "duplicate_markers": [],
-        "recognized_markers": {
-          "slow": {
-            "file_count": 2,
-            "pytest_count": 0,
-            "recognized": false,
-            "registered_in_pytest_ini": true,
-            "error": "subprocess error: 4",
-            "uncollected_tests": []
-          }
-        },
-        "issues": [
-          {
-            "type": "unrecognized_markers",
-            "message": "slow markers are not recognized by pytest (2 in file, 0 recognized)"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/performance/test_memory_benchmarks.py": {
-        "file_path": "/workspace/devsynth/tests/performance/test_memory_benchmarks.py",
-        "has_pytest_import": true,
-        "test_functions": 4,
-        "markers": {
-          "test_memory_store_benchmark": "slow",
-          "test_memory_query_benchmark": "slow",
-          "test_json_store_write_benchmark": "slow",
-          "test_json_store_search_benchmark": "slow"
-        },
-        "tests_with_markers": 4,
-        "tests_without_markers": 0,
-        "misaligned_markers": [],
-        "duplicate_markers": [],
-        "recognized_markers": {
-          "slow": {
-            "file_count": 4,
-            "pytest_count": 0,
-            "recognized": false,
-            "registered_in_pytest_ini": true,
-            "error": "subprocess error: 4",
-            "uncollected_tests": []
-          }
-        },
-        "issues": [
-          {
-            "type": "unrecognized_markers",
-            "message": "slow markers are not recognized by pytest (4 in file, 0 recognized)"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/performance/test_orchestration_benchmarks.py": {
-        "file_path": "/workspace/devsynth/tests/performance/test_orchestration_benchmarks.py",
-        "has_pytest_import": true,
-        "test_functions": 1,
-        "markers": {
-          "test_workflow_execution_benchmark": "slow"
-        },
-        "tests_with_markers": 1,
-        "tests_without_markers": 0,
-        "misaligned_markers": [],
-        "duplicate_markers": [],
-        "recognized_markers": {
-          "slow": {
-            "file_count": 1,
-            "pytest_count": 0,
-            "recognized": false,
-            "registered_in_pytest_ini": true,
-            "error": "subprocess error: 4",
-            "uncollected_tests": []
-          }
-        },
-        "issues": [
-          {
-            "type": "unrecognized_markers",
-            "message": "slow markers are not recognized by pytest (1 in file, 0 recognized)"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/performance/test_provider_factory_benchmarks.py": {
-        "file_path": "/workspace/devsynth/tests/performance/test_provider_factory_benchmarks.py",
-        "has_pytest_import": true,
-        "test_functions": 2,
-        "markers": {
-          "test_provider_factory_openai_benchmark": "slow",
-          "test_provider_factory_fallback_benchmark": "slow"
-        },
-        "tests_with_markers": 2,
-        "tests_without_markers": 0,
-        "misaligned_markers": [],
-        "duplicate_markers": [],
-        "recognized_markers": {
-          "slow": {
-            "file_count": 2,
-            "pytest_count": 0,
-            "recognized": false,
-            "registered_in_pytest_ini": true,
-            "error": "subprocess error: 4",
-            "uncollected_tests": []
-          }
-        },
-        "issues": [
-          {
-            "type": "unrecognized_markers",
-            "message": "slow markers are not recognized by pytest (2 in file, 0 recognized)"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/behavior/test_webui_diagnostics_audit.py": {
-        "file_path": "/workspace/devsynth/tests/behavior/test_webui_diagnostics_audit.py",
-        "has_pytest_import": true,
-        "test_functions": 2,
-        "markers": {
-          "test_view_dialectical_audit_log": "medium",
-          "test_audit_log_missing": "medium"
-        },
-        "tests_with_markers": 2,
-        "tests_without_markers": 0,
-        "misaligned_markers": [],
-        "duplicate_markers": [],
-        "recognized_markers": {
-          "medium": {
-            "file_count": 2,
-            "pytest_count": 0,
-            "recognized": false,
-            "registered_in_pytest_ini": true,
-            "error": "subprocess error: 4",
-            "uncollected_tests": []
-          }
-        },
-        "issues": [
-          {
-            "type": "unrecognized_markers",
-            "message": "medium markers are not recognized by pytest (2 in file, 0 recognized)"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/behavior/test_interactive_workflow.py": {
-        "file_path": "/workspace/devsynth/tests/behavior/test_interactive_workflow.py",
-        "has_pytest_import": true,
-        "test_functions": 2,
-        "markers": {
-          "test_run_workflow_cli_succeeds": "medium",
-          "test_run_workflow_webui_succeeds": "medium"
-        },
-        "tests_with_markers": 2,
-        "tests_without_markers": 0,
-        "misaligned_markers": [],
-        "duplicate_markers": [],
-        "recognized_markers": {
-          "medium": {
-            "file_count": 2,
-            "pytest_count": 0,
-            "recognized": false,
-            "registered_in_pytest_ini": true,
-            "error": "subprocess error: 4",
-            "uncollected_tests": []
-          }
-        },
-        "issues": [
-          {
-            "type": "unrecognized_markers",
-            "message": "medium markers are not recognized by pytest (2 in file, 0 recognized)"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/behavior/test_agentapi.py": {
-        "file_path": "/workspace/devsynth/tests/behavior/test_agentapi.py",
-        "has_pytest_import": true,
-        "test_functions": 1,
-        "markers": {
-          "test_json_requests_succeeds": "medium"
-        },
-        "tests_with_markers": 1,
-        "tests_without_markers": 0,
-        "misaligned_markers": [],
-        "duplicate_markers": [],
-        "recognized_markers": {
-          "medium": {
-            "file_count": 1,
-            "pytest_count": 0,
-            "recognized": false,
-            "registered_in_pytest_ini": true,
-            "error": "subprocess error: 4",
-            "uncollected_tests": []
-          }
-        },
-        "issues": [
-          {
-            "type": "unrecognized_markers",
-            "message": "medium markers are not recognized by pytest (1 in file, 0 recognized)"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/behavior/test_sprint_edrr_cycle.py": {
-        "file_path": "/workspace/devsynth/tests/behavior/test_sprint_edrr_cycle.py",
-        "has_pytest_import": true,
-        "test_functions": 1,
-        "markers": {
-          "test_sprint_adapter_phase_hooks": "medium"
-        },
-        "tests_with_markers": 1,
-        "tests_without_markers": 0,
-        "misaligned_markers": [],
-        "duplicate_markers": [],
-        "recognized_markers": {
-          "medium": {
-            "file_count": 1,
-            "pytest_count": 0,
-            "recognized": false,
-            "registered_in_pytest_ini": true,
-            "error": "subprocess error: 4",
-            "uncollected_tests": []
-          }
-        },
-        "issues": [
-          {
-            "type": "unrecognized_markers",
-            "message": "medium markers are not recognized by pytest (1 in file, 0 recognized)"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/behavior/test_documentation_generation.py": {
-        "file_path": "/workspace/devsynth/tests/behavior/test_documentation_generation.py",
-        "has_pytest_import": true,
-        "test_functions": 1,
-        "markers": {
-          "test_docs_build": "fast"
-        },
-        "tests_with_markers": 1,
-        "tests_without_markers": 0,
-        "misaligned_markers": [],
-        "duplicate_markers": [],
-        "recognized_markers": {
-          "fast": {
-            "file_count": 1,
-            "pytest_count": 0,
-            "recognized": false,
-            "registered_in_pytest_ini": true,
-            "error": "subprocess error: 4",
-            "uncollected_tests": []
-          }
-        },
-        "issues": [
-          {
-            "type": "unrecognized_markers",
-            "message": "fast markers are not recognized by pytest (1 in file, 0 recognized)"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/unit/adapters/test_sync_manager.py": {
-        "file_path": "/workspace/devsynth/tests/unit/adapters/test_sync_manager.py",
-        "has_pytest_import": true,
-        "test_functions": 5,
-        "markers": {
-          "test_cross_store_query_returns_results_succeeds": "medium",
-          "test_query_results_cached_succeeds": "medium",
-          "test_cross_store_query_async_succeeds": "medium",
-          "test_queue_updates_from_multiple_tasks_succeeds": "medium",
-          "test_conflict_resolution_with_concurrent_updates": "medium"
-        },
-        "tests_with_markers": 5,
-        "tests_without_markers": 0,
-        "misaligned_markers": [],
-        "duplicate_markers": [],
-        "recognized_markers": {
-          "medium": {
-            "file_count": 5,
-            "pytest_count": 0,
-            "recognized": false,
-            "registered_in_pytest_ini": true,
-            "error": "subprocess error: 4",
-            "uncollected_tests": []
-          }
-        },
-        "issues": [
-          {
-            "type": "unrecognized_markers",
-            "message": "medium markers are not recognized by pytest (5 in file, 0 recognized)"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/behavior/test_cli_webui_parity.py": {
-        "file_path": "/workspace/devsynth/tests/behavior/test_cli_webui_parity.py",
-        "has_pytest_import": true,
-        "test_functions": 4,
-        "markers": {
-          "test_init_parity_succeeds": "medium",
-          "test_spec_parity_succeeds": "medium",
-          "test_code_parity_succeeds": "medium",
-          "test_doctor_parity_succeeds": "medium"
-        },
-        "tests_with_markers": 4,
-        "tests_without_markers": 0,
-        "misaligned_markers": [],
-        "duplicate_markers": [],
-        "recognized_markers": {
-          "medium": {
-            "file_count": 4,
-            "pytest_count": 0,
-            "recognized": false,
-            "registered_in_pytest_ini": true,
-            "error": "subprocess error: 4",
-            "uncollected_tests": []
-          }
-        },
-        "issues": [
-          {
-            "type": "unrecognized_markers",
-            "message": "medium markers are not recognized by pytest (4 in file, 0 recognized)"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/unit/adapters/test_provider_system.py": {
-        "file_path": "/workspace/devsynth/tests/unit/adapters/test_provider_system.py",
-        "has_pytest_import": true,
-        "test_functions": 25,
-        "markers": {
-          "test_embed_success_succeeds": "medium",
-          "test_embed_error_succeeds": "medium",
-          "test_aembed_success_succeeds": "medium",
-          "test_aembed_error_succeeds": "medium",
-          "test_complete_success_succeeds": "medium",
-          "test_complete_error_succeeds": "medium",
-          "test_acomplete_success_succeeds": "medium",
-          "test_acomplete_error_succeeds": "medium",
-          "test_provider_factory_create_provider_succeeds": "medium",
-          "test_get_provider_succeeds": "medium",
-          "test_base_provider_methods_succeeds": "medium",
-          "test_provider_initialization_succeeds": "medium",
-          "test_fallback_provider_succeeds": "medium",
-          "test_get_env_or_default_succeeds": "medium",
-          "test_get_provider_config_has_expected": "medium",
-          "test_openai_provider_complete_has_expected": "medium",
-          "test_openai_provider_complete_error_raises_error": "medium",
-          "test_openai_provider_complete_retry_has_expected": "medium",
-          "test_openai_provider_acomplete_has_expected": "medium",
-          "test_openai_provider_embed_has_expected": "medium",
-          "test_lmstudio_provider_complete_has_expected": "medium",
-          "test_fallback_provider_async_methods_has_expected": "medium",
-          "test_provider_with_empty_inputs_has_expected": "medium",
-          "test_provider_factory_injected_config_selects_provider": "medium",
-          "test_fallback_provider_respects_order": "medium"
-        },
-        "tests_with_markers": 25,
-        "tests_without_markers": 0,
-        "misaligned_markers": [],
-        "duplicate_markers": [],
-        "recognized_markers": {
-          "medium": {
-            "file_count": 25,
-            "pytest_count": 0,
-            "recognized": false,
-            "registered_in_pytest_ini": true,
-            "error": "subprocess error: 4",
-            "uncollected_tests": []
-          }
-        },
-        "issues": [
-          {
-            "type": "unrecognized_markers",
-            "message": "medium markers are not recognized by pytest (25 in file, 0 recognized)"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/unit/adapters/test_kuzu_memory_store.py": {
-        "file_path": "/workspace/devsynth/tests/unit/adapters/test_kuzu_memory_store.py",
-        "has_pytest_import": true,
-        "test_functions": 5,
-        "markers": {
-          "test_store_and_search_succeeds": "medium",
-          "test_create_ephemeral_fallback": "medium",
-          "test_create_ephemeral_embedded": "medium",
-          "test_store_failure_raises_memory_store_error": "medium",
-          "test_delete_returns_false_on_error": "medium"
-        },
-        "tests_with_markers": 5,
-        "tests_without_markers": 0,
-        "misaligned_markers": [],
-        "duplicate_markers": [],
-        "recognized_markers": {
-          "medium": {
-            "file_count": 5,
-            "pytest_count": 0,
-            "recognized": false,
-            "registered_in_pytest_ini": true,
-            "error": "subprocess error: 4",
-            "uncollected_tests": []
-          }
-        },
-        "issues": [
-          {
-            "type": "unrecognized_markers",
-            "message": "medium markers are not recognized by pytest (5 in file, 0 recognized)"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/unit/adapters/test_provider_factory.py": {
-        "file_path": "/workspace/devsynth/tests/unit/adapters/test_provider_factory.py",
-        "has_pytest_import": true,
-        "test_functions": 2,
-        "markers": {
-          "test_create_provider_env_fallback_has_expected": "medium",
-          "test_explicit_openai_missing_key_raises_error": "medium"
-        },
-        "tests_with_markers": 2,
-        "tests_without_markers": 0,
-        "misaligned_markers": [],
-        "duplicate_markers": [],
-        "recognized_markers": {
-          "medium": {
-            "file_count": 2,
-            "pytest_count": 0,
-            "recognized": false,
-            "registered_in_pytest_ini": true,
-            "error": "subprocess error: 4",
-            "uncollected_tests": []
-          }
-        },
-        "issues": [
-          {
-            "type": "unrecognized_markers",
-            "message": "medium markers are not recognized by pytest (2 in file, 0 recognized)"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/unit/adapters/test_chromadb_vector_adapter.py": {
-        "file_path": "/workspace/devsynth/tests/unit/adapters/test_chromadb_vector_adapter.py",
-        "has_pytest_import": true,
-        "test_functions": 3,
-        "markers": {
-          "test_store_and_retrieve_vector": "medium",
-          "test_similarity_search": "medium",
-          "test_delete_vector": "medium"
-        },
-        "tests_with_markers": 3,
-        "tests_without_markers": 0,
-        "misaligned_markers": [],
-        "duplicate_markers": [],
-        "recognized_markers": {
-          "medium": {
-            "file_count": 3,
-            "pytest_count": 0,
-            "recognized": false,
-            "registered_in_pytest_ini": true,
-            "error": "subprocess error: 4",
-            "uncollected_tests": []
-          }
-        },
-        "issues": [
-          {
-            "type": "unrecognized_markers",
-            "message": "medium markers are not recognized by pytest (3 in file, 0 recognized)"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/unit/adapters/test_provider_factory_env_vars.py": {
-        "file_path": "/workspace/devsynth/tests/unit/adapters/test_provider_factory_env_vars.py",
-        "has_pytest_import": true,
-        "test_functions": 2,
-        "markers": {
-          "test_env_provider_openai_succeeds": "medium",
-          "test_env_provider_lmstudio_succeeds": "medium"
-        },
-        "tests_with_markers": 2,
-        "tests_without_markers": 0,
-        "misaligned_markers": [],
-        "duplicate_markers": [],
-        "recognized_markers": {
-          "medium": {
-            "file_count": 2,
-            "pytest_count": 0,
-            "recognized": false,
-            "registered_in_pytest_ini": true,
-            "error": "subprocess error: 4",
-            "uncollected_tests": []
-          }
-        },
-        "issues": [
-          {
-            "type": "unrecognized_markers",
-            "message": "medium markers are not recognized by pytest (2 in file, 0 recognized)"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/unit/adapters/test_chromadb_memory_store.py": {
-        "file_path": "/workspace/devsynth/tests/unit/adapters/test_chromadb_memory_store.py",
-        "has_pytest_import": true,
-        "test_functions": 12,
-        "markers": {
-          "test_initialization_with_default_embedder_has_expected": "medium",
-          "test_initialization_with_provider_system_has_expected": "medium",
-          "test_fallback_to_default_embedder_when_provider_fails": "medium",
-          "test_store_and_retrieve_succeeds": "medium",
-          "test_search_succeeds": "medium",
-          "test_delete_succeeds": "medium",
-          "test_get_all_items_returns_items": "medium",
-          "test_transaction_begin_creates_transaction": "medium",
-          "test_transaction_commit_executes_operations": "medium",
-          "test_transaction_rollback_discards_operations": "medium",
-          "test_transaction_with_multiple_operations": "medium",
-          "test_add_to_transaction_with_invalid_transaction": "medium"
-        },
-        "tests_with_markers": 12,
-        "tests_without_markers": 0,
-        "misaligned_markers": [],
-        "duplicate_markers": [],
-        "recognized_markers": {
-          "medium": {
-            "file_count": 12,
-            "pytest_count": 0,
-            "recognized": false,
-            "registered_in_pytest_ini": true,
-            "error": "subprocess error: 4",
-            "uncollected_tests": []
-          }
-        },
-        "issues": [
-          {
-            "type": "unrecognized_markers",
-            "message": "medium markers are not recognized by pytest (12 in file, 0 recognized)"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/unit/cli/test_command_registry.py": {
-        "file_path": "/workspace/devsynth/tests/unit/cli/test_command_registry.py",
-        "has_pytest_import": true,
-        "test_functions": 2,
-        "markers": {
-          "test_build_app_registers_commands_from_registry": "fast",
-          "test_enable_feature_not_top_level": "fast"
-        },
-        "tests_with_markers": 2,
-        "tests_without_markers": 0,
-        "misaligned_markers": [],
-        "duplicate_markers": [],
-        "recognized_markers": {
-          "fast": {
-            "file_count": 2,
-            "pytest_count": 0,
-            "recognized": false,
-            "registered_in_pytest_ini": true,
-            "error": "subprocess error: 4",
-            "uncollected_tests": []
-          }
-        },
-        "issues": [
-          {
-            "type": "unrecognized_markers",
-            "message": "fast markers are not recognized by pytest (2 in file, 0 recognized)"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/unit/cli/test_completion_progress.py": {
-        "file_path": "/workspace/devsynth/tests/unit/cli/test_completion_progress.py",
-        "has_pytest_import": true,
-        "test_functions": 1,
-        "markers": {
-          "test_completion_cmd_outputs_script_and_progress": "fast"
-        },
-        "tests_with_markers": 1,
-        "tests_without_markers": 0,
-        "misaligned_markers": [],
-        "duplicate_markers": [],
-        "recognized_markers": {
-          "fast": {
-            "file_count": 1,
-            "pytest_count": 0,
-            "recognized": false,
-            "registered_in_pytest_ini": true,
-            "error": "subprocess error: 4",
-            "uncollected_tests": []
-          }
-        },
-        "issues": [
-          {
-            "type": "unrecognized_markers",
-            "message": "fast markers are not recognized by pytest (1 in file, 0 recognized)"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/unit/cli/test_cli_error_handling.py": {
-        "file_path": "/workspace/devsynth/tests/unit/cli/test_cli_error_handling.py",
-        "has_pytest_import": true,
-        "test_functions": 1,
-        "markers": {
-          "test_main_handles_run_cli_errors": "fast"
-        },
-        "tests_with_markers": 1,
-        "tests_without_markers": 0,
-        "misaligned_markers": [],
-        "duplicate_markers": [],
-        "recognized_markers": {
-          "fast": {
-            "file_count": 1,
-            "pytest_count": 0,
-            "recognized": false,
-            "registered_in_pytest_ini": true,
-            "error": "subprocess error: 4",
-            "uncollected_tests": []
-          }
-        },
-        "issues": [
-          {
-            "type": "unrecognized_markers",
-            "message": "fast markers are not recognized by pytest (1 in file, 0 recognized)"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/unit/cli/test_command_module_loading.py": {
-        "file_path": "/workspace/devsynth/tests/unit/cli/test_command_module_loading.py",
-        "has_pytest_import": true,
-        "test_functions": 1,
-        "markers": {
-          "test_command_modules_register_commands_and_build_app": "fast"
-        },
-        "tests_with_markers": 1,
-        "tests_without_markers": 0,
-        "misaligned_markers": [],
-        "duplicate_markers": [],
-        "recognized_markers": {
-          "fast": {
-            "file_count": 1,
-            "pytest_count": 0,
-            "recognized": false,
-            "registered_in_pytest_ini": true,
-            "error": "subprocess error: 4",
-            "uncollected_tests": []
-          }
-        },
-        "issues": [
-          {
-            "type": "unrecognized_markers",
-            "message": "fast markers are not recognized by pytest (1 in file, 0 recognized)"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/unit/cli/test_help_examples.py": {
-        "file_path": "/workspace/devsynth/tests/unit/cli/test_help_examples.py",
-        "has_pytest_import": true,
-        "test_functions": 2,
-        "markers": {
-          "test_get_command_help_includes_examples": "fast",
-          "test_get_command_help_unknown_command": "fast"
-        },
-        "tests_with_markers": 2,
-        "tests_without_markers": 0,
-        "misaligned_markers": [],
-        "duplicate_markers": [
-          {
-            "test_name": "test_get_command_help_unknown_command",
-            "marker_count": 2
-          }
-        ],
-        "recognized_markers": {
-          "fast": {
-            "file_count": 2,
-            "pytest_count": 0,
-            "recognized": false,
-            "registered_in_pytest_ini": true,
-            "error": "subprocess error: 4",
-            "uncollected_tests": []
-          }
-        },
-        "issues": [
-          {
-            "type": "duplicate_markers",
-            "message": "File has 1 tests with duplicate markers"
-          },
-          {
-            "type": "unrecognized_markers",
-            "message": "fast markers are not recognized by pytest (2 in file, 0 recognized)"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/unit/cli/test_cli_entry.py": {
-        "file_path": "/workspace/devsynth/tests/unit/cli/test_cli_entry.py",
-        "has_pytest_import": true,
-        "test_functions": 1,
-        "markers": {
-          "test_cli_entry_invokes_run_cli": "fast"
-        },
-        "tests_with_markers": 1,
-        "tests_without_markers": 0,
-        "misaligned_markers": [],
-        "duplicate_markers": [],
-        "recognized_markers": {
-          "fast": {
-            "file_count": 1,
-            "pytest_count": 0,
-            "recognized": false,
-            "registered_in_pytest_ini": true,
-            "error": "subprocess error: 4",
-            "uncollected_tests": []
-          }
-        },
-        "issues": [
-          {
-            "type": "unrecognized_markers",
-            "message": "fast markers are not recognized by pytest (1 in file, 0 recognized)"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/unit/cli/test_init_features_option.py": {
-        "file_path": "/workspace/devsynth/tests/unit/cli/test_init_features_option.py",
-        "has_pytest_import": true,
-        "test_functions": 2,
-        "markers": {
-          "test_init_cmd_accepts_feature_list": "fast",
-          "test_init_cmd_accepts_feature_json": "fast"
-        },
-        "tests_with_markers": 2,
-        "tests_without_markers": 0,
-        "misaligned_markers": [],
-        "duplicate_markers": [
-          {
-            "test_name": "test_init_cmd_accepts_feature_json",
-            "marker_count": 2
-          }
-        ],
-        "recognized_markers": {
-          "fast": {
-            "file_count": 2,
-            "pytest_count": 0,
-            "recognized": false,
-            "registered_in_pytest_ini": true,
-            "error": "subprocess error: 4",
-            "uncollected_tests": []
-          }
-        },
-        "issues": [
-          {
-            "type": "duplicate_markers",
-            "message": "File has 1 tests with duplicate markers"
-          },
-          {
-            "type": "unrecognized_markers",
-            "message": "fast markers are not recognized by pytest (2 in file, 0 recognized)"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/unit/devsynth/test_simple_addition.py": {
-        "file_path": "/workspace/devsynth/tests/unit/devsynth/test_simple_addition.py",
-        "has_pytest_import": true,
-        "test_functions": 1,
-        "markers": {
-          "test_add_returns_sum": "fast"
-        },
-        "tests_with_markers": 1,
-        "tests_without_markers": 0,
-        "misaligned_markers": [],
-        "duplicate_markers": [],
-        "recognized_markers": {
-          "fast": {
-            "file_count": 1,
-            "pytest_count": 0,
-            "recognized": false,
-            "registered_in_pytest_ini": true,
-            "error": "subprocess error: 4",
-            "uncollected_tests": []
-          }
-        },
-        "issues": [
-          {
-            "type": "unrecognized_markers",
-            "message": "fast markers are not recognized by pytest (1 in file, 0 recognized)"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/unit/devsynth/test_fallback_reliability.py": {
-        "file_path": "/workspace/devsynth/tests/unit/devsynth/test_fallback_reliability.py",
-        "has_pytest_import": true,
-        "test_functions": 2,
-        "markers": {
-          "test_named_condition_callbacks_record_metrics": "fast",
-          "test_circuit_breaker_open_hook_and_metrics": "fast"
-        },
-        "tests_with_markers": 2,
-        "tests_without_markers": 0,
-        "misaligned_markers": [],
-        "duplicate_markers": [],
-        "recognized_markers": {
-          "fast": {
-            "file_count": 2,
-            "pytest_count": 0,
-            "recognized": false,
-            "registered_in_pytest_ini": true,
-            "error": "subprocess error: 4",
-            "uncollected_tests": []
-          }
-        },
-        "issues": [
-          {
-            "type": "unrecognized_markers",
-            "message": "fast markers are not recognized by pytest (2 in file, 0 recognized)"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/unit/agents/test_critique_agent.py": {
-        "file_path": "/workspace/devsynth/tests/unit/agents/test_critique_agent.py",
-        "has_pytest_import": true,
-        "test_functions": 4,
-        "markers": {
-          "test_feedback_loop": "medium",
-          "test_detects_test_failures": "medium",
-          "test_warns_on_missing_docstring": "medium",
-          "test_accepts_docstring": "medium"
-        },
-        "tests_with_markers": 4,
-        "tests_without_markers": 0,
-        "misaligned_markers": [],
-        "duplicate_markers": [],
-        "recognized_markers": {
-          "medium": {
-            "file_count": 4,
-            "pytest_count": 0,
-            "recognized": false,
-            "registered_in_pytest_ini": true,
-            "error": "subprocess error: 4",
-            "uncollected_tests": []
-          }
-        },
-        "issues": [
-          {
-            "type": "unrecognized_markers",
-            "message": "medium markers are not recognized by pytest (4 in file, 0 recognized)"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/unit/general/test_cli.py": {
-        "file_path": "/workspace/devsynth/tests/unit/general/test_cli.py",
-        "has_pytest_import": true,
-        "test_functions": 14,
-        "markers": {
-          "test_show_help_succeeds": "medium",
-          "test_cli_init_succeeds": "medium",
-          "test_cli_spec_succeeds": "medium",
-          "test_cli_test_succeeds": "medium",
-          "test_cli_code_succeeds": "medium",
-          "test_cli_run_succeeds": "medium",
-          "test_cli_config_succeeds": "medium",
-          "test_cli_enable_feature_succeeds": "medium",
-          "test_cli_edrr_cycle_succeeds": "medium",
-          "test_cli_inspect_config_update_succeeds": "medium",
-          "test_cli_inspect_config_prune_succeeds": "medium",
-          "test_cli_spec_invalid_file_succeeds": "medium",
-          "test_cli_config_missing_succeeds": "medium",
-          "test_parse_args_help_has_new_commands_succeeds": "medium"
-        },
-        "tests_with_markers": 14,
-        "tests_without_markers": 0,
-        "misaligned_markers": [],
-        "duplicate_markers": [],
-        "recognized_markers": {
-          "medium": {
-            "file_count": 14,
-            "pytest_count": 0,
-            "recognized": false,
-            "registered_in_pytest_ini": true,
-            "error": "subprocess error: 4",
-            "uncollected_tests": []
-          }
-        },
-        "issues": [
-          {
-            "type": "unrecognized_markers",
-            "message": "medium markers are not recognized by pytest (14 in file, 0 recognized)"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/unit/general/test_requirement_repository_interface.py": {
-        "file_path": "/workspace/devsynth/tests/unit/general/test_requirement_repository_interface.py",
-        "has_pytest_import": true,
-        "test_functions": 1,
-        "markers": {
-          "test_requirement_repository_interface_crud": "fast"
-        },
-        "tests_with_markers": 1,
-        "tests_without_markers": 0,
-        "misaligned_markers": [],
-        "duplicate_markers": [],
-        "recognized_markers": {
-          "fast": {
-            "file_count": 1,
-            "pytest_count": 0,
-            "recognized": false,
-            "registered_in_pytest_ini": true,
-            "error": "subprocess error: 4",
-            "uncollected_tests": []
-          }
-        },
-        "issues": [
-          {
-            "type": "unrecognized_markers",
-            "message": "fast markers are not recognized by pytest (1 in file, 0 recognized)"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/unit/general/test_api.py": {
-        "file_path": "/workspace/devsynth/tests/unit/general/test_api.py",
-        "has_pytest_import": true,
-        "test_functions": 2,
-        "markers": {
-          "test_verify_token_rejects_invalid_token": "fast",
-          "test_health_endpoint_accepts_valid_token": "fast"
-        },
-        "tests_with_markers": 2,
-        "tests_without_markers": 0,
-        "misaligned_markers": [],
-        "duplicate_markers": [],
-        "recognized_markers": {
-          "fast": {
-            "file_count": 2,
-            "pytest_count": 0,
-            "recognized": false,
-            "registered_in_pytest_ini": true,
-            "error": "subprocess error: 4",
-            "uncollected_tests": []
-          }
-        },
-        "issues": [
-          {
-            "type": "unrecognized_markers",
-            "message": "fast markers are not recognized by pytest (2 in file, 0 recognized)"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/unit/general/test_metrics_dashboard_hook.py": {
-        "file_path": "/workspace/devsynth/tests/unit/general/test_metrics_dashboard_hook.py",
-        "has_pytest_import": true,
-        "test_functions": 1,
-        "markers": {
-          "test_dashboard_hook_receives_events": "medium"
-        },
-        "tests_with_markers": 1,
-        "tests_without_markers": 0,
-        "misaligned_markers": [],
-        "duplicate_markers": [],
-        "recognized_markers": {
-          "medium": {
-            "file_count": 1,
-            "pytest_count": 0,
-            "recognized": false,
-            "registered_in_pytest_ini": true,
-            "error": "subprocess error: 4",
-            "uncollected_tests": []
-          }
-        },
-        "issues": [
-          {
-            "type": "unrecognized_markers",
-            "message": "medium markers are not recognized by pytest (1 in file, 0 recognized)"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/unit/general/test_unified_agent.py": {
-        "file_path": "/workspace/devsynth/tests/unit/general/test_unified_agent.py",
-        "has_pytest_import": true,
-        "test_functions": 8,
-        "markers": {
-          "test_agent_initialization_succeeds": "medium",
-          "test_process_specification_task_succeeds": "medium",
-          "test_process_test_task_succeeds": "medium",
-          "test_process_code_task_succeeds": "medium",
-          "test_process_validation_task_is_valid": "medium",
-          "test_process_documentation_task_succeeds": "medium",
-          "test_process_project_initialization_task_succeeds": "medium",
-          "test_process_generic_task_succeeds": "medium"
-        },
-        "tests_with_markers": 8,
-        "tests_without_markers": 0,
-        "misaligned_markers": [],
-        "duplicate_markers": [],
-        "recognized_markers": {
-          "medium": {
-            "file_count": 8,
-            "pytest_count": 0,
-            "recognized": false,
-            "registered_in_pytest_ini": true,
-            "error": "subprocess error: 4",
-            "uncollected_tests": []
-          }
-        },
-        "issues": [
-          {
-            "type": "unrecognized_markers",
-            "message": "medium markers are not recognized by pytest (8 in file, 0 recognized)"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/unit/general/test_speed_option.py": {
-        "file_path": "/workspace/devsynth/tests/unit/general/test_speed_option.py",
-        "has_pytest_import": true,
-        "test_functions": 2,
-        "markers": {
-          "test_speed_option_recognized": "fast",
-          "test_dummy": "fast"
-        },
-        "tests_with_markers": 2,
-        "tests_without_markers": 0,
-        "misaligned_markers": [
-          {
-            "line": 12,
-            "marker": "fast",
-            "text": "\"import pytest\\n@pytest.mark.fast\\ndef test_dummy():\\n    assert True\\n\""
-          }
-        ],
-        "duplicate_markers": [],
-        "recognized_markers": {
-          "fast": {
-            "file_count": 2,
-            "pytest_count": 0,
-            "recognized": false,
-            "registered_in_pytest_ini": true,
-            "error": "subprocess error: 4",
-            "uncollected_tests": []
-          }
-        },
-        "issues": [
-          {
-            "type": "misaligned_markers",
-            "message": "File has 1 misaligned markers"
-          },
-          {
-            "type": "unrecognized_markers",
-            "message": "fast markers are not recognized by pytest (2 in file, 0 recognized)"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/unit/general/test_agent_adapter_delegate.py": {
-        "file_path": "/workspace/devsynth/tests/unit/general/test_agent_adapter_delegate.py",
-        "has_pytest_import": true,
-        "test_functions": 5,
-        "markers": {
-          "test_delegate_task_single_agent_succeeds": "medium",
-          "test_delegate_task_multi_agent_succeeds": "medium",
-          "test_parse_args_runs_succeeds": "medium",
-          "test_show_help_lists_groups": "medium",
-          "test_show_help_fallback_registered_typers": "medium"
-        },
-        "tests_with_markers": 5,
-        "tests_without_markers": 0,
-        "misaligned_markers": [],
-        "duplicate_markers": [],
-        "recognized_markers": {
-          "medium": {
-            "file_count": 5,
-            "pytest_count": 0,
-            "recognized": false,
-            "registered_in_pytest_ini": true,
-            "error": "subprocess error: 4",
-            "uncollected_tests": []
-          }
-        },
-        "issues": [
-          {
-            "type": "unrecognized_markers",
-            "message": "medium markers are not recognized by pytest (5 in file, 0 recognized)"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/unit/general/test_unit_cli_commands.py": {
-        "file_path": "/workspace/devsynth/tests/unit/general/test_unit_cli_commands.py",
-        "has_pytest_import": true,
-        "test_functions": 56,
-        "markers": {
-          "test_init_cmd_success_succeeds": "medium",
-          "test_init_cmd_already_initialized_succeeds": "medium",
-          "test_init_cmd_exception_raises_error": "medium",
-          "test_spec_cmd_success_succeeds": "medium",
-          "test_test_cmd_success_succeeds": "medium",
-          "test_code_cmd_success_succeeds": "medium",
-          "test_run_pipeline_cmd_success_with_target_succeeds": "medium",
-          "test_run_pipeline_cmd_success_without_target_succeeds": "medium",
-          "test_config_cmd_set_value_succeeds": "medium",
-          "test_config_cmd_get_value_succeeds": "medium",
-          "test_config_cmd_list_all_succeeds": "medium",
-          "test_enable_feature_cmd_succeeds": "medium",
-          "test_config_cmd_updates_yaml_succeeds": "medium",
-          "test_enable_feature_cmd_yaml_succeeds": "medium",
-          "test_config_cmd_uses_loader_succeeds": "medium",
-          "test_enable_feature_cmd_loader_succeeds": "medium",
-          "test_enable_feature_cmd_load_error_displays_error": "medium",
-          "test_enable_feature_cmd_save_error_displays_error": "medium",
-          "test_enable_feature_cmd_nonexistent_feature_creates_feature": "medium",
-          "test_enable_feature_cmd_already_enabled_feature_succeeds": "medium",
-          "test_enable_feature_cmd_persists_existing_flags": "medium",
-          "test_init_creates_config_and_commands_use_loader_succeeds": "medium",
-          "test_inspect_cmd_file_succeeds": "medium",
-          "test_inspect_cmd_interactive_succeeds": "medium",
-          "test_spec_cmd_missing_openai_key_succeeds": "medium",
-          "test_spec_cmd_missing_chromadb_package_succeeds": "medium",
-          "test_spec_cmd_missing_kuzu_package_succeeds": "medium",
-          "test_config_key_autocomplete_succeeds": "medium",
-          "test_check_services_warns_succeeds": "medium",
-          "test_doctor_cmd_invokes_loader_succeeds": "medium",
-          "test_check_cmd_alias_succeeds": "medium",
-          "test_gather_cmd_creates_file_succeeds": "medium",
-          "test_init_cmd_wizard_runs_wizard": "medium",
-          "test_spec_cmd_invalid_file": "medium",
-          "test_test_cmd_invalid_file": "medium",
-          "test_code_cmd_no_tests": "medium",
-          "test_run_pipeline_cmd_invalid_target": "medium",
-          "test_config_cmd_invalid_key": "medium",
-          "test_gather_cmd_error_propagates": "medium",
-          "test_refactor_cmd_error": "medium",
-          "test_inspect_cmd_failure": "medium",
-          "test_webapp_cmd_invalid_framework": "medium",
-          "test_serve_cmd_passes_options": "medium",
-          "test_webapp_cmd_flask_succeeds": "medium",
-          "test_webapp_cmd_fastapi_succeeds": "medium",
-          "test_webapp_cmd_existing_dir_without_force_fails": "medium",
-          "test_webapp_cmd_existing_dir_with_force_succeeds": "medium",
-          "test_dbschema_cmd_invalid_type": "medium",
-          "test_dbschema_cmd_sqlite_succeeds": "medium",
-          "test_dbschema_cmd_mysql_succeeds": "medium",
-          "test_dbschema_cmd_mongodb_succeeds": "medium",
-          "test_dbschema_cmd_existing_dir_without_force_fails": "medium",
-          "test_dbschema_cmd_existing_dir_with_force_succeeds": "medium",
-          "test_webui_cmd_success_succeeds": "medium",
-          "test_webui_cmd_import_error_displays_error": "medium",
-          "test_webui_cmd_runtime_error_displays_error": "medium"
-        },
-        "tests_with_markers": 56,
-        "tests_without_markers": 0,
-        "misaligned_markers": [],
-        "duplicate_markers": [
-          {
-            "test_name": "test_config_cmd_invalid_key",
-            "marker_count": 2
-          }
-        ],
-        "recognized_markers": {
-          "medium": {
-            "file_count": 56,
-            "pytest_count": 0,
-            "recognized": false,
-            "registered_in_pytest_ini": true,
-            "error": "subprocess error: 4",
-            "uncollected_tests": []
-          }
-        },
-        "issues": [
-          {
-            "type": "duplicate_markers",
-            "message": "File has 1 tests with duplicate markers"
-          },
-          {
-            "type": "unrecognized_markers",
-            "message": "medium markers are not recognized by pytest (56 in file, 0 recognized)"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/unit/general/test_wsde_team_coordinator.py": {
-        "file_path": "/workspace/devsynth/tests/unit/general/test_wsde_team_coordinator.py",
-        "has_pytest_import": true,
-        "test_functions": 13,
-        "markers": {
-          "test_create_team_succeeds": "medium",
-          "test_add_agent_succeeds": "medium",
-          "test_delegate_task_single_agent_succeeds": "medium",
-          "test_delegate_task_multi_agent_consensus_succeeds": "medium",
-          "test_delegate_task_critical_decision_succeeds": "medium",
-          "test_delegate_task_agent_failure_continues_fails": "medium",
-          "test_delegate_task_propagates_agent_execution_error_raises_error": "medium",
-          "test_delegate_task_coverage_succeeds": "medium",
-          "test_delegate_task_no_team_succeeds": "medium",
-          "test_delegate_task_no_agents_succeeds": "medium",
-          "test_get_team_succeeds": "medium",
-          "test_set_current_team_succeeds": "medium",
-          "test_set_current_team_nonexistent_succeeds": "medium"
-        },
-        "tests_with_markers": 13,
-        "tests_without_markers": 0,
-        "misaligned_markers": [],
-        "duplicate_markers": [],
-        "recognized_markers": {
-          "medium": {
-            "file_count": 13,
-            "pytest_count": 0,
-            "recognized": false,
-            "registered_in_pytest_ini": true,
-            "error": "subprocess error: 4",
-            "uncollected_tests": []
-          }
-        },
-        "issues": [
-          {
-            "type": "unrecognized_markers",
-            "message": "medium markers are not recognized by pytest (13 in file, 0 recognized)"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/unit/general/test_agent_adapter.py": {
-        "file_path": "/workspace/devsynth/tests/unit/general/test_agent_adapter.py",
-        "has_pytest_import": true,
-        "test_functions": 1,
-        "markers": {
-          "test_register_agent_type_succeeds": "medium"
-        },
-        "tests_with_markers": 1,
-        "tests_without_markers": 0,
-        "misaligned_markers": [],
-        "duplicate_markers": [],
-        "recognized_markers": {
-          "medium": {
-            "file_count": 1,
-            "pytest_count": 0,
-            "recognized": false,
-            "registered_in_pytest_ini": true,
-            "error": "subprocess error: 4",
-            "uncollected_tests": []
-          }
-        },
-        "issues": [
-          {
-            "type": "unrecognized_markers",
-            "message": "medium markers are not recognized by pytest (1 in file, 0 recognized)"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/unit/general/test_requirement_repository_port_interface.py": {
-        "file_path": "/workspace/devsynth/tests/unit/general/test_requirement_repository_port_interface.py",
-        "has_pytest_import": true,
-        "test_functions": 2,
-        "markers": {
-          "test_requirement_repository_port_is_abstract": "fast",
-          "test_dummy_requirement_port_methods_raise_not_implemented": "fast"
-        },
-        "tests_with_markers": 2,
-        "tests_without_markers": 0,
-        "misaligned_markers": [],
-        "duplicate_markers": [
-          {
-            "test_name": "test_dummy_requirement_port_methods_raise_not_implemented",
-            "marker_count": 2
-          }
-        ],
-        "recognized_markers": {
-          "fast": {
-            "file_count": 2,
-            "pytest_count": 0,
-            "recognized": false,
-            "registered_in_pytest_ini": true,
-            "error": "subprocess error: 4",
-            "uncollected_tests": []
-          }
-        },
-        "issues": [
-          {
-            "type": "duplicate_markers",
-            "message": "File has 1 tests with duplicate markers"
-          },
-          {
-            "type": "unrecognized_markers",
-            "message": "fast markers are not recognized by pytest (2 in file, 0 recognized)"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/unit/general/test_kuzu_embedded_missing.py": {
-        "file_path": "/workspace/devsynth/tests/unit/general/test_kuzu_embedded_missing.py",
-        "has_pytest_import": true,
-        "test_functions": 1,
-        "markers": {
-          "test_ephemeral_kuzu_store_initialises_without_kuzu_embedded": "fast"
-        },
-        "tests_with_markers": 1,
-        "tests_without_markers": 0,
-        "misaligned_markers": [],
-        "duplicate_markers": [],
-        "recognized_markers": {
-          "fast": {
-            "file_count": 1,
-            "pytest_count": 0,
-            "recognized": false,
-            "registered_in_pytest_ini": true,
-            "error": "subprocess error: 4",
-            "uncollected_tests": []
-          }
-        },
-        "issues": [
-          {
-            "type": "unrecognized_markers",
-            "message": "fast markers are not recognized by pytest (1 in file, 0 recognized)"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/unit/testing/test_run_tests_no_xdist_assertions.py": {
-        "file_path": "/workspace/devsynth/tests/unit/testing/test_run_tests_no_xdist_assertions.py",
-        "has_pytest_import": true,
-        "test_functions": 2,
-        "markers": {
-          "test_run_tests_completes_without_xdist_assertions": "fast",
-          "test_dummy": "fast"
-        },
-        "tests_with_markers": 2,
-        "tests_without_markers": 0,
-        "misaligned_markers": [
-          {
-            "line": 9,
-            "marker": "fast",
-            "text": "\"import pytest\\n\\n@pytest.mark.fast\\ndef test_dummy():\\n    assert True\\n\""
-          }
-        ],
-        "duplicate_markers": [],
-        "recognized_markers": {
-          "fast": {
-            "file_count": 2,
-            "pytest_count": 0,
-            "recognized": false,
-            "registered_in_pytest_ini": true,
-            "error": "subprocess error: 4",
-            "uncollected_tests": []
-          }
-        },
-        "issues": [
-          {
-            "type": "misaligned_markers",
-            "message": "File has 1 misaligned markers"
-          },
-          {
-            "type": "unrecognized_markers",
-            "message": "fast markers are not recognized by pytest (2 in file, 0 recognized)"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/unit/scripts/test_gen_ref_pages.py": {
-        "file_path": "/workspace/devsynth/tests/unit/scripts/test_gen_ref_pages.py",
-        "has_pytest_import": true,
-        "test_functions": 1,
-        "markers": {
-          "test_gen_ref_pages_matches_examples": "fast"
-        },
-        "tests_with_markers": 1,
-        "tests_without_markers": 0,
-        "misaligned_markers": [],
-        "duplicate_markers": [],
-        "recognized_markers": {
-          "fast": {
-            "file_count": 1,
-            "pytest_count": 0,
-            "recognized": false,
-            "registered_in_pytest_ini": true,
-            "error": "subprocess error: 4",
-            "uncollected_tests": []
-          }
-        },
-        "issues": [
-          {
-            "type": "unrecognized_markers",
-            "message": "fast markers are not recognized by pytest (1 in file, 0 recognized)"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/unit/security/test_policy_audit.py": {
-        "file_path": "/workspace/devsynth/tests/unit/security/test_policy_audit.py",
-        "has_pytest_import": true,
-        "test_functions": 2,
-        "markers": {
-          "test_audit_detects_violation": "fast",
-          "test_audit_passes_clean_file": "fast"
-        },
-        "tests_with_markers": 2,
-        "tests_without_markers": 0,
-        "misaligned_markers": [],
-        "duplicate_markers": [],
-        "recognized_markers": {
-          "fast": {
-            "file_count": 2,
-            "pytest_count": 0,
-            "recognized": false,
-            "registered_in_pytest_ini": true,
-            "error": "subprocess error: 4",
-            "uncollected_tests": []
-          }
-        },
-        "issues": [
-          {
-            "type": "unrecognized_markers",
-            "message": "fast markers are not recognized by pytest (2 in file, 0 recognized)"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/unit/security/test_security_audit.py": {
-        "file_path": "/workspace/devsynth/tests/unit/security/test_security_audit.py",
-        "has_pytest_import": true,
-        "test_functions": 5,
-        "markers": {
-          "test_run_executes_checks": "fast",
-          "test_run_raises_on_policy_failure": "fast",
-          "test_report_writes_results": "fast",
-          "test_report_records_failure": "fast",
-          "test_run_requires_pre_deploy": "fast"
-        },
-        "tests_with_markers": 5,
-        "tests_without_markers": 0,
-        "misaligned_markers": [],
-        "duplicate_markers": [],
-        "recognized_markers": {
-          "fast": {
-            "file_count": 5,
-            "pytest_count": 0,
-            "recognized": false,
-            "registered_in_pytest_ini": true,
-            "error": "subprocess error: 4",
-            "uncollected_tests": []
-          }
-        },
-        "issues": [
-          {
-            "type": "unrecognized_markers",
-            "message": "fast markers are not recognized by pytest (5 in file, 0 recognized)"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/unit/security/test_security_audit_cmd.py": {
-        "file_path": "/workspace/devsynth/tests/unit/security/test_security_audit_cmd.py",
-        "has_pytest_import": true,
-        "test_functions": 3,
-        "markers": {
-          "test_security_audit_cmd_runs_checks": "fast",
-          "test_security_audit_cmd_respects_skip_flags": "fast",
-          "test_security_audit_cmd_registered": "fast"
-        },
-        "tests_with_markers": 3,
-        "tests_without_markers": 0,
-        "misaligned_markers": [],
-        "duplicate_markers": [],
-        "recognized_markers": {
-          "fast": {
-            "file_count": 3,
-            "pytest_count": 0,
-            "recognized": false,
-            "registered_in_pytest_ini": true,
-            "error": "subprocess error: 4",
-            "uncollected_tests": []
-          }
-        },
-        "issues": [
-          {
-            "type": "unrecognized_markers",
-            "message": "fast markers are not recognized by pytest (3 in file, 0 recognized)"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/unit/security/test_argon2_hash.py": {
-        "file_path": "/workspace/devsynth/tests/unit/security/test_argon2_hash.py",
-        "has_pytest_import": true,
-        "test_functions": 1,
-        "markers": {
-          "test_argon2_hash_roundtrip": "medium"
-        },
-        "tests_with_markers": 1,
-        "tests_without_markers": 0,
-        "misaligned_markers": [],
-        "duplicate_markers": [],
-        "recognized_markers": {
-          "medium": {
-            "file_count": 1,
-            "pytest_count": 0,
-            "recognized": false,
-            "registered_in_pytest_ini": true,
-            "error": "subprocess error: 4",
-            "uncollected_tests": []
-          }
-        },
-        "issues": [
-          {
-            "type": "unrecognized_markers",
-            "message": "medium markers are not recognized by pytest (1 in file, 0 recognized)"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/unit/security/test_authentication.py": {
-        "file_path": "/workspace/devsynth/tests/unit/security/test_authentication.py",
-        "has_pytest_import": true,
-        "test_functions": 3,
-        "markers": {
-          "test_hash_and_verify_password_succeeds": "medium",
-          "test_authenticate_success_succeeds": "medium",
-          "test_authenticate_failure_succeeds": "medium"
-        },
-        "tests_with_markers": 3,
-        "tests_without_markers": 0,
-        "misaligned_markers": [],
-        "duplicate_markers": [],
-        "recognized_markers": {
-          "medium": {
-            "file_count": 3,
-            "pytest_count": 0,
-            "recognized": false,
-            "registered_in_pytest_ini": true,
-            "error": "subprocess error: 4",
-            "uncollected_tests": []
-          }
-        },
-        "issues": [
-          {
-            "type": "unrecognized_markers",
-            "message": "medium markers are not recognized by pytest (3 in file, 0 recognized)"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/unit/methodology/test_dialectical_reasoner.py": {
-        "file_path": "/workspace/devsynth/tests/unit/methodology/test_dialectical_reasoner.py",
-        "has_pytest_import": true,
-        "test_functions": 3,
-        "markers": {
-          "test_evaluate_change_persists_reasoning_to_memory": "medium",
-          "test_create_session_adds_welcome_message": "medium",
-          "test_process_message_records_conversation": "medium"
-        },
-        "tests_with_markers": 3,
-        "tests_without_markers": 0,
-        "misaligned_markers": [],
-        "duplicate_markers": [],
-        "recognized_markers": {
-          "medium": {
-            "file_count": 3,
-            "pytest_count": 0,
-            "recognized": false,
-            "registered_in_pytest_ini": true,
-            "error": "subprocess error: 4",
-            "uncollected_tests": []
-          }
-        },
-        "issues": [
-          {
-            "type": "unrecognized_markers",
-            "message": "medium markers are not recognized by pytest (3 in file, 0 recognized)"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/unit/methodology/test_dialectical_reasoner_hooks.py": {
-        "file_path": "/workspace/devsynth/tests/unit/methodology/test_dialectical_reasoner_hooks.py",
-        "has_pytest_import": true,
-        "test_functions": 3,
-        "markers": {
-          "test_hook_receives_consensus_flag": "medium",
-          "test_hook_runs_on_failure": "medium",
-          "test_hook_exception_suppressed": "medium"
-        },
-        "tests_with_markers": 3,
-        "tests_without_markers": 0,
-        "misaligned_markers": [],
-        "duplicate_markers": [],
-        "recognized_markers": {
-          "medium": {
-            "file_count": 3,
-            "pytest_count": 0,
-            "recognized": false,
-            "registered_in_pytest_ini": true,
-            "error": "subprocess error: 4",
-            "uncollected_tests": []
-          }
-        },
-        "issues": [
-          {
-            "type": "unrecognized_markers",
-            "message": "medium markers are not recognized by pytest (3 in file, 0 recognized)"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/unit/domain/test_requirement_interfaces.py": {
-        "file_path": "/workspace/devsynth/tests/unit/domain/test_requirement_interfaces.py",
-        "has_pytest_import": true,
-        "test_functions": 5,
-        "markers": {
-          "test_inmemory_requirement_repository_crud": "medium",
-          "test_inmemory_change_repository": "medium",
-          "test_inmemory_impact_assessment_repository": "medium",
-          "test_inmemory_requirement_repository_filters": "medium",
-          "test_dialectical_reasoner_creates_session_and_message": "medium"
-        },
-        "tests_with_markers": 5,
-        "tests_without_markers": 0,
-        "misaligned_markers": [],
-        "duplicate_markers": [],
-        "recognized_markers": {
-          "medium": {
-            "file_count": 5,
-            "pytest_count": 0,
-            "recognized": false,
-            "registered_in_pytest_ini": true,
-            "error": "subprocess error: 4",
-            "uncollected_tests": []
-          }
-        },
-        "issues": [
-          {
-            "type": "unrecognized_markers",
-            "message": "medium markers are not recognized by pytest (5 in file, 0 recognized)"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/unit/domain/test_memory_type.py": {
-        "file_path": "/workspace/devsynth/tests/unit/domain/test_memory_type.py",
-        "has_pytest_import": true,
-        "test_functions": 4,
-        "markers": {
-          "test_memory_type_serialization_deserialization": "medium",
-          "test_working_memory_alias": "medium",
-          "test_memory_type_members_complete": "medium",
-          "test_memory_type_lookup_by_value": "medium"
-        },
-        "tests_with_markers": 4,
-        "tests_without_markers": 0,
-        "misaligned_markers": [],
-        "duplicate_markers": [
-          {
-            "test_name": "test_memory_type_members_complete",
-            "marker_count": 2
-          }
-        ],
-        "recognized_markers": {
-          "medium": {
-            "file_count": 4,
-            "pytest_count": 0,
-            "recognized": false,
-            "registered_in_pytest_ini": true,
-            "error": "subprocess error: 4",
-            "uncollected_tests": []
-          }
-        },
-        "issues": [
-          {
-            "type": "duplicate_markers",
-            "message": "File has 1 tests with duplicate markers"
-          },
-          {
-            "type": "unrecognized_markers",
-            "message": "medium markers are not recognized by pytest (4 in file, 0 recognized)"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/unit/domain/test_primus_selection_edge_cases.py": {
-        "file_path": "/workspace/devsynth/tests/unit/domain/test_primus_selection_edge_cases.py",
-        "has_pytest_import": true,
-        "test_functions": 4,
-        "markers": {
-          "test_rotation_without_expertise_is_deterministic_succeeds": "medium",
-          "test_documentation_task_prefers_doc_agents_succeeds": "medium",
-          "test_has_been_primus_resets_after_full_rotation_succeeds": "medium",
-          "test_edge_case_coverage_succeeds": "medium"
-        },
-        "tests_with_markers": 4,
-        "tests_without_markers": 0,
-        "misaligned_markers": [],
-        "duplicate_markers": [],
-        "recognized_markers": {
-          "medium": {
-            "file_count": 4,
-            "pytest_count": 0,
-            "recognized": false,
-            "registered_in_pytest_ini": true,
-            "error": "subprocess error: 4",
-            "uncollected_tests": []
-          }
-        },
-        "issues": [
-          {
-            "type": "unrecognized_markers",
-            "message": "medium markers are not recognized by pytest (4 in file, 0 recognized)"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/unit/domain/test_wsde_core_methods.py": {
-        "file_path": "/workspace/devsynth/tests/unit/domain/test_wsde_core_methods.py",
-        "has_pytest_import": true,
-        "test_functions": 3,
-        "markers": {
-          "test_assign_roles_sets_roles": "medium",
-          "test_select_primus_by_expertise_prefers_match": "medium",
-          "test_build_consensus_produces_result": "medium"
-        },
-        "tests_with_markers": 3,
-        "tests_without_markers": 0,
-        "misaligned_markers": [],
-        "duplicate_markers": [],
-        "recognized_markers": {
-          "medium": {
-            "file_count": 3,
-            "pytest_count": 0,
-            "recognized": false,
-            "registered_in_pytest_ini": true,
-            "error": "subprocess error: 4",
-            "uncollected_tests": []
-          }
-        },
-        "issues": [
-          {
-            "type": "unrecognized_markers",
-            "message": "medium markers are not recognized by pytest (3 in file, 0 recognized)"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/unit/config/test_exception_handling.py": {
-        "file_path": "/workspace/devsynth/tests/unit/config/test_exception_handling.py",
-        "has_pytest_import": true,
-        "test_functions": 5,
-        "markers": {
-          "test_is_devsynth_managed_project_invalid_toml_returns_false": "fast",
-          "test_unified_config_exists_returns_false_on_invalid_toml": "fast",
-          "test_load_config_malformed_toml_raises_configuration_error": "fast",
-          "test_load_config_invalid_values_raises_configuration_error": "fast",
-          "test_set_default_memory_dir_handles_configuration_error": "fast"
-        },
-        "tests_with_markers": 5,
-        "tests_without_markers": 0,
-        "misaligned_markers": [],
-        "duplicate_markers": [],
-        "recognized_markers": {
-          "fast": {
-            "file_count": 5,
-            "pytest_count": 0,
-            "recognized": false,
-            "registered_in_pytest_ini": true,
-            "error": "subprocess error: 4",
-            "uncollected_tests": []
-          }
-        },
-        "issues": [
-          {
-            "type": "unrecognized_markers",
-            "message": "fast markers are not recognized by pytest (5 in file, 0 recognized)"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/unit/config/test_project_config_validation.py": {
-        "file_path": "/workspace/devsynth/tests/unit/config/test_project_config_validation.py",
-        "has_pytest_import": true,
-        "test_functions": 2,
-        "markers": {
-          "test_valid_project_config_loads_succeeds": "medium",
-          "test_invalid_project_config_raises": "medium"
-        },
-        "tests_with_markers": 2,
-        "tests_without_markers": 0,
-        "misaligned_markers": [],
-        "duplicate_markers": [],
-        "recognized_markers": {
-          "medium": {
-            "file_count": 2,
-            "pytest_count": 0,
-            "recognized": false,
-            "registered_in_pytest_ini": true,
-            "error": "subprocess error: 4",
-            "uncollected_tests": []
-          }
-        },
-        "issues": [
-          {
-            "type": "unrecognized_markers",
-            "message": "medium markers are not recognized by pytest (2 in file, 0 recognized)"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/unit/config/test_config_llm_env.py": {
-        "file_path": "/workspace/devsynth/tests/unit/config/test_config_llm_env.py",
-        "has_pytest_import": true,
-        "test_functions": 1,
-        "markers": {
-          "test_configure_llm_settings_reads_env": "fast"
-        },
-        "tests_with_markers": 1,
-        "tests_without_markers": 0,
-        "misaligned_markers": [],
-        "duplicate_markers": [],
-        "recognized_markers": {
-          "fast": {
-            "file_count": 1,
-            "pytest_count": 0,
-            "recognized": false,
-            "registered_in_pytest_ini": true,
-            "error": "subprocess error: 4",
-            "uncollected_tests": []
-          }
-        },
-        "issues": [
-          {
-            "type": "unrecognized_markers",
-            "message": "fast markers are not recognized by pytest (1 in file, 0 recognized)"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/unit/config/test_config_validation_extended.py": {
-        "file_path": "/workspace/devsynth/tests/unit/config/test_config_validation_extended.py",
-        "has_pytest_import": true,
-        "test_functions": 11,
-        "markers": {
-          "test_invalid_config_type_is_valid": "medium",
-          "test_invalid_config_range_is_valid": "medium",
-          "test_invalid_config_syntax_raises_error": "medium",
-          "test_missing_required_fields_is_valid": "medium",
-          "test_env_var_override_succeeds": "medium",
-          "test_config_file_merging_succeeds": "medium",
-          "test_invalid_feature_flag_is_valid": "medium",
-          "test_unknown_setting_is_valid": "medium",
-          "test_config_with_comments_succeeds": "medium",
-          "test_empty_config_file_succeeds": "medium",
-          "test_config_with_null_values_succeeds": "medium"
-        },
-        "tests_with_markers": 11,
-        "tests_without_markers": 0,
-        "misaligned_markers": [],
-        "duplicate_markers": [],
-        "recognized_markers": {
-          "medium": {
-            "file_count": 11,
-            "pytest_count": 0,
-            "recognized": false,
-            "registered_in_pytest_ini": true,
-            "error": "subprocess error: 4",
-            "uncollected_tests": []
-          }
-        },
-        "issues": [
-          {
-            "type": "unrecognized_markers",
-            "message": "medium markers are not recognized by pytest (11 in file, 0 recognized)"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/unit/config/test_feature_flags_mvuu_gui.py": {
-        "file_path": "/workspace/devsynth/tests/unit/config/test_feature_flags_mvuu_gui.py",
-        "has_pytest_import": true,
-        "test_functions": 1,
-        "markers": {
-          "test_gui_and_mvuu_dashboard_flags_recognized": "medium"
-        },
-        "tests_with_markers": 1,
-        "tests_without_markers": 0,
-        "misaligned_markers": [],
-        "duplicate_markers": [],
-        "recognized_markers": {
-          "medium": {
-            "file_count": 1,
-            "pytest_count": 0,
-            "recognized": false,
-            "registered_in_pytest_ini": true,
-            "error": "subprocess error: 4",
-            "uncollected_tests": []
-          }
-        },
-        "issues": [
-          {
-            "type": "unrecognized_markers",
-            "message": "medium markers are not recognized by pytest (1 in file, 0 recognized)"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/unit/core/test_unified_config_loader.py": {
-        "file_path": "/workspace/devsynth/tests/unit/core/test_unified_config_loader.py",
-        "has_pytest_import": true,
-        "test_functions": 5,
-        "markers": {
-          "test_unified_loader_detects_yaml_succeeds": "medium",
-          "test_unified_loader_detects_pyproject_succeeds": "medium",
-          "test_unified_loader_prefers_pyproject_succeeds": "medium",
-          "test_unified_config_save_updates_pyproject_succeeds": "medium",
-          "test_unified_config_exists_for_both_formats_returns_expected_result": "medium"
-        },
-        "tests_with_markers": 5,
-        "tests_without_markers": 0,
-        "misaligned_markers": [],
-        "duplicate_markers": [],
-        "recognized_markers": {
-          "medium": {
-            "file_count": 5,
-            "pytest_count": 0,
-            "recognized": false,
-            "registered_in_pytest_ini": true,
-            "error": "subprocess error: 4",
-            "uncollected_tests": []
-          }
-        },
-        "issues": [
-          {
-            "type": "unrecognized_markers",
-            "message": "medium markers are not recognized by pytest (5 in file, 0 recognized)"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/unit/core/test_config_loader.py": {
-        "file_path": "/workspace/devsynth/tests/unit/core/test_config_loader.py",
-        "has_pytest_import": true,
-        "test_functions": 5,
-        "markers": {
-          "test_load_from_dev_synth_yaml_succeeds": "medium",
-          "test_load_from_pyproject_toml_succeeds": "medium",
-          "test_yaml_toml_equivalence_succeeds": "medium",
-          "test_load_project_config_yaml_succeeds": "medium",
-          "test_load_project_config_pyproject_succeeds": "medium"
-        },
-        "tests_with_markers": 5,
-        "tests_without_markers": 0,
-        "misaligned_markers": [],
-        "duplicate_markers": [],
-        "recognized_markers": {
-          "medium": {
-            "file_count": 5,
-            "pytest_count": 0,
-            "recognized": false,
-            "registered_in_pytest_ini": true,
-            "error": "subprocess error: 4",
-            "uncollected_tests": []
-          }
-        },
-        "issues": [
-          {
-            "type": "unrecognized_markers",
-            "message": "medium markers are not recognized by pytest (5 in file, 0 recognized)"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/unit/config/test_unified_loader.py": {
-        "file_path": "/workspace/devsynth/tests/unit/config/test_unified_loader.py",
-        "has_pytest_import": true,
-        "test_functions": 4,
-        "markers": {
-          "test_loads_from_pyproject_succeeds": "fast",
-          "test_loads_from_yaml_succeeds": "medium",
-          "test_save_round_trip_yaml_succeeds": "medium",
-          "test_save_round_trip_pyproject_succeeds": "medium"
-        },
-        "tests_with_markers": 4,
-        "tests_without_markers": 0,
-        "misaligned_markers": [],
-        "duplicate_markers": [],
-        "recognized_markers": {
-          "fast": {
-            "file_count": 1,
-            "pytest_count": 0,
-            "recognized": false,
-            "registered_in_pytest_ini": true,
-            "error": "subprocess error: 4",
-            "uncollected_tests": []
-          },
-          "medium": {
-            "file_count": 3,
-            "pytest_count": 0,
-            "recognized": false,
-            "registered_in_pytest_ini": true,
-            "error": "subprocess error: 4",
-            "uncollected_tests": []
-          }
-        },
-        "issues": [
-          {
-            "type": "unrecognized_markers",
-            "message": "fast markers are not recognized by pytest (1 in file, 0 recognized)"
-          },
-          {
-            "type": "unrecognized_markers",
-            "message": "medium markers are not recognized by pytest (3 in file, 0 recognized)"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/unit/docs/test_feature_matrix.py": {
-        "file_path": "/workspace/devsynth/tests/unit/docs/test_feature_matrix.py",
-        "has_pytest_import": true,
-        "test_functions": 1,
-        "markers": {
-          "test_feature_rows_have_status_succeeds": "medium"
-        },
-        "tests_with_markers": 1,
-        "tests_without_markers": 0,
-        "misaligned_markers": [],
-        "duplicate_markers": [],
-        "recognized_markers": {
-          "medium": {
-            "file_count": 1,
-            "pytest_count": 0,
-            "recognized": false,
-            "registered_in_pytest_ini": true,
-            "error": "subprocess error: 4",
-            "uncollected_tests": []
-          }
-        },
-        "issues": [
-          {
-            "type": "unrecognized_markers",
-            "message": "medium markers are not recognized by pytest (1 in file, 0 recognized)"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/unit/docs/test_dialectical_audit.py": {
-        "file_path": "/workspace/devsynth/tests/unit/docs/test_dialectical_audit.py",
-        "has_pytest_import": true,
-        "test_functions": 2,
-        "markers": {
-          "test_fails_when_feature_in_tests_but_not_docs": "fast",
-          "test_fails_when_feature_in_docs_but_not_tests": "fast"
-        },
-        "tests_with_markers": 2,
-        "tests_without_markers": 0,
-        "misaligned_markers": [],
-        "duplicate_markers": [],
-        "recognized_markers": {
-          "fast": {
-            "file_count": 2,
-            "pytest_count": 0,
-            "recognized": false,
-            "registered_in_pytest_ini": true,
-            "error": "subprocess error: 4",
-            "uncollected_tests": []
-          }
-        },
-        "issues": [
-          {
-            "type": "unrecognized_markers",
-            "message": "fast markers are not recognized by pytest (2 in file, 0 recognized)"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/unit/behavior/test_wsde_team_extended.py": {
-        "file_path": "/workspace/devsynth/tests/unit/behavior/test_wsde_team_extended.py",
-        "has_pytest_import": true,
-        "test_functions": 1,
-        "markers": {
-          "test_summarize_and_store_consensus": "medium"
-        },
-        "tests_with_markers": 1,
-        "tests_without_markers": 0,
-        "misaligned_markers": [],
-        "duplicate_markers": [],
-        "recognized_markers": {
-          "medium": {
-            "file_count": 1,
-            "pytest_count": 0,
-            "recognized": false,
-            "registered_in_pytest_ini": true,
-            "error": "subprocess error: 4",
-            "uncollected_tests": []
-          }
-        },
-        "issues": [
-          {
-            "type": "unrecognized_markers",
-            "message": "medium markers are not recognized by pytest (1 in file, 0 recognized)"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/unit/application/test_documentation_fetcher.py": {
-        "file_path": "/workspace/devsynth/tests/unit/application/test_documentation_fetcher.py",
-        "has_pytest_import": true,
-        "test_functions": 5,
-        "markers": {
-          "test_fetch_documentation_offline_without_cache_raises_error": "medium",
-          "test_fetch_documentation_no_source_raises_error": "medium",
-          "test_get_available_versions_no_source_raises_error": "medium",
-          "test_supports_library_returns_false_when_no_source": "medium",
-          "test_mvu_smoke_coverage": "medium"
-        },
-        "tests_with_markers": 5,
-        "tests_without_markers": 0,
-        "misaligned_markers": [],
-        "duplicate_markers": [],
-        "recognized_markers": {
-          "medium": {
-            "file_count": 5,
-            "pytest_count": 0,
-            "recognized": false,
-            "registered_in_pytest_ini": true,
-            "error": "subprocess error: 4",
-            "uncollected_tests": []
-          }
-        },
-        "issues": [
-          {
-            "type": "unrecognized_markers",
-            "message": "medium markers are not recognized by pytest (5 in file, 0 recognized)"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/unit/application/test_prompt_auto_tuning.py": {
-        "file_path": "/workspace/devsynth/tests/unit/application/test_prompt_auto_tuning.py",
-        "has_pytest_import": true,
-        "test_functions": 16,
-        "markers": {
-          "test_initialization_succeeds": "medium",
-          "test_success_rate_succeeds": "medium",
-          "test_average_feedback_score_succeeds": "medium",
-          "test_performance_score_succeeds": "medium",
-          "test_record_usage_succeeds": "medium",
-          "test_to_dict_and_from_dict_succeeds": "medium",
-          "test_register_template_succeeds": "medium",
-          "test_select_variant_single_succeeds": "medium",
-          "test_select_variant_error_succeeds": "medium",
-          "test_select_variant_performance_succeeds": "medium",
-          "test_record_feedback_succeeds": "medium",
-          "test_record_feedback_error_succeeds": "medium",
-          "test_generate_variants_succeeds": "medium",
-          "test_mutation_methods_succeeds": "medium",
-          "test_storage_succeeds": "medium"
-        },
-        "tests_with_markers": 15,
-        "tests_without_markers": 1,
-        "misaligned_markers": [],
-        "duplicate_markers": [
-          {
-            "test_name": "test_initialization_succeeds",
-            "marker_count": 2
-          },
-          {
-            "test_name": "test_initialization_succeeds",
-            "marker_count": 2
-          },
-          {
-            "test_name": "test_select_variant_performance_succeeds",
-            "marker_count": 2
-          }
-        ],
-        "recognized_markers": {
-          "medium": {
-            "file_count": 15,
-            "pytest_count": 0,
-            "recognized": false,
-            "registered_in_pytest_ini": true,
-            "error": "subprocess error: 4",
-            "uncollected_tests": []
-          }
-        },
-        "issues": [
-          {
-            "type": "duplicate_markers",
-            "message": "File has 3 tests with duplicate markers"
-          },
-          {
-            "type": "unrecognized_markers",
-            "message": "medium markers are not recognized by pytest (15 in file, 0 recognized)"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/unit/application/test_offline_provider_cli.py": {
-        "file_path": "/workspace/devsynth/tests/unit/application/test_offline_provider_cli.py",
-        "has_pytest_import": true,
-        "test_functions": 1,
-        "markers": {
-          "test_generate_does_not_call_external_succeeds": "medium"
-        },
-        "tests_with_markers": 1,
-        "tests_without_markers": 0,
-        "misaligned_markers": [],
-        "duplicate_markers": [],
-        "recognized_markers": {
-          "medium": {
-            "file_count": 1,
-            "pytest_count": 0,
-            "recognized": false,
-            "registered_in_pytest_ini": true,
-            "error": "subprocess error: 4",
-            "uncollected_tests": []
-          }
-        },
-        "issues": [
-          {
-            "type": "unrecognized_markers",
-            "message": "medium markers are not recognized by pytest (1 in file, 0 recognized)"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/unit/interface/test_webui_enhanced.py": {
-        "file_path": "/workspace/devsynth/tests/unit/interface/test_webui_enhanced.py",
-        "has_pytest_import": true,
-        "test_functions": 9,
-        "markers": {
-          "test_webui_display_result_highlight_succeeds": "medium",
-          "test_webui_display_result_error_raises_error": "medium",
-          "test_webui_display_result_warning_succeeds": "medium",
-          "test_webui_display_result_success_succeeds": "medium",
-          "test_webui_display_result_heading_succeeds": "medium",
-          "test_webui_display_result_subheading_succeeds": "medium",
-          "test_webui_display_result_rich_markup_succeeds": "medium",
-          "test_webui_display_result_normal_succeeds": "medium",
-          "test_webui_progress_indicator_succeeds": "medium"
-        },
-        "tests_with_markers": 9,
-        "tests_without_markers": 0,
-        "misaligned_markers": [],
-        "duplicate_markers": [],
-        "recognized_markers": {
-          "medium": {
-            "file_count": 9,
-            "pytest_count": 0,
-            "recognized": false,
-            "registered_in_pytest_ini": true,
-            "error": "subprocess error: 4",
-            "uncollected_tests": []
-          }
-        },
-        "issues": [
-          {
-            "type": "unrecognized_markers",
-            "message": "medium markers are not recognized by pytest (9 in file, 0 recognized)"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/unit/application/test_offline_provider_unit.py": {
-        "file_path": "/workspace/devsynth/tests/unit/application/test_offline_provider_unit.py",
-        "has_pytest_import": true,
-        "test_functions": 1,
-        "markers": {
-          "test_offline_provider_instantiation_succeeds": "medium"
-        },
-        "tests_with_markers": 1,
-        "tests_without_markers": 0,
-        "misaligned_markers": [],
-        "duplicate_markers": [],
-        "recognized_markers": {
-          "medium": {
-            "file_count": 1,
-            "pytest_count": 0,
-            "recognized": false,
-            "registered_in_pytest_ini": true,
-            "error": "subprocess error: 4",
-            "uncollected_tests": []
-          }
-        },
-        "issues": [
-          {
-            "type": "unrecognized_markers",
-            "message": "medium markers are not recognized by pytest (1 in file, 0 recognized)"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/unit/interface/test_webui_run_edge_cases.py": {
-        "file_path": "/workspace/devsynth/tests/unit/interface/test_webui_run_edge_cases.py",
-        "has_pytest_import": true,
-        "test_functions": 8,
-        "markers": {
-          "test_run_method_with_invalid_navigation_option": "medium",
-          "test_run_method_with_page_exception_raises_error": "medium",
-          "test_run_method_with_streamlit_exception_raises_error": "medium",
-          "test_run_method_with_sidebar_exception_raises_error": "medium",
-          "test_run_method_with_multiple_exceptions_raises_error": "medium",
-          "test_standalone_run_function_succeeds": "medium",
-          "test_run_webui_alias_succeeds": "medium",
-          "test_main_block_succeeds": "medium"
-        },
-        "tests_with_markers": 8,
-        "tests_without_markers": 0,
-        "misaligned_markers": [],
-        "duplicate_markers": [],
-        "recognized_markers": {
-          "medium": {
-            "file_count": 8,
-            "pytest_count": 0,
-            "recognized": false,
-            "registered_in_pytest_ini": true,
-            "error": "subprocess error: 4",
-            "uncollected_tests": []
-          }
-        },
-        "issues": [
-          {
-            "type": "unrecognized_markers",
-            "message": "medium markers are not recognized by pytest (8 in file, 0 recognized)"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/unit/interface/test_webui_requirements_wizard.py": {
-        "file_path": "/workspace/devsynth/tests/unit/interface/test_webui_requirements_wizard.py",
-        "has_pytest_import": true,
-        "test_functions": 8,
-        "markers": {
-          "test_requirements_wizard_initialization": "medium",
-          "test_requirements_wizard_step_navigation_succeeds": "medium",
-          "test_requirements_wizard_save_requirements_succeeds": "medium",
-          "test_validate_requirements_step": "medium",
-          "test_handle_requirements_navigation_next": "medium",
-          "test_save_requirements_writes_file": "medium",
-          "test_priority_persists_through_navigation": "medium",
-          "test_title_and_description_persist": "medium"
-        },
-        "tests_with_markers": 8,
-        "tests_without_markers": 0,
-        "misaligned_markers": [],
-        "duplicate_markers": [],
-        "recognized_markers": {
-          "medium": {
-            "file_count": 8,
-            "pytest_count": 0,
-            "recognized": false,
-            "registered_in_pytest_ini": true,
-            "error": "subprocess error: 4",
-            "uncollected_tests": []
-          }
-        },
-        "issues": [
-          {
-            "type": "unrecognized_markers",
-            "message": "medium markers are not recognized by pytest (8 in file, 0 recognized)"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/unit/interface/test_uxbridge_config.py": {
-        "file_path": "/workspace/devsynth/tests/unit/interface/test_uxbridge_config.py",
-        "has_pytest_import": true,
-        "test_functions": 6,
-        "markers": {
-          "test_apply_uxbridge_settings": "medium",
-          "test_get_default_bridge_cli_succeeds": "medium",
-          "test_get_default_bridge_webui_succeeds": "medium",
-          "test_get_default_bridge_api_succeeds": "medium",
-          "test_get_default_bridge_webui_fallback_succeeds": "medium",
-          "test_get_default_bridge_api_fallback_succeeds": "medium"
-        },
-        "tests_with_markers": 6,
-        "tests_without_markers": 0,
-        "misaligned_markers": [],
-        "duplicate_markers": [],
-        "recognized_markers": {
-          "medium": {
-            "file_count": 6,
-            "pytest_count": 0,
-            "recognized": false,
-            "registered_in_pytest_ini": true,
-            "error": "subprocess error: 4",
-            "uncollected_tests": []
-          }
-        },
-        "issues": [
-          {
-            "type": "unrecognized_markers",
-            "message": "medium markers are not recognized by pytest (6 in file, 0 recognized)"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/unit/interface/test_webui_wizard_state.py": {
-        "file_path": "/workspace/devsynth/tests/unit/interface/test_webui_wizard_state.py",
-        "has_pytest_import": true,
-        "test_functions": 11,
-        "markers": {
-          "test_function": "slow",
-          "test_wizard_state_navigation": "medium",
-          "test_wizard_state_data_persistence": "medium",
-          "test_wizard_state_completion": "medium",
-          "test_wizard_state_reset": "medium",
-          "test_gather_wizard_state_initialization": "medium",
-          "test_gather_wizard_workflow": "medium",
-          "test_simulate_wizard_navigation": "medium",
-          "test_set_wizard_data": "medium",
-          "test_manager_clears_temp_state": "medium",
-          "test_wizard_state_in_streamlit_context": "medium"
-        },
-        "tests_with_markers": 11,
-        "tests_without_markers": 0,
-        "misaligned_markers": [],
-        "duplicate_markers": [
-          {
-            "test_name": "test_function",
-            "marker_count": 2
-          }
-        ],
-        "recognized_markers": {
-          "medium": {
-            "file_count": 10,
-            "pytest_count": 0,
-            "recognized": false,
-            "registered_in_pytest_ini": true,
-            "error": "subprocess error: 4",
-            "uncollected_tests": []
-          },
-          "slow": {
-            "file_count": 1,
-            "pytest_count": 0,
-            "recognized": false,
-            "registered_in_pytest_ini": true,
-            "error": "subprocess error: 4",
-            "uncollected_tests": []
-          }
-        },
-        "issues": [
-          {
-            "type": "duplicate_markers",
-            "message": "File has 1 tests with duplicate markers"
-          },
-          {
-            "type": "unrecognized_markers",
-            "message": "medium markers are not recognized by pytest (10 in file, 0 recognized)"
-          },
-          {
-            "type": "unrecognized_markers",
-            "message": "slow markers are not recognized by pytest (1 in file, 0 recognized)"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/unit/interface/test_uxbridge_sanitization.py": {
-        "file_path": "/workspace/devsynth/tests/unit/interface/test_uxbridge_sanitization.py",
-        "has_pytest_import": true,
-        "test_functions": 3,
-        "markers": {
-          "test_with_clean_state": "medium",
-          "test_apibridge_sanitizes_display_result_succeeds": "medium",
-          "test_webui_sanitizes_display_result_succeeds": "medium"
-        },
-        "tests_with_markers": 3,
-        "tests_without_markers": 0,
-        "misaligned_markers": [],
-        "duplicate_markers": [],
-        "recognized_markers": {
-          "medium": {
-            "file_count": 3,
-            "pytest_count": 0,
-            "recognized": false,
-            "registered_in_pytest_ini": true,
-            "error": "subprocess error: 4",
-            "uncollected_tests": []
-          }
-        },
-        "issues": [
-          {
-            "type": "unrecognized_markers",
-            "message": "medium markers are not recognized by pytest (3 in file, 0 recognized)"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/unit/interface/test_webui_requirements.py": {
-        "file_path": "/workspace/devsynth/tests/unit/interface/test_webui_requirements.py",
-        "has_pytest_import": true,
-        "test_functions": 2,
-        "markers": {
-          "test_requirements_page_succeeds": "medium",
-          "test_requirements_wizard_succeeds": "medium"
-        },
-        "tests_with_markers": 2,
-        "tests_without_markers": 0,
-        "misaligned_markers": [],
-        "duplicate_markers": [],
-        "recognized_markers": {
-          "medium": {
-            "file_count": 2,
-            "pytest_count": 0,
-            "recognized": false,
-            "registered_in_pytest_ini": true,
-            "error": "subprocess error: 4",
-            "uncollected_tests": []
-          }
-        },
-        "issues": [
-          {
-            "type": "unrecognized_markers",
-            "message": "medium markers are not recognized by pytest (2 in file, 0 recognized)"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/unit/interface/test_cli_progress_indicator.py": {
-        "file_path": "/workspace/devsynth/tests/unit/interface/test_cli_progress_indicator.py",
-        "has_pytest_import": true,
-        "test_functions": 3,
-        "markers": {
-          "test_progress_indicator_init_with_bad_description_uses_fallback": "fast",
-          "test_progress_indicator_update_with_bad_inputs_uses_fallback": "fast",
-          "test_progress_indicator_subtasks_with_bad_inputs_use_fallbacks": "fast"
-        },
-        "tests_with_markers": 3,
-        "tests_without_markers": 0,
-        "misaligned_markers": [],
-        "duplicate_markers": [],
-        "recognized_markers": {
-          "fast": {
-            "file_count": 3,
-            "pytest_count": 0,
-            "recognized": false,
-            "registered_in_pytest_ini": true,
-            "error": "subprocess error: 4",
-            "uncollected_tests": []
-          }
-        },
-        "issues": [
-          {
-            "type": "unrecognized_markers",
-            "message": "fast markers are not recognized by pytest (3 in file, 0 recognized)"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/unit/interface/test_uxbridge_question_result.py": {
-        "file_path": "/workspace/devsynth/tests/unit/interface/test_uxbridge_question_result.py",
-        "has_pytest_import": true,
-        "test_functions": 1,
-        "markers": {
-          "test_ask_question_and_display_result_consistency": "medium"
-        },
-        "tests_with_markers": 1,
-        "tests_without_markers": 0,
-        "misaligned_markers": [],
-        "duplicate_markers": [],
-        "recognized_markers": {
-          "medium": {
-            "file_count": 1,
-            "pytest_count": 0,
-            "recognized": false,
-            "registered_in_pytest_ini": true,
-            "error": "subprocess error: 4",
-            "uncollected_tests": []
-          }
-        },
-        "issues": [
-          {
-            "type": "unrecognized_markers",
-            "message": "medium markers are not recognized by pytest (1 in file, 0 recognized)"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/unit/interface/test_cli_components.py": {
-        "file_path": "/workspace/devsynth/tests/unit/interface/test_cli_components.py",
-        "has_pytest_import": true,
-        "test_functions": 8,
-        "markers": {
-          "test_function": "slow",
-          "test_CLIProgressIndicator_update_succeeds": "slow",
-          "test_cliprogressindicator_sanitize_output_succeeds": "slow",
-          "test_cliprogressindicator_multiple_subtasks_succeeds": "medium",
-          "test_cliuxbridge_display_result_heading_levels_succeeds": "medium",
-          "test_cliuxbridge_display_result_smart_styling_succeeds": "medium",
-          "test_cliuxbridge_display_result_rich_markup_succeeds": "medium",
-          "test_cliuxbridge_display_result_highlight_succeeds": "medium"
-        },
-        "tests_with_markers": 8,
-        "tests_without_markers": 0,
-        "misaligned_markers": [],
-        "duplicate_markers": [
-          {
-            "test_name": "test_function",
-            "marker_count": 2
-          },
-          {
-            "test_name": "test_CLIProgressIndicator_update_succeeds",
-            "marker_count": 2
-          }
-        ],
-        "recognized_markers": {
-          "medium": {
-            "file_count": 5,
-            "pytest_count": 0,
-            "recognized": false,
-            "registered_in_pytest_ini": true,
-            "error": "subprocess error: 4",
-            "uncollected_tests": []
-          },
-          "slow": {
-            "file_count": 3,
-            "pytest_count": 0,
-            "recognized": false,
-            "registered_in_pytest_ini": true,
-            "error": "subprocess error: 4",
-            "uncollected_tests": []
-          }
-        },
-        "issues": [
-          {
-            "type": "duplicate_markers",
-            "message": "File has 2 tests with duplicate markers"
-          },
-          {
-            "type": "unrecognized_markers",
-            "message": "medium markers are not recognized by pytest (5 in file, 0 recognized)"
-          },
-          {
-            "type": "unrecognized_markers",
-            "message": "slow markers are not recognized by pytest (3 in file, 0 recognized)"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/unit/interface/test_bridge_conformance.py": {
-        "file_path": "/workspace/devsynth/tests/unit/interface/test_bridge_conformance.py",
-        "has_pytest_import": true,
-        "test_functions": 1,
-        "markers": {
-          "test_bridge_implements_methods_succeeds": "slow"
-        },
-        "tests_with_markers": 1,
-        "tests_without_markers": 0,
-        "misaligned_markers": [],
-        "duplicate_markers": [],
-        "recognized_markers": {
-          "slow": {
-            "file_count": 1,
-            "pytest_count": 0,
-            "recognized": false,
-            "registered_in_pytest_ini": true,
-            "error": "subprocess error: 4",
-            "uncollected_tests": []
-          }
-        },
-        "issues": [
-          {
-            "type": "unrecognized_markers",
-            "message": "slow markers are not recognized by pytest (1 in file, 0 recognized)"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/unit/interface/test_webui_error_handling.py": {
-        "file_path": "/workspace/devsynth/tests/unit/interface/test_webui_error_handling.py",
-        "has_pytest_import": true,
-        "test_functions": 9,
-        "markers": {
-          "test_init_cmd_error_handling": "medium",
-          "test_onboarding_page_setup_wizard_error_raises_error": "medium",
-          "test_requirements_page_spec_cmd_error_raises_error": "medium",
-          "test_requirements_page_inspect_cmd_error_raises_error": "medium",
-          "test_requirements_page_file_not_found_raises_error": "medium",
-          "test_analysis_page_inspect_code_cmd_error_raises_error": "medium",
-          "test_synthesis_page_test_cmd_error_raises_error": "medium",
-          "test_config_page_load_config_error_raises_error": "medium",
-          "test_config_page_save_config_error_raises_error": "medium"
-        },
-        "tests_with_markers": 9,
-        "tests_without_markers": 0,
-        "misaligned_markers": [],
-        "duplicate_markers": [],
-        "recognized_markers": {
-          "medium": {
-            "file_count": 9,
-            "pytest_count": 0,
-            "recognized": false,
-            "registered_in_pytest_ini": true,
-            "error": "subprocess error: 4",
-            "uncollected_tests": []
-          }
-        },
-        "issues": [
-          {
-            "type": "unrecognized_markers",
-            "message": "medium markers are not recognized by pytest (9 in file, 0 recognized)"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/unit/interface/test_output_formatter.py": {
-        "file_path": "/workspace/devsynth/tests/unit/interface/test_output_formatter.py",
-        "has_pytest_import": true,
-        "test_functions": 8,
-        "markers": {
-          "test_sanitize_output": "medium",
-          "test_detect_message_type_succeeds": "medium",
-          "test_format_message_succeeds": "medium",
-          "test_display_succeeds": "medium",
-          "test_set_console_succeeds": "medium",
-          "test_format_table_succeeds": "medium",
-          "test_format_list_succeeds": "medium",
-          "test_formatter_singleton_succeeds": "medium"
-        },
-        "tests_with_markers": 8,
-        "tests_without_markers": 0,
-        "misaligned_markers": [],
-        "duplicate_markers": [
-          {
-            "test_name": "test_format_table_succeeds",
-            "marker_count": 2
-          }
-        ],
-        "recognized_markers": {
-          "medium": {
-            "file_count": 8,
-            "pytest_count": 0,
-            "recognized": false,
-            "registered_in_pytest_ini": true,
-            "error": "subprocess error: 4",
-            "uncollected_tests": []
-          }
-        },
-        "issues": [
-          {
-            "type": "duplicate_markers",
-            "message": "File has 1 tests with duplicate markers"
-          },
-          {
-            "type": "unrecognized_markers",
-            "message": "medium markers are not recognized by pytest (8 in file, 0 recognized)"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/unit/interface/test_webui_cli_imports.py": {
-        "file_path": "/workspace/devsynth/tests/unit/interface/test_webui_cli_imports.py",
-        "has_pytest_import": true,
-        "test_functions": 1,
-        "markers": {
-          "test_with_clean_state": "medium"
-        },
-        "tests_with_markers": 1,
-        "tests_without_markers": 0,
-        "misaligned_markers": [],
-        "duplicate_markers": [],
-        "recognized_markers": {
-          "medium": {
-            "file_count": 1,
-            "pytest_count": 0,
-            "recognized": false,
-            "registered_in_pytest_ini": true,
-            "error": "subprocess error: 4",
-            "uncollected_tests": []
-          }
-        },
-        "issues": [
-          {
-            "type": "unrecognized_markers",
-            "message": "medium markers are not recognized by pytest (1 in file, 0 recognized)"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/unit/interface/test_uxbridge_consistency.py": {
-        "file_path": "/workspace/devsynth/tests/unit/interface/test_uxbridge_consistency.py",
-        "has_pytest_import": true,
-        "test_functions": 1,
-        "markers": {
-          "test_function": "slow"
-        },
-        "tests_with_markers": 1,
-        "tests_without_markers": 0,
-        "misaligned_markers": [],
-        "duplicate_markers": [],
-        "recognized_markers": {
-          "slow": {
-            "file_count": 1,
-            "pytest_count": 0,
-            "recognized": false,
-            "registered_in_pytest_ini": true,
-            "error": "subprocess error: 4",
-            "uncollected_tests": []
-          }
-        },
-        "issues": [
-          {
-            "type": "unrecognized_markers",
-            "message": "slow markers are not recognized by pytest (1 in file, 0 recognized)"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/unit/interface/test_webui_progress.py": {
-        "file_path": "/workspace/devsynth/tests/unit/interface/test_webui_progress.py",
-        "has_pytest_import": true,
-        "test_functions": 6,
-        "markers": {
-          "test_ui_progress_init_succeeds": "medium",
-          "test_ui_progress_update_succeeds": "medium",
-          "test_ui_progress_complete_succeeds": "medium",
-          "test_ui_progress_add_subtask_succeeds": "medium",
-          "test_ui_progress_update_subtask_succeeds": "medium",
-          "test_ui_progress_complete_subtask_succeeds": "medium"
-        },
-        "tests_with_markers": 6,
-        "tests_without_markers": 0,
-        "misaligned_markers": [],
-        "duplicate_markers": [],
-        "recognized_markers": {
-          "medium": {
-            "file_count": 6,
-            "pytest_count": 0,
-            "recognized": false,
-            "registered_in_pytest_ini": true,
-            "error": "subprocess error: 4",
-            "uncollected_tests": []
-          }
-        },
-        "issues": [
-          {
-            "type": "unrecognized_markers",
-            "message": "medium markers are not recognized by pytest (6 in file, 0 recognized)"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/unit/interface/test_webui_gather_wizard.py": {
-        "file_path": "/workspace/devsynth/tests/unit/interface/test_webui_gather_wizard.py",
-        "has_pytest_import": true,
-        "test_functions": 4,
-        "markers": {
-          "test_gather_wizard_start_button_not_clicked": "medium",
-          "test_gather_wizard_finish_calls_gather_requirements": "medium",
-          "test_gather_wizard_import_error": "medium",
-          "test_gather_wizard_exception": "medium"
-        },
-        "tests_with_markers": 4,
-        "tests_without_markers": 0,
-        "misaligned_markers": [],
-        "duplicate_markers": [],
-        "recognized_markers": {
-          "medium": {
-            "file_count": 4,
-            "pytest_count": 0,
-            "recognized": false,
-            "registered_in_pytest_ini": true,
-            "error": "subprocess error: 4",
-            "uncollected_tests": []
-          }
-        },
-        "issues": [
-          {
-            "type": "unrecognized_markers",
-            "message": "medium markers are not recognized by pytest (4 in file, 0 recognized)"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/unit/interface/test_nicegui_bridge.py": {
-        "file_path": "/workspace/devsynth/tests/unit/interface/test_nicegui_bridge.py",
-        "has_pytest_import": true,
-        "test_functions": 1,
-        "markers": {
-          "test_session_storage_roundtrip": "fast"
-        },
-        "tests_with_markers": 1,
-        "tests_without_markers": 0,
-        "misaligned_markers": [],
-        "duplicate_markers": [],
-        "recognized_markers": {
-          "fast": {
-            "file_count": 1,
-            "pytest_count": 0,
-            "recognized": false,
-            "registered_in_pytest_ini": true,
-            "error": "subprocess error: 4",
-            "uncollected_tests": []
-          }
-        },
-        "issues": [
-          {
-            "type": "unrecognized_markers",
-            "message": "fast markers are not recognized by pytest (1 in file, 0 recognized)"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/unit/interface/test_webui.py": {
-        "file_path": "/workspace/devsynth/tests/unit/interface/test_webui.py",
-        "has_pytest_import": true,
-        "test_functions": 23,
-        "markers": {
-          "test_onboarding_calls_init_succeeds": "medium",
-          "test_requirements_calls_spec_succeeds": "medium",
-          "test_analysis_calls_analyze_succeeds": "medium",
-          "test_synthesis_buttons_succeeds": "medium",
-          "test_config_update_succeeds": "medium",
-          "test_diagnostics_runs_doctor_succeeds": "medium",
-          "test_edrr_cycle_page_succeeds": "medium",
-          "test_alignment_page_succeeds": "medium",
-          "test_alignment_metrics_page_succeeds": "medium",
-          "test_inspect_config_page_succeeds": "medium",
-          "test_validate_manifest_page_succeeds": "medium",
-          "test_validate_metadata_page_succeeds": "medium",
-          "test_test_metrics_page_succeeds": "medium",
-          "test_docs_generation_page_succeeds": "medium",
-          "test_ingestion_page_succeeds": "medium",
-          "test_apispec_page_succeeds": "medium",
-          "test_refactor_page_succeeds": "medium",
-          "test_webapp_page_succeeds": "medium",
-          "test_serve_page_succeeds": "medium",
-          "test_dbschema_page_succeeds": "medium",
-          "test_doctor_page_succeeds": "medium",
-          "test_run_method_renders_pages_succeeds": "medium",
-          "test_wizard_navigation_helper_clamps_steps": "medium"
-        },
-        "tests_with_markers": 23,
-        "tests_without_markers": 0,
-        "misaligned_markers": [],
-        "duplicate_markers": [],
-        "recognized_markers": {
-          "medium": {
-            "file_count": 23,
-            "pytest_count": 0,
-            "recognized": false,
-            "registered_in_pytest_ini": true,
-            "error": "subprocess error: 4",
-            "uncollected_tests": []
-          }
-        },
-        "issues": [
-          {
-            "type": "unrecognized_markers",
-            "message": "medium markers are not recognized by pytest (23 in file, 0 recognized)"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/unit/interface/test_output_sanitization.py": {
-        "file_path": "/workspace/devsynth/tests/unit/interface/test_output_sanitization.py",
-        "has_pytest_import": true,
-        "test_functions": 7,
-        "markers": {
-          "test_function": "slow",
-          "test_cliuxbridge_escapes_html_succeeds": "medium",
-          "test_apibridge_sanitizes_output_succeeds": "medium",
-          "test_webui_sanitizes_output_succeeds": "medium",
-          "test_webapp_cmd_error_sanitized_raises_error": "medium",
-          "test_cliuxbridge_removes_self_closing_script": "medium",
-          "test_sanitize_output_respects_env": "medium"
-        },
-        "tests_with_markers": 7,
-        "tests_without_markers": 0,
-        "misaligned_markers": [],
-        "duplicate_markers": [],
-        "recognized_markers": {
-          "medium": {
-            "file_count": 6,
-            "pytest_count": 0,
-            "recognized": false,
-            "registered_in_pytest_ini": true,
-            "error": "subprocess error: 4",
-            "uncollected_tests": []
-          },
-          "slow": {
-            "file_count": 1,
-            "pytest_count": 0,
-            "recognized": false,
-            "registered_in_pytest_ini": true,
-            "error": "subprocess error: 4",
-            "uncollected_tests": []
-          }
-        },
-        "issues": [
-          {
-            "type": "unrecognized_markers",
-            "message": "medium markers are not recognized by pytest (6 in file, 0 recognized)"
-          },
-          {
-            "type": "unrecognized_markers",
-            "message": "slow markers are not recognized by pytest (1 in file, 0 recognized)"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/unit/interface/test_state_access.py": {
-        "file_path": "/workspace/devsynth/tests/unit/interface/test_state_access.py",
-        "has_pytest_import": true,
-        "test_functions": 14,
-        "markers": {
-          "test_is_session_state_available": "medium",
-          "test_handle_state_error": "medium",
-          "test_get_session_value_with_none_session_state": "medium",
-          "test_get_session_value_with_attribute_access": "medium",
-          "test_get_session_value_with_dict_access": "medium",
-          "test_get_session_value_with_missing_key": "medium",
-          "test_get_session_value_with_exception": "medium",
-          "test_set_session_value_with_none_session_state": "medium",
-          "test_set_session_value_with_attribute_access": "medium",
-          "test_set_session_value_with_dict_access": "medium",
-          "test_set_session_value_with_attribute_exception": "medium",
-          "test_set_session_value_with_dict_exception": "medium",
-          "test_set_session_value_with_both_exceptions": "medium",
-          "test_integration_with_streamlit": "medium"
-        },
-        "tests_with_markers": 14,
-        "tests_without_markers": 0,
-        "misaligned_markers": [
-          {
-            "line": 20,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          }
-        ],
-        "duplicate_markers": [],
-        "recognized_markers": {
-          "medium": {
-            "file_count": 14,
-            "pytest_count": 0,
-            "recognized": false,
-            "registered_in_pytest_ini": true,
-            "error": "subprocess error: 4",
-            "uncollected_tests": []
-          }
-        },
-        "issues": [
-          {
-            "type": "misaligned_markers",
-            "message": "File has 1 misaligned markers"
-          },
-          {
-            "type": "unrecognized_markers",
-            "message": "medium markers are not recognized by pytest (14 in file, 0 recognized)"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/unit/interface/test_cliuxbridge.py": {
-        "file_path": "/workspace/devsynth/tests/unit/interface/test_cliuxbridge.py",
-        "has_pytest_import": true,
-        "test_functions": 12,
-        "markers": {
-          "test_function": "slow",
-          "test_cliuxbridge_confirm_choice_succeeds": "medium",
-          "test_cliuxbridge_display_result_highlight_succeeds": "medium",
-          "test_cliuxbridge_display_result_error_succeeds": "medium",
-          "test_cliuxbridge_display_result_warning_succeeds": "medium",
-          "test_cliuxbridge_display_result_success_succeeds": "medium",
-          "test_cliuxbridge_display_result_heading_succeeds": "medium",
-          "test_cliuxbridge_display_result_subheading_succeeds": "medium",
-          "test_cliuxbridge_display_result_rich_markup_succeeds": "medium",
-          "test_cliuxbridge_display_result_normal_succeeds": "medium",
-          "test_cliuxbridge_ask_question_validates_input_succeeds": "medium",
-          "test_cliprogressindicator_subtasks_succeeds": "medium"
-        },
-        "tests_with_markers": 12,
-        "tests_without_markers": 0,
-        "misaligned_markers": [],
-        "duplicate_markers": [
-          {
-            "test_name": "test_function",
-            "marker_count": 2
-          }
-        ],
-        "recognized_markers": {
-          "medium": {
-            "file_count": 11,
-            "pytest_count": 0,
-            "recognized": false,
-            "registered_in_pytest_ini": true,
-            "error": "subprocess error: 4",
-            "uncollected_tests": []
-          },
-          "slow": {
-            "file_count": 1,
-            "pytest_count": 0,
-            "recognized": false,
-            "registered_in_pytest_ini": true,
-            "error": "subprocess error: 4",
-            "uncollected_tests": []
-          }
-        },
-        "issues": [
-          {
-            "type": "duplicate_markers",
-            "message": "File has 1 tests with duplicate markers"
-          },
-          {
-            "type": "unrecognized_markers",
-            "message": "medium markers are not recognized by pytest (11 in file, 0 recognized)"
-          },
-          {
-            "type": "unrecognized_markers",
-            "message": "slow markers are not recognized by pytest (1 in file, 0 recognized)"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/unit/interface/test_uxbridge_aliases.py": {
-        "file_path": "/workspace/devsynth/tests/unit/interface/test_uxbridge_aliases.py",
-        "has_pytest_import": true,
-        "test_functions": 2,
-        "markers": {
-          "test_function": "slow",
-          "test_print_alias_delegates": "medium"
-        },
-        "tests_with_markers": 2,
-        "tests_without_markers": 0,
-        "misaligned_markers": [],
-        "duplicate_markers": [],
-        "recognized_markers": {
-          "medium": {
-            "file_count": 1,
-            "pytest_count": 0,
-            "recognized": false,
-            "registered_in_pytest_ini": true,
-            "error": "subprocess error: 4",
-            "uncollected_tests": []
-          },
-          "slow": {
-            "file_count": 1,
-            "pytest_count": 0,
-            "recognized": false,
-            "registered_in_pytest_ini": true,
-            "error": "subprocess error: 4",
-            "uncollected_tests": []
-          }
-        },
-        "issues": [
-          {
-            "type": "unrecognized_markers",
-            "message": "medium markers are not recognized by pytest (1 in file, 0 recognized)"
-          },
-          {
-            "type": "unrecognized_markers",
-            "message": "slow markers are not recognized by pytest (1 in file, 0 recognized)"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/unit/interface/test_api_advanced.py": {
-        "file_path": "/workspace/devsynth/tests/unit/interface/test_api_advanced.py",
-        "has_pytest_import": true,
-        "test_functions": 4,
-        "markers": {
-          "test_error_handling_in_all_endpoints": "slow",
-          "test_all_endpoints_authentication_succeeds": "slow",
-          "test_parameter_validation_is_valid": "slow",
-          "test_edge_cases_succeeds": "slow"
-        },
-        "tests_with_markers": 4,
-        "tests_without_markers": 0,
-        "misaligned_markers": [],
-        "duplicate_markers": [],
-        "recognized_markers": {
-          "slow": {
-            "file_count": 4,
-            "pytest_count": 0,
-            "recognized": false,
-            "registered_in_pytest_ini": true,
-            "error": "subprocess error: 4",
-            "uncollected_tests": []
-          }
-        },
-        "issues": [
-          {
-            "type": "unrecognized_markers",
-            "message": "slow markers are not recognized by pytest (4 in file, 0 recognized)"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/unit/interface/test_webui_onboarding.py": {
-        "file_path": "/workspace/devsynth/tests/unit/interface/test_webui_onboarding.py",
-        "has_pytest_import": true,
-        "test_functions": 2,
-        "markers": {
-          "test_onboarding_page_succeeds": "medium",
-          "test_onboarding_page_no_submit_succeeds": "medium"
-        },
-        "tests_with_markers": 2,
-        "tests_without_markers": 0,
-        "misaligned_markers": [],
-        "duplicate_markers": [],
-        "recognized_markers": {
-          "medium": {
-            "file_count": 2,
-            "pytest_count": 0,
-            "recognized": false,
-            "registered_in_pytest_ini": true,
-            "error": "subprocess error: 4",
-            "uncollected_tests": []
-          }
-        },
-        "issues": [
-          {
-            "type": "unrecognized_markers",
-            "message": "medium markers are not recognized by pytest (2 in file, 0 recognized)"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/unit/interface/test_dpg_bridge.py": {
-        "file_path": "/workspace/devsynth/tests/unit/interface/test_dpg_bridge.py",
-        "has_pytest_import": true,
-        "test_functions": 10,
-        "markers": {
-          "test_ask_question_returns_string": "medium",
-          "test_confirm_choice_returns_boolean": "medium",
-          "test_display_result_sanitizes_output": "medium",
-          "test_create_progress_returns_indicator": "medium",
-          "test_cancellable_progress_allows_cancel": "medium",
-          "test_run_cli_command_executes_and_polls": "medium",
-          "test_run_cli_command_handles_exception": "medium",
-          "test_run_cli_command_cancellation": "medium",
-          "test_run_cli_command_propagates_async_error": "medium",
-          "test_run_cli_command_progress_and_error_hooks": "medium"
-        },
-        "tests_with_markers": 10,
-        "tests_without_markers": 0,
-        "misaligned_markers": [],
-        "duplicate_markers": [],
-        "recognized_markers": {
-          "medium": {
-            "file_count": 10,
-            "pytest_count": 0,
-            "recognized": false,
-            "registered_in_pytest_ini": true,
-            "error": "subprocess error: 4",
-            "uncollected_tests": []
-          }
-        },
-        "issues": [
-          {
-            "type": "unrecognized_markers",
-            "message": "medium markers are not recognized by pytest (10 in file, 0 recognized)"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/unit/interface/test_webui_navigation_and_validation.py": {
-        "file_path": "/workspace/devsynth/tests/unit/interface/test_webui_navigation_and_validation.py",
-        "has_pytest_import": true,
-        "test_functions": 2,
-        "markers": {
-          "test_navigation_persists_wizard_state": "medium",
-          "test_analysis_page_invalid_path_shows_error": "medium"
-        },
-        "tests_with_markers": 2,
-        "tests_without_markers": 0,
-        "misaligned_markers": [],
-        "duplicate_markers": [],
-        "recognized_markers": {
-          "medium": {
-            "file_count": 2,
-            "pytest_count": 0,
-            "recognized": false,
-            "registered_in_pytest_ini": true,
-            "error": "subprocess error: 4",
-            "uncollected_tests": []
-          }
-        },
-        "issues": [
-          {
-            "type": "unrecognized_markers",
-            "message": "medium markers are not recognized by pytest (2 in file, 0 recognized)"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/unit/interface/test_webui_gather_wizard_with_state.py": {
-        "file_path": "/workspace/devsynth/tests/unit/interface/test_webui_gather_wizard_with_state.py",
-        "has_pytest_import": true,
-        "test_functions": 8,
-        "markers": {
-          "test_gather_wizard_initialization_with_state": "medium",
-          "test_gather_wizard_navigation_with_state": "medium",
-          "test_gather_wizard_data_persistence_with_state": "medium",
-          "test_gather_wizard_completion_with_state": "medium",
-          "test_gather_wizard_error_handling_with_state": "medium",
-          "test_gather_wizard_cancel_with_state": "medium",
-          "test_gather_wizard_validation_with_state": "medium",
-          "test_gather_wizard_start_resets_state": "medium"
-        },
-        "tests_with_markers": 8,
-        "tests_without_markers": 0,
-        "misaligned_markers": [],
-        "duplicate_markers": [],
-        "recognized_markers": {
-          "medium": {
-            "file_count": 8,
-            "pytest_count": 0,
-            "recognized": false,
-            "registered_in_pytest_ini": true,
-            "error": "subprocess error: 4",
-            "uncollected_tests": []
-          }
-        },
-        "issues": [
-          {
-            "type": "unrecognized_markers",
-            "message": "medium markers are not recognized by pytest (8 in file, 0 recognized)"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/unit/interface/test_ux_bridge.py": {
-        "file_path": "/workspace/devsynth/tests/unit/interface/test_ux_bridge.py",
-        "has_pytest_import": true,
-        "test_functions": 1,
-        "markers": {
-          "test_function": "slow"
-        },
-        "tests_with_markers": 1,
-        "tests_without_markers": 0,
-        "misaligned_markers": [],
-        "duplicate_markers": [
-          {
-            "test_name": "test_function",
-            "marker_count": 2
-          }
-        ],
-        "recognized_markers": {
-          "slow": {
-            "file_count": 1,
-            "pytest_count": 0,
-            "recognized": false,
-            "registered_in_pytest_ini": true,
-            "error": "subprocess error: 4",
-            "uncollected_tests": []
-          }
-        },
-        "issues": [
-          {
-            "type": "duplicate_markers",
-            "message": "File has 1 tests with duplicate markers"
-          },
-          {
-            "type": "unrecognized_markers",
-            "message": "slow markers are not recognized by pytest (1 in file, 0 recognized)"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/unit/interface/test_api_endpoints.py": {
-        "file_path": "/workspace/devsynth/tests/unit/interface/test_api_endpoints.py",
-        "has_pytest_import": true,
-        "test_functions": 13,
-        "markers": {
-          "test_health_endpoint_requires_authentication_succeeds": "slow",
-          "test_metrics_endpoint_requires_authentication_succeeds": "slow",
-          "test_init_endpoint_initializes_project_succeeds": "slow",
-          "test_gather_endpoint_collects_requirements_succeeds": "slow",
-          "test_synthesize_endpoint_runs_pipeline_succeeds": "slow",
-          "test_spec_endpoint_generates_specifications_succeeds": "slow",
-          "test_test_endpoint_generates_tests_succeeds": "slow",
-          "test_code_endpoint_generates_code_succeeds": "slow",
-          "test_doctor_endpoint_runs_diagnostics_succeeds": "slow",
-          "test_edrr_cycle_endpoint_runs_cycle_succeeds": "slow",
-          "test_status_endpoint_returns_messages_returns_expected_result": "slow",
-          "test_test_endpoint_generates_tests_from_spec_succeeds": "slow",
-          "test_endpoints_handle_errors_properly_raises_error": "medium"
-        },
-        "tests_with_markers": 13,
-        "tests_without_markers": 0,
-        "misaligned_markers": [],
-        "duplicate_markers": [
-          {
-            "test_name": "test_endpoints_handle_errors_properly_raises_error",
-            "marker_count": 2
-          }
-        ],
-        "recognized_markers": {
-          "medium": {
-            "file_count": 1,
-            "pytest_count": 0,
-            "recognized": false,
-            "registered_in_pytest_ini": true,
-            "error": "subprocess error: 4",
-            "uncollected_tests": []
-          },
-          "slow": {
-            "file_count": 12,
-            "pytest_count": 0,
-            "recognized": false,
-            "registered_in_pytest_ini": true,
-            "error": "subprocess error: 4",
-            "uncollected_tests": []
-          }
-        },
-        "issues": [
-          {
-            "type": "duplicate_markers",
-            "message": "File has 1 tests with duplicate markers"
-          },
-          {
-            "type": "unrecognized_markers",
-            "message": "medium markers are not recognized by pytest (1 in file, 0 recognized)"
-          },
-          {
-            "type": "unrecognized_markers",
-            "message": "slow markers are not recognized by pytest (12 in file, 0 recognized)"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/unit/interface/test_uxbridge.py": {
-        "file_path": "/workspace/devsynth/tests/unit/interface/test_uxbridge.py",
-        "has_pytest_import": true,
-        "test_functions": 1,
-        "markers": {
-          "test_prompt_and_result_consistency": "medium"
-        },
-        "tests_with_markers": 1,
-        "tests_without_markers": 0,
-        "misaligned_markers": [
-          {
-            "line": 62,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          }
-        ],
-        "duplicate_markers": [],
-        "recognized_markers": {
-          "medium": {
-            "file_count": 1,
-            "pytest_count": 0,
-            "recognized": false,
-            "registered_in_pytest_ini": true,
-            "error": "subprocess error: 4",
-            "uncollected_tests": []
-          }
-        },
-        "issues": [
-          {
-            "type": "misaligned_markers",
-            "message": "File has 1 misaligned markers"
-          },
-          {
-            "type": "unrecognized_markers",
-            "message": "medium markers are not recognized by pytest (1 in file, 0 recognized)"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/unit/policies/test_verify_security_policy.py": {
-        "file_path": "/workspace/devsynth/tests/unit/policies/test_verify_security_policy.py",
-        "has_pytest_import": true,
-        "test_functions": 2,
-        "markers": {
-          "test_passes_when_all_variables_set": "fast",
-          "test_fails_when_variable_missing": "fast"
-        },
-        "tests_with_markers": 2,
-        "tests_without_markers": 0,
-        "misaligned_markers": [],
-        "duplicate_markers": [],
-        "recognized_markers": {
-          "fast": {
-            "file_count": 2,
-            "pytest_count": 0,
-            "recognized": false,
-            "registered_in_pytest_ini": true,
-            "error": "subprocess error: 4",
-            "uncollected_tests": []
-          }
-        },
-        "issues": [
-          {
-            "type": "unrecognized_markers",
-            "message": "fast markers are not recognized by pytest (2 in file, 0 recognized)"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/unit/fallback/test_circuit_breaker_metrics.py": {
-        "file_path": "/workspace/devsynth/tests/unit/fallback/test_circuit_breaker_metrics.py",
-        "has_pytest_import": true,
-        "test_functions": 1,
-        "markers": {
-          "test_circuit_breaker_state_metrics": "medium"
-        },
-        "tests_with_markers": 1,
-        "tests_without_markers": 0,
-        "misaligned_markers": [],
-        "duplicate_markers": [],
-        "recognized_markers": {
-          "medium": {
-            "file_count": 1,
-            "pytest_count": 0,
-            "recognized": false,
-            "registered_in_pytest_ini": true,
-            "error": "subprocess error: 4",
-            "uncollected_tests": []
-          }
-        },
-        "issues": [
-          {
-            "type": "unrecognized_markers",
-            "message": "medium markers are not recognized by pytest (1 in file, 0 recognized)"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/unit/interface/test_agentapi_class.py": {
-        "file_path": "/workspace/devsynth/tests/unit/interface/test_agentapi_class.py",
-        "has_pytest_import": true,
-        "test_functions": 8,
-        "markers": {
-          "test_cmd_succeeds": "medium",
-          "test_init_succeeds": "slow",
-          "test_gather_synthesize_status_succeeds": "slow",
-          "test_spec_succeeds": "slow",
-          "test_test_succeeds": "slow",
-          "test_code_succeeds": "slow",
-          "test_doctor_succeeds": "slow",
-          "test_edrr_cycle_succeeds": "slow"
-        },
-        "tests_with_markers": 8,
-        "tests_without_markers": 0,
-        "misaligned_markers": [],
-        "duplicate_markers": [],
-        "recognized_markers": {
-          "medium": {
-            "file_count": 1,
-            "pytest_count": 0,
-            "recognized": false,
-            "registered_in_pytest_ini": true,
-            "error": "subprocess error: 4",
-            "uncollected_tests": []
-          },
-          "slow": {
-            "file_count": 7,
-            "pytest_count": 0,
-            "recognized": false,
-            "registered_in_pytest_ini": true,
-            "error": "subprocess error: 4",
-            "uncollected_tests": []
-          }
-        },
-        "issues": [
-          {
-            "type": "unrecognized_markers",
-            "message": "medium markers are not recognized by pytest (1 in file, 0 recognized)"
-          },
-          {
-            "type": "unrecognized_markers",
-            "message": "slow markers are not recognized by pytest (7 in file, 0 recognized)"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/unit/fallback/test_retry_logic.py": {
-        "file_path": "/workspace/devsynth/tests/unit/fallback/test_retry_logic.py",
-        "has_pytest_import": true,
-        "test_functions": 4,
-        "markers": {
-          "test_retry_conditions_respected_with_circuit_breaker": "medium",
-          "test_circuit_breaker_opens_and_records_metrics": "medium",
-          "test_retry_stat_prometheus_metrics_recorded": "medium",
-          "test_with_fallback_conditions_and_circuit_breaker": "medium"
-        },
-        "tests_with_markers": 4,
-        "tests_without_markers": 0,
-        "misaligned_markers": [],
-        "duplicate_markers": [],
-        "recognized_markers": {
-          "medium": {
-            "file_count": 4,
-            "pytest_count": 0,
-            "recognized": false,
-            "registered_in_pytest_ini": true,
-            "error": "subprocess error: 4",
-            "uncollected_tests": []
-          }
-        },
-        "issues": [
-          {
-            "type": "unrecognized_markers",
-            "message": "medium markers are not recognized by pytest (4 in file, 0 recognized)"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/unit/fallback/test_condition_callbacks_prometheus.py": {
-        "file_path": "/workspace/devsynth/tests/unit/fallback/test_condition_callbacks_prometheus.py",
-        "has_pytest_import": true,
-        "test_functions": 6,
-        "markers": {
-          "test_condition_callback_prevents_retry": "medium",
-          "test_prometheus_metrics_recorded": "medium",
-          "test_memory_retry_metrics_and_callback": "medium",
-          "test_condition_callback_records_metrics": "medium",
-          "test_memory_condition_callback_records_metrics": "medium",
-          "test_memory_retry_condition_records_metrics": "medium"
-        },
-        "tests_with_markers": 6,
-        "tests_without_markers": 0,
-        "misaligned_markers": [],
-        "duplicate_markers": [],
-        "recognized_markers": {
-          "medium": {
-            "file_count": 6,
-            "pytest_count": 0,
-            "recognized": false,
-            "registered_in_pytest_ini": true,
-            "error": "subprocess error: 4",
-            "uncollected_tests": []
-          }
-        },
-        "issues": [
-          {
-            "type": "unrecognized_markers",
-            "message": "medium markers are not recognized by pytest (6 in file, 0 recognized)"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/unit/fallback/test_retry_with_conditions.py": {
-        "file_path": "/workspace/devsynth/tests/unit/fallback/test_retry_with_conditions.py",
-        "has_pytest_import": true,
-        "test_functions": 3,
-        "markers": {
-          "test_error_policy_overrides_max_retries": "medium",
-          "test_error_policy_prevents_retry": "medium",
-          "test_condition_metrics_track_trigger_and_suppress": "medium"
-        },
-        "tests_with_markers": 3,
-        "tests_without_markers": 0,
-        "misaligned_markers": [],
-        "duplicate_markers": [],
-        "recognized_markers": {
-          "medium": {
-            "file_count": 3,
-            "pytest_count": 0,
-            "recognized": false,
-            "registered_in_pytest_ini": true,
-            "error": "subprocess error: 4",
-            "uncollected_tests": []
-          }
-        },
-        "issues": [
-          {
-            "type": "unrecognized_markers",
-            "message": "medium markers are not recognized by pytest (3 in file, 0 recognized)"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/unit/fallback/test_retry_predicates.py": {
-        "file_path": "/workspace/devsynth/tests/unit/fallback/test_retry_predicates.py",
-        "has_pytest_import": true,
-        "test_functions": 2,
-        "markers": {
-          "test_retry_predicate_triggers_retry": "fast",
-          "test_integer_predicate_records_metrics": "fast"
-        },
-        "tests_with_markers": 2,
-        "tests_without_markers": 0,
-        "misaligned_markers": [],
-        "duplicate_markers": [],
-        "recognized_markers": {
-          "fast": {
-            "file_count": 2,
-            "pytest_count": 0,
-            "recognized": false,
-            "registered_in_pytest_ini": true,
-            "error": "subprocess error: 4",
-            "uncollected_tests": []
-          }
-        },
-        "issues": [
-          {
-            "type": "unrecognized_markers",
-            "message": "fast markers are not recognized by pytest (2 in file, 0 recognized)"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/unit/fallback/test_retry_condition_metrics.py": {
-        "file_path": "/workspace/devsynth/tests/unit/fallback/test_retry_condition_metrics.py",
-        "has_pytest_import": true,
-        "test_functions": 3,
-        "markers": {
-          "test_named_retry_condition_records_metrics_on_abort": "medium",
-          "test_named_retry_condition_allows_retry": "medium",
-          "test_exception_class_condition_records_metrics": "medium"
-        },
-        "tests_with_markers": 3,
-        "tests_without_markers": 0,
-        "misaligned_markers": [],
-        "duplicate_markers": [],
-        "recognized_markers": {
-          "medium": {
-            "file_count": 3,
-            "pytest_count": 0,
-            "recognized": false,
-            "registered_in_pytest_ini": true,
-            "error": "subprocess error: 4",
-            "uncollected_tests": []
-          }
-        },
-        "issues": [
-          {
-            "type": "unrecognized_markers",
-            "message": "medium markers are not recognized by pytest (3 in file, 0 recognized)"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/unit/fallback/test_retry_metrics_prometheus_integration.py": {
-        "file_path": "/workspace/devsynth/tests/unit/fallback/test_retry_metrics_prometheus_integration.py",
-        "has_pytest_import": true,
-        "test_functions": 1,
-        "markers": {
-          "test_retry_metrics_synced_with_prometheus": "medium"
-        },
-        "tests_with_markers": 1,
-        "tests_without_markers": 0,
-        "misaligned_markers": [],
-        "duplicate_markers": [],
-        "recognized_markers": {
-          "medium": {
-            "file_count": 1,
-            "pytest_count": 0,
-            "recognized": false,
-            "registered_in_pytest_ini": true,
-            "error": "subprocess error: 4",
-            "uncollected_tests": []
-          }
-        },
-        "issues": [
-          {
-            "type": "unrecognized_markers",
-            "message": "medium markers are not recognized by pytest (1 in file, 0 recognized)"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/unit/fallback/test_retry_conditions.py": {
-        "file_path": "/workspace/devsynth/tests/unit/fallback/test_retry_conditions.py",
-        "has_pytest_import": true,
-        "test_functions": 11,
-        "markers": {
-          "test_should_retry_prevents_retry": "medium",
-          "test_should_retry_allows_retry_until_success": "medium",
-          "test_retry_on_result_triggers_retry": "medium",
-          "test_retry_conditions_abort_when_condition_fails": "medium",
-          "test_retry_conditions_allow_retry": "medium",
-          "test_string_condition_allows_retry": "medium",
-          "test_string_condition_aborts_when_missing": "medium",
-          "test_class_condition_allows_retry": "medium",
-          "test_class_condition_aborts_on_mismatch": "medium",
-          "test_exponential_backoff": "medium",
-          "test_fallback_provider_order": "medium"
-        },
-        "tests_with_markers": 11,
-        "tests_without_markers": 0,
-        "misaligned_markers": [],
-        "duplicate_markers": [],
-        "recognized_markers": {
-          "medium": {
-            "file_count": 11,
-            "pytest_count": 0,
-            "recognized": false,
-            "registered_in_pytest_ini": true,
-            "error": "subprocess error: 4",
-            "uncollected_tests": []
-          }
-        },
-        "issues": [
-          {
-            "type": "unrecognized_markers",
-            "message": "medium markers are not recognized by pytest (11 in file, 0 recognized)"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/unit/fallback/test_retry_metrics.py": {
-        "file_path": "/workspace/devsynth/tests/unit/fallback/test_retry_metrics.py",
-        "has_pytest_import": true,
-        "test_functions": 9,
-        "markers": {
-          "test_retry_metrics_success": "medium",
-          "test_retry_metrics_failure": "medium",
-          "test_retry_metrics_abort_when_not_retryable": "medium",
-          "test_retry_metrics_invalid_result": "medium",
-          "test_retry_metrics_success_without_retries": "medium",
-          "test_retry_error_metrics": "medium",
-          "test_retry_error_map_prevents_retry": "medium",
-          "test_retry_error_map_matches_subclass": "medium",
-          "test_fallback_handler_predicate_metrics": "medium"
-        },
-        "tests_with_markers": 9,
-        "tests_without_markers": 0,
-        "misaligned_markers": [],
-        "duplicate_markers": [],
-        "recognized_markers": {
-          "medium": {
-            "file_count": 9,
-            "pytest_count": 0,
-            "recognized": false,
-            "registered_in_pytest_ini": true,
-            "error": "subprocess error: 4",
-            "uncollected_tests": []
-          }
-        },
-        "issues": [
-          {
-            "type": "unrecognized_markers",
-            "message": "medium markers are not recognized by pytest (9 in file, 0 recognized)"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/unit/fallback/test_retry_counts.py": {
-        "file_path": "/workspace/devsynth/tests/unit/fallback/test_retry_counts.py",
-        "has_pytest_import": true,
-        "test_functions": 2,
-        "markers": {
-          "test_retry_count_metrics": "medium",
-          "test_retry_only_network_errors": "medium"
-        },
-        "tests_with_markers": 2,
-        "tests_without_markers": 0,
-        "misaligned_markers": [],
-        "duplicate_markers": [],
-        "recognized_markers": {
-          "medium": {
-            "file_count": 2,
-            "pytest_count": 0,
-            "recognized": false,
-            "registered_in_pytest_ini": true,
-            "error": "subprocess error: 4",
-            "uncollected_tests": []
-          }
-        },
-        "issues": [
-          {
-            "type": "unrecognized_markers",
-            "message": "medium markers are not recognized by pytest (2 in file, 0 recognized)"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/unit/fallback/test_retry.py": {
-        "file_path": "/workspace/devsynth/tests/unit/fallback/test_retry.py",
-        "has_pytest_import": true,
-        "test_functions": 2,
-        "markers": {
-          "test_anonymous_retry_condition_records_metrics": "medium",
-          "test_circuit_breaker_open_emits_metrics": "medium"
-        },
-        "tests_with_markers": 2,
-        "tests_without_markers": 0,
-        "misaligned_markers": [],
-        "duplicate_markers": [],
-        "recognized_markers": {
-          "medium": {
-            "file_count": 2,
-            "pytest_count": 0,
-            "recognized": false,
-            "registered_in_pytest_ini": true,
-            "error": "subprocess error: 4",
-            "uncollected_tests": []
-          }
-        },
-        "issues": [
-          {
-            "type": "unrecognized_markers",
-            "message": "medium markers are not recognized by pytest (2 in file, 0 recognized)"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/unit/adapters/providers/test_fallback.py": {
-        "file_path": "/workspace/devsynth/tests/unit/adapters/providers/test_fallback.py",
-        "has_pytest_import": true,
-        "test_functions": 6,
-        "markers": {
-          "test_retry_with_exponential_backoff_success_succeeds": "medium",
-          "test_retry_with_exponential_backoff_failure_raises_error": "medium",
-          "test_retry_with_exponential_backoff_jitter_succeeds": "medium",
-          "test_retry_with_exponential_backoff_on_retry_callback_succeeds": "medium",
-          "test_retry_with_exponential_backoff_retryable_exceptions_raises_error": "medium",
-          "test_retry_with_exponential_backoff_no_jitter_succeeds": "medium"
-        },
-        "tests_with_markers": 6,
-        "tests_without_markers": 0,
-        "misaligned_markers": [],
-        "duplicate_markers": [],
-        "recognized_markers": {
-          "medium": {
-            "file_count": 6,
-            "pytest_count": 0,
-            "recognized": false,
-            "registered_in_pytest_ini": true,
-            "error": "subprocess error: 4",
-            "uncollected_tests": []
-          }
-        },
-        "issues": [
-          {
-            "type": "unrecognized_markers",
-            "message": "medium markers are not recognized by pytest (6 in file, 0 recognized)"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/unit/adapters/providers/test_provider_factory.py": {
-        "file_path": "/workspace/devsynth/tests/unit/adapters/providers/test_provider_factory.py",
-        "has_pytest_import": true,
-        "test_functions": 3,
-        "markers": {
-          "test_explicit_openai_missing_key_raises": "medium",
-          "test_create_provider_default_with_missing_key_succeeds": "medium",
-          "test_create_provider_openai_succeeds": "medium"
-        },
-        "tests_with_markers": 3,
-        "tests_without_markers": 0,
-        "misaligned_markers": [],
-        "duplicate_markers": [],
-        "recognized_markers": {
-          "medium": {
-            "file_count": 3,
-            "pytest_count": 0,
-            "recognized": false,
-            "registered_in_pytest_ini": true,
-            "error": "subprocess error: 4",
-            "uncollected_tests": []
-          }
-        },
-        "issues": [
-          {
-            "type": "unrecognized_markers",
-            "message": "medium markers are not recognized by pytest (3 in file, 0 recognized)"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/unit/adapters/cli/test_typer_adapter.py": {
-        "file_path": "/workspace/devsynth/tests/unit/adapters/cli/test_typer_adapter.py",
-        "has_pytest_import": true,
-        "test_functions": 9,
-        "markers": {
-          "test_build_app_returns_expected_result": "medium",
-          "test_warn_if_features_disabled_all_disabled_succeeds": "medium",
-          "test_warn_if_features_disabled_some_enabled_succeeds": "medium",
-          "test_warn_if_features_disabled_exception_raises_error": "medium",
-          "test_show_help_succeeds": "medium",
-          "test_parse_args_has_expected": "medium",
-          "test_run_cli_succeeds": "medium",
-          "test_completion_cmd_displays_script": "medium",
-          "test_dashboard_hook_option_registers": "medium"
-        },
-        "tests_with_markers": 9,
-        "tests_without_markers": 0,
-        "misaligned_markers": [],
-        "duplicate_markers": [],
-        "recognized_markers": {
-          "medium": {
-            "file_count": 9,
-            "pytest_count": 0,
-            "recognized": false,
-            "registered_in_pytest_ini": true,
-            "error": "subprocess error: 4",
-            "uncollected_tests": []
-          }
-        },
-        "issues": [
-          {
-            "type": "unrecognized_markers",
-            "message": "medium markers are not recognized by pytest (9 in file, 0 recognized)"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/unit/adapters/llm/test_llm_adapter.py": {
-        "file_path": "/workspace/devsynth/tests/unit/adapters/llm/test_llm_adapter.py",
-        "has_pytest_import": true,
-        "test_functions": 5,
-        "markers": {
-          "test_llm_backend_adapter_init_succeeds": "medium",
-          "test_create_provider_has_expected": "medium",
-          "test_register_provider_type_has_expected": "medium",
-          "test_integration_with_openai_provider_has_expected": "medium",
-          "test_integration_with_anthropic_provider_has_expected": "medium"
-        },
-        "tests_with_markers": 5,
-        "tests_without_markers": 0,
-        "misaligned_markers": [],
-        "duplicate_markers": [],
-        "recognized_markers": {
-          "medium": {
-            "file_count": 5,
-            "pytest_count": 0,
-            "recognized": false,
-            "registered_in_pytest_ini": true,
-            "error": "subprocess error: 4",
-            "uncollected_tests": []
-          }
-        },
-        "issues": [
-          {
-            "type": "unrecognized_markers",
-            "message": "medium markers are not recognized by pytest (5 in file, 0 recognized)"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/unit/adapters/memory/test_vector_store_provider_factory.py": {
-        "file_path": "/workspace/devsynth/tests/unit/adapters/memory/test_vector_store_provider_factory.py",
-        "has_pytest_import": true,
-        "test_functions": 2,
-        "markers": {
-          "test_register_and_create_succeeds": "medium",
-          "test_unknown_type_succeeds": "medium"
-        },
-        "tests_with_markers": 2,
-        "tests_without_markers": 0,
-        "misaligned_markers": [],
-        "duplicate_markers": [],
-        "recognized_markers": {
-          "medium": {
-            "file_count": 2,
-            "pytest_count": 0,
-            "recognized": false,
-            "registered_in_pytest_ini": true,
-            "error": "subprocess error: 4",
-            "uncollected_tests": []
-          }
-        },
-        "issues": [
-          {
-            "type": "unrecognized_markers",
-            "message": "medium markers are not recognized by pytest (2 in file, 0 recognized)"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/unit/adapters/providers/test_embeddings.py": {
-        "file_path": "/workspace/devsynth/tests/unit/adapters/providers/test_embeddings.py",
-        "has_pytest_import": true,
-        "test_functions": 7,
-        "markers": {
-          "test_openai_provider_embed_calls_api_succeeds": "medium",
-          "test_openai_provider_aembed_calls_api": "medium",
-          "test_lmstudio_provider_embed_calls_api_succeeds": "medium",
-          "test_embed_function_success_with_lmstudio_succeeds": "medium",
-          "test_aembed_function_success_with_lmstudio": "medium",
-          "test_lmstudio_provider_embed_error_succeeds": "slow",
-          "test_aembed_function_error_propagation": "medium"
-        },
-        "tests_with_markers": 7,
-        "tests_without_markers": 0,
-        "misaligned_markers": [],
-        "duplicate_markers": [],
-        "recognized_markers": {
-          "medium": {
-            "file_count": 6,
-            "pytest_count": 0,
-            "recognized": false,
-            "registered_in_pytest_ini": true,
-            "error": "subprocess error: 4",
-            "uncollected_tests": []
-          },
-          "slow": {
-            "file_count": 1,
-            "pytest_count": 0,
-            "recognized": false,
-            "registered_in_pytest_ini": true,
-            "error": "subprocess error: 4",
-            "uncollected_tests": []
-          }
-        },
-        "issues": [
-          {
-            "type": "unrecognized_markers",
-            "message": "medium markers are not recognized by pytest (6 in file, 0 recognized)"
-          },
-          {
-            "type": "unrecognized_markers",
-            "message": "slow markers are not recognized by pytest (1 in file, 0 recognized)"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/unit/adapters/memory/test_memory_adapter_factory.py": {
-        "file_path": "/workspace/devsynth/tests/unit/adapters/memory/test_memory_adapter_factory.py",
-        "has_pytest_import": true,
-        "test_functions": 3,
-        "markers": {
-          "test_create_for_testing_defaults_to_memory": "medium",
-          "test_create_for_testing_file_does_not_create_path": "medium",
-          "test_create_for_testing_kuzu_avoids_attribute_error": "medium"
-        },
-        "tests_with_markers": 3,
-        "tests_without_markers": 0,
-        "misaligned_markers": [],
-        "duplicate_markers": [],
-        "recognized_markers": {
-          "medium": {
-            "file_count": 3,
-            "pytest_count": 0,
-            "recognized": false,
-            "registered_in_pytest_ini": true,
-            "error": "subprocess error: 4",
-            "uncollected_tests": []
-          }
-        },
-        "issues": [
-          {
-            "type": "unrecognized_markers",
-            "message": "medium markers are not recognized by pytest (3 in file, 0 recognized)"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/unit/adapters/memory/test_kuzu_adapter.py": {
-        "file_path": "/workspace/devsynth/tests/unit/adapters/memory/test_kuzu_adapter.py",
-        "has_pytest_import": true,
-        "test_functions": 1,
-        "markers": {
-          "test_ephemeral_adapter_cleanup": "medium"
-        },
-        "tests_with_markers": 1,
-        "tests_without_markers": 0,
-        "misaligned_markers": [],
-        "duplicate_markers": [],
-        "recognized_markers": {
-          "medium": {
-            "file_count": 1,
-            "pytest_count": 0,
-            "recognized": false,
-            "registered_in_pytest_ini": true,
-            "error": "subprocess error: 4",
-            "uncollected_tests": []
-          }
-        },
-        "issues": [
-          {
-            "type": "unrecognized_markers",
-            "message": "medium markers are not recognized by pytest (1 in file, 0 recognized)"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/unit/domain/models/test_wsde_base_methods.py": {
-        "file_path": "/workspace/devsynth/tests/unit/domain/models/test_wsde_base_methods.py",
-        "has_pytest_import": true,
-        "test_functions": 8,
-        "markers": {
-          "test_add_agents_succeeds": "medium",
-          "test_register_dialectical_hook_succeeds": "medium",
-          "test_hook_succeeds": "medium",
-          "test_send_message_succeeds": "medium",
-          "test_send_message_updates_memory_manager": "medium",
-          "test_broadcast_message_succeeds": "medium",
-          "test_get_messages_succeeds": "medium",
-          "test_conduct_peer_review_succeeds": "medium"
-        },
-        "tests_with_markers": 8,
-        "tests_without_markers": 0,
-        "misaligned_markers": [],
-        "duplicate_markers": [
-          {
-            "test_name": "test_hook_succeeds",
-            "marker_count": 2
-          }
-        ],
-        "recognized_markers": {
-          "medium": {
-            "file_count": 8,
-            "pytest_count": 0,
-            "recognized": false,
-            "registered_in_pytest_ini": true,
-            "error": "subprocess error: 4",
-            "uncollected_tests": []
-          }
-        },
-        "issues": [
-          {
-            "type": "duplicate_markers",
-            "message": "File has 1 tests with duplicate markers"
-          },
-          {
-            "type": "unrecognized_markers",
-            "message": "medium markers are not recognized by pytest (8 in file, 0 recognized)"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/unit/domain/models/test_wsde_context_driven_leadership.py": {
-        "file_path": "/workspace/devsynth/tests/unit/domain/models/test_wsde_context_driven_leadership.py",
-        "has_pytest_import": true,
-        "test_functions": 15,
-        "markers": {
-          "test_enhanced_calculate_expertise_score_exact_match_matches_expected": "medium",
-          "test_enhanced_calculate_expertise_score_partial_match_matches_expected": "medium",
-          "test_enhanced_calculate_expertise_score_experience_level_succeeds": "medium",
-          "test_enhanced_calculate_expertise_score_performance_history_succeeds": "medium",
-          "test_enhanced_calculate_expertise_score_nested_task_succeeds": "medium",
-          "test_enhanced_calculate_phase_expertise_score_has_expected": "medium",
-          "test_enhanced_select_primus_by_expertise_code_task_succeeds": "medium",
-          "test_enhanced_select_primus_by_expertise_doc_task_succeeds": "medium",
-          "test_enhanced_select_primus_by_expertise_security_task_succeeds": "medium",
-          "test_enhanced_select_primus_by_expertise_rotation_succeeds": "medium",
-          "test_enhanced_select_primus_by_expertise_unused_priority_succeeds": "medium",
-          "test_dynamic_role_reassignment_enhanced_code_task_succeeds": "medium",
-          "test_dynamic_role_reassignment_enhanced_doc_task_succeeds": "medium",
-          "test_dynamic_role_reassignment_enhanced_testing_task_succeeds": "medium",
-          "test_dynamic_role_reassignment_enhanced_security_task_succeeds": "medium"
-        },
-        "tests_with_markers": 15,
-        "tests_without_markers": 0,
-        "misaligned_markers": [],
-        "duplicate_markers": [],
-        "recognized_markers": {
-          "medium": {
-            "file_count": 15,
-            "pytest_count": 0,
-            "recognized": false,
-            "registered_in_pytest_ini": true,
-            "error": "subprocess error: 4",
-            "uncollected_tests": []
-          }
-        },
-        "issues": [
-          {
-            "type": "unrecognized_markers",
-            "message": "medium markers are not recognized by pytest (15 in file, 0 recognized)"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/unit/adapters/memory/test_memory_adapter.py": {
-        "file_path": "/workspace/devsynth/tests/unit/adapters/memory/test_memory_adapter.py",
-        "has_pytest_import": true,
-        "test_functions": 12,
-        "markers": {
-          "test_init_with_file_storage_succeeds": "medium",
-          "test_init_with_tinydb_storage_succeeds": "slow",
-          "test_init_with_duckdb_storage_succeeds": "slow",
-          "test_init_with_lmdb_storage_succeeds": "slow",
-          "test_init_with_kuzu_storage_succeeds": "medium",
-          "test_init_with_faiss_storage_succeeds": "medium",
-          "test_faiss_vector_store_operations_succeeds": "medium",
-          "test_memory_and_vector_store_integration_succeeds": "medium",
-          "test_init_with_rdflib_storage_succeeds": "medium",
-          "test_init_with_in_memory_storage_succeeds": "medium",
-          "test_lmdb_synchronizes_to_kuzu": "isolation",
-          "test_faiss_vectors_synchronize_to_kuzu": "isolation"
-        },
-        "tests_with_markers": 12,
-        "tests_without_markers": 0,
-        "misaligned_markers": [],
-        "duplicate_markers": [
-          {
-            "test_name": "test_lmdb_synchronizes_to_kuzu",
-            "marker_count": 2
-          },
-          {
-            "test_name": "test_faiss_vectors_synchronize_to_kuzu",
-            "marker_count": 2
-          }
-        ],
-        "recognized_markers": {
-          "medium": {
-            "file_count": 7,
-            "pytest_count": 0,
-            "recognized": false,
-            "registered_in_pytest_ini": true,
-            "error": "subprocess error: 4",
-            "uncollected_tests": []
-          },
-          "slow": {
-            "file_count": 3,
-            "pytest_count": 0,
-            "recognized": false,
-            "registered_in_pytest_ini": true,
-            "error": "subprocess error: 4",
-            "uncollected_tests": []
-          }
-        },
-        "issues": [
-          {
-            "type": "duplicate_markers",
-            "message": "File has 2 tests with duplicate markers"
-          },
-          {
-            "type": "unrecognized_markers",
-            "message": "medium markers are not recognized by pytest (7 in file, 0 recognized)"
-          },
-          {
-            "type": "unrecognized_markers",
-            "message": "slow markers are not recognized by pytest (3 in file, 0 recognized)"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/unit/domain/models/test_wsde_dialectical_reasoning.py": {
-        "file_path": "/workspace/devsynth/tests/unit/domain/models/test_wsde_dialectical_reasoning.py",
-        "has_pytest_import": true,
-        "test_functions": 13,
-        "markers": {
-          "test_categorize_critiques_by_domain_succeeds": "medium",
-          "test_identify_domain_conflicts_succeeds": "medium",
-          "test_prioritize_critiques_succeeds": "medium",
-          "test_resolve_code_improvement_conflict_succeeds": "medium",
-          "test_resolve_content_improvement_conflict_succeeds": "medium",
-          "test_check_code_standards_compliance_succeeds": "medium",
-          "test_check_content_standards_compliance_succeeds": "medium",
-          "test_check_pep8_compliance_succeeds": "medium",
-          "test_check_security_best_practices_succeeds": "medium",
-          "test_balance_security_and_performance_succeeds": "medium",
-          "test_balance_security_and_usability_succeeds": "medium",
-          "test_balance_performance_and_maintainability_succeeds": "medium",
-          "test_generate_detailed_synthesis_reasoning_succeeds": "medium"
-        },
-        "tests_with_markers": 13,
-        "tests_without_markers": 0,
-        "misaligned_markers": [],
-        "duplicate_markers": [],
-        "recognized_markers": {
-          "medium": {
-            "file_count": 13,
-            "pytest_count": 0,
-            "recognized": false,
-            "registered_in_pytest_ini": true,
-            "error": "subprocess error: 4",
-            "uncollected_tests": []
-          }
-        },
-        "issues": [
-          {
-            "type": "unrecognized_markers",
-            "message": "medium markers are not recognized by pytest (13 in file, 0 recognized)"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/unit/application/documentation/test_documentation_ingestion_manager.py": {
-        "file_path": "/workspace/devsynth/tests/unit/application/documentation/test_documentation_ingestion_manager.py",
-        "has_pytest_import": true,
-        "test_functions": 15,
-        "markers": {
-          "test_initialization_succeeds": "medium",
-          "test_ingest_from_directory_markdown_succeeds": "medium",
-          "test_ingest_from_directory_text_succeeds": "medium",
-          "test_ingest_from_directory_json_succeeds": "medium",
-          "test_ingest_from_directory_python_succeeds": "medium",
-          "test_ingest_from_directory_html_succeeds": "medium",
-          "test_ingest_from_directory_rst_succeeds": "medium",
-          "test_ingest_from_url_succeeds": "medium",
-          "test_ingest_from_url_error_raises_error": "medium",
-          "test_process_markdown_succeeds": "medium",
-          "test_process_text_succeeds": "medium",
-          "test_process_json_succeeds": "medium",
-          "test_process_python_succeeds": "medium",
-          "test_process_html_succeeds": "medium",
-          "test_process_rst_succeeds": "medium"
-        },
-        "tests_with_markers": 15,
-        "tests_without_markers": 0,
-        "misaligned_markers": [],
-        "duplicate_markers": [],
-        "recognized_markers": {
-          "medium": {
-            "file_count": 15,
-            "pytest_count": 0,
-            "recognized": false,
-            "registered_in_pytest_ini": true,
-            "error": "subprocess error: 4",
-            "uncollected_tests": []
-          }
-        },
-        "issues": [
-          {
-            "type": "unrecognized_markers",
-            "message": "medium markers are not recognized by pytest (15 in file, 0 recognized)"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/unit/application/documentation/test_documentation_manager_utils.py": {
-        "file_path": "/workspace/devsynth/tests/unit/application/documentation/test_documentation_manager_utils.py",
-        "has_pytest_import": true,
-        "test_functions": 7,
-        "markers": {
-          "test_get_function_documentation_succeeds": "medium",
-          "test_get_class_documentation_succeeds": "medium",
-          "test_get_usage_examples_succeeds": "medium",
-          "test_get_api_compatibility_succeeds": "medium",
-          "test_get_related_functions_succeeds": "medium",
-          "test_get_usage_patterns_succeeds": "medium",
-          "test_offline_fetch_uses_cache_returns_expected_result": "medium"
-        },
-        "tests_with_markers": 7,
-        "tests_without_markers": 0,
-        "misaligned_markers": [],
-        "duplicate_markers": [],
-        "recognized_markers": {
-          "medium": {
-            "file_count": 7,
-            "pytest_count": 0,
-            "recognized": false,
-            "registered_in_pytest_ini": true,
-            "error": "subprocess error: 4",
-            "uncollected_tests": []
-          }
-        },
-        "issues": [
-          {
-            "type": "unrecognized_markers",
-            "message": "medium markers are not recognized by pytest (7 in file, 0 recognized)"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/unit/application/orchestration/test_dialectical_reasoner.py": {
-        "file_path": "/workspace/devsynth/tests/unit/application/orchestration/test_dialectical_reasoner.py",
-        "has_pytest_import": true,
-        "test_functions": 3,
-        "markers": {
-          "test_edrr_coordinator_delegates_to_helper": "medium",
-          "test_dialectical_reasoner_returns_result": "medium",
-          "test_dialectical_reasoner_logs_consensus_failure": "medium"
-        },
-        "tests_with_markers": 3,
-        "tests_without_markers": 0,
-        "misaligned_markers": [],
-        "duplicate_markers": [],
-        "recognized_markers": {
-          "medium": {
-            "file_count": 3,
-            "pytest_count": 0,
-            "recognized": false,
-            "registered_in_pytest_ini": true,
-            "error": "subprocess error: 4",
-            "uncollected_tests": []
-          }
-        },
-        "issues": [
-          {
-            "type": "unrecognized_markers",
-            "message": "medium markers are not recognized by pytest (3 in file, 0 recognized)"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/unit/application/orchestration/test_workflow_manager.py": {
-        "file_path": "/workspace/devsynth/tests/unit/application/orchestration/test_workflow_manager.py",
-        "has_pytest_import": true,
-        "test_functions": 1,
-        "markers": {
-          "test_get_workflow_status_delegates_to_port_succeeds": "medium"
-        },
-        "tests_with_markers": 1,
-        "tests_without_markers": 0,
-        "misaligned_markers": [],
-        "duplicate_markers": [],
-        "recognized_markers": {
-          "medium": {
-            "file_count": 1,
-            "pytest_count": 0,
-            "recognized": false,
-            "registered_in_pytest_ini": true,
-            "error": "subprocess error: 4",
-            "uncollected_tests": []
-          }
-        },
-        "issues": [
-          {
-            "type": "unrecognized_markers",
-            "message": "medium markers are not recognized by pytest (1 in file, 0 recognized)"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/unit/application/sprint/test_planning.py": {
-        "file_path": "/workspace/devsynth/tests/unit/application/sprint/test_planning.py",
-        "has_pytest_import": true,
-        "test_functions": 1,
-        "markers": {
-          "test_map_requirements_to_plan_extracts_fields": "fast"
-        },
-        "tests_with_markers": 1,
-        "tests_without_markers": 0,
-        "misaligned_markers": [],
-        "duplicate_markers": [],
-        "recognized_markers": {
-          "fast": {
-            "file_count": 1,
-            "pytest_count": 0,
-            "recognized": false,
-            "registered_in_pytest_ini": true,
-            "error": "subprocess error: 4",
-            "uncollected_tests": []
-          }
-        },
-        "issues": [
-          {
-            "type": "unrecognized_markers",
-            "message": "fast markers are not recognized by pytest (1 in file, 0 recognized)"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/unit/application/promises/test_timeout.py": {
-        "file_path": "/workspace/devsynth/tests/unit/application/promises/test_timeout.py",
-        "has_pytest_import": true,
-        "test_functions": 2,
-        "markers": {
-          "test_promise_auto_reject_after_timeout_succeeds": "medium",
-          "test_timeout_timer_cancellation_on_fulfill_succeeds": "medium"
-        },
-        "tests_with_markers": 2,
-        "tests_without_markers": 0,
-        "misaligned_markers": [],
-        "duplicate_markers": [],
-        "recognized_markers": {
-          "medium": {
-            "file_count": 2,
-            "pytest_count": 0,
-            "recognized": false,
-            "registered_in_pytest_ini": true,
-            "error": "subprocess error: 4",
-            "uncollected_tests": []
-          }
-        },
-        "issues": [
-          {
-            "type": "unrecognized_markers",
-            "message": "medium markers are not recognized by pytest (2 in file, 0 recognized)"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/unit/application/promises/test_basic_promise.py": {
-        "file_path": "/workspace/devsynth/tests/unit/application/promises/test_basic_promise.py",
-        "has_pytest_import": true,
-        "test_functions": 4,
-        "markers": {
-          "test_basic_promise_resolve_and_value": "medium",
-          "test_basic_promise_then_chains": "medium",
-          "test_basic_promise_catch_handles_rejection": "medium",
-          "test_access_value_wrong_state_raises": "medium"
-        },
-        "tests_with_markers": 4,
-        "tests_without_markers": 0,
-        "misaligned_markers": [],
-        "duplicate_markers": [
-          {
-            "test_name": "test_basic_promise_catch_handles_rejection",
-            "marker_count": 2
-          },
-          {
-            "test_name": "test_access_value_wrong_state_raises",
-            "marker_count": 2
-          }
-        ],
-        "recognized_markers": {
-          "medium": {
-            "file_count": 4,
-            "pytest_count": 0,
-            "recognized": false,
-            "registered_in_pytest_ini": true,
-            "error": "subprocess error: 4",
-            "uncollected_tests": []
-          }
-        },
-        "issues": [
-          {
-            "type": "duplicate_markers",
-            "message": "File has 2 tests with duplicate markers"
-          },
-          {
-            "type": "unrecognized_markers",
-            "message": "medium markers are not recognized by pytest (4 in file, 0 recognized)"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/unit/application/cli/test_autocomplete.py": {
-        "file_path": "/workspace/devsynth/tests/unit/application/cli/test_autocomplete.py",
-        "has_pytest_import": true,
-        "test_functions": 6,
-        "markers": {
-          "test_get_completions_returns_expected_result": "medium",
-          "test_complete_command_returns_expected_result": "medium",
-          "test_command_autocomplete_returns_expected_result": "medium",
-          "test_file_path_autocomplete_returns_expected_result": "medium",
-          "test_get_command_help_returns_expected_result": "medium",
-          "test_get_all_commands_help_returns_expected_result": "medium"
-        },
-        "tests_with_markers": 6,
-        "tests_without_markers": 0,
-        "misaligned_markers": [],
-        "duplicate_markers": [],
-        "recognized_markers": {
-          "medium": {
-            "file_count": 6,
-            "pytest_count": 0,
-            "recognized": false,
-            "registered_in_pytest_ini": true,
-            "error": "subprocess error: 4",
-            "uncollected_tests": []
-          }
-        },
-        "issues": [
-          {
-            "type": "unrecognized_markers",
-            "message": "medium markers are not recognized by pytest (6 in file, 0 recognized)"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/unit/application/cli/test_ingest_phases.py": {
-        "file_path": "/workspace/devsynth/tests/unit/application/cli/test_ingest_phases.py",
-        "has_pytest_import": true,
-        "test_functions": 5,
-        "markers": {
-          "test_expand_phase_succeeds": "medium",
-          "test_differentiate_phase_succeeds": "medium",
-          "test_refine_phase_succeeds": "medium",
-          "test_retrospect_phase_succeeds": "medium"
-        },
-        "tests_with_markers": 4,
-        "tests_without_markers": 1,
-        "misaligned_markers": [],
-        "duplicate_markers": [],
-        "recognized_markers": {
-          "medium": {
-            "file_count": 4,
-            "pytest_count": 0,
-            "recognized": false,
-            "registered_in_pytest_ini": true,
-            "error": "subprocess error: 4",
-            "uncollected_tests": []
-          }
-        },
-        "issues": [
-          {
-            "type": "unrecognized_markers",
-            "message": "medium markers are not recognized by pytest (4 in file, 0 recognized)"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/unit/application/cli/test_doctor_cmd.py": {
-        "file_path": "/workspace/devsynth/tests/unit/application/cli/test_doctor_cmd.py",
-        "has_pytest_import": true,
-        "test_functions": 12,
-        "markers": {
-          "test_doctor_cmd_old_python_and_missing_env_warn_succeeds": "medium",
-          "test_doctor_cmd_success_is_valid": "medium",
-          "test_doctor_cmd_invalid_config_is_valid": "medium",
-          "test_doctor_cmd_missing_env_vars_succeeds": "medium",
-          "test_doctor_cmd_warns_missing_optional_feature_pkg_succeeds": "medium",
-          "test_doctor_cmd_warns_missing_memory_store_pkg_succeeds": "medium",
-          "test_doctor_cmd_warns_missing_uvicorn_succeeds": "medium",
-          "test_check_cmd_alias_succeeds": "medium",
-          "test_doctor_cmd_invokes_service_check": "medium",
-          "test_doctor_cmd_warns_missing_required_dependency": "medium",
-          "test_doctor_cmd_reports_missing_directories": "medium",
-          "test_doctor_cmd_quick_tests_failure_warns": "medium"
-        },
-        "tests_with_markers": 12,
-        "tests_without_markers": 0,
-        "misaligned_markers": [],
-        "duplicate_markers": [],
-        "recognized_markers": {
-          "medium": {
-            "file_count": 12,
-            "pytest_count": 0,
-            "recognized": false,
-            "registered_in_pytest_ini": true,
-            "error": "subprocess error: 4",
-            "uncollected_tests": []
-          }
-        },
-        "issues": [
-          {
-            "type": "unrecognized_markers",
-            "message": "medium markers are not recognized by pytest (12 in file, 0 recognized)"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/unit/application/cli/test_metrics_commands.py": {
-        "file_path": "/workspace/devsynth/tests/unit/application/cli/test_metrics_commands.py",
-        "has_pytest_import": true,
-        "test_functions": 4,
-        "markers": {
-          "test_alignment_metrics_cmd_success": "medium",
-          "test_alignment_metrics_cmd_failure": "medium",
-          "test_test_metrics_cmd_writes_report": "medium",
-          "test_test_metrics_cmd_no_commits": "medium"
-        },
-        "tests_with_markers": 4,
-        "tests_without_markers": 0,
-        "misaligned_markers": [],
-        "duplicate_markers": [],
-        "recognized_markers": {
-          "medium": {
-            "file_count": 4,
-            "pytest_count": 0,
-            "recognized": false,
-            "registered_in_pytest_ini": true,
-            "error": "subprocess error: 4",
-            "uncollected_tests": []
-          }
-        },
-        "issues": [
-          {
-            "type": "unrecognized_markers",
-            "message": "medium markers are not recognized by pytest (4 in file, 0 recognized)"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/unit/application/cli/test_help.py": {
-        "file_path": "/workspace/devsynth/tests/unit/application/cli/test_help.py",
-        "has_pytest_import": true,
-        "test_functions": 12,
-        "markers": {
-          "test_get_command_help_returns_expected_result": "medium",
-          "test_display_command_help_succeeds": "medium",
-          "test_get_all_commands_help_returns_expected_result": "medium",
-          "test_display_all_commands_help_succeeds": "medium",
-          "test_create_command_table_succeeds": "medium",
-          "test_display_command_table_succeeds": "medium",
-          "test_format_command_help_markdown_succeeds": "medium",
-          "test_display_command_help_markdown_succeeds": "medium",
-          "test_get_command_usage_returns_expected_result": "medium",
-          "test_display_command_usage_succeeds": "medium",
-          "test_get_command_examples_returns_expected_result": "medium",
-          "test_display_command_examples_succeeds": "medium"
-        },
-        "tests_with_markers": 12,
-        "tests_without_markers": 0,
-        "misaligned_markers": [],
-        "duplicate_markers": [],
-        "recognized_markers": {
-          "medium": {
-            "file_count": 12,
-            "pytest_count": 0,
-            "recognized": false,
-            "registered_in_pytest_ini": true,
-            "error": "subprocess error: 4",
-            "uncollected_tests": []
-          }
-        },
-        "issues": [
-          {
-            "type": "unrecognized_markers",
-            "message": "medium markers are not recognized by pytest (12 in file, 0 recognized)"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/unit/application/cli/test_config_validation.py": {
-        "file_path": "/workspace/devsynth/tests/unit/application/cli/test_config_validation.py",
-        "has_pytest_import": true,
-        "test_functions": 2,
-        "markers": {
-          "test_config_warnings_succeeds": "medium",
-          "test_config_success_succeeds": "medium"
-        },
-        "tests_with_markers": 2,
-        "tests_without_markers": 0,
-        "misaligned_markers": [],
-        "duplicate_markers": [],
-        "recognized_markers": {
-          "medium": {
-            "file_count": 2,
-            "pytest_count": 0,
-            "recognized": false,
-            "registered_in_pytest_ini": true,
-            "error": "subprocess error: 4",
-            "uncollected_tests": []
-          }
-        },
-        "issues": [
-          {
-            "type": "unrecognized_markers",
-            "message": "medium markers are not recognized by pytest (2 in file, 0 recognized)"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/unit/application/cli/test_init_cmd.py": {
-        "file_path": "/workspace/devsynth/tests/unit/application/cli/test_init_cmd.py",
-        "has_pytest_import": true,
-        "test_functions": 9,
-        "markers": {
-          "test_init_cmd_creates_config_succeeds": "medium",
-          "test_init_cmd_idempotent_succeeds": "medium",
-          "test_init_cmd_metrics_dashboard_option": "medium",
-          "test_init_cmd_wizard_option_invokes_setup": "medium",
-          "test_init_cmd_reports_progress": "medium",
-          "test_init_cmd_non_interactive_flag_skips_prompts": "medium",
-          "test_init_cmd_defaults_non_interactive_skips_prompts": "medium",
-          "test_init_cmd_env_non_interactive_skips_prompts": "medium",
-          "test_cli_help_lists_renamed_commands_succeeds": "medium"
-        },
-        "tests_with_markers": 9,
-        "tests_without_markers": 0,
-        "misaligned_markers": [],
-        "duplicate_markers": [],
-        "recognized_markers": {
-          "medium": {
-            "file_count": 9,
-            "pytest_count": 0,
-            "recognized": false,
-            "registered_in_pytest_ini": true,
-            "error": "subprocess error: 4",
-            "uncollected_tests": []
-          }
-        },
-        "issues": [
-          {
-            "type": "unrecognized_markers",
-            "message": "medium markers are not recognized by pytest (9 in file, 0 recognized)"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/unit/application/cli/test_requirements_commands.py": {
-        "file_path": "/workspace/devsynth/tests/unit/application/cli/test_requirements_commands.py",
-        "has_pytest_import": true,
-        "test_functions": 2,
-        "markers": {
-          "test_wizard_cmd_back_navigation_succeeds": "medium",
-          "test_gather_requirements_cmd_yaml_succeeds": "medium"
-        },
-        "tests_with_markers": 2,
-        "tests_without_markers": 0,
-        "misaligned_markers": [],
-        "duplicate_markers": [],
-        "recognized_markers": {
-          "medium": {
-            "file_count": 2,
-            "pytest_count": 0,
-            "recognized": false,
-            "registered_in_pytest_ini": true,
-            "error": "subprocess error: 4",
-            "uncollected_tests": []
-          }
-        },
-        "issues": [
-          {
-            "type": "unrecognized_markers",
-            "message": "medium markers are not recognized by pytest (2 in file, 0 recognized)"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/unit/application/cli/test_setup_wizard.py": {
-        "file_path": "/workspace/devsynth/tests/unit/application/cli/test_setup_wizard.py",
-        "has_pytest_import": true,
-        "test_functions": 4,
-        "markers": {
-          "test_setup_wizard_instantiation_succeeds": "medium",
-          "test_wizard_prompts_via_cli_bridge_succeeds": "medium",
-          "test_setup_wizard_run_succeeds": "medium",
-          "test_setup_wizard_abort_succeeds": "medium"
-        },
-        "tests_with_markers": 4,
-        "tests_without_markers": 0,
-        "misaligned_markers": [],
-        "duplicate_markers": [],
-        "recognized_markers": {
-          "medium": {
-            "file_count": 4,
-            "pytest_count": 0,
-            "recognized": false,
-            "registered_in_pytest_ini": true,
-            "error": "subprocess error: 4",
-            "uncollected_tests": []
-          }
-        },
-        "issues": [
-          {
-            "type": "unrecognized_markers",
-            "message": "medium markers are not recognized by pytest (4 in file, 0 recognized)"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/unit/application/cli/test_completion_cmd.py": {
-        "file_path": "/workspace/devsynth/tests/unit/application/cli/test_completion_cmd.py",
-        "has_pytest_import": true,
-        "test_functions": 3,
-        "markers": {
-          "test_completion_cmd_outputs_script": "medium",
-          "test_completion_cmd_installs_script": "medium",
-          "test_cli_supports_install_completion": "medium"
-        },
-        "tests_with_markers": 3,
-        "tests_without_markers": 0,
-        "misaligned_markers": [],
-        "duplicate_markers": [],
-        "recognized_markers": {
-          "medium": {
-            "file_count": 3,
-            "pytest_count": 0,
-            "recognized": false,
-            "registered_in_pytest_ini": true,
-            "error": "subprocess error: 4",
-            "uncollected_tests": []
-          }
-        },
-        "issues": [
-          {
-            "type": "unrecognized_markers",
-            "message": "medium markers are not recognized by pytest (3 in file, 0 recognized)"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/unit/application/cli/test_ingest_cmd.py": {
-        "file_path": "/workspace/devsynth/tests/unit/application/cli/test_ingest_cmd.py",
-        "has_pytest_import": true,
-        "test_functions": 2,
-        "markers": {
-          "test_ingest_cmd_non_interactive_skips_prompts": "medium",
-          "test_ingest_cmd_defaults_enable_non_interactive": "medium"
-        },
-        "tests_with_markers": 2,
-        "tests_without_markers": 0,
-        "misaligned_markers": [],
-        "duplicate_markers": [],
-        "recognized_markers": {
-          "medium": {
-            "file_count": 2,
-            "pytest_count": 0,
-            "recognized": false,
-            "registered_in_pytest_ini": true,
-            "error": "subprocess error: 4",
-            "uncollected_tests": []
-          }
-        },
-        "issues": [
-          {
-            "type": "unrecognized_markers",
-            "message": "medium markers are not recognized by pytest (2 in file, 0 recognized)"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/unit/application/cli/test_serve_cmd.py": {
-        "file_path": "/workspace/devsynth/tests/unit/application/cli/test_serve_cmd.py",
-        "has_pytest_import": true,
-        "test_functions": 1,
-        "markers": {
-          "test_serve_cmd_missing_uvicorn_succeeds": "medium"
-        },
-        "tests_with_markers": 1,
-        "tests_without_markers": 0,
-        "misaligned_markers": [],
-        "duplicate_markers": [],
-        "recognized_markers": {
-          "medium": {
-            "file_count": 1,
-            "pytest_count": 0,
-            "recognized": false,
-            "registered_in_pytest_ini": true,
-            "error": "subprocess error: 4",
-            "uncollected_tests": []
-          }
-        },
-        "issues": [
-          {
-            "type": "unrecognized_markers",
-            "message": "medium markers are not recognized by pytest (1 in file, 0 recognized)"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/unit/application/agents/test_specification_agent.py": {
-        "file_path": "/workspace/devsynth/tests/unit/application/agents/test_specification_agent.py",
-        "has_pytest_import": true,
-        "test_functions": 2,
-        "markers": {
-          "test_process_succeeds": "medium",
-          "test_get_capabilities_with_custom_capabilities_succeeds": "medium"
-        },
-        "tests_with_markers": 2,
-        "tests_without_markers": 0,
-        "misaligned_markers": [],
-        "duplicate_markers": [],
-        "recognized_markers": {
-          "medium": {
-            "file_count": 2,
-            "pytest_count": 0,
-            "recognized": false,
-            "registered_in_pytest_ini": true,
-            "error": "subprocess error: 4",
-            "uncollected_tests": []
-          }
-        },
-        "issues": [
-          {
-            "type": "unrecognized_markers",
-            "message": "medium markers are not recognized by pytest (2 in file, 0 recognized)"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/unit/application/agents/test_critic_agent.py": {
-        "file_path": "/workspace/devsynth/tests/unit/application/agents/test_critic_agent.py",
-        "has_pytest_import": true,
-        "test_functions": 8,
-        "markers": {
-          "test_initialization_succeeds": "medium",
-          "test_process_succeeds": "medium",
-          "test_process_with_empty_inputs_succeeds": "medium",
-          "test_process_no_llm_port_succeeds": "medium",
-          "test_get_capabilities_succeeds": "medium",
-          "test_get_capabilities_with_custom_capabilities_succeeds": "medium",
-          "test_process_error_handling_raises_error": "medium",
-          "test_create_wsde_error_fails": "medium"
-        },
-        "tests_with_markers": 8,
-        "tests_without_markers": 0,
-        "misaligned_markers": [],
-        "duplicate_markers": [],
-        "recognized_markers": {
-          "medium": {
-            "file_count": 8,
-            "pytest_count": 0,
-            "recognized": false,
-            "registered_in_pytest_ini": true,
-            "error": "subprocess error: 4",
-            "uncollected_tests": []
-          }
-        },
-        "issues": [
-          {
-            "type": "unrecognized_markers",
-            "message": "medium markers are not recognized by pytest (8 in file, 0 recognized)"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/unit/application/agents/test_base_agent.py": {
-        "file_path": "/workspace/devsynth/tests/unit/application/agents/test_base_agent.py",
-        "has_pytest_import": true,
-        "test_functions": 11,
-        "markers": {
-          "test_initialization_succeeds": "medium",
-          "test_generate_text_succeeds": "medium",
-          "test_generate_text_with_context_succeeds": "medium",
-          "test_generate_text_no_llm_port_succeeds": "medium",
-          "test_generate_text_with_context_no_llm_port_succeeds": "medium",
-          "test_process_abstract_method_succeeds": "medium",
-          "test_create_wsde_succeeds": "medium",
-          "test_update_wsde_succeeds": "medium",
-          "test_get_role_prompt_succeeds": "medium",
-          "test_generate_text_error_raises_error": "medium",
-          "test_generate_text_with_context_error_raises_error": "medium"
-        },
-        "tests_with_markers": 11,
-        "tests_without_markers": 0,
-        "misaligned_markers": [],
-        "duplicate_markers": [
-          {
-            "test_name": "test_create_wsde_succeeds",
-            "marker_count": 2
-          }
-        ],
-        "recognized_markers": {
-          "medium": {
-            "file_count": 11,
-            "pytest_count": 0,
-            "recognized": false,
-            "registered_in_pytest_ini": true,
-            "error": "subprocess error: 4",
-            "uncollected_tests": []
-          }
-        },
-        "issues": [
-          {
-            "type": "duplicate_markers",
-            "message": "File has 1 tests with duplicate markers"
-          },
-          {
-            "type": "unrecognized_markers",
-            "message": "medium markers are not recognized by pytest (11 in file, 0 recognized)"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/unit/application/agents/test_wsde_memory_integration.py": {
-        "file_path": "/workspace/devsynth/tests/unit/application/agents/test_wsde_memory_integration.py",
-        "has_pytest_import": true,
-        "test_functions": 15,
-        "markers": {
-          "test_store_dialectical_process_succeeds": "medium",
-          "test_retrieve_dialectical_process_succeeds": "medium",
-          "test_store_agent_solution_succeeds": "medium",
-          "test_retrieve_agent_solutions_succeeds": "medium",
-          "test_store_team_context_succeeds": "medium",
-          "test_retrieve_team_context_succeeds": "medium",
-          "test_search_similar_solutions_succeeds": "medium",
-          "test_store_agent_solution_with_edrr_phase_has_expected": "medium",
-          "test_retrieve_solutions_by_edrr_phase_has_expected": "medium",
-          "test_query_knowledge_graph_succeeds": "medium",
-          "test_query_knowledge_graph_not_supported_succeeds": "medium",
-          "test_query_related_concepts_succeeds": "medium",
-          "test_query_concept_relationships_succeeds": "medium",
-          "test_query_by_concept_type_succeeds": "medium",
-          "test_query_knowledge_for_task_succeeds": "medium"
-        },
-        "tests_with_markers": 15,
-        "tests_without_markers": 0,
-        "misaligned_markers": [],
-        "duplicate_markers": [],
-        "recognized_markers": {
-          "medium": {
-            "file_count": 15,
-            "pytest_count": 0,
-            "recognized": false,
-            "registered_in_pytest_ini": true,
-            "error": "subprocess error: 4",
-            "uncollected_tests": []
-          }
-        },
-        "issues": [
-          {
-            "type": "unrecognized_markers",
-            "message": "medium markers are not recognized by pytest (15 in file, 0 recognized)"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/unit/application/agents/test_planner_agent.py": {
-        "file_path": "/workspace/devsynth/tests/unit/application/agents/test_planner_agent.py",
-        "has_pytest_import": true,
-        "test_functions": 6,
-        "markers": {
-          "test_initialization_succeeds": "medium",
-          "test_process_succeeds": "medium",
-          "test_process_with_empty_inputs_succeeds": "medium",
-          "test_get_capabilities_succeeds": "medium",
-          "test_get_capabilities_with_custom_capabilities_succeeds": "medium",
-          "test_process_error_handling_raises_error": "medium"
-        },
-        "tests_with_markers": 6,
-        "tests_without_markers": 0,
-        "misaligned_markers": [],
-        "duplicate_markers": [],
-        "recognized_markers": {
-          "medium": {
-            "file_count": 6,
-            "pytest_count": 0,
-            "recognized": false,
-            "registered_in_pytest_ini": true,
-            "error": "subprocess error: 4",
-            "uncollected_tests": []
-          }
-        },
-        "issues": [
-          {
-            "type": "unrecognized_markers",
-            "message": "medium markers are not recognized by pytest (6 in file, 0 recognized)"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/unit/application/agents/test_diagram_agent.py": {
-        "file_path": "/workspace/devsynth/tests/unit/application/agents/test_diagram_agent.py",
-        "has_pytest_import": true,
-        "test_functions": 6,
-        "markers": {
-          "test_initialization_succeeds": "medium",
-          "test_process_succeeds": "medium",
-          "test_process_with_empty_inputs_succeeds": "medium",
-          "test_get_capabilities_succeeds": "medium",
-          "test_get_capabilities_with_custom_capabilities_succeeds": "medium",
-          "test_process_error_handling_raises_error": "medium"
-        },
-        "tests_with_markers": 6,
-        "tests_without_markers": 0,
-        "misaligned_markers": [],
-        "duplicate_markers": [],
-        "recognized_markers": {
-          "medium": {
-            "file_count": 6,
-            "pytest_count": 0,
-            "recognized": false,
-            "registered_in_pytest_ini": true,
-            "error": "subprocess error: 4",
-            "uncollected_tests": []
-          }
-        },
-        "issues": [
-          {
-            "type": "unrecognized_markers",
-            "message": "medium markers are not recognized by pytest (6 in file, 0 recognized)"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/unit/application/agents/test_test_agent_integration.py": {
-        "file_path": "/workspace/devsynth/tests/unit/application/agents/test_test_agent_integration.py",
-        "has_pytest_import": true,
-        "test_functions": 1,
-        "markers": {
-          "test_process_scaffolds_tests_from_context": "fast"
-        },
-        "tests_with_markers": 1,
-        "tests_without_markers": 0,
-        "misaligned_markers": [],
-        "duplicate_markers": [],
-        "recognized_markers": {
-          "fast": {
-            "file_count": 1,
-            "pytest_count": 0,
-            "recognized": false,
-            "registered_in_pytest_ini": true,
-            "error": "subprocess error: 4",
-            "uncollected_tests": []
-          }
-        },
-        "issues": [
-          {
-            "type": "unrecognized_markers",
-            "message": "fast markers are not recognized by pytest (1 in file, 0 recognized)"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/unit/application/agents/test_unified_agent_generic.py": {
-        "file_path": "/workspace/devsynth/tests/unit/application/agents/test_unified_agent_generic.py",
-        "has_pytest_import": true,
-        "test_functions": 1,
-        "markers": {
-          "test_process_generic_task_succeeds": "medium"
-        },
-        "tests_with_markers": 1,
-        "tests_without_markers": 0,
-        "misaligned_markers": [],
-        "duplicate_markers": [],
-        "recognized_markers": {
-          "medium": {
-            "file_count": 1,
-            "pytest_count": 0,
-            "recognized": false,
-            "registered_in_pytest_ini": true,
-            "error": "subprocess error: 4",
-            "uncollected_tests": []
-          }
-        },
-        "issues": [
-          {
-            "type": "unrecognized_markers",
-            "message": "medium markers are not recognized by pytest (1 in file, 0 recognized)"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/unit/application/agents/test_validation_agent.py": {
-        "file_path": "/workspace/devsynth/tests/unit/application/agents/test_validation_agent.py",
-        "has_pytest_import": true,
-        "test_functions": 1,
-        "markers": {
-          "test_process_succeeds": "medium"
-        },
-        "tests_with_markers": 1,
-        "tests_without_markers": 0,
-        "misaligned_markers": [],
-        "duplicate_markers": [],
-        "recognized_markers": {
-          "medium": {
-            "file_count": 1,
-            "pytest_count": 0,
-            "recognized": false,
-            "registered_in_pytest_ini": true,
-            "error": "subprocess error: 4",
-            "uncollected_tests": []
-          }
-        },
-        "issues": [
-          {
-            "type": "unrecognized_markers",
-            "message": "medium markers are not recognized by pytest (1 in file, 0 recognized)"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/unit/application/agents/test_agent_memory_integration.py": {
-        "file_path": "/workspace/devsynth/tests/unit/application/agents/test_agent_memory_integration.py",
-        "has_pytest_import": true,
-        "test_functions": 15,
-        "markers": {
-          "test_store_agent_solution_succeeds": "medium",
-          "test_retrieve_agent_solutions_succeeds": "medium",
-          "test_store_dialectical_reasoning_succeeds": "medium",
-          "test_retrieve_dialectical_reasoning_succeeds": "medium",
-          "test_store_agent_context_succeeds": "medium",
-          "test_retrieve_agent_context_succeeds": "medium",
-          "test_search_similar_solutions_succeeds": "medium",
-          "test_search_similar_solutions_no_vector_store_succeeds": "medium",
-          "test_store_memory_succeeds": "medium",
-          "test_retrieve_memory_succeeds": "medium",
-          "test_search_memory_succeeds": "medium",
-          "test_update_memory_succeeds": "medium",
-          "test_delete_memory_succeeds": "medium",
-          "test_store_memory_with_context_succeeds": "medium",
-          "test_retrieve_memory_with_context_succeeds": "medium"
-        },
-        "tests_with_markers": 15,
-        "tests_without_markers": 0,
-        "misaligned_markers": [],
-        "duplicate_markers": [
-          {
-            "test_name": "test_store_memory_with_context_succeeds",
-            "marker_count": 2
-          }
-        ],
-        "recognized_markers": {
-          "medium": {
-            "file_count": 15,
-            "pytest_count": 0,
-            "recognized": false,
-            "registered_in_pytest_ini": true,
-            "error": "subprocess error: 4",
-            "uncollected_tests": []
-          }
-        },
-        "issues": [
-          {
-            "type": "duplicate_markers",
-            "message": "File has 1 tests with duplicate markers"
-          },
-          {
-            "type": "unrecognized_markers",
-            "message": "medium markers are not recognized by pytest (15 in file, 0 recognized)"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/unit/application/agents/test_test_agent.py": {
-        "file_path": "/workspace/devsynth/tests/unit/application/agents/test_test_agent.py",
-        "has_pytest_import": true,
-        "test_functions": 5,
-        "markers": {
-          "test_agent": "medium",
-          "test_initialization_succeeds": "medium",
-          "test_process_succeeds": "medium",
-          "test_get_capabilities_with_custom_capabilities_succeeds": "medium",
-          "test_process_error_handling": "medium"
-        },
-        "tests_with_markers": 5,
-        "tests_without_markers": 0,
-        "misaligned_markers": [],
-        "duplicate_markers": [],
-        "recognized_markers": {
-          "medium": {
-            "file_count": 5,
-            "pytest_count": 0,
-            "recognized": false,
-            "registered_in_pytest_ini": true,
-            "error": "subprocess error: 4",
-            "uncollected_tests": []
-          }
-        },
-        "issues": [
-          {
-            "type": "unrecognized_markers",
-            "message": "medium markers are not recognized by pytest (5 in file, 0 recognized)"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/unit/application/agents/test_multi_language_code.py": {
-        "file_path": "/workspace/devsynth/tests/unit/application/agents/test_multi_language_code.py",
-        "has_pytest_import": true,
-        "test_functions": 8,
-        "markers": {
-          "test_initialization_succeeds": "medium",
-          "test_process_supported_languages_succeed": "medium",
-          "test_process_polyglot_succeeds": "medium",
-          "test_process_polyglot_with_invalid_language": "medium",
-          "test_process_unsupported_language_raises_error": "medium",
-          "test_process_wsde_creation_error_logs_and_returns": "medium",
-          "test_process_calls_llm_generate": "medium",
-          "test_process_without_llm_returns_placeholder": "medium"
-        },
-        "tests_with_markers": 8,
-        "tests_without_markers": 0,
-        "misaligned_markers": [],
-        "duplicate_markers": [
-          {
-            "test_name": "test_process_unsupported_language_raises_error",
-            "marker_count": 2
-          },
-          {
-            "test_name": "test_process_wsde_creation_error_logs_and_returns",
-            "marker_count": 2
-          },
-          {
-            "test_name": "test_process_calls_llm_generate",
-            "marker_count": 2
-          },
-          {
-            "test_name": "test_process_without_llm_returns_placeholder",
-            "marker_count": 2
-          }
-        ],
-        "recognized_markers": {
-          "medium": {
-            "file_count": 8,
-            "pytest_count": 0,
-            "recognized": false,
-            "registered_in_pytest_ini": true,
-            "error": "subprocess error: 4",
-            "uncollected_tests": []
-          }
-        },
-        "issues": [
-          {
-            "type": "duplicate_markers",
-            "message": "File has 4 tests with duplicate markers"
-          },
-          {
-            "type": "unrecognized_markers",
-            "message": "medium markers are not recognized by pytest (8 in file, 0 recognized)"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/unit/application/agents/test_refactor_agent.py": {
-        "file_path": "/workspace/devsynth/tests/unit/application/agents/test_refactor_agent.py",
-        "has_pytest_import": true,
-        "test_functions": 7,
-        "markers": {
-          "test_initialization_succeeds": "medium",
-          "test_process_succeeds": "medium",
-          "test_process_with_empty_inputs_succeeds": "medium",
-          "test_get_capabilities_succeeds": "medium",
-          "test_get_capabilities_with_custom_capabilities_succeeds": "medium",
-          "test_process_error_handling_code_wsde_fails": "medium",
-          "test_process_error_handling_explanation_wsde_fails": "medium"
-        },
-        "tests_with_markers": 7,
-        "tests_without_markers": 0,
-        "misaligned_markers": [],
-        "duplicate_markers": [],
-        "recognized_markers": {
-          "medium": {
-            "file_count": 7,
-            "pytest_count": 0,
-            "recognized": false,
-            "registered_in_pytest_ini": true,
-            "error": "subprocess error: 4",
-            "uncollected_tests": []
-          }
-        },
-        "issues": [
-          {
-            "type": "unrecognized_markers",
-            "message": "medium markers are not recognized by pytest (7 in file, 0 recognized)"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/unit/application/agents/test_code_agent.py": {
-        "file_path": "/workspace/devsynth/tests/unit/application/agents/test_code_agent.py",
-        "has_pytest_import": true,
-        "test_functions": 7,
-        "markers": {
-          "test_initialization_succeeds": "medium",
-          "test_process_succeeds": "medium",
-          "test_process_with_empty_inputs_succeeds": "medium",
-          "test_get_capabilities_succeeds": "medium",
-          "test_get_capabilities_with_custom_capabilities_succeeds": "medium",
-          "test_process_error_handling_raises_error": "medium"
-        },
-        "tests_with_markers": 6,
-        "tests_without_markers": 1,
-        "misaligned_markers": [],
-        "duplicate_markers": [],
-        "recognized_markers": {
-          "medium": {
-            "file_count": 6,
-            "pytest_count": 0,
-            "recognized": false,
-            "registered_in_pytest_ini": true,
-            "error": "subprocess error: 4",
-            "uncollected_tests": []
-          }
-        },
-        "issues": [
-          {
-            "type": "unrecognized_markers",
-            "message": "medium markers are not recognized by pytest (6 in file, 0 recognized)"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/unit/application/agents/test_documentation_agent.py": {
-        "file_path": "/workspace/devsynth/tests/unit/application/agents/test_documentation_agent.py",
-        "has_pytest_import": true,
-        "test_functions": 6,
-        "markers": {
-          "test_initialization_succeeds": "medium",
-          "test_process_succeeds": "medium",
-          "test_process_with_empty_inputs_succeeds": "medium",
-          "test_get_capabilities_succeeds": "medium",
-          "test_get_capabilities_with_custom_capabilities_succeeds": "medium",
-          "test_process_error_handling_raises_error": "medium"
-        },
-        "tests_with_markers": 6,
-        "tests_without_markers": 0,
-        "misaligned_markers": [],
-        "duplicate_markers": [],
-        "recognized_markers": {
-          "medium": {
-            "file_count": 6,
-            "pytest_count": 0,
-            "recognized": false,
-            "registered_in_pytest_ini": true,
-            "error": "subprocess error: 4",
-            "uncollected_tests": []
-          }
-        },
-        "issues": [
-          {
-            "type": "unrecognized_markers",
-            "message": "medium markers are not recognized by pytest (6 in file, 0 recognized)"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/unit/application/llm/test_provider_selection.py": {
-        "file_path": "/workspace/devsynth/tests/unit/application/llm/test_provider_selection.py",
-        "has_pytest_import": true,
-        "test_functions": 2,
-        "markers": {
-          "test_get_llm_provider_offline": "fast",
-          "test_get_llm_provider_default": "fast"
-        },
-        "tests_with_markers": 2,
-        "tests_without_markers": 0,
-        "misaligned_markers": [],
-        "duplicate_markers": [],
-        "recognized_markers": {
-          "fast": {
-            "file_count": 2,
-            "pytest_count": 0,
-            "recognized": false,
-            "registered_in_pytest_ini": true,
-            "error": "subprocess error: 4",
-            "uncollected_tests": []
-          }
-        },
-        "issues": [
-          {
-            "type": "unrecognized_markers",
-            "message": "fast markers are not recognized by pytest (2 in file, 0 recognized)"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/unit/application/llm/test_offline_provider_deps.py": {
-        "file_path": "/workspace/devsynth/tests/unit/application/llm/test_offline_provider_deps.py",
-        "has_pytest_import": true,
-        "test_functions": 3,
-        "markers": {
-          "test_load_transformer_deps_imports_when_available": "medium",
-          "test_load_transformer_deps_noop_when_already_loaded": "medium",
-          "test_load_transformer_deps_handles_import_error": "medium"
-        },
-        "tests_with_markers": 3,
-        "tests_without_markers": 0,
-        "misaligned_markers": [],
-        "duplicate_markers": [],
-        "recognized_markers": {
-          "medium": {
-            "file_count": 3,
-            "pytest_count": 0,
-            "recognized": false,
-            "registered_in_pytest_ini": true,
-            "error": "subprocess error: 4",
-            "uncollected_tests": []
-          }
-        },
-        "issues": [
-          {
-            "type": "unrecognized_markers",
-            "message": "medium markers are not recognized by pytest (3 in file, 0 recognized)"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/unit/application/llm/test_import_without_openai.py": {
-        "file_path": "/workspace/devsynth/tests/unit/application/llm/test_import_without_openai.py",
-        "has_pytest_import": true,
-        "test_functions": 2,
-        "markers": {
-          "test_import_openai_provider_without_openai_succeeds": "fast",
-          "test_openai_provider_requires_api_key": "fast"
-        },
-        "tests_with_markers": 2,
-        "tests_without_markers": 0,
-        "misaligned_markers": [],
-        "duplicate_markers": [],
-        "recognized_markers": {
-          "fast": {
-            "file_count": 2,
-            "pytest_count": 0,
-            "recognized": false,
-            "registered_in_pytest_ini": true,
-            "error": "subprocess error: 4",
-            "uncollected_tests": []
-          }
-        },
-        "issues": [
-          {
-            "type": "unrecognized_markers",
-            "message": "fast markers are not recognized by pytest (2 in file, 0 recognized)"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/unit/application/llm/test_offline_provider.py": {
-        "file_path": "/workspace/devsynth/tests/unit/application/llm/test_offline_provider.py",
-        "has_pytest_import": true,
-        "test_functions": 8,
-        "markers": {
-          "test_offline_provider_fallback_succeeds": "medium",
-          "test_offline_provider_loads_local_model_succeeds": "medium",
-          "test_generate_with_context_succeeds": "medium",
-          "test_generate_with_empty_context_succeeds": "medium",
-          "test_generate_with_empty_prompt_succeeds": "medium",
-          "test_get_embedding_consistency_succeeds": "medium",
-          "test_get_embedding_different_inputs_succeeds": "medium",
-          "test_model_loading_error_fails": "medium"
-        },
-        "tests_with_markers": 8,
-        "tests_without_markers": 0,
-        "misaligned_markers": [],
-        "duplicate_markers": [],
-        "recognized_markers": {
-          "medium": {
-            "file_count": 8,
-            "pytest_count": 0,
-            "recognized": false,
-            "registered_in_pytest_ini": true,
-            "error": "subprocess error: 4",
-            "uncollected_tests": []
-          }
-        },
-        "issues": [
-          {
-            "type": "unrecognized_markers",
-            "message": "medium markers are not recognized by pytest (8 in file, 0 recognized)"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/unit/application/llm/test_import_without_lmstudio.py": {
-        "file_path": "/workspace/devsynth/tests/unit/application/llm/test_import_without_lmstudio.py",
-        "has_pytest_import": true,
-        "test_functions": 1,
-        "markers": {
-          "test_import_lmstudio_provider_without_lmstudio_succeeds": "medium"
-        },
-        "tests_with_markers": 1,
-        "tests_without_markers": 0,
-        "misaligned_markers": [],
-        "duplicate_markers": [],
-        "recognized_markers": {
-          "medium": {
-            "file_count": 1,
-            "pytest_count": 0,
-            "recognized": false,
-            "registered_in_pytest_ini": true,
-            "error": "subprocess error: 4",
-            "uncollected_tests": []
-          }
-        },
-        "issues": [
-          {
-            "type": "unrecognized_markers",
-            "message": "medium markers are not recognized by pytest (1 in file, 0 recognized)"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/unit/application/code_analysis/test_project_state_analyzer.py": {
-        "file_path": "/workspace/devsynth/tests/unit/application/code_analysis/test_project_state_analyzer.py",
-        "has_pytest_import": true,
-        "test_functions": 10,
-        "markers": {
-          "test_project_dir_succeeds": "medium",
-          "test_initialization_succeeds": "medium",
-          "test_analyze_succeeds": "medium",
-          "test_index_files_succeeds": "medium",
-          "test_detect_languages_succeeds": "medium",
-          "test_infer_architecture_succeeds": "medium",
-          "test_identify_components_succeeds": "medium",
-          "test_analyze_requirements_spec_alignment_succeeds": "medium",
-          "test_generate_health_report_succeeds": "medium"
-        },
-        "tests_with_markers": 9,
-        "tests_without_markers": 1,
-        "misaligned_markers": [],
-        "duplicate_markers": [],
-        "recognized_markers": {
-          "medium": {
-            "file_count": 9,
-            "pytest_count": 0,
-            "recognized": false,
-            "registered_in_pytest_ini": true,
-            "error": "subprocess error: 4",
-            "uncollected_tests": []
-          }
-        },
-        "issues": [
-          {
-            "type": "unrecognized_markers",
-            "message": "medium markers are not recognized by pytest (9 in file, 0 recognized)"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/unit/application/code_analysis/test_ast_transformer.py": {
-        "file_path": "/workspace/devsynth/tests/unit/application/code_analysis/test_ast_transformer.py",
-        "has_pytest_import": true,
-        "test_functions": 9,
-        "markers": {
-          "test_rename_function_succeeds": "medium",
-          "test_rename_variable_succeeds": "medium",
-          "test_rename_parameter_succeeds": "medium",
-          "test_extract_function_succeeds": "medium",
-          "test_add_docstring_succeeds": "medium",
-          "test_validate_syntax_is_valid": "medium",
-          "test_complex_transformations_succeeds": "medium",
-          "test_remove_unused_imports_and_variables_succeeds": "medium",
-          "test_optimize_string_literals_succeeds": "medium"
-        },
-        "tests_with_markers": 9,
-        "tests_without_markers": 0,
-        "misaligned_markers": [],
-        "duplicate_markers": [],
-        "recognized_markers": {
-          "medium": {
-            "file_count": 9,
-            "pytest_count": 0,
-            "recognized": false,
-            "registered_in_pytest_ini": true,
-            "error": "subprocess error: 4",
-            "uncollected_tests": []
-          }
-        },
-        "issues": [
-          {
-            "type": "unrecognized_markers",
-            "message": "medium markers are not recognized by pytest (9 in file, 0 recognized)"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/unit/application/code_analysis/test_repo_analyzer.py": {
-        "file_path": "/workspace/devsynth/tests/unit/application/code_analysis/test_repo_analyzer.py",
-        "has_pytest_import": true,
-        "test_functions": 2,
-        "markers": {
-          "test_analyze_maps_dependencies_and_structure": "medium",
-          "test_cli_entry_invokes_repo_analyzer": "medium"
-        },
-        "tests_with_markers": 2,
-        "tests_without_markers": 0,
-        "misaligned_markers": [],
-        "duplicate_markers": [],
-        "recognized_markers": {
-          "medium": {
-            "file_count": 2,
-            "pytest_count": 0,
-            "recognized": false,
-            "registered_in_pytest_ini": true,
-            "error": "subprocess error: 4",
-            "uncollected_tests": []
-          }
-        },
-        "issues": [
-          {
-            "type": "unrecognized_markers",
-            "message": "medium markers are not recognized by pytest (2 in file, 0 recognized)"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/unit/application/code_analysis/test_transformer.py": {
-        "file_path": "/workspace/devsynth/tests/unit/application/code_analysis/test_transformer.py",
-        "has_pytest_import": true,
-        "test_functions": 14,
-        "markers": {
-          "test_file_path_succeeds": "medium",
-          "test_directory_succeeds": "medium",
-          "test_record_change_succeeds": "medium",
-          "test_remove_unused_imports_succeeds": "medium",
-          "test_remove_redundant_assignments_succeeds": "medium",
-          "test_remove_unused_variables_succeeds": "medium",
-          "test_optimize_string_literals_succeeds": "medium",
-          "test_improve_code_style_succeeds": "medium",
-          "test_transform_code_succeeds": "medium",
-          "test_transform_file_succeeds": "medium",
-          "test_transform_directory_succeeds": "medium",
-          "test_find_python_files_succeeds": "medium",
-          "test_count_symbol_usage_succeeds": "medium"
-        },
-        "tests_with_markers": 13,
-        "tests_without_markers": 1,
-        "misaligned_markers": [],
-        "duplicate_markers": [],
-        "recognized_markers": {
-          "medium": {
-            "file_count": 13,
-            "pytest_count": 0,
-            "recognized": false,
-            "registered_in_pytest_ini": true,
-            "error": "subprocess error: 4",
-            "uncollected_tests": []
-          }
-        },
-        "issues": [
-          {
-            "type": "unrecognized_markers",
-            "message": "medium markers are not recognized by pytest (13 in file, 0 recognized)"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/unit/application/code_analysis/test_ast_workflow_integration.py": {
-        "file_path": "/workspace/devsynth/tests/unit/application/code_analysis/test_ast_workflow_integration.py",
-        "has_pytest_import": true,
-        "test_functions": 5,
-        "markers": {
-          "test_complexity_and_readability_metrics_succeeds": "medium",
-          "test_differentiate_selects_best_option_succeeds": "medium",
-          "test_expand_implementation_options_succeeds": "medium",
-          "test_refine_implementation_succeeds": "medium",
-          "test_retrospect_code_quality_succeeds": "medium"
-        },
-        "tests_with_markers": 5,
-        "tests_without_markers": 0,
-        "misaligned_markers": [],
-        "duplicate_markers": [],
-        "recognized_markers": {
-          "medium": {
-            "file_count": 5,
-            "pytest_count": 0,
-            "recognized": false,
-            "registered_in_pytest_ini": true,
-            "error": "subprocess error: 4",
-            "uncollected_tests": []
-          }
-        },
-        "issues": [
-          {
-            "type": "unrecognized_markers",
-            "message": "medium markers are not recognized by pytest (5 in file, 0 recognized)"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/unit/application/code_analysis/test_self_analyzer.py": {
-        "file_path": "/workspace/devsynth/tests/unit/application/code_analysis/test_self_analyzer.py",
-        "has_pytest_import": true,
-        "test_functions": 13,
-        "markers": {
-          "test_project_dir_succeeds": "medium",
-          "test_initialization_succeeds": "medium",
-          "test_analyze_succeeds": "medium",
-          "test_analyze_architecture_succeeds": "medium",
-          "test_detect_architecture_type_succeeds": "medium",
-          "test_identify_layers_succeeds": "medium",
-          "test_analyze_layer_dependencies_succeeds": "medium",
-          "test_check_architecture_violations_succeeds": "medium",
-          "test_analyze_code_quality_succeeds": "medium",
-          "test_analyze_test_coverage_succeeds": "medium",
-          "test_identify_improvement_opportunities_succeeds": "medium"
-        },
-        "tests_with_markers": 11,
-        "tests_without_markers": 2,
-        "misaligned_markers": [],
-        "duplicate_markers": [],
-        "recognized_markers": {
-          "medium": {
-            "file_count": 11,
-            "pytest_count": 0,
-            "recognized": false,
-            "registered_in_pytest_ini": true,
-            "error": "subprocess error: 4",
-            "uncollected_tests": []
-          }
-        },
-        "issues": [
-          {
-            "type": "unrecognized_markers",
-            "message": "medium markers are not recognized by pytest (11 in file, 0 recognized)"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/unit/application/collaboration/test_message_protocol.py": {
-        "file_path": "/workspace/devsynth/tests/unit/application/collaboration/test_message_protocol.py",
-        "has_pytest_import": true,
-        "test_functions": 2,
-        "markers": {
-          "test_send_message_priority_succeeds": "medium",
-          "test_get_messages_filtered_succeeds": "medium"
-        },
-        "tests_with_markers": 2,
-        "tests_without_markers": 0,
-        "misaligned_markers": [],
-        "duplicate_markers": [],
-        "recognized_markers": {
-          "medium": {
-            "file_count": 2,
-            "pytest_count": 0,
-            "recognized": false,
-            "registered_in_pytest_ini": true,
-            "error": "subprocess error: 4",
-            "uncollected_tests": []
-          }
-        },
-        "issues": [
-          {
-            "type": "unrecognized_markers",
-            "message": "medium markers are not recognized by pytest (2 in file, 0 recognized)"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/unit/application/collaboration/test_wsde_memory_sync_hooks.py": {
-        "file_path": "/workspace/devsynth/tests/unit/application/collaboration/test_wsde_memory_sync_hooks.py",
-        "has_pytest_import": true,
-        "test_functions": 2,
-        "markers": {
-          "test_build_consensus_stores_decision_and_summary": "medium",
-          "test_summarize_voting_result_persists_summary": "medium"
-        },
-        "tests_with_markers": 2,
-        "tests_without_markers": 0,
-        "misaligned_markers": [],
-        "duplicate_markers": [],
-        "recognized_markers": {
-          "medium": {
-            "file_count": 2,
-            "pytest_count": 0,
-            "recognized": false,
-            "registered_in_pytest_ini": true,
-            "error": "subprocess error: 4",
-            "uncollected_tests": []
-          }
-        },
-        "issues": [
-          {
-            "type": "unrecognized_markers",
-            "message": "medium markers are not recognized by pytest (2 in file, 0 recognized)"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/unit/application/collaboration/test_delegate_task.py": {
-        "file_path": "/workspace/devsynth/tests/unit/application/collaboration/test_delegate_task.py",
-        "has_pytest_import": true,
-        "test_functions": 5,
-        "markers": {
-          "test_team_task_returns_consensus_succeeds": "medium",
-          "test_team_task_no_agents_succeeds": "medium",
-          "test_invalid_task_format_succeeds": "medium",
-          "test_delegate_task_propagates_agent_error_succeeds": "medium",
-          "test_delegate_task_role_assignment_error_succeeds": "medium"
-        },
-        "tests_with_markers": 5,
-        "tests_without_markers": 0,
-        "misaligned_markers": [],
-        "duplicate_markers": [
-          {
-            "test_name": "test_delegate_task_propagates_agent_error_succeeds",
-            "marker_count": 2
-          }
-        ],
-        "recognized_markers": {
-          "medium": {
-            "file_count": 5,
-            "pytest_count": 0,
-            "recognized": false,
-            "registered_in_pytest_ini": true,
-            "error": "subprocess error: 4",
-            "uncollected_tests": []
-          }
-        },
-        "issues": [
-          {
-            "type": "duplicate_markers",
-            "message": "File has 1 tests with duplicate markers"
-          },
-          {
-            "type": "unrecognized_markers",
-            "message": "medium markers are not recognized by pytest (5 in file, 0 recognized)"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/unit/application/collaboration/test_collaborative_wsde_team.py": {
-        "file_path": "/workspace/devsynth/tests/unit/application/collaboration/test_collaborative_wsde_team.py",
-        "has_pytest_import": true,
-        "test_functions": 6,
-        "markers": {
-          "test_initialization_succeeds": "medium",
-          "test_build_consensus_no_conflicts_succeeds": "medium",
-          "test_build_consensus_with_conflicts_succeeds": "medium",
-          "test_vote_on_critical_decision_with_expertise_weighting_succeeds": "medium",
-          "test_tie_breaking_strategies_succeeds": "medium",
-          "test_decision_tracking_and_explanation_succeeds": "medium"
-        },
-        "tests_with_markers": 6,
-        "tests_without_markers": 0,
-        "misaligned_markers": [],
-        "duplicate_markers": [],
-        "recognized_markers": {
-          "medium": {
-            "file_count": 6,
-            "pytest_count": 0,
-            "recognized": false,
-            "registered_in_pytest_ini": true,
-            "error": "subprocess error: 4",
-            "uncollected_tests": []
-          }
-        },
-        "issues": [
-          {
-            "type": "unrecognized_markers",
-            "message": "medium markers are not recognized by pytest (6 in file, 0 recognized)"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/unit/application/collaboration/test_memory_utils_edge_cases.py": {
-        "file_path": "/workspace/devsynth/tests/unit/application/collaboration/test_memory_utils_edge_cases.py",
-        "has_pytest_import": true,
-        "test_functions": 3,
-        "markers": {
-          "test_flush_memory_queue_handles_missing_manager": "medium",
-          "test_flush_memory_queue_without_sync_manager": "medium",
-          "test_restore_memory_queue_requeues_items_in_order": "medium"
-        },
-        "tests_with_markers": 3,
-        "tests_without_markers": 0,
-        "misaligned_markers": [],
-        "duplicate_markers": [
-          {
-            "test_name": "test_flush_memory_queue_without_sync_manager",
-            "marker_count": 2
-          }
-        ],
-        "recognized_markers": {
-          "medium": {
-            "file_count": 3,
-            "pytest_count": 0,
-            "recognized": false,
-            "registered_in_pytest_ini": true,
-            "error": "subprocess error: 4",
-            "uncollected_tests": []
-          }
-        },
-        "issues": [
-          {
-            "type": "duplicate_markers",
-            "message": "File has 1 tests with duplicate markers"
-          },
-          {
-            "type": "unrecognized_markers",
-            "message": "medium markers are not recognized by pytest (3 in file, 0 recognized)"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/unit/application/collaboration/test_delegate_workflows.py": {
-        "file_path": "/workspace/devsynth/tests/unit/application/collaboration/test_delegate_workflows.py",
-        "has_pytest_import": true,
-        "test_functions": 4,
-        "markers": {
-          "test_delegate_specific_agent_succeeds": "medium",
-          "test_delegate_team_task_succeeds": "medium",
-          "test_missing_agent_succeeds": "medium",
-          "test_team_task_no_agents_succeeds": "medium"
-        },
-        "tests_with_markers": 4,
-        "tests_without_markers": 0,
-        "misaligned_markers": [],
-        "duplicate_markers": [],
-        "recognized_markers": {
-          "medium": {
-            "file_count": 4,
-            "pytest_count": 0,
-            "recognized": false,
-            "registered_in_pytest_ini": true,
-            "error": "subprocess error: 4",
-            "uncollected_tests": []
-          }
-        },
-        "issues": [
-          {
-            "type": "unrecognized_markers",
-            "message": "medium markers are not recognized by pytest (4 in file, 0 recognized)"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/unit/application/collaboration/test_collaborative_wsde_team_task_management.py": {
-        "file_path": "/workspace/devsynth/tests/unit/application/collaboration/test_collaborative_wsde_team_task_management.py",
-        "has_pytest_import": true,
-        "test_functions": 8,
-        "markers": {
-          "test_process_task_non_hierarchical_succeeds": "medium",
-          "test_process_task_hierarchical_succeeds": "medium",
-          "test_get_contribution_metrics_succeeds": "medium",
-          "test_get_role_history_succeeds": "medium",
-          "test_associate_subtasks_succeeds": "medium",
-          "test_delegate_subtasks_succeeds": "medium",
-          "test_update_subtask_progress_succeeds": "medium",
-          "test_reassign_subtasks_based_on_progress_succeeds": "medium"
-        },
-        "tests_with_markers": 8,
-        "tests_without_markers": 0,
-        "misaligned_markers": [],
-        "duplicate_markers": [],
-        "recognized_markers": {
-          "medium": {
-            "file_count": 8,
-            "pytest_count": 0,
-            "recognized": false,
-            "registered_in_pytest_ini": true,
-            "error": "subprocess error: 4",
-            "uncollected_tests": []
-          }
-        },
-        "issues": [
-          {
-            "type": "unrecognized_markers",
-            "message": "medium markers are not recognized by pytest (8 in file, 0 recognized)"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/unit/application/collaboration/test_coordinator.py": {
-        "file_path": "/workspace/devsynth/tests/unit/application/collaboration/test_coordinator.py",
-        "has_pytest_import": true,
-        "test_functions": 6,
-        "markers": {
-          "test_primus_selection_and_consensus_fields_succeeds": "medium",
-          "test_multi_agent_consensus_reached_succeeds": "medium",
-          "test_role_assignment_and_primus_selection_succeeds": "medium",
-          "test_missing_agent_type_succeeds": "medium",
-          "test_critical_decision_invokes_voting_succeeds": "medium",
-          "test_delegate_task_no_agents_registered_succeeds": "medium"
-        },
-        "tests_with_markers": 6,
-        "tests_without_markers": 0,
-        "misaligned_markers": [],
-        "duplicate_markers": [],
-        "recognized_markers": {
-          "medium": {
-            "file_count": 6,
-            "pytest_count": 0,
-            "recognized": false,
-            "registered_in_pytest_ini": true,
-            "error": "subprocess error: 4",
-            "uncollected_tests": []
-          }
-        },
-        "issues": [
-          {
-            "type": "unrecognized_markers",
-            "message": "medium markers are not recognized by pytest (6 in file, 0 recognized)"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/unit/application/collaboration/test_memory_utils_fallback.py": {
-        "file_path": "/workspace/devsynth/tests/unit/application/collaboration/test_memory_utils_fallback.py",
-        "has_pytest_import": true,
-        "test_functions": 1,
-        "markers": {
-          "test_flush_memory_queue_falls_back_to_sync_manager": "medium"
-        },
-        "tests_with_markers": 1,
-        "tests_without_markers": 0,
-        "misaligned_markers": [],
-        "duplicate_markers": [],
-        "recognized_markers": {
-          "medium": {
-            "file_count": 1,
-            "pytest_count": 0,
-            "recognized": false,
-            "registered_in_pytest_ini": true,
-            "error": "subprocess error: 4",
-            "uncollected_tests": []
-          }
-        },
-        "issues": [
-          {
-            "type": "unrecognized_markers",
-            "message": "medium markers are not recognized by pytest (1 in file, 0 recognized)"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/unit/application/collaboration/test_wsde_team_consensus_summary.py": {
-        "file_path": "/workspace/devsynth/tests/unit/application/collaboration/test_wsde_team_consensus_summary.py",
-        "has_pytest_import": true,
-        "test_functions": 3,
-        "markers": {
-          "test_summarize_voting_result_tie": "medium",
-          "test_summarize_voting_result_winner": "medium",
-          "test_summarize_consensus_result_methods": "medium"
-        },
-        "tests_with_markers": 3,
-        "tests_without_markers": 0,
-        "misaligned_markers": [],
-        "duplicate_markers": [
-          {
-            "test_name": "test_summarize_voting_result_winner",
-            "marker_count": 2
-          },
-          {
-            "test_name": "test_summarize_consensus_result_methods",
-            "marker_count": 2
-          }
-        ],
-        "recognized_markers": {
-          "medium": {
-            "file_count": 3,
-            "pytest_count": 0,
-            "recognized": false,
-            "registered_in_pytest_ini": true,
-            "error": "subprocess error: 4",
-            "uncollected_tests": []
-          }
-        },
-        "issues": [
-          {
-            "type": "duplicate_markers",
-            "message": "File has 2 tests with duplicate markers"
-          },
-          {
-            "type": "unrecognized_markers",
-            "message": "medium markers are not recognized by pytest (3 in file, 0 recognized)"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/unit/application/collaboration/test_wsde_phase_transition_and_memory_flush.py": {
-        "file_path": "/workspace/devsynth/tests/unit/application/collaboration/test_wsde_phase_transition_and_memory_flush.py",
-        "has_pytest_import": true,
-        "test_functions": 2,
-        "markers": {
-          "test_progress_roles_triggers_memory_flush": "medium",
-          "test_flush_memory_queue_waits_for_sync": "medium"
-        },
-        "tests_with_markers": 2,
-        "tests_without_markers": 0,
-        "misaligned_markers": [],
-        "duplicate_markers": [],
-        "recognized_markers": {
-          "medium": {
-            "file_count": 2,
-            "pytest_count": 0,
-            "recognized": false,
-            "registered_in_pytest_ini": true,
-            "error": "subprocess error: 4",
-            "uncollected_tests": []
-          }
-        },
-        "issues": [
-          {
-            "type": "unrecognized_markers",
-            "message": "medium markers are not recognized by pytest (2 in file, 0 recognized)"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/unit/application/prompts/test_auto_tuning.py": {
-        "file_path": "/workspace/devsynth/tests/unit/application/prompts/test_auto_tuning.py",
-        "has_pytest_import": true,
-        "test_functions": 4,
-        "markers": {
-          "test_temperature_adjustment_succeeds": "medium",
-          "test_unified_agent_uses_tuner_succeeds": "medium",
-          "test_run_tuning_iteration_records_feedback_succeeds": "medium",
-          "test_iterative_prompt_adjustment_returns_best_variant_succeeds": "medium"
-        },
-        "tests_with_markers": 4,
-        "tests_without_markers": 0,
-        "misaligned_markers": [],
-        "duplicate_markers": [],
-        "recognized_markers": {
-          "medium": {
-            "file_count": 4,
-            "pytest_count": 0,
-            "recognized": false,
-            "registered_in_pytest_ini": true,
-            "error": "subprocess error: 4",
-            "uncollected_tests": []
-          }
-        },
-        "issues": [
-          {
-            "type": "unrecognized_markers",
-            "message": "medium markers are not recognized by pytest (4 in file, 0 recognized)"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/unit/application/config/test_unified_config_loader.py": {
-        "file_path": "/workspace/devsynth/tests/unit/application/config/test_unified_config_loader.py",
-        "has_pytest_import": true,
-        "test_functions": 5,
-        "markers": {
-          "test_load_from_yaml_succeeds": "medium",
-          "test_load_from_pyproject_succeeds": "medium",
-          "test_save_and_exists_succeeds": "medium",
-          "test_loader_save_function_yaml_succeeds": "medium",
-          "test_loader_save_function_pyproject_succeeds": "medium"
-        },
-        "tests_with_markers": 5,
-        "tests_without_markers": 0,
-        "misaligned_markers": [],
-        "duplicate_markers": [
-          {
-            "test_name": "test_loader_save_function_pyproject_succeeds",
-            "marker_count": 2
-          }
-        ],
-        "recognized_markers": {
-          "medium": {
-            "file_count": 5,
-            "pytest_count": 0,
-            "recognized": false,
-            "registered_in_pytest_ini": true,
-            "error": "subprocess error: 4",
-            "uncollected_tests": []
-          }
-        },
-        "issues": [
-          {
-            "type": "duplicate_markers",
-            "message": "File has 1 tests with duplicate markers"
-          },
-          {
-            "type": "unrecognized_markers",
-            "message": "medium markers are not recognized by pytest (5 in file, 0 recognized)"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/unit/application/wsde/test_wsde_utils.py": {
-        "file_path": "/workspace/devsynth/tests/unit/application/wsde/test_wsde_utils.py",
-        "has_pytest_import": true,
-        "test_functions": 3,
-        "markers": {
-          "test_reassign_roles_uses_dynamic_reassignment": "medium",
-          "test_run_consensus_falls_back_to_build": "medium",
-          "test_run_consensus_no_fallback_when_complete": "medium"
-        },
-        "tests_with_markers": 3,
-        "tests_without_markers": 0,
-        "misaligned_markers": [],
-        "duplicate_markers": [],
-        "recognized_markers": {
-          "medium": {
-            "file_count": 3,
-            "pytest_count": 0,
-            "recognized": false,
-            "registered_in_pytest_ini": true,
-            "error": "subprocess error: 4",
-            "uncollected_tests": []
-          }
-        },
-        "issues": [
-          {
-            "type": "unrecognized_markers",
-            "message": "medium markers are not recognized by pytest (3 in file, 0 recognized)"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/unit/application/edrr/test_execute_single_agent_task.py": {
-        "file_path": "/workspace/devsynth/tests/unit/application/edrr/test_execute_single_agent_task.py",
-        "has_pytest_import": true,
-        "test_functions": 1,
-        "markers": {
-          "test_execute_single_agent_task_stores_result_and_calls_agent": "medium"
-        },
-        "tests_with_markers": 1,
-        "tests_without_markers": 0,
-        "misaligned_markers": [],
-        "duplicate_markers": [],
-        "recognized_markers": {
-          "medium": {
-            "file_count": 1,
-            "pytest_count": 0,
-            "recognized": false,
-            "registered_in_pytest_ini": true,
-            "error": "subprocess error: 4",
-            "uncollected_tests": []
-          }
-        },
-        "issues": [
-          {
-            "type": "unrecognized_markers",
-            "message": "medium markers are not recognized by pytest (1 in file, 0 recognized)"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/unit/application/edrr/test_threshold_helpers.py": {
-        "file_path": "/workspace/devsynth/tests/unit/application/edrr/test_threshold_helpers.py",
-        "has_pytest_import": true,
-        "test_functions": 2,
-        "markers": {
-          "test_assess_phase_quality_uses_config_threshold": "medium",
-          "test_micro_cycle_config_sanitization": "medium"
-        },
-        "tests_with_markers": 2,
-        "tests_without_markers": 0,
-        "misaligned_markers": [],
-        "duplicate_markers": [],
-        "recognized_markers": {
-          "medium": {
-            "file_count": 2,
-            "pytest_count": 0,
-            "recognized": false,
-            "registered_in_pytest_ini": true,
-            "error": "subprocess error: 4",
-            "uncollected_tests": []
-          }
-        },
-        "issues": [
-          {
-            "type": "unrecognized_markers",
-            "message": "medium markers are not recognized by pytest (2 in file, 0 recognized)"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/unit/application/edrr/test_recursion_features.py": {
-        "file_path": "/workspace/devsynth/tests/unit/application/edrr/test_recursion_features.py",
-        "has_pytest_import": true,
-        "test_functions": 26,
-        "markers": {
-          "test_human_override_terminate_succeeds": "medium",
-          "test_human_override_continue_succeeds": "medium",
-          "test_granularity_threshold_succeeds": "medium",
-          "test_cost_benefit_analysis_succeeds": "medium",
-          "test_quality_threshold_succeeds": "medium",
-          "test_resource_limit_succeeds": "medium",
-          "test_complexity_threshold_succeeds": "medium",
-          "test_convergence_threshold_succeeds": "medium",
-          "test_diminishing_returns": "medium",
-          "test_parent_phase_compatibility_succeeds": "medium",
-          "test_historical_effectiveness_succeeds": "medium",
-          "test_process_phase_results_merge_similar_has_expected": "medium",
-          "test_process_phase_results_prioritize_by_quality_has_expected": "medium",
-          "test_process_phase_results_handle_conflicts_has_expected": "medium",
-          "test_merge_cycle_results_succeeds": "medium",
-          "test_calculate_similarity_key_succeeds": "medium",
-          "test_merge_similar_results_succeeds": "medium",
-          "test_merge_dicts_succeeds": "medium",
-          "test_merge_lists_succeeds": "medium",
-          "test_are_items_similar_succeeds": "medium",
-          "test_calculate_quality_score_succeeds": "medium",
-          "test_identify_conflicts_succeeds": "medium",
-          "test_resolve_conflict_succeeds": "medium",
-          "test_calculate_recursion_metrics_no_children_succeeds": "medium",
-          "test_calculate_recursion_metrics_with_children_succeeds": "medium",
-          "test_aggregate_results_with_metrics_contains_expected": "medium"
-        },
-        "tests_with_markers": 26,
-        "tests_without_markers": 0,
-        "misaligned_markers": [],
-        "duplicate_markers": [],
-        "recognized_markers": {
-          "medium": {
-            "file_count": 26,
-            "pytest_count": 0,
-            "recognized": false,
-            "registered_in_pytest_ini": true,
-            "error": "subprocess error: 4",
-            "uncollected_tests": []
-          }
-        },
-        "issues": [
-          {
-            "type": "unrecognized_markers",
-            "message": "medium markers are not recognized by pytest (26 in file, 0 recognized)"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/unit/application/edrr/test_auto_progress.py": {
-        "file_path": "/workspace/devsynth/tests/unit/application/edrr/test_auto_progress.py",
-        "has_pytest_import": true,
-        "test_functions": 2,
-        "markers": {
-          "test_maybe_auto_progress_loops_until_none_succeeds": "medium",
-          "test_maybe_auto_progress_disabled_succeeds": "medium"
-        },
-        "tests_with_markers": 2,
-        "tests_without_markers": 0,
-        "misaligned_markers": [],
-        "duplicate_markers": [],
-        "recognized_markers": {
-          "medium": {
-            "file_count": 2,
-            "pytest_count": 0,
-            "recognized": false,
-            "registered_in_pytest_ini": true,
-            "error": "subprocess error: 4",
-            "uncollected_tests": []
-          }
-        },
-        "issues": [
-          {
-            "type": "unrecognized_markers",
-            "message": "medium markers are not recognized by pytest (2 in file, 0 recognized)"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/unit/application/edrr/test_phase_recovery_helpers.py": {
-        "file_path": "/workspace/devsynth/tests/unit/application/edrr/test_phase_recovery_helpers.py",
-        "has_pytest_import": true,
-        "test_functions": 2,
-        "markers": {
-          "test_recovery_registration_and_threshold_config": "medium",
-          "test_micro_cycle_inherits_recovery_config": "medium"
-        },
-        "tests_with_markers": 2,
-        "tests_without_markers": 0,
-        "misaligned_markers": [],
-        "duplicate_markers": [],
-        "recognized_markers": {
-          "medium": {
-            "file_count": 2,
-            "pytest_count": 0,
-            "recognized": false,
-            "registered_in_pytest_ini": true,
-            "error": "subprocess error: 4",
-            "uncollected_tests": []
-          }
-        },
-        "issues": [
-          {
-            "type": "unrecognized_markers",
-            "message": "medium markers are not recognized by pytest (2 in file, 0 recognized)"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/unit/application/edrr/test_progress_recursion.py": {
-        "file_path": "/workspace/devsynth/tests/unit/application/edrr/test_progress_recursion.py",
-        "has_pytest_import": true,
-        "test_functions": 9,
-        "markers": {
-          "test_progress_to_phase_auto_recursion_succeeds": "medium",
-          "test_should_terminate_recursion_granularity_succeeds": "medium",
-          "test_should_terminate_recursion_cost_benefit_succeeds": "medium",
-          "test_should_terminate_recursion_quality_threshold_succeeds": "medium",
-          "test_should_terminate_recursion_resource_limit_succeeds": "medium",
-          "test_should_terminate_recursion_human_override_succeeds": "medium",
-          "test_should_terminate_recursion_no_factors_succeeds": "medium",
-          "test_should_terminate_recursion_at_thresholds_succeeds": "medium",
-          "test_should_terminate_recursion_combined_factors_fails": "medium"
-        },
-        "tests_with_markers": 9,
-        "tests_without_markers": 0,
-        "misaligned_markers": [],
-        "duplicate_markers": [],
-        "recognized_markers": {
-          "medium": {
-            "file_count": 9,
-            "pytest_count": 0,
-            "recognized": false,
-            "registered_in_pytest_ini": true,
-            "error": "subprocess error: 4",
-            "uncollected_tests": []
-          }
-        },
-        "issues": [
-          {
-            "type": "unrecognized_markers",
-            "message": "medium markers are not recognized by pytest (9 in file, 0 recognized)"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/unit/application/edrr/test_micro_cycle.py": {
-        "file_path": "/workspace/devsynth/tests/unit/application/edrr/test_micro_cycle.py",
-        "has_pytest_import": true,
-        "test_functions": 6,
-        "markers": {
-          "test_recursion_depth_exceeded_succeeds": "medium",
-          "test_recursion_depth_increments_succeeds": "medium",
-          "test_abort_when_should_terminate_succeeds": "medium",
-          "test_store_metadata_and_results_succeeds": "medium",
-          "test_parent_aggregates_after_micro_phase_succeeds": "medium",
-          "test_create_micro_cycle_from_manifest_dict_succeeds": "medium"
-        },
-        "tests_with_markers": 6,
-        "tests_without_markers": 0,
-        "misaligned_markers": [],
-        "duplicate_markers": [],
-        "recognized_markers": {
-          "medium": {
-            "file_count": 6,
-            "pytest_count": 0,
-            "recognized": false,
-            "registered_in_pytest_ini": true,
-            "error": "subprocess error: 4",
-            "uncollected_tests": []
-          }
-        },
-        "issues": [
-          {
-            "type": "unrecognized_markers",
-            "message": "medium markers are not recognized by pytest (6 in file, 0 recognized)"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/unit/application/edrr/test_edrr_coordinator_enhanced.py": {
-        "file_path": "/workspace/devsynth/tests/unit/application/edrr/test_edrr_coordinator_enhanced.py",
-        "has_pytest_import": true,
-        "test_functions": 10,
-        "markers": {
-          "test_initialization_succeeds": "medium",
-          "test_progress_to_phase_has_expected": "medium",
-          "test_enhanced_decide_next_phase_has_expected": "medium",
-          "test_phase_failure_hook_called": "medium",
-          "test_enhanced_maybe_auto_progress_succeeds": "medium",
-          "test_calculate_quality_score_succeeds": "medium",
-          "test_get_phase_metrics_has_expected": "medium",
-          "test_get_all_metrics_has_expected": "medium",
-          "test_get_metrics_history_has_expected": "medium",
-          "test_create_micro_cycle_succeeds": "medium"
-        },
-        "tests_with_markers": 10,
-        "tests_without_markers": 0,
-        "misaligned_markers": [],
-        "duplicate_markers": [],
-        "recognized_markers": {
-          "medium": {
-            "file_count": 10,
-            "pytest_count": 0,
-            "recognized": false,
-            "registered_in_pytest_ini": true,
-            "error": "subprocess error: 4",
-            "uncollected_tests": []
-          }
-        },
-        "issues": [
-          {
-            "type": "unrecognized_markers",
-            "message": "medium markers are not recognized by pytest (10 in file, 0 recognized)"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/unit/application/edrr/test_phase_progression.py": {
-        "file_path": "/workspace/devsynth/tests/unit/application/edrr/test_phase_progression.py",
-        "has_pytest_import": true,
-        "test_functions": 3,
-        "markers": {
-          "test_auto_phase_progression_succeeds": "medium",
-          "test_micro_cycle_result_aggregation_succeeds": "medium",
-          "test_result_aggregation_after_full_cycle_has_expected": "medium"
-        },
-        "tests_with_markers": 3,
-        "tests_without_markers": 0,
-        "misaligned_markers": [],
-        "duplicate_markers": [],
-        "recognized_markers": {
-          "medium": {
-            "file_count": 3,
-            "pytest_count": 0,
-            "recognized": false,
-            "registered_in_pytest_ini": true,
-            "error": "subprocess error: 4",
-            "uncollected_tests": []
-          }
-        },
-        "issues": [
-          {
-            "type": "unrecognized_markers",
-            "message": "medium markers are not recognized by pytest (3 in file, 0 recognized)"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/unit/application/edrr/test_recursive_edrr_coordinator.py": {
-        "file_path": "/workspace/devsynth/tests/unit/application/edrr/test_recursive_edrr_coordinator.py",
-        "has_pytest_import": true,
-        "test_functions": 26,
-        "markers": {
-          "test_initialization_with_recursion_support_succeeds": "medium",
-          "test_create_micro_cycle_succeeds": "medium",
-          "test_recursion_depth_limit_succeeds": "medium",
-          "test_create_micro_cycle_terminated_succeeds": "medium",
-          "test_micro_edrr_within_expand_phase_has_expected": "medium",
-          "test_micro_edrr_within_differentiate_phase_has_expected": "medium",
-          "test_micro_edrr_within_refine_phase_has_expected": "medium",
-          "test_micro_edrr_within_retrospect_phase_has_expected": "medium",
-          "test_granularity_threshold_check_succeeds": "medium",
-          "test_cost_benefit_analysis_succeeds": "medium",
-          "test_create_micro_cycle_termination_succeeds": "medium",
-          "test_quality_threshold_monitoring_succeeds": "medium",
-          "test_resource_limits_succeeds": "medium",
-          "test_human_judgment_override_succeeds": "medium",
-          "test_recursive_execution_tracking_succeeds": "medium",
-          "test_auto_micro_cycle_creation_succeeds": "medium",
-          "test_create_micro_cycle_max_depth_stop_fails": "medium",
-          "test_decide_next_phase_phase_complete_has_expected": "medium",
-          "test_decide_next_phase_timeout_has_expected": "medium",
-          "test_decide_next_phase_no_transition_returns_expected_result": "medium",
-          "test_should_terminate_recursion_all_factors_true_succeeds": "medium",
-          "test_should_terminate_recursion_all_factors_false_succeeds": "medium",
-          "test_get_performance_metrics_total_duration_succeeds": "medium",
-          "test_create_micro_cycle_persists_results_succeeds": "medium",
-          "test_micro_cycle_updates_parent_results_succeeds": "medium",
-          "test_human_continue_overrides_delimiting_principles_succeeds": "medium"
-        },
-        "tests_with_markers": 26,
-        "tests_without_markers": 0,
-        "misaligned_markers": [],
-        "duplicate_markers": [],
-        "recognized_markers": {
-          "medium": {
-            "file_count": 26,
-            "pytest_count": 0,
-            "recognized": false,
-            "registered_in_pytest_ini": true,
-            "error": "subprocess error: 4",
-            "uncollected_tests": []
-          }
-        },
-        "issues": [
-          {
-            "type": "unrecognized_markers",
-            "message": "medium markers are not recognized by pytest (26 in file, 0 recognized)"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/unit/application/edrr/test_templates.py": {
-        "file_path": "/workspace/devsynth/tests/unit/application/edrr/test_templates.py",
-        "has_pytest_import": true,
-        "test_functions": 4,
-        "markers": {
-          "test_template_definitions_succeeds": "medium",
-          "test_register_edrr_templates_succeeds": "medium",
-          "test_register_edrr_templates_error_handling_raises_error": "medium",
-          "test_template_for_each_phase_has_expected": "medium"
-        },
-        "tests_with_markers": 4,
-        "tests_without_markers": 0,
-        "misaligned_markers": [],
-        "duplicate_markers": [],
-        "recognized_markers": {
-          "medium": {
-            "file_count": 4,
-            "pytest_count": 0,
-            "recognized": false,
-            "registered_in_pytest_ini": true,
-            "error": "subprocess error: 4",
-            "uncollected_tests": []
-          }
-        },
-        "issues": [
-          {
-            "type": "unrecognized_markers",
-            "message": "medium markers are not recognized by pytest (4 in file, 0 recognized)"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/unit/application/edrr/test_edrr_phase_transitions.py": {
-        "file_path": "/workspace/devsynth/tests/unit/application/edrr/test_edrr_phase_transitions.py",
-        "has_pytest_import": true,
-        "test_functions": 27,
-        "markers": {
-          "test_start_phase_has_expected": "medium",
-          "test_end_phase_has_expected": "medium",
-          "test_should_transition_all_thresholds_met_succeeds": "medium",
-          "test_should_transition_some_thresholds_not_met_succeeds": "medium",
-          "test_should_transition_missing_metrics_succeeds": "medium",
-          "test_should_transition_too_many_conflicts_succeeds": "medium",
-          "test_configure_thresholds_override": "medium",
-          "test_should_transition_recovery_hook_recovers": "medium",
-          "test_should_transition_recovery_hook_fails": "medium",
-          "test_failure_hook_invoked_on_unrecovered_failure": "medium",
-          "test_calculate_enhanced_quality_score_non_dict_succeeds": "medium",
-          "test_calculate_enhanced_quality_score_empty_dict_succeeds": "medium",
-          "test_calculate_enhanced_quality_score_good_result_succeeds": "medium",
-          "test_calculate_enhanced_quality_score_with_errors": "medium",
-          "test_collect_phase_metrics_expand_phase_has_expected": "medium",
-          "test_collect_phase_metrics_differentiate_phase_has_expected": "medium",
-          "test_collect_phase_metrics_refine_phase_has_expected": "medium",
-          "test_collect_phase_metrics_retrospect_phase_has_expected": "medium",
-          "test_progress_to_phase_collects_metrics_has_expected": "medium",
-          "test_enhanced_decide_next_phase_quality_based_has_expected": "medium",
-          "test_enhanced_decide_next_phase_timeout_based_has_expected": "medium",
-          "test_enhanced_decide_next_phase_no_transition_returns_expected_result": "medium",
-          "test_enhanced_maybe_auto_progress_has_expected": "medium",
-          "test_enhanced_maybe_auto_progress_reentry_prevention_succeeds": "medium",
-          "test_enhanced_maybe_auto_progress_max_iterations_succeeds": "medium",
-          "test_calculate_quality_score_succeeds": "medium"
-        },
-        "tests_with_markers": 26,
-        "tests_without_markers": 1,
-        "misaligned_markers": [],
-        "duplicate_markers": [],
-        "recognized_markers": {
-          "medium": {
-            "file_count": 26,
-            "pytest_count": 0,
-            "recognized": false,
-            "registered_in_pytest_ini": true,
-            "error": "subprocess error: 4",
-            "uncollected_tests": []
-          }
-        },
-        "issues": [
-          {
-            "type": "unrecognized_markers",
-            "message": "medium markers are not recognized by pytest (26 in file, 0 recognized)"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/unit/application/edrr/test_manifest_parser.py": {
-        "file_path": "/workspace/devsynth/tests/unit/application/edrr/test_manifest_parser.py",
-        "has_pytest_import": true,
-        "test_functions": 42,
-        "markers": {
-          "test_init_succeeds": "medium",
-          "test_parse_file_valid_is_valid": "medium",
-          "test_parse_file_invalid_json_is_valid": "medium",
-          "test_parse_file_not_found_succeeds": "medium",
-          "test_parse_string_valid_is_valid": "medium",
-          "test_parse_string_invalid_json_is_valid": "medium",
-          "test_validate_valid_is_valid": "medium",
-          "test_validate_invalid_is_valid": "medium",
-          "test_get_phase_instructions_has_expected": "medium",
-          "test_get_phase_instructions_no_manifest_has_expected": "medium",
-          "test_get_phase_instructions_phase_not_found_has_expected": "medium",
-          "test_get_phase_templates_has_expected": "medium",
-          "test_get_phase_templates_no_manifest_has_expected": "medium",
-          "test_get_phase_templates_phase_not_found_has_expected": "medium",
-          "test_get_phase_resources_has_expected": "medium",
-          "test_get_phase_resources_no_manifest_has_expected": "medium",
-          "test_get_phase_resources_phase_not_found_has_expected": "medium",
-          "test_get_manifest_id_succeeds": "medium",
-          "test_get_manifest_id_no_manifest_succeeds": "medium",
-          "test_get_manifest_description_succeeds": "medium",
-          "test_get_manifest_description_no_manifest_succeeds": "medium",
-          "test_get_manifest_metadata_succeeds": "medium",
-          "test_get_manifest_metadata_no_manifest_succeeds": "medium",
-          "test_get_manifest_metadata_no_metadata_succeeds": "medium",
-          "test_start_execution_succeeds": "medium",
-          "test_start_execution_no_manifest_succeeds": "medium",
-          "test_check_phase_dependencies_has_expected": "medium",
-          "test_check_phase_dependencies_no_manifest_has_expected": "medium",
-          "test_start_phase_has_expected": "medium",
-          "test_start_phase_no_manifest_has_expected": "medium",
-          "test_start_phase_dependencies_not_met_has_expected": "medium",
-          "test_complete_phase_has_expected": "medium",
-          "test_complete_phase_no_manifest_has_expected": "medium",
-          "test_complete_phase_not_in_progress_has_expected": "medium",
-          "test_complete_execution_succeeds": "medium",
-          "test_complete_execution_no_manifest_succeeds": "medium",
-          "test_complete_execution_not_all_phases_completed_has_expected": "medium",
-          "test_get_execution_trace_succeeds": "medium",
-          "test_get_execution_trace_no_manifest_succeeds": "medium",
-          "test_get_phase_status_has_expected": "medium",
-          "test_get_phase_status_no_manifest_has_expected": "medium",
-          "test_get_phase_status_unknown_phase_has_expected": "medium"
-        },
-        "tests_with_markers": 42,
-        "tests_without_markers": 0,
-        "misaligned_markers": [],
-        "duplicate_markers": [
-          {
-            "test_name": "test_get_phase_instructions_no_manifest_has_expected",
-            "marker_count": 2
-          },
-          {
-            "test_name": "test_get_phase_templates_no_manifest_has_expected",
-            "marker_count": 2
-          },
-          {
-            "test_name": "test_get_phase_resources_no_manifest_has_expected",
-            "marker_count": 2
-          },
-          {
-            "test_name": "test_get_manifest_id_no_manifest_succeeds",
-            "marker_count": 2
-          },
-          {
-            "test_name": "test_get_manifest_description_no_manifest_succeeds",
-            "marker_count": 2
-          },
-          {
-            "test_name": "test_get_manifest_metadata_no_manifest_succeeds",
-            "marker_count": 2
-          }
-        ],
-        "recognized_markers": {
-          "medium": {
-            "file_count": 42,
-            "pytest_count": 0,
-            "recognized": false,
-            "registered_in_pytest_ini": true,
-            "error": "subprocess error: 4",
-            "uncollected_tests": []
-          }
-        },
-        "issues": [
-          {
-            "type": "duplicate_markers",
-            "message": "File has 6 tests with duplicate markers"
-          },
-          {
-            "type": "unrecognized_markers",
-            "message": "medium markers are not recognized by pytest (42 in file, 0 recognized)"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/unit/application/edrr/test_coordinator_phases_simple.py": {
-        "file_path": "/workspace/devsynth/tests/unit/application/edrr/test_coordinator_phases_simple.py",
-        "has_pytest_import": true,
-        "test_functions": 5,
-        "markers": {
-          "test_progress_to_phase_runs_succeeds": "medium",
-          "test_execute_expand_phase_succeeds": "medium",
-          "test_execute_differentiate_phase_succeeds": "medium",
-          "test_execute_refine_phase_succeeds": "medium",
-          "test_execute_retrospect_phase_succeeds": "medium"
-        },
-        "tests_with_markers": 5,
-        "tests_without_markers": 0,
-        "misaligned_markers": [],
-        "duplicate_markers": [],
-        "recognized_markers": {
-          "medium": {
-            "file_count": 5,
-            "pytest_count": 0,
-            "recognized": false,
-            "registered_in_pytest_ini": true,
-            "error": "subprocess error: 4",
-            "uncollected_tests": []
-          }
-        },
-        "issues": [
-          {
-            "type": "unrecognized_markers",
-            "message": "medium markers are not recognized by pytest (5 in file, 0 recognized)"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/unit/application/edrr/test_coordinator.py": {
-        "file_path": "/workspace/devsynth/tests/unit/application/edrr/test_coordinator.py",
-        "has_pytest_import": true,
-        "test_functions": 3,
-        "markers": {
-          "test_micro_cycle_iterations_until_threshold": "medium",
-          "test_phase_execution_recovery_hook": "medium",
-          "test_micro_cycle_respects_max_iterations": "medium"
-        },
-        "tests_with_markers": 3,
-        "tests_without_markers": 0,
-        "misaligned_markers": [],
-        "duplicate_markers": [],
-        "recognized_markers": {
-          "medium": {
-            "file_count": 3,
-            "pytest_count": 0,
-            "recognized": false,
-            "registered_in_pytest_ini": true,
-            "error": "subprocess error: 4",
-            "uncollected_tests": []
-          }
-        },
-        "issues": [
-          {
-            "type": "unrecognized_markers",
-            "message": "medium markers are not recognized by pytest (3 in file, 0 recognized)"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/unit/application/edrr/test_coordinator_core.py": {
-        "file_path": "/workspace/devsynth/tests/unit/application/edrr/test_coordinator_core.py",
-        "has_pytest_import": true,
-        "test_functions": 19,
-        "markers": {
-          "test_initialization_succeeds": "medium",
-          "test_start_cycle_succeeds": "medium",
-          "test_start_cycle_from_manifest_succeeds": "medium",
-          "test_start_cycle_from_manifest_string_succeeds": "medium",
-          "test_progress_to_phase_has_expected": "medium",
-          "test_progress_to_next_phase_has_expected": "medium",
-          "test_execute_current_phase_has_expected": "medium",
-          "test_generate_report_succeeds": "medium",
-          "test_get_execution_traces_succeeds": "medium",
-          "test_get_execution_history_succeeds": "medium",
-          "test_get_performance_metrics_succeeds": "medium",
-          "test_decide_next_phase_has_expected": "medium",
-          "test_maybe_auto_progress_succeeds": "medium",
-          "test_start_cycle_with_invalid_task_is_valid": "medium",
-          "test_start_cycle_from_manifest_with_invalid_file_is_valid": "medium",
-          "test_progress_to_phase_without_cycle_has_expected": "medium",
-          "test_progress_to_next_phase_without_cycle_has_expected": "medium",
-          "test_execute_current_phase_without_cycle_has_expected": "medium",
-          "test_generate_report_without_cycle_succeeds": "medium"
-        },
-        "tests_with_markers": 19,
-        "tests_without_markers": 0,
-        "misaligned_markers": [],
-        "duplicate_markers": [
-          {
-            "test_name": "test_progress_to_next_phase_without_cycle_has_expected",
-            "marker_count": 2
-          },
-          {
-            "test_name": "test_execute_current_phase_without_cycle_has_expected",
-            "marker_count": 2
-          },
-          {
-            "test_name": "test_generate_report_without_cycle_succeeds",
-            "marker_count": 2
-          }
-        ],
-        "recognized_markers": {
-          "medium": {
-            "file_count": 19,
-            "pytest_count": 0,
-            "recognized": false,
-            "registered_in_pytest_ini": true,
-            "error": "subprocess error: 4",
-            "uncollected_tests": []
-          }
-        },
-        "issues": [
-          {
-            "type": "duplicate_markers",
-            "message": "File has 3 tests with duplicate markers"
-          },
-          {
-            "type": "unrecognized_markers",
-            "message": "medium markers are not recognized by pytest (19 in file, 0 recognized)"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/unit/application/edrr/test_result_analysis.py": {
-        "file_path": "/workspace/devsynth/tests/unit/application/edrr/test_result_analysis.py",
-        "has_pytest_import": true,
-        "test_functions": 7,
-        "markers": {
-          "test_extract_key_insights_succeeds": "medium",
-          "test_summarize_implementation_succeeds": "medium",
-          "test_summarize_quality_checks_succeeds": "medium",
-          "test_extract_key_learnings_succeeds": "medium",
-          "test_generate_next_steps_succeeds": "medium",
-          "test_extract_future_considerations_succeeds": "medium",
-          "test_final_report_includes_value_conflicts_succeeds": "medium"
-        },
-        "tests_with_markers": 7,
-        "tests_without_markers": 0,
-        "misaligned_markers": [],
-        "duplicate_markers": [],
-        "recognized_markers": {
-          "medium": {
-            "file_count": 7,
-            "pytest_count": 0,
-            "recognized": false,
-            "registered_in_pytest_ini": true,
-            "error": "subprocess error: 4",
-            "uncollected_tests": []
-          }
-        },
-        "issues": [
-          {
-            "type": "unrecognized_markers",
-            "message": "medium markers are not recognized by pytest (7 in file, 0 recognized)"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/unit/application/edrr/test_enhanced_recursion_termination.py": {
-        "file_path": "/workspace/devsynth/tests/unit/application/edrr/test_enhanced_recursion_termination.py",
-        "has_pytest_import": true,
-        "test_functions": 6,
-        "markers": {
-          "test_should_terminate_recursion_max_depth_succeeds": "medium",
-          "test_should_terminate_recursion_time_based_succeeds": "medium",
-          "test_should_terminate_recursion_memory_usage_succeeds": "medium",
-          "test_should_terminate_recursion_historical_effectiveness_succeeds": "medium",
-          "test_should_not_terminate_recursion_historical_effectiveness_succeeds": "medium",
-          "test_should_terminate_recursion_combined_new_factors_succeeds": "medium"
-        },
-        "tests_with_markers": 6,
-        "tests_without_markers": 0,
-        "misaligned_markers": [],
-        "duplicate_markers": [],
-        "recognized_markers": {
-          "medium": {
-            "file_count": 6,
-            "pytest_count": 0,
-            "recognized": false,
-            "registered_in_pytest_ini": true,
-            "error": "subprocess error: 4",
-            "uncollected_tests": []
-          }
-        },
-        "issues": [
-          {
-            "type": "unrecognized_markers",
-            "message": "medium markers are not recognized by pytest (6 in file, 0 recognized)"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/unit/application/edrr/test_micro_cycle_hooks.py": {
-        "file_path": "/workspace/devsynth/tests/unit/application/edrr/test_micro_cycle_hooks.py",
-        "has_pytest_import": true,
-        "test_functions": 1,
-        "markers": {
-          "test_micro_cycle_hooks_invoked": "medium"
-        },
-        "tests_with_markers": 1,
-        "tests_without_markers": 0,
-        "misaligned_markers": [],
-        "duplicate_markers": [],
-        "recognized_markers": {
-          "medium": {
-            "file_count": 1,
-            "pytest_count": 0,
-            "recognized": false,
-            "registered_in_pytest_ini": true,
-            "error": "subprocess error: 4",
-            "uncollected_tests": []
-          }
-        },
-        "issues": [
-          {
-            "type": "unrecognized_markers",
-            "message": "medium markers are not recognized by pytest (1 in file, 0 recognized)"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/unit/application/edrr/test_micro_cycle_execution.py": {
-        "file_path": "/workspace/devsynth/tests/unit/application/edrr/test_micro_cycle_execution.py",
-        "has_pytest_import": true,
-        "test_functions": 4,
-        "markers": {
-          "test_execute_micro_cycle_uses_dialectical_reasoning": "medium",
-          "test_execute_micro_cycle_handles_dialectical_errors": "medium",
-          "test_assess_result_quality_from_score": "medium",
-          "test_assess_result_quality_handles_error": "medium"
-        },
-        "tests_with_markers": 4,
-        "tests_without_markers": 0,
-        "misaligned_markers": [],
-        "duplicate_markers": [
-          {
-            "test_name": "test_assess_result_quality_handles_error",
-            "marker_count": 2
-          }
-        ],
-        "recognized_markers": {
-          "medium": {
-            "file_count": 4,
-            "pytest_count": 0,
-            "recognized": false,
-            "registered_in_pytest_ini": true,
-            "error": "subprocess error: 4",
-            "uncollected_tests": []
-          }
-        },
-        "issues": [
-          {
-            "type": "duplicate_markers",
-            "message": "File has 1 tests with duplicate markers"
-          },
-          {
-            "type": "unrecognized_markers",
-            "message": "medium markers are not recognized by pytest (4 in file, 0 recognized)"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/unit/application/edrr/test_edrr_coordinator.py": {
-        "file_path": "/workspace/devsynth/tests/unit/application/edrr/test_edrr_coordinator.py",
-        "has_pytest_import": true,
-        "test_functions": 20,
-        "markers": {
-          "test_initialization_succeeds": "medium",
-          "test_start_cycle_succeeds": "medium",
-          "test_expand_phase_execution_has_expected": "medium",
-          "test_differentiate_phase_execution_has_expected": "medium",
-          "test_refine_phase_execution_has_expected": "medium",
-          "test_retrospect_phase_execution_has_expected": "medium",
-          "test_generate_final_report_succeeds": "medium",
-          "test_execute_current_phase_has_expected": "medium",
-          "test_progress_to_phase_has_expected": "medium",
-          "test_progress_to_phase_dependency_failure_no_auto_fails": "medium",
-          "test_full_cycle_succeeds": "medium",
-          "test_progress_to_next_phase_has_expected": "medium",
-          "test_progress_to_next_phase_without_current_fails": "medium",
-          "test_start_cycle_from_manifest_succeeds": "medium",
-          "test_maybe_create_micro_cycles_succeeds": "medium",
-          "test_create_micro_cycle_succeeds": "medium",
-          "test_micro_cycle_result_aggregation_succeeds": "medium",
-          "test_execution_history_logging_succeeds": "medium",
-          "test_create_micro_cycle_triggers_termination_succeeds": "medium",
-          "test_safe_retrieve_always_returns_dict_for_list": "medium"
-        },
-        "tests_with_markers": 20,
-        "tests_without_markers": 0,
-        "misaligned_markers": [],
-        "duplicate_markers": [
-          {
-            "test_name": "test_start_cycle_from_manifest_succeeds",
-            "marker_count": 2
-          }
-        ],
-        "recognized_markers": {
-          "medium": {
-            "file_count": 20,
-            "pytest_count": 0,
-            "recognized": false,
-            "registered_in_pytest_ini": true,
-            "error": "subprocess error: 4",
-            "uncollected_tests": []
-          }
-        },
-        "issues": [
-          {
-            "type": "duplicate_markers",
-            "message": "File has 1 tests with duplicate markers"
-          },
-          {
-            "type": "unrecognized_markers",
-            "message": "medium markers are not recognized by pytest (20 in file, 0 recognized)"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/unit/application/edrr/test_recovery_hooks.py": {
-        "file_path": "/workspace/devsynth/tests/unit/application/edrr/test_recovery_hooks.py",
-        "has_pytest_import": true,
-        "test_functions": 2,
-        "markers": {
-          "test_recovery_hook_handles_error": "medium",
-          "test_recovery_hook_fallback_retry": "medium"
-        },
-        "tests_with_markers": 2,
-        "tests_without_markers": 0,
-        "misaligned_markers": [],
-        "duplicate_markers": [],
-        "recognized_markers": {
-          "medium": {
-            "file_count": 2,
-            "pytest_count": 0,
-            "recognized": false,
-            "registered_in_pytest_ini": true,
-            "error": "subprocess error: 4",
-            "uncollected_tests": []
-          }
-        },
-        "issues": [
-          {
-            "type": "unrecognized_markers",
-            "message": "medium markers are not recognized by pytest (2 in file, 0 recognized)"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/unit/application/memory/test_fallback.py": {
-        "file_path": "/workspace/devsynth/tests/unit/application/memory/test_fallback.py",
-        "has_pytest_import": true,
-        "test_functions": 27,
-        "markers": {
-          "test_initialization": "medium",
-          "test_store_primary_success": "medium",
-          "test_store_primary_failure": "medium",
-          "test_store_all_failures": "medium",
-          "test_retrieve_primary_success": "medium",
-          "test_retrieve_primary_failure": "medium",
-          "test_retrieve_primary_not_found": "medium",
-          "test_retrieve_all_failures": "medium",
-          "test_search_primary_success": "medium",
-          "test_search_primary_failure": "medium",
-          "test_search_all_failures": "medium",
-          "test_delete_primary_success": "medium",
-          "test_delete_primary_failure": "medium",
-          "test_delete_all_failures": "medium",
-          "test_get_all_items_primary_success": "medium",
-          "test_get_all_items_primary_failure": "medium",
-          "test_get_all_items_all_failures": "medium",
-          "test_begin_transaction_primary_success": "medium",
-          "test_begin_transaction_primary_failure": "medium",
-          "test_begin_transaction_all_failures": "medium",
-          "test_commit_transaction_primary_success": "medium",
-          "test_commit_transaction_primary_failure": "medium",
-          "test_commit_transaction_all_failures": "medium",
-          "test_reconcile_pending_operations": "medium",
-          "test_get_store_status": "medium",
-          "test_get_pending_operations_count": "medium",
-          "test_with_fallback": "medium"
-        },
-        "tests_with_markers": 27,
-        "tests_without_markers": 0,
-        "misaligned_markers": [],
-        "duplicate_markers": [
-          {
-            "test_name": "test_initialization",
-            "marker_count": 2
-          },
-          {
-            "test_name": "test_get_pending_operations_count",
-            "marker_count": 2
-          }
-        ],
-        "recognized_markers": {
-          "medium": {
-            "file_count": 27,
-            "pytest_count": 0,
-            "recognized": false,
-            "registered_in_pytest_ini": true,
-            "error": "subprocess error: 4",
-            "uncollected_tests": []
-          }
-        },
-        "issues": [
-          {
-            "type": "duplicate_markers",
-            "message": "File has 2 tests with duplicate markers"
-          },
-          {
-            "type": "unrecognized_markers",
-            "message": "medium markers are not recognized by pytest (27 in file, 0 recognized)"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/unit/application/memory/test_retry_logic.py": {
-        "file_path": "/workspace/devsynth/tests/unit/application/memory/test_retry_logic.py",
-        "has_pytest_import": true,
-        "test_functions": 2,
-        "markers": {
-          "test_condition_callback_aborts_retry": "medium",
-          "test_circuit_breaker_stops_retries": "medium"
-        },
-        "tests_with_markers": 2,
-        "tests_without_markers": 0,
-        "misaligned_markers": [],
-        "duplicate_markers": [
-          {
-            "test_name": "test_condition_callback_aborts_retry",
-            "marker_count": 2
-          }
-        ],
-        "recognized_markers": {
-          "medium": {
-            "file_count": 2,
-            "pytest_count": 0,
-            "recognized": false,
-            "registered_in_pytest_ini": true,
-            "error": "subprocess error: 4",
-            "uncollected_tests": []
-          }
-        },
-        "issues": [
-          {
-            "type": "duplicate_markers",
-            "message": "File has 1 tests with duplicate markers"
-          },
-          {
-            "type": "unrecognized_markers",
-            "message": "medium markers are not recognized by pytest (2 in file, 0 recognized)"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/unit/application/memory/test_recovery.py": {
-        "file_path": "/workspace/devsynth/tests/unit/application/memory/test_recovery.py",
-        "has_pytest_import": true,
-        "test_functions": 28,
-        "markers": {
-          "test_initialization": "medium",
-          "test_add_item": "medium",
-          "test_remove_item": "medium",
-          "test_get_item": "medium",
-          "test_save_and_load": "medium",
-          "test_load_invalid_file": "medium",
-          "test_log_operation": "medium",
-          "test_replay": "medium",
-          "test_replay_with_time_range": "medium",
-          "test_replay_failure": "medium",
-          "test_create_snapshot": "medium",
-          "test_get_operation_log": "medium",
-          "test_restore_from_snapshot": "medium",
-          "test_restore_from_snapshot_no_snapshot": "medium",
-          "test_restore_from_snapshot_failure": "medium",
-          "test_recover_store": "medium",
-          "test_recover_store_no_snapshot": "medium",
-          "test_successful_execution": "medium",
-          "test_func": "medium",
-          "test_execution_failure_with_recovery": "medium",
-          "test_no_snapshot_creation": "medium",
-          "test_global_recovery_manager": "medium"
-        },
-        "tests_with_markers": 22,
-        "tests_without_markers": 6,
-        "misaligned_markers": [],
-        "duplicate_markers": [
-          {
-            "test_name": "test_initialization",
-            "marker_count": 6
-          },
-          {
-            "test_name": "test_save_and_load",
-            "marker_count": 2
-          },
-          {
-            "test_name": "test_load_invalid_file",
-            "marker_count": 2
-          },
-          {
-            "test_name": "test_initialization",
-            "marker_count": 6
-          },
-          {
-            "test_name": "test_log_operation",
-            "marker_count": 3
-          },
-          {
-            "test_name": "test_save_and_load",
-            "marker_count": 2
-          },
-          {
-            "test_name": "test_load_invalid_file",
-            "marker_count": 2
-          },
-          {
-            "test_name": "test_initialization",
-            "marker_count": 6
-          },
-          {
-            "test_name": "test_log_operation",
-            "marker_count": 3
-          },
-          {
-            "test_name": "test_successful_execution",
-            "marker_count": 2
-          },
-          {
-            "test_name": "test_func",
-            "marker_count": 4
-          },
-          {
-            "test_name": "test_execution_failure_with_recovery",
-            "marker_count": 2
-          },
-          {
-            "test_name": "test_func",
-            "marker_count": 4
-          },
-          {
-            "test_name": "test_global_recovery_manager",
-            "marker_count": 2
-          }
-        ],
-        "recognized_markers": {
-          "medium": {
-            "file_count": 22,
-            "pytest_count": 0,
-            "recognized": false,
-            "registered_in_pytest_ini": true,
-            "error": "subprocess error: 4",
-            "uncollected_tests": []
-          }
-        },
-        "issues": [
-          {
-            "type": "duplicate_markers",
-            "message": "File has 14 tests with duplicate markers"
-          },
-          {
-            "type": "unrecognized_markers",
-            "message": "medium markers are not recognized by pytest (22 in file, 0 recognized)"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/unit/application/memory/test_graph_memory_adapter.py": {
-        "file_path": "/workspace/devsynth/tests/unit/application/memory/test_graph_memory_adapter.py",
-        "has_pytest_import": true,
-        "test_functions": 19,
-        "markers": {
-          "test_initialization_basic_succeeds": "medium",
-          "test_initialization_rdflib_succeeds": "medium",
-          "test_store_and_retrieve_basic_succeeds": "medium",
-          "test_store_and_retrieve_rdflib_succeeds": "medium",
-          "test_store_with_relationships_succeeds": "medium",
-          "test_search_succeeds": "medium",
-          "test_delete_succeeds": "medium",
-          "test_get_all_relationships_succeeds": "medium",
-          "test_add_memory_volatility_succeeds": "medium",
-          "test_apply_memory_decay_succeeds": "medium",
-          "test_advanced_memory_decay_succeeds": "medium",
-          "test_integrate_with_store_succeeds": "medium",
-          "test_integrate_with_vector_store_succeeds": "medium",
-          "test_save_graph_with_rdflib_store_succeeds": "medium",
-          "test_memory_item_triple_creation_succeeds": "medium",
-          "test_cascading_query_with_missing_adapter_succeeds": "medium",
-          "test_context_aware_query_succeeds": "medium",
-          "test_query_router_route_succeeds": "medium",
-          "test_store_and_retrieve_with_edrr_phase_has_expected": "medium"
-        },
-        "tests_with_markers": 19,
-        "tests_without_markers": 0,
-        "misaligned_markers": [],
-        "duplicate_markers": [
-          {
-            "test_name": "test_context_aware_query_succeeds",
-            "marker_count": 2
-          }
-        ],
-        "recognized_markers": {
-          "medium": {
-            "file_count": 19,
-            "pytest_count": 0,
-            "recognized": false,
-            "registered_in_pytest_ini": true,
-            "error": "subprocess error: 4",
-            "uncollected_tests": []
-          }
-        },
-        "issues": [
-          {
-            "type": "duplicate_markers",
-            "message": "File has 1 tests with duplicate markers"
-          },
-          {
-            "type": "unrecognized_markers",
-            "message": "medium markers are not recognized by pytest (19 in file, 0 recognized)"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/unit/application/memory/test_knowledge_graph_utils.py": {
-        "file_path": "/workspace/devsynth/tests/unit/application/memory/test_knowledge_graph_utils.py",
-        "has_pytest_import": true,
-        "test_functions": 10,
-        "markers": {
-          "test_find_related_items_succeeds": "medium",
-          "test_find_items_by_relationship_succeeds": "medium",
-          "test_get_item_relationships_succeeds": "medium",
-          "test_create_and_delete_relationship_succeeds": "medium",
-          "test_query_graph_pattern_succeeds": "medium",
-          "test_get_subgraph_succeeds": "medium",
-          "test_synchronize_basic_succeeds": "medium",
-          "test_synchronize_missing_adapter_succeeds": "medium",
-          "test_synchronize_bidirectional_succeeds": "medium",
-          "test_update_and_queue_succeeds": "medium"
-        },
-        "tests_with_markers": 10,
-        "tests_without_markers": 0,
-        "misaligned_markers": [],
-        "duplicate_markers": [
-          {
-            "test_name": "test_synchronize_bidirectional_succeeds",
-            "marker_count": 2
-          }
-        ],
-        "recognized_markers": {
-          "medium": {
-            "file_count": 10,
-            "pytest_count": 0,
-            "recognized": false,
-            "registered_in_pytest_ini": true,
-            "error": "subprocess error: 4",
-            "uncollected_tests": []
-          }
-        },
-        "issues": [
-          {
-            "type": "duplicate_markers",
-            "message": "File has 1 tests with duplicate markers"
-          },
-          {
-            "type": "unrecognized_markers",
-            "message": "medium markers are not recognized by pytest (10 in file, 0 recognized)"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/unit/application/memory/test_memory_adapters_regression.py": {
-        "file_path": "/workspace/devsynth/tests/unit/application/memory/test_memory_adapters_regression.py",
-        "has_pytest_import": true,
-        "test_functions": 3,
-        "markers": {
-          "test_store_retrieve_search_update": "medium",
-          "test_vector_adapter_operations": "medium",
-          "test_tinydb_adapter_transaction_support": "medium"
-        },
-        "tests_with_markers": 3,
-        "tests_without_markers": 0,
-        "misaligned_markers": [],
-        "duplicate_markers": [],
-        "recognized_markers": {
-          "medium": {
-            "file_count": 3,
-            "pytest_count": 0,
-            "recognized": false,
-            "registered_in_pytest_ini": true,
-            "error": "subprocess error: 4",
-            "uncollected_tests": []
-          }
-        },
-        "issues": [
-          {
-            "type": "unrecognized_markers",
-            "message": "medium markers are not recognized by pytest (3 in file, 0 recognized)"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/unit/application/memory/test_sync_across_backends.py": {
-        "file_path": "/workspace/devsynth/tests/unit/application/memory/test_sync_across_backends.py",
-        "has_pytest_import": true,
-        "test_functions": 3,
-        "markers": {
-          "test_basic_synchronization_succeeds": "medium",
-          "test_conflict_detection_and_resolution": "medium"
-        },
-        "tests_with_markers": 2,
-        "tests_without_markers": 1,
-        "misaligned_markers": [],
-        "duplicate_markers": [],
-        "recognized_markers": {
-          "medium": {
-            "file_count": 2,
-            "pytest_count": 0,
-            "recognized": false,
-            "registered_in_pytest_ini": true,
-            "error": "subprocess error: 4",
-            "uncollected_tests": []
-          }
-        },
-        "issues": [
-          {
-            "type": "unrecognized_markers",
-            "message": "medium markers are not recognized by pytest (2 in file, 0 recognized)"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/unit/application/memory/test_lmdb_store.py": {
-        "file_path": "/workspace/devsynth/tests/unit/application/memory/test_lmdb_store.py",
-        "has_pytest_import": true,
-        "test_functions": 10,
-        "markers": {
-          "test_init_succeeds": "medium",
-          "test_store_and_retrieve_succeeds": "medium",
-          "test_retrieve_nonexistent_succeeds": "medium",
-          "test_search_succeeds": "medium",
-          "test_delete_succeeds": "medium",
-          "test_token_usage_succeeds": "medium",
-          "test_persistence_succeeds": "medium",
-          "test_close_and_reopen_succeeds": "medium",
-          "test_transaction_isolation_succeeds": "medium",
-          "test_transaction_abort_succeeds": "medium"
-        },
-        "tests_with_markers": 10,
-        "tests_without_markers": 0,
-        "misaligned_markers": [],
-        "duplicate_markers": [
-          {
-            "test_name": "test_search_succeeds",
-            "marker_count": 2
-          }
-        ],
-        "recognized_markers": {
-          "medium": {
-            "file_count": 10,
-            "pytest_count": 0,
-            "recognized": false,
-            "registered_in_pytest_ini": true,
-            "error": "subprocess error: 4",
-            "uncollected_tests": []
-          }
-        },
-        "issues": [
-          {
-            "type": "duplicate_markers",
-            "message": "File has 1 tests with duplicate markers"
-          },
-          {
-            "type": "unrecognized_markers",
-            "message": "medium markers are not recognized by pytest (10 in file, 0 recognized)"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/unit/application/memory/test_duckdb_store_hnsw.py": {
-        "file_path": "/workspace/devsynth/tests/unit/application/memory/test_duckdb_store_hnsw.py",
-        "has_pytest_import": true,
-        "test_functions": 5,
-        "markers": {
-          "test_hnsw_initialization_succeeds": "medium",
-          "test_custom_hnsw_initialization_succeeds": "medium",
-          "test_hnsw_index_creation_succeeds": "medium",
-          "test_similarity_search_with_hnsw_succeeds": "medium",
-          "test_similarity_search_performance_comparison_succeeds": "medium"
-        },
-        "tests_with_markers": 5,
-        "tests_without_markers": 0,
-        "misaligned_markers": [],
-        "duplicate_markers": [],
-        "recognized_markers": {
-          "medium": {
-            "file_count": 5,
-            "pytest_count": 0,
-            "recognized": false,
-            "registered_in_pytest_ini": true,
-            "error": "subprocess error: 4",
-            "uncollected_tests": []
-          }
-        },
-        "issues": [
-          {
-            "type": "unrecognized_markers",
-            "message": "medium markers are not recognized by pytest (5 in file, 0 recognized)"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/unit/application/memory/test_mixed_backend_transactions.py": {
-        "file_path": "/workspace/devsynth/tests/unit/application/memory/test_mixed_backend_transactions.py",
-        "has_pytest_import": true,
-        "test_functions": 1,
-        "markers": {
-          "test_transaction_across_backends": "medium"
-        },
-        "tests_with_markers": 1,
-        "tests_without_markers": 0,
-        "misaligned_markers": [],
-        "duplicate_markers": [],
-        "recognized_markers": {
-          "medium": {
-            "file_count": 1,
-            "pytest_count": 0,
-            "recognized": false,
-            "registered_in_pytest_ini": true,
-            "error": "subprocess error: 4",
-            "uncollected_tests": []
-          }
-        },
-        "issues": [
-          {
-            "type": "unrecognized_markers",
-            "message": "medium markers are not recognized by pytest (1 in file, 0 recognized)"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/unit/application/memory/test_memory_manager_search.py": {
-        "file_path": "/workspace/devsynth/tests/unit/application/memory/test_memory_manager_search.py",
-        "has_pytest_import": true,
-        "test_functions": 2,
-        "markers": {
-          "test_search_returns_similar_results_succeeds": "medium",
-          "test_search_filters_by_metadata_succeeds": "medium"
-        },
-        "tests_with_markers": 2,
-        "tests_without_markers": 0,
-        "misaligned_markers": [],
-        "duplicate_markers": [],
-        "recognized_markers": {
-          "medium": {
-            "file_count": 2,
-            "pytest_count": 0,
-            "recognized": false,
-            "registered_in_pytest_ini": true,
-            "error": "subprocess error: 4",
-            "uncollected_tests": []
-          }
-        },
-        "issues": [
-          {
-            "type": "unrecognized_markers",
-            "message": "medium markers are not recognized by pytest (2 in file, 0 recognized)"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/unit/application/memory/test_rdflib_store.py": {
-        "file_path": "/workspace/devsynth/tests/unit/application/memory/test_rdflib_store.py",
-        "has_pytest_import": true,
-        "test_functions": 12,
-        "markers": {
-          "test_init_succeeds": "medium",
-          "test_store_and_retrieve_succeeds": "medium",
-          "test_retrieve_nonexistent_succeeds": "medium",
-          "test_search_succeeds": "medium",
-          "test_search_by_id_and_date_range_succeeds": "medium",
-          "test_delete_succeeds": "medium",
-          "test_token_usage_succeeds": "medium",
-          "test_persistence_succeeds": "medium",
-          "test_store_vector_succeeds": "medium",
-          "test_similarity_search_succeeds": "medium",
-          "test_delete_vector_succeeds": "medium",
-          "test_get_collection_stats_succeeds": "medium"
-        },
-        "tests_with_markers": 12,
-        "tests_without_markers": 0,
-        "misaligned_markers": [],
-        "duplicate_markers": [
-          {
-            "test_name": "test_search_succeeds",
-            "marker_count": 2
-          }
-        ],
-        "recognized_markers": {
-          "medium": {
-            "file_count": 12,
-            "pytest_count": 0,
-            "recognized": false,
-            "registered_in_pytest_ini": true,
-            "error": "subprocess error: 4",
-            "uncollected_tests": []
-          }
-        },
-        "issues": [
-          {
-            "type": "duplicate_markers",
-            "message": "File has 1 tests with duplicate markers"
-          },
-          {
-            "type": "unrecognized_markers",
-            "message": "medium markers are not recognized by pytest (12 in file, 0 recognized)"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/unit/application/memory/test_basic_crud_adapters.py": {
-        "file_path": "/workspace/devsynth/tests/unit/application/memory/test_basic_crud_adapters.py",
-        "has_pytest_import": true,
-        "test_functions": 1,
-        "markers": {
-          "test_basic_crud_lifecycle": "medium"
-        },
-        "tests_with_markers": 1,
-        "tests_without_markers": 0,
-        "misaligned_markers": [],
-        "duplicate_markers": [],
-        "recognized_markers": {
-          "medium": {
-            "file_count": 1,
-            "pytest_count": 0,
-            "recognized": false,
-            "registered_in_pytest_ini": true,
-            "error": "subprocess error: 4",
-            "uncollected_tests": []
-          }
-        },
-        "issues": [
-          {
-            "type": "unrecognized_markers",
-            "message": "medium markers are not recognized by pytest (1 in file, 0 recognized)"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/unit/application/memory/test_import_without_duckdb.py": {
-        "file_path": "/workspace/devsynth/tests/unit/application/memory/test_import_without_duckdb.py",
-        "has_pytest_import": true,
-        "test_functions": 1,
-        "markers": {
-          "test_init_duckdb_store_without_duckdb_fails": "medium"
-        },
-        "tests_with_markers": 1,
-        "tests_without_markers": 0,
-        "misaligned_markers": [],
-        "duplicate_markers": [],
-        "recognized_markers": {
-          "medium": {
-            "file_count": 1,
-            "pytest_count": 0,
-            "recognized": false,
-            "registered_in_pytest_ini": true,
-            "error": "subprocess error: 4",
-            "uncollected_tests": []
-          }
-        },
-        "issues": [
-          {
-            "type": "unrecognized_markers",
-            "message": "medium markers are not recognized by pytest (1 in file, 0 recognized)"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/unit/application/memory/test_kuzu_store.py": {
-        "file_path": "/workspace/devsynth/tests/unit/application/memory/test_kuzu_store.py",
-        "has_pytest_import": true,
-        "test_functions": 4,
-        "markers": {
-          "test_init_creates_directory": "medium",
-          "test_store_and_retrieve_succeeds": "medium",
-          "test_transaction_rollback_restores_snapshot": "medium",
-          "test_concurrent_transactions": "medium"
-        },
-        "tests_with_markers": 4,
-        "tests_without_markers": 0,
-        "misaligned_markers": [],
-        "duplicate_markers": [],
-        "recognized_markers": {
-          "medium": {
-            "file_count": 4,
-            "pytest_count": 0,
-            "recognized": false,
-            "registered_in_pytest_ini": true,
-            "error": "subprocess error: 4",
-            "uncollected_tests": []
-          }
-        },
-        "issues": [
-          {
-            "type": "unrecognized_markers",
-            "message": "medium markers are not recognized by pytest (4 in file, 0 recognized)"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/unit/application/memory/test_import_without_tinydb.py": {
-        "file_path": "/workspace/devsynth/tests/unit/application/memory/test_import_without_tinydb.py",
-        "has_pytest_import": true,
-        "test_functions": 1,
-        "markers": {
-          "test_import_memory_without_tinydb_succeeds": "medium"
-        },
-        "tests_with_markers": 1,
-        "tests_without_markers": 0,
-        "misaligned_markers": [],
-        "duplicate_markers": [],
-        "recognized_markers": {
-          "medium": {
-            "file_count": 1,
-            "pytest_count": 0,
-            "recognized": false,
-            "registered_in_pytest_ini": true,
-            "error": "subprocess error: 4",
-            "uncollected_tests": []
-          }
-        },
-        "issues": [
-          {
-            "type": "unrecognized_markers",
-            "message": "medium markers are not recognized by pytest (1 in file, 0 recognized)"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/unit/application/memory/test_vector_memory_adapter_extra.py": {
-        "file_path": "/workspace/devsynth/tests/unit/application/memory/test_vector_memory_adapter_extra.py",
-        "has_pytest_import": true,
-        "test_functions": 4,
-        "markers": {
-          "test_similarity_empty_store": "medium",
-          "test_similarity_zero_norm": "medium",
-          "test_delete_missing": "medium",
-          "test_collection_stats": "medium"
-        },
-        "tests_with_markers": 4,
-        "tests_without_markers": 0,
-        "misaligned_markers": [],
-        "duplicate_markers": [
-          {
-            "test_name": "test_similarity_zero_norm",
-            "marker_count": 2
-          },
-          {
-            "test_name": "test_delete_missing",
-            "marker_count": 2
-          },
-          {
-            "test_name": "test_collection_stats",
-            "marker_count": 2
-          }
-        ],
-        "recognized_markers": {
-          "medium": {
-            "file_count": 4,
-            "pytest_count": 0,
-            "recognized": false,
-            "registered_in_pytest_ini": true,
-            "error": "subprocess error: 4",
-            "uncollected_tests": []
-          }
-        },
-        "issues": [
-          {
-            "type": "duplicate_markers",
-            "message": "File has 3 tests with duplicate markers"
-          },
-          {
-            "type": "unrecognized_markers",
-            "message": "medium markers are not recognized by pytest (4 in file, 0 recognized)"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/unit/application/memory/test_duckdb_store.py": {
-        "file_path": "/workspace/devsynth/tests/unit/application/memory/test_duckdb_store.py",
-        "has_pytest_import": true,
-        "test_functions": 11,
-        "markers": {
-          "test_init_succeeds": "medium",
-          "test_store_and_retrieve_succeeds": "medium",
-          "test_retrieve_nonexistent_succeeds": "medium",
-          "test_search_succeeds": "medium",
-          "test_delete_succeeds": "medium",
-          "test_token_usage_succeeds": "medium",
-          "test_persistence_succeeds": "medium",
-          "test_store_vector_succeeds": "medium",
-          "test_similarity_search_succeeds": "medium",
-          "test_delete_vector_succeeds": "medium",
-          "test_get_collection_stats_succeeds": "medium"
-        },
-        "tests_with_markers": 11,
-        "tests_without_markers": 0,
-        "misaligned_markers": [],
-        "duplicate_markers": [
-          {
-            "test_name": "test_search_succeeds",
-            "marker_count": 2
-          }
-        ],
-        "recognized_markers": {
-          "medium": {
-            "file_count": 11,
-            "pytest_count": 0,
-            "recognized": false,
-            "registered_in_pytest_ini": true,
-            "error": "subprocess error: 4",
-            "uncollected_tests": []
-          }
-        },
-        "issues": [
-          {
-            "type": "duplicate_markers",
-            "message": "File has 1 tests with duplicate markers"
-          },
-          {
-            "type": "unrecognized_markers",
-            "message": "medium markers are not recognized by pytest (11 in file, 0 recognized)"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/unit/application/memory/test_sync_wrappers.py": {
-        "file_path": "/workspace/devsynth/tests/unit/application/memory/test_sync_wrappers.py",
-        "has_pytest_import": true,
-        "test_functions": 1,
-        "markers": {
-          "test_cross_store_query_and_update_wrappers": "medium"
-        },
-        "tests_with_markers": 1,
-        "tests_without_markers": 0,
-        "misaligned_markers": [],
-        "duplicate_markers": [],
-        "recognized_markers": {
-          "medium": {
-            "file_count": 1,
-            "pytest_count": 0,
-            "recognized": false,
-            "registered_in_pytest_ini": true,
-            "error": "subprocess error: 4",
-            "uncollected_tests": []
-          }
-        },
-        "issues": [
-          {
-            "type": "unrecognized_markers",
-            "message": "medium markers are not recognized by pytest (1 in file, 0 recognized)"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/unit/application/memory/test_tinydb_store.py": {
-        "file_path": "/workspace/devsynth/tests/unit/application/memory/test_tinydb_store.py",
-        "has_pytest_import": true,
-        "test_functions": 7,
-        "markers": {
-          "test_init_succeeds": "medium",
-          "test_store_and_retrieve_succeeds": "medium",
-          "test_retrieve_nonexistent_succeeds": "medium",
-          "test_search_succeeds": "medium",
-          "test_delete_succeeds": "medium",
-          "test_token_usage_succeeds": "medium",
-          "test_persistence_succeeds": "medium"
-        },
-        "tests_with_markers": 7,
-        "tests_without_markers": 0,
-        "misaligned_markers": [],
-        "duplicate_markers": [
-          {
-            "test_name": "test_search_succeeds",
-            "marker_count": 2
-          }
-        ],
-        "recognized_markers": {
-          "medium": {
-            "file_count": 7,
-            "pytest_count": 0,
-            "recognized": false,
-            "registered_in_pytest_ini": true,
-            "error": "subprocess error: 4",
-            "uncollected_tests": []
-          }
-        },
-        "issues": [
-          {
-            "type": "duplicate_markers",
-            "message": "File has 1 tests with duplicate markers"
-          },
-          {
-            "type": "unrecognized_markers",
-            "message": "medium markers are not recognized by pytest (7 in file, 0 recognized)"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/unit/application/memory/test_retry.py": {
-        "file_path": "/workspace/devsynth/tests/unit/application/memory/test_retry.py",
-        "has_pytest_import": true,
-        "test_functions": 20,
-        "markers": {
-          "test_successful_execution": "medium",
-          "test_func": "medium",
-          "test_retry_on_failure": "medium",
-          "test_max_retries_exceeded": "medium",
-          "test_exceptions_to_retry": "medium",
-          "test_backoff_calculation": "medium",
-          "test_max_backoff": "medium",
-          "test_retry_config_initialization": "medium",
-          "test_default_retry_config": "medium",
-          "test_quick_retry_config": "medium",
-          "test_persistent_retry_config": "medium",
-          "test_network_retry_config": "medium",
-          "test_with_retry_default_config": "medium",
-          "test_with_retry_custom_config": "medium"
-        },
-        "tests_with_markers": 14,
-        "tests_without_markers": 6,
-        "misaligned_markers": [],
-        "duplicate_markers": [
-          {
-            "test_name": "test_successful_execution",
-            "marker_count": 4
-          },
-          {
-            "test_name": "test_func",
-            "marker_count": 7
-          },
-          {
-            "test_name": "test_retry_on_failure",
-            "marker_count": 3
-          },
-          {
-            "test_name": "test_max_retries_exceeded",
-            "marker_count": 2
-          },
-          {
-            "test_name": "test_successful_execution",
-            "marker_count": 4
-          },
-          {
-            "test_name": "test_func",
-            "marker_count": 7
-          },
-          {
-            "test_name": "test_retry_on_failure",
-            "marker_count": 3
-          },
-          {
-            "test_name": "test_max_retries_exceeded",
-            "marker_count": 2
-          },
-          {
-            "test_name": "test_retry_config_initialization",
-            "marker_count": 2
-          },
-          {
-            "test_name": "test_with_retry_default_config",
-            "marker_count": 2
-          },
-          {
-            "test_name": "test_func",
-            "marker_count": 7
-          },
-          {
-            "test_name": "test_func",
-            "marker_count": 7
-          }
-        ],
-        "recognized_markers": {
-          "medium": {
-            "file_count": 14,
-            "pytest_count": 0,
-            "recognized": false,
-            "registered_in_pytest_ini": true,
-            "error": "subprocess error: 4",
-            "uncollected_tests": []
-          }
-        },
-        "issues": [
-          {
-            "type": "duplicate_markers",
-            "message": "File has 12 tests with duplicate markers"
-          },
-          {
-            "type": "unrecognized_markers",
-            "message": "medium markers are not recognized by pytest (14 in file, 0 recognized)"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/unit/application/memory/test_memory_manager.py": {
-        "file_path": "/workspace/devsynth/tests/unit/application/memory/test_memory_manager.py",
-        "has_pytest_import": true,
-        "test_functions": 9,
-        "markers": {
-          "test_store_prefers_graph_for_edrr_succeeds": "medium",
-          "test_store_falls_back_to_tinydb_succeeds": "medium",
-          "test_store_falls_back_to_first_succeeds": "medium",
-          "test_retrieve_with_edrr_phase_succeeds": "medium",
-          "test_retrieve_with_edrr_phase_not_found_succeeds": "medium",
-          "test_retrieve_with_edrr_phase_with_metadata_succeeds": "medium",
-          "test_fallback_and_provider_succeeds": "medium",
-          "test_register_and_notify_sync_hook_succeeds": "fast",
-          "test_sync_hook_errors_are_logged": "fast"
-        },
-        "tests_with_markers": 9,
-        "tests_without_markers": 0,
-        "misaligned_markers": [],
-        "duplicate_markers": [
-          {
-            "test_name": "test_retrieve_with_edrr_phase_with_metadata_succeeds",
-            "marker_count": 2
-          }
-        ],
-        "recognized_markers": {
-          "fast": {
-            "file_count": 2,
-            "pytest_count": 0,
-            "recognized": false,
-            "registered_in_pytest_ini": true,
-            "error": "subprocess error: 4",
-            "uncollected_tests": []
-          },
-          "medium": {
-            "file_count": 7,
-            "pytest_count": 0,
-            "recognized": false,
-            "registered_in_pytest_ini": true,
-            "error": "subprocess error: 4",
-            "uncollected_tests": []
-          }
-        },
-        "issues": [
-          {
-            "type": "duplicate_markers",
-            "message": "File has 1 tests with duplicate markers"
-          },
-          {
-            "type": "unrecognized_markers",
-            "message": "fast markers are not recognized by pytest (2 in file, 0 recognized)"
-          },
-          {
-            "type": "unrecognized_markers",
-            "message": "medium markers are not recognized by pytest (7 in file, 0 recognized)"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/unit/application/memory/test_faiss_store.py": {
-        "file_path": "/workspace/devsynth/tests/unit/application/memory/test_faiss_store.py",
-        "has_pytest_import": true,
-        "test_functions": 7,
-        "markers": {
-          "test_init_succeeds": "medium",
-          "test_store_vector_succeeds": "medium",
-          "test_retrieve_vector_nonexistent_succeeds": "medium",
-          "test_similarity_search_succeeds": "medium",
-          "test_delete_vector_succeeds": "medium",
-          "test_get_collection_stats_succeeds": "medium",
-          "test_persistence_succeeds": "medium"
-        },
-        "tests_with_markers": 7,
-        "tests_without_markers": 0,
-        "misaligned_markers": [],
-        "duplicate_markers": [
-          {
-            "test_name": "test_similarity_search_succeeds",
-            "marker_count": 2
-          }
-        ],
-        "recognized_markers": {
-          "medium": {
-            "file_count": 7,
-            "pytest_count": 0,
-            "recognized": false,
-            "registered_in_pytest_ini": true,
-            "error": "subprocess error: 4",
-            "uncollected_tests": []
-          }
-        },
-        "issues": [
-          {
-            "type": "duplicate_markers",
-            "message": "File has 1 tests with duplicate markers"
-          },
-          {
-            "type": "unrecognized_markers",
-            "message": "medium markers are not recognized by pytest (7 in file, 0 recognized)"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/unit/application/memory/test_multi_layered_memory.py": {
-        "file_path": "/workspace/devsynth/tests/unit/application/memory/test_multi_layered_memory.py",
-        "has_pytest_import": true,
-        "test_functions": 13,
-        "markers": {
-          "test_init_succeeds": "medium",
-          "test_store_short_term_memory_succeeds": "medium",
-          "test_store_episodic_memory_succeeds": "medium",
-          "test_store_semantic_memory_succeeds": "medium",
-          "test_store_unknown_memory_type_succeeds": "medium",
-          "test_store_without_id_succeeds": "medium",
-          "test_retrieve_succeeds": "medium",
-          "test_retrieve_with_cache_succeeds": "medium",
-          "test_get_items_by_layer_succeeds": "medium",
-          "test_query_succeeds": "medium",
-          "test_tiered_cache_succeeds": "medium",
-          "test_clear_cache_succeeds": "medium",
-          "test_clear_succeeds": "medium"
-        },
-        "tests_with_markers": 13,
-        "tests_without_markers": 0,
-        "misaligned_markers": [],
-        "duplicate_markers": [],
-        "recognized_markers": {
-          "medium": {
-            "file_count": 13,
-            "pytest_count": 0,
-            "recognized": false,
-            "registered_in_pytest_ini": true,
-            "error": "subprocess error: 4",
-            "uncollected_tests": []
-          }
-        },
-        "issues": [
-          {
-            "type": "unrecognized_markers",
-            "message": "medium markers are not recognized by pytest (13 in file, 0 recognized)"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/unit/application/memory/test_chromadb_store.py": {
-        "file_path": "/workspace/devsynth/tests/unit/application/memory/test_chromadb_store.py",
-        "has_pytest_import": true,
-        "test_functions": 8,
-        "markers": {
-          "test_init_logs_error_on_bad_fallback_raises_error": "medium",
-          "test_init_fallback_when_collection_creation_fails": "medium",
-          "test_save_fallback_logs_error_raises_error": "medium",
-          "test_http_client_used_when_host_provided": "medium",
-          "test_persistent_client_used_by_default": "medium",
-          "test_ephemeral_client_used_in_no_file_mode": "medium",
-          "test_store_retrieve_delete_succeeds": "medium",
-          "test_search_by_metadata_succeeds": "medium"
-        },
-        "tests_with_markers": 8,
-        "tests_without_markers": 0,
-        "misaligned_markers": [],
-        "duplicate_markers": [],
-        "recognized_markers": {
-          "medium": {
-            "file_count": 8,
-            "pytest_count": 0,
-            "recognized": false,
-            "registered_in_pytest_ini": true,
-            "error": "subprocess error: 4",
-            "uncollected_tests": []
-          }
-        },
-        "issues": [
-          {
-            "type": "unrecognized_markers",
-            "message": "medium markers are not recognized by pytest (8 in file, 0 recognized)"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/unit/application/ingestion/test_phases.py": {
-        "file_path": "/workspace/devsynth/tests/unit/application/ingestion/test_phases.py",
-        "has_pytest_import": true,
-        "test_functions": 2,
-        "markers": {
-          "test_run_expand_phase_populates_artifacts": "fast",
-          "test_run_differentiate_phase_uses_structure": "fast"
-        },
-        "tests_with_markers": 2,
-        "tests_without_markers": 0,
-        "misaligned_markers": [],
-        "duplicate_markers": [],
-        "recognized_markers": {
-          "fast": {
-            "file_count": 2,
-            "pytest_count": 0,
-            "recognized": false,
-            "registered_in_pytest_ini": true,
-            "error": "subprocess error: 4",
-            "uncollected_tests": []
-          }
-        },
-        "issues": [
-          {
-            "type": "unrecognized_markers",
-            "message": "fast markers are not recognized by pytest (2 in file, 0 recognized)"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/integration/utils/test_logging_integration.py": {
-        "file_path": "/workspace/devsynth/tests/integration/utils/test_logging_integration.py",
-        "has_pytest_import": true,
-        "test_functions": 2,
-        "markers": {
-          "test_setup_logging_returns_project_logger": "fast",
-          "test_log_normalizes_exception": "fast"
-        },
-        "tests_with_markers": 2,
-        "tests_without_markers": 0,
-        "misaligned_markers": [],
-        "duplicate_markers": [],
-        "recognized_markers": {
-          "fast": {
-            "file_count": 2,
-            "pytest_count": 0,
-            "recognized": false,
-            "registered_in_pytest_ini": true,
-            "error": "subprocess error: 4",
-            "uncollected_tests": []
-          }
-        },
-        "issues": [
-          {
-            "type": "unrecognized_markers",
-            "message": "fast markers are not recognized by pytest (2 in file, 0 recognized)"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/integration/general/test_wsde_memory_edrr_integration.py": {
-        "file_path": "/workspace/devsynth/tests/integration/general/test_wsde_memory_edrr_integration.py",
-        "has_pytest_import": true,
-        "test_functions": 3,
-        "markers": {
-          "test_store_and_retrieve_solution_by_phase_succeeds": "medium",
-          "test_cross_store_sync_and_peer_review_workflow": "medium",
-          "test_sync_manager_coordinated_backends": "medium"
-        },
-        "tests_with_markers": 3,
-        "tests_without_markers": 0,
-        "misaligned_markers": [],
-        "duplicate_markers": [],
-        "recognized_markers": {
-          "medium": {
-            "file_count": 3,
-            "pytest_count": 0,
-            "recognized": false,
-            "registered_in_pytest_ini": true,
-            "error": "subprocess error: 4",
-            "uncollected_tests": []
-          }
-        },
-        "issues": [
-          {
-            "type": "unrecognized_markers",
-            "message": "medium markers are not recognized by pytest (3 in file, 0 recognized)"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/integration/general/test_recursive_recovery_flow.py": {
-        "file_path": "/workspace/devsynth/tests/integration/general/test_recursive_recovery_flow.py",
-        "has_pytest_import": true,
-        "test_functions": 1,
-        "markers": {
-          "test_recursive_recovery_flow": "medium"
-        },
-        "tests_with_markers": 1,
-        "tests_without_markers": 0,
-        "misaligned_markers": [],
-        "duplicate_markers": [],
-        "recognized_markers": {
-          "medium": {
-            "file_count": 1,
-            "pytest_count": 0,
-            "recognized": false,
-            "registered_in_pytest_ini": true,
-            "error": "subprocess error: 4",
-            "uncollected_tests": []
-          }
-        },
-        "issues": [
-          {
-            "type": "unrecognized_markers",
-            "message": "medium markers are not recognized by pytest (1 in file, 0 recognized)"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/integration/general/test_agent_api_security.py": {
-        "file_path": "/workspace/devsynth/tests/integration/general/test_agent_api_security.py",
-        "has_pytest_import": true,
-        "test_functions": 6,
-        "markers": {
-          "test_api_requires_authentication_succeeds": "medium",
-          "test_api_authentication_disabled_succeeds": "medium",
-          "test_api_error_handling_raises_error": "medium",
-          "test_api_validation_is_valid": "medium",
-          "test_api_health_endpoint_succeeds": "medium",
-          "test_api_metrics_endpoint_succeeds": "medium"
-        },
-        "tests_with_markers": 6,
-        "tests_without_markers": 0,
-        "misaligned_markers": [],
-        "duplicate_markers": [],
-        "recognized_markers": {
-          "medium": {
-            "file_count": 6,
-            "pytest_count": 0,
-            "recognized": false,
-            "registered_in_pytest_ini": true,
-            "error": "subprocess error: 4",
-            "uncollected_tests": []
-          }
-        },
-        "issues": [
-          {
-            "type": "unrecognized_markers",
-            "message": "medium markers are not recognized by pytest (6 in file, 0 recognized)"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/integration/general/test_project_state_analyzer.py": {
-        "file_path": "/workspace/devsynth/tests/integration/general/test_project_state_analyzer.py",
-        "has_pytest_import": true,
-        "test_functions": 3,
-        "markers": {
-          "test_analyze_devsynth_project_succeeds": "medium",
-          "test_analyze_with_missing_files_succeeds": "medium",
-          "test_analyze_with_requirements_and_code_succeeds": "medium"
-        },
-        "tests_with_markers": 3,
-        "tests_without_markers": 0,
-        "misaligned_markers": [],
-        "duplicate_markers": [],
-        "recognized_markers": {
-          "medium": {
-            "file_count": 3,
-            "pytest_count": 0,
-            "recognized": false,
-            "registered_in_pytest_ini": true,
-            "error": "subprocess error: 4",
-            "uncollected_tests": []
-          }
-        },
-        "issues": [
-          {
-            "type": "unrecognized_markers",
-            "message": "medium markers are not recognized by pytest (3 in file, 0 recognized)"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/integration/general/test_provider_system.py": {
-        "file_path": "/workspace/devsynth/tests/integration/general/test_provider_system.py",
-        "has_pytest_import": true,
-        "test_functions": 11,
-        "markers": {
-          "test_get_provider_config_has_expected": "medium",
-          "test_create_openai_provider_has_expected": "medium",
-          "test_create_lm_studio_provider_has_expected": "medium",
-          "test_fallback_to_lm_studio_succeeds": "medium",
-          "test_openai_complete_succeeds": "medium",
-          "test_lm_studio_complete_succeeds": "medium",
-          "test_fallback_provider_complete_has_expected": "medium",
-          "test_fallback_provider_all_fail_fails": "medium",
-          "test_get_provider_has_expected": "medium",
-          "test_complete_function_succeeds": "medium",
-          "test_embed_function_succeeds": "medium"
-        },
-        "tests_with_markers": 11,
-        "tests_without_markers": 0,
-        "misaligned_markers": [],
-        "duplicate_markers": [],
-        "recognized_markers": {
-          "medium": {
-            "file_count": 11,
-            "pytest_count": 0,
-            "recognized": false,
-            "registered_in_pytest_ini": true,
-            "error": "subprocess error: 4",
-            "uncollected_tests": []
-          }
-        },
-        "issues": [
-          {
-            "type": "unrecognized_markers",
-            "message": "medium markers are not recognized by pytest (11 in file, 0 recognized)"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/integration/general/test_webui_e2e_workflows.py": {
-        "file_path": "/workspace/devsynth/tests/integration/general/test_webui_e2e_workflows.py",
-        "has_pytest_import": true,
-        "test_functions": 5,
-        "markers": {
-          "test_analysis_to_synthesis_workflow_succeeds": "medium",
-          "test_config_to_analysis_workflow_succeeds": "medium",
-          "test_complete_e2e_workflow_succeeds": "medium",
-          "test_error_handling_in_workflow_succeeds": "medium",
-          "test_state_preservation_in_workflow_succeeds": "medium"
-        },
-        "tests_with_markers": 5,
-        "tests_without_markers": 0,
-        "misaligned_markers": [],
-        "duplicate_markers": [],
-        "recognized_markers": {
-          "medium": {
-            "file_count": 5,
-            "pytest_count": 0,
-            "recognized": false,
-            "registered_in_pytest_ini": true,
-            "error": "subprocess error: 4",
-            "uncollected_tests": []
-          }
-        },
-        "issues": [
-          {
-            "type": "unrecognized_markers",
-            "message": "medium markers are not recognized by pytest (5 in file, 0 recognized)"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/integration/general/test_wsde_edrr_component_interactions.py": {
-        "file_path": "/workspace/devsynth/tests/integration/general/test_wsde_edrr_component_interactions.py",
-        "has_pytest_import": true,
-        "test_functions": 8,
-        "markers": {
-          "test_wsde_team_role_assignment_in_edrr_phases_has_expected": "medium",
-          "test_wsde_method_calls_in_edrr_phases_has_expected": "medium",
-          "test_memory_integration_in_edrr_wsde_workflow_succeeds": "medium",
-          "test_error_handling_in_edrr_wsde_integration_raises_error": "medium",
-          "test_phase_progression_flushes_memory_queue": "medium",
-          "test_memory_sync_hook_receives_events": "medium",
-          "test_retrospective_flushes_pending_memory_without_record": "medium",
-          "test_role_assignment_mapping_is_accessible": "medium"
-        },
-        "tests_with_markers": 8,
-        "tests_without_markers": 0,
-        "misaligned_markers": [],
-        "duplicate_markers": [],
-        "recognized_markers": {
-          "medium": {
-            "file_count": 8,
-            "pytest_count": 0,
-            "recognized": false,
-            "registered_in_pytest_ini": true,
-            "error": "subprocess error: 4",
-            "uncollected_tests": []
-          }
-        },
-        "issues": [
-          {
-            "type": "unrecognized_markers",
-            "message": "medium markers are not recognized by pytest (8 in file, 0 recognized)"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/integration/general/test_cli_webui_agentapi_pipeline.py": {
-        "file_path": "/workspace/devsynth/tests/integration/general/test_cli_webui_agentapi_pipeline.py",
-        "has_pytest_import": true,
-        "test_functions": 8,
-        "markers": {
-          "test_init_command_pipeline_succeeds": "medium",
-          "test_spec_command_pipeline_succeeds": "medium",
-          "test_test_command_pipeline_succeeds": "medium",
-          "test_code_command_pipeline_succeeds": "medium",
-          "test_edrr_cycle_command_pipeline_succeeds": "medium",
-          "test_error_handling_in_pipeline_raises_error": "medium",
-          "test_webui_command_pipeline_succeeds": "medium",
-          "test_webui_command_error_handling_succeeds": "medium"
-        },
-        "tests_with_markers": 8,
-        "tests_without_markers": 0,
-        "misaligned_markers": [],
-        "duplicate_markers": [],
-        "recognized_markers": {
-          "medium": {
-            "file_count": 8,
-            "pytest_count": 0,
-            "recognized": false,
-            "registered_in_pytest_ini": true,
-            "error": "subprocess error: 4",
-            "uncollected_tests": []
-          }
-        },
-        "issues": [
-          {
-            "type": "unrecognized_markers",
-            "message": "medium markers are not recognized by pytest (8 in file, 0 recognized)"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/integration/general/test_wsde_edrr_integration_advanced.py": {
-        "file_path": "/workspace/devsynth/tests/integration/general/test_wsde_edrr_integration_advanced.py",
-        "has_pytest_import": true,
-        "test_functions": 6,
-        "markers": {
-          "test_phase_specific_role_assignment_has_expected": "medium",
-          "test_quality_based_phase_transitions_has_expected": "medium",
-          "test_micro_cycle_implementation_succeeds": "medium",
-          "test_error_handling_and_recovery_raises_error": "medium",
-          "test_performance_metrics_and_traceability_succeeds": "medium",
-          "test_memory_sync_hook_handles_wsde_events": "medium"
-        },
-        "tests_with_markers": 6,
-        "tests_without_markers": 0,
-        "misaligned_markers": [],
-        "duplicate_markers": [],
-        "recognized_markers": {
-          "medium": {
-            "file_count": 6,
-            "pytest_count": 0,
-            "recognized": false,
-            "registered_in_pytest_ini": true,
-            "error": "subprocess error: 4",
-            "uncollected_tests": []
-          }
-        },
-        "issues": [
-          {
-            "type": "unrecognized_markers",
-            "message": "medium markers are not recognized by pytest (6 in file, 0 recognized)"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/integration/general/test_prompt_auto_tuning.py": {
-        "file_path": "/workspace/devsynth/tests/integration/general/test_prompt_auto_tuning.py",
-        "has_pytest_import": true,
-        "test_functions": 2,
-        "markers": {
-          "test_auto_tuner_disabled_by_default_succeeds": "medium",
-          "test_prompt_auto_tuning_feedback_loop_succeeds": "medium"
-        },
-        "tests_with_markers": 2,
-        "tests_without_markers": 0,
-        "misaligned_markers": [],
-        "duplicate_markers": [],
-        "recognized_markers": {
-          "medium": {
-            "file_count": 2,
-            "pytest_count": 0,
-            "recognized": false,
-            "registered_in_pytest_ini": true,
-            "error": "subprocess error: 4",
-            "uncollected_tests": []
-          }
-        },
-        "issues": [
-          {
-            "type": "unrecognized_markers",
-            "message": "medium markers are not recognized by pytest (2 in file, 0 recognized)"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/integration/general/test_agentapi.py": {
-        "file_path": "/workspace/devsynth/tests/integration/general/test_agentapi.py",
-        "has_pytest_import": true,
-        "test_functions": 3,
-        "markers": {
-          "test_init_succeeds": "medium",
-          "test_gather_succeeds": "medium",
-          "test_synthesize_and_status_succeeds": "medium"
-        },
-        "tests_with_markers": 3,
-        "tests_without_markers": 0,
-        "misaligned_markers": [],
-        "duplicate_markers": [],
-        "recognized_markers": {
-          "medium": {
-            "file_count": 3,
-            "pytest_count": 0,
-            "recognized": false,
-            "registered_in_pytest_ini": true,
-            "error": "subprocess error: 4",
-            "uncollected_tests": []
-          }
-        },
-        "issues": [
-          {
-            "type": "unrecognized_markers",
-            "message": "medium markers are not recognized by pytest (3 in file, 0 recognized)"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/integration/general/test_webui_setup.py": {
-        "file_path": "/workspace/devsynth/tests/integration/general/test_webui_setup.py",
-        "has_pytest_import": true,
-        "test_functions": 3,
-        "markers": {
-          "test_guided_setup_button_invokes_wizard_succeeds": "medium",
-          "test_offline_toggle_saves_config_succeeds": "medium",
-          "test_webui_bridge_error_display_succeeds": "medium"
-        },
-        "tests_with_markers": 3,
-        "tests_without_markers": 0,
-        "misaligned_markers": [],
-        "duplicate_markers": [],
-        "recognized_markers": {
-          "medium": {
-            "file_count": 3,
-            "pytest_count": 0,
-            "recognized": false,
-            "registered_in_pytest_ini": true,
-            "error": "subprocess error: 4",
-            "uncollected_tests": []
-          }
-        },
-        "issues": [
-          {
-            "type": "unrecognized_markers",
-            "message": "medium markers are not recognized by pytest (3 in file, 0 recognized)"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/integration/general/test_agent_system_integration.py": {
-        "file_path": "/workspace/devsynth/tests/integration/general/test_agent_system_integration.py",
-        "has_pytest_import": true,
-        "test_functions": 4,
-        "markers": {
-          "test_base_agent_graph_successful_invocation_succeeds": "medium",
-          "test_base_agent_graph_error_in_input_processing_raises_error": "medium",
-          "test_base_agent_graph_error_in_llm_call_raises_error": "medium",
-          "test_base_agent_graph_llm_response_is_none_for_parsing_raises_error": "medium"
-        },
-        "tests_with_markers": 4,
-        "tests_without_markers": 0,
-        "misaligned_markers": [],
-        "duplicate_markers": [],
-        "recognized_markers": {
-          "medium": {
-            "file_count": 4,
-            "pytest_count": 0,
-            "recognized": false,
-            "registered_in_pytest_ini": true,
-            "error": "subprocess error: 4",
-            "uncollected_tests": []
-          }
-        },
-        "issues": [
-          {
-            "type": "unrecognized_markers",
-            "message": "medium markers are not recognized by pytest (4 in file, 0 recognized)"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/integration/general/test_config_loader_workflow.py": {
-        "file_path": "/workspace/devsynth/tests/integration/general/test_config_loader_workflow.py",
-        "has_pytest_import": true,
-        "test_functions": 3,
-        "markers": {
-          "test_load_config_merges_defaults_succeeds": "medium",
-          "test_malformed_yaml_raises": "medium",
-          "test_malformed_toml_raises": "medium"
-        },
-        "tests_with_markers": 3,
-        "tests_without_markers": 0,
-        "misaligned_markers": [],
-        "duplicate_markers": [],
-        "recognized_markers": {
-          "medium": {
-            "file_count": 3,
-            "pytest_count": 0,
-            "recognized": false,
-            "registered_in_pytest_ini": true,
-            "error": "subprocess error: 4",
-            "uncollected_tests": []
-          }
-        },
-        "issues": [
-          {
-            "type": "unrecognized_markers",
-            "message": "medium markers are not recognized by pytest (3 in file, 0 recognized)"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/integration/general/test_config_loader_integration.py": {
-        "file_path": "/workspace/devsynth/tests/integration/general/test_config_loader_integration.py",
-        "has_pytest_import": true,
-        "test_functions": 3,
-        "markers": {
-          "test_load_config_from_yaml_succeeds": "medium",
-          "test_load_config_from_pyproject_succeeds": "medium",
-          "test_pyproject_precedence_over_yaml_succeeds": "medium"
-        },
-        "tests_with_markers": 3,
-        "tests_without_markers": 0,
-        "misaligned_markers": [],
-        "duplicate_markers": [],
-        "recognized_markers": {
-          "medium": {
-            "file_count": 3,
-            "pytest_count": 0,
-            "recognized": false,
-            "registered_in_pytest_ini": true,
-            "error": "subprocess error: 4",
-            "uncollected_tests": []
-          }
-        },
-        "issues": [
-          {
-            "type": "unrecognized_markers",
-            "message": "medium markers are not recognized by pytest (3 in file, 0 recognized)"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/integration/general/test_webui_pages.py": {
-        "file_path": "/workspace/devsynth/tests/integration/general/test_webui_pages.py",
-        "has_pytest_import": true,
-        "test_functions": 1,
-        "markers": {
-          "test_webui_pages_invoke_commands_succeeds": "medium"
-        },
-        "tests_with_markers": 1,
-        "tests_without_markers": 0,
-        "misaligned_markers": [],
-        "duplicate_markers": [],
-        "recognized_markers": {
-          "medium": {
-            "file_count": 1,
-            "pytest_count": 0,
-            "recognized": false,
-            "registered_in_pytest_ini": true,
-            "error": "subprocess error: 4",
-            "uncollected_tests": []
-          }
-        },
-        "issues": [
-          {
-            "type": "unrecognized_markers",
-            "message": "medium markers are not recognized by pytest (1 in file, 0 recognized)"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/integration/general/test_graph_memory_error_handling.py": {
-        "file_path": "/workspace/devsynth/tests/integration/general/test_graph_memory_error_handling.py",
-        "has_pytest_import": true,
-        "test_functions": 10,
-        "markers": {
-          "test_store_with_invalid_path_raises_permission_error": "medium",
-          "test_retrieve_nonexistent_item_succeeds": "medium",
-          "test_delete_nonexistent_item_succeeds": "medium",
-          "test_search_with_invalid_criteria_returns_empty_list": "medium",
-          "test_query_related_items_nonexistent_succeeds": "medium",
-          "test_store_with_corrupted_graph_raises_memory_store_error": "medium",
-          "test_concurrent_access_succeeds": "medium",
-          "test_store_and_retrieve_with_special_characters_succeeds": "medium",
-          "test_store_and_retrieve_with_unicode_characters_succeeds": "medium",
-          "test_store_with_very_large_content_succeeds": "slow"
-        },
-        "tests_with_markers": 10,
-        "tests_without_markers": 0,
-        "misaligned_markers": [],
-        "duplicate_markers": [
-          {
-            "test_name": "test_delete_nonexistent_item_succeeds",
-            "marker_count": 2
-          },
-          {
-            "test_name": "test_search_with_invalid_criteria_returns_empty_list",
-            "marker_count": 2
-          },
-          {
-            "test_name": "test_query_related_items_nonexistent_succeeds",
-            "marker_count": 2
-          },
-          {
-            "test_name": "test_store_with_corrupted_graph_raises_memory_store_error",
-            "marker_count": 2
-          }
-        ],
-        "recognized_markers": {
-          "medium": {
-            "file_count": 9,
-            "pytest_count": 0,
-            "recognized": false,
-            "registered_in_pytest_ini": true,
-            "error": "subprocess error: 4",
-            "uncollected_tests": []
-          },
-          "slow": {
-            "file_count": 1,
-            "pytest_count": 0,
-            "recognized": false,
-            "registered_in_pytest_ini": true,
-            "error": "subprocess error: 4",
-            "uncollected_tests": []
-          }
-        },
-        "issues": [
-          {
-            "type": "duplicate_markers",
-            "message": "File has 4 tests with duplicate markers"
-          },
-          {
-            "type": "unrecognized_markers",
-            "message": "medium markers are not recognized by pytest (9 in file, 0 recognized)"
-          },
-          {
-            "type": "unrecognized_markers",
-            "message": "slow markers are not recognized by pytest (1 in file, 0 recognized)"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/integration/general/test_query_router_integration.py": {
-        "file_path": "/workspace/devsynth/tests/integration/general/test_query_router_integration.py",
-        "has_pytest_import": true,
-        "test_functions": 4,
-        "markers": {
-          "test_direct_query": "medium",
-          "test_cross_store_query": "medium",
-          "test_cross_store_query_subset": "medium",
-          "test_federated_query": "medium"
-        },
-        "tests_with_markers": 4,
-        "tests_without_markers": 0,
-        "misaligned_markers": [],
-        "duplicate_markers": [
-          {
-            "test_name": "test_cross_store_query",
-            "marker_count": 2
-          },
-          {
-            "test_name": "test_federated_query",
-            "marker_count": 2
-          }
-        ],
-        "recognized_markers": {
-          "medium": {
-            "file_count": 4,
-            "pytest_count": 0,
-            "recognized": false,
-            "registered_in_pytest_ini": true,
-            "error": "subprocess error: 4",
-            "uncollected_tests": []
-          }
-        },
-        "issues": [
-          {
-            "type": "duplicate_markers",
-            "message": "File has 2 tests with duplicate markers"
-          },
-          {
-            "type": "unrecognized_markers",
-            "message": "medium markers are not recognized by pytest (4 in file, 0 recognized)"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/integration/general/test_provider_system_configurations.py": {
-        "file_path": "/workspace/devsynth/tests/integration/general/test_provider_system_configurations.py",
-        "has_pytest_import": true,
-        "test_functions": 7,
-        "markers": {
-          "test_openai_provider_with_different_models_has_expected": "medium",
-          "test_openai_provider_with_different_parameters_has_expected": "medium",
-          "test_lm_studio_provider_with_different_endpoints_has_expected": "medium",
-          "test_lm_studio_provider_with_different_parameters_has_expected": "medium",
-          "test_fallback_provider_with_different_configurations_has_expected": "medium",
-          "test_provider_system_with_different_default_providers_has_expected": "medium",
-          "test_provider_system_with_context_aware_completion_has_expected": "medium"
-        },
-        "tests_with_markers": 7,
-        "tests_without_markers": 0,
-        "misaligned_markers": [],
-        "duplicate_markers": [],
-        "recognized_markers": {
-          "medium": {
-            "file_count": 7,
-            "pytest_count": 0,
-            "recognized": false,
-            "registered_in_pytest_ini": true,
-            "error": "subprocess error: 4",
-            "uncollected_tests": []
-          }
-        },
-        "issues": [
-          {
-            "type": "unrecognized_markers",
-            "message": "medium markers are not recognized by pytest (7 in file, 0 recognized)"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/integration/general/test_agent_api.py": {
-        "file_path": "/workspace/devsynth/tests/integration/general/test_agent_api.py",
-        "has_pytest_import": true,
-        "test_functions": 9,
-        "markers": {
-          "test_cmd": "medium",
-          "test_init_route_succeeds": "medium",
-          "test_gather_route_succeeds": "medium",
-          "test_synthesize_and_status_succeeds": "medium",
-          "test_spec_route_succeeds": "medium",
-          "test_test_route_succeeds": "medium",
-          "test_code_route_succeeds": "medium",
-          "test_doctor_route_succeeds": "medium",
-          "test_edrr_cycle_route_succeeds": "medium"
-        },
-        "tests_with_markers": 9,
-        "tests_without_markers": 0,
-        "misaligned_markers": [],
-        "duplicate_markers": [],
-        "recognized_markers": {
-          "medium": {
-            "file_count": 9,
-            "pytest_count": 0,
-            "recognized": false,
-            "registered_in_pytest_ini": true,
-            "error": "subprocess error: 4",
-            "uncollected_tests": []
-          }
-        },
-        "issues": [
-          {
-            "type": "unrecognized_markers",
-            "message": "medium markers are not recognized by pytest (9 in file, 0 recognized)"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/integration/general/test_agentapi_routes.py": {
-        "file_path": "/workspace/devsynth/tests/integration/general/test_agentapi_routes.py",
-        "has_pytest_import": true,
-        "test_functions": 3,
-        "markers": {
-          "test_init_route_succeeds": "medium",
-          "test_gather_route_succeeds": "medium",
-          "test_synthesize_and_status_succeeds": "medium"
-        },
-        "tests_with_markers": 3,
-        "tests_without_markers": 0,
-        "misaligned_markers": [],
-        "duplicate_markers": [],
-        "recognized_markers": {
-          "medium": {
-            "file_count": 3,
-            "pytest_count": 0,
-            "recognized": false,
-            "registered_in_pytest_ini": true,
-            "error": "subprocess error: 4",
-            "uncollected_tests": []
-          }
-        },
-        "issues": [
-          {
-            "type": "unrecognized_markers",
-            "message": "medium markers are not recognized by pytest (3 in file, 0 recognized)"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/integration/general/test_wsde_edrr_integration_end_to_end.py": {
-        "file_path": "/workspace/devsynth/tests/integration/general/test_wsde_edrr_integration_end_to_end.py",
-        "has_pytest_import": true,
-        "test_functions": 6,
-        "markers": {
-          "test_wsde_edrr_integration_end_to_end_succeeds": "medium",
-          "test_multi_agent_collaboration_with_memory_succeeds": "medium",
-          "test_dialectical_reasoning_in_full_workflow_succeeds": "medium",
-          "test_peer_review_integration_in_edrr_workflow_succeeds": "medium",
-          "test_retrospective_phase_synchronizes_memory": "medium",
-          "test_memory_sync_hook_captures_events_during_team_sync": "medium"
-        },
-        "tests_with_markers": 6,
-        "tests_without_markers": 0,
-        "misaligned_markers": [],
-        "duplicate_markers": [],
-        "recognized_markers": {
-          "medium": {
-            "file_count": 6,
-            "pytest_count": 0,
-            "recognized": false,
-            "registered_in_pytest_ini": true,
-            "error": "subprocess error: 4",
-            "uncollected_tests": []
-          }
-        },
-        "issues": [
-          {
-            "type": "unrecognized_markers",
-            "message": "medium markers are not recognized by pytest (6 in file, 0 recognized)"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/integration/general/test_provider_system_async.py": {
-        "file_path": "/workspace/devsynth/tests/integration/general/test_provider_system_async.py",
-        "has_pytest_import": true,
-        "test_functions": 5,
-        "markers": {
-          "test_openai_provider_acomplete": "medium",
-          "test_acomplete_function": "medium",
-          "test_aembed_function": "medium",
-          "test_fallback_provider_acomplete": "medium",
-          "test_fallback_provider_aembed": "medium"
-        },
-        "tests_with_markers": 5,
-        "tests_without_markers": 0,
-        "misaligned_markers": [],
-        "duplicate_markers": [],
-        "recognized_markers": {
-          "medium": {
-            "file_count": 5,
-            "pytest_count": 0,
-            "recognized": false,
-            "registered_in_pytest_ini": true,
-            "error": "subprocess error: 4",
-            "uncollected_tests": []
-          }
-        },
-        "issues": [
-          {
-            "type": "unrecognized_markers",
-            "message": "medium markers are not recognized by pytest (5 in file, 0 recognized)"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/integration/general/test_config_loader.py": {
-        "file_path": "/workspace/devsynth/tests/integration/general/test_config_loader.py",
-        "has_pytest_import": true,
-        "test_functions": 4,
-        "markers": {
-          "test_load_and_save_yaml_config_succeeds": "medium",
-          "test_load_and_save_pyproject_config_succeeds": "medium",
-          "test_version_mismatch_warning_yaml_succeeds": "medium",
-          "test_version_mismatch_warning_pyproject_succeeds": "medium"
-        },
-        "tests_with_markers": 4,
-        "tests_without_markers": 0,
-        "misaligned_markers": [],
-        "duplicate_markers": [],
-        "recognized_markers": {
-          "medium": {
-            "file_count": 4,
-            "pytest_count": 0,
-            "recognized": false,
-            "registered_in_pytest_ini": true,
-            "error": "subprocess error: 4",
-            "uncollected_tests": []
-          }
-        },
-        "issues": [
-          {
-            "type": "unrecognized_markers",
-            "message": "medium markers are not recognized by pytest (4 in file, 0 recognized)"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/integration/general/test_cli_webui_parity.py": {
-        "file_path": "/workspace/devsynth/tests/integration/general/test_cli_webui_parity.py",
-        "has_pytest_import": true,
-        "test_functions": 3,
-        "markers": {
-          "test_init_invocations_match_succeeds": "medium",
-          "test_display_result_sanitization_succeeds": "medium",
-          "test_progress_indicator_parity_succeeds": "medium"
-        },
-        "tests_with_markers": 3,
-        "tests_without_markers": 0,
-        "misaligned_markers": [],
-        "duplicate_markers": [],
-        "recognized_markers": {
-          "medium": {
-            "file_count": 3,
-            "pytest_count": 0,
-            "recognized": false,
-            "registered_in_pytest_ini": true,
-            "error": "subprocess error: 4",
-            "uncollected_tests": []
-          }
-        },
-        "issues": [
-          {
-            "type": "unrecognized_markers",
-            "message": "medium markers are not recognized by pytest (3 in file, 0 recognized)"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/integration/general/test_self_analyzer.py": {
-        "file_path": "/workspace/devsynth/tests/integration/general/test_self_analyzer.py",
-        "has_pytest_import": true,
-        "test_functions": 3,
-        "markers": {
-          "test_analyze_devsynth_codebase_succeeds": "medium",
-          "test_architecture_violations_succeeds": "medium",
-          "test_improvement_opportunities_succeeds": "medium"
-        },
-        "tests_with_markers": 3,
-        "tests_without_markers": 0,
-        "misaligned_markers": [],
-        "duplicate_markers": [],
-        "recognized_markers": {
-          "medium": {
-            "file_count": 3,
-            "pytest_count": 0,
-            "recognized": false,
-            "registered_in_pytest_ini": true,
-            "error": "subprocess error: 4",
-            "uncollected_tests": []
-          }
-        },
-        "issues": [
-          {
-            "type": "unrecognized_markers",
-            "message": "medium markers are not recognized by pytest (3 in file, 0 recognized)"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/integration/general/test_memory_agent_integration.py": {
-        "file_path": "/workspace/devsynth/tests/integration/general/test_memory_agent_integration.py",
-        "has_pytest_import": true,
-        "test_functions": 9,
-        "markers": {
-          "test_agent_can_store_and_retrieve_memory_succeeds": "medium",
-          "test_agent_can_search_memory_succeeds": "medium",
-          "test_agent_can_update_memory_succeeds": "medium",
-          "test_agent_can_delete_memory_succeeds": "medium",
-          "test_multiple_agents_can_share_memory_succeeds": "medium",
-          "test_agent_memory_isolation_succeeds": "medium",
-          "test_agent_memory_with_context_succeeds": "medium",
-          "test_persistent_sync_across_stores": "medium",
-          "test_sync_manager_transaction_rolls_back_succeeds": "medium"
-        },
-        "tests_with_markers": 9,
-        "tests_without_markers": 0,
-        "misaligned_markers": [],
-        "duplicate_markers": [],
-        "recognized_markers": {
-          "medium": {
-            "file_count": 9,
-            "pytest_count": 0,
-            "recognized": false,
-            "registered_in_pytest_ini": true,
-            "error": "subprocess error: 4",
-            "uncollected_tests": []
-          }
-        },
-        "issues": [
-          {
-            "type": "unrecognized_markers",
-            "message": "medium markers are not recognized by pytest (9 in file, 0 recognized)"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/integration/collaboration/test_role_reassignment_shared_memory.py": {
-        "file_path": "/workspace/devsynth/tests/integration/collaboration/test_role_reassignment_shared_memory.py",
-        "has_pytest_import": true,
-        "test_functions": 1,
-        "markers": {
-          "test_role_reassignment_shared_memory": "fast"
-        },
-        "tests_with_markers": 1,
-        "tests_without_markers": 0,
-        "misaligned_markers": [],
-        "duplicate_markers": [],
-        "recognized_markers": {
-          "fast": {
-            "file_count": 1,
-            "pytest_count": 0,
-            "recognized": false,
-            "registered_in_pytest_ini": true,
-            "error": "subprocess error: 4",
-            "uncollected_tests": []
-          }
-        },
-        "issues": [
-          {
-            "type": "unrecognized_markers",
-            "message": "fast markers are not recognized by pytest (1 in file, 0 recognized)"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/integration/collaboration/test_cross_store_memory_sync.py": {
-        "file_path": "/workspace/devsynth/tests/integration/collaboration/test_cross_store_memory_sync.py",
-        "has_pytest_import": true,
-        "test_functions": 1,
-        "markers": {
-          "test_consensus_syncs_across_stores": "medium"
-        },
-        "tests_with_markers": 1,
-        "tests_without_markers": 0,
-        "misaligned_markers": [],
-        "duplicate_markers": [],
-        "recognized_markers": {
-          "medium": {
-            "file_count": 1,
-            "pytest_count": 0,
-            "recognized": false,
-            "registered_in_pytest_ini": true,
-            "error": "subprocess error: 4",
-            "uncollected_tests": []
-          }
-        },
-        "issues": [
-          {
-            "type": "unrecognized_markers",
-            "message": "medium markers are not recognized by pytest (1 in file, 0 recognized)"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/integration/collaboration/test_voting_summary_edrr.py": {
-        "file_path": "/workspace/devsynth/tests/integration/collaboration/test_voting_summary_edrr.py",
-        "has_pytest_import": true,
-        "test_functions": 1,
-        "markers": {
-          "test_voting_summary_in_edrr_phases": "medium"
-        },
-        "tests_with_markers": 1,
-        "tests_without_markers": 0,
-        "misaligned_markers": [],
-        "duplicate_markers": [],
-        "recognized_markers": {
-          "medium": {
-            "file_count": 1,
-            "pytest_count": 0,
-            "recognized": false,
-            "registered_in_pytest_ini": true,
-            "error": "subprocess error: 4",
-            "uncollected_tests": []
-          }
-        },
-        "issues": [
-          {
-            "type": "unrecognized_markers",
-            "message": "medium markers are not recognized by pytest (1 in file, 0 recognized)"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/integration/config/test_unified_loader.py": {
-        "file_path": "/workspace/devsynth/tests/integration/config/test_unified_loader.py",
-        "has_pytest_import": true,
-        "test_functions": 2,
-        "markers": {
-          "test_unified_loader_prefers_pyproject_succeeds": "medium",
-          "test_env_var_override_with_custom_path_succeeds": "medium"
-        },
-        "tests_with_markers": 2,
-        "tests_without_markers": 0,
-        "misaligned_markers": [],
-        "duplicate_markers": [],
-        "recognized_markers": {
-          "medium": {
-            "file_count": 2,
-            "pytest_count": 0,
-            "recognized": false,
-            "registered_in_pytest_ini": true,
-            "error": "subprocess error: 4",
-            "uncollected_tests": []
-          }
-        },
-        "issues": [
-          {
-            "type": "unrecognized_markers",
-            "message": "medium markers are not recognized by pytest (2 in file, 0 recognized)"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/integration/wsde/test_wsde_edrr_integration.py": {
-        "file_path": "/workspace/devsynth/tests/integration/wsde/test_wsde_edrr_integration.py",
-        "has_pytest_import": true,
-        "test_functions": 1,
-        "markers": {
-          "test_message_persisted_with_edrr_phase": "medium"
-        },
-        "tests_with_markers": 1,
-        "tests_without_markers": 0,
-        "misaligned_markers": [],
-        "duplicate_markers": [],
-        "recognized_markers": {
-          "medium": {
-            "file_count": 1,
-            "pytest_count": 0,
-            "recognized": false,
-            "registered_in_pytest_ini": true,
-            "error": "subprocess error: 4",
-            "uncollected_tests": []
-          }
-        },
-        "issues": [
-          {
-            "type": "unrecognized_markers",
-            "message": "medium markers are not recognized by pytest (1 in file, 0 recognized)"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/integration/edrr/test_wsde_edrr_integration.py": {
-        "file_path": "/workspace/devsynth/tests/integration/edrr/test_wsde_edrr_integration.py",
-        "has_pytest_import": true,
-        "test_functions": 5,
-        "markers": {
-          "test_phase_specific_role_assignment_has_expected": "medium",
-          "test_role_rotation_on_phase_transition_has_expected": "medium",
-          "test_phase_specific_expertise_scoring_succeeds": "medium",
-          "test_dynamic_role_reassignment_and_consensus": "medium",
-          "test_dialectical_hooks_invoked": "medium"
-        },
-        "tests_with_markers": 5,
-        "tests_without_markers": 0,
-        "misaligned_markers": [],
-        "duplicate_markers": [],
-        "recognized_markers": {
-          "medium": {
-            "file_count": 5,
-            "pytest_count": 0,
-            "recognized": false,
-            "registered_in_pytest_ini": true,
-            "error": "subprocess error: 4",
-            "uncollected_tests": []
-          }
-        },
-        "issues": [
-          {
-            "type": "unrecognized_markers",
-            "message": "medium markers are not recognized by pytest (5 in file, 0 recognized)"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/integration/interface/test_bridge_consistency.py": {
-        "file_path": "/workspace/devsynth/tests/integration/interface/test_bridge_consistency.py",
-        "has_pytest_import": true,
-        "test_functions": 2,
-        "markers": {
-          "test_bridge_output_consistency_succeeds": "medium",
-          "test_bridge_method_signatures_succeeds": "medium"
-        },
-        "tests_with_markers": 2,
-        "tests_without_markers": 0,
-        "misaligned_markers": [],
-        "duplicate_markers": [],
-        "recognized_markers": {
-          "medium": {
-            "file_count": 2,
-            "pytest_count": 0,
-            "recognized": false,
-            "registered_in_pytest_ini": true,
-            "error": "subprocess error: 4",
-            "uncollected_tests": []
-          }
-        },
-        "issues": [
-          {
-            "type": "unrecognized_markers",
-            "message": "medium markers are not recognized by pytest (2 in file, 0 recognized)"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/integration/interface/test_small_workflow_bridge.py": {
-        "file_path": "/workspace/devsynth/tests/integration/interface/test_small_workflow_bridge.py",
-        "has_pytest_import": true,
-        "test_functions": 1,
-        "markers": {
-          "test_cli_and_api_bridges_consistent_succeeds": "medium"
-        },
-        "tests_with_markers": 1,
-        "tests_without_markers": 0,
-        "misaligned_markers": [],
-        "duplicate_markers": [],
-        "recognized_markers": {
-          "medium": {
-            "file_count": 1,
-            "pytest_count": 0,
-            "recognized": false,
-            "registered_in_pytest_ini": true,
-            "error": "subprocess error: 4",
-            "uncollected_tests": []
-          }
-        },
-        "issues": [
-          {
-            "type": "unrecognized_markers",
-            "message": "medium markers are not recognized by pytest (1 in file, 0 recognized)"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/integration/deployment/test_docker_non_root.py": {
-        "file_path": "/workspace/devsynth/tests/integration/deployment/test_docker_non_root.py",
-        "has_pytest_import": true,
-        "test_functions": 1,
-        "markers": {
-          "test_temporary_container_runs_as_non_root": "slow"
-        },
-        "tests_with_markers": 1,
-        "tests_without_markers": 0,
-        "misaligned_markers": [],
-        "duplicate_markers": [],
-        "recognized_markers": {
-          "slow": {
-            "file_count": 1,
-            "pytest_count": 0,
-            "recognized": false,
-            "registered_in_pytest_ini": true,
-            "error": "subprocess error: 4",
-            "uncollected_tests": []
-          }
-        },
-        "issues": [
-          {
-            "type": "unrecognized_markers",
-            "message": "slow markers are not recognized by pytest (1 in file, 0 recognized)"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/integration/deployment/test_compose_workflow.py": {
-        "file_path": "/workspace/devsynth/tests/integration/deployment/test_compose_workflow.py",
-        "has_pytest_import": true,
-        "test_functions": 3,
-        "markers": {
-          "test_setup_env_refuses_root": "fast",
-          "test_check_health_env_permissions": "fast",
-          "test_rollback_requires_tag": "fast"
-        },
-        "tests_with_markers": 3,
-        "tests_without_markers": 0,
-        "misaligned_markers": [],
-        "duplicate_markers": [],
-        "recognized_markers": {
-          "fast": {
-            "file_count": 3,
-            "pytest_count": 0,
-            "recognized": false,
-            "registered_in_pytest_ini": true,
-            "error": "subprocess error: 4",
-            "uncollected_tests": []
-          }
-        },
-        "issues": [
-          {
-            "type": "unrecognized_markers",
-            "message": "fast markers are not recognized by pytest (3 in file, 0 recognized)"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/integration/deployment/test_deployment_scripts.py": {
-        "file_path": "/workspace/devsynth/tests/integration/deployment/test_deployment_scripts.py",
-        "has_pytest_import": true,
-        "test_functions": 4,
-        "markers": {
-          "test_bootstrap_env_refuses_root": "fast",
-          "test_health_check_validates_url": "fast",
-          "test_prometheus_exporter_refuses_root": "fast",
-          "test_stack_scripts_env_permissions": "fast"
-        },
-        "tests_with_markers": 4,
-        "tests_without_markers": 0,
-        "misaligned_markers": [],
-        "duplicate_markers": [],
-        "recognized_markers": {
-          "fast": {
-            "file_count": 4,
-            "pytest_count": 0,
-            "recognized": false,
-            "registered_in_pytest_ini": true,
-            "error": "subprocess error: 4",
-            "uncollected_tests": []
-          }
-        },
-        "issues": [
-          {
-            "type": "unrecognized_markers",
-            "message": "fast markers are not recognized by pytest (4 in file, 0 recognized)"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/integration/sprint_edrr/test_ceremony_phase_alignment.py": {
-        "file_path": "/workspace/devsynth/tests/integration/sprint_edrr/test_ceremony_phase_alignment.py",
-        "has_pytest_import": true,
-        "test_functions": 1,
-        "markers": {
-          "test_default_ceremony_mapping_aligns_with_edrr": "medium"
-        },
-        "tests_with_markers": 1,
-        "tests_without_markers": 0,
-        "misaligned_markers": [],
-        "duplicate_markers": [],
-        "recognized_markers": {
-          "medium": {
-            "file_count": 1,
-            "pytest_count": 0,
-            "recognized": false,
-            "registered_in_pytest_ini": true,
-            "error": "subprocess error: 4",
-            "uncollected_tests": []
-          }
-        },
-        "issues": [
-          {
-            "type": "unrecognized_markers",
-            "message": "medium markers are not recognized by pytest (1 in file, 0 recognized)"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/integration/deployment/test_end_to_end_deploy.py": {
-        "file_path": "/workspace/devsynth/tests/integration/deployment/test_end_to_end_deploy.py",
-        "has_pytest_import": true,
-        "test_functions": 1,
-        "markers": {
-          "test_deploy_script_requires_docker": "slow"
-        },
-        "tests_with_markers": 1,
-        "tests_without_markers": 0,
-        "misaligned_markers": [],
-        "duplicate_markers": [],
-        "recognized_markers": {
-          "slow": {
-            "file_count": 1,
-            "pytest_count": 0,
-            "recognized": false,
-            "registered_in_pytest_ini": true,
-            "error": "subprocess error: 4",
-            "uncollected_tests": []
-          }
-        },
-        "issues": [
-          {
-            "type": "unrecognized_markers",
-            "message": "slow markers are not recognized by pytest (1 in file, 0 recognized)"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/integration/generated/test_run_generated_tests.py": {
-        "file_path": "/workspace/devsynth/tests/integration/generated/test_run_generated_tests.py",
-        "has_pytest_import": true,
-        "test_functions": 2,
-        "markers": {
-          "test_run_generated_tests_success": "fast",
-          "test_run_generated_tests_failure": "fast"
-        },
-        "tests_with_markers": 2,
-        "tests_without_markers": 0,
-        "misaligned_markers": [],
-        "duplicate_markers": [],
-        "recognized_markers": {
-          "fast": {
-            "file_count": 2,
-            "pytest_count": 0,
-            "recognized": false,
-            "registered_in_pytest_ini": true,
-            "error": "subprocess error: 4",
-            "uncollected_tests": []
-          }
-        },
-        "issues": [
-          {
-            "type": "unrecognized_markers",
-            "message": "fast markers are not recognized by pytest (2 in file, 0 recognized)"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/integration/memory/test_transactional_sync.py": {
-        "file_path": "/workspace/devsynth/tests/integration/memory/test_transactional_sync.py",
-        "has_pytest_import": true,
-        "test_functions": 1,
-        "markers": {
-          "test_transactional_sync_rollback": "medium"
-        },
-        "tests_with_markers": 1,
-        "tests_without_markers": 0,
-        "misaligned_markers": [],
-        "duplicate_markers": [],
-        "recognized_markers": {
-          "medium": {
-            "file_count": 1,
-            "pytest_count": 0,
-            "recognized": false,
-            "registered_in_pytest_ini": true,
-            "error": "subprocess error: 4",
-            "uncollected_tests": []
-          }
-        },
-        "issues": [
-          {
-            "type": "unrecognized_markers",
-            "message": "medium markers are not recognized by pytest (1 in file, 0 recognized)"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/integration/memory/test_reverse_sync_retrieval.py": {
-        "file_path": "/workspace/devsynth/tests/integration/memory/test_reverse_sync_retrieval.py",
-        "has_pytest_import": true,
-        "test_functions": 1,
-        "markers": {
-          "test_bidirectional_persistence_and_retrieval": "medium"
-        },
-        "tests_with_markers": 1,
-        "tests_without_markers": 0,
-        "misaligned_markers": [],
-        "duplicate_markers": [],
-        "recognized_markers": {
-          "medium": {
-            "file_count": 1,
-            "pytest_count": 0,
-            "recognized": false,
-            "registered_in_pytest_ini": true,
-            "error": "subprocess error: 4",
-            "uncollected_tests": []
-          }
-        },
-        "issues": [
-          {
-            "type": "unrecognized_markers",
-            "message": "medium markers are not recognized by pytest (1 in file, 0 recognized)"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/integration/memory/test_sync_manager_core_transactions.py": {
-        "file_path": "/workspace/devsynth/tests/integration/memory/test_sync_manager_core_transactions.py",
-        "has_pytest_import": true,
-        "test_functions": 2,
-        "markers": {
-          "test_synchronize_core_commit": "medium",
-          "test_synchronize_core_rollback": "medium"
-        },
-        "tests_with_markers": 2,
-        "tests_without_markers": 0,
-        "misaligned_markers": [],
-        "duplicate_markers": [],
-        "recognized_markers": {
-          "medium": {
-            "file_count": 2,
-            "pytest_count": 0,
-            "recognized": false,
-            "registered_in_pytest_ini": true,
-            "error": "subprocess error: 4",
-            "uncollected_tests": []
-          }
-        },
-        "issues": [
-          {
-            "type": "unrecognized_markers",
-            "message": "medium markers are not recognized by pytest (2 in file, 0 recognized)"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/integration/memory/test_transaction_failure_recovery.py": {
-        "file_path": "/workspace/devsynth/tests/integration/memory/test_transaction_failure_recovery.py",
-        "has_pytest_import": true,
-        "test_functions": 1,
-        "markers": {
-          "test_commit_failure_triggers_rollback": "medium"
-        },
-        "tests_with_markers": 1,
-        "tests_without_markers": 0,
-        "misaligned_markers": [],
-        "duplicate_markers": [],
-        "recognized_markers": {
-          "medium": {
-            "file_count": 1,
-            "pytest_count": 0,
-            "recognized": false,
-            "registered_in_pytest_ini": true,
-            "error": "subprocess error: 4",
-            "uncollected_tests": []
-          }
-        },
-        "issues": [
-          {
-            "type": "unrecognized_markers",
-            "message": "medium markers are not recognized by pytest (1 in file, 0 recognized)"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/integration/memory/test_cross_store_sync.py": {
-        "file_path": "/workspace/devsynth/tests/integration/memory/test_cross_store_sync.py",
-        "has_pytest_import": true,
-        "test_functions": 1,
-        "markers": {
-          "test_full_backend_synchronization": "medium"
-        },
-        "tests_with_markers": 1,
-        "tests_without_markers": 0,
-        "misaligned_markers": [],
-        "duplicate_markers": [],
-        "recognized_markers": {
-          "medium": {
-            "file_count": 1,
-            "pytest_count": 0,
-            "recognized": false,
-            "registered_in_pytest_ini": true,
-            "error": "subprocess error: 4",
-            "uncollected_tests": []
-          }
-        },
-        "issues": [
-          {
-            "type": "unrecognized_markers",
-            "message": "medium markers are not recognized by pytest (1 in file, 0 recognized)"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/integration/memory/test_cross_store_transactions.py": {
-        "file_path": "/workspace/devsynth/tests/integration/memory/test_cross_store_transactions.py",
-        "has_pytest_import": true,
-        "test_functions": 2,
-        "markers": {
-          "test_cross_store_transaction_commit": "medium",
-          "test_cross_store_transaction_rollback": "medium"
-        },
-        "tests_with_markers": 2,
-        "tests_without_markers": 0,
-        "misaligned_markers": [],
-        "duplicate_markers": [],
-        "recognized_markers": {
-          "medium": {
-            "file_count": 2,
-            "pytest_count": 0,
-            "recognized": false,
-            "registered_in_pytest_ini": true,
-            "error": "subprocess error: 4",
-            "uncollected_tests": []
-          }
-        },
-        "issues": [
-          {
-            "type": "unrecognized_markers",
-            "message": "medium markers are not recognized by pytest (2 in file, 0 recognized)"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/integration/memory/test_multistore_transaction_wrapper.py": {
-        "file_path": "/workspace/devsynth/tests/integration/memory/test_multistore_transaction_wrapper.py",
-        "has_pytest_import": true,
-        "test_functions": 1,
-        "markers": {
-          "test_transaction_context_commit_and_rollback": "medium"
-        },
-        "tests_with_markers": 1,
-        "tests_without_markers": 0,
-        "misaligned_markers": [],
-        "duplicate_markers": [],
-        "recognized_markers": {
-          "medium": {
-            "file_count": 1,
-            "pytest_count": 0,
-            "recognized": false,
-            "registered_in_pytest_ini": true,
-            "error": "subprocess error: 4",
-            "uncollected_tests": []
-          }
-        },
-        "issues": [
-          {
-            "type": "unrecognized_markers",
-            "message": "medium markers are not recognized by pytest (1 in file, 0 recognized)"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/integration/memory/test_cross_store_query.py": {
-        "file_path": "/workspace/devsynth/tests/integration/memory/test_cross_store_query.py",
-        "has_pytest_import": true,
-        "test_functions": 1,
-        "markers": {
-          "test_cross_store_query_returns_results": "medium"
-        },
-        "tests_with_markers": 1,
-        "tests_without_markers": 0,
-        "misaligned_markers": [],
-        "duplicate_markers": [],
-        "recognized_markers": {
-          "medium": {
-            "file_count": 1,
-            "pytest_count": 0,
-            "recognized": false,
-            "registered_in_pytest_ini": true,
-            "error": "subprocess error: 4",
-            "uncollected_tests": []
-          }
-        },
-        "issues": [
-          {
-            "type": "unrecognized_markers",
-            "message": "medium markers are not recognized by pytest (1 in file, 0 recognized)"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/integration/memory/test_faiss_transactions.py": {
-        "file_path": "/workspace/devsynth/tests/integration/memory/test_faiss_transactions.py",
-        "has_pytest_import": true,
-        "test_functions": 1,
-        "markers": {
-          "test_faiss_transaction_commit_and_rollback": "medium"
-        },
-        "tests_with_markers": 1,
-        "tests_without_markers": 0,
-        "misaligned_markers": [],
-        "duplicate_markers": [],
-        "recognized_markers": {
-          "medium": {
-            "file_count": 1,
-            "pytest_count": 0,
-            "recognized": false,
-            "registered_in_pytest_ini": true,
-            "error": "subprocess error: 4",
-            "uncollected_tests": []
-          }
-        },
-        "issues": [
-          {
-            "type": "unrecognized_markers",
-            "message": "medium markers are not recognized by pytest (1 in file, 0 recognized)"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/behavior/steps/test_dialectical_reasoning_memory_persistence_steps.py": {
-        "file_path": "/workspace/devsynth/tests/behavior/steps/test_dialectical_reasoning_memory_persistence_steps.py",
+      "/workspace/devsynth/tests/behavior/steps/test_chromadb_steps.py": {
+        "file_path": "/workspace/devsynth/tests/behavior/steps/test_chromadb_steps.py",
         "has_pytest_import": true,
         "test_functions": 0,
         "markers": {},
@@ -9969,34 +25,947 @@
         "tests_without_markers": 0,
         "misaligned_markers": [
           {
-            "line": 37,
-            "marker": "fast",
-            "text": "@pytest.mark.fast"
+            "line": 55,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 65,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
           },
           {
             "line": 74,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 84,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 96,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 115,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 153,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 166,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 189,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 203,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          }
+        ],
+        "duplicate_markers": [],
+        "recognized_markers": {},
+        "issues": [
+          {
+            "type": "misaligned_markers",
+            "message": "File has 10 misaligned markers"
+          }
+        ]
+      },
+      "/workspace/devsynth/tests/behavior/steps/test_webapp_generation_steps.py": {
+        "file_path": "/workspace/devsynth/tests/behavior/steps/test_webapp_generation_steps.py",
+        "has_pytest_import": true,
+        "test_functions": 0,
+        "markers": {},
+        "tests_with_markers": 0,
+        "tests_without_markers": 0,
+        "misaligned_markers": [
+          {
+            "line": 21,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 27,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 33,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          }
+        ],
+        "duplicate_markers": [],
+        "recognized_markers": {},
+        "issues": [
+          {
+            "type": "misaligned_markers",
+            "message": "File has 3 misaligned markers"
+          }
+        ]
+      },
+      "/workspace/devsynth/tests/behavior/steps/test_ingest_command_steps.py": {
+        "file_path": "/workspace/devsynth/tests/behavior/steps/test_ingest_command_steps.py",
+        "has_pytest_import": true,
+        "test_functions": 0,
+        "markers": {},
+        "tests_with_markers": 0,
+        "tests_without_markers": 0,
+        "misaligned_markers": [
+          {
+            "line": 35,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 51,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 66,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 73,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 126,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 135,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 142,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 151,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 161,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 170,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 178,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 188,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 196,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          }
+        ],
+        "duplicate_markers": [],
+        "recognized_markers": {},
+        "issues": [
+          {
+            "type": "misaligned_markers",
+            "message": "File has 13 misaligned markers"
+          }
+        ]
+      },
+      "/workspace/devsynth/tests/behavior/steps/test_retry_mechanism_steps.py": {
+        "file_path": "/workspace/devsynth/tests/behavior/steps/test_retry_mechanism_steps.py",
+        "has_pytest_import": true,
+        "test_functions": 0,
+        "markers": {},
+        "tests_with_markers": 0,
+        "tests_without_markers": 0,
+        "misaligned_markers": [
+          {
+            "line": 13,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 19,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 25,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          }
+        ],
+        "duplicate_markers": [],
+        "recognized_markers": {},
+        "issues": [
+          {
+            "type": "misaligned_markers",
+            "message": "File has 3 misaligned markers"
+          }
+        ]
+      },
+      "/workspace/devsynth/tests/behavior/steps/test_dialectical_reasoning_impact_memory_persistence_steps.py": {
+        "file_path": "/workspace/devsynth/tests/behavior/steps/test_dialectical_reasoning_impact_memory_persistence_steps.py",
+        "has_pytest_import": true,
+        "test_functions": 0,
+        "markers": {},
+        "tests_with_markers": 0,
+        "tests_without_markers": 0,
+        "misaligned_markers": [
+          {
+            "line": 69,
             "marker": "fast",
             "text": "@pytest.mark.fast"
           },
           {
-            "line": 87,
+            "line": 77,
             "marker": "fast",
             "text": "@pytest.mark.fast"
           },
           {
-            "line": 93,
+            "line": 85,
             "marker": "fast",
             "text": "@pytest.mark.fast"
           },
           {
-            "line": 102,
+            "line": 98,
             "marker": "fast",
             "text": "@pytest.mark.fast"
+          },
+          {
+            "line": 104,
+            "marker": "fast",
+            "text": "@pytest.mark.fast"
+          },
+          {
+            "line": 118,
+            "marker": "fast",
+            "text": "@pytest.mark.fast"
+          },
+          {
+            "line": 124,
+            "marker": "fast",
+            "text": "@pytest.mark.fast"
+          }
+        ],
+        "duplicate_markers": [],
+        "recognized_markers": {},
+        "issues": [
+          {
+            "type": "misaligned_markers",
+            "message": "File has 7 misaligned markers"
+          }
+        ]
+      },
+      "/workspace/devsynth/tests/behavior/steps/test_webui_serve_steps.py": {
+        "file_path": "/workspace/devsynth/tests/behavior/steps/test_webui_serve_steps.py",
+        "has_pytest_import": true,
+        "test_functions": 0,
+        "markers": {},
+        "tests_with_markers": 0,
+        "tests_without_markers": 0,
+        "misaligned_markers": [
+          {
+            "line": 9,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 15,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 21,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 30,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 38,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 47,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 54,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 63,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 70,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 77,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 84,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 91,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 98,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 105,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 112,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 120,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 127,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 135,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 142,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 149,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 161,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 168,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 175,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 187,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          }
+        ],
+        "duplicate_markers": [],
+        "recognized_markers": {},
+        "issues": [
+          {
+            "type": "misaligned_markers",
+            "message": "File has 24 misaligned markers"
+          }
+        ]
+      },
+      "/workspace/devsynth/tests/behavior/steps/test_metrics_steps.py": {
+        "file_path": "/workspace/devsynth/tests/behavior/steps/test_metrics_steps.py",
+        "has_pytest_import": true,
+        "test_functions": 0,
+        "markers": {},
+        "tests_with_markers": 0,
+        "tests_without_markers": 0,
+        "misaligned_markers": [
+          {
+            "line": 118,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 133,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 147,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 163,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 190,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 222,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 339,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 357,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 372,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 387,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 405,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 420,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 435,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 450,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 460,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 470,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          }
+        ],
+        "duplicate_markers": [],
+        "recognized_markers": {},
+        "issues": [
+          {
+            "type": "misaligned_markers",
+            "message": "File has 16 misaligned markers"
+          }
+        ]
+      },
+      "/workspace/devsynth/tests/behavior/steps/test_webui_spec_editor_extended_steps.py": {
+        "file_path": "/workspace/devsynth/tests/behavior/steps/test_webui_spec_editor_extended_steps.py",
+        "has_pytest_import": true,
+        "test_functions": 0,
+        "markers": {},
+        "tests_with_markers": 0,
+        "tests_without_markers": 0,
+        "misaligned_markers": [
+          {
+            "line": 8,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 15,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 25,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 35,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 50,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 66,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 73,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 107,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
           },
           {
             "line": 116,
-            "marker": "fast",
-            "text": "@pytest.mark.fast"
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 124,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 131,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          }
+        ],
+        "duplicate_markers": [],
+        "recognized_markers": {},
+        "issues": [
+          {
+            "type": "misaligned_markers",
+            "message": "File has 11 misaligned markers"
+          }
+        ]
+      },
+      "/workspace/devsynth/tests/behavior/steps/test_webui_requirements_wizard_with_state_steps.py": {
+        "file_path": "/workspace/devsynth/tests/behavior/steps/test_webui_requirements_wizard_with_state_steps.py",
+        "has_pytest_import": true,
+        "test_functions": 0,
+        "markers": {},
+        "tests_with_markers": 0,
+        "tests_without_markers": 0,
+        "misaligned_markers": [
+          {
+            "line": 274,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 282,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 290,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 301,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 309,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 317,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 344,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 354,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 365,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 384,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 404,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 418,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 433,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 440,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 449,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 460,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 471,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 481,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 490,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 500,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 511,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 518,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 529,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 560,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 568,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          }
+        ],
+        "duplicate_markers": [],
+        "recognized_markers": {},
+        "issues": [
+          {
+            "type": "misaligned_markers",
+            "message": "File has 25 misaligned markers"
+          }
+        ]
+      },
+      "/workspace/devsynth/tests/behavior/steps/test_project_ingestion_steps.py": {
+        "file_path": "/workspace/devsynth/tests/behavior/steps/test_project_ingestion_steps.py",
+        "has_pytest_import": true,
+        "test_functions": 0,
+        "markers": {},
+        "tests_with_markers": 0,
+        "tests_without_markers": 0,
+        "misaligned_markers": [
+          {
+            "line": 10,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 16,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 22,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          }
+        ],
+        "duplicate_markers": [],
+        "recognized_markers": {},
+        "issues": [
+          {
+            "type": "misaligned_markers",
+            "message": "File has 3 misaligned markers"
+          }
+        ]
+      },
+      "/workspace/devsynth/tests/behavior/steps/test_webui_inspect_config_steps.py": {
+        "file_path": "/workspace/devsynth/tests/behavior/steps/test_webui_inspect_config_steps.py",
+        "has_pytest_import": true,
+        "test_functions": 0,
+        "markers": {},
+        "tests_with_markers": 0,
+        "tests_without_markers": 0,
+        "misaligned_markers": [
+          {
+            "line": 9,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 15,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 21,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 27,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 36,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 42,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 49,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 57,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 65,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 72,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 79,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          }
+        ],
+        "duplicate_markers": [],
+        "recognized_markers": {},
+        "issues": [
+          {
+            "type": "misaligned_markers",
+            "message": "File has 11 misaligned markers"
+          }
+        ]
+      },
+      "/workspace/devsynth/tests/behavior/steps/test_code_command_steps.py": {
+        "file_path": "/workspace/devsynth/tests/behavior/steps/test_code_command_steps.py",
+        "has_pytest_import": true,
+        "test_functions": 1,
+        "markers": {
+          "test_sample": "medium"
+        },
+        "tests_with_markers": 1,
+        "tests_without_markers": 0,
+        "misaligned_markers": [],
+        "duplicate_markers": [
+          {
+            "test_name": "test_sample",
+            "marker_count": 3
+          }
+        ],
+        "recognized_markers": {
+          "medium": {
+            "file_count": 1,
+            "pytest_count": 0,
+            "recognized": false,
+            "registered_in_pytest_ini": true,
+            "error": "exit code 2",
+            "uncollected_tests": []
+          }
+        },
+        "issues": [
+          {
+            "type": "duplicate_markers",
+            "message": "File has 1 tests with duplicate markers"
+          },
+          {
+            "type": "unrecognized_markers",
+            "message": "medium markers are not recognized by pytest (1 in file, 0 recognized)"
+          },
+          {
+            "type": "pytest_error",
+            "marker": "medium",
+            "message": "pytest collection failed for /workspace/devsynth/tests/behavior/steps/test_code_command_steps.py [marker=medium]: exit code 2"
+          }
+        ]
+      },
+      "/workspace/devsynth/tests/behavior/steps/test_interactive_flow_steps.py": {
+        "file_path": "/workspace/devsynth/tests/behavior/steps/test_interactive_flow_steps.py",
+        "has_pytest_import": true,
+        "test_functions": 0,
+        "markers": {},
+        "tests_with_markers": 0,
+        "tests_without_markers": 0,
+        "misaligned_markers": [
+          {
+            "line": 42,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 48,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 54,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 66,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 81,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          }
+        ],
+        "duplicate_markers": [],
+        "recognized_markers": {},
+        "issues": [
+          {
+            "type": "misaligned_markers",
+            "message": "File has 5 misaligned markers"
+          }
+        ]
+      },
+      "/workspace/devsynth/tests/behavior/steps/test_mddr_evaluation_steps.py": {
+        "file_path": "/workspace/devsynth/tests/behavior/steps/test_mddr_evaluation_steps.py",
+        "has_pytest_import": true,
+        "test_functions": 0,
+        "markers": {},
+        "tests_with_markers": 0,
+        "tests_without_markers": 0,
+        "misaligned_markers": [
+          {
+            "line": 9,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 72,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 176,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 205,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 252,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 302,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
           }
         ],
         "duplicate_markers": [],
@@ -10008,8 +977,8 @@
           }
         ]
       },
-      "/workspace/devsynth/tests/behavior/steps/test_requirements_wizard_navigation_steps.py": {
-        "file_path": "/workspace/devsynth/tests/behavior/steps/test_requirements_wizard_navigation_steps.py",
+      "/workspace/devsynth/tests/behavior/steps/test_uxbridge_shared_steps.py": {
+        "file_path": "/workspace/devsynth/tests/behavior/steps/test_uxbridge_shared_steps.py",
         "has_pytest_import": true,
         "test_functions": 0,
         "markers": {},
@@ -10017,42 +986,17 @@
         "tests_without_markers": 0,
         "misaligned_markers": [
           {
-            "line": 70,
+            "line": 87,
             "marker": "medium",
             "text": "@pytest.mark.medium"
           },
           {
-            "line": 76,
+            "line": 94,
             "marker": "medium",
             "text": "@pytest.mark.medium"
           },
           {
-            "line": 86,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 96,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 106,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 116,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 122,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 128,
+            "line": 118,
             "marker": "medium",
             "text": "@pytest.mark.medium"
           }
@@ -10062,12 +1006,12 @@
         "issues": [
           {
             "type": "misaligned_markers",
-            "message": "File has 8 misaligned markers"
+            "message": "File has 3 misaligned markers"
           }
         ]
       },
-      "/workspace/devsynth/tests/behavior/steps/test_webui_commands_steps.py": {
-        "file_path": "/workspace/devsynth/tests/behavior/steps/test_webui_commands_steps.py",
+      "/workspace/devsynth/tests/behavior/steps/test_requirements_wizard_steps.py": {
+        "file_path": "/workspace/devsynth/tests/behavior/steps/test_requirements_wizard_steps.py",
         "has_pytest_import": true,
         "test_functions": 0,
         "markers": {},
@@ -10075,92 +1019,27 @@
         "tests_without_markers": 0,
         "misaligned_markers": [
           {
-            "line": 11,
+            "line": 62,
             "marker": "medium",
             "text": "@pytest.mark.medium"
           },
           {
-            "line": 17,
+            "line": 68,
             "marker": "medium",
             "text": "@pytest.mark.medium"
           },
           {
-            "line": 25,
+            "line": 79,
             "marker": "medium",
             "text": "@pytest.mark.medium"
           },
           {
-            "line": 33,
+            "line": 90,
             "marker": "medium",
             "text": "@pytest.mark.medium"
           },
           {
-            "line": 42,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 51,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 60,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 69,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 77,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 85,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 93,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 99,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 105,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 111,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 117,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 123,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 129,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 135,
+            "line": 101,
             "marker": "medium",
             "text": "@pytest.mark.medium"
           }
@@ -10170,75 +1049,7 @@
         "issues": [
           {
             "type": "misaligned_markers",
-            "message": "File has 18 misaligned markers"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/behavior/steps/test_cross_interface_consistency_extended_steps.py": {
-        "file_path": "/workspace/devsynth/tests/behavior/steps/test_cross_interface_consistency_extended_steps.py",
-        "has_pytest_import": true,
-        "test_functions": 0,
-        "markers": {},
-        "tests_with_markers": 0,
-        "tests_without_markers": 0,
-        "misaligned_markers": [
-          {
-            "line": 145,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 153,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 268,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 319,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 351,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 399,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 449,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 483,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 518,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 543,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          }
-        ],
-        "duplicate_markers": [],
-        "recognized_markers": {},
-        "issues": [
-          {
-            "type": "misaligned_markers",
-            "message": "File has 10 misaligned markers"
+            "message": "File has 5 misaligned markers"
           }
         ]
       },
@@ -10347,4014 +1158,6 @@
           {
             "type": "misaligned_markers",
             "message": "File has 18 misaligned markers"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/behavior/steps/test_chromadb_integration_steps.py": {
-        "file_path": "/workspace/devsynth/tests/behavior/steps/test_chromadb_integration_steps.py",
-        "has_pytest_import": true,
-        "test_functions": 0,
-        "markers": {},
-        "tests_with_markers": 0,
-        "tests_without_markers": 0,
-        "misaligned_markers": [
-          {
-            "line": 30,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 37,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 49,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          }
-        ],
-        "duplicate_markers": [],
-        "recognized_markers": {},
-        "issues": [
-          {
-            "type": "misaligned_markers",
-            "message": "File has 3 misaligned markers"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/behavior/steps/test_webui_onboarding_steps.py": {
-        "file_path": "/workspace/devsynth/tests/behavior/steps/test_webui_onboarding_steps.py",
-        "has_pytest_import": true,
-        "test_functions": 0,
-        "markers": {},
-        "tests_with_markers": 0,
-        "tests_without_markers": 0,
-        "misaligned_markers": [
-          {
-            "line": 114,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 120,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 127,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 135,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 141,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          }
-        ],
-        "duplicate_markers": [],
-        "recognized_markers": {},
-        "issues": [
-          {
-            "type": "misaligned_markers",
-            "message": "File has 5 misaligned markers"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/behavior/steps/test_requirement_analysis_steps.py": {
-        "file_path": "/workspace/devsynth/tests/behavior/steps/test_requirement_analysis_steps.py",
-        "has_pytest_import": true,
-        "test_functions": 0,
-        "markers": {},
-        "tests_with_markers": 0,
-        "tests_without_markers": 0,
-        "misaligned_markers": [
-          {
-            "line": 14,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 24,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 54,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 73,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 84,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 130,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 150,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          }
-        ],
-        "duplicate_markers": [],
-        "recognized_markers": {},
-        "issues": [
-          {
-            "type": "misaligned_markers",
-            "message": "File has 7 misaligned markers"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/behavior/steps/test_project_ingestion_steps.py": {
-        "file_path": "/workspace/devsynth/tests/behavior/steps/test_project_ingestion_steps.py",
-        "has_pytest_import": true,
-        "test_functions": 0,
-        "markers": {},
-        "tests_with_markers": 0,
-        "tests_without_markers": 0,
-        "misaligned_markers": [
-          {
-            "line": 10,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 16,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 22,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          }
-        ],
-        "duplicate_markers": [],
-        "recognized_markers": {},
-        "issues": [
-          {
-            "type": "misaligned_markers",
-            "message": "File has 3 misaligned markers"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/behavior/steps/test_webui_integration_steps.py": {
-        "file_path": "/workspace/devsynth/tests/behavior/steps/test_webui_integration_steps.py",
-        "has_pytest_import": true,
-        "test_functions": 0,
-        "markers": {},
-        "tests_with_markers": 0,
-        "tests_without_markers": 0,
-        "misaligned_markers": [
-          {
-            "line": 154,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 160,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 169,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 176,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 184,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 192,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 204,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 213,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 222,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 231,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 241,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 251,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 263,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 290,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 312,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 322,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 334,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 360,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 387,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 397,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 407,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 441,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 464,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 492,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 521,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 532,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 545,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 570,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          }
-        ],
-        "duplicate_markers": [],
-        "recognized_markers": {},
-        "issues": [
-          {
-            "type": "misaligned_markers",
-            "message": "File has 28 misaligned markers"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/behavior/steps/test_webui_alignment_metrics_steps.py": {
-        "file_path": "/workspace/devsynth/tests/behavior/steps/test_webui_alignment_metrics_steps.py",
-        "has_pytest_import": true,
-        "test_functions": 0,
-        "markers": {},
-        "tests_with_markers": 0,
-        "tests_without_markers": 0,
-        "misaligned_markers": [
-          {
-            "line": 9,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 15,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 21,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 30,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 36,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 43,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 50,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 58,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 65,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 73,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          }
-        ],
-        "duplicate_markers": [],
-        "recognized_markers": {},
-        "issues": [
-          {
-            "type": "misaligned_markers",
-            "message": "File has 10 misaligned markers"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/behavior/steps/test_validate_metadata_steps.py": {
-        "file_path": "/workspace/devsynth/tests/behavior/steps/test_validate_metadata_steps.py",
-        "has_pytest_import": true,
-        "test_functions": 0,
-        "markers": {},
-        "tests_with_markers": 0,
-        "tests_without_markers": 0,
-        "misaligned_markers": [
-          {
-            "line": 10,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 16,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 22,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          }
-        ],
-        "duplicate_markers": [],
-        "recognized_markers": {},
-        "issues": [
-          {
-            "type": "misaligned_markers",
-            "message": "File has 3 misaligned markers"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/behavior/steps/test_cli_webui_parity_steps.py": {
-        "file_path": "/workspace/devsynth/tests/behavior/steps/test_cli_webui_parity_steps.py",
-        "has_pytest_import": true,
-        "test_functions": 0,
-        "markers": {},
-        "tests_with_markers": 0,
-        "tests_without_markers": 0,
-        "misaligned_markers": [
-          {
-            "line": 11,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 18,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 25,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 31,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 37,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 44,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 51,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 57,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 64,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 75,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          }
-        ],
-        "duplicate_markers": [],
-        "recognized_markers": {},
-        "issues": [
-          {
-            "type": "misaligned_markers",
-            "message": "File has 10 misaligned markers"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/behavior/steps/test_prompt_management_steps.py": {
-        "file_path": "/workspace/devsynth/tests/behavior/steps/test_prompt_management_steps.py",
-        "has_pytest_import": true,
-        "test_functions": 0,
-        "markers": {},
-        "tests_with_markers": 0,
-        "tests_without_markers": 0,
-        "misaligned_markers": [
-          {
-            "line": 74,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 86,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 125,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 136,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 157,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 174,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 190,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 229,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 239,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 251,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 284,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 293,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 311,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 339,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 380,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 389,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 412,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 425,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 474,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 483,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 499,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 517,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 578,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 593,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 612,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 630,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 687,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 719,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 739,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 762,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 785,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 812,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 839,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 856,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 889,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 910,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 948,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 991,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 1010,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 1027,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 1049,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 1079,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 1094,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 1111,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 1152,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 1189,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 1213,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 1235,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 1290,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 1316,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 1395,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          }
-        ],
-        "duplicate_markers": [],
-        "recognized_markers": {},
-        "issues": [
-          {
-            "type": "misaligned_markers",
-            "message": "File has 51 misaligned markers"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/behavior/steps/test_cli_ux_enhancements_steps.py": {
-        "file_path": "/workspace/devsynth/tests/behavior/steps/test_cli_ux_enhancements_steps.py",
-        "has_pytest_import": true,
-        "test_functions": 0,
-        "markers": {},
-        "tests_with_markers": 0,
-        "tests_without_markers": 0,
-        "misaligned_markers": [
-          {
-            "line": 65,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 70,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 76,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 81,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 87,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 94,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 100,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 106,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 113,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 125,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 130,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 136,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 143,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 151,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 157,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 164,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 170,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 178,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 194,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 207,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 226,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          }
-        ],
-        "duplicate_markers": [],
-        "recognized_markers": {},
-        "issues": [
-          {
-            "type": "misaligned_markers",
-            "message": "File has 21 misaligned markers"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/behavior/steps/test_enhanced_chromadb_integration_steps.py": {
-        "file_path": "/workspace/devsynth/tests/behavior/steps/test_enhanced_chromadb_integration_steps.py",
-        "has_pytest_import": true,
-        "test_functions": 0,
-        "markers": {},
-        "tests_with_markers": 0,
-        "tests_without_markers": 0,
-        "misaligned_markers": [
-          {
-            "line": 13,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 19,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 25,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          }
-        ],
-        "duplicate_markers": [],
-        "recognized_markers": {},
-        "issues": [
-          {
-            "type": "misaligned_markers",
-            "message": "File has 3 misaligned markers"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/behavior/steps/test_interactive_init_wizard_steps.py": {
-        "file_path": "/workspace/devsynth/tests/behavior/steps/test_interactive_init_wizard_steps.py",
-        "has_pytest_import": true,
-        "test_functions": 0,
-        "markers": {},
-        "tests_with_markers": 0,
-        "tests_without_markers": 0,
-        "misaligned_markers": [
-          {
-            "line": 17,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 23,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 39,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          }
-        ],
-        "duplicate_markers": [],
-        "recognized_markers": {},
-        "issues": [
-          {
-            "type": "misaligned_markers",
-            "message": "File has 3 misaligned markers"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/behavior/steps/test_webui_apispec_steps.py": {
-        "file_path": "/workspace/devsynth/tests/behavior/steps/test_webui_apispec_steps.py",
-        "has_pytest_import": true,
-        "test_functions": 0,
-        "markers": {},
-        "tests_with_markers": 0,
-        "tests_without_markers": 0,
-        "misaligned_markers": [
-          {
-            "line": 9,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 15,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 22,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 28,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 34,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 40,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 46,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 55,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 64,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 70,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 77,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 84,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 93,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 101,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 108,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 115,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 122,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 129,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 136,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          }
-        ],
-        "duplicate_markers": [],
-        "recognized_markers": {},
-        "issues": [
-          {
-            "type": "misaligned_markers",
-            "message": "File has 19 misaligned markers"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/behavior/steps/test_micro_edrr_cycle_steps.py": {
-        "file_path": "/workspace/devsynth/tests/behavior/steps/test_micro_edrr_cycle_steps.py",
-        "has_pytest_import": true,
-        "test_functions": 0,
-        "markers": {},
-        "tests_with_markers": 0,
-        "tests_without_markers": 0,
-        "misaligned_markers": [
-          {
-            "line": 57,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 140,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 155,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 187,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 232,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 260,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 319,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          }
-        ],
-        "duplicate_markers": [],
-        "recognized_markers": {},
-        "issues": [
-          {
-            "type": "misaligned_markers",
-            "message": "File has 7 misaligned markers"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/behavior/steps/test_environment_variables_steps.py": {
-        "file_path": "/workspace/devsynth/tests/behavior/steps/test_environment_variables_steps.py",
-        "has_pytest_import": true,
-        "test_functions": 0,
-        "markers": {},
-        "tests_with_markers": 0,
-        "tests_without_markers": 0,
-        "misaligned_markers": [
-          {
-            "line": 14,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 31,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          }
-        ],
-        "duplicate_markers": [],
-        "recognized_markers": {},
-        "issues": [
-          {
-            "type": "misaligned_markers",
-            "message": "File has 2 misaligned markers"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/behavior/steps/test_webui_validate_manifest_steps.py": {
-        "file_path": "/workspace/devsynth/tests/behavior/steps/test_webui_validate_manifest_steps.py",
-        "has_pytest_import": true,
-        "test_functions": 0,
-        "markers": {},
-        "tests_with_markers": 0,
-        "tests_without_markers": 0,
-        "misaligned_markers": [
-          {
-            "line": 9,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 15,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 21,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 30,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 39,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 48,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 55,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 63,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 72,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 79,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 86,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 93,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          }
-        ],
-        "duplicate_markers": [],
-        "recognized_markers": {},
-        "issues": [
-          {
-            "type": "misaligned_markers",
-            "message": "File has 12 misaligned markers"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/behavior/steps/test_code_transformer_steps.py": {
-        "file_path": "/workspace/devsynth/tests/behavior/steps/test_code_transformer_steps.py",
-        "has_pytest_import": true,
-        "test_functions": 0,
-        "markers": {},
-        "tests_with_markers": 0,
-        "tests_without_markers": 0,
-        "misaligned_markers": [
-          {
-            "line": 43,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 51,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 59,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 74,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 81,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 96,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 111,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 120,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 132,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 145,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 161,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 174,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 185,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 202,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 216,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 224,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 249,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 266,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 291,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 315,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 338,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 347,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 362,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 377,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 386,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 417,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 430,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 445,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 455,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 473,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 483,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 518,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 531,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 547,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 558,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 567,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 576,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 585,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 596,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 606,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 621,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 630,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 639,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 651,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 659,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 671,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 680,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 690,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 703,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 711,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 723,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 733,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 741,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          }
-        ],
-        "duplicate_markers": [],
-        "recognized_markers": {},
-        "issues": [
-          {
-            "type": "misaligned_markers",
-            "message": "File has 53 misaligned markers"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/behavior/steps/test_requirements_gathering_steps.py": {
-        "file_path": "/workspace/devsynth/tests/behavior/steps/test_requirements_gathering_steps.py",
-        "has_pytest_import": true,
-        "test_functions": 0,
-        "markers": {},
-        "tests_with_markers": 0,
-        "tests_without_markers": 0,
-        "misaligned_markers": [
-          {
-            "line": 46,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 52,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 70,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 76,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 100,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          }
-        ],
-        "duplicate_markers": [],
-        "recognized_markers": {},
-        "issues": [
-          {
-            "type": "misaligned_markers",
-            "message": "File has 5 misaligned markers"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/behavior/steps/test_enhanced_dialectical_reasoning_steps.py": {
-        "file_path": "/workspace/devsynth/tests/behavior/steps/test_enhanced_dialectical_reasoning_steps.py",
-        "has_pytest_import": true,
-        "test_functions": 0,
-        "markers": {},
-        "tests_with_markers": 0,
-        "tests_without_markers": 0,
-        "misaligned_markers": [
-          {
-            "line": 58,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 86,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 96,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 110,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 142,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 153,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 166,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 173,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 182,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 189,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 200,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 269,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 282,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 291,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 301,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 308,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 316,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 326,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 366,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 378,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 394,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 413,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 433,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 451,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 478,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 513,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 585,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 606,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 616,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 624,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 632,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 644,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 716,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 774,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 786,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 794,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 801,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 809,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 816,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 830,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 849,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 857,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 867,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 878,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 888,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 901,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 965,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 980,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 989,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 1000,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 1010,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 1025,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 1090,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 1099,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 1116,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 1125,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 1135,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 1145,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          }
-        ],
-        "duplicate_markers": [],
-        "recognized_markers": {},
-        "issues": [
-          {
-            "type": "misaligned_markers",
-            "message": "File has 58 misaligned markers"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/behavior/steps/test_metrics_steps.py": {
-        "file_path": "/workspace/devsynth/tests/behavior/steps/test_metrics_steps.py",
-        "has_pytest_import": true,
-        "test_functions": 0,
-        "markers": {},
-        "tests_with_markers": 0,
-        "tests_without_markers": 0,
-        "misaligned_markers": [
-          {
-            "line": 118,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 133,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 147,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 163,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 190,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 222,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 339,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 357,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 372,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 387,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 405,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 420,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 435,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 450,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 460,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 470,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          }
-        ],
-        "duplicate_markers": [],
-        "recognized_markers": {},
-        "issues": [
-          {
-            "type": "misaligned_markers",
-            "message": "File has 16 misaligned markers"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/behavior/steps/test_memory_adapter_integration_steps.py": {
-        "file_path": "/workspace/devsynth/tests/behavior/steps/test_memory_adapter_integration_steps.py",
-        "has_pytest_import": true,
-        "test_functions": 0,
-        "markers": {},
-        "tests_with_markers": 0,
-        "tests_without_markers": 0,
-        "misaligned_markers": [
-          {
-            "line": 62,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 70,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 80,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 90,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          }
-        ],
-        "duplicate_markers": [],
-        "recognized_markers": {},
-        "issues": [
-          {
-            "type": "misaligned_markers",
-            "message": "File has 4 misaligned markers"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/behavior/steps/test_recursive_edrr_coordinator_steps.py": {
-        "file_path": "/workspace/devsynth/tests/behavior/steps/test_recursive_edrr_coordinator_steps.py",
-        "has_pytest_import": true,
-        "test_functions": 0,
-        "markers": {},
-        "tests_with_markers": 0,
-        "tests_without_markers": 0,
-        "misaligned_markers": [
-          {
-            "line": 49,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 90,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 99,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 108,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 119,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 128,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 139,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 147,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 227,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 234,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 241,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 260,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 282,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 290,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 299,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 306,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 313,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 325,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 332,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 346,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 361,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 376,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 414,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 431,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 456,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 476,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 495,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 514,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 537,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 560,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 581,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 602,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 626,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 645,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 664,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          }
-        ],
-        "duplicate_markers": [],
-        "recognized_markers": {},
-        "issues": [
-          {
-            "type": "misaligned_markers",
-            "message": "File has 35 misaligned markers"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/behavior/steps/test_mddr_common_steps.py": {
-        "file_path": "/workspace/devsynth/tests/behavior/steps/test_mddr_common_steps.py",
-        "has_pytest_import": true,
-        "test_functions": 0,
-        "markers": {},
-        "tests_with_markers": 0,
-        "tests_without_markers": 0,
-        "misaligned_markers": [
-          {
-            "line": 44,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 82,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 119,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          }
-        ],
-        "duplicate_markers": [],
-        "recognized_markers": {},
-        "issues": [
-          {
-            "type": "misaligned_markers",
-            "message": "File has 3 misaligned markers"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/behavior/steps/test_config_loader_steps.py": {
-        "file_path": "/workspace/devsynth/tests/behavior/steps/test_config_loader_steps.py",
-        "has_pytest_import": true,
-        "test_functions": 0,
-        "markers": {},
-        "tests_with_markers": 0,
-        "tests_without_markers": 0,
-        "misaligned_markers": [
-          {
-            "line": 21,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 33,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 43,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 52,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 59,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 65,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 71,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          }
-        ],
-        "duplicate_markers": [],
-        "recognized_markers": {},
-        "issues": [
-          {
-            "type": "misaligned_markers",
-            "message": "File has 7 misaligned markers"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/behavior/steps/test_promise_system_steps.py": {
-        "file_path": "/workspace/devsynth/tests/behavior/steps/test_promise_system_steps.py",
-        "has_pytest_import": true,
-        "test_functions": 0,
-        "markers": {},
-        "tests_with_markers": 0,
-        "tests_without_markers": 0,
-        "misaligned_markers": [
-          {
-            "line": 29,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 35,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 43,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 60,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 68,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 77,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 86,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 109,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 115,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 122,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 134,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 158,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 174,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 187,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 195,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 206,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 212,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 239,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 245,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 253,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 279,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 314,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 322,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          }
-        ],
-        "duplicate_markers": [],
-        "recognized_markers": {},
-        "issues": [
-          {
-            "type": "misaligned_markers",
-            "message": "File has 23 misaligned markers"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/integration/agents/test_generation/test_run_generated_tests.py": {
-        "file_path": "/workspace/devsynth/tests/integration/agents/test_generation/test_run_generated_tests.py",
-        "has_pytest_import": true,
-        "test_functions": 3,
-        "markers": {
-          "test_run_generated_tests_pass": "fast",
-          "test_run_generated_tests_failure": "fast"
-        },
-        "tests_with_markers": 2,
-        "tests_without_markers": 1,
-        "misaligned_markers": [],
-        "duplicate_markers": [],
-        "recognized_markers": {
-          "fast": {
-            "file_count": 2,
-            "pytest_count": 0,
-            "recognized": false,
-            "registered_in_pytest_ini": true,
-            "error": "subprocess error: 4",
-            "uncollected_tests": []
-          }
-        },
-        "issues": [
-          {
-            "type": "unrecognized_markers",
-            "message": "fast markers are not recognized by pytest (2 in file, 0 recognized)"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/integration/memory/test_chromadb_adapter_transactions.py": {
-        "file_path": "/workspace/devsynth/tests/integration/memory/test_chromadb_adapter_transactions.py",
-        "has_pytest_import": true,
-        "test_functions": 1,
-        "markers": {
-          "test_chromadb_transaction_commit_and_rollback": "medium"
-        },
-        "tests_with_markers": 1,
-        "tests_without_markers": 0,
-        "misaligned_markers": [],
-        "duplicate_markers": [],
-        "recognized_markers": {
-          "medium": {
-            "file_count": 1,
-            "pytest_count": 0,
-            "recognized": false,
-            "registered_in_pytest_ini": true,
-            "error": "subprocess error: 4",
-            "uncollected_tests": []
-          }
-        },
-        "issues": [
-          {
-            "type": "unrecognized_markers",
-            "message": "medium markers are not recognized by pytest (1 in file, 0 recognized)"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/behavior/steps/test_spec_command_steps.py": {
-        "file_path": "/workspace/devsynth/tests/behavior/steps/test_spec_command_steps.py",
-        "has_pytest_import": true,
-        "test_functions": 0,
-        "markers": {},
-        "tests_with_markers": 0,
-        "tests_without_markers": 0,
-        "misaligned_markers": [
-          {
-            "line": 12,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 17,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 22,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 45,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 51,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 57,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 63,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          }
-        ],
-        "duplicate_markers": [],
-        "recognized_markers": {},
-        "issues": [
-          {
-            "type": "misaligned_markers",
-            "message": "File has 7 misaligned markers"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/behavior/steps/test_config_enable_feature_steps.py": {
-        "file_path": "/workspace/devsynth/tests/behavior/steps/test_config_enable_feature_steps.py",
-        "has_pytest_import": true,
-        "test_functions": 0,
-        "markers": {},
-        "tests_with_markers": 0,
-        "tests_without_markers": 0,
-        "misaligned_markers": [
-          {
-            "line": 26,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 39,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 50,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          }
-        ],
-        "duplicate_markers": [],
-        "recognized_markers": {},
-        "issues": [
-          {
-            "type": "misaligned_markers",
-            "message": "File has 3 misaligned markers"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/behavior/steps/test_uxbridge_steps.py": {
-        "file_path": "/workspace/devsynth/tests/behavior/steps/test_uxbridge_steps.py",
-        "has_pytest_import": true,
-        "test_functions": 0,
-        "markers": {},
-        "tests_with_markers": 0,
-        "tests_without_markers": 0,
-        "misaligned_markers": [
-          {
-            "line": 28,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 44,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 65,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 89,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 99,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 107,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 115,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 124,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 132,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          }
-        ],
-        "duplicate_markers": [],
-        "recognized_markers": {},
-        "issues": [
-          {
-            "type": "misaligned_markers",
-            "message": "File has 9 misaligned markers"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/behavior/steps/test_inspect_code_command_steps.py": {
-        "file_path": "/workspace/devsynth/tests/behavior/steps/test_inspect_code_command_steps.py",
-        "has_pytest_import": true,
-        "test_functions": 0,
-        "markers": {},
-        "tests_with_markers": 0,
-        "tests_without_markers": 0,
-        "misaligned_markers": [
-          {
-            "line": 54,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 60,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 67,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 162,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 168,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 174,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 181,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 188,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 195,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 204,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 215,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 223,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 232,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 246,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 261,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          }
-        ],
-        "duplicate_markers": [],
-        "recognized_markers": {},
-        "issues": [
-          {
-            "type": "misaligned_markers",
-            "message": "File has 15 misaligned markers"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/behavior/steps/test_requirements_wizard_steps.py": {
-        "file_path": "/workspace/devsynth/tests/behavior/steps/test_requirements_wizard_steps.py",
-        "has_pytest_import": true,
-        "test_functions": 0,
-        "markers": {},
-        "tests_with_markers": 0,
-        "tests_without_markers": 0,
-        "misaligned_markers": [
-          {
-            "line": 62,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 68,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 79,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 90,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 101,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          }
-        ],
-        "duplicate_markers": [],
-        "recognized_markers": {},
-        "issues": [
-          {
-            "type": "misaligned_markers",
-            "message": "File has 5 misaligned markers"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/behavior/steps/test_validate_metadata_command_steps.py": {
-        "file_path": "/workspace/devsynth/tests/behavior/steps/test_validate_metadata_command_steps.py",
-        "has_pytest_import": true,
-        "test_functions": 0,
-        "markers": {},
-        "tests_with_markers": 0,
-        "tests_without_markers": 0,
-        "misaligned_markers": [
-          {
-            "line": 13,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 24,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          }
-        ],
-        "duplicate_markers": [],
-        "recognized_markers": {},
-        "issues": [
-          {
-            "type": "misaligned_markers",
-            "message": "File has 2 misaligned markers"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/integration/agents/test_generation/test_scaffold_generation.py": {
-        "file_path": "/workspace/devsynth/tests/integration/agents/test_generation/test_scaffold_generation.py",
-        "has_pytest_import": true,
-        "test_functions": 2,
-        "markers": {
-          "test_scaffold_hook_creates_placeholder": "fast",
-          "test_process_generates_tests_and_scaffolds": "fast"
-        },
-        "tests_with_markers": 2,
-        "tests_without_markers": 0,
-        "misaligned_markers": [],
-        "duplicate_markers": [],
-        "recognized_markers": {
-          "fast": {
-            "file_count": 2,
-            "pytest_count": 0,
-            "recognized": false,
-            "registered_in_pytest_ini": true,
-            "error": "subprocess error: 4",
-            "uncollected_tests": []
-          }
-        },
-        "issues": [
-          {
-            "type": "unrecognized_markers",
-            "message": "fast markers are not recognized by pytest (2 in file, 0 recognized)"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/behavior/steps/test_error_handling_steps.py": {
-        "file_path": "/workspace/devsynth/tests/behavior/steps/test_error_handling_steps.py",
-        "has_pytest_import": true,
-        "test_functions": 0,
-        "markers": {},
-        "tests_with_markers": 0,
-        "tests_without_markers": 0,
-        "misaligned_markers": [
-          {
-            "line": 21,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 27,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 33,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          }
-        ],
-        "duplicate_markers": [],
-        "recognized_markers": {},
-        "issues": [
-          {
-            "type": "misaligned_markers",
-            "message": "File has 3 misaligned markers"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/behavior/steps/test_enhanced_chromadb_steps.py": {
-        "file_path": "/workspace/devsynth/tests/behavior/steps/test_enhanced_chromadb_steps.py",
-        "has_pytest_import": true,
-        "test_functions": 0,
-        "markers": {},
-        "tests_with_markers": 0,
-        "tests_without_markers": 0,
-        "misaligned_markers": [
-          {
-            "line": 81,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 109,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 120,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 131,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 159,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 186,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 241,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 257,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 273,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 298,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 333,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          }
-        ],
-        "duplicate_markers": [],
-        "recognized_markers": {},
-        "issues": [
-          {
-            "type": "misaligned_markers",
-            "message": "File has 11 misaligned markers"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/behavior/steps/test_doctor_missing_env_steps.py": {
-        "file_path": "/workspace/devsynth/tests/behavior/steps/test_doctor_missing_env_steps.py",
-        "has_pytest_import": true,
-        "test_functions": 0,
-        "markers": {},
-        "tests_with_markers": 0,
-        "tests_without_markers": 0,
-        "misaligned_markers": [
-          {
-            "line": 8,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 15,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          }
-        ],
-        "duplicate_markers": [],
-        "recognized_markers": {},
-        "issues": [
-          {
-            "type": "misaligned_markers",
-            "message": "File has 2 misaligned markers"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/behavior/steps/test_wsde_edrr_integration_steps.py": {
-        "file_path": "/workspace/devsynth/tests/behavior/steps/test_wsde_edrr_integration_steps.py",
-        "has_pytest_import": true,
-        "test_functions": 0,
-        "markers": {},
-        "tests_with_markers": 0,
-        "tests_without_markers": 0,
-        "misaligned_markers": [
-          {
-            "line": 81,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 88,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 118,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 150,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 164,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 180,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 191,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 213,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 230,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 252,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 266,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 293,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 319,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 348,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 367,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 400,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 440,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 476,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 519,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 544,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 559,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 574,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 610,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          }
-        ],
-        "duplicate_markers": [],
-        "recognized_markers": {},
-        "issues": [
-          {
-            "type": "misaligned_markers",
-            "message": "File has 23 misaligned markers"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/behavior/steps/test_chromadb_steps.py": {
-        "file_path": "/workspace/devsynth/tests/behavior/steps/test_chromadb_steps.py",
-        "has_pytest_import": true,
-        "test_functions": 0,
-        "markers": {},
-        "tests_with_markers": 0,
-        "tests_without_markers": 0,
-        "misaligned_markers": [
-          {
-            "line": 55,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 65,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 74,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 84,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 96,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 115,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 153,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 166,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 189,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 203,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          }
-        ],
-        "duplicate_markers": [],
-        "recognized_markers": {},
-        "issues": [
-          {
-            "type": "misaligned_markers",
-            "message": "File has 10 misaligned markers"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/behavior/steps/test_retry_mechanism_steps.py": {
-        "file_path": "/workspace/devsynth/tests/behavior/steps/test_retry_mechanism_steps.py",
-        "has_pytest_import": true,
-        "test_functions": 0,
-        "markers": {},
-        "tests_with_markers": 0,
-        "tests_without_markers": 0,
-        "misaligned_markers": [
-          {
-            "line": 13,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 19,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 25,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          }
-        ],
-        "duplicate_markers": [],
-        "recognized_markers": {},
-        "issues": [
-          {
-            "type": "misaligned_markers",
-            "message": "File has 3 misaligned markers"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/behavior/steps/test_ingest_command_steps.py": {
-        "file_path": "/workspace/devsynth/tests/behavior/steps/test_ingest_command_steps.py",
-        "has_pytest_import": true,
-        "test_functions": 0,
-        "markers": {},
-        "tests_with_markers": 0,
-        "tests_without_markers": 0,
-        "misaligned_markers": [
-          {
-            "line": 35,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 51,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 66,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 73,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 126,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 135,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 142,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 151,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 161,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 170,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 178,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 188,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 196,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          }
-        ],
-        "duplicate_markers": [],
-        "recognized_markers": {},
-        "issues": [
-          {
-            "type": "misaligned_markers",
-            "message": "File has 13 misaligned markers"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/behavior/steps/test_apispec_generation_steps.py": {
-        "file_path": "/workspace/devsynth/tests/behavior/steps/test_apispec_generation_steps.py",
-        "has_pytest_import": true,
-        "test_functions": 0,
-        "markers": {},
-        "tests_with_markers": 0,
-        "tests_without_markers": 0,
-        "misaligned_markers": [
-          {
-            "line": 25,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 32,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 42,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          }
-        ],
-        "duplicate_markers": [],
-        "recognized_markers": {},
-        "issues": [
-          {
-            "type": "misaligned_markers",
-            "message": "File has 3 misaligned markers"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/behavior/steps/test_webui_test_metrics_steps.py": {
-        "file_path": "/workspace/devsynth/tests/behavior/steps/test_webui_test_metrics_steps.py",
-        "has_pytest_import": true,
-        "test_functions": 0,
-        "markers": {},
-        "tests_with_markers": 0,
-        "tests_without_markers": 0,
-        "misaligned_markers": [
-          {
-            "line": 9,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 15,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 21,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 27,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 33,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 40,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 47,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 55,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 63,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 71,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 78,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 86,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 94,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          }
-        ],
-        "duplicate_markers": [],
-        "recognized_markers": {},
-        "issues": [
-          {
-            "type": "misaligned_markers",
-            "message": "File has 13 misaligned markers"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/behavior/steps/test_non_hierarchical_collaboration_steps.py": {
-        "file_path": "/workspace/devsynth/tests/behavior/steps/test_non_hierarchical_collaboration_steps.py",
-        "has_pytest_import": true,
-        "test_functions": 0,
-        "markers": {},
-        "tests_with_markers": 0,
-        "tests_without_markers": 0,
-        "misaligned_markers": [
-          {
-            "line": 55,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 91,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 105,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 117,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 138,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 157,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 175,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 199,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 216,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 256,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 273,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 287,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 306,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 321,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 340,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 387,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 398,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 413,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 438,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 472,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 506,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 527,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 546,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 561,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 582,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 603,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 627,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 642,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 656,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 673,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 715,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 734,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          }
-        ],
-        "duplicate_markers": [],
-        "recognized_markers": {},
-        "issues": [
-          {
-            "type": "misaligned_markers",
-            "message": "File has 32 misaligned markers"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/behavior/steps/test_self_analyzer_steps.py": {
-        "file_path": "/workspace/devsynth/tests/behavior/steps/test_self_analyzer_steps.py",
-        "has_pytest_import": true,
-        "test_functions": 3,
-        "markers": {
-          "test_project_dir": "medium"
-        },
-        "tests_with_markers": 1,
-        "tests_without_markers": 2,
-        "misaligned_markers": [
-          {
-            "line": 110,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 118,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 126,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 151,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 162,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 173,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 182,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 192,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 201,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 211,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 220,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 232,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 249,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 262,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 272,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 282,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 294,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 305,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 337,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 348,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 360,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 371,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 446,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 456,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 465,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 475,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 488,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 498,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 518,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 529,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 542,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 552,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 562,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 573,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 586,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 596,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 606,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 616,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 626,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 649,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 659,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 668,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 677,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 686,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 696,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 704,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 712,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 721,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 729,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 741,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          }
-        ],
-        "duplicate_markers": [],
-        "recognized_markers": {
-          "medium": {
-            "file_count": 1,
-            "pytest_count": 0,
-            "recognized": false,
-            "registered_in_pytest_ini": true,
-            "error": "subprocess error: 4",
-            "uncollected_tests": []
-          }
-        },
-        "issues": [
-          {
-            "type": "misaligned_markers",
-            "message": "File has 50 misaligned markers"
-          },
-          {
-            "type": "unrecognized_markers",
-            "message": "medium markers are not recognized by pytest (1 in file, 0 recognized)"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/behavior/steps/test_memory_context_steps.py": {
-        "file_path": "/workspace/devsynth/tests/behavior/steps/test_memory_context_steps.py",
-        "has_pytest_import": true,
-        "test_functions": 0,
-        "markers": {},
-        "tests_with_markers": 0,
-        "tests_without_markers": 0,
-        "misaligned_markers": [
-          {
-            "line": 113,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 121,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 129,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 139,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 150,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 159,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 167,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 177,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 190,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 202,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 216,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 226,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 234,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 241,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 250,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 256,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 263,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 270,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 278,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 287,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 295,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 302,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 310,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 319,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 329,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          }
-        ],
-        "duplicate_markers": [],
-        "recognized_markers": {},
-        "issues": [
-          {
-            "type": "misaligned_markers",
-            "message": "File has 25 misaligned markers"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/behavior/steps/test_dbschema_generation_steps.py": {
-        "file_path": "/workspace/devsynth/tests/behavior/steps/test_dbschema_generation_steps.py",
-        "has_pytest_import": true,
-        "test_functions": 0,
-        "markers": {},
-        "tests_with_markers": 0,
-        "tests_without_markers": 0,
-        "misaligned_markers": [
-          {
-            "line": 21,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 28,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 34,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          }
-        ],
-        "duplicate_markers": [],
-        "recognized_markers": {},
-        "issues": [
-          {
-            "type": "misaligned_markers",
-            "message": "File has 3 misaligned markers"
           }
         ]
       },
@@ -14511,8 +1314,8 @@
           }
         ]
       },
-      "/workspace/devsynth/tests/behavior/steps/test_simple_addition_steps.py": {
-        "file_path": "/workspace/devsynth/tests/behavior/steps/test_simple_addition_steps.py",
+      "/workspace/devsynth/tests/behavior/steps/test_devsynth_doctor_steps.py": {
+        "file_path": "/workspace/devsynth/tests/behavior/steps/test_devsynth_doctor_steps.py",
         "has_pytest_import": true,
         "test_functions": 0,
         "markers": {},
@@ -14520,40 +1323,7 @@
         "tests_without_markers": 0,
         "misaligned_markers": [
           {
-            "line": 23,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 30,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 37,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          }
-        ],
-        "duplicate_markers": [],
-        "recognized_markers": {},
-        "issues": [
-          {
-            "type": "misaligned_markers",
-            "message": "File has 3 misaligned markers"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/behavior/steps/test_docs_fetch_steps.py": {
-        "file_path": "/workspace/devsynth/tests/behavior/steps/test_docs_fetch_steps.py",
-        "has_pytest_import": true,
-        "test_functions": 0,
-        "markers": {},
-        "tests_with_markers": 0,
-        "tests_without_markers": 0,
-        "misaligned_markers": [
-          {
-            "line": 13,
+            "line": 7,
             "marker": "medium",
             "text": "@pytest.mark.medium"
           },
@@ -14563,7 +1333,27 @@
             "text": "@pytest.mark.medium"
           },
           {
-            "line": 25,
+            "line": 26,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 34,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 46,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 58,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 69,
             "marker": "medium",
             "text": "@pytest.mark.medium"
           }
@@ -14573,12 +1363,12 @@
         "issues": [
           {
             "type": "misaligned_markers",
-            "message": "File has 3 misaligned markers"
+            "message": "File has 7 misaligned markers"
           }
         ]
       },
-      "/workspace/devsynth/tests/behavior/steps/test_webui_inspect_config_steps.py": {
-        "file_path": "/workspace/devsynth/tests/behavior/steps/test_webui_inspect_config_steps.py",
+      "/workspace/devsynth/tests/behavior/steps/test_webui_alignment_metrics_steps.py": {
+        "file_path": "/workspace/devsynth/tests/behavior/steps/test_webui_alignment_metrics_steps.py",
         "has_pytest_import": true,
         "test_functions": 0,
         "markers": {},
@@ -14601,828 +1391,7 @@
             "text": "@pytest.mark.medium"
           },
           {
-            "line": 27,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 36,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 42,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 49,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 57,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 65,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 72,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 79,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          }
-        ],
-        "duplicate_markers": [],
-        "recognized_markers": {},
-        "issues": [
-          {
-            "type": "misaligned_markers",
-            "message": "File has 11 misaligned markers"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/behavior/steps/test_analyze_commands_steps.py": {
-        "file_path": "/workspace/devsynth/tests/behavior/steps/test_analyze_commands_steps.py",
-        "has_pytest_import": true,
-        "test_functions": 0,
-        "markers": {},
-        "tests_with_markers": 0,
-        "tests_without_markers": 0,
-        "misaligned_markers": [
-          {
-            "line": 60,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 73,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 83,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 181,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 191,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 206,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 236,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 267,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 285,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 297,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 309,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 319,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 329,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 339,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 349,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 361,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 373,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 383,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 393,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 403,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 415,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 425,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 437,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 447,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 457,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 471,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 481,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          }
-        ],
-        "duplicate_markers": [],
-        "recognized_markers": {},
-        "issues": [
-          {
-            "type": "misaligned_markers",
-            "message": "File has 27 misaligned markers"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/behavior/steps/test_webui_spec_editor_extended_steps.py": {
-        "file_path": "/workspace/devsynth/tests/behavior/steps/test_webui_spec_editor_extended_steps.py",
-        "has_pytest_import": true,
-        "test_functions": 0,
-        "markers": {},
-        "tests_with_markers": 0,
-        "tests_without_markers": 0,
-        "misaligned_markers": [
-          {
-            "line": 8,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 15,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 25,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 35,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 50,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 66,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 73,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 107,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 116,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 124,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 131,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          }
-        ],
-        "duplicate_markers": [],
-        "recognized_markers": {},
-        "issues": [
-          {
-            "type": "misaligned_markers",
-            "message": "File has 11 misaligned markers"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/behavior/steps/test_additional_storage_backends_steps.py": {
-        "file_path": "/workspace/devsynth/tests/behavior/steps/test_additional_storage_backends_steps.py",
-        "has_pytest_import": true,
-        "test_functions": 0,
-        "markers": {},
-        "tests_with_markers": 0,
-        "tests_without_markers": 0,
-        "misaligned_markers": [
-          {
-            "line": 103,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 114,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 127,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 150,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 180,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 192,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 211,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 249,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 258,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 281,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 292,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 318,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 344,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 355,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 384,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 411,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 461,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 487,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 499,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 527,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 554,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 579,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 601,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 620,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 638,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 664,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 676,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 696,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 723,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 735,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          }
-        ],
-        "duplicate_markers": [],
-        "recognized_markers": {},
-        "issues": [
-          {
-            "type": "misaligned_markers",
-            "message": "File has 30 misaligned markers"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/behavior/steps/test_advanced_graph_memory_features_steps.py": {
-        "file_path": "/workspace/devsynth/tests/behavior/steps/test_advanced_graph_memory_features_steps.py",
-        "has_pytest_import": true,
-        "test_functions": 0,
-        "markers": {},
-        "tests_with_markers": 0,
-        "tests_without_markers": 0,
-        "misaligned_markers": [
-          {
-            "line": 50,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 57,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 66,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 76,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 90,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 104,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 117,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 144,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 156,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 176,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 212,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 236,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 254,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 279,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 299,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 316,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 337,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 359,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 430,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 439,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 467,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 499,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 527,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 536,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 547,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 581,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 614,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 631,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 648,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 668,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 678,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          }
-        ],
-        "duplicate_markers": [],
-        "recognized_markers": {},
-        "issues": [
-          {
-            "type": "misaligned_markers",
-            "message": "File has 31 misaligned markers"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/behavior/steps/test_webapp_generation_steps.py": {
-        "file_path": "/workspace/devsynth/tests/behavior/steps/test_webapp_generation_steps.py",
-        "has_pytest_import": true,
-        "test_functions": 0,
-        "markers": {},
-        "tests_with_markers": 0,
-        "tests_without_markers": 0,
-        "misaligned_markers": [
-          {
-            "line": 21,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 27,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 33,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          }
-        ],
-        "duplicate_markers": [],
-        "recognized_markers": {},
-        "issues": [
-          {
-            "type": "misaligned_markers",
-            "message": "File has 3 misaligned markers"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/behavior/steps/test_webui_gather_wizard_steps.py": {
-        "file_path": "/workspace/devsynth/tests/behavior/steps/test_webui_gather_wizard_steps.py",
-        "has_pytest_import": true,
-        "test_functions": 0,
-        "markers": {},
-        "tests_with_markers": 0,
-        "tests_without_markers": 0,
-        "misaligned_markers": [
-          {
-            "line": 18,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 25,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 148,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 159,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 168,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 176,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 218,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 228,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 242,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 254,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 266,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 287,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 313,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 321,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 329,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 338,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 352,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 362,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 369,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 380,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 391,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 398,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 405,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 417,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 438,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 467,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          }
-        ],
-        "duplicate_markers": [],
-        "recognized_markers": {},
-        "issues": [
-          {
-            "type": "misaligned_markers",
-            "message": "File has 26 misaligned markers"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/behavior/steps/test_webui_dbschema_steps.py": {
-        "file_path": "/workspace/devsynth/tests/behavior/steps/test_webui_dbschema_steps.py",
-        "has_pytest_import": true,
-        "test_functions": 0,
-        "markers": {},
-        "tests_with_markers": 0,
-        "tests_without_markers": 0,
-        "misaligned_markers": [
-          {
-            "line": 9,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 15,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 22,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 29,
+            "line": 30,
             "marker": "medium",
             "text": "@pytest.mark.medium"
           },
@@ -15437,140 +1406,7 @@
             "text": "@pytest.mark.medium"
           },
           {
-            "line": 52,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 59,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 65,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 71,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 78,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 85,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 91,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 98,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 105,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 112,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 119,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 126,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 133,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 140,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 147,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 154,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 161,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          }
-        ],
-        "duplicate_markers": [],
-        "recognized_markers": {},
-        "issues": [
-          {
-            "type": "misaligned_markers",
-            "message": "File has 23 misaligned markers"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/behavior/steps/test_webui_validate_metadata_steps.py": {
-        "file_path": "/workspace/devsynth/tests/behavior/steps/test_webui_validate_metadata_steps.py",
-        "has_pytest_import": true,
-        "test_functions": 0,
-        "markers": {},
-        "tests_with_markers": 0,
-        "tests_without_markers": 0,
-        "misaligned_markers": [
-          {
-            "line": 9,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 15,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 21,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 27,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 34,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 42,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 51,
+            "line": 50,
             "marker": "medium",
             "text": "@pytest.mark.medium"
           },
@@ -15588,9 +1424,162 @@
             "line": 73,
             "marker": "medium",
             "text": "@pytest.mark.medium"
+          }
+        ],
+        "duplicate_markers": [],
+        "recognized_markers": {},
+        "issues": [
+          {
+            "type": "misaligned_markers",
+            "message": "File has 10 misaligned markers"
+          }
+        ]
+      },
+      "/workspace/devsynth/tests/behavior/steps/test_webui_config_steps.py": {
+        "file_path": "/workspace/devsynth/tests/behavior/steps/test_webui_config_steps.py",
+        "has_pytest_import": true,
+        "test_functions": 0,
+        "markers": {},
+        "tests_with_markers": 0,
+        "tests_without_markers": 0,
+        "misaligned_markers": [
+          {
+            "line": 222,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
           },
           {
-            "line": 80,
+            "line": 228,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 238,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 246,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 253,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 269,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 285,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 301,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 308,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 317,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 326,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 333,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 340,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 352,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 359,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 367,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 375,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 382,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 389,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 395,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 401,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 413,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 419,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 425,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 434,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 440,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 447,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 454,
             "marker": "medium",
             "text": "@pytest.mark.medium"
           }
@@ -15600,12 +1589,12 @@
         "issues": [
           {
             "type": "misaligned_markers",
-            "message": "File has 11 misaligned markers"
+            "message": "File has 28 misaligned markers"
           }
         ]
       },
-      "/workspace/devsynth/tests/behavior/steps/test_interactive_requirements_steps.py": {
-        "file_path": "/workspace/devsynth/tests/behavior/steps/test_interactive_requirements_steps.py",
+      "/workspace/devsynth/tests/behavior/steps/test_spec_command_steps.py": {
+        "file_path": "/workspace/devsynth/tests/behavior/steps/test_spec_command_steps.py",
         "has_pytest_import": true,
         "test_functions": 0,
         "markers": {},
@@ -15613,17 +1602,37 @@
         "tests_without_markers": 0,
         "misaligned_markers": [
           {
-            "line": 13,
+            "line": 12,
             "marker": "medium",
             "text": "@pytest.mark.medium"
           },
           {
-            "line": 19,
+            "line": 17,
             "marker": "medium",
             "text": "@pytest.mark.medium"
           },
           {
-            "line": 39,
+            "line": 22,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 45,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 51,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 57,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 63,
             "marker": "medium",
             "text": "@pytest.mark.medium"
           }
@@ -15633,18 +1642,38 @@
         "issues": [
           {
             "type": "misaligned_markers",
-            "message": "File has 3 misaligned markers"
+            "message": "File has 7 misaligned markers"
           }
         ]
       },
-      "/workspace/devsynth/tests/behavior/steps/test_uxbridge_shared_steps.py": {
-        "file_path": "/workspace/devsynth/tests/behavior/steps/test_uxbridge_shared_steps.py",
+      "/workspace/devsynth/tests/behavior/steps/test_cli_ux_enhancements_steps.py": {
+        "file_path": "/workspace/devsynth/tests/behavior/steps/test_cli_ux_enhancements_steps.py",
         "has_pytest_import": true,
         "test_functions": 0,
         "markers": {},
         "tests_with_markers": 0,
         "tests_without_markers": 0,
         "misaligned_markers": [
+          {
+            "line": 65,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 70,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 76,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 81,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
           {
             "line": 87,
             "marker": "medium",
@@ -15656,7 +1685,148 @@
             "text": "@pytest.mark.medium"
           },
           {
-            "line": 118,
+            "line": 100,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 106,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 113,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 125,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 130,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 136,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 143,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 151,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 157,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 164,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 170,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 178,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 194,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 207,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 226,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          }
+        ],
+        "duplicate_markers": [],
+        "recognized_markers": {},
+        "issues": [
+          {
+            "type": "misaligned_markers",
+            "message": "File has 21 misaligned markers"
+          }
+        ]
+      },
+      "/workspace/devsynth/tests/behavior/steps/test_chromadb_store_steps.py": {
+        "file_path": "/workspace/devsynth/tests/behavior/steps/test_chromadb_store_steps.py",
+        "has_pytest_import": true,
+        "test_functions": 0,
+        "markers": {},
+        "tests_with_markers": 0,
+        "tests_without_markers": 0,
+        "misaligned_markers": [
+          {
+            "line": 21,
+            "marker": "fast",
+            "text": "@pytest.mark.fast"
+          },
+          {
+            "line": 28,
+            "marker": "fast",
+            "text": "@pytest.mark.fast"
+          },
+          {
+            "line": 35,
+            "marker": "fast",
+            "text": "@pytest.mark.fast"
+          },
+          {
+            "line": 41,
+            "marker": "fast",
+            "text": "@pytest.mark.fast"
+          }
+        ],
+        "duplicate_markers": [],
+        "recognized_markers": {},
+        "issues": [
+          {
+            "type": "misaligned_markers",
+            "message": "File has 4 misaligned markers"
+          }
+        ]
+      },
+      "/workspace/devsynth/tests/behavior/steps/test_api_stub_steps.py": {
+        "file_path": "/workspace/devsynth/tests/behavior/steps/test_api_stub_steps.py",
+        "has_pytest_import": true,
+        "test_functions": 0,
+        "markers": {},
+        "tests_with_markers": 0,
+        "tests_without_markers": 0,
+        "misaligned_markers": [
+          {
+            "line": 25,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 31,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 38,
             "marker": "medium",
             "text": "@pytest.mark.medium"
           }
@@ -15667,6 +1837,74 @@
           {
             "type": "misaligned_markers",
             "message": "File has 3 misaligned markers"
+          }
+        ]
+      },
+      "/workspace/devsynth/tests/behavior/steps/test_cross_interface_consistency_extended_steps.py": {
+        "file_path": "/workspace/devsynth/tests/behavior/steps/test_cross_interface_consistency_extended_steps.py",
+        "has_pytest_import": true,
+        "test_functions": 0,
+        "markers": {},
+        "tests_with_markers": 0,
+        "tests_without_markers": 0,
+        "misaligned_markers": [
+          {
+            "line": 145,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 153,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 268,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 319,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 351,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 399,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 449,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 483,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 518,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 543,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          }
+        ],
+        "duplicate_markers": [],
+        "recognized_markers": {},
+        "issues": [
+          {
+            "type": "misaligned_markers",
+            "message": "File has 10 misaligned markers"
           }
         ]
       },
@@ -15843,8 +2081,8 @@
           }
         ]
       },
-      "/workspace/devsynth/tests/behavior/steps/test_devsynth_doctor_steps.py": {
-        "file_path": "/workspace/devsynth/tests/behavior/steps/test_devsynth_doctor_steps.py",
+      "/workspace/devsynth/tests/behavior/steps/test_memory_manager_steps.py": {
+        "file_path": "/workspace/devsynth/tests/behavior/steps/test_memory_manager_steps.py",
         "has_pytest_import": true,
         "test_functions": 0,
         "markers": {},
@@ -15852,65 +2090,7 @@
         "tests_without_markers": 0,
         "misaligned_markers": [
           {
-            "line": 7,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 19,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 26,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 34,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 46,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 58,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 69,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          }
-        ],
-        "duplicate_markers": [],
-        "recognized_markers": {},
-        "issues": [
-          {
-            "type": "misaligned_markers",
-            "message": "File has 7 misaligned markers"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/behavior/steps/test_serve_command_steps.py": {
-        "file_path": "/workspace/devsynth/tests/behavior/steps/test_serve_command_steps.py",
-        "has_pytest_import": true,
-        "test_functions": 0,
-        "markers": {},
-        "tests_with_markers": 0,
-        "tests_without_markers": 0,
-        "misaligned_markers": [
-          {
-            "line": 36,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 43,
+            "line": 45,
             "marker": "medium",
             "text": "@pytest.mark.medium"
           },
@@ -15920,153 +2100,7 @@
             "text": "@pytest.mark.medium"
           },
           {
-            "line": 60,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 103,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 109,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 115,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 122,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 129,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 137,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 146,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 153,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 162,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          }
-        ],
-        "duplicate_markers": [],
-        "recognized_markers": {},
-        "issues": [
-          {
-            "type": "misaligned_markers",
-            "message": "File has 13 misaligned markers"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/behavior/steps/test_doctor_command_steps.py": {
-        "file_path": "/workspace/devsynth/tests/behavior/steps/test_doctor_command_steps.py",
-        "has_pytest_import": true,
-        "test_functions": 0,
-        "markers": {},
-        "tests_with_markers": 0,
-        "tests_without_markers": 0,
-        "misaligned_markers": [
-          {
-            "line": 8,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 17,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 25,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 33,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 41,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          }
-        ],
-        "duplicate_markers": [],
-        "recognized_markers": {},
-        "issues": [
-          {
-            "type": "misaligned_markers",
-            "message": "File has 5 misaligned markers"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/behavior/steps/test_agent_api_health_metrics_steps.py": {
-        "file_path": "/workspace/devsynth/tests/behavior/steps/test_agent_api_health_metrics_steps.py",
-        "has_pytest_import": true,
-        "test_functions": 0,
-        "markers": {},
-        "tests_with_markers": 0,
-        "tests_without_markers": 0,
-        "misaligned_markers": [
-          {
-            "line": 40,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 49,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 58,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 66,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 77,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 87,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 95,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 106,
+            "line": 80,
             "marker": "medium",
             "text": "@pytest.mark.medium"
           },
@@ -16081,12 +2115,97 @@
             "text": "@pytest.mark.medium"
           },
           {
-            "line": 132,
+            "line": 131,
             "marker": "medium",
             "text": "@pytest.mark.medium"
           },
           {
-            "line": 140,
+            "line": 144,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 168,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 176,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 184,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 191,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 200,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 224,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 240,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 249,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 263,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 271,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 279,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 289,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 310,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 319,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 357,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 364,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 373,
             "marker": "medium",
             "text": "@pytest.mark.medium"
           }
@@ -16096,12 +2215,12 @@
         "issues": [
           {
             "type": "misaligned_markers",
-            "message": "File has 12 misaligned markers"
+            "message": "File has 24 misaligned markers"
           }
         ]
       },
-      "/workspace/devsynth/tests/behavior/steps/test_webui_navigation_prompts_steps.py": {
-        "file_path": "/workspace/devsynth/tests/behavior/steps/test_webui_navigation_prompts_steps.py",
+      "/workspace/devsynth/tests/behavior/steps/test_project_documentation_ingestion_steps.py": {
+        "file_path": "/workspace/devsynth/tests/behavior/steps/test_project_documentation_ingestion_steps.py",
         "has_pytest_import": true,
         "test_functions": 0,
         "markers": {},
@@ -16109,27 +2228,17 @@
         "tests_without_markers": 0,
         "misaligned_markers": [
           {
-            "line": 8,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 14,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 21,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 29,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
             "line": 35,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 59,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 65,
             "marker": "medium",
             "text": "@pytest.mark.medium"
           }
@@ -16139,7 +2248,256 @@
         "issues": [
           {
             "type": "misaligned_markers",
-            "message": "File has 5 misaligned markers"
+            "message": "File has 3 misaligned markers"
+          }
+        ]
+      },
+      "/workspace/devsynth/tests/behavior/steps/test_documentation_utility_functions_steps.py": {
+        "file_path": "/workspace/devsynth/tests/behavior/steps/test_documentation_utility_functions_steps.py",
+        "has_pytest_import": true,
+        "test_functions": 0,
+        "markers": {},
+        "tests_with_markers": 0,
+        "tests_without_markers": 0,
+        "misaligned_markers": [
+          {
+            "line": 27,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 40,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 58,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 80,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 102,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 126,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 156,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 181,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 216,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 224,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 233,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 240,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 247,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 255,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 264,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 271,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 278,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 287,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 295,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 302,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 310,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 320,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 330,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 338,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 346,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 354,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 362,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 369,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          }
+        ],
+        "duplicate_markers": [],
+        "recognized_markers": {},
+        "issues": [
+          {
+            "type": "misaligned_markers",
+            "message": "File has 28 misaligned markers"
+          }
+        ]
+      },
+      "/workspace/devsynth/tests/behavior/steps/test_delegate_task_consensus_steps.py": {
+        "file_path": "/workspace/devsynth/tests/behavior/steps/test_delegate_task_consensus_steps.py",
+        "has_pytest_import": true,
+        "test_functions": 0,
+        "markers": {},
+        "tests_with_markers": 0,
+        "tests_without_markers": 0,
+        "misaligned_markers": [
+          {
+            "line": 27,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 40,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 54,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 60,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 95,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 102,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 109,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 116,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          }
+        ],
+        "duplicate_markers": [],
+        "recognized_markers": {},
+        "issues": [
+          {
+            "type": "misaligned_markers",
+            "message": "File has 8 misaligned markers"
+          }
+        ]
+      },
+      "/workspace/devsynth/tests/behavior/steps/test_agent_api_steps.py": {
+        "file_path": "/workspace/devsynth/tests/behavior/steps/test_agent_api_steps.py",
+        "has_pytest_import": true,
+        "test_functions": 1,
+        "markers": {
+          "test_cmd": "medium"
+        },
+        "tests_with_markers": 1,
+        "tests_without_markers": 0,
+        "misaligned_markers": [],
+        "duplicate_markers": [],
+        "recognized_markers": {
+          "medium": {
+            "file_count": 1,
+            "pytest_count": 0,
+            "recognized": false,
+            "registered_in_pytest_ini": true,
+            "error": "exit code 2",
+            "uncollected_tests": []
+          }
+        },
+        "issues": [
+          {
+            "type": "unrecognized_markers",
+            "message": "medium markers are not recognized by pytest (1 in file, 0 recognized)"
+          },
+          {
+            "type": "pytest_error",
+            "marker": "medium",
+            "message": "pytest collection failed for /workspace/devsynth/tests/behavior/steps/test_agent_api_steps.py [marker=medium]: exit code 2"
           }
         ]
       },
@@ -16481,8 +2839,8 @@
           }
         ]
       },
-      "/workspace/devsynth/tests/behavior/steps/test_project_init_steps.py": {
-        "file_path": "/workspace/devsynth/tests/behavior/steps/test_project_init_steps.py",
+      "/workspace/devsynth/tests/behavior/steps/test_enhanced_chromadb_integration_steps.py": {
+        "file_path": "/workspace/devsynth/tests/behavior/steps/test_enhanced_chromadb_integration_steps.py",
         "has_pytest_import": true,
         "test_functions": 0,
         "markers": {},
@@ -16490,27 +2848,93 @@
         "tests_without_markers": 0,
         "misaligned_markers": [
           {
-            "line": 21,
+            "line": 13,
             "marker": "medium",
             "text": "@pytest.mark.medium"
           },
           {
-            "line": 40,
+            "line": 19,
             "marker": "medium",
             "text": "@pytest.mark.medium"
           },
           {
-            "line": 49,
+            "line": 25,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          }
+        ],
+        "duplicate_markers": [],
+        "recognized_markers": {},
+        "issues": [
+          {
+            "type": "misaligned_markers",
+            "message": "File has 3 misaligned markers"
+          }
+        ]
+      },
+      "/workspace/devsynth/tests/behavior/steps/test_interactive_requirements_steps.py": {
+        "file_path": "/workspace/devsynth/tests/behavior/steps/test_interactive_requirements_steps.py",
+        "has_pytest_import": true,
+        "test_functions": 0,
+        "markers": {},
+        "tests_with_markers": 0,
+        "tests_without_markers": 0,
+        "misaligned_markers": [
+          {
+            "line": 13,
             "marker": "medium",
             "text": "@pytest.mark.medium"
           },
           {
-            "line": 58,
+            "line": 19,
             "marker": "medium",
             "text": "@pytest.mark.medium"
           },
           {
-            "line": 70,
+            "line": 39,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          }
+        ],
+        "duplicate_markers": [],
+        "recognized_markers": {},
+        "issues": [
+          {
+            "type": "misaligned_markers",
+            "message": "File has 3 misaligned markers"
+          }
+        ]
+      },
+      "/workspace/devsynth/tests/behavior/steps/test_webui_onboarding_steps.py": {
+        "file_path": "/workspace/devsynth/tests/behavior/steps/test_webui_onboarding_steps.py",
+        "has_pytest_import": true,
+        "test_functions": 0,
+        "markers": {},
+        "tests_with_markers": 0,
+        "tests_without_markers": 0,
+        "misaligned_markers": [
+          {
+            "line": 114,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 120,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 127,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 135,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 141,
             "marker": "medium",
             "text": "@pytest.mark.medium"
           }
@@ -16524,8 +2948,8 @@
           }
         ]
       },
-      "/workspace/devsynth/tests/behavior/steps/test_memory_manager_steps.py": {
-        "file_path": "/workspace/devsynth/tests/behavior/steps/test_memory_manager_steps.py",
+      "/workspace/devsynth/tests/behavior/steps/test_dialectical_reasoning_memory_persistence_steps.py": {
+        "file_path": "/workspace/devsynth/tests/behavior/steps/test_dialectical_reasoning_memory_persistence_steps.py",
         "has_pytest_import": true,
         "test_functions": 0,
         "markers": {},
@@ -16533,7 +2957,55 @@
         "tests_without_markers": 0,
         "misaligned_markers": [
           {
-            "line": 45,
+            "line": 37,
+            "marker": "fast",
+            "text": "@pytest.mark.fast"
+          },
+          {
+            "line": 74,
+            "marker": "fast",
+            "text": "@pytest.mark.fast"
+          },
+          {
+            "line": 87,
+            "marker": "fast",
+            "text": "@pytest.mark.fast"
+          },
+          {
+            "line": 93,
+            "marker": "fast",
+            "text": "@pytest.mark.fast"
+          },
+          {
+            "line": 102,
+            "marker": "fast",
+            "text": "@pytest.mark.fast"
+          },
+          {
+            "line": 116,
+            "marker": "fast",
+            "text": "@pytest.mark.fast"
+          }
+        ],
+        "duplicate_markers": [],
+        "recognized_markers": {},
+        "issues": [
+          {
+            "type": "misaligned_markers",
+            "message": "File has 6 misaligned markers"
+          }
+        ]
+      },
+      "/workspace/devsynth/tests/behavior/steps/test_wsde_agent_model_steps.py": {
+        "file_path": "/workspace/devsynth/tests/behavior/steps/test_wsde_agent_model_steps.py",
+        "has_pytest_import": true,
+        "test_functions": 0,
+        "markers": {},
+        "tests_with_markers": 0,
+        "tests_without_markers": 0,
+        "misaligned_markers": [
+          {
+            "line": 44,
             "marker": "medium",
             "text": "@pytest.mark.medium"
           },
@@ -16543,7 +3015,190 @@
             "text": "@pytest.mark.medium"
           },
           {
-            "line": 80,
+            "line": 63,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 74,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 100,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 111,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 124,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 201,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 238,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 251,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 278,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 358,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 417,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 443,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 457,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 496,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 529,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 580,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 606,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 625,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 653,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 688,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 715,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 733,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 745,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 783,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 816,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 867,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 918,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 929,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 935,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          }
+        ],
+        "duplicate_markers": [],
+        "recognized_markers": {},
+        "issues": [
+          {
+            "type": "misaligned_markers",
+            "message": "File has 31 misaligned markers"
+          }
+        ]
+      },
+      "/workspace/devsynth/tests/behavior/steps/test_requirements_wizard_navigation_steps.py": {
+        "file_path": "/workspace/devsynth/tests/behavior/steps/test_requirements_wizard_navigation_steps.py",
+        "has_pytest_import": true,
+        "test_functions": 0,
+        "markers": {},
+        "tests_with_markers": 0,
+        "tests_without_markers": 0,
+        "misaligned_markers": [
+          {
+            "line": 70,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 76,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 86,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 96,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 106,
             "marker": "medium",
             "text": "@pytest.mark.medium"
           },
@@ -16553,12 +3208,65 @@
             "text": "@pytest.mark.medium"
           },
           {
-            "line": 123,
+            "line": 122,
             "marker": "medium",
             "text": "@pytest.mark.medium"
           },
           {
-            "line": 131,
+            "line": 128,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          }
+        ],
+        "duplicate_markers": [],
+        "recognized_markers": {},
+        "issues": [
+          {
+            "type": "misaligned_markers",
+            "message": "File has 8 misaligned markers"
+          }
+        ]
+      },
+      "/workspace/devsynth/tests/behavior/steps/test_advanced_graph_memory_features_steps.py": {
+        "file_path": "/workspace/devsynth/tests/behavior/steps/test_advanced_graph_memory_features_steps.py",
+        "has_pytest_import": true,
+        "test_functions": 0,
+        "markers": {},
+        "tests_with_markers": 0,
+        "tests_without_markers": 0,
+        "misaligned_markers": [
+          {
+            "line": 50,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 57,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 66,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 76,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 90,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 104,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 117,
             "marker": "medium",
             "text": "@pytest.mark.medium"
           },
@@ -16568,7 +3276,504 @@
             "text": "@pytest.mark.medium"
           },
           {
-            "line": 168,
+            "line": 156,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 176,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 212,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 236,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 254,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 279,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 299,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 316,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 337,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 359,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 430,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 439,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 467,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 499,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 527,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 536,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 547,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 581,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 614,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 631,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 648,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 668,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 678,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          }
+        ],
+        "duplicate_markers": [],
+        "recognized_markers": {},
+        "issues": [
+          {
+            "type": "misaligned_markers",
+            "message": "File has 31 misaligned markers"
+          }
+        ]
+      },
+      "/workspace/devsynth/tests/behavior/steps/test_interactive_init_wizard_steps.py": {
+        "file_path": "/workspace/devsynth/tests/behavior/steps/test_interactive_init_wizard_steps.py",
+        "has_pytest_import": true,
+        "test_functions": 0,
+        "markers": {},
+        "tests_with_markers": 0,
+        "tests_without_markers": 0,
+        "misaligned_markers": [
+          {
+            "line": 17,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 23,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 39,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          }
+        ],
+        "duplicate_markers": [],
+        "recognized_markers": {},
+        "issues": [
+          {
+            "type": "misaligned_markers",
+            "message": "File has 3 misaligned markers"
+          }
+        ]
+      },
+      "/workspace/devsynth/tests/behavior/steps/test_simple_coordinator_steps.py": {
+        "file_path": "/workspace/devsynth/tests/behavior/steps/test_simple_coordinator_steps.py",
+        "has_pytest_import": true,
+        "test_functions": 4,
+        "markers": {
+          "test_store_method_succeeds": "medium"
+        },
+        "tests_with_markers": 1,
+        "tests_without_markers": 3,
+        "misaligned_markers": [
+          {
+            "line": 142,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 143,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 144,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 145,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 146,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 147,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 253,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 254,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 255,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 256,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 257,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 258,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 301,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 302,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 303,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 304,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 305,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 306,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 658,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 659,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 660,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 661,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 662,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 663,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          }
+        ],
+        "duplicate_markers": [
+          {
+            "test_name": "test_store_method_succeeds",
+            "marker_count": 36
+          },
+          {
+            "test_name": "test_store_method_succeeds",
+            "marker_count": 36
+          },
+          {
+            "test_name": "test_store_method_succeeds",
+            "marker_count": 36
+          },
+          {
+            "test_name": "test_store_method_succeeds",
+            "marker_count": 36
+          }
+        ],
+        "recognized_markers": {
+          "medium": {
+            "file_count": 1,
+            "pytest_count": 6,
+            "recognized": false,
+            "registered_in_pytest_ini": true,
+            "uncollected_tests": [
+              "test_store_method_succeeds"
+            ]
+          }
+        },
+        "issues": [
+          {
+            "type": "misaligned_markers",
+            "message": "File has 24 misaligned markers"
+          },
+          {
+            "type": "duplicate_markers",
+            "message": "File has 4 tests with duplicate markers"
+          },
+          {
+            "type": "unrecognized_markers",
+            "message": "medium markers are not recognized by pytest (1 in file, 6 recognized)"
+          }
+        ]
+      },
+      "/workspace/devsynth/tests/behavior/steps/test_requirements_management_steps.py": {
+        "file_path": "/workspace/devsynth/tests/behavior/steps/test_requirements_management_steps.py",
+        "has_pytest_import": true,
+        "test_functions": 0,
+        "markers": {},
+        "tests_with_markers": 0,
+        "tests_without_markers": 0,
+        "misaligned_markers": [
+          {
+            "line": 23,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 30,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 37,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          }
+        ],
+        "duplicate_markers": [],
+        "recognized_markers": {},
+        "issues": [
+          {
+            "type": "misaligned_markers",
+            "message": "File has 3 misaligned markers"
+          }
+        ]
+      },
+      "/workspace/devsynth/tests/behavior/steps/test_webui_apispec_steps.py": {
+        "file_path": "/workspace/devsynth/tests/behavior/steps/test_webui_apispec_steps.py",
+        "has_pytest_import": true,
+        "test_functions": 0,
+        "markers": {},
+        "tests_with_markers": 0,
+        "tests_without_markers": 0,
+        "misaligned_markers": [
+          {
+            "line": 9,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 15,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 22,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 28,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 34,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 40,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 46,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 55,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 64,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 70,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 77,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 84,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 93,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 101,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 108,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 115,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 122,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 129,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 136,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          }
+        ],
+        "duplicate_markers": [],
+        "recognized_markers": {},
+        "issues": [
+          {
+            "type": "misaligned_markers",
+            "message": "File has 19 misaligned markers"
+          }
+        ]
+      },
+      "/workspace/devsynth/tests/behavior/steps/test_webui_integration_steps.py": {
+        "file_path": "/workspace/devsynth/tests/behavior/steps/test_webui_integration_steps.py",
+        "has_pytest_import": true,
+        "test_functions": 0,
+        "markers": {},
+        "tests_with_markers": 0,
+        "tests_without_markers": 0,
+        "misaligned_markers": [
+          {
+            "line": 154,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 160,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 169,
             "marker": "medium",
             "text": "@pytest.mark.medium"
           },
@@ -16583,27 +3788,37 @@
             "text": "@pytest.mark.medium"
           },
           {
-            "line": 191,
+            "line": 192,
             "marker": "medium",
             "text": "@pytest.mark.medium"
           },
           {
-            "line": 200,
+            "line": 204,
             "marker": "medium",
             "text": "@pytest.mark.medium"
           },
           {
-            "line": 224,
+            "line": 213,
             "marker": "medium",
             "text": "@pytest.mark.medium"
           },
           {
-            "line": 240,
+            "line": 222,
             "marker": "medium",
             "text": "@pytest.mark.medium"
           },
           {
-            "line": 249,
+            "line": 231,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 241,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 251,
             "marker": "medium",
             "text": "@pytest.mark.medium"
           },
@@ -16613,42 +3828,77 @@
             "text": "@pytest.mark.medium"
           },
           {
-            "line": 271,
+            "line": 290,
             "marker": "medium",
             "text": "@pytest.mark.medium"
           },
           {
-            "line": 279,
+            "line": 312,
             "marker": "medium",
             "text": "@pytest.mark.medium"
           },
           {
-            "line": 289,
+            "line": 322,
             "marker": "medium",
             "text": "@pytest.mark.medium"
           },
           {
-            "line": 310,
+            "line": 334,
             "marker": "medium",
             "text": "@pytest.mark.medium"
           },
           {
-            "line": 319,
+            "line": 360,
             "marker": "medium",
             "text": "@pytest.mark.medium"
           },
           {
-            "line": 357,
+            "line": 387,
             "marker": "medium",
             "text": "@pytest.mark.medium"
           },
           {
-            "line": 364,
+            "line": 397,
             "marker": "medium",
             "text": "@pytest.mark.medium"
           },
           {
-            "line": 373,
+            "line": 407,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 441,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 464,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 492,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 521,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 532,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 545,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 570,
             "marker": "medium",
             "text": "@pytest.mark.medium"
           }
@@ -16658,22 +3908,103 @@
         "issues": [
           {
             "type": "misaligned_markers",
-            "message": "File has 24 misaligned markers"
+            "message": "File has 28 misaligned markers"
           }
         ]
       },
-      "/workspace/devsynth/tests/behavior/steps/test_performance_testing_steps.py": {
-        "file_path": "/workspace/devsynth/tests/behavior/steps/test_performance_testing_steps.py",
+      "/workspace/devsynth/tests/behavior/steps/test_requirements_gathering_steps.py": {
+        "file_path": "/workspace/devsynth/tests/behavior/steps/test_requirements_gathering_steps.py",
         "has_pytest_import": true,
-        "test_functions": 1,
-        "markers": {
-          "test_project_loaded_succeeds": "medium"
-        },
-        "tests_with_markers": 1,
+        "test_functions": 0,
+        "markers": {},
+        "tests_with_markers": 0,
         "tests_without_markers": 0,
         "misaligned_markers": [
           {
-            "line": 58,
+            "line": 46,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 52,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 70,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 76,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 100,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          }
+        ],
+        "duplicate_markers": [],
+        "recognized_markers": {},
+        "issues": [
+          {
+            "type": "misaligned_markers",
+            "message": "File has 5 misaligned markers"
+          }
+        ]
+      },
+      "/workspace/devsynth/tests/behavior/steps/test_webui_refactor_steps.py": {
+        "file_path": "/workspace/devsynth/tests/behavior/steps/test_webui_refactor_steps.py",
+        "has_pytest_import": true,
+        "test_functions": 0,
+        "markers": {},
+        "tests_with_markers": 0,
+        "tests_without_markers": 0,
+        "misaligned_markers": [
+          {
+            "line": 9,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 15,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 22,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 28,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 35,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 41,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 47,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 56,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 62,
             "marker": "medium",
             "text": "@pytest.mark.medium"
           },
@@ -16683,12 +4014,724 @@
             "text": "@pytest.mark.medium"
           },
           {
-            "line": 77,
+            "line": 78,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 85,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 92,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 99,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 106,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 113,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 120,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 127,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 134,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          }
+        ],
+        "duplicate_markers": [],
+        "recognized_markers": {},
+        "issues": [
+          {
+            "type": "misaligned_markers",
+            "message": "File has 19 misaligned markers"
+          }
+        ]
+      },
+      "/workspace/devsynth/tests/behavior/steps/test_webui_webapp_steps.py": {
+        "file_path": "/workspace/devsynth/tests/behavior/steps/test_webui_webapp_steps.py",
+        "has_pytest_import": true,
+        "test_functions": 0,
+        "markers": {},
+        "tests_with_markers": 0,
+        "tests_without_markers": 0,
+        "misaligned_markers": [
+          {
+            "line": 9,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 15,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 22,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 28,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 37,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 43,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 52,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 58,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 65,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 74,
             "marker": "medium",
             "text": "@pytest.mark.medium"
           },
           {
             "line": 83,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 90,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 97,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 104,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 112,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 120,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 127,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 134,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 141,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 148,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          }
+        ],
+        "duplicate_markers": [],
+        "recognized_markers": {},
+        "issues": [
+          {
+            "type": "misaligned_markers",
+            "message": "File has 20 misaligned markers"
+          }
+        ]
+      },
+      "/workspace/devsynth/tests/behavior/steps/test_chromadb_integration_steps.py": {
+        "file_path": "/workspace/devsynth/tests/behavior/steps/test_chromadb_integration_steps.py",
+        "has_pytest_import": true,
+        "test_functions": 0,
+        "markers": {},
+        "tests_with_markers": 0,
+        "tests_without_markers": 0,
+        "misaligned_markers": [
+          {
+            "line": 30,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 37,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 49,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          }
+        ],
+        "duplicate_markers": [],
+        "recognized_markers": {},
+        "issues": [
+          {
+            "type": "misaligned_markers",
+            "message": "File has 3 misaligned markers"
+          }
+        ]
+      },
+      "/workspace/devsynth/tests/behavior/steps/test_edrr_enhanced_recursion_steps.py": {
+        "file_path": "/workspace/devsynth/tests/behavior/steps/test_edrr_enhanced_recursion_steps.py",
+        "has_pytest_import": true,
+        "test_functions": 4,
+        "markers": {
+          "test_store_method_succeeds": "medium"
+        },
+        "tests_with_markers": 1,
+        "tests_without_markers": 3,
+        "misaligned_markers": [
+          {
+            "line": 143,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 144,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 145,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 146,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 147,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 148,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 254,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 255,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 256,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 257,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 258,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 259,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 302,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 303,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 304,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 305,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 306,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 307,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 659,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 660,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 661,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 662,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 663,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 664,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          }
+        ],
+        "duplicate_markers": [
+          {
+            "test_name": "test_store_method_succeeds",
+            "marker_count": 36
+          },
+          {
+            "test_name": "test_store_method_succeeds",
+            "marker_count": 36
+          },
+          {
+            "test_name": "test_store_method_succeeds",
+            "marker_count": 36
+          },
+          {
+            "test_name": "test_store_method_succeeds",
+            "marker_count": 36
+          }
+        ],
+        "recognized_markers": {
+          "medium": {
+            "file_count": 1,
+            "pytest_count": 11,
+            "recognized": false,
+            "registered_in_pytest_ini": true,
+            "uncollected_tests": [
+              "test_store_method_succeeds"
+            ]
+          }
+        },
+        "issues": [
+          {
+            "type": "misaligned_markers",
+            "message": "File has 24 misaligned markers"
+          },
+          {
+            "type": "duplicate_markers",
+            "message": "File has 4 tests with duplicate markers"
+          },
+          {
+            "type": "unrecognized_markers",
+            "message": "medium markers are not recognized by pytest (1 in file, 11 recognized)"
+          }
+        ]
+      },
+      "/workspace/devsynth/tests/behavior/steps/test_code_transformer_steps.py": {
+        "file_path": "/workspace/devsynth/tests/behavior/steps/test_code_transformer_steps.py",
+        "has_pytest_import": true,
+        "test_functions": 0,
+        "markers": {},
+        "tests_with_markers": 0,
+        "tests_without_markers": 0,
+        "misaligned_markers": [
+          {
+            "line": 43,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 51,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 59,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 74,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 81,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 96,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 111,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 120,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 132,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 145,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 161,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 174,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 185,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 202,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 216,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 224,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 249,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 266,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 291,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 315,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 338,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 347,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 362,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 377,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 386,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 417,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 430,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 445,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 455,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 473,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 483,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 518,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 531,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 547,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 558,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 567,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 576,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 585,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 596,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 606,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 621,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 630,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 639,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 651,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 659,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 671,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 680,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 690,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 703,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 711,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 723,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 733,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 741,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          }
+        ],
+        "duplicate_markers": [],
+        "recognized_markers": {},
+        "issues": [
+          {
+            "type": "misaligned_markers",
+            "message": "File has 53 misaligned markers"
+          }
+        ]
+      },
+      "/workspace/devsynth/tests/behavior/steps/test_user_guide_enhancement_steps.py": {
+        "file_path": "/workspace/devsynth/tests/behavior/steps/test_user_guide_enhancement_steps.py",
+        "has_pytest_import": true,
+        "test_functions": 0,
+        "markers": {},
+        "tests_with_markers": 0,
+        "tests_without_markers": 0,
+        "misaligned_markers": [
+          {
+            "line": 29,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 37,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 43,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 57,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 64,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 72,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 81,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 87,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 94,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 101,
             "marker": "medium",
             "text": "@pytest.mark.medium"
           },
@@ -16703,7 +4746,27 @@
             "text": "@pytest.mark.medium"
           },
           {
-            "line": 138,
+            "line": 122,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 127,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 132,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 139,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 147,
             "marker": "medium",
             "text": "@pytest.mark.medium"
           },
@@ -16713,15 +4776,522 @@
             "text": "@pytest.mark.medium"
           },
           {
-            "line": 167,
+            "line": 158,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 163,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 168,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 173,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 178,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 183,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 191,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 200,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 218,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 228,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 238,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 248,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 256,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          }
+        ],
+        "duplicate_markers": [],
+        "recognized_markers": {},
+        "issues": [
+          {
+            "type": "misaligned_markers",
+            "message": "File has 31 misaligned markers"
+          }
+        ]
+      },
+      "/workspace/devsynth/tests/behavior/steps/test_config_enable_feature_steps.py": {
+        "file_path": "/workspace/devsynth/tests/behavior/steps/test_config_enable_feature_steps.py",
+        "has_pytest_import": true,
+        "test_functions": 0,
+        "markers": {},
+        "tests_with_markers": 0,
+        "tests_without_markers": 0,
+        "misaligned_markers": [
+          {
+            "line": 26,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 39,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 50,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          }
+        ],
+        "duplicate_markers": [],
+        "recognized_markers": {},
+        "issues": [
+          {
+            "type": "misaligned_markers",
+            "message": "File has 3 misaligned markers"
+          }
+        ]
+      },
+      "/workspace/devsynth/tests/behavior/steps/test_non_hierarchical_collaboration_steps.py": {
+        "file_path": "/workspace/devsynth/tests/behavior/steps/test_non_hierarchical_collaboration_steps.py",
+        "has_pytest_import": true,
+        "test_functions": 0,
+        "markers": {},
+        "tests_with_markers": 0,
+        "tests_without_markers": 0,
+        "misaligned_markers": [
+          {
+            "line": 55,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 91,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 105,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 117,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 138,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 157,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 175,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 199,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 216,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 256,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 273,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 287,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 306,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 321,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 340,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 387,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 398,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 413,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 438,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 472,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 506,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 527,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 546,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 561,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 582,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 603,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 627,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 642,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 656,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 673,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 715,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 734,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          }
+        ],
+        "duplicate_markers": [],
+        "recognized_markers": {},
+        "issues": [
+          {
+            "type": "misaligned_markers",
+            "message": "File has 32 misaligned markers"
+          }
+        ]
+      },
+      "/workspace/devsynth/tests/behavior/steps/test_mddr_identifying_conflicts_steps.py": {
+        "file_path": "/workspace/devsynth/tests/behavior/steps/test_mddr_identifying_conflicts_steps.py",
+        "has_pytest_import": true,
+        "test_functions": 0,
+        "markers": {},
+        "tests_with_markers": 0,
+        "tests_without_markers": 0,
+        "misaligned_markers": [
+          {
+            "line": 9,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 64,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 127,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 141,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 162,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 202,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          }
+        ],
+        "duplicate_markers": [],
+        "recognized_markers": {},
+        "issues": [
+          {
+            "type": "misaligned_markers",
+            "message": "File has 6 misaligned markers"
+          }
+        ]
+      },
+      "/workspace/devsynth/tests/behavior/steps/test_webui_docs_generation_steps.py": {
+        "file_path": "/workspace/devsynth/tests/behavior/steps/test_webui_docs_generation_steps.py",
+        "has_pytest_import": true,
+        "test_functions": 0,
+        "markers": {},
+        "tests_with_markers": 0,
+        "tests_without_markers": 0,
+        "misaligned_markers": [
+          {
+            "line": 9,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 15,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 21,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 30,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 39,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 45,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 54,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 61,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 70,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 78,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 86,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 93,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 100,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 107,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          }
+        ],
+        "duplicate_markers": [],
+        "recognized_markers": {},
+        "issues": [
+          {
+            "type": "misaligned_markers",
+            "message": "File has 14 misaligned markers"
+          }
+        ]
+      },
+      "/workspace/devsynth/tests/behavior/steps/test_wsde_memory_integration_fixed2_steps.py": {
+        "file_path": "/workspace/devsynth/tests/behavior/steps/test_wsde_memory_integration_fixed2_steps.py",
+        "has_pytest_import": true,
+        "test_functions": 1,
+        "markers": {
+          "test_function": "medium"
+        },
+        "tests_with_markers": 1,
+        "tests_without_markers": 0,
+        "misaligned_markers": [
+          {
+            "line": 561,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 562,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 563,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 564,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 565,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 566,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 567,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 568,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 569,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 570,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 571,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 572,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 573,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 574,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 575,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 576,
             "marker": "medium",
             "text": "@pytest.mark.medium"
           }
         ],
         "duplicate_markers": [
           {
-            "test_name": "test_project_loaded_succeeds",
-            "marker_count": 2
+            "test_name": "test_function",
+            "marker_count": 9
           }
         ],
         "recognized_markers": {
@@ -16730,14 +5300,14 @@
             "pytest_count": 0,
             "recognized": false,
             "registered_in_pytest_ini": true,
-            "error": "subprocess error: 4",
+            "error": "exit code 2",
             "uncollected_tests": []
           }
         },
         "issues": [
           {
             "type": "misaligned_markers",
-            "message": "File has 9 misaligned markers"
+            "message": "File has 16 misaligned markers"
           },
           {
             "type": "duplicate_markers",
@@ -16746,6 +5316,343 @@
           {
             "type": "unrecognized_markers",
             "message": "medium markers are not recognized by pytest (1 in file, 0 recognized)"
+          },
+          {
+            "type": "pytest_error",
+            "marker": "medium",
+            "message": "pytest collection failed for /workspace/devsynth/tests/behavior/steps/test_wsde_memory_integration_fixed2_steps.py [marker=medium]: exit code 2"
+          }
+        ]
+      },
+      "/workspace/devsynth/tests/behavior/steps/test_mddr_common_steps.py": {
+        "file_path": "/workspace/devsynth/tests/behavior/steps/test_mddr_common_steps.py",
+        "has_pytest_import": true,
+        "test_functions": 0,
+        "markers": {},
+        "tests_with_markers": 0,
+        "tests_without_markers": 0,
+        "misaligned_markers": [
+          {
+            "line": 44,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 82,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 119,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          }
+        ],
+        "duplicate_markers": [],
+        "recognized_markers": {},
+        "issues": [
+          {
+            "type": "misaligned_markers",
+            "message": "File has 3 misaligned markers"
+          }
+        ]
+      },
+      "/workspace/devsynth/tests/behavior/steps/test_requirement_analysis_steps.py": {
+        "file_path": "/workspace/devsynth/tests/behavior/steps/test_requirement_analysis_steps.py",
+        "has_pytest_import": true,
+        "test_functions": 0,
+        "markers": {},
+        "tests_with_markers": 0,
+        "tests_without_markers": 0,
+        "misaligned_markers": [
+          {
+            "line": 14,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 24,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 54,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 73,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 84,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 130,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 150,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          }
+        ],
+        "duplicate_markers": [],
+        "recognized_markers": {},
+        "issues": [
+          {
+            "type": "misaligned_markers",
+            "message": "File has 7 misaligned markers"
+          }
+        ]
+      },
+      "/workspace/devsynth/tests/behavior/steps/test_webui_ingestion_steps.py": {
+        "file_path": "/workspace/devsynth/tests/behavior/steps/test_webui_ingestion_steps.py",
+        "has_pytest_import": true,
+        "test_functions": 0,
+        "markers": {},
+        "tests_with_markers": 0,
+        "tests_without_markers": 0,
+        "misaligned_markers": [
+          {
+            "line": 9,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 15,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 21,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 28,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 37,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 43,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 50,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 57,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 66,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 73,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 82,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 89,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 96,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 104,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 111,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 118,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          }
+        ],
+        "duplicate_markers": [],
+        "recognized_markers": {},
+        "issues": [
+          {
+            "type": "misaligned_markers",
+            "message": "File has 16 misaligned markers"
+          }
+        ]
+      },
+      "/workspace/devsynth/tests/behavior/steps/test_webui_gather_wizard_steps.py": {
+        "file_path": "/workspace/devsynth/tests/behavior/steps/test_webui_gather_wizard_steps.py",
+        "has_pytest_import": true,
+        "test_functions": 0,
+        "markers": {},
+        "tests_with_markers": 0,
+        "tests_without_markers": 0,
+        "misaligned_markers": [
+          {
+            "line": 18,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 25,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 148,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 159,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 168,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 176,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 218,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 228,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 242,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 254,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 266,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 287,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 313,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 321,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 329,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 338,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 352,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 362,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 369,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 380,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 391,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 398,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 405,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 417,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 438,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 467,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          }
+        ],
+        "duplicate_markers": [],
+        "recognized_markers": {},
+        "issues": [
+          {
+            "type": "misaligned_markers",
+            "message": "File has 26 misaligned markers"
           }
         ]
       },
@@ -16967,616 +5874,6 @@
           }
         ]
       },
-      "/workspace/devsynth/tests/behavior/steps/test_consensus_building_steps.py": {
-        "file_path": "/workspace/devsynth/tests/behavior/steps/test_consensus_building_steps.py",
-        "has_pytest_import": true,
-        "test_functions": 0,
-        "markers": {},
-        "tests_with_markers": 0,
-        "tests_without_markers": 0,
-        "misaligned_markers": [
-          {
-            "line": 51,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 89,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 103,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 115,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 177,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 188,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 207,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 250,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 267,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 289,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 341,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 352,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 369,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 386,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 419,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 434,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 449,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 493,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 504,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 532,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 552,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 570,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 585,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 627,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 646,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 661,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 679,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 701,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 717,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 770,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 791,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 811,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 832,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 852,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 879,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          }
-        ],
-        "duplicate_markers": [],
-        "recognized_markers": {},
-        "issues": [
-          {
-            "type": "misaligned_markers",
-            "message": "File has 35 misaligned markers"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/behavior/steps/test_memory_backend_integration_steps.py": {
-        "file_path": "/workspace/devsynth/tests/behavior/steps/test_memory_backend_integration_steps.py",
-        "has_pytest_import": true,
-        "test_functions": 1,
-        "markers": {
-          "test_cross_backend": "medium"
-        },
-        "tests_with_markers": 1,
-        "tests_without_markers": 0,
-        "misaligned_markers": [
-          {
-            "line": 86,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 94,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 105,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 116,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 137,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 166,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 200,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 241,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 258,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 275,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 296,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 345,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 372,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 401,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 438,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 482,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 520,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 546,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 587,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 624,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 644,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 676,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 698,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 720,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 737,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          }
-        ],
-        "duplicate_markers": [],
-        "recognized_markers": {
-          "medium": {
-            "file_count": 1,
-            "pytest_count": 0,
-            "recognized": false,
-            "registered_in_pytest_ini": true,
-            "error": "subprocess error: 4",
-            "uncollected_tests": []
-          }
-        },
-        "issues": [
-          {
-            "type": "misaligned_markers",
-            "message": "File has 25 misaligned markers"
-          },
-          {
-            "type": "unrecognized_markers",
-            "message": "medium markers are not recognized by pytest (1 in file, 0 recognized)"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/behavior/steps/test_user_guide_enhancement_steps.py": {
-        "file_path": "/workspace/devsynth/tests/behavior/steps/test_user_guide_enhancement_steps.py",
-        "has_pytest_import": true,
-        "test_functions": 0,
-        "markers": {},
-        "tests_with_markers": 0,
-        "tests_without_markers": 0,
-        "misaligned_markers": [
-          {
-            "line": 29,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 37,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 43,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 57,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 64,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 72,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 81,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 87,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 94,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 101,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 108,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 116,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 122,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 127,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 132,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 139,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 147,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 153,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 158,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 163,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 168,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 173,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 178,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 183,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 191,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 200,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 218,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 228,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 238,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 248,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 256,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          }
-        ],
-        "duplicate_markers": [],
-        "recognized_markers": {},
-        "issues": [
-          {
-            "type": "misaligned_markers",
-            "message": "File has 31 misaligned markers"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/behavior/steps/test_api_stub_steps.py": {
-        "file_path": "/workspace/devsynth/tests/behavior/steps/test_api_stub_steps.py",
-        "has_pytest_import": true,
-        "test_functions": 0,
-        "markers": {},
-        "tests_with_markers": 0,
-        "tests_without_markers": 0,
-        "misaligned_markers": [
-          {
-            "line": 25,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 31,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 38,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          }
-        ],
-        "duplicate_markers": [],
-        "recognized_markers": {},
-        "issues": [
-          {
-            "type": "misaligned_markers",
-            "message": "File has 3 misaligned markers"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/behavior/steps/test_dialectical_reasoning_impact_memory_persistence_steps.py": {
-        "file_path": "/workspace/devsynth/tests/behavior/steps/test_dialectical_reasoning_impact_memory_persistence_steps.py",
-        "has_pytest_import": true,
-        "test_functions": 0,
-        "markers": {},
-        "tests_with_markers": 0,
-        "tests_without_markers": 0,
-        "misaligned_markers": [
-          {
-            "line": 69,
-            "marker": "fast",
-            "text": "@pytest.mark.fast"
-          },
-          {
-            "line": 77,
-            "marker": "fast",
-            "text": "@pytest.mark.fast"
-          },
-          {
-            "line": 85,
-            "marker": "fast",
-            "text": "@pytest.mark.fast"
-          },
-          {
-            "line": 98,
-            "marker": "fast",
-            "text": "@pytest.mark.fast"
-          },
-          {
-            "line": 104,
-            "marker": "fast",
-            "text": "@pytest.mark.fast"
-          },
-          {
-            "line": 118,
-            "marker": "fast",
-            "text": "@pytest.mark.fast"
-          },
-          {
-            "line": 124,
-            "marker": "fast",
-            "text": "@pytest.mark.fast"
-          }
-        ],
-        "duplicate_markers": [],
-        "recognized_markers": {},
-        "issues": [
-          {
-            "type": "misaligned_markers",
-            "message": "File has 7 misaligned markers"
-          }
-        ]
-      },
       "/workspace/devsynth/tests/behavior/steps/test_webui_analysis_steps.py": {
         "file_path": "/workspace/devsynth/tests/behavior/steps/test_webui_analysis_steps.py",
         "has_pytest_import": true,
@@ -17690,8 +5987,8 @@
           }
         ]
       },
-      "/workspace/devsynth/tests/behavior/steps/test_workflow_execution_steps.py": {
-        "file_path": "/workspace/devsynth/tests/behavior/steps/test_workflow_execution_steps.py",
+      "/workspace/devsynth/tests/behavior/steps/test_project_init_steps.py": {
+        "file_path": "/workspace/devsynth/tests/behavior/steps/test_project_init_steps.py",
         "has_pytest_import": true,
         "test_functions": 0,
         "markers": {},
@@ -17704,2426 +6001,17 @@
             "text": "@pytest.mark.medium"
           },
           {
-            "line": 27,
+            "line": 40,
             "marker": "medium",
             "text": "@pytest.mark.medium"
           },
           {
-            "line": 33,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          }
-        ],
-        "duplicate_markers": [],
-        "recognized_markers": {},
-        "issues": [
-          {
-            "type": "misaligned_markers",
-            "message": "File has 3 misaligned markers"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/behavior/steps/test_webui_requirements_wizard_with_state_steps.py": {
-        "file_path": "/workspace/devsynth/tests/behavior/steps/test_webui_requirements_wizard_with_state_steps.py",
-        "has_pytest_import": true,
-        "test_functions": 0,
-        "markers": {},
-        "tests_with_markers": 0,
-        "tests_without_markers": 0,
-        "misaligned_markers": [
-          {
-            "line": 274,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 282,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 290,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 301,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 309,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 317,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 344,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 354,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 365,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 384,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 404,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 418,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 433,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 440,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 449,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 460,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 471,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 481,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 490,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 500,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 511,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 518,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 529,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 560,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 568,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          }
-        ],
-        "duplicate_markers": [],
-        "recognized_markers": {},
-        "issues": [
-          {
-            "type": "misaligned_markers",
-            "message": "File has 25 misaligned markers"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/behavior/steps/test_mddr_gathering_perspectives_steps.py": {
-        "file_path": "/workspace/devsynth/tests/behavior/steps/test_mddr_gathering_perspectives_steps.py",
-        "has_pytest_import": true,
-        "test_functions": 0,
-        "markers": {},
-        "tests_with_markers": 0,
-        "tests_without_markers": 0,
-        "misaligned_markers": [
-          {
-            "line": 9,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 31,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 41,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 48,
+            "line": 49,
             "marker": "medium",
             "text": "@pytest.mark.medium"
           },
           {
             "line": 58,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 65,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 77,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 84,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 156,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 181,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 260,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 307,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          }
-        ],
-        "duplicate_markers": [],
-        "recognized_markers": {},
-        "issues": [
-          {
-            "type": "misaligned_markers",
-            "message": "File has 12 misaligned markers"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/behavior/steps/test_webui_webapp_steps.py": {
-        "file_path": "/workspace/devsynth/tests/behavior/steps/test_webui_webapp_steps.py",
-        "has_pytest_import": true,
-        "test_functions": 0,
-        "markers": {},
-        "tests_with_markers": 0,
-        "tests_without_markers": 0,
-        "misaligned_markers": [
-          {
-            "line": 9,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 15,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 22,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 28,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 37,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 43,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 52,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 58,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 65,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 74,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 83,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 90,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 97,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 104,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 112,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 120,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 127,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 134,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 141,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 148,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          }
-        ],
-        "duplicate_markers": [],
-        "recognized_markers": {},
-        "issues": [
-          {
-            "type": "misaligned_markers",
-            "message": "File has 20 misaligned markers"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/behavior/steps/test_code_generation_steps.py": {
-        "file_path": "/workspace/devsynth/tests/behavior/steps/test_code_generation_steps.py",
-        "has_pytest_import": true,
-        "test_functions": 1,
-        "markers": {
-          "test_dummy": "medium"
-        },
-        "tests_with_markers": 1,
-        "tests_without_markers": 0,
-        "misaligned_markers": [
-          {
-            "line": 21,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 39,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 50,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 62,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 69,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 77,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 84,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 90,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 96,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 102,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          }
-        ],
-        "duplicate_markers": [],
-        "recognized_markers": {
-          "medium": {
-            "file_count": 1,
-            "pytest_count": 0,
-            "recognized": false,
-            "registered_in_pytest_ini": true,
-            "error": "subprocess error: 4",
-            "uncollected_tests": []
-          }
-        },
-        "issues": [
-          {
-            "type": "misaligned_markers",
-            "message": "File has 10 misaligned markers"
-          },
-          {
-            "type": "unrecognized_markers",
-            "message": "medium markers are not recognized by pytest (1 in file, 0 recognized)"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/behavior/steps/test_doctor_steps.py": {
-        "file_path": "/workspace/devsynth/tests/behavior/steps/test_doctor_steps.py",
-        "has_pytest_import": true,
-        "test_functions": 0,
-        "markers": {},
-        "tests_with_markers": 0,
-        "tests_without_markers": 0,
-        "misaligned_markers": [
-          {
-            "line": 8,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 16,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          }
-        ],
-        "duplicate_markers": [],
-        "recognized_markers": {},
-        "issues": [
-          {
-            "type": "misaligned_markers",
-            "message": "File has 2 misaligned markers"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/behavior/steps/test_delegate_task_steps.py": {
-        "file_path": "/workspace/devsynth/tests/behavior/steps/test_delegate_task_steps.py",
-        "has_pytest_import": true,
-        "test_functions": 0,
-        "markers": {},
-        "tests_with_markers": 0,
-        "tests_without_markers": 0,
-        "misaligned_markers": [
-          {
-            "line": 81,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 96,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 105,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 112,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 119,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 127,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 135,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 141,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 147,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          }
-        ],
-        "duplicate_markers": [],
-        "recognized_markers": {},
-        "issues": [
-          {
-            "type": "misaligned_markers",
-            "message": "File has 9 misaligned markers"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/behavior/steps/test_webui_synthesis_steps.py": {
-        "file_path": "/workspace/devsynth/tests/behavior/steps/test_webui_synthesis_steps.py",
-        "has_pytest_import": true,
-        "test_functions": 2,
-        "markers": {
-          "test_generation_executed": "medium",
-          "test_generation_executed_custom": "medium"
-        },
-        "tests_with_markers": 2,
-        "tests_without_markers": 0,
-        "misaligned_markers": [
-          {
-            "line": 206,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 212,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 222,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 230,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 237,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 248,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 259,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 270,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 277,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 289,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 303,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 310,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 317,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 324,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 342,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 349,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 355,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 362,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 385,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 395,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 401,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 408,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          }
-        ],
-        "duplicate_markers": [
-          {
-            "test_name": "test_generation_executed",
-            "marker_count": 2
-          },
-          {
-            "test_name": "test_generation_executed_custom",
-            "marker_count": 2
-          }
-        ],
-        "recognized_markers": {
-          "medium": {
-            "file_count": 2,
-            "pytest_count": 0,
-            "recognized": false,
-            "registered_in_pytest_ini": true,
-            "error": "subprocess error: 4",
-            "uncollected_tests": []
-          }
-        },
-        "issues": [
-          {
-            "type": "misaligned_markers",
-            "message": "File has 22 misaligned markers"
-          },
-          {
-            "type": "duplicate_markers",
-            "message": "File has 2 tests with duplicate markers"
-          },
-          {
-            "type": "unrecognized_markers",
-            "message": "medium markers are not recognized by pytest (2 in file, 0 recognized)"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/behavior/steps/test_generate_docs_steps.py": {
-        "file_path": "/workspace/devsynth/tests/behavior/steps/test_generate_docs_steps.py",
-        "has_pytest_import": true,
-        "test_functions": 0,
-        "markers": {},
-        "tests_with_markers": 0,
-        "tests_without_markers": 0,
-        "misaligned_markers": [
-          {
-            "line": 31,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 38,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 48,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          }
-        ],
-        "duplicate_markers": [],
-        "recognized_markers": {},
-        "issues": [
-          {
-            "type": "misaligned_markers",
-            "message": "File has 3 misaligned markers"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/behavior/steps/test_mddr_identifying_conflicts_steps.py": {
-        "file_path": "/workspace/devsynth/tests/behavior/steps/test_mddr_identifying_conflicts_steps.py",
-        "has_pytest_import": true,
-        "test_functions": 0,
-        "markers": {},
-        "tests_with_markers": 0,
-        "tests_without_markers": 0,
-        "misaligned_markers": [
-          {
-            "line": 9,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 64,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 127,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 141,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 162,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 202,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          }
-        ],
-        "duplicate_markers": [],
-        "recognized_markers": {},
-        "issues": [
-          {
-            "type": "misaligned_markers",
-            "message": "File has 6 misaligned markers"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/behavior/steps/test_edrr_real_llm_integration_steps.py": {
-        "file_path": "/workspace/devsynth/tests/behavior/steps/test_edrr_real_llm_integration_steps.py",
-        "has_pytest_import": true,
-        "test_functions": 0,
-        "markers": {},
-        "tests_with_markers": 0,
-        "tests_without_markers": 0,
-        "misaligned_markers": [
-          {
-            "line": 68,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 93,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 136,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 150,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 164,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 179,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 192,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 205,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 218,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 237,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 253,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 269,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 296,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 316,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          }
-        ],
-        "duplicate_markers": [],
-        "recognized_markers": {},
-        "issues": [
-          {
-            "type": "misaligned_markers",
-            "message": "File has 14 misaligned markers"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/behavior/steps/test_memory_steps.py": {
-        "file_path": "/workspace/devsynth/tests/behavior/steps/test_memory_steps.py",
-        "has_pytest_import": true,
-        "test_functions": 0,
-        "markers": {},
-        "tests_with_markers": 0,
-        "tests_without_markers": 0,
-        "misaligned_markers": [
-          {
-            "line": 19,
-            "marker": "fast",
-            "text": "@pytest.mark.fast"
-          },
-          {
-            "line": 25,
-            "marker": "fast",
-            "text": "@pytest.mark.fast"
-          },
-          {
-            "line": 32,
-            "marker": "fast",
-            "text": "@pytest.mark.fast"
-          },
-          {
-            "line": 38,
-            "marker": "fast",
-            "text": "@pytest.mark.fast"
-          }
-        ],
-        "duplicate_markers": [],
-        "recognized_markers": {},
-        "issues": [
-          {
-            "type": "misaligned_markers",
-            "message": "File has 4 misaligned markers"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/behavior/steps/test_edrr_enhanced_memory_integration_steps.py": {
-        "file_path": "/workspace/devsynth/tests/behavior/steps/test_edrr_enhanced_memory_integration_steps.py",
-        "has_pytest_import": true,
-        "test_functions": 4,
-        "markers": {
-          "test_store_method_succeeds": "medium"
-        },
-        "tests_with_markers": 1,
-        "tests_without_markers": 3,
-        "misaligned_markers": [
-          {
-            "line": 59,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 87,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 95,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 103,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 113,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 121,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 131,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 139,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 224,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 231,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 238,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 306,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 315,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 339,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 358,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 374,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 396,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 428,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 448,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 468,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 526,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 546,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 578,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 605,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 629,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 709,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 730,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 775,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 782,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 793,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 803,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 814,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 828,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 840,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 868,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 919,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 930,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 940,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 949,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 960,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 973,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 1082,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 1094,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 1103,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 1111,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 1118,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 1125,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 1133,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 1142,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 1167,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 1176,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 1185,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 1194,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 1203,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 1212,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 1222,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 1243,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 1255,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 1280,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 1290,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 1300,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 1312,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 1322,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 1331,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 1351,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 1360,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 1369,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 1378,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 1389,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 1415,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 1424,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 1443,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          }
-        ],
-        "duplicate_markers": [
-          {
-            "test_name": "test_store_method_succeeds",
-            "marker_count": 5
-          },
-          {
-            "test_name": "test_store_method_succeeds",
-            "marker_count": 5
-          },
-          {
-            "test_name": "test_store_method_succeeds",
-            "marker_count": 5
-          },
-          {
-            "test_name": "test_store_method_succeeds",
-            "marker_count": 5
-          }
-        ],
-        "recognized_markers": {
-          "medium": {
-            "file_count": 1,
-            "pytest_count": 0,
-            "recognized": false,
-            "registered_in_pytest_ini": true,
-            "error": "subprocess error: 4",
-            "uncollected_tests": []
-          }
-        },
-        "issues": [
-          {
-            "type": "misaligned_markers",
-            "message": "File has 72 misaligned markers"
-          },
-          {
-            "type": "duplicate_markers",
-            "message": "File has 4 tests with duplicate markers"
-          },
-          {
-            "type": "unrecognized_markers",
-            "message": "medium markers are not recognized by pytest (1 in file, 0 recognized)"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/behavior/steps/test_webui_config_steps.py": {
-        "file_path": "/workspace/devsynth/tests/behavior/steps/test_webui_config_steps.py",
-        "has_pytest_import": true,
-        "test_functions": 0,
-        "markers": {},
-        "tests_with_markers": 0,
-        "tests_without_markers": 0,
-        "misaligned_markers": [
-          {
-            "line": 222,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 228,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 238,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 246,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 253,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 269,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 285,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 301,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 308,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 317,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 326,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 333,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 340,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 352,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 359,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 367,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 375,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 382,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 389,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 395,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 401,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 413,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 419,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 425,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 434,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 440,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 447,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 454,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          }
-        ],
-        "duplicate_markers": [],
-        "recognized_markers": {},
-        "issues": [
-          {
-            "type": "misaligned_markers",
-            "message": "File has 28 misaligned markers"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/behavior/steps/test_agent_api_steps.py": {
-        "file_path": "/workspace/devsynth/tests/behavior/steps/test_agent_api_steps.py",
-        "has_pytest_import": true,
-        "test_functions": 1,
-        "markers": {
-          "test_cmd": "medium"
-        },
-        "tests_with_markers": 1,
-        "tests_without_markers": 0,
-        "misaligned_markers": [
-          {
-            "line": 89,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 96,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 102,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 111,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 117,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 127,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 135,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 142,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 154,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 162,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 168,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 174,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 180,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 186,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 192,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 198,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 204,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 210,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 216,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 222,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 228,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 234,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 240,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 246,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          }
-        ],
-        "duplicate_markers": [],
-        "recognized_markers": {
-          "medium": {
-            "file_count": 1,
-            "pytest_count": 0,
-            "recognized": false,
-            "registered_in_pytest_ini": true,
-            "error": "subprocess error: 4",
-            "uncollected_tests": []
-          }
-        },
-        "issues": [
-          {
-            "type": "misaligned_markers",
-            "message": "File has 24 misaligned markers"
-          },
-          {
-            "type": "unrecognized_markers",
-            "message": "medium markers are not recognized by pytest (1 in file, 0 recognized)"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/behavior/steps/test_simple_coordinator_steps.py": {
-        "file_path": "/workspace/devsynth/tests/behavior/steps/test_simple_coordinator_steps.py",
-        "has_pytest_import": true,
-        "test_functions": 4,
-        "markers": {
-          "test_store_method_succeeds": "medium"
-        },
-        "tests_with_markers": 1,
-        "tests_without_markers": 3,
-        "misaligned_markers": [
-          {
-            "line": 60,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 88,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 96,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 104,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 114,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 122,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 132,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 140,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 225,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 232,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 239,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 307,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 316,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 340,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 359,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 375,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 397,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 429,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 449,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 469,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 527,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 547,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 579,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 606,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 630,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 710,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 731,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 776,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 783,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 794,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 804,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 815,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 829,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 841,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 869,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 920,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 931,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 941,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 950,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 961,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 974,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          }
-        ],
-        "duplicate_markers": [
-          {
-            "test_name": "test_store_method_succeeds",
-            "marker_count": 5
-          },
-          {
-            "test_name": "test_store_method_succeeds",
-            "marker_count": 5
-          },
-          {
-            "test_name": "test_store_method_succeeds",
-            "marker_count": 5
-          },
-          {
-            "test_name": "test_store_method_succeeds",
-            "marker_count": 5
-          }
-        ],
-        "recognized_markers": {
-          "medium": {
-            "file_count": 1,
-            "pytest_count": 0,
-            "recognized": false,
-            "registered_in_pytest_ini": true,
-            "error": "subprocess error: 4",
-            "uncollected_tests": []
-          }
-        },
-        "issues": [
-          {
-            "type": "misaligned_markers",
-            "message": "File has 41 misaligned markers"
-          },
-          {
-            "type": "duplicate_markers",
-            "message": "File has 4 tests with duplicate markers"
-          },
-          {
-            "type": "unrecognized_markers",
-            "message": "medium markers are not recognized by pytest (1 in file, 0 recognized)"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/behavior/steps/test_run_pipeline_command_steps.py": {
-        "file_path": "/workspace/devsynth/tests/behavior/steps/test_run_pipeline_command_steps.py",
-        "has_pytest_import": true,
-        "test_functions": 2,
-        "markers": {
-          "test_add": "medium",
-          "test_subtract": "medium"
-        },
-        "tests_with_markers": 2,
-        "tests_without_markers": 0,
-        "misaligned_markers": [
-          {
-            "line": 85,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 93,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 103,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 249,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 258,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 265,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 273,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 283,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 291,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 299,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 309,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 323,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 331,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 341,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          }
-        ],
-        "duplicate_markers": [
-          {
-            "test_name": "test_subtract",
-            "marker_count": 2
-          }
-        ],
-        "recognized_markers": {
-          "medium": {
-            "file_count": 2,
-            "pytest_count": 0,
-            "recognized": false,
-            "registered_in_pytest_ini": true,
-            "error": "subprocess error: 4",
-            "uncollected_tests": []
-          }
-        },
-        "issues": [
-          {
-            "type": "misaligned_markers",
-            "message": "File has 14 misaligned markers"
-          },
-          {
-            "type": "duplicate_markers",
-            "message": "File has 1 tests with duplicate markers"
-          },
-          {
-            "type": "unrecognized_markers",
-            "message": "medium markers are not recognized by pytest (2 in file, 0 recognized)"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/behavior/steps/test_webui_spec_editor_steps.py": {
-        "file_path": "/workspace/devsynth/tests/behavior/steps/test_webui_spec_editor_steps.py",
-        "has_pytest_import": true,
-        "test_functions": 0,
-        "markers": {},
-        "tests_with_markers": 0,
-        "tests_without_markers": 0,
-        "misaligned_markers": [
-          {
-            "line": 8,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 23,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 29,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          }
-        ],
-        "duplicate_markers": [],
-        "recognized_markers": {},
-        "issues": [
-          {
-            "type": "misaligned_markers",
-            "message": "File has 3 misaligned markers"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/behavior/steps/test_refactor_command_steps.py": {
-        "file_path": "/workspace/devsynth/tests/behavior/steps/test_refactor_command_steps.py",
-        "has_pytest_import": true,
-        "test_functions": 0,
-        "markers": {},
-        "tests_with_markers": 0,
-        "tests_without_markers": 0,
-        "misaligned_markers": [
-          {
-            "line": 48,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 55,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 62,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 128,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 134,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 140,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 146,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 154,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 163,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 172,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 180,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 189,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 198,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          }
-        ],
-        "duplicate_markers": [],
-        "recognized_markers": {},
-        "issues": [
-          {
-            "type": "misaligned_markers",
-            "message": "File has 13 misaligned markers"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/behavior/steps/test_wsde_agent_model_steps.py": {
-        "file_path": "/workspace/devsynth/tests/behavior/steps/test_wsde_agent_model_steps.py",
-        "has_pytest_import": true,
-        "test_functions": 0,
-        "markers": {},
-        "tests_with_markers": 0,
-        "tests_without_markers": 0,
-        "misaligned_markers": [
-          {
-            "line": 44,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 52,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 63,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 74,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 100,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 111,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 124,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 201,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 238,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 251,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 278,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 358,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 417,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 443,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 457,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 496,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 529,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 580,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 606,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 625,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 653,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 688,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 715,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 733,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 745,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 783,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 816,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 867,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 918,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 929,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 935,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          }
-        ],
-        "duplicate_markers": [],
-        "recognized_markers": {},
-        "issues": [
-          {
-            "type": "misaligned_markers",
-            "message": "File has 31 misaligned markers"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/behavior/steps/test_training_materials_steps.py": {
-        "file_path": "/workspace/devsynth/tests/behavior/steps/test_training_materials_steps.py",
-        "has_pytest_import": true,
-        "test_functions": 0,
-        "markers": {},
-        "tests_with_markers": 0,
-        "tests_without_markers": 0,
-        "misaligned_markers": [
-          {
-            "line": 33,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 41,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 50,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 69,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 80,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 103,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 135,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 143,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 152,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 159,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 172,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 185,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 220,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 226,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 235,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          }
-        ],
-        "duplicate_markers": [],
-        "recognized_markers": {},
-        "issues": [
-          {
-            "type": "misaligned_markers",
-            "message": "File has 15 misaligned markers"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/behavior/steps/test_webui_serve_steps.py": {
-        "file_path": "/workspace/devsynth/tests/behavior/steps/test_webui_serve_steps.py",
-        "has_pytest_import": true,
-        "test_functions": 0,
-        "markers": {},
-        "tests_with_markers": 0,
-        "tests_without_markers": 0,
-        "misaligned_markers": [
-          {
-            "line": 9,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 15,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 21,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 30,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 38,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 47,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 54,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 63,
             "marker": "medium",
             "text": "@pytest.mark.medium"
           },
@@ -20131,81 +6019,6 @@
             "line": 70,
             "marker": "medium",
             "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 77,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 84,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 91,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 98,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 105,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 112,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 120,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 127,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 135,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 142,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 149,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 161,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 168,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 175,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 187,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
           }
         ],
         "duplicate_markers": [],
@@ -20213,1209 +6026,7 @@
         "issues": [
           {
             "type": "misaligned_markers",
-            "message": "File has 24 misaligned markers"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/behavior/steps/test_edrr_enhanced_recursion_steps.py": {
-        "file_path": "/workspace/devsynth/tests/behavior/steps/test_edrr_enhanced_recursion_steps.py",
-        "has_pytest_import": true,
-        "test_functions": 4,
-        "markers": {
-          "test_store_method_succeeds": "medium"
-        },
-        "tests_with_markers": 1,
-        "tests_without_markers": 3,
-        "misaligned_markers": [
-          {
-            "line": 61,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 89,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 97,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 105,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 115,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 123,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 133,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 141,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 226,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 233,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 240,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 308,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 317,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 341,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 360,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 376,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 398,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 430,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 450,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 470,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 528,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 548,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 580,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 607,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 631,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 711,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 732,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 777,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 784,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 795,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 805,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 816,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 830,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 842,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 870,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 921,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 932,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 942,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 951,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 962,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 975,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 1040,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 1102,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 1120,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 1140,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 1153,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 1167,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 1186,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 1207,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 1233,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 1250,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 1291,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 1357,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 1376,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 1405,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 1434,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 1514,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 1555,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 1568,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 1641,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 1682,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 1698,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 1713,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 1730,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 1743,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 1769,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 1786,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 1814,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 1854,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 1866,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 1877,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 1888,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 1899,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 1916,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 1971,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 2075,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 2109,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 2144,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 2195,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 2227,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          }
-        ],
-        "duplicate_markers": [
-          {
-            "test_name": "test_store_method_succeeds",
-            "marker_count": 5
-          },
-          {
-            "test_name": "test_store_method_succeeds",
-            "marker_count": 5
-          },
-          {
-            "test_name": "test_store_method_succeeds",
-            "marker_count": 5
-          },
-          {
-            "test_name": "test_store_method_succeeds",
-            "marker_count": 5
-          }
-        ],
-        "recognized_markers": {
-          "medium": {
-            "file_count": 1,
-            "pytest_count": 0,
-            "recognized": false,
-            "registered_in_pytest_ini": true,
-            "error": "subprocess error: 4",
-            "uncollected_tests": []
-          }
-        },
-        "issues": [
-          {
-            "type": "misaligned_markers",
-            "message": "File has 80 misaligned markers"
-          },
-          {
-            "type": "duplicate_markers",
-            "message": "File has 4 tests with duplicate markers"
-          },
-          {
-            "type": "unrecognized_markers",
-            "message": "medium markers are not recognized by pytest (1 in file, 0 recognized)"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/behavior/steps/test_edrr_coordinator_steps.py": {
-        "file_path": "/workspace/devsynth/tests/behavior/steps/test_edrr_coordinator_steps.py",
-        "has_pytest_import": true,
-        "test_functions": 4,
-        "markers": {
-          "test_store_method_succeeds": "medium"
-        },
-        "tests_with_markers": 1,
-        "tests_without_markers": 3,
-        "misaligned_markers": [
-          {
-            "line": 51,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 79,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 87,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 95,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 105,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 113,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 123,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 131,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 216,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 223,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 230,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 298,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 307,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 331,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 350,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 366,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 388,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 420,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 440,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 460,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 518,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 538,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 570,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 597,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 621,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 701,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 722,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 767,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 774,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 785,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 795,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 806,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 820,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 832,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 860,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 911,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 922,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 932,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 941,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 952,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 965,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          }
-        ],
-        "duplicate_markers": [
-          {
-            "test_name": "test_store_method_succeeds",
-            "marker_count": 5
-          },
-          {
-            "test_name": "test_store_method_succeeds",
-            "marker_count": 5
-          },
-          {
-            "test_name": "test_store_method_succeeds",
-            "marker_count": 5
-          },
-          {
-            "test_name": "test_store_method_succeeds",
-            "marker_count": 5
-          }
-        ],
-        "recognized_markers": {
-          "medium": {
-            "file_count": 1,
-            "pytest_count": 0,
-            "recognized": false,
-            "registered_in_pytest_ini": true,
-            "error": "subprocess error: 4",
-            "uncollected_tests": []
-          }
-        },
-        "issues": [
-          {
-            "type": "misaligned_markers",
-            "message": "File has 41 misaligned markers"
-          },
-          {
-            "type": "duplicate_markers",
-            "message": "File has 4 tests with duplicate markers"
-          },
-          {
-            "type": "unrecognized_markers",
-            "message": "medium markers are not recognized by pytest (1 in file, 0 recognized)"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/behavior/steps/test_wsde_message_passing_peer_review_steps.py": {
-        "file_path": "/workspace/devsynth/tests/behavior/steps/test_wsde_message_passing_peer_review_steps.py",
-        "has_pytest_import": true,
-        "test_functions": 1,
-        "markers": {
-          "test_example": "medium"
-        },
-        "tests_with_markers": 1,
-        "tests_without_markers": 0,
-        "misaligned_markers": [
-          {
-            "line": 33,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 39,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 48,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 54,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 76,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 94,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 101,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 108,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 114,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 125,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 134,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 142,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 148,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 166,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 177,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 184,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 190,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 218,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 229,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 235,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 243,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 254,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 260,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 269,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 276,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 283,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 290,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 310,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 320,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 327,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 353,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 382,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 411,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 436,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 471,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 505,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 526,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 544,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 583,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 617,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 649,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 661,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 673,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 685,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 703,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 711,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 718,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 725,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 732,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 738,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 745,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          }
-        ],
-        "duplicate_markers": [],
-        "recognized_markers": {
-          "medium": {
-            "file_count": 1,
-            "pytest_count": 0,
-            "recognized": false,
-            "registered_in_pytest_ini": true,
-            "error": "subprocess error: 4",
-            "uncollected_tests": []
-          }
-        },
-        "issues": [
-          {
-            "type": "misaligned_markers",
-            "message": "File has 51 misaligned markers"
-          },
-          {
-            "type": "unrecognized_markers",
-            "message": "medium markers are not recognized by pytest (1 in file, 0 recognized)"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/behavior/steps/test_project_initialization_steps.py": {
-        "file_path": "/workspace/devsynth/tests/behavior/steps/test_project_initialization_steps.py",
-        "has_pytest_import": true,
-        "test_functions": 0,
-        "markers": {},
-        "tests_with_markers": 0,
-        "tests_without_markers": 0,
-        "misaligned_markers": [
-          {
-            "line": 21,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 27,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 33,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          }
-        ],
-        "duplicate_markers": [],
-        "recognized_markers": {},
-        "issues": [
-          {
-            "type": "misaligned_markers",
-            "message": "File has 3 misaligned markers"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/behavior/steps/test_wsde_memory_integration_steps.py": {
-        "file_path": "/workspace/devsynth/tests/behavior/steps/test_wsde_memory_integration_steps.py",
-        "has_pytest_import": true,
-        "test_functions": 1,
-        "markers": {
-          "test_function": "medium"
-        },
-        "tests_with_markers": 1,
-        "tests_without_markers": 0,
-        "misaligned_markers": [
-          {
-            "line": 50,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 58,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 69,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 77,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 103,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 122,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 148,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 174,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 191,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 220,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 244,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 268,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 288,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 308,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 326,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 338,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 360,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 383,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 402,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 416,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 456,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 469,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 489,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 552,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 571,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 638,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 677,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          }
-        ],
-        "duplicate_markers": [],
-        "recognized_markers": {
-          "medium": {
-            "file_count": 1,
-            "pytest_count": 0,
-            "recognized": false,
-            "registered_in_pytest_ini": true,
-            "error": "subprocess error: 4",
-            "uncollected_tests": []
-          }
-        },
-        "issues": [
-          {
-            "type": "misaligned_markers",
-            "message": "File has 27 misaligned markers"
-          },
-          {
-            "type": "unrecognized_markers",
-            "message": "medium markers are not recognized by pytest (1 in file, 0 recognized)"
+            "message": "File has 5 misaligned markers"
           }
         ]
       },
@@ -21707,8 +6318,8 @@
           }
         ]
       },
-      "/workspace/devsynth/tests/behavior/steps/test_invalid_config_steps.py": {
-        "file_path": "/workspace/devsynth/tests/behavior/steps/test_invalid_config_steps.py",
+      "/workspace/devsynth/tests/behavior/steps/test_docs_fetch_steps.py": {
+        "file_path": "/workspace/devsynth/tests/behavior/steps/test_docs_fetch_steps.py",
         "has_pytest_import": true,
         "test_functions": 0,
         "markers": {},
@@ -21716,32 +6327,17 @@
         "tests_without_markers": 0,
         "misaligned_markers": [
           {
-            "line": 6,
+            "line": 13,
             "marker": "medium",
             "text": "@pytest.mark.medium"
           },
           {
-            "line": 11,
+            "line": 19,
             "marker": "medium",
             "text": "@pytest.mark.medium"
           },
           {
-            "line": 18,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 23,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 31,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 36,
+            "line": 25,
             "marker": "medium",
             "text": "@pytest.mark.medium"
           }
@@ -21751,12 +6347,12 @@
         "issues": [
           {
             "type": "misaligned_markers",
-            "message": "File has 6 misaligned markers"
+            "message": "File has 3 misaligned markers"
           }
         ]
       },
-      "/workspace/devsynth/tests/behavior/steps/test_delegate_task_consensus_steps.py": {
-        "file_path": "/workspace/devsynth/tests/behavior/steps/test_delegate_task_consensus_steps.py",
+      "/workspace/devsynth/tests/behavior/steps/test_validate_metadata_command_steps.py": {
+        "file_path": "/workspace/devsynth/tests/behavior/steps/test_validate_metadata_command_steps.py",
         "has_pytest_import": true,
         "test_functions": 0,
         "markers": {},
@@ -21764,42 +6360,12 @@
         "tests_without_markers": 0,
         "misaligned_markers": [
           {
-            "line": 27,
+            "line": 13,
             "marker": "medium",
             "text": "@pytest.mark.medium"
           },
           {
-            "line": 40,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 54,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 60,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 95,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 102,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 109,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 116,
+            "line": 24,
             "marker": "medium",
             "text": "@pytest.mark.medium"
           }
@@ -21809,12 +6375,12 @@
         "issues": [
           {
             "type": "misaligned_markers",
-            "message": "File has 8 misaligned markers"
+            "message": "File has 2 misaligned markers"
           }
         ]
       },
-      "/workspace/devsynth/tests/behavior/steps/test_webui_doctor_steps.py": {
-        "file_path": "/workspace/devsynth/tests/behavior/steps/test_webui_doctor_steps.py",
+      "/workspace/devsynth/tests/behavior/steps/test_webui_dbschema_steps.py": {
+        "file_path": "/workspace/devsynth/tests/behavior/steps/test_webui_dbschema_steps.py",
         "has_pytest_import": true,
         "test_functions": 0,
         "markers": {},
@@ -21837,102 +6403,102 @@
             "text": "@pytest.mark.medium"
           },
           {
-            "line": 28,
+            "line": 29,
             "marker": "medium",
             "text": "@pytest.mark.medium"
           },
           {
-            "line": 35,
+            "line": 36,
             "marker": "medium",
             "text": "@pytest.mark.medium"
           },
           {
-            "line": 42,
+            "line": 43,
             "marker": "medium",
             "text": "@pytest.mark.medium"
           },
           {
-            "line": 49,
+            "line": 52,
             "marker": "medium",
             "text": "@pytest.mark.medium"
           },
           {
-            "line": 56,
+            "line": 59,
             "marker": "medium",
             "text": "@pytest.mark.medium"
           },
           {
-            "line": 63,
+            "line": 65,
             "marker": "medium",
             "text": "@pytest.mark.medium"
           },
           {
-            "line": 69,
+            "line": 71,
             "marker": "medium",
             "text": "@pytest.mark.medium"
           },
           {
-            "line": 76,
+            "line": 78,
             "marker": "medium",
             "text": "@pytest.mark.medium"
           },
           {
-            "line": 89,
+            "line": 85,
             "marker": "medium",
             "text": "@pytest.mark.medium"
           },
           {
-            "line": 96,
+            "line": 91,
             "marker": "medium",
             "text": "@pytest.mark.medium"
           },
           {
-            "line": 107,
+            "line": 98,
             "marker": "medium",
             "text": "@pytest.mark.medium"
           },
           {
-            "line": 114,
+            "line": 105,
             "marker": "medium",
             "text": "@pytest.mark.medium"
           },
           {
-            "line": 125,
+            "line": 112,
             "marker": "medium",
             "text": "@pytest.mark.medium"
           },
           {
-            "line": 132,
+            "line": 119,
             "marker": "medium",
             "text": "@pytest.mark.medium"
           },
           {
-            "line": 139,
+            "line": 126,
             "marker": "medium",
             "text": "@pytest.mark.medium"
           },
           {
-            "line": 146,
+            "line": 133,
             "marker": "medium",
             "text": "@pytest.mark.medium"
           },
           {
-            "line": 153,
+            "line": 140,
             "marker": "medium",
             "text": "@pytest.mark.medium"
           },
           {
-            "line": 164,
+            "line": 147,
             "marker": "medium",
             "text": "@pytest.mark.medium"
           },
           {
-            "line": 171,
+            "line": 154,
             "marker": "medium",
             "text": "@pytest.mark.medium"
           },
           {
-            "line": 178,
+            "line": 161,
             "marker": "medium",
             "text": "@pytest.mark.medium"
           }
@@ -21946,8 +6512,8 @@
           }
         ]
       },
-      "/workspace/devsynth/tests/behavior/steps/test_setup_wizard_steps.py": {
-        "file_path": "/workspace/devsynth/tests/behavior/steps/test_setup_wizard_steps.py",
+      "/workspace/devsynth/tests/behavior/steps/test_doctor_command_steps.py": {
+        "file_path": "/workspace/devsynth/tests/behavior/steps/test_doctor_command_steps.py",
         "has_pytest_import": true,
         "test_functions": 0,
         "markers": {},
@@ -21955,27 +6521,27 @@
         "tests_without_markers": 0,
         "misaligned_markers": [
           {
-            "line": 38,
+            "line": 8,
             "marker": "medium",
             "text": "@pytest.mark.medium"
           },
           {
-            "line": 44,
+            "line": 17,
             "marker": "medium",
             "text": "@pytest.mark.medium"
           },
           {
-            "line": 65,
+            "line": 25,
             "marker": "medium",
             "text": "@pytest.mark.medium"
           },
           {
-            "line": 93,
+            "line": 33,
             "marker": "medium",
             "text": "@pytest.mark.medium"
           },
           {
-            "line": 104,
+            "line": 41,
             "marker": "medium",
             "text": "@pytest.mark.medium"
           }
@@ -21989,8 +6555,8 @@
           }
         ]
       },
-      "/workspace/devsynth/tests/behavior/steps/test_documentation_utility_functions_steps.py": {
-        "file_path": "/workspace/devsynth/tests/behavior/steps/test_documentation_utility_functions_steps.py",
+      "/workspace/devsynth/tests/behavior/steps/test_enhanced_dialectical_reasoning_steps.py": {
+        "file_path": "/workspace/devsynth/tests/behavior/steps/test_enhanced_dialectical_reasoning_steps.py",
         "has_pytest_import": true,
         "test_functions": 0,
         "markers": {},
@@ -21998,197 +6564,32 @@
         "tests_without_markers": 0,
         "misaligned_markers": [
           {
-            "line": 27,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 40,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
             "line": 58,
             "marker": "medium",
             "text": "@pytest.mark.medium"
           },
           {
-            "line": 80,
+            "line": 86,
             "marker": "medium",
             "text": "@pytest.mark.medium"
           },
           {
-            "line": 102,
+            "line": 96,
             "marker": "medium",
             "text": "@pytest.mark.medium"
           },
           {
-            "line": 126,
+            "line": 110,
             "marker": "medium",
             "text": "@pytest.mark.medium"
           },
           {
-            "line": 156,
+            "line": 142,
             "marker": "medium",
             "text": "@pytest.mark.medium"
           },
           {
-            "line": 181,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 216,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 224,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 233,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 240,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 247,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 255,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 264,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 271,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 278,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 287,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 295,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 302,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 310,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 320,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 330,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 338,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 346,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 354,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 362,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 369,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          }
-        ],
-        "duplicate_markers": [],
-        "recognized_markers": {},
-        "issues": [
-          {
-            "type": "misaligned_markers",
-            "message": "File has 28 misaligned markers"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/behavior/steps/test_project_state_analyzer_steps.py": {
-        "file_path": "/workspace/devsynth/tests/behavior/steps/test_project_state_analyzer_steps.py",
-        "has_pytest_import": true,
-        "test_functions": 2,
-        "markers": {
-          "test_project_dir": "medium"
-        },
-        "tests_with_markers": 1,
-        "tests_without_markers": 1,
-        "misaligned_markers": [
-          {
-            "line": 85,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 93,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 101,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 109,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 124,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 138,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 151,
+            "line": 153,
             "marker": "medium",
             "text": "@pytest.mark.medium"
           },
@@ -22198,57 +6599,32 @@
             "text": "@pytest.mark.medium"
           },
           {
-            "line": 175,
+            "line": 173,
             "marker": "medium",
             "text": "@pytest.mark.medium"
           },
           {
-            "line": 183,
+            "line": 182,
             "marker": "medium",
             "text": "@pytest.mark.medium"
           },
           {
-            "line": 197,
+            "line": 189,
             "marker": "medium",
             "text": "@pytest.mark.medium"
           },
           {
-            "line": 207,
+            "line": 200,
             "marker": "medium",
             "text": "@pytest.mark.medium"
           },
           {
-            "line": 222,
+            "line": 269,
             "marker": "medium",
             "text": "@pytest.mark.medium"
           },
           {
-            "line": 230,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 239,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 252,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 263,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 275,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 283,
+            "line": 282,
             "marker": "medium",
             "text": "@pytest.mark.medium"
           },
@@ -22258,7 +6634,7 @@
             "text": "@pytest.mark.medium"
           },
           {
-            "line": 300,
+            "line": 301,
             "marker": "medium",
             "text": "@pytest.mark.medium"
           },
@@ -22268,254 +6644,212 @@
             "text": "@pytest.mark.medium"
           },
           {
-            "line": 320,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          }
-        ],
-        "duplicate_markers": [],
-        "recognized_markers": {
-          "medium": {
-            "file_count": 1,
-            "pytest_count": 0,
-            "recognized": false,
-            "registered_in_pytest_ini": true,
-            "error": "subprocess error: 4",
-            "uncollected_tests": []
-          }
-        },
-        "issues": [
-          {
-            "type": "misaligned_markers",
-            "message": "File has 23 misaligned markers"
-          },
-          {
-            "type": "unrecognized_markers",
-            "message": "medium markers are not recognized by pytest (1 in file, 0 recognized)"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/behavior/steps/test_project_documentation_ingestion_steps.py": {
-        "file_path": "/workspace/devsynth/tests/behavior/steps/test_project_documentation_ingestion_steps.py",
-        "has_pytest_import": true,
-        "test_functions": 0,
-        "markers": {},
-        "tests_with_markers": 0,
-        "tests_without_markers": 0,
-        "misaligned_markers": [
-          {
-            "line": 35,
+            "line": 316,
             "marker": "medium",
             "text": "@pytest.mark.medium"
           },
           {
-            "line": 59,
+            "line": 326,
             "marker": "medium",
             "text": "@pytest.mark.medium"
           },
           {
-            "line": 65,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          }
-        ],
-        "duplicate_markers": [],
-        "recognized_markers": {},
-        "issues": [
-          {
-            "type": "misaligned_markers",
-            "message": "File has 3 misaligned markers"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/behavior/steps/test_wsde_memory_integration_fixed2_steps.py": {
-        "file_path": "/workspace/devsynth/tests/behavior/steps/test_wsde_memory_integration_fixed2_steps.py",
-        "has_pytest_import": true,
-        "test_functions": 1,
-        "markers": {
-          "test_function": "medium"
-        },
-        "tests_with_markers": 1,
-        "tests_without_markers": 0,
-        "misaligned_markers": [
-          {
-            "line": 49,
+            "line": 366,
             "marker": "medium",
             "text": "@pytest.mark.medium"
           },
           {
-            "line": 57,
+            "line": 378,
             "marker": "medium",
             "text": "@pytest.mark.medium"
           },
           {
-            "line": 68,
+            "line": 394,
             "marker": "medium",
             "text": "@pytest.mark.medium"
           },
           {
-            "line": 76,
+            "line": 413,
             "marker": "medium",
             "text": "@pytest.mark.medium"
           },
           {
-            "line": 95,
+            "line": 433,
             "marker": "medium",
             "text": "@pytest.mark.medium"
           },
           {
-            "line": 121,
+            "line": 451,
             "marker": "medium",
             "text": "@pytest.mark.medium"
           },
           {
-            "line": 147,
+            "line": 478,
             "marker": "medium",
             "text": "@pytest.mark.medium"
           },
           {
-            "line": 164,
+            "line": 513,
             "marker": "medium",
             "text": "@pytest.mark.medium"
           },
           {
-            "line": 193,
+            "line": 585,
             "marker": "medium",
             "text": "@pytest.mark.medium"
           },
           {
-            "line": 217,
+            "line": 606,
             "marker": "medium",
             "text": "@pytest.mark.medium"
           },
           {
-            "line": 241,
+            "line": 616,
             "marker": "medium",
             "text": "@pytest.mark.medium"
           },
           {
-            "line": 261,
+            "line": 624,
             "marker": "medium",
             "text": "@pytest.mark.medium"
           },
           {
-            "line": 281,
+            "line": 632,
             "marker": "medium",
             "text": "@pytest.mark.medium"
           },
           {
-            "line": 307,
+            "line": 644,
             "marker": "medium",
             "text": "@pytest.mark.medium"
           },
           {
-            "line": 325,
+            "line": 716,
             "marker": "medium",
             "text": "@pytest.mark.medium"
           },
           {
-            "line": 337,
+            "line": 774,
             "marker": "medium",
             "text": "@pytest.mark.medium"
           },
           {
-            "line": 359,
+            "line": 786,
             "marker": "medium",
             "text": "@pytest.mark.medium"
           },
           {
-            "line": 382,
+            "line": 794,
             "marker": "medium",
             "text": "@pytest.mark.medium"
           },
           {
-            "line": 401,
+            "line": 801,
             "marker": "medium",
             "text": "@pytest.mark.medium"
           },
           {
-            "line": 415,
+            "line": 809,
             "marker": "medium",
             "text": "@pytest.mark.medium"
           },
           {
-            "line": 448,
+            "line": 816,
             "marker": "medium",
             "text": "@pytest.mark.medium"
           },
           {
-            "line": 461,
+            "line": 830,
             "marker": "medium",
             "text": "@pytest.mark.medium"
           },
           {
-            "line": 480,
+            "line": 849,
             "marker": "medium",
             "text": "@pytest.mark.medium"
           },
           {
-            "line": 542,
+            "line": 857,
             "marker": "medium",
             "text": "@pytest.mark.medium"
           },
           {
-            "line": 561,
+            "line": 867,
             "marker": "medium",
             "text": "@pytest.mark.medium"
           },
           {
-            "line": 628,
+            "line": 878,
             "marker": "medium",
             "text": "@pytest.mark.medium"
           },
           {
-            "line": 667,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          }
-        ],
-        "duplicate_markers": [],
-        "recognized_markers": {
-          "medium": {
-            "file_count": 1,
-            "pytest_count": 0,
-            "recognized": false,
-            "registered_in_pytest_ini": true,
-            "error": "subprocess error: 4",
-            "uncollected_tests": []
-          }
-        },
-        "issues": [
-          {
-            "type": "misaligned_markers",
-            "message": "File has 27 misaligned markers"
-          },
-          {
-            "type": "unrecognized_markers",
-            "message": "medium markers are not recognized by pytest (1 in file, 0 recognized)"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/behavior/steps/test_requirements_management_steps.py": {
-        "file_path": "/workspace/devsynth/tests/behavior/steps/test_requirements_management_steps.py",
-        "has_pytest_import": true,
-        "test_functions": 0,
-        "markers": {},
-        "tests_with_markers": 0,
-        "tests_without_markers": 0,
-        "misaligned_markers": [
-          {
-            "line": 23,
+            "line": 888,
             "marker": "medium",
             "text": "@pytest.mark.medium"
           },
           {
-            "line": 30,
+            "line": 901,
             "marker": "medium",
             "text": "@pytest.mark.medium"
           },
           {
-            "line": 37,
+            "line": 965,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 980,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 989,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 1000,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 1010,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 1025,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 1090,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 1099,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 1116,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 1125,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 1135,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 1145,
             "marker": "medium",
             "text": "@pytest.mark.medium"
           }
@@ -22525,7 +6859,7 @@
         "issues": [
           {
             "type": "misaligned_markers",
-            "message": "File has 3 misaligned markers"
+            "message": "File has 58 misaligned markers"
           }
         ]
       },
@@ -22538,12 +6872,17 @@
         "tests_without_markers": 0,
         "misaligned_markers": [
           {
-            "line": 48,
+            "line": 39,
             "marker": "medium",
             "text": "@pytest.mark.medium"
           },
           {
-            "line": 56,
+            "line": 47,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 58,
             "marker": "medium",
             "text": "@pytest.mark.medium"
           },
@@ -22553,82 +6892,77 @@
             "text": "@pytest.mark.medium"
           },
           {
-            "line": 76,
+            "line": 104,
             "marker": "medium",
             "text": "@pytest.mark.medium"
           },
           {
-            "line": 113,
+            "line": 134,
             "marker": "medium",
             "text": "@pytest.mark.medium"
           },
           {
-            "line": 143,
+            "line": 168,
             "marker": "medium",
             "text": "@pytest.mark.medium"
           },
           {
-            "line": 177,
+            "line": 215,
             "marker": "medium",
             "text": "@pytest.mark.medium"
           },
           {
-            "line": 224,
+            "line": 264,
             "marker": "medium",
             "text": "@pytest.mark.medium"
           },
           {
-            "line": 273,
+            "line": 284,
             "marker": "medium",
             "text": "@pytest.mark.medium"
           },
           {
-            "line": 293,
+            "line": 321,
             "marker": "medium",
             "text": "@pytest.mark.medium"
           },
           {
-            "line": 330,
+            "line": 392,
             "marker": "medium",
             "text": "@pytest.mark.medium"
           },
           {
-            "line": 401,
+            "line": 445,
             "marker": "medium",
             "text": "@pytest.mark.medium"
           },
           {
-            "line": 454,
+            "line": 464,
             "marker": "medium",
             "text": "@pytest.mark.medium"
           },
           {
-            "line": 473,
+            "line": 488,
             "marker": "medium",
             "text": "@pytest.mark.medium"
           },
           {
-            "line": 497,
+            "line": 534,
             "marker": "medium",
             "text": "@pytest.mark.medium"
           },
           {
-            "line": 543,
+            "line": 565,
             "marker": "medium",
             "text": "@pytest.mark.medium"
           },
           {
-            "line": 574,
+            "line": 642,
             "marker": "medium",
             "text": "@pytest.mark.medium"
           },
           {
-            "line": 651,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 673,
+            "line": 664,
             "marker": "medium",
             "text": "@pytest.mark.medium"
           }
@@ -22642,8 +6976,8 @@
           }
         ]
       },
-      "/workspace/devsynth/tests/behavior/steps/test_webui_command_steps.py": {
-        "file_path": "/workspace/devsynth/tests/behavior/steps/test_webui_command_steps.py",
+      "/workspace/devsynth/tests/behavior/steps/test_consensus_building_steps.py": {
+        "file_path": "/workspace/devsynth/tests/behavior/steps/test_consensus_building_steps.py",
         "has_pytest_import": true,
         "test_functions": 0,
         "markers": {},
@@ -22651,27 +6985,177 @@
         "tests_without_markers": 0,
         "misaligned_markers": [
           {
-            "line": 28,
+            "line": 51,
             "marker": "medium",
             "text": "@pytest.mark.medium"
           },
           {
-            "line": 48,
+            "line": 89,
             "marker": "medium",
             "text": "@pytest.mark.medium"
           },
           {
-            "line": 68,
+            "line": 103,
             "marker": "medium",
             "text": "@pytest.mark.medium"
           },
           {
-            "line": 78,
+            "line": 115,
             "marker": "medium",
             "text": "@pytest.mark.medium"
           },
           {
-            "line": 93,
+            "line": 177,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 188,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 207,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 250,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 267,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 289,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 341,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 352,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 369,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 386,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 419,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 434,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 449,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 493,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 504,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 532,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 552,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 570,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 585,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 627,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 646,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 661,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 679,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 701,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 717,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 770,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 791,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 811,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 832,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 852,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 879,
             "marker": "medium",
             "text": "@pytest.mark.medium"
           }
@@ -22681,12 +7165,12 @@
         "issues": [
           {
             "type": "misaligned_markers",
-            "message": "File has 5 misaligned markers"
+            "message": "File has 35 misaligned markers"
           }
         ]
       },
-      "/workspace/devsynth/tests/behavior/steps/test_mddr_domain_knowledge_integration_steps.py": {
-        "file_path": "/workspace/devsynth/tests/behavior/steps/test_mddr_domain_knowledge_integration_steps.py",
+      "/workspace/devsynth/tests/behavior/steps/test_webui_test_metrics_steps.py": {
+        "file_path": "/workspace/devsynth/tests/behavior/steps/test_webui_test_metrics_steps.py",
         "has_pytest_import": true,
         "test_functions": 0,
         "markers": {},
@@ -22699,32 +7183,62 @@
             "text": "@pytest.mark.medium"
           },
           {
-            "line": 35,
+            "line": 15,
             "marker": "medium",
             "text": "@pytest.mark.medium"
           },
           {
-            "line": 174,
+            "line": 21,
             "marker": "medium",
             "text": "@pytest.mark.medium"
           },
           {
-            "line": 346,
+            "line": 27,
             "marker": "medium",
             "text": "@pytest.mark.medium"
           },
           {
-            "line": 384,
+            "line": 33,
             "marker": "medium",
             "text": "@pytest.mark.medium"
           },
           {
-            "line": 434,
+            "line": 40,
             "marker": "medium",
             "text": "@pytest.mark.medium"
           },
           {
-            "line": 481,
+            "line": 47,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 55,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 63,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 71,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 78,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 86,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 94,
             "marker": "medium",
             "text": "@pytest.mark.medium"
           }
@@ -22734,12 +7248,12 @@
         "issues": [
           {
             "type": "misaligned_markers",
-            "message": "File has 7 misaligned markers"
+            "message": "File has 13 misaligned markers"
           }
         ]
       },
-      "/workspace/devsynth/tests/behavior/steps/test_methodology_adapters_steps.py": {
-        "file_path": "/workspace/devsynth/tests/behavior/steps/test_methodology_adapters_steps.py",
+      "/workspace/devsynth/tests/behavior/steps/test_webui_spec_editor_steps.py": {
+        "file_path": "/workspace/devsynth/tests/behavior/steps/test_webui_spec_editor_steps.py",
         "has_pytest_import": true,
         "test_functions": 0,
         "markers": {},
@@ -22747,77 +7261,60 @@
         "tests_without_markers": 0,
         "misaligned_markers": [
           {
-            "line": 28,
+            "line": 8,
             "marker": "medium",
             "text": "@pytest.mark.medium"
           },
           {
-            "line": 46,
+            "line": 23,
             "marker": "medium",
             "text": "@pytest.mark.medium"
           },
           {
-            "line": 53,
+            "line": 29,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          }
+        ],
+        "duplicate_markers": [],
+        "recognized_markers": {},
+        "issues": [
+          {
+            "type": "misaligned_markers",
+            "message": "File has 3 misaligned markers"
+          }
+        ]
+      },
+      "/workspace/devsynth/tests/behavior/steps/test_prompt_management_steps.py": {
+        "file_path": "/workspace/devsynth/tests/behavior/steps/test_prompt_management_steps.py",
+        "has_pytest_import": true,
+        "test_functions": 0,
+        "markers": {},
+        "tests_with_markers": 0,
+        "tests_without_markers": 0,
+        "misaligned_markers": [
+          {
+            "line": 74,
             "marker": "medium",
             "text": "@pytest.mark.medium"
           },
           {
-            "line": 59,
+            "line": 86,
             "marker": "medium",
             "text": "@pytest.mark.medium"
           },
           {
-            "line": 64,
+            "line": 125,
             "marker": "medium",
             "text": "@pytest.mark.medium"
           },
           {
-            "line": 73,
+            "line": 136,
             "marker": "medium",
             "text": "@pytest.mark.medium"
           },
           {
-            "line": 85,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 90,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 104,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 115,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 129,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 142,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 147,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 156,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 165,
+            "line": 157,
             "marker": "medium",
             "text": "@pytest.mark.medium"
           },
@@ -22827,22 +7324,12 @@
             "text": "@pytest.mark.medium"
           },
           {
-            "line": 193,
+            "line": 190,
             "marker": "medium",
             "text": "@pytest.mark.medium"
           },
           {
-            "line": 199,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 206,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 234,
+            "line": 229,
             "marker": "medium",
             "text": "@pytest.mark.medium"
           },
@@ -22852,17 +7339,212 @@
             "text": "@pytest.mark.medium"
           },
           {
-            "line": 244,
+            "line": 251,
             "marker": "medium",
             "text": "@pytest.mark.medium"
           },
           {
-            "line": 249,
+            "line": 284,
             "marker": "medium",
             "text": "@pytest.mark.medium"
           },
           {
-            "line": 255,
+            "line": 293,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 311,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 339,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 380,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 389,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 412,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 425,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 474,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 483,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 499,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 517,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 578,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 593,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 612,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 630,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 687,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 719,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 739,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 762,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 785,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 812,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 839,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 856,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 889,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 910,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 948,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 991,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 1010,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 1027,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 1049,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 1079,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 1094,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 1111,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 1152,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 1189,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 1213,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 1235,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 1290,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 1316,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 1395,
             "marker": "medium",
             "text": "@pytest.mark.medium"
           }
@@ -22872,12 +7554,198 @@
         "issues": [
           {
             "type": "misaligned_markers",
-            "message": "File has 24 misaligned markers"
+            "message": "File has 51 misaligned markers"
           }
         ]
       },
-      "/workspace/devsynth/tests/behavior/steps/test_webui_docs_generation_steps.py": {
-        "file_path": "/workspace/devsynth/tests/behavior/steps/test_webui_docs_generation_steps.py",
+      "/workspace/devsynth/tests/behavior/steps/test_webui_commands_steps.py": {
+        "file_path": "/workspace/devsynth/tests/behavior/steps/test_webui_commands_steps.py",
+        "has_pytest_import": true,
+        "test_functions": 0,
+        "markers": {},
+        "tests_with_markers": 0,
+        "tests_without_markers": 0,
+        "misaligned_markers": [
+          {
+            "line": 11,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 17,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 25,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 33,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 42,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 51,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 60,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 69,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 77,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 85,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 93,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 99,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 105,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 111,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 117,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 123,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 129,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 135,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          }
+        ],
+        "duplicate_markers": [],
+        "recognized_markers": {},
+        "issues": [
+          {
+            "type": "misaligned_markers",
+            "message": "File has 18 misaligned markers"
+          }
+        ]
+      },
+      "/workspace/devsynth/tests/behavior/steps/test_agent_api_health_metrics_steps.py": {
+        "file_path": "/workspace/devsynth/tests/behavior/steps/test_agent_api_health_metrics_steps.py",
+        "has_pytest_import": true,
+        "test_functions": 0,
+        "markers": {},
+        "tests_with_markers": 0,
+        "tests_without_markers": 0,
+        "misaligned_markers": [
+          {
+            "line": 40,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 49,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 58,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 66,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 77,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 87,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 95,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 106,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 116,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 123,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 132,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 140,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          }
+        ],
+        "duplicate_markers": [],
+        "recognized_markers": {},
+        "issues": [
+          {
+            "type": "misaligned_markers",
+            "message": "File has 12 misaligned markers"
+          }
+        ]
+      },
+      "/workspace/devsynth/tests/behavior/steps/test_webui_validate_manifest_steps.py": {
+        "file_path": "/workspace/devsynth/tests/behavior/steps/test_webui_validate_manifest_steps.py",
         "has_pytest_import": true,
         "test_functions": 0,
         "markers": {},
@@ -22910,27 +7778,27 @@
             "text": "@pytest.mark.medium"
           },
           {
-            "line": 45,
+            "line": 48,
             "marker": "medium",
             "text": "@pytest.mark.medium"
           },
           {
-            "line": 54,
+            "line": 55,
             "marker": "medium",
             "text": "@pytest.mark.medium"
           },
           {
-            "line": 61,
+            "line": 63,
             "marker": "medium",
             "text": "@pytest.mark.medium"
           },
           {
-            "line": 70,
+            "line": 72,
             "marker": "medium",
             "text": "@pytest.mark.medium"
           },
           {
-            "line": 78,
+            "line": 79,
             "marker": "medium",
             "text": "@pytest.mark.medium"
           },
@@ -22941,210 +7809,6 @@
           },
           {
             "line": 93,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 100,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 107,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          }
-        ],
-        "duplicate_markers": [],
-        "recognized_markers": {},
-        "issues": [
-          {
-            "type": "misaligned_markers",
-            "message": "File has 14 misaligned markers"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/behavior/steps/test_mddr_evaluation_steps.py": {
-        "file_path": "/workspace/devsynth/tests/behavior/steps/test_mddr_evaluation_steps.py",
-        "has_pytest_import": true,
-        "test_functions": 0,
-        "markers": {},
-        "tests_with_markers": 0,
-        "tests_without_markers": 0,
-        "misaligned_markers": [
-          {
-            "line": 9,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 72,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 176,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 205,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 252,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 302,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          }
-        ],
-        "duplicate_markers": [],
-        "recognized_markers": {},
-        "issues": [
-          {
-            "type": "misaligned_markers",
-            "message": "File has 6 misaligned markers"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/behavior/steps/test_simple_steps.py": {
-        "file_path": "/workspace/devsynth/tests/behavior/steps/test_simple_steps.py",
-        "has_pytest_import": true,
-        "test_functions": 0,
-        "markers": {},
-        "tests_with_markers": 0,
-        "tests_without_markers": 0,
-        "misaligned_markers": [
-          {
-            "line": 35,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 58,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 66,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 79,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 104,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 110,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 116,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 122,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 129,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 136,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          }
-        ],
-        "duplicate_markers": [],
-        "recognized_markers": {},
-        "issues": [
-          {
-            "type": "misaligned_markers",
-            "message": "File has 10 misaligned markers"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/behavior/steps/test_validate_manifest_steps.py": {
-        "file_path": "/workspace/devsynth/tests/behavior/steps/test_validate_manifest_steps.py",
-        "has_pytest_import": true,
-        "test_functions": 0,
-        "markers": {},
-        "tests_with_markers": 0,
-        "tests_without_markers": 0,
-        "misaligned_markers": [
-          {
-            "line": 14,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 26,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 37,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 46,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 55,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 64,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 73,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 81,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 90,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 98,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 106,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 114,
             "marker": "medium",
             "text": "@pytest.mark.medium"
           }
@@ -23158,8 +7822,8 @@
           }
         ]
       },
-      "/workspace/devsynth/tests/behavior/steps/test_mddr_synthesis_generation_steps.py": {
-        "file_path": "/workspace/devsynth/tests/behavior/steps/test_mddr_synthesis_generation_steps.py",
+      "/workspace/devsynth/tests/behavior/steps/test_enhanced_chromadb_steps.py": {
+        "file_path": "/workspace/devsynth/tests/behavior/steps/test_enhanced_chromadb_steps.py",
         "has_pytest_import": true,
         "test_functions": 0,
         "markers": {},
@@ -23167,130 +7831,12 @@
         "tests_without_markers": 0,
         "misaligned_markers": [
           {
-            "line": 9,
+            "line": 81,
             "marker": "medium",
             "text": "@pytest.mark.medium"
           },
           {
-            "line": 101,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 175,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 227,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 299,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 323,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          }
-        ],
-        "duplicate_markers": [],
-        "recognized_markers": {},
-        "issues": [
-          {
-            "type": "misaligned_markers",
-            "message": "File has 6 misaligned markers"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/behavior/steps/test_webui_refactor_steps.py": {
-        "file_path": "/workspace/devsynth/tests/behavior/steps/test_webui_refactor_steps.py",
-        "has_pytest_import": true,
-        "test_functions": 0,
-        "markers": {},
-        "tests_with_markers": 0,
-        "tests_without_markers": 0,
-        "misaligned_markers": [
-          {
-            "line": 9,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 15,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 22,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 28,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 35,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 41,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 47,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 56,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 62,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 71,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 78,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 85,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 92,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 99,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 106,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 113,
+            "line": 109,
             "marker": "medium",
             "text": "@pytest.mark.medium"
           },
@@ -23300,82 +7846,17 @@
             "text": "@pytest.mark.medium"
           },
           {
-            "line": 127,
+            "line": 131,
             "marker": "medium",
             "text": "@pytest.mark.medium"
           },
           {
-            "line": 134,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          }
-        ],
-        "duplicate_markers": [],
-        "recognized_markers": {},
-        "issues": [
-          {
-            "type": "misaligned_markers",
-            "message": "File has 19 misaligned markers"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/behavior/steps/test_wsde_memory_integration_fixed_steps.py": {
-        "file_path": "/workspace/devsynth/tests/behavior/steps/test_wsde_memory_integration_fixed_steps.py",
-        "has_pytest_import": true,
-        "test_functions": 1,
-        "markers": {
-          "test_function": "medium"
-        },
-        "tests_with_markers": 1,
-        "tests_without_markers": 0,
-        "misaligned_markers": [
-          {
-            "line": 50,
+            "line": 159,
             "marker": "medium",
             "text": "@pytest.mark.medium"
           },
           {
-            "line": 58,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 69,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 95,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 103,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 119,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 145,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 171,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 188,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 217,
+            "line": 186,
             "marker": "medium",
             "text": "@pytest.mark.medium"
           },
@@ -23385,105 +7866,253 @@
             "text": "@pytest.mark.medium"
           },
           {
-            "line": 265,
+            "line": 257,
             "marker": "medium",
             "text": "@pytest.mark.medium"
           },
           {
-            "line": 285,
+            "line": 273,
             "marker": "medium",
             "text": "@pytest.mark.medium"
           },
           {
-            "line": 305,
+            "line": 298,
             "marker": "medium",
             "text": "@pytest.mark.medium"
           },
           {
-            "line": 323,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 335,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 357,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 380,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 399,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 413,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 453,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 466,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 486,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 549,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 570,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 637,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 676,
+            "line": 333,
             "marker": "medium",
             "text": "@pytest.mark.medium"
           }
         ],
         "duplicate_markers": [],
-        "recognized_markers": {
-          "medium": {
-            "file_count": 1,
-            "pytest_count": 0,
-            "recognized": false,
-            "registered_in_pytest_ini": true,
-            "error": "subprocess error: 4",
-            "uncollected_tests": []
-          }
-        },
+        "recognized_markers": {},
         "issues": [
           {
             "type": "misaligned_markers",
-            "message": "File has 27 misaligned markers"
+            "message": "File has 11 misaligned markers"
+          }
+        ]
+      },
+      "/workspace/devsynth/tests/behavior/steps/test_validate_manifest_command_steps.py": {
+        "file_path": "/workspace/devsynth/tests/behavior/steps/test_validate_manifest_command_steps.py",
+        "has_pytest_import": false,
+        "test_functions": 0,
+        "markers": {},
+        "tests_with_markers": 0,
+        "tests_without_markers": 0,
+        "misaligned_markers": [
+          {
+            "line": 13,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
           },
           {
-            "type": "unrecognized_markers",
-            "message": "medium markers are not recognized by pytest (1 in file, 0 recognized)"
+            "line": 25,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          }
+        ],
+        "duplicate_markers": [],
+        "recognized_markers": {},
+        "issues": [
+          {
+            "type": "misaligned_markers",
+            "message": "File has 2 misaligned markers"
+          }
+        ]
+      },
+      "/workspace/devsynth/tests/behavior/steps/test_recursive_edrr_coordinator_steps.py": {
+        "file_path": "/workspace/devsynth/tests/behavior/steps/test_recursive_edrr_coordinator_steps.py",
+        "has_pytest_import": true,
+        "test_functions": 0,
+        "markers": {},
+        "tests_with_markers": 0,
+        "tests_without_markers": 0,
+        "misaligned_markers": [
+          {
+            "line": 49,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 90,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 99,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 108,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 119,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 128,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 139,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 147,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 227,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 234,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 241,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 260,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 282,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 290,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 299,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 306,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 313,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 325,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 332,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 346,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 361,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 376,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 414,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 431,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 456,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 476,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 495,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 514,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 537,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 560,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 581,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 602,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 626,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 645,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 664,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          }
+        ],
+        "duplicate_markers": [],
+        "recognized_markers": {},
+        "issues": [
+          {
+            "type": "misaligned_markers",
+            "message": "File has 35 misaligned markers"
           }
         ]
       },
@@ -23630,8 +8259,8 @@
           }
         ]
       },
-      "/workspace/devsynth/tests/behavior/steps/test_interactive_flow_steps.py": {
-        "file_path": "/workspace/devsynth/tests/behavior/steps/test_interactive_flow_steps.py",
+      "/workspace/devsynth/tests/behavior/steps/test_simple_addition_input_validation_steps.py": {
+        "file_path": "/workspace/devsynth/tests/behavior/steps/test_simple_addition_input_validation_steps.py",
         "has_pytest_import": true,
         "test_functions": 0,
         "markers": {},
@@ -23639,29 +8268,19 @@
         "tests_without_markers": 0,
         "misaligned_markers": [
           {
-            "line": 42,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
+            "line": 23,
+            "marker": "fast",
+            "text": "@pytest.mark.fast"
           },
           {
-            "line": 48,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
+            "line": 30,
+            "marker": "fast",
+            "text": "@pytest.mark.fast"
           },
           {
-            "line": 54,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 66,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 81,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
+            "line": 39,
+            "marker": "fast",
+            "text": "@pytest.mark.fast"
           }
         ],
         "duplicate_markers": [],
@@ -23669,12 +8288,12 @@
         "issues": [
           {
             "type": "misaligned_markers",
-            "message": "File has 5 misaligned markers"
+            "message": "File has 3 misaligned markers"
           }
         ]
       },
-      "/workspace/devsynth/tests/behavior/steps/test_webui_ingestion_steps.py": {
-        "file_path": "/workspace/devsynth/tests/behavior/steps/test_webui_ingestion_steps.py",
+      "/workspace/devsynth/tests/behavior/steps/test_webui_validate_metadata_steps.py": {
+        "file_path": "/workspace/devsynth/tests/behavior/steps/test_webui_validate_metadata_steps.py",
         "has_pytest_import": true,
         "test_functions": 0,
         "markers": {},
@@ -23697,32 +8316,32 @@
             "text": "@pytest.mark.medium"
           },
           {
-            "line": 28,
+            "line": 27,
             "marker": "medium",
             "text": "@pytest.mark.medium"
           },
           {
-            "line": 37,
+            "line": 34,
             "marker": "medium",
             "text": "@pytest.mark.medium"
           },
           {
-            "line": 43,
+            "line": 42,
             "marker": "medium",
             "text": "@pytest.mark.medium"
           },
           {
-            "line": 50,
+            "line": 51,
             "marker": "medium",
             "text": "@pytest.mark.medium"
           },
           {
-            "line": 57,
+            "line": 58,
             "marker": "medium",
             "text": "@pytest.mark.medium"
           },
           {
-            "line": 66,
+            "line": 65,
             "marker": "medium",
             "text": "@pytest.mark.medium"
           },
@@ -23732,7 +8351,2572 @@
             "text": "@pytest.mark.medium"
           },
           {
-            "line": 82,
+            "line": 80,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          }
+        ],
+        "duplicate_markers": [],
+        "recognized_markers": {},
+        "issues": [
+          {
+            "type": "misaligned_markers",
+            "message": "File has 11 misaligned markers"
+          }
+        ]
+      },
+      "/workspace/devsynth/tests/behavior/steps/test_simple_addition_steps.py": {
+        "file_path": "/workspace/devsynth/tests/behavior/steps/test_simple_addition_steps.py",
+        "has_pytest_import": true,
+        "test_functions": 0,
+        "markers": {},
+        "tests_with_markers": 0,
+        "tests_without_markers": 0,
+        "misaligned_markers": [
+          {
+            "line": 23,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 30,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 37,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          }
+        ],
+        "duplicate_markers": [],
+        "recognized_markers": {},
+        "issues": [
+          {
+            "type": "misaligned_markers",
+            "message": "File has 3 misaligned markers"
+          }
+        ]
+      },
+      "/workspace/devsynth/tests/behavior/steps/test_performance_testing_steps.py": {
+        "file_path": "/workspace/devsynth/tests/behavior/steps/test_performance_testing_steps.py",
+        "has_pytest_import": true,
+        "test_functions": 1,
+        "markers": {
+          "test_project_loaded_succeeds": "medium"
+        },
+        "tests_with_markers": 1,
+        "tests_without_markers": 0,
+        "misaligned_markers": [],
+        "duplicate_markers": [
+          {
+            "test_name": "test_project_loaded_succeeds",
+            "marker_count": 2
+          }
+        ],
+        "recognized_markers": {
+          "medium": {
+            "file_count": 1,
+            "pytest_count": 4,
+            "recognized": false,
+            "registered_in_pytest_ini": true,
+            "uncollected_tests": []
+          }
+        },
+        "issues": [
+          {
+            "type": "duplicate_markers",
+            "message": "File has 1 tests with duplicate markers"
+          },
+          {
+            "type": "unrecognized_markers",
+            "message": "medium markers are not recognized by pytest (1 in file, 4 recognized)"
+          }
+        ]
+      },
+      "/workspace/devsynth/tests/behavior/steps/test_mddr_domain_knowledge_integration_steps.py": {
+        "file_path": "/workspace/devsynth/tests/behavior/steps/test_mddr_domain_knowledge_integration_steps.py",
+        "has_pytest_import": true,
+        "test_functions": 0,
+        "markers": {},
+        "tests_with_markers": 0,
+        "tests_without_markers": 0,
+        "misaligned_markers": [
+          {
+            "line": 9,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 35,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 174,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 346,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 384,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 434,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 481,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          }
+        ],
+        "duplicate_markers": [],
+        "recognized_markers": {},
+        "issues": [
+          {
+            "type": "misaligned_markers",
+            "message": "File has 7 misaligned markers"
+          }
+        ]
+      },
+      "/workspace/devsynth/tests/behavior/steps/test_invalid_config_steps.py": {
+        "file_path": "/workspace/devsynth/tests/behavior/steps/test_invalid_config_steps.py",
+        "has_pytest_import": true,
+        "test_functions": 0,
+        "markers": {},
+        "tests_with_markers": 0,
+        "tests_without_markers": 0,
+        "misaligned_markers": [
+          {
+            "line": 6,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 11,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 18,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 23,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 31,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 36,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          }
+        ],
+        "duplicate_markers": [],
+        "recognized_markers": {},
+        "issues": [
+          {
+            "type": "misaligned_markers",
+            "message": "File has 6 misaligned markers"
+          }
+        ]
+      },
+      "/workspace/devsynth/tests/behavior/steps/test_generation_steps.py": {
+        "file_path": "/workspace/devsynth/tests/behavior/steps/test_generation_steps.py",
+        "has_pytest_import": true,
+        "test_functions": 1,
+        "markers": {
+          "test_sample": "medium"
+        },
+        "tests_with_markers": 1,
+        "tests_without_markers": 0,
+        "misaligned_markers": [],
+        "duplicate_markers": [
+          {
+            "test_name": "test_sample",
+            "marker_count": 2
+          }
+        ],
+        "recognized_markers": {
+          "medium": {
+            "file_count": 1,
+            "pytest_count": 0,
+            "recognized": false,
+            "registered_in_pytest_ini": true,
+            "error": "exit code 2",
+            "uncollected_tests": []
+          }
+        },
+        "issues": [
+          {
+            "type": "duplicate_markers",
+            "message": "File has 1 tests with duplicate markers"
+          },
+          {
+            "type": "unrecognized_markers",
+            "message": "medium markers are not recognized by pytest (1 in file, 0 recognized)"
+          },
+          {
+            "type": "pytest_error",
+            "marker": "medium",
+            "message": "pytest collection failed for /workspace/devsynth/tests/behavior/steps/test_generation_steps.py [marker=medium]: exit code 2"
+          }
+        ]
+      },
+      "/workspace/devsynth/tests/behavior/steps/test_validate_manifest_steps.py": {
+        "file_path": "/workspace/devsynth/tests/behavior/steps/test_validate_manifest_steps.py",
+        "has_pytest_import": true,
+        "test_functions": 0,
+        "markers": {},
+        "tests_with_markers": 0,
+        "tests_without_markers": 0,
+        "misaligned_markers": [
+          {
+            "line": 14,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 26,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 37,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 46,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 55,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 64,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 73,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 81,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 90,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 98,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 106,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 114,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          }
+        ],
+        "duplicate_markers": [],
+        "recognized_markers": {},
+        "issues": [
+          {
+            "type": "misaligned_markers",
+            "message": "File has 12 misaligned markers"
+          }
+        ]
+      },
+      "/workspace/devsynth/tests/behavior/steps/test_memory_steps.py": {
+        "file_path": "/workspace/devsynth/tests/behavior/steps/test_memory_steps.py",
+        "has_pytest_import": true,
+        "test_functions": 0,
+        "markers": {},
+        "tests_with_markers": 0,
+        "tests_without_markers": 0,
+        "misaligned_markers": [
+          {
+            "line": 19,
+            "marker": "fast",
+            "text": "@pytest.mark.fast"
+          },
+          {
+            "line": 25,
+            "marker": "fast",
+            "text": "@pytest.mark.fast"
+          },
+          {
+            "line": 32,
+            "marker": "fast",
+            "text": "@pytest.mark.fast"
+          },
+          {
+            "line": 38,
+            "marker": "fast",
+            "text": "@pytest.mark.fast"
+          }
+        ],
+        "duplicate_markers": [],
+        "recognized_markers": {},
+        "issues": [
+          {
+            "type": "misaligned_markers",
+            "message": "File has 4 misaligned markers"
+          }
+        ]
+      },
+      "/workspace/devsynth/tests/behavior/steps/test_analyze_commands_steps.py": {
+        "file_path": "/workspace/devsynth/tests/behavior/steps/test_analyze_commands_steps.py",
+        "has_pytest_import": true,
+        "test_functions": 0,
+        "markers": {},
+        "tests_with_markers": 0,
+        "tests_without_markers": 0,
+        "misaligned_markers": [
+          {
+            "line": 60,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 73,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 83,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 181,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 191,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 206,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 236,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 267,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 285,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 297,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 309,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 319,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 329,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 339,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 349,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 361,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 373,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 383,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 393,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 403,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 415,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 425,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 437,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 447,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 457,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 471,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 481,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          }
+        ],
+        "duplicate_markers": [],
+        "recognized_markers": {},
+        "issues": [
+          {
+            "type": "misaligned_markers",
+            "message": "File has 27 misaligned markers"
+          }
+        ]
+      },
+      "/workspace/devsynth/tests/behavior/steps/test_memory_backend_integration_steps.py": {
+        "file_path": "/workspace/devsynth/tests/behavior/steps/test_memory_backend_integration_steps.py",
+        "has_pytest_import": true,
+        "test_functions": 1,
+        "markers": {
+          "test_cross_backend": "medium"
+        },
+        "tests_with_markers": 1,
+        "tests_without_markers": 0,
+        "misaligned_markers": [
+          {
+            "line": 401,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 402,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 403,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 404,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 405,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          }
+        ],
+        "duplicate_markers": [
+          {
+            "test_name": "test_cross_backend",
+            "marker_count": 9
+          }
+        ],
+        "recognized_markers": {
+          "medium": {
+            "file_count": 1,
+            "pytest_count": 0,
+            "recognized": false,
+            "registered_in_pytest_ini": true,
+            "error": "exit code 2",
+            "uncollected_tests": []
+          }
+        },
+        "issues": [
+          {
+            "type": "misaligned_markers",
+            "message": "File has 5 misaligned markers"
+          },
+          {
+            "type": "duplicate_markers",
+            "message": "File has 1 tests with duplicate markers"
+          },
+          {
+            "type": "unrecognized_markers",
+            "message": "medium markers are not recognized by pytest (1 in file, 0 recognized)"
+          },
+          {
+            "type": "pytest_error",
+            "marker": "medium",
+            "message": "pytest collection failed for /workspace/devsynth/tests/behavior/steps/test_memory_backend_integration_steps.py [marker=medium]: exit code 2"
+          }
+        ]
+      },
+      "/workspace/devsynth/tests/behavior/steps/test_generate_docs_steps.py": {
+        "file_path": "/workspace/devsynth/tests/behavior/steps/test_generate_docs_steps.py",
+        "has_pytest_import": true,
+        "test_functions": 0,
+        "markers": {},
+        "tests_with_markers": 0,
+        "tests_without_markers": 0,
+        "misaligned_markers": [
+          {
+            "line": 31,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 38,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 48,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          }
+        ],
+        "duplicate_markers": [],
+        "recognized_markers": {},
+        "issues": [
+          {
+            "type": "misaligned_markers",
+            "message": "File has 3 misaligned markers"
+          }
+        ]
+      },
+      "/workspace/devsynth/tests/behavior/steps/test_simple_steps.py": {
+        "file_path": "/workspace/devsynth/tests/behavior/steps/test_simple_steps.py",
+        "has_pytest_import": true,
+        "test_functions": 0,
+        "markers": {},
+        "tests_with_markers": 0,
+        "tests_without_markers": 0,
+        "misaligned_markers": [
+          {
+            "line": 35,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 58,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 66,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 79,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 104,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 110,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 116,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 122,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 129,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 136,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          }
+        ],
+        "duplicate_markers": [],
+        "recognized_markers": {},
+        "issues": [
+          {
+            "type": "misaligned_markers",
+            "message": "File has 10 misaligned markers"
+          }
+        ]
+      },
+      "/workspace/devsynth/tests/behavior/steps/test_memory_context_steps.py": {
+        "file_path": "/workspace/devsynth/tests/behavior/steps/test_memory_context_steps.py",
+        "has_pytest_import": true,
+        "test_functions": 0,
+        "markers": {},
+        "tests_with_markers": 0,
+        "tests_without_markers": 0,
+        "misaligned_markers": [
+          {
+            "line": 113,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 121,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 129,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 139,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 150,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 159,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 167,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 177,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 190,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 202,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 216,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 226,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 234,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 241,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 250,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 256,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 263,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 270,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 278,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 287,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 295,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 302,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 310,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 319,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 329,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          }
+        ],
+        "duplicate_markers": [],
+        "recognized_markers": {},
+        "issues": [
+          {
+            "type": "misaligned_markers",
+            "message": "File has 25 misaligned markers"
+          }
+        ]
+      },
+      "/workspace/devsynth/tests/behavior/steps/test_webui_command_steps.py": {
+        "file_path": "/workspace/devsynth/tests/behavior/steps/test_webui_command_steps.py",
+        "has_pytest_import": true,
+        "test_functions": 0,
+        "markers": {},
+        "tests_with_markers": 0,
+        "tests_without_markers": 0,
+        "misaligned_markers": [
+          {
+            "line": 28,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 48,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 68,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 78,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 93,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          }
+        ],
+        "duplicate_markers": [],
+        "recognized_markers": {},
+        "issues": [
+          {
+            "type": "misaligned_markers",
+            "message": "File has 5 misaligned markers"
+          }
+        ]
+      },
+      "/workspace/devsynth/tests/behavior/steps/test_edrr_real_llm_integration_steps.py": {
+        "file_path": "/workspace/devsynth/tests/behavior/steps/test_edrr_real_llm_integration_steps.py",
+        "has_pytest_import": true,
+        "test_functions": 0,
+        "markers": {},
+        "tests_with_markers": 0,
+        "tests_without_markers": 0,
+        "misaligned_markers": [
+          {
+            "line": 68,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 93,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 136,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 150,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 164,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 179,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 192,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 205,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 218,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 237,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 253,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 269,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 296,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 316,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          }
+        ],
+        "duplicate_markers": [],
+        "recognized_markers": {},
+        "issues": [
+          {
+            "type": "misaligned_markers",
+            "message": "File has 14 misaligned markers"
+          }
+        ]
+      },
+      "/workspace/devsynth/tests/behavior/steps/test_workflow_execution_steps.py": {
+        "file_path": "/workspace/devsynth/tests/behavior/steps/test_workflow_execution_steps.py",
+        "has_pytest_import": true,
+        "test_functions": 0,
+        "markers": {},
+        "tests_with_markers": 0,
+        "tests_without_markers": 0,
+        "misaligned_markers": [
+          {
+            "line": 21,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 27,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 33,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          }
+        ],
+        "duplicate_markers": [],
+        "recognized_markers": {},
+        "issues": [
+          {
+            "type": "misaligned_markers",
+            "message": "File has 3 misaligned markers"
+          }
+        ]
+      },
+      "/workspace/devsynth/tests/behavior/steps/test_project_state_analyzer_steps.py": {
+        "file_path": "/workspace/devsynth/tests/behavior/steps/test_project_state_analyzer_steps.py",
+        "has_pytest_import": true,
+        "test_functions": 2,
+        "markers": {
+          "test_project_dir": "medium"
+        },
+        "tests_with_markers": 1,
+        "tests_without_markers": 1,
+        "misaligned_markers": [],
+        "duplicate_markers": [],
+        "recognized_markers": {
+          "medium": {
+            "file_count": 1,
+            "pytest_count": 13,
+            "recognized": false,
+            "registered_in_pytest_ini": true,
+            "uncollected_tests": [
+              "test_project_dir"
+            ]
+          }
+        },
+        "issues": [
+          {
+            "type": "unrecognized_markers",
+            "message": "medium markers are not recognized by pytest (1 in file, 13 recognized)"
+          }
+        ]
+      },
+      "/workspace/devsynth/tests/behavior/steps/test_serve_command_steps.py": {
+        "file_path": "/workspace/devsynth/tests/behavior/steps/test_serve_command_steps.py",
+        "has_pytest_import": true,
+        "test_functions": 0,
+        "markers": {},
+        "tests_with_markers": 0,
+        "tests_without_markers": 0,
+        "misaligned_markers": [
+          {
+            "line": 36,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 43,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 52,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 60,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 103,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 109,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 115,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 122,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 129,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 137,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 146,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 153,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 162,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          }
+        ],
+        "duplicate_markers": [],
+        "recognized_markers": {},
+        "issues": [
+          {
+            "type": "misaligned_markers",
+            "message": "File has 13 misaligned markers"
+          }
+        ]
+      },
+      "/workspace/devsynth/tests/behavior/steps/test_wsde_memory_integration_steps.py": {
+        "file_path": "/workspace/devsynth/tests/behavior/steps/test_wsde_memory_integration_steps.py",
+        "has_pytest_import": true,
+        "test_functions": 1,
+        "markers": {
+          "test_function": "medium"
+        },
+        "tests_with_markers": 1,
+        "tests_without_markers": 0,
+        "misaligned_markers": [
+          {
+            "line": 570,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 571,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 572,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 573,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 574,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 575,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 576,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 577,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 578,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 579,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 580,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 581,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 582,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 583,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 584,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 585,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          }
+        ],
+        "duplicate_markers": [
+          {
+            "test_name": "test_function",
+            "marker_count": 9
+          }
+        ],
+        "recognized_markers": {
+          "medium": {
+            "file_count": 1,
+            "pytest_count": 0,
+            "recognized": false,
+            "registered_in_pytest_ini": true,
+            "error": "exit code 2",
+            "uncollected_tests": []
+          }
+        },
+        "issues": [
+          {
+            "type": "misaligned_markers",
+            "message": "File has 16 misaligned markers"
+          },
+          {
+            "type": "duplicate_markers",
+            "message": "File has 1 tests with duplicate markers"
+          },
+          {
+            "type": "unrecognized_markers",
+            "message": "medium markers are not recognized by pytest (1 in file, 0 recognized)"
+          },
+          {
+            "type": "pytest_error",
+            "marker": "medium",
+            "message": "pytest collection failed for /workspace/devsynth/tests/behavior/steps/test_wsde_memory_integration_steps.py [marker=medium]: exit code 2"
+          }
+        ]
+      },
+      "/workspace/devsynth/tests/behavior/steps/test_doctor_missing_env_steps.py": {
+        "file_path": "/workspace/devsynth/tests/behavior/steps/test_doctor_missing_env_steps.py",
+        "has_pytest_import": true,
+        "test_functions": 0,
+        "markers": {},
+        "tests_with_markers": 0,
+        "tests_without_markers": 0,
+        "misaligned_markers": [
+          {
+            "line": 8,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 15,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          }
+        ],
+        "duplicate_markers": [],
+        "recognized_markers": {},
+        "issues": [
+          {
+            "type": "misaligned_markers",
+            "message": "File has 2 misaligned markers"
+          }
+        ]
+      },
+      "/workspace/devsynth/tests/behavior/steps/test_methodology_adapters_steps.py": {
+        "file_path": "/workspace/devsynth/tests/behavior/steps/test_methodology_adapters_steps.py",
+        "has_pytest_import": true,
+        "test_functions": 0,
+        "markers": {},
+        "tests_with_markers": 0,
+        "tests_without_markers": 0,
+        "misaligned_markers": [
+          {
+            "line": 28,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 46,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 53,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 59,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 64,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 73,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 85,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 90,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 104,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 115,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 129,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 142,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 147,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 156,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 165,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 174,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 193,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 199,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 206,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 234,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 239,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 244,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 249,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 255,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          }
+        ],
+        "duplicate_markers": [],
+        "recognized_markers": {},
+        "issues": [
+          {
+            "type": "misaligned_markers",
+            "message": "File has 24 misaligned markers"
+          }
+        ]
+      },
+      "/workspace/devsynth/tests/behavior/steps/test_refactor_command_steps.py": {
+        "file_path": "/workspace/devsynth/tests/behavior/steps/test_refactor_command_steps.py",
+        "has_pytest_import": true,
+        "test_functions": 0,
+        "markers": {},
+        "tests_with_markers": 0,
+        "tests_without_markers": 0,
+        "misaligned_markers": [
+          {
+            "line": 48,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 55,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 62,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 128,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 134,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 140,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 146,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 154,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 163,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 172,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 180,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 189,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 198,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          }
+        ],
+        "duplicate_markers": [],
+        "recognized_markers": {},
+        "issues": [
+          {
+            "type": "misaligned_markers",
+            "message": "File has 13 misaligned markers"
+          }
+        ]
+      },
+      "/workspace/devsynth/tests/behavior/steps/test_wsde_edrr_integration_steps.py": {
+        "file_path": "/workspace/devsynth/tests/behavior/steps/test_wsde_edrr_integration_steps.py",
+        "has_pytest_import": true,
+        "test_functions": 0,
+        "markers": {},
+        "tests_with_markers": 0,
+        "tests_without_markers": 0,
+        "misaligned_markers": [
+          {
+            "line": 81,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 88,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 118,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 150,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 164,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 180,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 191,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 213,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 230,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 252,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 266,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 293,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 319,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 348,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 367,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 400,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 440,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 476,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 519,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 544,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 559,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 574,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 610,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          }
+        ],
+        "duplicate_markers": [],
+        "recognized_markers": {},
+        "issues": [
+          {
+            "type": "misaligned_markers",
+            "message": "File has 23 misaligned markers"
+          }
+        ]
+      },
+      "/workspace/devsynth/tests/behavior/steps/test_cli_webui_parity_steps.py": {
+        "file_path": "/workspace/devsynth/tests/behavior/steps/test_cli_webui_parity_steps.py",
+        "has_pytest_import": true,
+        "test_functions": 0,
+        "markers": {},
+        "tests_with_markers": 0,
+        "tests_without_markers": 0,
+        "misaligned_markers": [
+          {
+            "line": 11,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 18,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 25,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 31,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 37,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 44,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 51,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 57,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 64,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 75,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          }
+        ],
+        "duplicate_markers": [],
+        "recognized_markers": {},
+        "issues": [
+          {
+            "type": "misaligned_markers",
+            "message": "File has 10 misaligned markers"
+          }
+        ]
+      },
+      "/workspace/devsynth/tests/behavior/steps/test_dbschema_generation_steps.py": {
+        "file_path": "/workspace/devsynth/tests/behavior/steps/test_dbschema_generation_steps.py",
+        "has_pytest_import": true,
+        "test_functions": 0,
+        "markers": {},
+        "tests_with_markers": 0,
+        "tests_without_markers": 0,
+        "misaligned_markers": [
+          {
+            "line": 21,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 28,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 34,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          }
+        ],
+        "duplicate_markers": [],
+        "recognized_markers": {},
+        "issues": [
+          {
+            "type": "misaligned_markers",
+            "message": "File has 3 misaligned markers"
+          }
+        ]
+      },
+      "/workspace/devsynth/tests/behavior/steps/test_promise_system_steps.py": {
+        "file_path": "/workspace/devsynth/tests/behavior/steps/test_promise_system_steps.py",
+        "has_pytest_import": true,
+        "test_functions": 0,
+        "markers": {},
+        "tests_with_markers": 0,
+        "tests_without_markers": 0,
+        "misaligned_markers": [
+          {
+            "line": 29,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 35,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 43,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 60,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 68,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 77,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 86,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 109,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 115,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 122,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 134,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 158,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 174,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 187,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 195,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 206,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 212,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 239,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 245,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 253,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 279,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 314,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 322,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          }
+        ],
+        "duplicate_markers": [],
+        "recognized_markers": {},
+        "issues": [
+          {
+            "type": "misaligned_markers",
+            "message": "File has 23 misaligned markers"
+          }
+        ]
+      },
+      "/workspace/devsynth/tests/behavior/steps/test_webui_navigation_prompts_steps.py": {
+        "file_path": "/workspace/devsynth/tests/behavior/steps/test_webui_navigation_prompts_steps.py",
+        "has_pytest_import": true,
+        "test_functions": 0,
+        "markers": {},
+        "tests_with_markers": 0,
+        "tests_without_markers": 0,
+        "misaligned_markers": [
+          {
+            "line": 8,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 14,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 21,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 29,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 35,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          }
+        ],
+        "duplicate_markers": [],
+        "recognized_markers": {},
+        "issues": [
+          {
+            "type": "misaligned_markers",
+            "message": "File has 5 misaligned markers"
+          }
+        ]
+      },
+      "/workspace/devsynth/tests/behavior/steps/test_validate_metadata_steps.py": {
+        "file_path": "/workspace/devsynth/tests/behavior/steps/test_validate_metadata_steps.py",
+        "has_pytest_import": true,
+        "test_functions": 0,
+        "markers": {},
+        "tests_with_markers": 0,
+        "tests_without_markers": 0,
+        "misaligned_markers": [
+          {
+            "line": 10,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 16,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 22,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          }
+        ],
+        "duplicate_markers": [],
+        "recognized_markers": {},
+        "issues": [
+          {
+            "type": "misaligned_markers",
+            "message": "File has 3 misaligned markers"
+          }
+        ]
+      },
+      "/workspace/devsynth/tests/behavior/steps/test_run_pipeline_command_steps.py": {
+        "file_path": "/workspace/devsynth/tests/behavior/steps/test_run_pipeline_command_steps.py",
+        "has_pytest_import": true,
+        "test_functions": 2,
+        "markers": {
+          "test_add": "medium",
+          "test_subtract": "medium"
+        },
+        "tests_with_markers": 2,
+        "tests_without_markers": 0,
+        "misaligned_markers": [],
+        "duplicate_markers": [
+          {
+            "test_name": "test_subtract",
+            "marker_count": 2
+          }
+        ],
+        "recognized_markers": {
+          "medium": {
+            "file_count": 2,
+            "pytest_count": 6,
+            "recognized": false,
+            "registered_in_pytest_ini": true,
+            "uncollected_tests": [
+              "test_add",
+              "test_subtract"
+            ]
+          }
+        },
+        "issues": [
+          {
+            "type": "duplicate_markers",
+            "message": "File has 1 tests with duplicate markers"
+          },
+          {
+            "type": "unrecognized_markers",
+            "message": "medium markers are not recognized by pytest (2 in file, 6 recognized)"
+          }
+        ]
+      },
+      "/workspace/devsynth/tests/behavior/steps/test_micro_edrr_cycle_steps.py": {
+        "file_path": "/workspace/devsynth/tests/behavior/steps/test_micro_edrr_cycle_steps.py",
+        "has_pytest_import": true,
+        "test_functions": 0,
+        "markers": {},
+        "tests_with_markers": 0,
+        "tests_without_markers": 0,
+        "misaligned_markers": [
+          {
+            "line": 57,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 140,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 155,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 187,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 232,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 260,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 319,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          }
+        ],
+        "duplicate_markers": [],
+        "recognized_markers": {},
+        "issues": [
+          {
+            "type": "misaligned_markers",
+            "message": "File has 7 misaligned markers"
+          }
+        ]
+      },
+      "/workspace/devsynth/tests/behavior/steps/test_apispec_generation_steps.py": {
+        "file_path": "/workspace/devsynth/tests/behavior/steps/test_apispec_generation_steps.py",
+        "has_pytest_import": true,
+        "test_functions": 0,
+        "markers": {},
+        "tests_with_markers": 0,
+        "tests_without_markers": 0,
+        "misaligned_markers": [
+          {
+            "line": 25,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 32,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 42,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          }
+        ],
+        "duplicate_markers": [],
+        "recognized_markers": {},
+        "issues": [
+          {
+            "type": "misaligned_markers",
+            "message": "File has 3 misaligned markers"
+          }
+        ]
+      },
+      "/workspace/devsynth/tests/behavior/steps/test_mddr_gathering_perspectives_steps.py": {
+        "file_path": "/workspace/devsynth/tests/behavior/steps/test_mddr_gathering_perspectives_steps.py",
+        "has_pytest_import": true,
+        "test_functions": 0,
+        "markers": {},
+        "tests_with_markers": 0,
+        "tests_without_markers": 0,
+        "misaligned_markers": [
+          {
+            "line": 9,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 31,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 41,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 48,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 58,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 65,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 77,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 84,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 156,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 181,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 260,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 307,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          }
+        ],
+        "duplicate_markers": [],
+        "recognized_markers": {},
+        "issues": [
+          {
+            "type": "misaligned_markers",
+            "message": "File has 12 misaligned markers"
+          }
+        ]
+      },
+      "/workspace/devsynth/tests/behavior/steps/test_edrr_enhanced_memory_integration_steps.py": {
+        "file_path": "/workspace/devsynth/tests/behavior/steps/test_edrr_enhanced_memory_integration_steps.py",
+        "has_pytest_import": true,
+        "test_functions": 4,
+        "markers": {
+          "test_store_method_succeeds": "medium"
+        },
+        "tests_with_markers": 1,
+        "tests_without_markers": 3,
+        "misaligned_markers": [
+          {
+            "line": 141,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 142,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 143,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 144,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 145,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 146,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 252,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 253,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 254,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 255,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 256,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 257,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 300,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 301,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 302,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 303,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 304,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 305,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 657,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 658,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 659,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 660,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 661,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 662,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          }
+        ],
+        "duplicate_markers": [
+          {
+            "test_name": "test_store_method_succeeds",
+            "marker_count": 36
+          },
+          {
+            "test_name": "test_store_method_succeeds",
+            "marker_count": 36
+          },
+          {
+            "test_name": "test_store_method_succeeds",
+            "marker_count": 36
+          },
+          {
+            "test_name": "test_store_method_succeeds",
+            "marker_count": 36
+          }
+        ],
+        "recognized_markers": {
+          "medium": {
+            "file_count": 1,
+            "pytest_count": 0,
+            "recognized": false,
+            "registered_in_pytest_ini": true,
+            "error": "exit code 5",
+            "uncollected_tests": []
+          }
+        },
+        "issues": [
+          {
+            "type": "misaligned_markers",
+            "message": "File has 24 misaligned markers"
+          },
+          {
+            "type": "duplicate_markers",
+            "message": "File has 4 tests with duplicate markers"
+          },
+          {
+            "type": "unrecognized_markers",
+            "message": "medium markers are not recognized by pytest (1 in file, 0 recognized)"
+          },
+          {
+            "type": "pytest_error",
+            "marker": "medium",
+            "message": "pytest collection failed for /workspace/devsynth/tests/behavior/steps/test_edrr_enhanced_memory_integration_steps.py [marker=medium]: exit code 5"
+          }
+        ]
+      },
+      "/workspace/devsynth/tests/behavior/steps/test_environment_variables_steps.py": {
+        "file_path": "/workspace/devsynth/tests/behavior/steps/test_environment_variables_steps.py",
+        "has_pytest_import": true,
+        "test_functions": 0,
+        "markers": {},
+        "tests_with_markers": 0,
+        "tests_without_markers": 0,
+        "misaligned_markers": [
+          {
+            "line": 14,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 31,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          }
+        ],
+        "duplicate_markers": [],
+        "recognized_markers": {},
+        "issues": [
+          {
+            "type": "misaligned_markers",
+            "message": "File has 2 misaligned markers"
+          }
+        ]
+      },
+      "/workspace/devsynth/tests/behavior/steps/test_uxbridge_steps.py": {
+        "file_path": "/workspace/devsynth/tests/behavior/steps/test_uxbridge_steps.py",
+        "has_pytest_import": true,
+        "test_functions": 0,
+        "markers": {},
+        "tests_with_markers": 0,
+        "tests_without_markers": 0,
+        "misaligned_markers": [
+          {
+            "line": 28,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 44,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 65,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 89,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 99,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 107,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 115,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 124,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 132,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          }
+        ],
+        "duplicate_markers": [],
+        "recognized_markers": {},
+        "issues": [
+          {
+            "type": "misaligned_markers",
+            "message": "File has 9 misaligned markers"
+          }
+        ]
+      },
+      "/workspace/devsynth/tests/behavior/steps/test_inspect_code_command_steps.py": {
+        "file_path": "/workspace/devsynth/tests/behavior/steps/test_inspect_code_command_steps.py",
+        "has_pytest_import": true,
+        "test_functions": 0,
+        "markers": {},
+        "tests_with_markers": 0,
+        "tests_without_markers": 0,
+        "misaligned_markers": [
+          {
+            "line": 54,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 60,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 67,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 162,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 168,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 174,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 181,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 188,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 195,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 204,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 215,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 223,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 232,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 246,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 261,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          }
+        ],
+        "duplicate_markers": [],
+        "recognized_markers": {},
+        "issues": [
+          {
+            "type": "misaligned_markers",
+            "message": "File has 15 misaligned markers"
+          }
+        ]
+      },
+      "/workspace/devsynth/tests/behavior/steps/test_project_initialization_steps.py": {
+        "file_path": "/workspace/devsynth/tests/behavior/steps/test_project_initialization_steps.py",
+        "has_pytest_import": true,
+        "test_functions": 0,
+        "markers": {},
+        "tests_with_markers": 0,
+        "tests_without_markers": 0,
+        "misaligned_markers": [
+          {
+            "line": 21,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 27,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 33,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          }
+        ],
+        "duplicate_markers": [],
+        "recognized_markers": {},
+        "issues": [
+          {
+            "type": "misaligned_markers",
+            "message": "File has 3 misaligned markers"
+          }
+        ]
+      },
+      "/workspace/devsynth/tests/behavior/steps/test_webui_doctor_steps.py": {
+        "file_path": "/workspace/devsynth/tests/behavior/steps/test_webui_doctor_steps.py",
+        "has_pytest_import": true,
+        "test_functions": 0,
+        "markers": {},
+        "tests_with_markers": 0,
+        "tests_without_markers": 0,
+        "misaligned_markers": [
+          {
+            "line": 9,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 15,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 22,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 28,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 35,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 42,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 49,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 56,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 63,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 69,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 76,
             "marker": "medium",
             "text": "@pytest.mark.medium"
           },
@@ -23747,17 +10931,52 @@
             "text": "@pytest.mark.medium"
           },
           {
-            "line": 104,
+            "line": 107,
             "marker": "medium",
             "text": "@pytest.mark.medium"
           },
           {
-            "line": 111,
+            "line": 114,
             "marker": "medium",
             "text": "@pytest.mark.medium"
           },
           {
-            "line": 118,
+            "line": 125,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 132,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 139,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 146,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 153,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 164,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 171,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 178,
             "marker": "medium",
             "text": "@pytest.mark.medium"
           }
@@ -23767,35 +10986,7 @@
         "issues": [
           {
             "type": "misaligned_markers",
-            "message": "File has 16 misaligned markers"
-          }
-        ]
-      },
-      "/workspace/devsynth/tests/behavior/steps/test_validate_manifest_command_steps.py": {
-        "file_path": "/workspace/devsynth/tests/behavior/steps/test_validate_manifest_command_steps.py",
-        "has_pytest_import": false,
-        "test_functions": 0,
-        "markers": {},
-        "tests_with_markers": 0,
-        "tests_without_markers": 0,
-        "misaligned_markers": [
-          {
-            "line": 13,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 25,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          }
-        ],
-        "duplicate_markers": [],
-        "recognized_markers": {},
-        "issues": [
-          {
-            "type": "misaligned_markers",
-            "message": "File has 2 misaligned markers"
+            "message": "File has 23 misaligned markers"
           }
         ]
       },
@@ -23832,28 +11023,54 @@
           }
         ]
       },
-      "/workspace/devsynth/tests/behavior/steps/test_edrr_enhanced_phase_transitions_steps.py": {
-        "file_path": "/workspace/devsynth/tests/behavior/steps/test_edrr_enhanced_phase_transitions_steps.py",
+      "/workspace/devsynth/tests/behavior/steps/test_error_handling_steps.py": {
+        "file_path": "/workspace/devsynth/tests/behavior/steps/test_error_handling_steps.py",
         "has_pytest_import": true,
-        "test_functions": 7,
-        "markers": {
-          "test_store_method_succeeds": "medium"
-        },
-        "tests_with_markers": 1,
-        "tests_without_markers": 6,
+        "test_functions": 0,
+        "markers": {},
+        "tests_with_markers": 0,
+        "tests_without_markers": 0,
         "misaligned_markers": [
           {
-            "line": 61,
+            "line": 21,
             "marker": "medium",
             "text": "@pytest.mark.medium"
           },
           {
-            "line": 89,
+            "line": 27,
             "marker": "medium",
             "text": "@pytest.mark.medium"
           },
           {
-            "line": 97,
+            "line": 33,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          }
+        ],
+        "duplicate_markers": [],
+        "recognized_markers": {},
+        "issues": [
+          {
+            "type": "misaligned_markers",
+            "message": "File has 3 misaligned markers"
+          }
+        ]
+      },
+      "/workspace/devsynth/tests/behavior/steps/test_delegate_task_steps.py": {
+        "file_path": "/workspace/devsynth/tests/behavior/steps/test_delegate_task_steps.py",
+        "has_pytest_import": true,
+        "test_functions": 0,
+        "markers": {},
+        "tests_with_markers": 0,
+        "tests_without_markers": 0,
+        "misaligned_markers": [
+          {
+            "line": 81,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 96,
             "marker": "medium",
             "text": "@pytest.mark.medium"
           },
@@ -23863,17 +11080,22 @@
             "text": "@pytest.mark.medium"
           },
           {
-            "line": 115,
+            "line": 112,
             "marker": "medium",
             "text": "@pytest.mark.medium"
           },
           {
-            "line": 123,
+            "line": 119,
             "marker": "medium",
             "text": "@pytest.mark.medium"
           },
           {
-            "line": 133,
+            "line": 127,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 135,
             "marker": "medium",
             "text": "@pytest.mark.medium"
           },
@@ -23883,428 +11105,35 @@
             "text": "@pytest.mark.medium"
           },
           {
-            "line": 226,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 233,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 240,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 308,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 317,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 341,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 360,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 376,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 398,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 430,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 450,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 470,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 528,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 548,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 580,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 607,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 631,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 711,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 732,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 777,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 784,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 795,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 805,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 816,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 830,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 842,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 870,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 921,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 932,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 942,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 951,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 962,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 975,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 1037,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 1086,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 1092,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 1098,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 1105,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 1111,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 1117,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 1129,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 1172,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 1192,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 1210,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 1223,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 1243,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 1256,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 1337,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 1347,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 1412,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 1447,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 1472,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 1479,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 1489,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 1501,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 1511,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 1553,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 1632,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 1644,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 1653,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 1674,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 1752,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 1804,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 1812,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 1822,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 1836,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 1852,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 1866,
+            "line": 147,
             "marker": "medium",
             "text": "@pytest.mark.medium"
           }
         ],
-        "duplicate_markers": [
-          {
-            "test_name": "test_store_method_succeeds",
-            "marker_count": 11
-          },
-          {
-            "test_name": "test_store_method_succeeds",
-            "marker_count": 11
-          },
-          {
-            "test_name": "test_store_method_succeeds",
-            "marker_count": 11
-          },
-          {
-            "test_name": "test_store_method_succeeds",
-            "marker_count": 11
-          },
-          {
-            "test_name": "test_store_method_succeeds",
-            "marker_count": 11
-          },
-          {
-            "test_name": "test_store_method_succeeds",
-            "marker_count": 11
-          },
-          {
-            "test_name": "test_store_method_succeeds",
-            "marker_count": 11
-          }
-        ],
-        "recognized_markers": {
-          "medium": {
-            "file_count": 1,
-            "pytest_count": 0,
-            "recognized": false,
-            "registered_in_pytest_ini": true,
-            "error": "subprocess error: 4",
-            "uncollected_tests": []
-          }
-        },
+        "duplicate_markers": [],
+        "recognized_markers": {},
         "issues": [
           {
             "type": "misaligned_markers",
-            "message": "File has 76 misaligned markers"
-          },
-          {
-            "type": "duplicate_markers",
-            "message": "File has 7 tests with duplicate markers"
-          },
-          {
-            "type": "unrecognized_markers",
-            "message": "medium markers are not recognized by pytest (1 in file, 0 recognized)"
+            "message": "File has 9 misaligned markers"
           }
         ]
       },
-      "/workspace/devsynth/tests/behavior/steps/test_code_command_steps.py": {
-        "file_path": "/workspace/devsynth/tests/behavior/steps/test_code_command_steps.py",
+      "/workspace/devsynth/tests/behavior/steps/test_training_materials_steps.py": {
+        "file_path": "/workspace/devsynth/tests/behavior/steps/test_training_materials_steps.py",
         "has_pytest_import": true,
-        "test_functions": 1,
-        "markers": {
-          "test_sample": "medium"
-        },
-        "tests_with_markers": 1,
+        "test_functions": 0,
+        "markers": {},
+        "tests_with_markers": 0,
         "tests_without_markers": 0,
         "misaligned_markers": [
           {
-            "line": 10,
+            "line": 33,
             "marker": "medium",
             "text": "@pytest.mark.medium"
           },
           {
-            "line": 15,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 23,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 44,
+            "line": 41,
             "marker": "medium",
             "text": "@pytest.mark.medium"
           },
@@ -24314,107 +11143,892 @@
             "text": "@pytest.mark.medium"
           },
           {
-            "line": 56,
+            "line": 69,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 80,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 103,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 135,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 143,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 152,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 159,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 172,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 185,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 220,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 226,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 235,
             "marker": "medium",
             "text": "@pytest.mark.medium"
           }
         ],
         "duplicate_markers": [],
-        "recognized_markers": {
-          "medium": {
-            "file_count": 1,
-            "pytest_count": 0,
-            "recognized": false,
-            "registered_in_pytest_ini": true,
-            "error": "subprocess error: 4",
-            "uncollected_tests": []
+        "recognized_markers": {},
+        "issues": [
+          {
+            "type": "misaligned_markers",
+            "message": "File has 15 misaligned markers"
           }
-        },
+        ]
+      },
+      "/workspace/devsynth/tests/behavior/steps/test_additional_storage_backends_steps.py": {
+        "file_path": "/workspace/devsynth/tests/behavior/steps/test_additional_storage_backends_steps.py",
+        "has_pytest_import": true,
+        "test_functions": 0,
+        "markers": {},
+        "tests_with_markers": 0,
+        "tests_without_markers": 0,
+        "misaligned_markers": [
+          {
+            "line": 103,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 114,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 127,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 150,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 180,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 192,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 211,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 249,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 258,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 281,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 292,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 318,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 344,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 355,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 384,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 411,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 461,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 487,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 499,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 527,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 554,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 579,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 601,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 620,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 638,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 664,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 676,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 696,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 723,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 735,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          }
+        ],
+        "duplicate_markers": [],
+        "recognized_markers": {},
+        "issues": [
+          {
+            "type": "misaligned_markers",
+            "message": "File has 30 misaligned markers"
+          }
+        ]
+      },
+      "/workspace/devsynth/tests/behavior/steps/test_mddr_synthesis_generation_steps.py": {
+        "file_path": "/workspace/devsynth/tests/behavior/steps/test_mddr_synthesis_generation_steps.py",
+        "has_pytest_import": true,
+        "test_functions": 0,
+        "markers": {},
+        "tests_with_markers": 0,
+        "tests_without_markers": 0,
+        "misaligned_markers": [
+          {
+            "line": 9,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 101,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 175,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 227,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 299,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 323,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          }
+        ],
+        "duplicate_markers": [],
+        "recognized_markers": {},
         "issues": [
           {
             "type": "misaligned_markers",
             "message": "File has 6 misaligned markers"
-          },
-          {
-            "type": "unrecognized_markers",
-            "message": "medium markers are not recognized by pytest (1 in file, 0 recognized)"
           }
         ]
       },
-      "/workspace/devsynth/tests/behavior/steps/test_generation_steps.py": {
-        "file_path": "/workspace/devsynth/tests/behavior/steps/test_generation_steps.py",
+      "/workspace/devsynth/tests/behavior/steps/test_memory_adapter_integration_steps.py": {
+        "file_path": "/workspace/devsynth/tests/behavior/steps/test_memory_adapter_integration_steps.py",
         "has_pytest_import": true,
-        "test_functions": 1,
-        "markers": {
-          "test_sample": "medium"
-        },
-        "tests_with_markers": 1,
+        "test_functions": 0,
+        "markers": {},
+        "tests_with_markers": 0,
         "tests_without_markers": 0,
         "misaligned_markers": [
-          {
-            "line": 13,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 23,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
           {
             "line": 62,
             "marker": "medium",
             "text": "@pytest.mark.medium"
           },
           {
-            "line": 75,
+            "line": 70,
             "marker": "medium",
             "text": "@pytest.mark.medium"
           },
           {
-            "line": 84,
+            "line": 80,
             "marker": "medium",
             "text": "@pytest.mark.medium"
           },
           {
-            "line": 92,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 105,
-            "marker": "medium",
-            "text": "@pytest.mark.medium"
-          },
-          {
-            "line": 113,
+            "line": 90,
             "marker": "medium",
             "text": "@pytest.mark.medium"
           }
         ],
         "duplicate_markers": [],
+        "recognized_markers": {},
+        "issues": [
+          {
+            "type": "misaligned_markers",
+            "message": "File has 4 misaligned markers"
+          }
+        ]
+      },
+      "/workspace/devsynth/tests/behavior/steps/test_setup_wizard_steps.py": {
+        "file_path": "/workspace/devsynth/tests/behavior/steps/test_setup_wizard_steps.py",
+        "has_pytest_import": true,
+        "test_functions": 0,
+        "markers": {},
+        "tests_with_markers": 0,
+        "tests_without_markers": 0,
+        "misaligned_markers": [
+          {
+            "line": 38,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 44,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 65,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 93,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 104,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          }
+        ],
+        "duplicate_markers": [],
+        "recognized_markers": {},
+        "issues": [
+          {
+            "type": "misaligned_markers",
+            "message": "File has 5 misaligned markers"
+          }
+        ]
+      },
+      "/workspace/devsynth/tests/behavior/steps/test_config_loader_steps.py": {
+        "file_path": "/workspace/devsynth/tests/behavior/steps/test_config_loader_steps.py",
+        "has_pytest_import": true,
+        "test_functions": 0,
+        "markers": {},
+        "tests_with_markers": 0,
+        "tests_without_markers": 0,
+        "misaligned_markers": [
+          {
+            "line": 21,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 33,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 43,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 52,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 59,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 65,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 71,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          }
+        ],
+        "duplicate_markers": [],
+        "recognized_markers": {},
+        "issues": [
+          {
+            "type": "misaligned_markers",
+            "message": "File has 7 misaligned markers"
+          }
+        ]
+      },
+      "/workspace/devsynth/tests/behavior/steps/test_self_analyzer_steps.py": {
+        "file_path": "/workspace/devsynth/tests/behavior/steps/test_self_analyzer_steps.py",
+        "has_pytest_import": true,
+        "test_functions": 3,
+        "markers": {
+          "test_project_dir": "medium"
+        },
+        "tests_with_markers": 1,
+        "tests_without_markers": 2,
+        "misaligned_markers": [],
+        "duplicate_markers": [],
+        "recognized_markers": {
+          "medium": {
+            "file_count": 1,
+            "pytest_count": 14,
+            "recognized": false,
+            "registered_in_pytest_ini": true,
+            "uncollected_tests": [
+              "test_project_dir"
+            ]
+          }
+        },
+        "issues": [
+          {
+            "type": "unrecognized_markers",
+            "message": "medium markers are not recognized by pytest (1 in file, 14 recognized)"
+          }
+        ]
+      },
+      "/workspace/devsynth/tests/behavior/steps/test_doctor_steps.py": {
+        "file_path": "/workspace/devsynth/tests/behavior/steps/test_doctor_steps.py",
+        "has_pytest_import": true,
+        "test_functions": 0,
+        "markers": {},
+        "tests_with_markers": 0,
+        "tests_without_markers": 0,
+        "misaligned_markers": [
+          {
+            "line": 8,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 16,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          }
+        ],
+        "duplicate_markers": [],
+        "recognized_markers": {},
+        "issues": [
+          {
+            "type": "misaligned_markers",
+            "message": "File has 2 misaligned markers"
+          }
+        ]
+      },
+      "/workspace/devsynth/tests/behavior/steps/test_wsde_memory_integration_fixed_steps.py": {
+        "file_path": "/workspace/devsynth/tests/behavior/steps/test_wsde_memory_integration_fixed_steps.py",
+        "has_pytest_import": true,
+        "test_functions": 1,
+        "markers": {
+          "test_function": "medium"
+        },
+        "tests_with_markers": 1,
+        "tests_without_markers": 0,
+        "misaligned_markers": [
+          {
+            "line": 569,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 570,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 571,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 572,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 573,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 574,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 575,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 576,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 577,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 578,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 579,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 580,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 581,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 582,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 583,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 584,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          }
+        ],
+        "duplicate_markers": [
+          {
+            "test_name": "test_function",
+            "marker_count": 9
+          }
+        ],
         "recognized_markers": {
           "medium": {
             "file_count": 1,
             "pytest_count": 0,
             "recognized": false,
             "registered_in_pytest_ini": true,
-            "error": "subprocess error: 4",
+            "error": "exit code 2",
             "uncollected_tests": []
           }
         },
         "issues": [
           {
             "type": "misaligned_markers",
-            "message": "File has 8 misaligned markers"
+            "message": "File has 16 misaligned markers"
+          },
+          {
+            "type": "duplicate_markers",
+            "message": "File has 1 tests with duplicate markers"
           },
           {
             "type": "unrecognized_markers",
             "message": "medium markers are not recognized by pytest (1 in file, 0 recognized)"
+          },
+          {
+            "type": "pytest_error",
+            "marker": "medium",
+            "message": "pytest collection failed for /workspace/devsynth/tests/behavior/steps/test_wsde_memory_integration_fixed_steps.py [marker=medium]: exit code 2"
+          }
+        ]
+      },
+      "/workspace/devsynth/tests/behavior/steps/test_code_generation_steps.py": {
+        "file_path": "/workspace/devsynth/tests/behavior/steps/test_code_generation_steps.py",
+        "has_pytest_import": true,
+        "test_functions": 1,
+        "markers": {
+          "test_dummy": "medium"
+        },
+        "tests_with_markers": 1,
+        "tests_without_markers": 0,
+        "misaligned_markers": [],
+        "duplicate_markers": [
+          {
+            "test_name": "test_dummy",
+            "marker_count": 2
+          }
+        ],
+        "recognized_markers": {
+          "medium": {
+            "file_count": 1,
+            "pytest_count": 0,
+            "recognized": false,
+            "registered_in_pytest_ini": true,
+            "error": "exit code 2",
+            "uncollected_tests": []
+          }
+        },
+        "issues": [
+          {
+            "type": "duplicate_markers",
+            "message": "File has 1 tests with duplicate markers"
+          },
+          {
+            "type": "unrecognized_markers",
+            "message": "medium markers are not recognized by pytest (1 in file, 0 recognized)"
+          },
+          {
+            "type": "pytest_error",
+            "marker": "medium",
+            "message": "pytest collection failed for /workspace/devsynth/tests/behavior/steps/test_code_generation_steps.py [marker=medium]: exit code 2"
+          }
+        ]
+      },
+      "/workspace/devsynth/tests/behavior/steps/test_edrr_enhanced_phase_transitions_steps.py": {
+        "file_path": "/workspace/devsynth/tests/behavior/steps/test_edrr_enhanced_phase_transitions_steps.py",
+        "has_pytest_import": true,
+        "test_functions": 7,
+        "markers": {
+          "test_store_method_succeeds": "medium"
+        },
+        "tests_with_markers": 1,
+        "tests_without_markers": 6,
+        "misaligned_markers": [],
+        "duplicate_markers": [
+          {
+            "test_name": "test_store_method_succeeds",
+            "marker_count": 49
+          },
+          {
+            "test_name": "test_store_method_succeeds",
+            "marker_count": 49
+          },
+          {
+            "test_name": "test_store_method_succeeds",
+            "marker_count": 49
+          },
+          {
+            "test_name": "test_store_method_succeeds",
+            "marker_count": 49
+          },
+          {
+            "test_name": "test_store_method_succeeds",
+            "marker_count": 49
+          },
+          {
+            "test_name": "test_store_method_succeeds",
+            "marker_count": 49
+          },
+          {
+            "test_name": "test_store_method_succeeds",
+            "marker_count": 49
+          }
+        ],
+        "recognized_markers": {
+          "medium": {
+            "file_count": 1,
+            "pytest_count": 11,
+            "recognized": false,
+            "registered_in_pytest_ini": true,
+            "uncollected_tests": [
+              "test_store_method_succeeds"
+            ]
+          }
+        },
+        "issues": [
+          {
+            "type": "duplicate_markers",
+            "message": "File has 7 tests with duplicate markers"
+          },
+          {
+            "type": "unrecognized_markers",
+            "message": "medium markers are not recognized by pytest (1 in file, 11 recognized)"
+          }
+        ]
+      },
+      "/workspace/devsynth/tests/behavior/steps/test_wsde_message_passing_peer_review_steps.py": {
+        "file_path": "/workspace/devsynth/tests/behavior/steps/test_wsde_message_passing_peer_review_steps.py",
+        "has_pytest_import": true,
+        "test_functions": 1,
+        "markers": {
+          "test_example": "medium"
+        },
+        "tests_with_markers": 1,
+        "tests_without_markers": 0,
+        "misaligned_markers": [
+          {
+            "line": 425,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 426,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 427,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 428,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 429,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 430,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 431,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 432,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 433,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 434,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 435,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 436,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 437,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 438,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 439,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 440,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 441,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 442,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 443,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 444,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 445,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 446,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 447,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 448,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 449,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          },
+          {
+            "line": 450,
+            "marker": "medium",
+            "text": "@pytest.mark.medium"
+          }
+        ],
+        "duplicate_markers": [
+          {
+            "test_name": "test_example",
+            "marker_count": 9
+          }
+        ],
+        "recognized_markers": {
+          "medium": {
+            "file_count": 1,
+            "pytest_count": 0,
+            "recognized": false,
+            "registered_in_pytest_ini": true,
+            "error": "exit code 2",
+            "uncollected_tests": []
+          }
+        },
+        "issues": [
+          {
+            "type": "misaligned_markers",
+            "message": "File has 26 misaligned markers"
+          },
+          {
+            "type": "duplicate_markers",
+            "message": "File has 1 tests with duplicate markers"
+          },
+          {
+            "type": "unrecognized_markers",
+            "message": "medium markers are not recognized by pytest (1 in file, 0 recognized)"
+          },
+          {
+            "type": "pytest_error",
+            "marker": "medium",
+            "message": "pytest collection failed for /workspace/devsynth/tests/behavior/steps/test_wsde_message_passing_peer_review_steps.py [marker=medium]: exit code 2"
           }
         ]
       }
     },
-    "subprocess_timeouts": 0
+    "subprocess_timeouts": 0,
+    "success": false
   }
 }


### PR DESCRIPTION
## Summary
- Note ongoing speed marker misalignment in `tests/behavior/steps` within project and feature status docs
- Update `Expand test generation capabilities` issue to reflect verification failure
- Regenerate `test_markers_report.json`

## Testing
- `poetry run python scripts/verify_test_markers.py --module tests/behavior/steps --report --report-file test_markers_report.json` (fails: pytest collection errors)
- `poetry run devsynth run-tests --speed=fast` (fails: SyntaxError in multiple test modules)
- `poetry run pre-commit run --files docs/implementation/feature_status_matrix.md docs/implementation/project_status.md issues/Expand-test-generation-capabilities.md test_markers_report.json` (fails: find-syntax-errors)


------
https://chatgpt.com/codex/tasks/task_e_68a3bb6dfe208333b721ad411f86b5e6