### PR TITLE
docs: document release state verification

### DIFF
--- a/docs/release/0.1.0-alpha.1.md
+++ b/docs/release/0.1.0-alpha.1.md
@@ -43,6 +43,12 @@ last_reviewed: "2025-08-16"
    poetry run python scripts/dialectical_audit.py
    ```
    Record all audit questions and their resolutions in `dialectical_audit.log`.
+
+6. Verify the repository is in a release-ready state:
+   ```bash
+   poetry run python scripts/verify_release_state.py
+   ```
+   Tagging must only occur after this check passes and all audit questions in `dialectical_audit.log` are resolved.
    Review the log with another contributor before tagging the release.
    See the [Dialectical Audit Policy](../policies/dialectical_audit.md) for guidance.
 ## Post-Tag Version Bump


### PR DESCRIPTION
## Summary
- document running `poetry run python scripts/verify_release_state.py` when preparing a release
- caution that tagging requires the verification to pass and the dialectical audit log to be fully resolved

## Testing
- `python --version`
- `poetry env info --path`
- `PIP_NO_INDEX=1 poetry run pip check`
- `poetry run pre-commit run --files docs/release/0.1.0-alpha.1.md`
- `poetry run devsynth run-tests --speed=fast` *(fails: StepDefinitionNotFoundError)*
- `poetry run python tests/verify_test_organization.py` *(fails: numerous naming issues)*
- `poetry run python scripts/verify_test_markers.py` *(fails: pytest collection errors)*
- `poetry run python scripts/verify_requirements_traceability.py`
- `poetry run python scripts/verify_version_sync.py`
- `poetry run python scripts/verify_release_state.py`


------
https://chatgpt.com/codex/tasks/task_e_68a5081663ec833382550b68165db965