### PR TITLE
Add version bump helper and release documentation

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -149,6 +149,18 @@ tasks:
       - task: security:audit
       - poetry run python scripts/dialectical_audit.py
 
+  release:tag:
+    desc: Tag a release and bump to the next development version
+    deps:
+      - release:prep
+    vars:
+      VERSION: ""
+      NEXT_VERSION: ""
+    cmds:
+      - git tag -a {{.VERSION}} -m "Release {{.VERSION}}"
+      - git push origin {{.VERSION}}
+      - poetry run python scripts/bump_version.py {{.NEXT_VERSION}}
+
   # Development workflow tasks
   dev:
     desc: Run common development tasks (format, lint, test)

--- a/docs/release/0.1.0-alpha.1.md
+++ b/docs/release/0.1.0-alpha.1.md
@@ -46,6 +46,15 @@ last_reviewed: "2025-08-16"
    See the [Dialectical Audit Policy](../policies/dialectical_audit.md) for guidance.
 
 
+## Post-tagging
+
+After tagging the release, bump to the next development version and commit:
+
+```bash
+poetry version 0.1.0-alpha.2.dev0
+git commit -am "chore: start 0.1.0-alpha.2.dev0"
+```
+
 ## Features
 
 - Modular, hexagonal architecture

--- a/docs/specifications/bump-version-helper.md
+++ b/docs/specifications/bump-version-helper.md
@@ -1,0 +1,26 @@
+---
+author: DevSynth Team
+date: '2025-08-19'
+last_reviewed: '2025-08-19'
+status: draft
+tags:
+  - specification
+  - release
+title: Version Bump Helper
+---
+
+## Socratic Checklist
+- What is the problem?
+- What proofs confirm the solution?
+
+## Motivation
+Automating version bumps reduces manual steps and keeps project metadata in sync after a release tag.
+
+## Specification
+- A script `scripts/bump_version.py` accepts a target version string.
+- The script executes `poetry version <version>` to update `pyproject.toml`.
+- It updates `src/devsynth/__init__.py` so `__version__` matches the new version.
+
+## Acceptance Criteria
+- Running `python scripts/bump_version.py 0.1.0-alpha.2.dev0` updates Poetry and `__init__.py` to `0.1.0-alpha.2.dev0`.
+- The script exits with an error if `poetry version` fails or the update cannot be written.

--- a/docs/specifications/index.md
+++ b/docs/specifications/index.md
@@ -51,6 +51,7 @@ This section contains the official specifications for the DevSynth project, outl
 - **[Project Documentation Ingestion](project-documentation-ingestion.md)**: Indexes project documentation for retrieval.
 - **[Multi-disciplinary Dialectical Reasoning](multi-disciplinary-dialectical-reasoning.md)**: WSDE teams gather perspectives across disciplines.
 - **[Simple Addition Input Validation](simple_addition_input_validation.md)**: `add` rejects non-numeric inputs.
+- **[Version Bump Helper](bump-version-helper.md)**: Ensures project metadata is updated after tagging.
 
 ## Implementation Plans
 

--- a/scripts/bump_version.py
+++ b/scripts/bump_version.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python
+"""Synchronize project version between Poetry and package metadata."""
+
+from __future__ import annotations
+
+import argparse
+import re
+import subprocess
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+INIT_FILE = ROOT / "src" / "devsynth" / "__init__.py"
+
+
+def run_poetry_version(version: str) -> None:
+    """Run ``poetry version`` with the provided version."""
+    subprocess.run(["poetry", "version", version], check=True)
+
+
+def update_init(version: str) -> None:
+    """Update ``__version__`` in :mod:`devsynth` package."""
+    text = INIT_FILE.read_text(encoding="utf-8")
+    new_text = re.sub(r'(__version__\s*=\s*")[^"]+("\n)', rf"\1{version}\2", text)
+    INIT_FILE.write_text(new_text, encoding="utf-8")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Bump project version and sync metadata"
+    )
+    parser.add_argument("version", help="Target version, e.g., 0.1.0-alpha.2.dev0")
+    args = parser.parse_args()
+    run_poetry_version(args.version)
+    update_init(args.version)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/behavior/features/bump_version.feature
+++ b/tests/behavior/features/bump_version.feature
@@ -1,0 +1,9 @@
+Feature: Bump project version
+  As a release engineer
+  I want a helper script to bump the project version
+  So that package metadata stays consistent
+
+  Scenario: Update to next development version
+    Given the project is tagged for release
+    When I run the bump version script with "0.1.0-alpha.2.dev0"
+    Then the project files reflect "0.1.0-alpha.2.dev0"


### PR DESCRIPTION
## Summary
- document post-tagging version bump for 0.1.0-alpha.1 release
- add `bump_version.py` to sync Poetry and package versions
- run bump helper in new `release:tag` task
- capture specification and BDD feature for version bump helper

## Testing
- `PIP_NO_INDEX=1 poetry run pip check` *(fails: poetry 2.1.4 has requirement virtualenv<20.33.0,>=20.26.6, but you have virtualenv 20.33.1)*
- `poetry run pre-commit run --files Taskfile.yml docs/release/0.1.0-alpha.1.md docs/specifications/index.md docs/specifications/bump-version-helper.md scripts/bump_version.py tests/behavior/features/bump_version.feature`
- `poetry run devsynth run-tests --speed=fast`
- `poetry run python tests/verify_test_organization.py` *(fails: test organization verification failed)*
- `poetry run python scripts/verify_test_markers.py` *(fails: pytest collection failed for test_agentapi.py and test_api_benchmarks.py)*
- `poetry run python scripts/verify_requirements_traceability.py` *(no output)*
- `poetry run python scripts/verify_version_sync.py`


------
https://chatgpt.com/codex/tasks/task_e_68a4dc77a3ec8333b47766cb1a79f368