### PR TITLE
Ensure go-task installation via install_dev script

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,7 +31,7 @@ Directory-specific instructions live in scoped AGENTS guidelines within director
   ```bash
   bash scripts/install_dev.sh
   ```
-  This installs pre-commit hooks, caches optional extras from `pyproject.toml`, and runs verification commands to ensure project consistency.
+  This installs pre-commit hooks, caches optional extras from `pyproject.toml`, installs the `go-task` binary when missing, and runs verification commands to ensure project consistency.
 - Run **all** commands through `poetry run` to use the correct virtual environment.
 - Install dependencies with development and test extras:
 
@@ -93,7 +93,7 @@ Directory-specific instructions live in scoped AGENTS guidelines within director
 
 See `docs/release/0.1.0-alpha.1.md` for the full process. Summary:
 
-1. Run `poetry run task release:prep` to build artifacts.
+1. After running `bash scripts/install_dev.sh` (which installs `go-task`), run `poetry run task release:prep` to build artifacts.
 2. Generate and resolve `dialectical_audit.log` (`poetry run python scripts/dialectical_audit.py` or trigger the GitHub workflow`) per the [Dialectical Audit Policy](docs/policies/dialectical_audit.md).
 3. Conduct a dialectical review with another contributor.
 4. Tag and push the release: `git tag -a <version>`.

--- a/docs/release/0.1.0-alpha.1.md
+++ b/docs/release/0.1.0-alpha.1.md
@@ -14,7 +14,10 @@ last_reviewed: "2025-08-16"
 
 ## Setup
 
-1. Run the environment provisioning script.
+1. Run the environment provisioning script to install dependencies and ensure `go-task` is available:
+   ```bash
+   bash scripts/install_dev.sh
+   ```
 2. Install dependencies with development and test extras:
    ```bash
    poetry install --with dev --extras tests retrieval chromadb api
@@ -33,7 +36,7 @@ last_reviewed: "2025-08-16"
    ```bash
    poetry run pytest tests/unit/deployment -m fast
    ```
-5. Prepare release artifacts and run the dialectical audit:
+5. Prepare release artifacts with Taskfile and run the dialectical audit:
    ```bash
    poetry run task release:prep
    poetry run python scripts/dialectical_audit.py
@@ -70,7 +73,6 @@ last_reviewed: "2025-08-16"
 The following issues were identified during the `0.1.0-alpha.1` release cycle:
 
 - `poetry run python scripts/verify_test_markers.py` fails due to pytest collection errors in several test modules (e.g., `tests/performance/test_api_benchmarks.py`, `tests/behavior/test_agentapi.py`).
-- `poetry run task release:prep` reports `Command not found: task`, preventing release artifact preparation.
 
 ## Looking Ahead
 

--- a/scripts/install_dev.sh
+++ b/scripts/install_dev.sh
@@ -5,6 +5,15 @@ CACHE_DIR="${XDG_CACHE_HOME:-$HOME/.cache}/devsynth"
 WHEEL_DIR="$CACHE_DIR/wheels"
 mkdir -p "$WHEEL_DIR"
 
+# Ensure go-task is available for Taskfile-based workflows
+if ! command -v task >/dev/null 2>&1; then
+  echo "[info] installing go-task"
+  TASK_BIN_DIR="${HOME}/.local/bin"
+  mkdir -p "$TASK_BIN_DIR"
+  curl -sSL https://taskfile.dev/install.sh | bash -s -- -b "$TASK_BIN_DIR" >/tmp/task_install.log
+  export PATH="$TASK_BIN_DIR:$PATH"
+fi
+
 optional_pkgs=$(poetry run python - <<'PY'
 import re, tomllib
 


### PR DESCRIPTION
## Summary
- install go-task in `scripts/install_dev.sh` when missing
- clarify release prep instructions in docs and AGENTS

## Testing
- `poetry run pre-commit run --files scripts/install_dev.sh AGENTS.md docs/release/0.1.0-alpha.1.md`
- `poetry run python tests/verify_test_organization.py` *(fails: Test organization verification failed)*
- `poetry run python scripts/verify_version_sync.py`
- `poetry run task release:prep` *(fails: exit status 2 during test phase)*
- `poetry run devsynth run-tests --speed=fast` *(terminated early)*


------
https://chatgpt.com/codex/tasks/task_e_68a4bb9d73e08333b2685f3aa03ff45e