### PR TITLE
fix install script optional plugin

### DIFF
--- a/scripts/install_dev.sh
+++ b/scripts/install_dev.sh
@@ -43,6 +43,8 @@ poetry run pre-commit install --install-hooks
 PIP_NO_INDEX=1 poetry run pip check
 
 # Run repository verification commands
+export PYTEST_ADDOPTS="${PYTEST_ADDOPTS:-} -p benchmark"
+export PYTEST_DISABLE_PLUGIN_AUTOLOAD=0
 poetry run python tests/verify_test_organization.py
 poetry run python scripts/verify_test_markers.py
 poetry run python scripts/verify_requirements_traceability.py


### PR DESCRIPTION
## Summary
- ensure pytest-benchmark plugin loads by enabling autoload and forcing plugin

## Testing
- `poetry run pre-commit run --files scripts/install_dev.sh`
- `PIP_NO_INDEX=1 poetry run pip check`


------
https://chatgpt.com/codex/tasks/task_e_68a401b323788333ada198eb55ea724c