### PR TITLE
chore: add release state verification

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -147,6 +147,7 @@ tasks:
       - task: build:sdist
       - task: test:smoke
       - task: security:audit
+      - poetry run python scripts/verify_release_state.py
       - poetry run python scripts/dialectical_audit.py
 
   # Development workflow tasks

--- a/docs/release/0.1.0-alpha.1.md
+++ b/docs/release/0.1.0-alpha.1.md
@@ -5,7 +5,8 @@ version: "0.1.0-alpha.1"
 tags:
   - "devsynth"
   - "release"
-status: "published"
+status: "draft"
+note: "Release pending Git tag v0.1.0-alpha.1"
 author: "DevSynth Team"
 last_reviewed: "2025-08-16"
 ---

--- a/docs/requirements_traceability.md
+++ b/docs/requirements_traceability.md
@@ -194,6 +194,7 @@ report to standard output.
 | FR-92 | Multi-language code generation agent | [DevSynth Technical Specification](specifications/devsynth_specification.md) | src/devsynth/application/agents/multi_language_code.py | tests/unit/application/agents/test_multi_language_code.py | Implemented |
 | FR-93 | Embedded Kuzu graph memory store support | [Memory System Architecture](architecture/memory_system.md) | src/devsynth/application/memory/kuzu_store.py, src/devsynth/adapters/kuzu_memory_store.py | tests/unit/application/memory/test_kuzu_store.py, tests/integration/general/test_kuzu_memory_integration.py, tests/integration/general/test_kuzu_memory_fallback.py | Implemented |
 | FR-94 | ChromaDB store imports when ChromaDB extras installed | [ChromaDB Store](specifications/chromadb_store.md) | src/devsynth/application/memory/chromadb_store.py | tests/test_chromadb_store_import.py | Implemented |
+| FR-95 | Release state check fails when tag missing | [Release state check](specifications/release-state-check.md) | scripts/verify_release_state.py | tests/behavior/features/release_state_check.feature, tests/behavior/test_release_state_check.py | Implemented |
 
 _Last updated: August 19, 2025_
 ## Implementation Status

--- a/docs/specifications/index.md
+++ b/docs/specifications/index.md
@@ -51,6 +51,7 @@ This section contains the official specifications for the DevSynth project, outl
 - **[Project Documentation Ingestion](project-documentation-ingestion.md)**: Indexes project documentation for retrieval.
 - **[Multi-disciplinary Dialectical Reasoning](multi-disciplinary-dialectical-reasoning.md)**: WSDE teams gather perspectives across disciplines.
 - **[Simple Addition Input Validation](simple_addition_input_validation.md)**: `add` rejects non-numeric inputs.
+- **[Release state check](release-state-check.md)**: Ensures published releases have corresponding Git tags.
 
 ## Implementation Plans
 

--- a/docs/specifications/release-state-check.md
+++ b/docs/specifications/release-state-check.md
@@ -1,0 +1,42 @@
+---
+author: DevSynth Team
+date: 2025-08-19
+last_reviewed: 2025-08-19
+status: draft
+tags:
+- specification
+title: Release state check
+version: 0.1.0-alpha.1
+---
+
+<!--
+Required metadata fields:
+- author: document author
+- date: creation date
+- last_reviewed: last review date
+- status: draft | review | published
+- tags: search keywords
+- title: short descriptive name
+- version: specification version
+-->
+
+# Summary
+
+## Socratic Checklist
+- What is the problem?
+- What proofs confirm the solution?
+
+## Motivation
+
+Ensure release documentation marked as published has a corresponding Git tag.
+
+## Specification
+
+- Parse `docs/release/0.1.0-alpha.1.md` to read its `status` and `version`.
+- When `status` is `published`, verify a tag matching `v<version>` exists.
+- Fail with a non-zero exit code when the tag is missing.
+
+## Acceptance Criteria
+
+- Running `python scripts/verify_release_state.py` exits with status `1` when the release is marked as published and tag `v0.1.0-alpha.1` does not exist.
+- The script exits with status `0` otherwise.

--- a/scripts/verify_release_state.py
+++ b/scripts/verify_release_state.py
@@ -1,0 +1,56 @@
+"""Check release state against Git tags."""
+
+from __future__ import annotations
+
+import pathlib
+import subprocess
+import sys
+
+import yaml
+
+RELEASE_FILE = pathlib.Path("docs/release/0.1.0-alpha.1.md")
+
+
+def parse_front_matter(path: pathlib.Path) -> dict:
+    """Extract YAML front matter from a Markdown file."""
+    text = path.read_text().splitlines()
+    if text[0] != "---":
+        return {}
+    end = text[1:].index("---") + 1
+    front_matter = "\n".join(text[1:end])
+    return yaml.safe_load(front_matter) or {}
+
+
+def tag_exists(tag: str) -> bool:
+    """Return True if the given Git tag exists."""
+    result = subprocess.run(
+        [
+            "git",
+            "tag",
+            "--list",
+            tag,
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    return bool(result.stdout.strip())
+
+
+def main() -> int:
+    data = parse_front_matter(RELEASE_FILE)
+    status = data.get("status")
+    version = data.get("version")
+    tag = f"v{version}" if version else None
+
+    if status == "published" and tag and not tag_exists(tag):
+        print(
+            f"Release marked as published but Git tag {tag} is missing.",
+            file=sys.stderr,
+        )
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/behavior/features/release_state_check.feature
+++ b/tests/behavior/features/release_state_check.feature
@@ -1,0 +1,8 @@
+Feature: Release state check
+  As a release maintainer
+  I want verification to ensure published releases have tags
+  So that release documentation matches repository state
+
+  Scenario: Release verification fails without tag
+    When I verify the release state
+    Then the release verification should fail

--- a/tests/behavior/steps/release_state_steps.py
+++ b/tests/behavior/steps/release_state_steps.py
@@ -1,0 +1,27 @@
+import subprocess
+
+import pytest
+from pytest_bdd import then, when
+
+
+@pytest.fixture
+def context():
+    return {}
+
+
+@when("I verify the release state")
+def verify_release_state(context):
+    result = subprocess.run(
+        [
+            "python",
+            "scripts/verify_release_state.py",
+        ],
+        capture_output=True,
+        text=True,
+    )
+    context["result"] = result
+
+
+@then("the release verification should fail")
+def release_should_fail(context):
+    assert context["result"].returncode != 0

--- a/tests/behavior/test_release_state_check.py
+++ b/tests/behavior/test_release_state_check.py
@@ -1,0 +1,16 @@
+"""ReqID: FR-95"""
+
+import os
+
+import pytest
+from pytest_bdd import scenarios
+
+feature_file = os.path.join(
+    os.path.dirname(__file__),
+    "features",
+    "release_state_check.feature",
+)
+
+scenarios(feature_file)
+
+pytestmark = pytest.mark.fast


### PR DESCRIPTION
## Summary
- mark 0.1.0-alpha.1 release as a draft pending tag
- add verify_release_state script and wire into release prep task
- document release state check and add a failing BDD feature

## Testing
- `poetry run pre-commit run --files Taskfile.yml docs/release/0.1.0-alpha.1.md docs/requirements_traceability.md docs/specifications/index.md docs/specifications/release-state-check.md scripts/verify_release_state.py tests/behavior/features/release_state_check.feature tests/behavior/steps/release_state_steps.py tests/behavior/test_release_state_check.py` (fails: Executable `devsynth` not found)
- `PIP_NO_INDEX=1 poetry run pip check` (warns: poetry 2.1.4 requires virtualenv<20.33.0,>=20.26.6 but 20.33.1 is installed)
- `poetry run devsynth run-tests --speed=fast` (fails: ModuleNotFoundError: No module named 'devsynth')
- `poetry run python tests/verify_test_organization.py` (fails: behavior feature files do not follow naming patterns)
- `poetry run python scripts/verify_test_markers.py` (fails: pytest collection failures)
- `poetry run python scripts/verify_requirements_traceability.py`
- `poetry run python scripts/verify_version_sync.py`
- `poetry run python scripts/dialectical_audit.py`

------
https://chatgpt.com/codex/tasks/task_e_68a4dc4b3a348333a0aa1ac5248f33e7