### PR TITLE
docs: add feature docs to satisfy dialectical audit

### DIFF
--- a/dialectical_audit.log
+++ b/dialectical_audit.log
@@ -1,10 +1,4 @@
 {
   "questions": [],
-  "resolved": [
-    "Feature 'ChromaDB memory store' has tests but is not documented. Documented in docs/specifications/chromadb_store.md.",
-    "Feature 'MVU shell command execution' has tests but is not documented. Documented in docs/specifications/mvu-command-execution.md.",
-    "Feature 'Multi-disciplinary dialectical reasoning' has tests but is not documented. Documented in docs/specifications/multi-disciplinary-dialectical-reasoning.md.",
-    "Feature 'Simple addition input validation' has tests but is not documented. Documented in docs/specifications/simple_addition_input_validation.md.",
-    "Feature 'ChromaDB memory store' is referenced in docs or tests but not in code. Implemented in src/devsynth/adapters/chromadb_memory_store.py."
-  ]
+  "resolved": []
 }

--- a/docs/features/all_features.md
+++ b/docs/features/all_features.md
@@ -26,7 +26,7 @@ Feature: Alignment Metrics Command
 Feature: CLI Command Execution
 Feature: CLI UI Parity
 Feature: CLI UX Enhancements
-Feature: ChromaDB Integration
+Feature: ChromaDB memory store
 Feature: Code Command
 Feature: Code Generation
 Feature: Code Transformation
@@ -71,6 +71,7 @@ Feature: Interactive Requirements Flow WebUI
 Feature: Interactive Requirements Wizard
 Feature: Invalid configuration handling
 Feature: Kuzu memory integration
+Feature: MVU shell command execution
 Feature: MVU Command Execution
 Feature: Memory Adapter Integration
 Feature: Memory Backend Integration
@@ -82,6 +83,7 @@ Feature: Methodology Adapters Integration
 Feature: Micro EDRR Cycle
 Feature: Multi-Layered Memory System and Tiered Cache Strategy
 Feature: Multi-agent task delegation
+Feature: Multi-disciplinary dialectical reasoning
 Feature: Multi-disciplinary Dialectical Reasoning
 Feature: Multi-module test generation
 Feature: NiceGUI WebUI
@@ -115,8 +117,9 @@ Feature: Security audit reporting
 Feature: Self Analysis
 Feature: Serve Command
 Feature: Setup Wizard
-Feature: Shared UXBridge across CLI and WebUI
 Feature: Simple Addition
+Feature: Shared UXBridge across CLI and WebUI
+Feature: Simple addition input validation
 Feature: Spec Command
 Feature: Sprint ceremonies align with EDRR phases
 Feature: Streamlit WebUI Navigation

--- a/docs/features/chromadb_memory_store.md
+++ b/docs/features/chromadb_memory_store.md
@@ -1,0 +1,25 @@
+---
+
+title: "ChromaDB memory store"
+date: "2025-08-19"
+version: "0.1.0-alpha.1"
+tags:
+  - "documentation"
+  - "feature"
+status: "draft"
+author: "DevSynth Team"
+last_reviewed: "2025-08-19"
+---
+<div class="breadcrumbs">
+<a href="../index.md">Documentation</a> &gt; <a href="index.md">Feature Documentation</a> &gt; ChromaDB memory store
+</div>
+
+<div class="breadcrumbs">
+<a href="../index.md">Documentation</a> &gt; <a href="index.md">Feature Documentation</a> &gt; ChromaDB memory store
+</div>
+
+# ChromaDB memory store
+
+Feature: ChromaDB memory store
+
+Provides a persistent vector store for embeddings using ChromaDB.

--- a/docs/features/multi_disciplinary_dialectical_reasoning.md
+++ b/docs/features/multi_disciplinary_dialectical_reasoning.md
@@ -1,0 +1,25 @@
+---
+
+title: "Multi-disciplinary Dialectical Reasoning"
+date: "2025-08-19"
+version: "0.1.0-alpha.1"
+tags:
+  - "documentation"
+  - "feature"
+status: "draft"
+author: "DevSynth Team"
+last_reviewed: "2025-08-19"
+---
+<div class="breadcrumbs">
+<a href="../index.md">Documentation</a> &gt; <a href="index.md">Feature Documentation</a> &gt; Multi-disciplinary Dialectical Reasoning
+</div>
+
+<div class="breadcrumbs">
+<a href="../index.md">Documentation</a> &gt; <a href="index.md">Feature Documentation</a> &gt; Multi-disciplinary Dialectical Reasoning
+</div>
+
+# Multi-disciplinary Dialectical Reasoning
+
+Feature: Multi-disciplinary Dialectical Reasoning
+
+WSDE teams merge perspectives across disciplines to refine solutions.

--- a/docs/features/mvu_command_execution.md
+++ b/docs/features/mvu_command_execution.md
@@ -1,0 +1,25 @@
+---
+
+title: "MVU Command Execution"
+date: "2025-08-19"
+version: "0.1.0-alpha.1"
+tags:
+  - "documentation"
+  - "feature"
+status: "draft"
+author: "DevSynth Team"
+last_reviewed: "2025-08-19"
+---
+<div class="breadcrumbs">
+<a href="../index.md">Documentation</a> &gt; <a href="index.md">Feature Documentation</a> &gt; MVU Command Execution
+</div>
+
+<div class="breadcrumbs">
+<a href="../index.md">Documentation</a> &gt; <a href="index.md">Feature Documentation</a> &gt; MVU Command Execution
+</div>
+
+# MVU Command Execution
+
+Feature: MVU Command Execution
+
+MVU CLI commands manage metadata and project setup.

--- a/docs/features/mvu_shell_command_execution.md
+++ b/docs/features/mvu_shell_command_execution.md
@@ -1,0 +1,25 @@
+---
+
+title: "MVU shell command execution"
+date: "2025-08-19"
+version: "0.1.0-alpha.1"
+tags:
+  - "documentation"
+  - "feature"
+status: "draft"
+author: "DevSynth Team"
+last_reviewed: "2025-08-19"
+---
+<div class="breadcrumbs">
+<a href="../index.md">Documentation</a> &gt; <a href="index.md">Feature Documentation</a> &gt; MVU shell command execution
+</div>
+
+<div class="breadcrumbs">
+<a href="../index.md">Documentation</a> &gt; <a href="index.md">Feature Documentation</a> &gt; MVU shell command execution
+</div>
+
+# MVU shell command execution
+
+Feature: MVU shell command execution
+
+The MVU CLI runs shell commands within a traceable session.

--- a/docs/features/simple_addition.md
+++ b/docs/features/simple_addition.md
@@ -22,4 +22,4 @@ last_reviewed: "2025-07-21"
 
 Feature: Simple Addition
 
-This feature demonstrates adding two numbers as a basic example used in tests.
+Adds two numbers as a basic example used in tests.

--- a/docs/features/simple_addition_input_validation.md
+++ b/docs/features/simple_addition_input_validation.md
@@ -1,0 +1,25 @@
+---
+
+title: "Simple addition input validation"
+date: "2025-07-21"
+version: "0.1.0-alpha.1"
+tags:
+  - "documentation"
+  - "feature"
+status: "draft"
+author: "DevSynth Team"
+last_reviewed: "2025-07-21"
+---
+<div class="breadcrumbs">
+<a href="../index.md">Documentation</a> &gt; <a href="index.md">Feature Documentation</a> &gt; Simple addition input validation
+</div>
+
+<div class="breadcrumbs">
+<a href="../index.md">Documentation</a> &gt; <a href="index.md">Feature Documentation</a> &gt; Simple addition input validation
+</div>
+
+# Simple addition input validation
+
+Feature: Simple addition input validation
+
+The `add` function rejects non-numeric inputs, raising `TypeError` when parameters are not numbers.

--- a/src/devsynth/adapters/chromadb_memory_store.py
+++ b/src/devsynth/adapters/chromadb_memory_store.py
@@ -1,3 +1,4 @@
+# Feature: ChromaDB memory store
 try:
     import chromadb
     from chromadb.api import ClientAPI


### PR DESCRIPTION
## Summary
- document ChromaDB memory store
- document MVU command execution variants
- document multi-disciplinary dialectical reasoning
- document simple addition input validation
- tag ChromaDB memory store implementation

## Testing
- `PIP_NO_INDEX=1 poetry run pip check`
- `poetry run devsynth run-tests --speed=fast`
- `poetry run python tests/verify_test_organization.py`
- `poetry run python scripts/verify_test_markers.py` *(fails: pytest collection failed)*
- `poetry run python scripts/verify_requirements_traceability.py`
- `poetry run python scripts/verify_version_sync.py`
- `poetry run pytest tests/unit/deployment -m fast`
- `poetry run task release:prep` *(fails: test failure)*
- `poetry run python scripts/dialectical_audit.py`
- `poetry run pre-commit run --files dialectical_audit.log docs/features/all_features.md docs/features/simple_addition.md docs/features/simple_addition_input_validation.md docs/features/chromadb_memory_store.md docs/features/mvu_shell_command_execution.md docs/features/mvu_command_execution.md docs/features/multi_disciplinary_dialectical_reasoning.md src/devsynth/adapters/chromadb_memory_store.py`
- `poetry run pre-commit run --files docs/features/chromadb_memory_store.md docs/features/mvu_shell_command_execution.md docs/features/mvu_command_execution.md docs/features/multi_disciplinary_dialectical_reasoning.md docs/features/simple_addition_input_validation.md`


------
https://chatgpt.com/codex/tasks/task_e_68a3f1e382d883338290e63b3f26cb24