### PR TITLE
feat: add seedable WSDE voting RNG and fairness tests

### DIFF
--- a/tests/unit/domain/models/test_wsde_voting_logic.py
+++ b/tests/unit/domain/models/test_wsde_voting_logic.py
@@ -1,0 +1,99 @@
+import copy
+import random
+
+import pytest
+
+from devsynth.domain.models import wsde_voting
+
+
+class DummyAgent:
+    def __init__(self, name, expertise=None):
+        self.name = name
+        self.expertise = expertise or []
+
+
+class DummyTeam:
+    def __init__(self, agents, primus=None):
+        self.agents = agents
+        self.voting_history = []
+        self.logger = type(
+            "L", (), {"info": lambda *a, **k: None, "warning": lambda *a, **k: None}
+        )()
+        self._primus = primus
+
+    def get_primus(self):
+        return self._primus
+
+
+def bind(team):
+    team.vote_on_critical_decision = wsde_voting.vote_on_critical_decision.__get__(team)
+    team._apply_majority_voting = wsde_voting._apply_majority_voting.__get__(team)
+    team._apply_weighted_voting = wsde_voting._apply_weighted_voting.__get__(team)
+    team._handle_tied_vote = wsde_voting._handle_tied_vote.__get__(team)
+    team.build_consensus = wsde_voting.build_consensus.__get__(team)
+    team._record_voting_history = lambda *a, **k: None
+    return team
+
+
+@pytest.mark.fast
+def test_deterministic_voting_with_seed():
+    """Voting with a fixed seed yields reproducible results.
+
+    ReqID: WSDE-VOTE-DET-1"""
+    agents = [DummyAgent("a1"), DummyAgent("a2")]
+    team = bind(DummyTeam(agents))
+    task = {"options": ["A", "B"], "voting_method": "majority"}
+    rng = random.Random(42)
+    res1 = team.vote_on_critical_decision(task, rng=rng)
+    rng = random.Random(42)
+    res2 = team.vote_on_critical_decision(task, rng=rng)
+    assert res1["result"] == res2["result"]
+
+
+@pytest.mark.fast
+def test_weighted_voting_tie_is_fair():
+    """Random tie-breaking is statistically fair across options.
+
+    ReqID: WSDE-VOTE-FAIR-1"""
+    a1, a2 = DummyAgent("a1"), DummyAgent("a2")
+    team = bind(DummyTeam([a1, a2]))
+    base_voting = {
+        "options": ["A", "B"],
+        "votes": {"a1": "A", "a2": "B"},
+        "status": "pending",
+    }
+    counts = {"A": 0, "B": 0}
+    for seed in range(50):
+        rng = random.Random(seed)
+        res = team._apply_weighted_voting(
+            {"options": ["A", "B"]},
+            copy.deepcopy(base_voting),
+            "none",
+            rng=rng,
+        )
+        counts[res["result"]] += 1
+    assert abs(counts["A"] - counts["B"]) < 20
+
+
+@pytest.mark.fast
+def test_handle_tied_vote_produces_consensus_result():
+    """Tied votes include a consensus attempt in the result payload.
+
+    ReqID: WSDE-VOTE-TIE-1"""
+    agents = [DummyAgent("a1"), DummyAgent("a2")]
+    team = bind(DummyTeam(agents))
+    voting_result = {
+        "votes": {"a1": "A", "a2": "B"},
+        "options": ["A", "B"],
+        "status": "pending",
+    }
+    res = team._handle_tied_vote(
+        {"id": "t", "options": ["A", "B"]},
+        voting_result,
+        {"A": 1, "B": 1},
+        ["A", "B"],
+        rng=random.Random(0),
+    )
+    assert res["status"] == "tied"
+    assert res["result"]["tied"] is True
+    assert "consensus_result" in res["result"]


### PR DESCRIPTION
## Summary
- allow WSDE voting functions to accept a seedable RNG, enabling deterministic outcomes and uniform tie-breaking
- simulate vote fairness and tie handling with new unit tests covering seeded results and consensus fallbacks

## Testing
- `poetry run pre-commit run --files src/devsynth/domain/models/wsde_voting.py tests/unit/domain/models/test_wsde_voting_logic.py`
- `poetry run devsynth run-tests --speed=fast`
- `poetry run python tests/verify_test_organization.py`
- `poetry run python scripts/verify_test_markers.py` *(fails: pytest collection failed for several modules)*
- `poetry run python scripts/verify_requirements_traceability.py`
- `poetry run python scripts/verify_version_sync.py`


------
https://chatgpt.com/codex/tasks/task_e_68a5ecde6c708333a2b65a4854f3690d