### PR TITLE
Gate release on unresolved dialectical audit items

### DIFF
--- a/docs/policies/dialectical_audit.md
+++ b/docs/policies/dialectical_audit.md
@@ -34,6 +34,7 @@ This policy defines how Socratic dialogues support audits that seek consensus be
 
 - The dialectical audit script runs in continuous integration.
 - The build fails if `dialectical_audit.log` contains unanswered questions.
+- Release verification halts when `dialectical_audit.log` records unresolved questions.
 - The log is archived as a workflow artifact for review.
 
 ## Dialogue Procedure

--- a/docs/specifications/dialectical-audit-gating.md
+++ b/docs/specifications/dialectical-audit-gating.md
@@ -1,0 +1,42 @@
+---
+author: DevSynth Team
+date: 2025-08-19
+last_reviewed: 2025-08-19
+status: draft
+tags:
+- specification
+
+title: Dialectical audit gating
+version: 0.1.0-alpha.1
+---
+
+<!--
+Required metadata fields:
+- author: document author
+- date: creation date
+- last_reviewed: last review date
+- status: draft | review | published
+- tags: search keywords
+- title: short descriptive name
+- version: specification version
+-->
+
+# Summary
+
+## Socratic Checklist
+- What is the problem?
+- What proofs confirm the solution?
+
+## Motivation
+
+Prevent releases from proceeding when the dialectical audit log contains unresolved questions.
+
+## Specification
+
+- Parse `dialectical_audit.log` for unresolved questions.
+- Release verification fails with a non-zero exit code when unresolved questions are present.
+
+## Acceptance Criteria
+
+- Running `python scripts/verify_release_state.py` exits with status `1` when `dialectical_audit.log` lists unresolved questions.
+- The script exits with status `0` when the log has no unresolved questions.

--- a/tests/behavior/features/dialectical_audit_gating.feature
+++ b/tests/behavior/features/dialectical_audit_gating.feature
@@ -1,0 +1,9 @@
+Feature: Dialectical audit gating
+  As a release maintainer
+  I want release verification to fail when dialectical audit log has unresolved questions
+  So that unresolved issues block releases
+
+  Scenario: Release verification fails when unresolved questions remain
+    Given the dialectical audit log contains unresolved questions
+    When I verify the release state
+    Then the release verification should fail

--- a/tests/behavior/steps/test_dialectical_audit_gating_steps.py
+++ b/tests/behavior/steps/test_dialectical_audit_gating_steps.py
@@ -1,0 +1,39 @@
+import json
+import os
+import subprocess
+from pathlib import Path
+
+import pytest
+from pytest_bdd import given, then, when
+
+
+@pytest.fixture
+def context():
+    return {}
+
+
+@given("the dialectical audit log contains unresolved questions")
+def dialectical_log_with_questions():
+    root = Path(os.environ["ORIGINAL_CWD"])
+    log_path = root / "dialectical_audit.log"
+    original = log_path.read_text()
+    data = {"questions": ["Unresolved question"], "resolved": []}
+    log_path.write_text(json.dumps(data))
+    yield
+    log_path.write_text(original)
+
+
+@when("I verify the release state")
+def verify_release_state(context):
+    result = subprocess.run(
+        ["python", "scripts/verify_release_state.py"],
+        capture_output=True,
+        text=True,
+        cwd=os.environ["ORIGINAL_CWD"],
+    )
+    context["result"] = result
+
+
+@then("the release verification should fail")
+def release_should_fail(context):
+    assert context["result"].returncode != 0

--- a/tests/behavior/test_dialectical_audit_gating.py
+++ b/tests/behavior/test_dialectical_audit_gating.py
@@ -1,0 +1,16 @@
+import os
+
+import pytest
+from pytest_bdd import scenarios
+
+from .steps.test_dialectical_audit_gating_steps import *  # noqa: F401,F403
+
+feature_file = os.path.join(
+    os.path.dirname(__file__),
+    "features",
+    "dialectical_audit_gating.feature",
+)
+
+scenarios(feature_file)
+
+pytestmark = pytest.mark.fast


### PR DESCRIPTION
## Summary
- Specify and exercise dialectical audit gating for releases
- Fail `verify_release_state.py` when `dialectical_audit.log` has unresolved questions
- Document release gating in the Dialectical Audit Policy

## Testing
- `poetry run pytest tests/behavior/test_dialectical_audit_gating.py -vv`
- `poetry run python tests/verify_test_organization.py` *(fails: feature naming issues)*
- `poetry run python scripts/verify_test_markers.py` *(fails: pytest collection errors)*
- `poetry run python scripts/verify_requirements_traceability.py`
- `poetry run python scripts/verify_version_sync.py`


------
https://chatgpt.com/codex/tasks/task_e_68a4fbf864e88333b4f1849b9a39f829