### PR TITLE
docs: add mvu command execution coverage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,11 @@ DevSynth's pre-release milestones in the `0.1.x` range lead up to the first
 stable release. Version `0.1.0-alpha.1` marks the project's initial published
 milestone.
 
+## [Unreleased]
+
+### Added
+- Documented acceptance criteria for MVU command execution with linked BDD feature coverage.
+
 ## [0.1.0-alpha.1] - 2025-08-16
 
 ### Added

--- a/docs/specifications/mvu-command-execution.md
+++ b/docs/specifications/mvu-command-execution.md
@@ -35,6 +35,7 @@ Developers need a dependable way to run MVU-specific commands and capture their 
 
 - Executing `devsynth mvu exec echo hello` runs the shell command and outputs `hello`.
 - The command exits with code `0` when the underlying command succeeds.
+- Combined output includes both `stdout` and `stderr` streams.
 - Errors return a non-zero exit code and expose the underlying error message.
 
 ## References

--- a/tests/behavior/features/mvu/command_execution.feature
+++ b/tests/behavior/features/mvu/command_execution.feature
@@ -1,3 +1,4 @@
+# Specification: docs/specifications/mvu-command-execution.md
 Feature: MVU shell command execution
   As a developer
   I want MVU to run shell commands within a traceable session


### PR DESCRIPTION
## Summary
- expand MVU command execution specification with stdout/stderr criteria and link to BDD feature
- reference specification from MVU command execution feature file
- document added coverage in changelog

## Testing
- `poetry run pre-commit run --files CHANGELOG.md docs/specifications/mvu-command-execution.md tests/behavior/features/mvu/command_execution.feature`
- `poetry run devsynth run-tests --speed=fast`
- `poetry run python tests/verify_test_organization.py` *(fails: test organization verification failed)*
- `poetry run python scripts/verify_test_markers.py` *(fails: pytest collection errors)*
- `poetry run python scripts/verify_requirements_traceability.py`
- `poetry run python scripts/verify_version_sync.py`
- `poetry run python scripts/dialectical_audit.py`

------
https://chatgpt.com/codex/tasks/task_e_68a4bbcb9ddc833389aec8d447c704e0