### PR TITLE
docs: correct release milestone references

### DIFF
--- a/docs/archived/roadmaps/ROADMAP.md
+++ b/docs/archived/roadmaps/ROADMAP.md
@@ -31,7 +31,7 @@ A comprehensive plan for Phase 2 implementation is available in the [Task Progre
 - **0.1.0-alpha.1** – Core architecture completed with offline provider support, baseline CLI commands, and initial tests (~50% coverage).
 - **0.1.0-alpha.1** – Peer review workflow and Web UI preview with major tests passing and coverage ≥75%.
 - **0.1.0-rc.1** – Documentation freeze and full test suite passing with coverage ≥90%.
-- **0.2.0** – Expanded agent capabilities, improved memory backends, and API enhancements.
+- **0.1.x** – Expanded agent capabilities, improved memory backends, and API enhancements.
 - **1.0.0** – First stable release with comprehensive documentation and deployment automation.
 
 ## Current Release Status

--- a/docs/archived/roadmaps/release_plan.md
+++ b/docs/archived/roadmaps/release_plan.md
@@ -34,11 +34,11 @@ Dependencies among major features are summarized in [Feature Dependencies](featu
    - Establish baseline testing and documentation.
    - Phase 1 is largely complete; remaining tasks include finalizing the WSDE peer review workflow, stabilizing cross-store memory integration, and resolving outstanding test failures. See the [Feature Status Matrix](../implementation/feature_status_matrix.md) for detailed progress on collaboration features.
 
-2. **Production Readiness** (0.2.x–0.3.x – Q4 2025)
+2. **Production Readiness** (0.1.x–0.3.x – Q4 2025)
    - Polish CLI UX and integrate the initial Web UI.
    - Perform repository analysis and improve code organization.
    - Expand automated testing and CI/CD.
-   - Introduce multi-language code generation starting in **0.2.x**. See [Post-MVP Roadmap](post_mvp_roadmap.md#phase-4-advanced-code-generation-and-refactoring) for details.
+   - Introduce multi-language code generation starting in **0.1.x**. See [Post-MVP Roadmap](post_mvp_roadmap.md#phase-4-advanced-code-generation-and-refactoring) for details.
    - Provide AST mutation tooling for automated refactoring and testing in **0.3.x** (refer to [Post-MVP Roadmap](post_mvp_roadmap.md#phase-3-self-improvement-capabilities)).
 
 3. **Collaboration & Validation** (0.4.x–0.6.x – Q1–Q3 2026)
@@ -63,8 +63,8 @@ Dependencies among major features are summarized in [Feature Dependencies](featu
   tests passing.
 - **0.1.0-rc.1**: Documentation freeze and full test suite passing as the
   release candidate for version 0.1.0.
-- **0.2.0–0.6.0**: Incremental releases adding collaboration, Web UI, and testing improvements.
-- **0.2.x**: Multi-language code generation support.
+- **0.1.1–0.6.0**: Incremental releases adding collaboration, Web UI, and testing improvements.
+- **0.1.x**: Multi-language code generation support.
 - **0.3.x**: AST mutation tooling for refactoring.
 - **0.6.x**: Experimental DSPy-AI integration (finalize by **0.8.0**).
 - **0.7.x–0.9.0**: Optimization, Promise-Theory reliability work, and preparation for the 1.0 release.

--- a/docs/release/roadmap.md
+++ b/docs/release/roadmap.md
@@ -32,7 +32,7 @@ This roadmap outlines planned milestones and targeted features following the `0.
 - Harden security policies and release automation.
 - Conduct full dialectical audit and cross-functional review.
 
-### 0.2.0
+### 0.1.1
 - Expand plugin ecosystem and marketplace support.
 - Enable multi-agent orchestration and cross-platform integration.
 - Optimize performance and telemetry for production environments.

--- a/docs/roadmap/CONSOLIDATED_ROADMAP.md
+++ b/docs/roadmap/CONSOLIDATED_ROADMAP.md
@@ -58,12 +58,12 @@ The project will transition to Phase 2 (Production Readiness) after publishing `
 - Address adoption barriers and ensure offline capabilities
 - Establish baseline testing and documentation
 
-### 2. Production Readiness (0.2.x–0.3.x – Q4 2025) - PLANNED
+### 2. Production Readiness (0.1.x–0.3.x – Q4 2025) - PLANNED
 
 - Polish CLI UX and integrate the initial Web UI
 - Perform repository analysis and improve code organization
 - Expand automated testing and CI/CD
-- Introduce multi-language code generation starting in **0.2.x**
+- Introduce multi-language code generation starting in **0.1.x**
 - Provide AST mutation tooling for automated refactoring and testing in **0.3.x**
 
 #### Phase 2 Focus Areas
@@ -131,8 +131,8 @@ The project will transition to Phase 2 (Production Readiness) after publishing `
 
 - **[0.1.0-alpha.1](../../CHANGELOG.md#010-alpha1---unreleased)** (CURRENT TARGET): Core architecture in place with Anthropic and offline providers, baseline CLI commands, and initial EDRR/WSDE integration.
 - **0.1.0-rc.1** (PLANNED): Documentation freeze and full test suite passing as the release candidate for version 0.1.0.
-- **0.2.0–0.6.0** (PLANNED): Incremental releases adding collaboration, Web UI, and testing improvements.
-- **0.2.x** (PLANNED): Multi-language code generation support.
+- **0.1.1–0.6.0** (PLANNED): Incremental releases adding collaboration, Web UI, and testing improvements.
+- **0.1.x** (PLANNED): Multi-language code generation support.
 - **0.3.x** (PLANNED): AST mutation tooling for refactoring.
 - **0.6.x** (PLANNED): Experimental DSPy-AI integration (finalize by **0.8.0**).
 - **0.7.x–0.9.0** (PLANNED): Optimization, Promise-Theory reliability work, and preparation for the 1.0 release.

--- a/docs/roadmap/release_plan.md
+++ b/docs/roadmap/release_plan.md
@@ -52,7 +52,7 @@ git push origin v0.1.0-alpha.1
 - Finalize MVUU engine and Atomic-Rewrite tooling.
 - Complete MVUU dashboard for requirements traceability via `devsynth mvuu-dashboard`.
 
-### 0.2.0
+### 0.1.1
 - Achieve baseline Dear PyGui parity for core workflows via the desktop interface; requires the `gui` optional extras (`devsynth[gui]`). See the [Dear PyGui User Guide](../user_guides/dearpygui.md).
 - Expand WebUI features with enhanced requirements workflows.
 - Introduce plugin interfaces for third-party provider integration.
@@ -61,7 +61,7 @@ git push origin v0.1.0-alpha.1
 ### MVUU Dashboard (Completed)
 NiceGUI MVUU traceability dashboard accessible via `devsynth mvuu-dashboard`.
 
-### 0.2.0+ (Future Features)
+### 0.1.1+ (Future Features)
 - Implement feature flags for experimental modules.
 - Introduce feature flags for the MVUU dashboard and Dear PyGui interface.
 - Automate project-board synchronization with release milestones.

--- a/issues/Complete-Sprint-EDRR-integration.md
+++ b/issues/Complete-Sprint-EDRR-integration.md
@@ -1,5 +1,5 @@
 # Complete Sprint-EDRR integration
-Milestone: 0.2.0
+Milestone: 0.1.0-alpha.1
 Status: blocked
 
 Priority: low

--- a/issues/Complete-memory-system-integration.md
+++ b/issues/Complete-memory-system-integration.md
@@ -1,5 +1,5 @@
 # Complete memory system integration
-Milestone: 0.2.0
+Milestone: 0.1.0-alpha.1
 Status: open
 
 Priority: low

--- a/issues/Critical-recommendations-follow-up.md
+++ b/issues/Critical-recommendations-follow-up.md
@@ -1,5 +1,5 @@
 # Critical recommendations follow-up
-Milestone: 0.2.0
+Milestone: 0.1.0-alpha.1
 Status: in progress
 
 Priority: low

--- a/issues/Enhance-retry-mechanism.md
+++ b/issues/Enhance-retry-mechanism.md
@@ -1,5 +1,5 @@
 # Enhance retry mechanism
-Milestone: 0.2.0
+Milestone: 0.1.0-alpha.1
 Status: open
 
 Priority: low

--- a/issues/Finalize-WSDE-EDRR-workflow-logic.md
+++ b/issues/Finalize-WSDE-EDRR-workflow-logic.md
@@ -1,5 +1,5 @@
 # Finalize WSDE/EDRR workflow logic
-Milestone: 0.2.0
+Milestone: 0.1.0-alpha.1
 Status: blocked
 
 Priority: low

--- a/issues/Finalize-dialectical-reasoning.md
+++ b/issues/Finalize-dialectical-reasoning.md
@@ -1,5 +1,5 @@
 # Finalize dialectical reasoning
-Milestone: 0.2.0
+Milestone: 0.1.0-alpha.1
 Status: in progress
 
 Priority: low

--- a/issues/Improve-deployment-automation.md
+++ b/issues/Improve-deployment-automation.md
@@ -1,5 +1,5 @@
 # Improve deployment automation
-Milestone: 0.2.0
+Milestone: 0.1.0-alpha.1
 Status: open
 
 Priority: low

--- a/issues/additional-storage-backends.md
+++ b/issues/additional-storage-backends.md
@@ -1,5 +1,5 @@
 # Additional Storage Backends
-Milestone: 0.2.0
+Milestone: 0.1.0-alpha.1
 Status: in progress
 Priority: low
 Dependencies: docs/specifications/additional-storage-backends.md, tests/behavior/features/additional_storage_backends.feature

--- a/issues/advanced-graph-memory-features.md
+++ b/issues/advanced-graph-memory-features.md
@@ -1,5 +1,5 @@
 # Advanced Graph Memory Features
-Milestone: 0.2.0
+Milestone: 0.1.0-alpha.1
 Status: in progress
 Priority: low
 Dependencies: docs/specifications/advanced-graph-memory-features.md, tests/behavior/features/advanced_graph_memory_features.feature

--- a/issues/alignment-metrics-command.md
+++ b/issues/alignment-metrics-command.md
@@ -1,5 +1,5 @@
 # Alignment Metrics Command
-Milestone: 0.2.0
+Milestone: 0.1.0-alpha.1
 Status: in progress
 Priority: low
 Dependencies: docs/specifications/alignment-metrics-command.md, tests/behavior/features/alignment_metrics_command.feature

--- a/issues/ast-based-code-analysis-and-transformation.md
+++ b/issues/ast-based-code-analysis-and-transformation.md
@@ -1,5 +1,5 @@
 # AST-Based Code Analysis and Transformation
-Milestone: 0.2.0
+Milestone: 0.1.0-alpha.1
 Status: in progress
 Priority: low
 Dependencies: docs/specifications/ast-based-code-analysis-and-transformation.md, tests/behavior/features/ast_based_code_analysis_and_transformation.feature

--- a/issues/chromadb-integration.md
+++ b/issues/chromadb-integration.md
@@ -1,5 +1,5 @@
 # ChromaDB Integration
-Milestone: 0.2.0
+Milestone: 0.1.0-alpha.1
 Status: in progress
 Priority: low
 Dependencies: docs/specifications/chromadb-integration.md, tests/behavior/features/chromadb_integration.feature

--- a/issues/cli-command-execution.md
+++ b/issues/cli-command-execution.md
@@ -1,5 +1,5 @@
 # CLI Command Execution
-Milestone: 0.2.0
+Milestone: 0.1.0-alpha.1
 Status: in progress
 Priority: low
 Dependencies: docs/specifications/cli-command-execution.md, tests/behavior/features/cli_command_execution.feature

--- a/issues/cli-ui-parity.md
+++ b/issues/cli-ui-parity.md
@@ -1,5 +1,5 @@
 # CLI UI Parity
-Milestone: 0.2.0
+Milestone: 0.1.0-alpha.1
 Status: in progress
 Priority: low
 Dependencies: docs/specifications/cli-ui-parity.md, tests/behavior/features/cli_ui_parity.feature

--- a/issues/cli-ux-enhancements.md
+++ b/issues/cli-ux-enhancements.md
@@ -1,5 +1,5 @@
 # CLI UX Enhancements
-Milestone: 0.2.0
+Milestone: 0.1.0-alpha.1
 Status: in progress
 Priority: low
 Dependencies: docs/specifications/cli-ux-enhancements.md, tests/behavior/features/cli_ux_enhancements.feature

--- a/issues/code-analysis.md
+++ b/issues/code-analysis.md
@@ -1,5 +1,5 @@
 # Code Analysis
-Milestone: 0.2.0
+Milestone: 0.1.0-alpha.1
 Status: in progress
 Priority: low
 Dependencies: docs/specifications/code-analysis.md, tests/behavior/features/code_analysis.feature

--- a/issues/code-command.md
+++ b/issues/code-command.md
@@ -1,5 +1,5 @@
 # Code Command
-Milestone: 0.2.0
+Milestone: 0.1.0-alpha.1
 Status: in progress
 Priority: low
 Dependencies: docs/specifications/code-command.md, tests/behavior/features/code_command.feature

--- a/issues/code-generation.md
+++ b/issues/code-generation.md
@@ -1,5 +1,5 @@
 # Code Generation
-Milestone: 0.2.0
+Milestone: 0.1.0-alpha.1
 Status: in progress
 Priority: low
 Dependencies: docs/specifications/code-generation.md, tests/behavior/features/code_generation.feature

--- a/issues/code-transformation.md
+++ b/issues/code-transformation.md
@@ -1,5 +1,5 @@
 # Code Transformation
-Milestone: 0.2.0
+Milestone: 0.1.0-alpha.1
 Status: in progress
 Priority: low
 Dependencies: docs/specifications/code-transformation.md, tests/behavior/features/code_transformation.feature

--- a/issues/configuration-loader.md
+++ b/issues/configuration-loader.md
@@ -1,5 +1,5 @@
 # Configuration Loader
-Milestone: 0.2.0
+Milestone: 0.1.0-alpha.1
 Status: in progress
 Priority: low
 Dependencies: docs/specifications/configuration-loader.md, tests/behavior/features/configuration_loader.feature

--- a/issues/consensus-building.md
+++ b/issues/consensus-building.md
@@ -1,5 +1,5 @@
 # Consensus Building
-Milestone: 0.2.0
+Milestone: 0.1.0-alpha.1
 Status: in progress
 Priority: low
 Dependencies: docs/specifications/consensus-building.md, tests/behavior/features/consensus_building.feature

--- a/issues/cross-interface-consistency.md
+++ b/issues/cross-interface-consistency.md
@@ -1,5 +1,5 @@
 # Cross-Interface Consistency
-Milestone: 0.2.0
+Milestone: 0.1.0-alpha.1
 Status: in progress
 Priority: low
 Dependencies: docs/specifications/cross-interface-consistency.md, tests/behavior/features/cross_interface_consistency.feature

--- a/issues/database-schema-generation.md
+++ b/issues/database-schema-generation.md
@@ -1,5 +1,5 @@
 # Database Schema Generation
-Milestone: 0.2.0
+Milestone: 0.1.0-alpha.1
 Status: in progress
 Priority: low
 Dependencies: docs/specifications/database-schema-generation.md, tests/behavior/features/database_schema_generation.feature

--- a/issues/delegating-tasks-with-consensus-voting.md
+++ b/issues/delegating-tasks-with-consensus-voting.md
@@ -1,5 +1,5 @@
 # Delegating tasks with consensus voting
-Milestone: 0.2.0
+Milestone: 0.1.0-alpha.1
 Status: in progress
 Priority: low
 Dependencies: docs/specifications/delegating-tasks-with-consensus-voting.md, tests/behavior/features/delegating_tasks_with_consensus_voting.feature

--- a/issues/edrr-coordinator.md
+++ b/issues/edrr-coordinator.md
@@ -1,5 +1,5 @@
 # EDRR Coordinator
-Milestone: 0.2.0
+Milestone: 0.1.0-alpha.1
 Status: in progress
 Priority: low
 Dependencies: docs/specifications/edrr-coordinator.md, tests/behavior/features/edrr_coordinator.feature

--- a/issues/edrr-cycle-command.md
+++ b/issues/edrr-cycle-command.md
@@ -1,5 +1,5 @@
 # EDRR cycle command
-Milestone: 0.2.0
+Milestone: 0.1.0-alpha.1
 Status: in progress
 Priority: low
 Dependencies: docs/specifications/edrr-cycle-command.md, tests/behavior/features/edrr_cycle_command.feature

--- a/issues/edrr-integration-with-real-llm-providers.md
+++ b/issues/edrr-integration-with-real-llm-providers.md
@@ -1,5 +1,5 @@
 # EDRR Integration with Real LLM Providers
-Milestone: 0.2.0
+Milestone: 0.1.0-alpha.1
 Status: in progress
 Priority: low
 Dependencies: docs/specifications/edrr-integration-with-real-llm-providers.md, tests/behavior/features/edrr_integration_with_real_llm_providers.feature

--- a/issues/enable-optional-features.md
+++ b/issues/enable-optional-features.md
@@ -1,5 +1,5 @@
 # Enable optional features
-Milestone: 0.2.0
+Milestone: 0.1.0-alpha.1
 Status: in progress
 Priority: low
 Dependencies: docs/specifications/enable-optional-features.md, tests/behavior/features/enable_optional_features.feature

--- a/issues/enhanced-chromadb-integration.md
+++ b/issues/enhanced-chromadb-integration.md
@@ -1,5 +1,5 @@
 # Enhanced ChromaDB Integration
-Milestone: 0.2.0
+Milestone: 0.1.0-alpha.1
 Status: in progress
 Priority: low
 Dependencies: docs/specifications/enhanced-chromadb-integration.md, tests/behavior/features/enhanced_chromadb_integration.feature

--- a/issues/enhanced-edrr-memory-integration.md
+++ b/issues/enhanced-edrr-memory-integration.md
@@ -1,5 +1,5 @@
 # Enhanced EDRR Memory Integration
-Milestone: 0.2.0
+Milestone: 0.1.0-alpha.1
 Status: in progress
 Priority: low
 Dependencies: docs/specifications/enhanced-edrr-memory-integration.md, tests/behavior/features/enhanced_edrr_memory_integration.feature

--- a/issues/enhanced-edrr-phase-transitions.md
+++ b/issues/enhanced-edrr-phase-transitions.md
@@ -1,5 +1,5 @@
 # Enhanced EDRR Phase Transitions
-Milestone: 0.2.0
+Milestone: 0.1.0-alpha.1
 Status: in progress
 Priority: low
 Dependencies: docs/specifications/enhanced-edrr-phase-transitions.md, tests/behavior/features/enhanced_edrr_phase_transitions.feature

--- a/issues/enhanced-edrr-recursion-handling.md
+++ b/issues/enhanced-edrr-recursion-handling.md
@@ -1,5 +1,5 @@
 # Enhanced EDRR Recursion Handling
-Milestone: 0.2.0
+Milestone: 0.1.0-alpha.1
 Status: in progress
 Priority: low
 Dependencies: docs/specifications/enhanced-edrr-recursion-handling.md, tests/behavior/features/enhanced_edrr_recursion_handling.feature

--- a/issues/environment-variables-integration.md
+++ b/issues/environment-variables-integration.md
@@ -1,5 +1,5 @@
 # Environment Variables Integration
-Milestone: 0.2.0
+Milestone: 0.1.0-alpha.1
 Status: in progress
 Priority: low
 Dependencies: docs/specifications/environment-variables-integration.md, tests/behavior/features/environment_variables_integration.feature

--- a/issues/error-handling.md
+++ b/issues/error-handling.md
@@ -1,5 +1,5 @@
 # Error Handling
-Milestone: 0.2.0
+Milestone: 0.1.0-alpha.1
 Status: in progress
 Priority: low
 Dependencies: docs/specifications/error-handling.md, tests/behavior/features/error_handling.feature

--- a/issues/extended-cross-interface-consistency.md
+++ b/issues/extended-cross-interface-consistency.md
@@ -1,5 +1,5 @@
 # Extended Cross-Interface Consistency
-Milestone: 0.2.0
+Milestone: 0.1.0-alpha.1
 Status: in progress
 Priority: low
 Dependencies: docs/specifications/extended-cross-interface-consistency.md, tests/behavior/features/extended_cross_interface_consistency.feature

--- a/issues/hybrid-memory-query-patterns-and-synchronization.md
+++ b/issues/hybrid-memory-query-patterns-and-synchronization.md
@@ -1,5 +1,5 @@
 # Hybrid Memory Query Patterns and Synchronization
-Milestone: 0.2.0
+Milestone: 0.1.0-alpha.1
 Status: in progress
 Priority: low
 Dependencies: docs/specifications/hybrid-memory-query-patterns-and-synchronization.md, tests/behavior/features/hybrid_memory_query_patterns_and_synchronization.feature

--- a/issues/ingest-command.md
+++ b/issues/ingest-command.md
@@ -1,5 +1,5 @@
 # Ingest Command
-Milestone: 0.2.0
+Milestone: 0.1.0-alpha.1
 Status: in progress
 Priority: low
 Dependencies: docs/specifications/ingest-command.md, tests/behavior/features/ingest_command.feature

--- a/issues/inspect-code-command.md
+++ b/issues/inspect-code-command.md
@@ -1,5 +1,5 @@
 # Inspect Code Command
-Milestone: 0.2.0
+Milestone: 0.1.0-alpha.1
 Status: in progress
 Priority: low
 Dependencies: docs/specifications/inspect-code-command.md, tests/behavior/features/inspect_code_command.feature

--- a/issues/inspect-commands.md
+++ b/issues/inspect-commands.md
@@ -1,5 +1,5 @@
 # Inspect Commands
-Milestone: 0.2.0
+Milestone: 0.1.0-alpha.1
 Status: in progress
 Priority: low
 Dependencies: docs/specifications/inspect-commands.md, tests/behavior/features/inspect_commands.feature

--- a/issues/interactive-init-wizard.md
+++ b/issues/interactive-init-wizard.md
@@ -1,5 +1,5 @@
 # Interactive Init Wizard
-Milestone: 0.2.0
+Milestone: 0.1.0-alpha.1
 Status: in progress
 Priority: low
 Dependencies: docs/specifications/interactive-init-wizard.md, tests/behavior/features/interactive_init_wizard.feature

--- a/issues/interactive-requirements-flow-cli.md
+++ b/issues/interactive-requirements-flow-cli.md
@@ -1,5 +1,5 @@
 # Interactive Requirements Flow CLI
-Milestone: 0.2.0
+Milestone: 0.1.0-alpha.1
 Status: in progress
 Priority: low
 Dependencies: docs/specifications/interactive-requirements-flow-cli.md, tests/behavior/features/interactive_requirements_flow_cli.feature

--- a/issues/interactive-requirements-wizard.md
+++ b/issues/interactive-requirements-wizard.md
@@ -1,5 +1,5 @@
 # Interactive Requirements Wizard
-Milestone: 0.2.0
+Milestone: 0.1.0-alpha.1
 Status: in progress
 Priority: low
 Dependencies: docs/specifications/interactive-requirements-wizard.md, tests/behavior/features/interactive_requirements_wizard.feature

--- a/issues/invalid-configuration-handling.md
+++ b/issues/invalid-configuration-handling.md
@@ -1,5 +1,5 @@
 # Invalid configuration handling
-Milestone: 0.2.0
+Milestone: 0.1.0-alpha.1
 Status: in progress
 Priority: low
 Dependencies: docs/specifications/invalid-configuration-handling.md, tests/behavior/features/invalid_configuration_handling.feature

--- a/issues/memory-adapter-integration.md
+++ b/issues/memory-adapter-integration.md
@@ -1,5 +1,5 @@
 # Memory Adapter Integration
-Milestone: 0.2.0
+Milestone: 0.1.0-alpha.1
 Status: in progress
 Priority: low
 Dependencies: docs/specifications/memory-adapter-integration.md, tests/behavior/features/memory_adapter_integration.feature

--- a/issues/memory-adapter-read-and-write-operations.md
+++ b/issues/memory-adapter-read-and-write-operations.md
@@ -1,5 +1,5 @@
 # Memory adapter read and write operations
-Milestone: 0.2.0
+Milestone: 0.1.0-alpha.1
 Status: in progress
 Priority: low
 Dependencies: docs/specifications/memory-adapter-read-and-write-operations.md, tests/behavior/features/memory_adapter_read_and_write_operations.feature

--- a/issues/memory-and-context-system.md
+++ b/issues/memory-and-context-system.md
@@ -1,5 +1,5 @@
 # Memory and Context System
-Milestone: 0.2.0
+Milestone: 0.1.0-alpha.1
 Status: in progress
 Priority: low
 Dependencies: docs/specifications/memory-and-context-system.md, tests/behavior/features/memory_and_context_system.feature

--- a/issues/memory-backend-integration.md
+++ b/issues/memory-backend-integration.md
@@ -1,5 +1,5 @@
 # Memory Backend Integration
-Milestone: 0.2.0
+Milestone: 0.1.0-alpha.1
 Status: in progress
 Priority: low
 Dependencies: docs/specifications/memory-backend-integration.md, tests/behavior/features/memory_backend_integration.feature

--- a/issues/memory-manager-and-adapters.md
+++ b/issues/memory-manager-and-adapters.md
@@ -1,5 +1,5 @@
 # Memory Manager and Adapters
-Milestone: 0.2.0
+Milestone: 0.1.0-alpha.1
 Status: in progress
 Priority: low
 Dependencies: docs/specifications/memory-manager-and-adapters.md, tests/behavior/features/memory_manager_and_adapters.feature

--- a/issues/methodology-adapters-integration.md
+++ b/issues/methodology-adapters-integration.md
@@ -1,5 +1,5 @@
 # Methodology Adapters Integration
-Milestone: 0.2.0
+Milestone: 0.1.0-alpha.1
 Status: in progress
 Priority: low
 Dependencies: docs/specifications/methodology-adapters-integration.md, tests/behavior/features/methodology_adapters_integration.feature

--- a/issues/micro-edrr-cycle.md
+++ b/issues/micro-edrr-cycle.md
@@ -1,5 +1,5 @@
 # Micro EDRR Cycle
-Milestone: 0.2.0
+Milestone: 0.1.0-alpha.1
 Status: in progress
 Priority: low
 Dependencies: docs/specifications/micro-edrr-cycle.md, tests/behavior/features/micro_edrr_cycle.feature

--- a/issues/multi-agent-collaboration.md
+++ b/issues/multi-agent-collaboration.md
@@ -1,5 +1,5 @@
 # Multi-Agent Collaboration
-Milestone: 0.2.0
+Milestone: 0.1.0-alpha.1
 Status: in progress
 Priority: low
 Dependencies: docs/specifications/multi-agent-collaboration.md, tests/behavior/features/multi_agent_collaboration.feature

--- a/issues/multi-agent-task-delegation.md
+++ b/issues/multi-agent-task-delegation.md
@@ -1,5 +1,5 @@
 # Multi-agent task delegation
-Milestone: 0.2.0
+Milestone: 0.1.0-alpha.1
 Status: in progress
 Priority: low
 Dependencies: docs/specifications/multi-agent-task-delegation.md, tests/behavior/features/multi_agent_task_delegation.feature

--- a/issues/multi-layered-memory-system-and-tiered-cache-strategy.md
+++ b/issues/multi-layered-memory-system-and-tiered-cache-strategy.md
@@ -1,5 +1,5 @@
 # Multi-Layered Memory System and Tiered Cache Strategy
-Milestone: 0.2.0
+Milestone: 0.1.0-alpha.1
 Status: in progress
 Priority: low
 Dependencies: docs/specifications/multi-layered-memory-system-and-tiered-cache-strategy.md, tests/behavior/features/multi_layered_memory_system_and_tiered_cache_strategy.feature

--- a/issues/multi-layered-memory-system.md
+++ b/issues/multi-layered-memory-system.md
@@ -1,5 +1,5 @@
 # Multi-Layered Memory System
-Milestone: 0.2.0
+Milestone: 0.1.0-alpha.1
 Status: in progress
 Priority: low
 Dependencies: docs/specifications/multi-layered-memory-system.md, tests/behavior/features/multi_layered_memory_system.feature

--- a/issues/mvu-command-execution.md
+++ b/issues/mvu-command-execution.md
@@ -1,5 +1,5 @@
 # MVU Command Execution
-Milestone: 0.2.0
+Milestone: 0.1.0-alpha.1
 Status: in progress
 Priority: low
 Dependencies: docs/specifications/mvu-command-execution.md, tests/behavior/features/mvu/command_execution.feature

--- a/issues/non-hierarchical-collaboration.md
+++ b/issues/non-hierarchical-collaboration.md
@@ -1,5 +1,5 @@
 # Non-Hierarchical Collaboration
-Milestone: 0.2.0
+Milestone: 0.1.0-alpha.1
 Status: in progress
 Priority: low
 Dependencies: docs/specifications/non-hierarchical-collaboration.md, tests/behavior/features/non_hierarchical_collaboration.feature

--- a/issues/project-ingestion.md
+++ b/issues/project-ingestion.md
@@ -1,5 +1,5 @@
 # Project Ingestion
-Milestone: 0.2.0
+Milestone: 0.1.0-alpha.1
 Status: in progress
 Priority: low
 Dependencies: docs/specifications/project-ingestion.md, tests/behavior/features/project_ingestion.feature

--- a/issues/project-initialization.md
+++ b/issues/project-initialization.md
@@ -1,5 +1,5 @@
 # Project Initialization
-Milestone: 0.2.0
+Milestone: 0.1.0-alpha.1
 Status: in progress
 Priority: low
 Dependencies: docs/specifications/project-initialization.md, tests/behavior/features/project_initialization.feature

--- a/issues/project-state-analysis.md
+++ b/issues/project-state-analysis.md
@@ -1,5 +1,5 @@
 # Project State Analysis
-Milestone: 0.2.0
+Milestone: 0.1.0-alpha.1
 Status: in progress
 Priority: low
 Dependencies: tests/behavior/features/general/project_state_analyzer.feature

--- a/issues/promise-system-capability-management.md
+++ b/issues/promise-system-capability-management.md
@@ -1,5 +1,5 @@
 # Promise System Capability Management
-Milestone: 0.2.0
+Milestone: 0.1.0-alpha.1
 Status: in progress
 Priority: low
 Dependencies: docs/specifications/promise-system-capability-management.md, tests/behavior/features/promise_system_capability_management.feature

--- a/issues/prompt-management-with-dpsy-ai.md
+++ b/issues/prompt-management-with-dpsy-ai.md
@@ -1,5 +1,5 @@
 # Prompt Management with DPSy-AI
-Milestone: 0.2.0
+Milestone: 0.1.0-alpha.1
 Status: in progress
 Priority: low
 Dependencies: docs/specifications/prompt-management-with-dpsy-ai.md, tests/behavior/features/prompt_management_with_dpsy_ai.feature

--- a/issues/recursive-edrr-coordinator.md
+++ b/issues/recursive-edrr-coordinator.md
@@ -1,5 +1,5 @@
 # Recursive EDRR Coordinator
-Milestone: 0.2.0
+Milestone: 0.1.0-alpha.1
 Status: in progress
 Priority: low
 Dependencies: docs/specifications/recursive-edrr-coordinator.md, tests/behavior/features/recursive_edrr_coordinator.feature

--- a/issues/refactor-command.md
+++ b/issues/refactor-command.md
@@ -1,5 +1,5 @@
 # Refactor Command
-Milestone: 0.2.0
+Milestone: 0.1.0-alpha.1
 Status: in progress
 Priority: low
 Dependencies: docs/specifications/refactor-command.md, tests/behavior/features/refactor_command.feature

--- a/issues/requirement-analysis.md
+++ b/issues/requirement-analysis.md
@@ -1,5 +1,5 @@
 # Requirement Analysis
-Milestone: 0.2.0
+Milestone: 0.1.0-alpha.1
 Status: in progress
 Priority: low
 Dependencies: docs/specifications/requirement-analysis.md, tests/behavior/features/requirement_analysis.feature

--- a/issues/requirements-gathering-wizard.md
+++ b/issues/requirements-gathering-wizard.md
@@ -1,5 +1,5 @@
 # Requirements Gathering Wizard
-Milestone: 0.2.0
+Milestone: 0.1.0-alpha.1
 Status: in progress
 Priority: low
 Dependencies: docs/specifications/requirements-gathering-wizard.md, tests/behavior/features/requirements_gathering_wizard.feature

--- a/issues/requirements-management.md
+++ b/issues/requirements-management.md
@@ -1,5 +1,5 @@
 # Requirements Management
-Milestone: 0.2.0
+Milestone: 0.1.0-alpha.1
 Status: in progress
 Priority: low
 Dependencies: docs/specifications/requirements-management.md, tests/behavior/features/requirements_management.feature

--- a/issues/requirements-wizard-logging.md
+++ b/issues/requirements-wizard-logging.md
@@ -1,5 +1,5 @@
 # Requirements Wizard Logging
-Milestone: 0.2.0
+Milestone: 0.1.0-alpha.1
 Status: in progress
 Priority: low
 Dependencies: docs/specifications/requirements-wizard-logging.md, tests/behavior/features/requirements_wizard_logging.feature

--- a/issues/requirements-wizard-navigation.md
+++ b/issues/requirements-wizard-navigation.md
@@ -1,5 +1,5 @@
 # Requirements Wizard Navigation
-Milestone: 0.2.0
+Milestone: 0.1.0-alpha.1
 Status: in progress
 Priority: low
 Dependencies: docs/specifications/requirements-wizard-navigation.md, tests/behavior/features/requirements_wizard_navigation.feature

--- a/issues/requirements-wizard.md
+++ b/issues/requirements-wizard.md
@@ -1,5 +1,5 @@
 # Requirements Wizard
-Milestone: 0.2.0
+Milestone: 0.1.0-alpha.1
 Status: in progress
 Priority: low
 Dependencies: docs/specifications/requirements-wizard.md, tests/behavior/features/requirements_wizard.feature

--- a/issues/run-pipeline-command.md
+++ b/issues/run-pipeline-command.md
@@ -1,5 +1,5 @@
 # Run Pipeline Command
-Milestone: 0.2.0
+Milestone: 0.1.0-alpha.1
 Status: in progress
 Priority: low
 Dependencies: docs/specifications/run-pipeline-command.md, tests/behavior/features/run_pipeline_command.feature

--- a/issues/self-analysis.md
+++ b/issues/self-analysis.md
@@ -1,5 +1,5 @@
 # Self Analysis
-Milestone: 0.2.0
+Milestone: 0.1.0-alpha.1
 Status: in progress
 Priority: low
 Dependencies: docs/specifications/self-analysis.md, tests/behavior/features/self_analysis.feature

--- a/issues/serve-command.md
+++ b/issues/serve-command.md
@@ -1,5 +1,5 @@
 # Serve Command
-Milestone: 0.2.0
+Milestone: 0.1.0-alpha.1
 Status: in progress
 Priority: low
 Dependencies: docs/specifications/serve-command.md, tests/behavior/features/serve_command.feature

--- a/issues/setup-wizard.md
+++ b/issues/setup-wizard.md
@@ -1,5 +1,5 @@
 # Setup Wizard
-Milestone: 0.2.0
+Milestone: 0.1.0-alpha.1
 Status: in progress
 Priority: low
 Dependencies: docs/specifications/setup-wizard.md, tests/behavior/features/setup_wizard.feature

--- a/issues/spec-command.md
+++ b/issues/spec-command.md
@@ -1,5 +1,5 @@
 # Spec Command
-Milestone: 0.2.0
+Milestone: 0.1.0-alpha.1
 Status: in progress
 Priority: low
 Dependencies: docs/specifications/spec-command.md, tests/behavior/features/spec_command.feature

--- a/issues/training-materials-for-tdd-bdd-edrr-integration.md
+++ b/issues/training-materials-for-tdd-bdd-edrr-integration.md
@@ -1,5 +1,5 @@
 # Training Materials for TDD/BDD-EDRR Integration
-Milestone: 0.2.0
+Milestone: 0.1.0-alpha.1
 Status: in progress
 Priority: low
 Dependencies: docs/specifications/training-materials-for-tdd-bdd-edrr-integration.md, tests/behavior/features/training_materials_for_tdd_bdd_edrr_integration.feature

--- a/issues/user-authentication.md
+++ b/issues/user-authentication.md
@@ -1,5 +1,5 @@
 # User Authentication
-Milestone: 0.2.0
+Milestone: 0.1.0-alpha.1
 Status: in progress
 Priority: low
 Dependencies: docs/specifications/user-authentication.md, tests/behavior/features/user_authentication.feature

--- a/issues/user-guide-enhancement.md
+++ b/issues/user-guide-enhancement.md
@@ -1,5 +1,5 @@
 # User Guide Enhancement
-Milestone: 0.2.0
+Milestone: 0.1.0-alpha.1
 Status: in progress
 Priority: low
 Dependencies: docs/specifications/user-guide-enhancement.md, tests/behavior/features/user_guide_enhancement.feature

--- a/issues/uxbridge-interface.md
+++ b/issues/uxbridge-interface.md
@@ -1,5 +1,5 @@
 # UXBridge Interface
-Milestone: 0.2.0
+Milestone: 0.1.0-alpha.1
 Status: in progress
 Priority: low
 Dependencies: docs/specifications/uxbridge-interface.md, tests/behavior/features/uxbridge_interface.feature

--- a/issues/validate-manifest-command.md
+++ b/issues/validate-manifest-command.md
@@ -1,5 +1,5 @@
 # Validate Manifest Command
-Milestone: 0.2.0
+Milestone: 0.1.0-alpha.1
 Status: in progress
 Priority: low
 Dependencies: docs/specifications/validate-manifest-command.md, tests/behavior/features/validate_manifest_command.feature

--- a/issues/validate-metadata-command.md
+++ b/issues/validate-metadata-command.md
@@ -1,5 +1,5 @@
 # Validate Metadata Command
-Milestone: 0.2.0
+Milestone: 0.1.0-alpha.1
 Status: in progress
 Priority: low
 Dependencies: docs/specifications/validate-metadata-command.md, tests/behavior/features/validate_metadata_command.feature

--- a/issues/web-application-generation.md
+++ b/issues/web-application-generation.md
@@ -1,5 +1,5 @@
 # Web Application Generation
-Milestone: 0.2.0
+Milestone: 0.1.0-alpha.1
 Status: in progress
 Priority: low
 Dependencies: docs/specifications/web-application-generation.md, tests/behavior/features/web_application_generation.feature

--- a/issues/workflow-execution.md
+++ b/issues/workflow-execution.md
@@ -1,5 +1,5 @@
 # Workflow Execution
-Milestone: 0.2.0
+Milestone: 0.1.0-alpha.1
 Status: in progress
 Priority: low
 Dependencies: docs/specifications/workflow-execution.md, tests/behavior/features/workflow_execution.feature

--- a/issues/wsde-agent-model-refinement.md
+++ b/issues/wsde-agent-model-refinement.md
@@ -1,5 +1,5 @@
 # WSDE Agent Model Refinement
-Milestone: 0.2.0
+Milestone: 0.1.0-alpha.1
 Status: in progress
 Priority: low
 Dependencies: docs/specifications/wsde-agent-model-refinement.md, tests/behavior/features/wsde_agent_model_refinement.feature

--- a/issues/wsde-message-passing-and-peer-review.md
+++ b/issues/wsde-message-passing-and-peer-review.md
@@ -1,5 +1,5 @@
 # WSDE Message Passing and Peer Review
-Milestone: 0.2.0
+Milestone: 0.1.0-alpha.1
 Status: in progress
 Priority: low
 Dependencies: docs/specifications/wsde-message-passing-and-peer-review.md, tests/behavior/features/wsde_message_passing_and_peer_review.feature

--- a/issues/wsde-model-and-memory-system-integration.md
+++ b/issues/wsde-model-and-memory-system-integration.md
@@ -1,5 +1,5 @@
 # WSDE Model and Memory System Integration
-Milestone: 0.2.0
+Milestone: 0.1.0-alpha.1
 Status: in progress
 Priority: low
 Dependencies: docs/specifications/wsde-model-and-memory-system-integration.md, tests/behavior/features/wsde_model_and_memory_system_integration.feature

--- a/issues/wsde-peer-review-workflow.md
+++ b/issues/wsde-peer-review-workflow.md
@@ -1,5 +1,5 @@
 # WSDE Peer Review Workflow
-Milestone: 0.2.0
+Milestone: 0.1.0-alpha.1
 Status: in progress
 Priority: low
 Dependencies: docs/specifications/wsde-peer-review-workflow.md, tests/behavior/features/wsde_peer_review_workflow.feature


### PR DESCRIPTION
## Summary
- replace 0.2.0 milestone references with 0.1.0-alpha.1 across issue tracker
- align roadmap docs with upcoming 0.1.0-alpha.1 release

## Testing
- `poetry run pre-commit run --files docs/archived/roadmaps/ROADMAP.md docs/archived/roadmaps/release_plan.md docs/release/roadmap.md docs/roadmap/CONSOLIDATED_ROADMAP.md docs/roadmap/release_plan.md issues/*.md`
- `poetry run devsynth run-tests --speed=fast` *(fails: SyntaxError in multiple tests)*
- `poetry run python tests/verify_test_organization.py`
- `poetry run python scripts/verify_test_markers.py` *(terminated: KeyboardInterrupt)*
- `poetry run python scripts/verify_requirements_traceability.py`
- `poetry run python scripts/verify_version_sync.py`


------
https://chatgpt.com/codex/tasks/task_e_68a3d01e0bf08333957a49b0f5574189