### PR TITLE
test: add mvu command execution steps

### DIFF
--- a/tests/behavior/steps/mvu_command_execution_steps.py
+++ b/tests/behavior/steps/mvu_command_execution_steps.py
@@ -1,0 +1,38 @@
+import pytest
+from pytest_bdd import given, parsers, then, when
+from typer.testing import CliRunner
+
+from devsynth.adapters.cli.typer_adapter import build_app
+
+pytestmark = [pytest.mark.medium]
+
+
+@given("the DevSynth CLI is installed")
+def devsynth_cli_installed() -> bool:
+    return True
+
+
+@given("I have a valid DevSynth project")
+def valid_devsynth_project(tmp_project_dir):
+    return tmp_project_dir
+
+
+@when(parsers.parse('I run the command "{command}"'))
+def run_exec_command(command: str, command_context):
+    args = command.split()
+    if args[0] == "devsynth":
+        args = args[1:]
+    runner = CliRunner()
+    result = runner.invoke(build_app(), args)
+    command_context["exit_code"] = result.exit_code
+    command_context["output"] = result.output
+
+
+@then("the command should succeed")
+def command_should_succeed(command_context) -> None:
+    assert command_context.get("exit_code") == 0
+
+
+@then(parsers.parse('the output should contain "{text}"'))
+def output_should_contain(text: str, command_context) -> None:
+    assert text in command_context.get("output", "")

--- a/tests/behavior/steps/test_mvu_command_execution_steps.py
+++ b/tests/behavior/steps/test_mvu_command_execution_steps.py
@@ -1,8 +1,8 @@
 import pytest
 from pytest_bdd import scenarios
 
-from .test_mvu_commands_steps import *  # noqa: F401,F403
+from .mvu_command_execution_steps import *  # noqa: F401,F403
 
-pytestmark = pytest.mark.fast
+pytestmark = [pytest.mark.medium]
 
 scenarios("../features/mvu/command_execution.feature")


### PR DESCRIPTION
## Summary
- add BDD steps for MVU shell command execution
- use CliRunner to verify `devsynth mvu exec`

## Testing
- `poetry run pre-commit run --files tests/behavior/steps/test_mvu_command_execution_steps.py tests/behavior/steps/mvu_command_execution_steps.py`
- `poetry run pytest tests/behavior/steps/test_mvu_command_execution_steps.py`
- `poetry run devsynth run-tests --speed=medium` *(fails: command interrupted)*
- `poetry run python tests/verify_test_organization.py` *(fails: naming issues)*
- `poetry run python scripts/verify_test_markers.py` *(fails: collection errors)*
- `poetry run python scripts/verify_requirements_traceability.py`
- `poetry run python scripts/verify_version_sync.py`

------
https://chatgpt.com/codex/tasks/task_e_68a4bb9398fc8333a7e328bf24505b9c