### PR TITLE
docs: document post-tag version bump

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -150,6 +150,14 @@ tasks:
       - poetry run python scripts/verify_release_state.py
       - poetry run python scripts/dialectical_audit.py
 
+
+  release:bump:
+    desc: Bump version for next development cycle
+    deps:
+      - release:prep
+    cmds:
+      - git describe --tags --exact-match >/dev/null
+      - poetry run python scripts/bump_version.py {{.NEXT_VERSION}}
   # Development workflow tasks
   dev:
     desc: Run common development tasks (format, lint, test)

--- a/dialectical_audit.log
+++ b/dialectical_audit.log
@@ -30,6 +30,7 @@
     "Feature 'Multi-Layered Memory System' is referenced in docs or tests but not in code. - deferred to future documentation.",
     "Feature 'Resolve pytest-xdist assertion errors' is referenced in docs or tests but not in code. - deferred to future documentation.",
     "Feature 'Review and Reprioritize Open Issues' is referenced in docs or tests but not in code. - deferred to future documentation.",
-    "Feature 'User Authentication' is referenced in docs or tests but not in code. - deferred to future documentation."
+    "Feature 'User Authentication' is referenced in docs or tests but not in code. - deferred to future documentation.",
+    "Feature 'Version bump script' has tests and documentation; no action needed."
   ]
 }

--- a/docs/release/0.1.0-alpha.1.md
+++ b/docs/release/0.1.0-alpha.1.md
@@ -45,6 +45,9 @@ last_reviewed: "2025-08-16"
    Record all audit questions and their resolutions in `dialectical_audit.log`.
    Review the log with another contributor before tagging the release.
    See the [Dialectical Audit Policy](../policies/dialectical_audit.md) for guidance.
+## Post-Tag Version Bump
+After tagging, run `poetry version 0.1.0-alpha.2.dev0` (or appropriate next version) and commit.
+
 
 
 ## Features

--- a/docs/specifications/bump-version-script.md
+++ b/docs/specifications/bump-version-script.md
@@ -1,0 +1,41 @@
+---
+author: DevSynth Team
+date: 2025-08-19
+last_reviewed: 2025-08-19
+status: draft
+tags:
+- specification
+title: Version bump script
+version: 0.1.0-alpha.1
+---
+
+<!--
+Required metadata fields:
+- author: document author
+- date: creation date
+- last_reviewed: last review date
+- status: draft | review | published
+- tags: search keywords
+- title: short descriptive name
+- version: specification version
+-->
+
+# Summary
+
+## Socratic Checklist
+- What is the problem?
+- What proofs confirm the solution?
+
+## Motivation
+
+After cutting a release tag, developers need a consistent way to bump the project to the next development version.
+
+## Specification
+
+- Provide `scripts/bump_version.py` which wraps `poetry version <new_version>`.
+- After bumping, rewrite `src/devsynth/__init__.py` so `__version__` matches the new version.
+
+## Acceptance Criteria
+
+- Running `python scripts/bump_version.py 0.1.0-alpha.2.dev0` updates `src/devsynth/__init__.py` to `__version__ = "0.1.0-alpha.2.dev0"`.
+- The script exits with status `0` when the update succeeds.

--- a/docs/specifications/index.md
+++ b/docs/specifications/index.md
@@ -52,6 +52,7 @@ This section contains the official specifications for the DevSynth project, outl
 - **[Multi-disciplinary Dialectical Reasoning](multi-disciplinary-dialectical-reasoning.md)**: WSDE teams gather perspectives across disciplines.
 - **[Simple Addition Input Validation](simple_addition_input_validation.md)**: `add` rejects non-numeric inputs.
 - **[Release state check](release-state-check.md)**: Ensures published releases have corresponding Git tags.
+- **[Version bump script](bump-version-script.md)**: Helper script to bump the project version after releases.
 
 ## Implementation Plans
 

--- a/scripts/bump_version.py
+++ b/scripts/bump_version.py
@@ -1,0 +1,37 @@
+"""Helper script to bump project version and sync package metadata."""
+
+from __future__ import annotations
+
+import argparse
+import pathlib
+import re
+import subprocess
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+INIT_FILE = ROOT / "src" / "devsynth" / "__init__.py"
+
+
+def update_init(version: str, init_path: pathlib.Path = INIT_FILE) -> None:
+    """Rewrite ``__version__`` in ``__init__.py`` to match the new version."""
+    pattern = re.compile(r'(__version__\s*=\s*")([^"]+)(")')
+    text = init_path.read_text()
+    new_text = pattern.sub(rf"\1{version}\3", text)
+    init_path.write_text(new_text)
+
+
+def bump_version(version: str, init_path: pathlib.Path = INIT_FILE) -> None:
+    """Run ``poetry version`` and update ``__init__.py``."""
+    subprocess.run(["poetry", "version", version], check=True)
+    update_init(version, init_path)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Bump project version")
+    parser.add_argument("version", help="New version string")
+    args = parser.parse_args()
+    bump_version(args.version)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/behavior/features/bump_version_script.feature
+++ b/tests/behavior/features/bump_version_script.feature
@@ -1,0 +1,9 @@
+Feature: Version bump script
+  As a release maintainer
+  I want a helper to bump the project version
+  So that package metadata stays in sync
+
+  Scenario: Bumping the version updates package metadata
+    Given a sample __init__ file
+    When I bump the version to "0.1.0-alpha.2.dev0"
+    Then the __init__ version should be "0.1.0-alpha.2.dev0"

--- a/tests/behavior/features/index.md
+++ b/tests/behavior/features/index.md
@@ -8,6 +8,7 @@ This index lists all feature files for easy navigation.
 - [agent_api_interactions.feature](./agent_api_interactions.feature)
 - [agent_api_stub_usage.feature](./agent_api_stub_usage.feature)
 - [alignment_metrics_command.feature](./alignment_metrics_command.feature)
+- [bump_version_script.feature](./bump_version_script.feature)
 - [api_specification_generation.feature](./api_specification_generation.feature)
 - [ast_based_code_analysis_and_transformation.feature](./ast_based_code_analysis_and_transformation.feature)
 - [chromadb_integration.feature](./chromadb_integration.feature)

--- a/tests/behavior/steps/test_bump_version_script_steps.py
+++ b/tests/behavior/steps/test_bump_version_script_steps.py
@@ -1,0 +1,39 @@
+import subprocess
+
+import pytest
+from pytest_bdd import given, then, when
+
+from scripts import bump_version
+
+
+@pytest.fixture
+def context():
+    return {}
+
+
+@given("a sample __init__ file")
+def sample_init(tmp_path, context):
+    init_path = tmp_path / "__init__.py"
+    init_path.write_text('__version__ = "0.1.0-alpha.1"\n')
+    context["init_path"] = init_path
+
+
+@when('I bump the version to "0.1.0-alpha.2.dev0"')
+def run_bump(monkeypatch, context):
+    calls = []
+
+    def fake_run(cmd, check=True):
+        calls.append(cmd)
+        return subprocess.CompletedProcess(cmd, 0)
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    bump_version.bump_version("0.1.0-alpha.2.dev0", init_path=context["init_path"])
+    context["calls"] = calls
+
+
+@then('the __init__ version should be "0.1.0-alpha.2.dev0"')
+def assert_version(context):
+    assert (
+        context["init_path"].read_text().strip() == '__version__ = "0.1.0-alpha.2.dev0"'
+    )
+    assert ["poetry", "version", "0.1.0-alpha.2.dev0"] in context["calls"]


### PR DESCRIPTION
## Summary
- detail post-tag bump instructions
- add bump_version helper with spec and BDD coverage
- run bump script via Taskfile after tagging

## Testing
- `poetry run pre-commit run --files Taskfile.yml docs/release/0.1.0-alpha.1.md docs/specifications/bump-version-script.md scripts/bump_version.py tests/behavior/features/bump_version_script.feature tests/behavior/steps/test_bump_version_script_steps.py` *(fails: Executable `devsynth` not found)*
- `poetry run devsynth run-tests --speed=fast` *(fails: ModuleNotFoundError: No module named 'devsynth')*
- `poetry run python tests/verify_test_organization.py` *(fails: Test organization verification failed)*
- `poetry run python scripts/verify_test_markers.py` *(fails: pytest collection failed for multiple tests)*
- `poetry run python scripts/verify_requirements_traceability.py`
- `poetry run python scripts/verify_version_sync.py`
- `PIP_NO_INDEX=1 poetry run pip check` *(fails: poetry 2.1.4 requires virtualenv<20.33.0,>=20.26.6, but you have virtualenv 20.33.1)*
- `poetry run python scripts/dialectical_audit.py`

------
https://chatgpt.com/codex/tasks/task_e_68a4ef213594833383880211cd5d3799