### PR TITLE
test: gate memory backend tests behind flags

### DIFF
--- a/issues/memory-backend-integration.md
+++ b/issues/memory-backend-integration.md
@@ -16,6 +16,8 @@ Memory Backend Integration is not yet implemented, limiting DevSynth's capabilit
 
 ## Progress
 - 2025-02-19: extracted from dialectical audit backlog.
+- 2025-08-20: introduced `DEVSYNTH_RESOURCE_<BACKEND>_AVAILABLE` flags to gate
+  store-specific tests.
 
 ## References
 - Specification: docs/specifications/memory-backend-integration.md

--- a/tests/README.md
+++ b/tests/README.md
@@ -327,6 +327,22 @@ poetry install --extras retrieval
 pip install 'devsynth[retrieval]'
 ```
 
+### Memory Backend Resource Flags
+
+Store-specific memory tests are gated by environment flags and resource markers.
+Set the flag to `false` to skip tests when a backend is unavailable:
+
+- `DEVSYNTH_RESOURCE_CHROMADB_AVAILABLE`
+- `DEVSYNTH_RESOURCE_DUCKDB_AVAILABLE`
+- `DEVSYNTH_RESOURCE_FAISS_AVAILABLE`
+- `DEVSYNTH_RESOURCE_KUZU_AVAILABLE`
+- `DEVSYNTH_RESOURCE_LMDB_AVAILABLE`
+- `DEVSYNTH_RESOURCE_RDFLIB_AVAILABLE`
+- `DEVSYNTH_RESOURCE_TINYDB_AVAILABLE`
+
+Each corresponding test module uses `@pytest.mark.requires_resource("<backend>")`
+to declare its dependency.
+
 To run tests for a specific type:
 
 ```bash

--- a/tests/unit/application/memory/test_chromadb_store.py
+++ b/tests/unit/application/memory/test_chromadb_store.py
@@ -9,8 +9,8 @@ import pytest
 
 pytest.importorskip("chromadb")
 pytest.importorskip("tiktoken")
-if os.environ.get("ENABLE_CHROMADB", "false").lower() in {"0", "false", "no"}:
-    pytest.skip("ChromaDB feature not enabled", allow_module_level=True)
+if os.environ.get("DEVSYNTH_RESOURCE_CHROMADB_AVAILABLE", "true").lower() == "false":
+    pytest.skip("ChromaDB resource not available", allow_module_level=True)
 from devsynth.application.memory.chromadb_store import ChromaDBStore
 from devsynth.domain.models.memory import MemoryItem
 

--- a/tests/unit/application/memory/test_duckdb_store.py
+++ b/tests/unit/application/memory/test_duckdb_store.py
@@ -8,9 +8,13 @@ import numpy as np
 import pytest
 
 pytest.importorskip("duckdb")
+if os.environ.get("DEVSYNTH_RESOURCE_DUCKDB_AVAILABLE", "true").lower() == "false":
+    pytest.skip("DuckDB resource not available", allow_module_level=True)
 from devsynth.application.memory.duckdb_store import DuckDBStore
 from devsynth.domain.models.memory import MemoryItem, MemoryType, MemoryVector
 from devsynth.exceptions import MemoryStoreError
+
+pytestmark = pytest.mark.requires_resource("duckdb")
 
 
 class TestDuckDBStore:

--- a/tests/unit/application/memory/test_duckdb_store_hnsw.py
+++ b/tests/unit/application/memory/test_duckdb_store_hnsw.py
@@ -10,9 +10,13 @@ import numpy as np
 import pytest
 
 pytest.importorskip("duckdb")
+if os.environ.get("DEVSYNTH_RESOURCE_DUCKDB_AVAILABLE", "true").lower() == "false":
+    pytest.skip("DuckDB resource not available", allow_module_level=True)
 from devsynth.application.memory.duckdb_store import DuckDBStore
 from devsynth.domain.models.memory import MemoryItem, MemoryType, MemoryVector
 from devsynth.exceptions import MemoryStoreError
+
+pytestmark = pytest.mark.requires_resource("duckdb")
 
 
 class TestDuckDBStoreHNSW:

--- a/tests/unit/application/memory/test_faiss_store.py
+++ b/tests/unit/application/memory/test_faiss_store.py
@@ -8,7 +8,8 @@ import numpy as np
 import pytest
 
 faiss = pytest.importorskip("faiss")
-
+if os.environ.get("DEVSYNTH_RESOURCE_FAISS_AVAILABLE", "true").lower() == "false":
+    pytest.skip("FAISS resource not available", allow_module_level=True)
 from devsynth.application.memory.faiss_store import FAISSStore
 from devsynth.domain.models.memory import MemoryItem, MemoryType, MemoryVector
 from devsynth.exceptions import MemoryStoreError

--- a/tests/unit/application/memory/test_kuzu_store.py
+++ b/tests/unit/application/memory/test_kuzu_store.py
@@ -1,12 +1,18 @@
 import os
+import os
 import shutil
 import tempfile
 from concurrent.futures import ThreadPoolExecutor
 
 import pytest
 
+pytest.importorskip("kuzu")
+if os.environ.get("DEVSYNTH_RESOURCE_KUZU_AVAILABLE", "true").lower() == "false":
+    pytest.skip("Kuzu resource not available", allow_module_level=True)
 from devsynth.application.memory.kuzu_store import KuzuStore
 from devsynth.domain.models.memory import MemoryItem, MemoryType
+
+pytestmark = pytest.mark.requires_resource("kuzu")
 
 
 @pytest.fixture(autouse=True)

--- a/tests/unit/application/memory/test_lmdb_store.py
+++ b/tests/unit/application/memory/test_lmdb_store.py
@@ -9,10 +9,10 @@ import pytest
 
 from devsynth.domain.models.memory import MemoryItem, MemoryType
 
-try:
-    from devsynth.application.memory.lmdb_store import LMDBStore
-except ImportError:
-    LMDBStore = None
+pytest.importorskip("lmdb")
+if os.environ.get("DEVSYNTH_RESOURCE_LMDB_AVAILABLE", "true").lower() == "false":
+    pytest.skip("LMDB resource not available", allow_module_level=True)
+from devsynth.application.memory.lmdb_store import LMDBStore
 from devsynth.exceptions import MemoryStoreError
 
 pytestmark = pytest.mark.requires_resource("lmdb")

--- a/tests/unit/application/memory/test_rdflib_store.py
+++ b/tests/unit/application/memory/test_rdflib_store.py
@@ -7,9 +7,14 @@ from typing import Any, Dict, List, Optional
 import numpy as np
 import pytest
 
+pytest.importorskip("rdflib")
+if os.environ.get("DEVSYNTH_RESOURCE_RDFLIB_AVAILABLE", "true").lower() == "false":
+    pytest.skip("RDFLib resource not available", allow_module_level=True)
 from devsynth.application.memory.rdflib_store import RDFLibStore
 from devsynth.domain.models.memory import MemoryItem, MemoryType, MemoryVector
 from devsynth.exceptions import MemoryStoreError
+
+pytestmark = pytest.mark.requires_resource("rdflib")
 
 
 class TestRDFLibStore:

--- a/tests/unit/application/memory/test_tinydb_store.py
+++ b/tests/unit/application/memory/test_tinydb_store.py
@@ -6,9 +6,14 @@ from typing import Any, Dict, List, Optional
 
 import pytest
 
+pytest.importorskip("tinydb")
+if os.environ.get("DEVSYNTH_RESOURCE_TINYDB_AVAILABLE", "true").lower() == "false":
+    pytest.skip("TinyDB resource not available", allow_module_level=True)
 from devsynth.application.memory.tinydb_store import TinyDBStore
 from devsynth.domain.models.memory import MemoryItem, MemoryType
 from devsynth.exceptions import MemoryStoreError
+
+pytestmark = pytest.mark.requires_resource("tinydb")
 
 
 class TestTinyDBStore:


### PR DESCRIPTION
## Summary
- gate store-specific memory tests with DEVSYNTH_RESOURCE flags and resource markers
- document memory backend resource flags in test README
- note environment-gated tests in memory backend integration issue

## Testing
- `poetry run pre-commit run --files tests/unit/application/memory/test_chromadb_store.py tests/unit/application/memory/test_duckdb_store.py tests/unit/application/memory/test_duckdb_store_hnsw.py tests/unit/application/memory/test_faiss_store.py tests/unit/application/memory/test_kuzu_store.py tests/unit/application/memory/test_lmdb_store.py tests/unit/application/memory/test_rdflib_store.py tests/unit/application/memory/test_tinydb_store.py tests/README.md issues/memory-backend-integration.md` (failed: Command not found: pre-commit)
- `poetry run devsynth run-tests --speed=medium` (failed: [Errno 2] No such file or directory: b'/bin/python')
- `poetry run python scripts/verify_test_markers.py` (failed: Command not found: python)


------
https://chatgpt.com/codex/tasks/task_e_68a617e4ef08833395b5404e80108129