### PR TITLE
feat: verify task availability

### DIFF
--- a/docs/release/0.1.0-alpha.1.md
+++ b/docs/release/0.1.0-alpha.1.md
@@ -39,6 +39,7 @@ last_reviewed: "2025-08-16"
    ```
 5. Prepare release artifacts with Taskfile and run the dialectical audit:
    ```bash
+   task --version
    poetry run task release:prep
    poetry run python scripts/dialectical_audit.py
    ```

--- a/scripts/install_dev.sh
+++ b/scripts/install_dev.sh
@@ -14,6 +14,12 @@ if ! command -v task >/dev/null 2>&1; then
   export PATH="$TASK_BIN_DIR:$PATH"
 fi
 
+# Ensure the task binary is available after installation
+if ! command -v task >/dev/null 2>&1; then
+  echo "[error] task binary not found on PATH after installation" >&2
+  exit 1
+fi
+
 optional_pkgs=$(poetry run python - <<'PY'
 import re, tomllib
 


### PR DESCRIPTION
## Summary
- ensure install_dev.sh confirms the `task` binary is available on PATH after setup
- document a `task --version` check before running release prep

## Testing
- `poetry run pre-commit run --files scripts/install_dev.sh docs/release/0.1.0-alpha.1.md` *(fails: Executable `devsynth` not found)*
- `poetry run devsynth run-tests --speed=fast` *(fails: ModuleNotFoundError: No module named 'devsynth')*
- `poetry run python tests/verify_test_organization.py` *(fails: Test organization verification failed)*
- `poetry run python scripts/verify_test_markers.py` *(fails: interrupted due to KeyboardInterrupt)*
- `poetry run python scripts/verify_requirements_traceability.py`
- `poetry run python scripts/verify_version_sync.py`
- `PIP_NO_INDEX=1 poetry run pip check` *(fails: virtualenv version conflict)*

------
https://chatgpt.com/codex/tasks/task_e_68a5082090b88333a210471f1fb9e383