### PR TITLE
test: guard optional dependencies in API tests

### DIFF
--- a/tests/behavior/test_agentapi.py
+++ b/tests/behavior/test_agentapi.py
@@ -1,10 +1,11 @@
 import importlib
 import sys
-from importlib import util
 from types import ModuleType
 from unittest.mock import MagicMock
 
 import pytest
+
+pytest.importorskip("fastapi")
 
 
 def _setup(monkeypatch):
@@ -37,8 +38,6 @@ def test_json_requests_succeeds(monkeypatch):
     """Test that json requests succeeds.
 
     ReqID: AGENTAPI-001"""
-    if util.find_spec("fastapi") is None:
-        pytest.skip("fastapi required")
 
     from fastapi.testclient import TestClient
 

--- a/tests/performance/test_api_benchmarks.py
+++ b/tests/performance/test_api_benchmarks.py
@@ -4,12 +4,16 @@ from importlib import util
 
 import pytest
 
+pytest.importorskip("pytest_benchmark")
+if util.find_spec("pytest_benchmark.plugin") is None:
+    pytest.skip("pytest-benchmark plugin not installed", allow_module_level=True)
+
 
 @pytest.mark.slow
 def test_health_endpoint_benchmark(benchmark):
     """Benchmark the /health endpoint. ReqID: PERF-03"""
-    if util.find_spec("fastapi") is None or util.find_spec("pytest_benchmark") is None:
-        pytest.skip("fastapi and pytest-benchmark required")
+    if util.find_spec("fastapi") is None:
+        pytest.skip("fastapi required")
 
     from fastapi.testclient import TestClient
 


### PR DESCRIPTION
## Summary
- skip API benchmark tests when `pytest_benchmark` is missing
- ensure agent API tests require `fastapi` at import time

## Testing
- `poetry run pre-commit run --files tests/performance/test_api_benchmarks.py tests/behavior/test_agentapi.py`
- `poetry run python scripts/verify_test_markers.py -m tests/performance/test_api_benchmarks.py`
- `poetry run python scripts/verify_test_markers.py -m tests/behavior/test_agentapi.py`


------
https://chatgpt.com/codex/tasks/task_e_68a53fae67c083338a57aa4c1a5afd42