### PR TITLE
feat: gate releases on unresolved dialectical audit

### DIFF
--- a/docs/policies/dialectical_audit.md
+++ b/docs/policies/dialectical_audit.md
@@ -36,6 +36,12 @@ This policy defines how Socratic dialogues support audits that seek consensus be
 - The build fails if `dialectical_audit.log` contains unanswered questions.
 - The log is archived as a workflow artifact for review.
 
+## Release Gating
+
+- Run `python scripts/verify_release_state.py` before tagging a release.
+- The command fails when `dialectical_audit.log` lists unresolved questions.
+- Releases proceed only when the log exists and the `questions` array is empty.
+
 ## Dialogue Procedure
 
 1. Present each question to all relevant contributors.

--- a/docs/specifications/dialectical_audit_gating.md
+++ b/docs/specifications/dialectical_audit_gating.md
@@ -1,0 +1,28 @@
+---
+author: DevSynth Team
+date: 2025-09-24
+last_reviewed: 2025-09-24
+status: draft
+tags:
+- specification
+title: Dialectical Audit Gating
+version: 0.1.0-alpha.1
+---
+
+# Summary
+
+## Socratic Checklist
+- What is the problem?
+- What proofs confirm the solution?
+
+## Motivation
+Unresolved dialectical audit questions allow inconsistent releases. A gate is needed to block releases until all questions are resolved.
+
+## Specification
+- `verify_release_state` reads `dialectical_audit.log`.
+- The script exits with status `1` when the log is missing or the `questions` list is non-empty.
+- When `questions` is empty, the script exits with status `0` and reports success.
+
+## Acceptance Criteria
+- Running `python scripts/verify_release_state.py` with an unresolved question in `dialectical_audit.log` prints the question and exits with `1`.
+- Running the script with an empty `questions` list exits with `0`.

--- a/docs/specifications/index.md
+++ b/docs/specifications/index.md
@@ -47,6 +47,7 @@ This section contains the official specifications for the DevSynth project, outl
 - **[Generated Test Execution Failure](generated_test_execution_failure.md)**: Scaffolded tests fail until implemented.
 - **[Security Audit Reporting Specification](security_audit_reporting.md)**: JSON reporting for security audits.
 - **[Policy Audit Script](policy_audit.md)**: Scans configs and code for policy violations.
+- **[Dialectical Audit Gating](dialectical_audit_gating.md)**: Release verification fails when unresolved audit questions remain.
 - **[WebUI Diagnostics Audit Logs](webui_diagnostics_audit_logs.md)**: Display dialectical audit logs on the diagnostics page.
 - **[Project Documentation Ingestion](project-documentation-ingestion.md)**: Indexes project documentation for retrieval.
 - **[Multi-disciplinary Dialectical Reasoning](multi-disciplinary-dialectical-reasoning.md)**: WSDE teams gather perspectives across disciplines.

--- a/scripts/verify_release_state.py
+++ b/scripts/verify_release_state.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python3
+"""Verify release readiness via dialectical audit log.
+
+The script exits with status 1 when ``dialectical_audit.log`` contains
+unresolved questions or is missing.  A successful run indicates that the
+project's dialectical audit has no outstanding items.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+LOG_PATH = ROOT / "dialectical_audit.log"
+
+
+def main() -> int:
+    if not LOG_PATH.exists():
+        print("dialectical_audit.log not found.")
+        return 1
+    data = json.loads(LOG_PATH.read_text(encoding="utf-8"))
+    questions = data.get("questions", [])
+    if questions:
+        print("Unresolved questions remain in dialectical_audit.log:")
+        for q in questions:
+            print(f"- {q}")
+        return 1
+    print("dialectical_audit.log contains no unresolved questions.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/behavior/features/dialectical_audit_gating.feature
+++ b/tests/behavior/features/dialectical_audit_gating.feature
@@ -1,0 +1,9 @@
+Feature: Dialectical audit gating
+  As a release engineer
+  I want the release verification to fail when unresolved audit questions exist
+  So that releases only proceed with consensus
+
+  Scenario: Release verification fails with unresolved questions
+    Given dialectical_audit.log contains an unresolved question
+    When verifying the release state
+    Then the verification fails

--- a/tests/behavior/features/index.md
+++ b/tests/behavior/features/index.md
@@ -28,6 +28,7 @@ This index lists all feature files for easy navigation.
 - [database_schema_generation.feature](./database_schema_generation.feature)
 - [delegating_tasks_with_consensus_voting.feature](./delegating_tasks_with_consensus_voting.feature)
 - [devsynth_run_tests_command.feature](./devsynth_run_tests_command.feature)
+- [dialectical_audit_gating.feature](./dialectical_audit_gating.feature)
 - [dialectical_reasoning/edrr_phase_integration.feature](./dialectical_reasoning/edrr_phase_integration.feature)
 - [dialectical_reasoning/impact_assessment_memory_persistence.feature](./dialectical_reasoning/impact_assessment_memory_persistence.feature)
 - [dialectical_reasoning/multi_disciplinary_dialectical_reasoning.feature](./dialectical_reasoning/multi_disciplinary_dialectical_reasoning.feature)

--- a/tests/unit/scripts/test_verify_release_state.py
+++ b/tests/unit/scripts/test_verify_release_state.py
@@ -1,0 +1,29 @@
+import json
+
+import pytest
+
+from scripts import verify_release_state as vrs
+
+
+@pytest.mark.fast
+def test_fails_when_unresolved_questions(tmp_path, monkeypatch):
+    """ReqID: dialectical_audit_gating-1"""
+    monkeypatch.setenv("DEVSYNTH_NO_FILE_LOGGING", "0")
+    log = tmp_path / "dialectical_audit.log"
+    log.write_text(
+        json.dumps({"questions": ["Unresolved"], "resolved": []}), encoding="utf-8"
+    )
+    monkeypatch.setattr(vrs, "LOG_PATH", log)
+    assert vrs.main() == 1
+
+
+@pytest.mark.fast
+def test_succeeds_when_no_questions(tmp_path, monkeypatch):
+    """ReqID: dialectical_audit_gating-2"""
+    monkeypatch.setenv("DEVSYNTH_NO_FILE_LOGGING", "0")
+    log = tmp_path / "dialectical_audit.log"
+    log.write_text(
+        json.dumps({"questions": [], "resolved": ["done"]}), encoding="utf-8"
+    )
+    monkeypatch.setattr(vrs, "LOG_PATH", log)
+    assert vrs.main() == 0


### PR DESCRIPTION
## Summary
- fail release verification when dialectical audit log has unresolved questions
- document audit gating requirement and add behavior spec
- cover audit log check with unit and BDD tests

## Testing
- `poetry run pre-commit run --files docs/policies/dialectical_audit.md docs/specifications/index.md docs/specifications/dialectical_audit_gating.md scripts/verify_release_state.py tests/behavior/features/index.md tests/behavior/features/dialectical_audit_gating.feature tests/unit/scripts/test_verify_release_state.py`
- `PIP_NO_INDEX=1 poetry run pip check`
- `poetry run devsynth run-tests --speed=fast`
- `poetry run python tests/verify_test_organization.py` *(fails: Test organization verification failed)*
- `poetry run python scripts/verify_test_markers.py` *(collection errors, terminated)*
- `poetry run python scripts/verify_requirements_traceability.py`
- `poetry run python scripts/verify_version_sync.py`


------
https://chatgpt.com/codex/tasks/task_e_68a4dc7b585c8333849bb9e34829ec81