### PR TITLE
Add tiered cache validation spec and tests

### DIFF
--- a/docs/analysis/tiered_cache_eviction.md
+++ b/docs/analysis/tiered_cache_eviction.md
@@ -1,0 +1,28 @@
+---
+author: DevSynth Team
+date: '2025-08-20'
+last_reviewed: '2025-08-20'
+status: draft
+tags:
+  - analysis
+  - caching
+
+title: Tiered Cache Eviction Metrics
+version: "0.1.0-alpha.1"
+---
+<div class="breadcrumbs">
+<a href="../index.md">Documentation</a> &gt; <a href="index.md">Analysis</a> &gt; Tiered Cache Eviction Metrics
+</div>
+
+# Tiered Cache Eviction Metrics
+
+A simulated access pattern `['a', 'b', 'c', 'a', 'd', 'b', 'e', 'a', 'b', 'c', 'd']` with a cache size of 3 produced the following results:
+
+| Metric | Value |
+| --- | --- |
+| Cache size | 3 |
+| Hits | 2 |
+| Misses | 9 |
+| Final keys | `['b', 'c', 'd']` |
+
+These observations confirm least recently used eviction: once the cache filled, subsequent unique accesses displaced the oldest entry.

--- a/docs/specifications/tiered-cache-validation.md
+++ b/docs/specifications/tiered-cache-validation.md
@@ -1,0 +1,42 @@
+---
+author: DevSynth Team
+date: 2025-08-20
+last_reviewed: 2025-08-20
+status: draft
+tags:
+- specification
+
+title: Tiered Cache Validation
+version: 0.1.0-alpha.1
+---
+
+<!--
+Required metadata fields:
+- author: document author
+- date: creation date
+- last_reviewed: last review date
+- status: draft | review | published
+- tags: search keywords
+- title: short descriptive name
+- version: specification version
+-->
+
+# Summary
+
+## Socratic Checklist
+- What is the problem?
+- What proofs confirm the solution?
+
+## Motivation
+A tiered cache improves read performance, but only if it consistently evicts the least recently used entries and reports accurate hit and miss counts.
+
+## Specification
+- The cache exposes `get`, `put`, and `remove` operations and maintains at most `max_size` entries.
+- Each successful `get` promotes the entry to the most recently used position.
+- When inserting a new entry at capacity, the least recently used entry is evicted.
+- The memory adapter tracks cache hits and misses via `get_cache_stats`.
+
+## Acceptance Criteria
+- Cache size never exceeds `max_size` during any access sequence.
+- After exceeding capacity, the evicted key is the one least recently accessed.
+- Hit and miss counters reflect observed cache behavior.

--- a/tests/unit/application/memory/test_tiered_cache_validation.py
+++ b/tests/unit/application/memory/test_tiered_cache_validation.py
@@ -1,0 +1,60 @@
+"""Property-based tests validating TieredCache LRU behavior. ReqID: TCV-000"""
+
+from collections import OrderedDict
+
+import pytest
+
+pytest.importorskip("hypothesis")
+from hypothesis import given
+from hypothesis import strategies as st
+
+from devsynth.adapters.memory.memory_adapter import MemorySystemAdapter
+from devsynth.application.memory.tiered_cache import TieredCache
+from devsynth.domain.models.memory import MemoryItem, MemoryType
+
+
+@given(st.lists(st.text(min_size=1), min_size=1, max_size=50))
+@pytest.mark.medium
+def test_lru_eviction_matches_reference(accesses):
+    """Cache contents mirror reference LRU model. ReqID: TCV-001"""
+    cache = TieredCache(max_size=3)
+    reference = OrderedDict()
+    for key in accesses:
+        if cache.contains(key):
+            cache.get(key)
+            reference.move_to_end(key)
+        else:
+            cache.put(key, key)
+            if len(reference) >= 3:
+                reference.popitem(last=False)
+            reference[key] = key
+    assert cache.get_keys() == list(reference.keys())
+
+
+@given(st.lists(st.text(min_size=1), min_size=1, max_size=30))
+@pytest.mark.medium
+def test_hit_miss_counts_match_reference(accesses):
+    """Hit/miss counters align with simulated access patterns. ReqID: TCV-002"""
+    adapter = MemorySystemAdapter.create_for_testing()
+    adapter.enable_tiered_cache(max_size=3)
+    ids = {}
+    reference = OrderedDict()
+    hits = misses = 0
+    for key in accesses:
+        if key not in ids:
+            item = MemoryItem(id="", content=key, memory_type=MemoryType.SHORT_TERM)
+            ids[key] = adapter.write(item)
+        item_id = ids[key]
+        if key in reference:
+            hits += 1
+            reference.move_to_end(key)
+        else:
+            misses += 1
+            if len(reference) >= 3:
+                reference.popitem(last=False)
+            reference[key] = item_id
+        adapter.read(item_id)
+    stats = adapter.get_cache_stats()
+    assert stats["hits"] == hits
+    assert stats["misses"] == misses
+    assert adapter.cache.get_keys() == list(reference.keys())


### PR DESCRIPTION
## Summary
- document expected LRU semantics for tiered cache
- analyze eviction metrics for sample access patterns
- add Hypothesis-based tests covering varied cache accesses

## Testing
- `python --version`
- `poetry env info --path`
- `poetry run pre-commit run --files docs/specifications/tiered-cache-validation.md docs/analysis/tiered_cache_eviction.md tests/unit/application/memory/test_tiered_cache_validation.py`
- `poetry run devsynth run-tests --speed=fast`
- `poetry run python tests/verify_test_organization.py`
- `poetry run python scripts/verify_test_markers.py` *(fails: KeyboardInterrupt)*
- `poetry run python scripts/verify_requirements_traceability.py`
- `poetry run python scripts/verify_version_sync.py`


------
https://chatgpt.com/codex/tasks/task_e_68a617cd28148333bb1ff0383e18c017