### PR TITLE
docs: add analysis sections for EDRR specs

### DIFF
--- a/docs/specifications/delimiting_recursion_algorithms.md
+++ b/docs/specifications/delimiting_recursion_algorithms.md
@@ -8,6 +8,9 @@ tags:
   - "EDRR"
   - "heuristics"
 
+references:
+  - "Cormen, T. H., C. E. Leiserson, R. L. Rivest, and C. Stein. Introduction to Algorithms. 4th ed., MIT Press, 2022."
+
 status: "draft"
 author: "DevSynth Team"
 last_reviewed: "2025-07-10"
@@ -54,6 +57,14 @@ the system balances exploration with cost and quality constraints.
    - A task may include `human_override` with values `"terminate"` or
 
      `"continue"` to explicitly control recursion.
+
+## Proof of Termination
+
+Each heuristic places an upper bound on recursion depth or cost. With finite
+inputs, at least one threshold will eventually be met, guaranteeing that the
+EDRR cycle halts. Unit test `tests/unit/application/edrr/test_enhanced_recursion_termination.py`
+and integration test `tests/integration/general/test_recursive_recovery_flow.py`
+exercise these termination paths.
 
 These heuristics are implemented in `EDRRCoordinator.should_terminate_recursion`
 and referenced in the [Recursive EDRR Pseudocode](recursive_edrr_pseudocode.md).

--- a/docs/specifications/edrr_cycle_specification.md
+++ b/docs/specifications/edrr_cycle_specification.md
@@ -9,6 +9,9 @@ tags:
   - "methodology"
   - "workflow"
 
+references:
+  - "Cormen, T. H., C. E. Leiserson, R. L. Rivest, and C. Stein. Introduction to Algorithms. 4th ed., MIT Press, 2022."
+
 status: "published"
 author: "DevSynth Team"
 last_reviewed: "2025-07-10"
@@ -446,6 +449,16 @@ The EDRR behavior can be customized through configuration:
 - **Quality Thresholds**: Define acceptance criteria for outputs
 - **Human Intervention Points**: Configure when human input is requested
 
+## Complexity Analysis
+
+The EDRR cycle performs four stages per iteration. If each stage spawns a micro
+cycle and recursion continues to depth \(d\), the worst-case time complexity is
+\(O(4^d)\). The termination heuristics described in
+[Delimiting Recursion Algorithms](delimiting_recursion_algorithms.md) bound \(d\)
+and keep execution practical. Unit tests such as
+`tests/unit/application/edrr/test_coordinator.py` and behavior tests like
+`tests/behavior/features/general/edrr_cycle.feature` verify stage transitions and
+early termination.
 
 ## 7. Future Enhancements
 

--- a/docs/specifications/recursive_edrr_pseudocode.md
+++ b/docs/specifications/recursive_edrr_pseudocode.md
@@ -8,6 +8,9 @@ tags:
   - "EDRR"
   - "pseudocode"
 
+references:
+  - "Cormen, T. H., C. E. Leiserson, R. L. Rivest, and C. Stein. Introduction to Algorithms. 4th ed., MIT Press, 2022."
+
 status: "draft"
 author: "DevSynth Team"
 last_reviewed: "2025-07-10"
@@ -111,6 +114,16 @@ The coordinator checks `should_terminate_recursion` before spawning a micro
 cycle. If recursion proceeds, the child coordinator inherits the parent's
 dependencies and increments `recursion_depth`. Results from the micro cycle are
 stored under the parent's phase data so the overall cycle reflects nested work.
+## Complexity Analysis
+
+Let \(b\) be the maximum number of subtasks spawned in the **retrospect** phase
+and \(d\) the maximum recursion depth. The number of cycle invocations is
+bounded by \(O(b^d)\). Because each phase runs in linear time with respect to
+its inputs, overall complexity is \(O(b^d)\). Unit tests such as
+`tests/unit/application/edrr/test_recursive_edrr_coordinator.py` and behavior
+tests like `tests/behavior/steps/test_recursive_edrr_coordinator_steps.py`
+exercise this recursion and confirm termination behavior.
+
 ## Implementation Status
 
 .


### PR DESCRIPTION
## Summary
- add complexity analysis to EDRR specification and link to related tests
- document complexity of recursive EDRR pseudocode
- prove termination of recursion heuristics

## Testing
- `poetry run pre-commit run --files docs/specifications/delimiting_recursion_algorithms.md docs/specifications/edrr_cycle_specification.md docs/specifications/recursive_edrr_pseudocode.md`
- `poetry run devsynth run-tests --speed=fast`
- `poetry run python tests/verify_test_organization.py`
- `poetry run python scripts/verify_test_markers.py` *(fails: KeyboardInterrupt after partial collection)*
- `poetry run python scripts/verify_requirements_traceability.py`
- `poetry run python scripts/verify_version_sync.py`


------
https://chatgpt.com/codex/tasks/task_e_68a4022c82888333b39ed6711bca23e0