### PR TITLE
Link ChromaDB store import test to specification

### DIFF
--- a/docs/requirements_traceability.md
+++ b/docs/requirements_traceability.md
@@ -193,8 +193,9 @@ report to standard output.
 | FR-91 | Knowledge graph utility functions for advanced memory queries | [Hybrid Memory Architecture](specifications/hybrid_memory_architecture.md) | src/devsynth/application/memory/knowledge_graph_utils.py | tests/unit/application/memory/test_knowledge_graph_utils.py | Implemented |
 | FR-92 | Multi-language code generation agent | [DevSynth Technical Specification](specifications/devsynth_specification.md) | src/devsynth/application/agents/multi_language_code.py | tests/unit/application/agents/test_multi_language_code.py | Implemented |
 | FR-93 | Embedded Kuzu graph memory store support | [Memory System Architecture](architecture/memory_system.md) | src/devsynth/application/memory/kuzu_store.py, src/devsynth/adapters/kuzu_memory_store.py | tests/unit/application/memory/test_kuzu_store.py, tests/integration/general/test_kuzu_memory_integration.py, tests/integration/general/test_kuzu_memory_fallback.py | Implemented |
+| FR-94 | ChromaDB store imports when ChromaDB extras installed | [ChromaDB Store](specifications/chromadb_store.md) | src/devsynth/application/memory/chromadb_store.py | tests/test_chromadb_store_import.py | Implemented |
 
-_Last updated: September 1, 2025_
+_Last updated: August 19, 2025_
 ## Implementation Status
 
 Several requirements remain **partially implemented**. Consult the status column

--- a/docs/specifications/chromadb_store.md
+++ b/docs/specifications/chromadb_store.md
@@ -35,6 +35,11 @@ metric.
 - The `ChromaDBStore` exposes `get_embedding_storage_efficiency()` returning a
   float between 0 and 1 representing how effectively embeddings are stored.
 
+## Requirements
+
+- **CDS-001**: The ChromaDB store must import successfully when the `chromadb`
+  extras are installed.
+
 ## Acceptance Criteria
 
 - A ChromaDB memory store reports optimized embeddings when

--- a/tests/test_chromadb_store_import.py
+++ b/tests/test_chromadb_store_import.py
@@ -8,7 +8,7 @@ from tests.lightweight_imports import apply_lightweight_imports
 def test_chromadb_store_import() -> None:
     """ChromaDBStore should import when chromadb extras are installed.
 
-    ReqID: N/A
+    ReqID: CDS-001
     """
     apply_lightweight_imports()
     from devsynth.application.memory.chromadb_store import ChromaDBStore  # noqa: F401


### PR DESCRIPTION
## Summary
- assign requirement ID CDS-001 to ChromaDB store import test
- document CDS-001 requirement in ChromaDB store specification
- map new requirement FR-94 in requirements traceability matrix

## Testing
- `poetry run pre-commit run --files docs/specifications/chromadb_store.md docs/requirements_traceability.md tests/test_chromadb_store_import.py` *(fails: find-syntax-errors)*
- `poetry run devsynth run-tests --speed=fast` *(interrupted: no output captured)*
- `poetry run pytest tests/test_chromadb_store_import.py::test_chromadb_store_import -q`
- `poetry run python tests/verify_test_organization.py`
- `poetry run python scripts/verify_test_markers.py --module tests/test_chromadb_store_import.py`
- `poetry run python scripts/verify_requirements_traceability.py`
- `poetry run python scripts/verify_version_sync.py`


------
https://chatgpt.com/codex/tasks/task_e_68a3d8280a2c8333b20c17cd54c72427