### PR TITLE
docs: add testing guidelines

### DIFF
--- a/tests/AGENTS.md
+++ b/tests/AGENTS.md
@@ -1,0 +1,25 @@
+# AGENTS.md
+
+This directory summarizes test-specific guidance. For general contribution, environment, and policy information, see the repository [root AGENTS.md](../AGENTS.md).
+
+## Test isolation
+
+`tests/conftest.py` defines an autouse `global_test_isolation` fixture that resets environment variables, the working directory, and logging for each test. Avoid setting environment variables at import time; use `monkeypatch.setenv()` or set them inside the test body.
+
+## Speed markers
+
+`tests/conftest_extensions.py` provides `fast`, `medium`, and `slow` markers. Each test must include exactly one speed marker; unmarked tests default to `medium`. Combine speed markers with context markers like `memory_intensive` when appropriate.
+
+Run tests for a specific speed category:
+
+```bash
+poetry run devsynth run-tests --speed=<fast|medium|slow>
+```
+
+## Marker verification
+
+Verify that tests use the required speed markers:
+
+```bash
+poetry run python scripts/verify_test_markers.py
+```


### PR DESCRIPTION
## Summary
- document test isolation and speed marker usage in `tests/AGENTS.md`
- reference root AGENTS for broader contribution policies

## Testing
- `poetry run pre-commit run --files tests/AGENTS.md`
- `poetry run devsynth run-tests --speed=fast`
- `poetry run python tests/verify_test_organization.py` *(fails: behavior feature files do not follow naming conventions)*
- `poetry run python scripts/verify_test_markers.py` *(fails: pytest collection errors)*
- `poetry run python scripts/verify_requirements_traceability.py`
- `poetry run python scripts/verify_version_sync.py`


------
https://chatgpt.com/codex/tasks/task_e_68a4bbb5085483339a2d7a6423a26058