### PR TITLE
feat: register metrics and validation command groups

### DIFF
--- a/issues/Resolve-pytest-xdist-assertion-errors.md
+++ b/issues/Resolve-pytest-xdist-assertion-errors.md
@@ -25,6 +25,7 @@ Resolve pytest-xdist assertion errors is not yet implemented, limiting DevSynth'
 - 2025-02-14: `poetry run pytest -n auto --dist load` exposed a coverage collector assertion; updated test fixtures to reset coverage state between runs.
 - 2025-08-18: Added skip for missing MkDocs Material plugin so `poetry run devsynth run-tests --speed=fast` succeeds with 104 passed and 20 skipped tests. Attempts to run `--speed=medium` and `--speed=slow` launched extensive BDD suites and were aborted without pytest-xdist assertion errors.
 - 2025-08-19: Corrected missing CLI stub in `test_agent_api_steps` and verified MVU subcommands; `poetry run devsynth run-tests --speed=medium` and `--speed=slow` now complete without hanging.
+- 2025-08-20: Added registrations for metrics and validation CLI commands. `poetry run devsynth run-tests --speed=fast` failed due to missing BDD step definitions; `--speed=medium` and `--speed=slow` were aborted after hanging. No pytest-xdist assertion errors observed.
 
 ## References
 - Related: [Expand test generation capabilities](Expand-test-generation-capabilities.md)

--- a/src/devsynth/application/cli/cli_commands.py
+++ b/src/devsynth/application/cli/cli_commands.py
@@ -18,10 +18,13 @@ from devsynth.interface.ux_bridge import UXBridge
 from .commands import (
     config_cmds,
     diagnostics_cmds,
+    documentation_cmds,
     extra_cmds,
     generation_cmds,
     interface_cmds,
+    metrics_cmds,
     pipeline_cmds,
+    validation_cmds,
 )
 from .commands import spec_cmd as _spec_module
 from .help import get_all_commands_help, get_command_help

--- a/src/devsynth/application/cli/commands/documentation_cmds.py
+++ b/src/devsynth/application/cli/commands/documentation_cmds.py
@@ -1,0 +1,8 @@
+"""Register documentation-related CLI commands."""
+
+from ..registry import register
+from .generate_docs_cmd import generate_docs_cmd
+
+register("generate-docs", generate_docs_cmd)
+
+__all__ = ["generate_docs_cmd"]

--- a/src/devsynth/application/cli/commands/metrics_cmds.py
+++ b/src/devsynth/application/cli/commands/metrics_cmds.py
@@ -1,0 +1,10 @@
+"""Register metrics-related CLI commands."""
+
+from ..registry import register
+from .alignment_metrics_cmd import alignment_metrics_cmd
+from .test_metrics_cmd import test_metrics_cmd
+
+register("alignment-metrics", alignment_metrics_cmd)
+register("test-metrics", test_metrics_cmd)
+
+__all__ = ["alignment_metrics_cmd", "test_metrics_cmd"]

--- a/src/devsynth/application/cli/commands/validation_cmds.py
+++ b/src/devsynth/application/cli/commands/validation_cmds.py
@@ -1,0 +1,10 @@
+"""Register validation-related CLI commands."""
+
+from ..registry import register
+from .validate_manifest_cmd import validate_manifest_cmd
+from .validate_metadata_cmd import validate_metadata_cmd
+
+register("validate-manifest", validate_manifest_cmd)
+register("validate-metadata", validate_metadata_cmd)
+
+__all__ = ["validate_manifest_cmd", "validate_metadata_cmd"]


### PR DESCRIPTION
## Summary
- expose alignment-metrics and test-metrics CLI commands
- add validate-manifest, validate-metadata, and generate-docs commands to CLI registry
- track latest test run outcomes in issue log

## Testing
- `poetry run devsynth run-tests --speed=fast` *(fails: StepDefinitionNotFound)*
- `poetry run devsynth run-tests --speed=medium` *(aborted: command hung)*
- `poetry run devsynth run-tests --speed=slow` *(aborted: command hung)*
- `poetry run python tests/verify_test_organization.py` *(fails: naming patterns)*
- `poetry run python scripts/verify_test_markers.py` *(aborted: keyboard interrupt)*
- `poetry run python scripts/verify_requirements_traceability.py`
- `poetry run python scripts/verify_version_sync.py`


------
https://chatgpt.com/codex/tasks/task_e_68a551b660848333beb415fb723f8c2d