### PR TITLE
feat: enforce ReqID in tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,9 @@ jobs:
       - name: Verify MVUU references
         run: |
           python scripts/verify_mvuu_references.py origin/main..HEAD
+      - name: Check test ReqIDs
+        run: |
+          python scripts/check_reqid.py --rev-range origin/main..HEAD
       - name: Run Bandit
         run: |
           poetry run bandit -q -r src

--- a/.github/workflows/container_build.yml
+++ b/.github/workflows/container_build.yml
@@ -19,9 +19,11 @@ jobs:
       - name: Run project checks
         # Runs tests and documentation checks; fails if any script exits non-zero
         run: |
+          git fetch origin main
           python scripts/run_all_tests.py
           python scripts/check_internal_links.py
           python scripts/fix_code_blocks.py --check
+          python scripts/check_reqid.py --rev-range origin/main..HEAD
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
       - name: Build container

--- a/.github/workflows/dependency_check.yml
+++ b/.github/workflows/dependency_check.yml
@@ -25,6 +25,8 @@ jobs:
       - name: Run project checks
         # Runs tests and documentation checks; fails if any script exits non-zero
         run: |
+          git fetch origin main
           poetry run python scripts/run_all_tests.py
           poetry run python scripts/check_internal_links.py
           poetry run python scripts/fix_code_blocks.py --check
+          poetry run python scripts/check_reqid.py --rev-range origin/main..HEAD

--- a/.github/workflows/performance_benchmarks.yml
+++ b/.github/workflows/performance_benchmarks.yml
@@ -23,9 +23,11 @@ jobs:
       - name: Run project checks
         # Runs tests and documentation checks; fails if any script exits non-zero
         run: |
+          git fetch origin main
           poetry run python scripts/run_all_tests.py
           poetry run python scripts/check_internal_links.py
           poetry run python scripts/fix_code_blocks.py --check
+          poetry run python scripts/check_reqid.py --rev-range origin/main..HEAD
 
       - name: Run performance benchmarks
         run: |

--- a/.github/workflows/static_analysis.yml
+++ b/.github/workflows/static_analysis.yml
@@ -22,6 +22,8 @@ jobs:
       - name: Run project checks
         # Runs tests and documentation checks; fails if any script exits non-zero
         run: |
+          git fetch origin main
           python scripts/run_all_tests.py
           python scripts/check_internal_links.py
           python scripts/fix_code_blocks.py --check
+          python scripts/check_reqid.py --rev-range origin/main..HEAD

--- a/.github/workflows/test_coverage.yml
+++ b/.github/workflows/test_coverage.yml
@@ -27,9 +27,11 @@ jobs:
       - name: Run project checks
         # Runs tests and documentation checks; fails if any script exits non-zero
         run: |
+          git fetch origin main
           poetry run python scripts/run_all_tests.py
           poetry run python scripts/check_internal_links.py
           poetry run python scripts/fix_code_blocks.py --check
+          poetry run python scripts/check_reqid.py --rev-range origin/main..HEAD
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v3

--- a/.github/workflows/test_results.yml
+++ b/.github/workflows/test_results.yml
@@ -43,9 +43,11 @@ jobs:
       - name: Run project checks
         # Runs tests and documentation checks; fails if any script exits non-zero
         run: |
+          git fetch origin main
           poetry run python scripts/run_all_tests.py
           poetry run python scripts/check_internal_links.py
           poetry run python scripts/fix_code_blocks.py --check
+          poetry run python scripts/check_reqid.py --rev-range origin/main..HEAD
 
       - name: Publish Test Results
         uses: EnricoMi/publish-unit-test-result-action@v2

--- a/.github/workflows/validate_documentation.yml
+++ b/.github/workflows/validate_documentation.yml
@@ -43,10 +43,12 @@ jobs:
       - name: Run project checks
         # Runs tests and documentation checks; fails if any script exits non-zero
         run: |
+          git fetch origin main
           python scripts/run_all_tests.py
           python scripts/check_internal_links.py
           python scripts/fix_code_blocks.py --check
           python scripts/fix_frontmatter.py --check
+          python scripts/check_reqid.py --rev-range origin/main..HEAD
       - name: Summary
         run: |
           echo "Documentation validation completed successfully!"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -43,6 +43,12 @@ repos:
       entry: python scripts/check_spec_or_test_updates.py
       language: system
       pass_filenames: false
+    - id: check-reqid
+      name: check test ReqID
+      entry: python scripts/check_reqid.py
+      language: system
+      pass_filenames: true
+      files: ^tests/.*\.py$
     - id: update-traceability
       name: update traceability
       entry: python scripts/update_traceability.py

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -47,6 +47,13 @@
   entry: python scripts/check_spec_or_test_updates.py
   language: system
   pass_filenames: false
+- id: check-reqid
+  name: check test ReqID
+  description: "Ensure tests include valid requirement identifiers"
+  entry: python scripts/check_reqid.py
+  language: system
+  pass_filenames: true
+  files: ^tests/.*\.py$
 - id: update-traceability
   name: update traceability
   description: "Update traceability data"

--- a/scripts/check_reqid.py
+++ b/scripts/check_reqid.py
@@ -1,0 +1,95 @@
+"""Check that tests include valid requirement identifiers.
+
+Usage:
+    python scripts/check_reqid.py [FILES...]
+    python scripts/check_reqid.py --rev-range <range>
+
+The script validates that each test function's docstring contains a
+``ReqID`` field that is not ``N/A``. When ``--rev-range`` is supplied,
+only tests changed within the given Git revision range are checked.
+"""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import re
+import subprocess
+import sys
+from pathlib import Path
+from typing import Iterable, List
+
+REQID_PATTERN = re.compile(r"ReqID:\s*(?P<value>.+)")
+
+
+def _gather_changed_tests(rev_range: str) -> List[str]:
+    """Return test files changed in the given Git revision range."""
+    diff = subprocess.check_output(["git", "diff", "--name-only", rev_range], text=True)
+    return [
+        f
+        for f in diff.splitlines()
+        if f.startswith("tests/") and f.endswith(".py") and Path(f).is_file()
+    ]
+
+
+def _iter_test_functions(path: Path) -> Iterable[ast.FunctionDef]:
+    """Yield test function nodes from the given Python file."""
+    try:
+        tree = ast.parse(path.read_text(encoding="utf-8"))
+    except Exception as exc:  # pragma: no cover - surface parsing errors
+        raise RuntimeError(f"Failed to parse {path}: {exc}") from exc
+    for node in ast.walk(tree):
+        if isinstance(node, ast.FunctionDef) and node.name.startswith("test"):
+            yield node
+        if isinstance(node, ast.AsyncFunctionDef) and node.name.startswith("test"):
+            yield node
+
+
+def check_file(path: Path) -> List[str]:
+    """Return a list of ReqID violations for a single file."""
+    errors: List[str] = []
+    for node in _iter_test_functions(path):
+        doc = ast.get_docstring(node)
+        if not doc or "ReqID" not in doc:
+            errors.append(f"{path}:{node.lineno} {node.name} missing ReqID")
+            continue
+        match = REQID_PATTERN.search(doc)
+        if not match or match.group("value").strip() in {"N/A", "N\\A", "NA"}:
+            errors.append(f"{path}:{node.lineno} {node.name} has invalid ReqID")
+    return errors
+
+
+def main(argv: List[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Ensure tests include ReqID and do not use N/A",
+    )
+    parser.add_argument("files", nargs="*", help="Test files to check")
+    parser.add_argument(
+        "--rev-range",
+        help="Git revision range to locate changed tests (e.g., origin/main..HEAD)",
+    )
+    args = parser.parse_args(argv)
+
+    files: List[str]
+    if args.files:
+        files = [f for f in args.files if f.startswith("tests/") and f.endswith(".py")]
+    elif args.rev_range:
+        files = _gather_changed_tests(args.rev_range)
+    else:
+        files = [str(p) for p in Path("tests").rglob("test_*.py")]
+
+    if not files:
+        return 0
+
+    all_errors: List[str] = []
+    for f in files:
+        all_errors.extend(check_file(Path(f)))
+
+    if all_errors:
+        print("\n".join(all_errors), file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - script entry
+    sys.exit(main())


### PR DESCRIPTION
## Summary
- add `check_reqid` utility for validating `ReqID` markers in tests
- wire `check_reqid` into pre-commit
- run `check_reqid` in CI dispatch workflows

## Testing
- `SKIP=find-syntax-errors poetry run pre-commit run --files scripts/check_reqid.py .pre-commit-config.yaml .pre-commit-hooks.yaml .github/workflows/ci.yml .github/workflows/container_build.yml .github/workflows/dependency_check.yml .github/workflows/performance_benchmarks.yml .github/workflows/static_analysis.yml .github/workflows/test_coverage.yml .github/workflows/test_results.yml .github/workflows/validate_documentation.yml`
- `poetry run devsynth run-tests --speed=fast` *(fails: SyntaxError in several test files)*
- `poetry run python tests/verify_test_organization.py` *(fails: invalid syntax in existing tests)*
- `poetry run python scripts/verify_test_markers.py` *(fails: pytest collection failures, interrupted)*
- `poetry run python scripts/verify_requirements_traceability.py` *(fails: pytest collection failures, interrupted)*
- `poetry run python scripts/verify_version_sync.py`


------
https://chatgpt.com/codex/tasks/task_e_68a3d83485308333b3e63ac0c6cf455d