### PR TITLE
docs: note untagged 0.1.0-alpha.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ last_reviewed: "2025-08-08"
 
 DevSynth is an agentic software engineering platform that leverages LLMs, advanced memory systems, and dialectical reasoning to automate and enhance the software development lifecycle. The system is designed for extensibility, resilience, and traceability, supporting both autonomous and collaborative workflows.
 
-**Pre-release notice:** DevSynth is still pre-0.1.0 and no package has been published on PyPI. All versions should be considered experimental. Version labels follow our [Semantic Versioning+ policy](docs/policies/semantic_versioning.md). Release milestones and targeted features post-`0.1.0-alpha.1` are documented in [docs/release/roadmap.md](docs/release/roadmap.md); see [docs/roadmap/CONSOLIDATED_ROADMAP.md](docs/roadmap/CONSOLIDATED_ROADMAP.md) for the broader project plan.
+**Pre-release notice:** DevSynth is still pre-0.1.0 and no package has been published on PyPI. Version `0.1.0-alpha.1` remains untagged; see [docs/release/0.1.0-alpha.1.md](docs/release/0.1.0-alpha.1.md) for the full checklist. All versions should be considered experimental. Version labels follow our [Semantic Versioning+ policy](docs/policies/semantic_versioning.md). Release milestones and targeted features post-`0.1.0-alpha.1` are documented in [docs/release/roadmap.md](docs/release/roadmap.md); see [docs/roadmap/CONSOLIDATED_ROADMAP.md](docs/roadmap/CONSOLIDATED_ROADMAP.md) for the broader project plan.
 ## Key Features
 - Modular, hexagonal architecture for extensibility and testability
 - Unified memory system with Kuzu, TinyDB, RDFLib, and JSON backends


### PR DESCRIPTION
## Summary
- mention that 0.1.0-alpha.1 remains untagged and link to release checklist

## Testing
- `poetry run pre-commit run --files README.md`
- `poetry run devsynth run-tests --speed=fast` *(fails: Step definition is not found: When "I verify the release state")*
- `poetry run python tests/verify_test_organization.py` *(fails: Test organization verification failed)*
- `poetry run python scripts/verify_test_markers.py` *(fails: KeyboardInterrupt / pytest collection failed)*
- `poetry run python scripts/verify_requirements_traceability.py`
- `poetry run python scripts/verify_version_sync.py`


------
https://chatgpt.com/codex/tasks/task_e_68a508391e6c8333826e0f9144496ac7