### PR TITLE
docs: mark changelog as draft

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ tags:
   - "devsynth"
   - "changelog"
   - "version history"
-status: "published"
+status: "draft"
 author: "DevSynth Team"
 last_reviewed: "2025-08-16"
 ---
@@ -26,10 +26,6 @@ milestone.
 
 ### Added
 - Documented acceptance criteria for MVU command execution with linked BDD feature coverage.
-
-## [0.1.0-alpha.1] - 2025-08-16
-
-### Added
 - Modular, hexagonal architecture
 - Unified memory system with multiple backends
 - Agent system powered by LangGraph
@@ -76,3 +72,5 @@ milestone.
 
 - `poetry run python scripts/verify_test_markers.py` fails due to pytest collection errors in several test modules (e.g., `tests/performance/test_api_benchmarks.py`, `tests/behavior/test_agentapi.py`).
 - `poetry run task release:prep` reports `Command not found: task`, preventing release artifact preparation.
+
+## [0.1.0-alpha.1] - Unreleased


### PR DESCRIPTION
## Summary
- mark changelog front matter as draft
- move upcoming notes under Unreleased and mark 0.1.0-alpha.1 section unreleased

## Testing
- `python --version`
- `poetry env info --path` *(no output)*
- `bash scripts/install_dev.sh` *(fails: Cannot install urllib3)*
- `poetry run pre-commit run --files CHANGELOG.md` *(fails: Executable `devsynth` not found)*
- `PIP_NO_INDEX=1 poetry run pip check`
- `poetry run devsynth run-tests --speed=fast` *(fails: ModuleNotFoundError: No module named 'devsynth')*
- `poetry run python tests/verify_test_organization.py` *(fails: Test organization verification failed)*
- `poetry run python scripts/verify_test_markers.py` *(fails: KeyboardInterrupt during pytest collection)*
- `poetry run python scripts/verify_requirements_traceability.py`
- `poetry run python scripts/verify_version_sync.py`


------
https://chatgpt.com/codex/tasks/task_e_68a5080f75dc83338e05b0c2b64c0413