### PR TITLE
ci: fail dialectical audit on unresolved questions

### DIFF
--- a/.github/workflows/dialectical-audit.yml
+++ b/.github/workflows/dialectical-audit.yml
@@ -19,14 +19,19 @@ jobs:
       - name: Run dialectical audit
         run: poetry run python scripts/dialectical_audit.py
         continue-on-error: true
-      - name: Fail if unanswered questions
+      - name: Fail if unresolved questions
         run: |
           python - <<'PY'
-          import json, sys
-          with open('dialectical_audit.log') as f:
-            data = json.load(f)
-          if data.get("questions"):
-            sys.exit("Unanswered questions recorded in dialectical_audit.log")
+          import json, pathlib, sys
+
+          log_path = pathlib.Path('dialectical_audit.log')
+          if not log_path.is_file():
+            sys.exit('dialectical_audit.log not found')
+
+          data = json.loads(log_path.read_text())
+          unresolved = data.get('questions', [])
+          if unresolved:
+            sys.exit('Unresolved questions recorded in dialectical_audit.log')
           PY
       - name: Upload dialectical audit log
         if: always()

--- a/docs/policies/dialectical_audit.md
+++ b/docs/policies/dialectical_audit.md
@@ -33,6 +33,7 @@ This policy defines how Socratic dialogues support audits that seek consensus be
 ## Continuous Integration
 
 - The dialectical audit script runs in continuous integration.
+- The workflow may be triggered manually via GitHub's "Run workflow" dispatch for on-demand audits.
 - The build fails if `dialectical_audit.log` contains unanswered questions.
 - Release verification halts when `dialectical_audit.log` records unresolved questions.
 - The log is archived as a workflow artifact for review.


### PR DESCRIPTION
## Summary
- fail workflow when dialectical_audit.log reports unresolved questions
- note that the dialectical audit workflow can be run manually

## Testing
- `poetry run pre-commit run --files .github/workflows/dialectical-audit.yml docs/policies/dialectical_audit.md`
- `poetry run devsynth run-tests --speed=fast` *(fails: StepDefinitionNotFoundError for release verification scenario)*
- `poetry run python tests/verify_test_organization.py` *(fails: test organization verification failed)*
- `poetry run python scripts/verify_test_markers.py` *(fails: verification failed)*
- `poetry run python scripts/verify_requirements_traceability.py`
- `poetry run python scripts/verify_version_sync.py`

------
https://chatgpt.com/codex/tasks/task_e_68a55252c2a48333909b788d26c6a811