### PR TITLE
docs: remove duplicate breadcrumb from specs index

### DIFF
--- a/docs/specifications/index.md
+++ b/docs/specifications/index.md
@@ -15,10 +15,6 @@ version: "0.1.0-alpha.1"
 <a href="../index.md">Documentation</a> &gt; <a href="index.md">Specifications</a> &gt; DevSynth Specifications
 </div>
 
-<div class="breadcrumbs">
-<a href="../index.md">Documentation</a> &gt; <a href="index.md">Specifications</a> &gt; DevSynth Specifications
-</div>
-
 # DevSynth Specifications
 
 This section contains the official specifications for the DevSynth project, outlining its requirements, features, and intended behavior.


### PR DESCRIPTION
## Summary
- remove duplicate breadcrumbs from specifications index

## Testing
- `poetry run mkdocs build`
- `poetry run pre-commit run --files docs/specifications/index.md`
- `PIP_NO_INDEX=1 poetry run pip check`
- `poetry run devsynth run-tests --speed=fast`
- `poetry run python tests/verify_test_organization.py`
- `poetry run python scripts/verify_test_markers.py`
- `poetry run python scripts/verify_requirements_traceability.py`
- `poetry run python scripts/verify_version_sync.py`


------
https://chatgpt.com/codex/tasks/task_e_68a4bbbe4b888333b50e1b098d287ba4