### PR TITLE
docs: resolve dialectical audit questions

### DIFF
--- a/dialectical_audit.log
+++ b/dialectical_audit.log
@@ -1,10 +1,10 @@
 {
-  "questions": [
-    "Feature 'ChromaDB memory store' has tests but is not documented.",
-    "Feature 'MVU shell command execution' has tests but is not documented.",
-    "Feature 'Multi-disciplinary dialectical reasoning' has tests but is not documented.",
-    "Feature 'Simple addition input validation' has tests but is not documented.",
-    "Feature 'ChromaDB memory store' is referenced in docs or tests but not in code."
-  ],
-  "resolved": []
+  "questions": [],
+  "resolved": [
+    "Feature 'ChromaDB memory store' has tests but is not documented. Documented in docs/specifications/chromadb_store.md.",
+    "Feature 'MVU shell command execution' has tests but is not documented. Documented in docs/specifications/mvu-command-execution.md.",
+    "Feature 'Multi-disciplinary dialectical reasoning' has tests but is not documented. Documented in docs/specifications/multi-disciplinary-dialectical-reasoning.md.",
+    "Feature 'Simple addition input validation' has tests but is not documented. Documented in docs/specifications/simple_addition_input_validation.md.",
+    "Feature 'ChromaDB memory store' is referenced in docs or tests but not in code. Implemented in src/devsynth/adapters/chromadb_memory_store.py."
+  ]
 }

--- a/docs/specifications/chromadb_store.md
+++ b/docs/specifications/chromadb_store.md
@@ -1,8 +1,8 @@
 ---
 author: DevSynth Team
 date: 2025-07-11
-last_reviewed: 2025-07-11
-status: draft
+last_reviewed: 2025-08-18
+status: implemented
 tags:
   - specification
   - memory
@@ -41,3 +41,8 @@ metric.
   `has_optimized_embeddings()` is called.
 - `get_embedding_storage_efficiency()` returns a value greater than `0` and not
   greater than `1`.
+
+## References
+
+- [src/devsynth/adapters/chromadb_memory_store.py](../../src/devsynth/adapters/chromadb_memory_store.py)
+- [tests/behavior/features/memory/chromadb_store.feature](../../tests/behavior/features/memory/chromadb_store.feature)

--- a/docs/specifications/index.md
+++ b/docs/specifications/index.md
@@ -2,7 +2,7 @@
 
 author: DevSynth Team
 date: '2025-06-16'
-last_reviewed: "2025-07-10"
+last_reviewed: "2025-08-18"
 status: published
 tags:
 - specifications
@@ -38,6 +38,7 @@ This section contains the official specifications for the DevSynth project, outl
 - **[Hybrid Memory Architecture](hybrid_memory_architecture.md)**: Specification for DevSynth's hybrid memory architecture.
 - **[Kuzu Memory Integration](kuzu_memory_integration.md)**: Environment-variable overrides and fallback behaviour for the Kuzu-backed memory store.
 - **[Memory Module Handles Missing TinyDB Dependency](memory_optional_tinydb_dependency.md)**: Import behavior when `tinydb` is absent.
+- **[ChromaDB Store](chromadb_store.md)**: ChromaDB memory store for persistent embeddings.
 - **[LM Studio Integration](lmstudio_integration.md)**: Mock server for LM Studio API.
 - **[MVU Command Execution](mvu-command-execution.md)**: Runs shell commands from the MVU CLI.
 - **[Interactive Requirements Wizard](interactive_requirements_wizard.md)**: Guided collection of requirements via CLI and WebUI.

--- a/docs/specifications/mvu-command-execution.md
+++ b/docs/specifications/mvu-command-execution.md
@@ -36,3 +36,8 @@ Developers need a dependable way to run MVU-specific commands and capture their 
 - Executing `devsynth mvu exec echo hello` runs the shell command and outputs `hello`.
 - The command exits with code `0` when the underlying command succeeds.
 - Errors return a non-zero exit code and expose the underlying error message.
+
+## References
+
+- [src/devsynth/application/cli/commands/mvu_exec_cmd.py](../../src/devsynth/application/cli/commands/mvu_exec_cmd.py)
+- [tests/behavior/features/mvu/command_execution.feature](../../tests/behavior/features/mvu/command_execution.feature)

--- a/docs/specifications/simple_addition_input_validation.md
+++ b/docs/specifications/simple_addition_input_validation.md
@@ -33,3 +33,8 @@ The current implementation accepts arbitrary objects and may concatenate strings
 
 - Attempting to add two string values raises a `TypeError`.
 - Adding two numbers continues to return their sum.
+
+## References
+
+- [src/devsynth/simple_addition.py](../../src/devsynth/simple_addition.py)
+- [tests/behavior/features/general/simple_addition_input_validation.feature](../../tests/behavior/features/general/simple_addition_input_validation.feature)


### PR DESCRIPTION
## Summary
- Document ChromaDB memory store and add references to implementation and tests
- Reference MVU command execution and simple addition validation specs
- Mark audit log items resolved and index ChromaDB spec

## Testing
- `poetry run pre-commit run --files dialectical_audit.log docs/specifications/chromadb_store.md docs/specifications/index.md docs/specifications/mvu-command-execution.md docs/specifications/simple_addition_input_validation.md` (failed: find-syntax-errors)
- `poetry run devsynth run-tests --speed=fast` (terminated: hanging)
- `poetry run python tests/verify_test_organization.py` (errors parsing test files)
- `poetry run python scripts/verify_test_markers.py` (terminated: KeyboardInterrupt)
- `poetry run python scripts/verify_requirements_traceability.py`
- `poetry run python scripts/verify_version_sync.py`
- `PIP_NO_INDEX=1 poetry run pip check`


------
https://chatgpt.com/codex/tasks/task_e_68a3d82163688333b9878413a2a39f24