### PR TITLE
docs: note dialectical log and release prep

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -65,6 +65,8 @@ Directory-specific instructions live in scoped AGENTS guidelines within director
   poetry run python scripts/verify_version_sync.py
   ```
 
+- Resolve `dialectical_audit.log` before submitting a PR. Release preparation steps are outlined in `docs/release/0.1.0-alpha.1.md`.
+
 ## Issue Tracking
 
 - Use the in-repo issue tracker under `issues/` (see [issues/README.md](issues/README.md)).
@@ -81,12 +83,12 @@ Directory-specific instructions live in scoped AGENTS guidelines within director
 
 ## Release
 
-The `0.1.0-alpha.1` release process is documented in [docs/release/0.1.0-alpha.1.md](docs/release/0.1.0-alpha.1.md). Follow these steps:
+See `docs/release/0.1.0-alpha.1.md` for the full process. Summary:
 
-1. Run `poetry run task release:prep` to generate release artifacts.
-2. Generate a dialectical audit log with `poetry run python scripts/dialectical_audit.py` or trigger the `Dialectical Audit` workflow in GitHub Actions. See the [Dialectical Audit Policy](docs/policies/dialectical_audit.md).
-3. Conduct a dialectical review with at least one other contributor.
-4. Tag the release with `git tag -a <version>` and push the tag.
+1. Run `poetry run task release:prep` to build artifacts.
+2. Generate and resolve `dialectical_audit.log` (`poetry run python scripts/dialectical_audit.py` or trigger the GitHub workflow`) per the [Dialectical Audit Policy](docs/policies/dialectical_audit.md).
+3. Conduct a dialectical review with another contributor.
+4. Tag and push the release: `git tag -a <version>`.
 
 ## Automation
 

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -6,6 +6,8 @@ This directory hosts DevSynth documentation.
 - Follow the specification-first BDD workflow: capture new requirements in `specifications/` and pair them with a failing BDD feature in `../tests/behavior/features/` before implementation.
 - Documentation updates must follow the [Documentation Policies](policies/documentation_policies.md) and the [Dialectical Audit Policy](policies/dialectical_audit.md).
 
+- Resolve `dialectical_audit.log` before submitting a PR. Release preparation steps are outlined in `docs/release/0.1.0-alpha.1.md`.
+
 ## External Resources
 
 - Treat `inspirational_docs/` as brainstorming material only; do not reference these files directly.

--- a/src/AGENTS.md
+++ b/src/AGENTS.md
@@ -6,3 +6,5 @@ This directory holds DevSynth source code.
 - Follow the specification-first BDD workflow: draft a specification in `../docs/specifications/` and add a failing BDD feature in `../tests/behavior/features/` before writing code.
 - Implementations must follow the [Security Policy](../docs/policies/security.md) and the [Dialectical Audit Policy](../docs/policies/dialectical_audit.md).
 - Verify changes with `poetry run pre-commit run --files <changed>` and `poetry run devsynth run-tests --speed=<cat>`.
+
+- Resolve `dialectical_audit.log` before submitting a PR. Release preparation steps are outlined in `docs/release/0.1.0-alpha.1.md`.


### PR DESCRIPTION
## Summary
- remind contributors to resolve `dialectical_audit.log` before opening PRs
- link AGENTS guides to release prep instructions and provide concise release steps

## Testing
- `poetry run pre-commit run --files AGENTS.md docs/AGENTS.md src/AGENTS.md` *(fails: interrupted)*
- `poetry run devsynth run-tests --speed=fast` *(fails: aborted)*
- `poetry run python tests/verify_test_organization.py`
- `poetry run python scripts/verify_test_markers.py` *(fails: collection errors)*
- `poetry run python scripts/verify_requirements_traceability.py` *(fails: collection errors)*
- `poetry run python scripts/verify_version_sync.py` *(fails: collection errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a3d85805a883338bb2d5e52b805d60