### PR TITLE
ci: verify test markers in workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,9 @@ jobs:
       - name: Check test ReqIDs
         run: |
           python scripts/check_reqid.py --rev-range origin/main..HEAD
+      - name: Verify test markers
+        run: |
+          poetry run python scripts/verify_test_markers.py
       - name: Run Bandit
         run: |
           poetry run bandit -q -r src

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,6 +37,7 @@ poetry run python scripts/verify_test_markers.py
 poetry run python scripts/verify_requirements_traceability.py
 poetry run python scripts/verify_version_sync.py
 ```
+CI runs `poetry run python scripts/verify_test_markers.py` to ensure each test carries a speed marker.
 `tests/conftest.py` provides an autouse `global_test_isolation` fixture; avoid setting environment variables at import time. Use speed markers `fast`, `medium`, or `slow` from `tests/conftest_extensions.py` and combine them with context markers when needed. Optional services should be guarded with environment variables like `DEVSYNTH_RESOURCE_<NAME>_AVAILABLE` or `pytest.importorskip`.
 
 ## Conventions

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -21,6 +21,8 @@ poetry run devsynth run-tests --speed=<fast|medium|slow>
 poetry run python scripts/verify_test_markers.py
 ```
 
+CI runs this verification to ensure tests include appropriate speed markers.
+
 ## Conventions
 
 **What guidelines shape documentation?**

--- a/docs/testing/verify_test_markers.md
+++ b/docs/testing/verify_test_markers.md
@@ -1,0 +1,16 @@
+# Verifying test markers
+
+DevSynth enforces speed markers on tests to keep runtimes predictable. The CI workflow
+now runs `poetry run python scripts/verify_test_markers.py` to ensure each test is
+marked appropriately.
+
+## Local usage
+
+Run the verification script before committing new or updated tests:
+
+```bash
+poetry run python scripts/verify_test_markers.py
+```
+
+The script fails if a test is missing a `fast`, `medium`, or `slow` marker or if
+markers are misapplied.


### PR DESCRIPTION
## Summary
- run verify_test_markers.py in CI workflow
- document test marker verification

## Testing
- `poetry run pre-commit run --files .github/workflows/ci.yml AGENTS.md docs/AGENTS.md docs/testing/verify_test_markers.md`
- `poetry run devsynth run-tests --speed=fast` *(fails: StepDefinitionNotFoundError)*
- `poetry run python tests/verify_test_organization.py` *(fails: Test organization verification failed)*
- `poetry run python scripts/verify_test_markers.py --workers 1` *(fails: KeyboardInterrupt)*
- `poetry run python scripts/verify_requirements_traceability.py`
- `poetry run python scripts/verify_version_sync.py`


------
https://chatgpt.com/codex/tasks/task_e_68a552159e348333ab3969f2757673b8