### PR TITLE
docs: track test marker verification failures

### DIFF
--- a/issues/verify-test-markers-script.md
+++ b/issues/verify-test-markers-script.md
@@ -1,0 +1,21 @@
+# Verify test markers script failures
+Milestone: Phase 2
+Status: open
+Priority: high
+Dependencies: scripts/verify_test_markers.py, test_markers_report.json
+
+## Problem Statement
+The `scripts/verify_test_markers.py` guard fails for several test modules, reporting unrecognized markers when parameterized tests increase the collected count. This indicates inconsistent or missing speed markers and blocks the verification pipeline.
+
+## Action Plan
+- Analyze files listed in `test_markers_report.json` to identify causes of count mismatches.
+- Ensure each test function carries exactly one `fast`, `medium`, or `slow` marker.
+- Adjust `scripts/verify_test_markers.py` to account for parameterized tests or update affected tests.
+- Re-run marker verification and regenerate the report.
+
+## Progress
+- 2025-08-20: Verified script fails with multiple `unrecognized_markers` entries.
+
+## References
+- scripts/verify_test_markers.py
+- test_markers_report.json


### PR DESCRIPTION
## Summary
- document failure of `scripts/verify_test_markers.py` by adding an in-repo issue

## Testing
- `poetry run pre-commit run --files issues/verify-test-markers-script.md`
- `poetry run devsynth run-tests --speed=fast`
- `poetry run python tests/verify_test_organization.py`
- `poetry run python scripts/verify_test_markers.py` *(fails: verification failed)*
- `poetry run python scripts/verify_requirements_traceability.py`
- `poetry run python scripts/verify_version_sync.py`


------
https://chatgpt.com/codex/tasks/task_e_68a611b1d7948333b0ff75ac9720b7f0