### PR TITLE
test: cover recursion termination bounds

### DIFF
--- a/docs/specifications/edrr-recursion-termination.md
+++ b/docs/specifications/edrr-recursion-termination.md
@@ -1,0 +1,56 @@
+---
+title: "EDRR Recursion Termination"
+date: "2025-05-09"
+version: "0.1.0-alpha.1"
+tags:
+  - "specification"
+  - "EDRR"
+  - "recursion"
+status: "draft"
+author: "DevSynth Team"
+last_reviewed: "2025-05-09"
+---
+<div class="breadcrumbs">
+<a href="../index.md">Documentation</a> &gt; <a href="index.md">Specifications</a> &gt; EDRR Recursion Termination
+</div>
+
+# EDRR Recursion Termination
+
+This specification captures invariants and termination criteria for recursive
+EDRR cycles managed by the coordinator.
+
+## Invariants
+
+- The coordinator enforces a default maximum recursion depth of three and
+  sanitizes the configured limit before use【F:src/devsynth/application/edrr/coordinator.py†L88-L97】【F:src/devsynth/application/edrr/coordinator.py†L235-L238】
+- Micro cycles may only be created when the current depth is below the maximum;
+  attempts beyond that bound raise an error【F:src/devsynth/application/edrr/coordinator.py†L960-L968】
+
+## Termination Conditions
+
+Recursion halts when any of the following criteria evaluated by
+`should_terminate_recursion` are satisfied【F:src/devsynth/application/edrr/coordinator.py†L1072-L1099】:
+
+1. Human override directives
+2. Granularity falls below the threshold
+3. Cost outweighs benefit
+4. Quality already meets requirements
+5. Resource usage exceeds configured limits
+6. Complexity exceeds permissible bounds
+7. Results have converged
+8. Diminishing returns on further recursion
+9. Incompatibility with parent phase
+10. Historical ineffectiveness for similar tasks
+11. Maximum recursion depth reached
+12. Time limit exceeded
+13. Memory usage exceeds limits
+14. Approaching any of the above limits
+15. Combined moderate factors indicating termination
+
+These rules guarantee that recursive exploration remains bounded and
+predictable.
+
+## Acceptance Criteria
+
+- Documentation aligns with coordinator invariants.
+- Tests assert depth bounds and termination triggers.

--- a/tests/behavior/features/recursive_edrr_coordinator.feature
+++ b/tests/behavior/features/recursive_edrr_coordinator.feature
@@ -1,30 +1,27 @@
 Feature: Recursive EDRR Coordinator
-  As a [role]
-  I want to [capability]
-  So that [benefit]
+  As a system maintainer
+  I want recursion to terminate predictably
+  So that micro cycles do not run indefinitely
 
   Background:
-    Given [common setup step 1]
-    And [common setup step 2]
+    Given a configured EDRR coordinator
 
-  Scenario: [Scenario 1 Name]
-    Given [precondition 1]
-    When [action 1]
-    Then [expected outcome 1]
-    And [expected outcome 2]
+  Scenario: Recursion stops at maximum depth
+    Given a task requiring nested analysis
+    When the coordinator reaches its maximum recursion depth
+    Then no further micro cycles are spawned
 
-  Scenario: [Scenario 2 Name]
-    Given [precondition 1]
-    When [action 1]
-    Then [expected outcome 1]
+  Scenario: Termination criteria halt recursion early
+    Given a task whose complexity exceeds configured thresholds
+    When the coordinator evaluates recursion termination
+    Then recursion ends due to complexity limits
 
-  Scenario Outline: [Parameterized Scenario Name]
-    Given [precondition with <parameter>]
-    When [action with <parameter>]
-    Then [expected outcome with <parameter>]
+  Scenario Outline: Resource constraints force recursion termination
+    Given a task with <factor> beyond safe limits
+    When the coordinator evaluates recursion termination
+    Then recursion ends because of <factor>
 
     Examples:
-      | parameter | other_value |
-      | value1    | result1     |
-      | value2    | result2     |
-      | value3    | result3     |
+      | factor       |
+      | memory usage |
+      | time limit   |

--- a/tests/unit/application/edrr/test_recursion_termination.py
+++ b/tests/unit/application/edrr/test_recursion_termination.py
@@ -1,0 +1,87 @@
+"""Property-based tests for recursion termination in the EDRRCoordinator."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from hypothesis import HealthCheck, given, settings
+from hypothesis import strategies as st
+
+from devsynth.application.code_analysis.analyzer import CodeAnalyzer
+from devsynth.application.code_analysis.ast_transformer import AstTransformer
+from devsynth.application.documentation.documentation_manager import (
+    DocumentationManager,
+)
+from devsynth.application.edrr.coordinator import EDRRCoordinator, EDRRCoordinatorError
+from devsynth.application.memory.memory_manager import MemoryManager
+from devsynth.application.prompts.prompt_manager import PromptManager
+from devsynth.domain.models.wsde_facade import WSDETeam
+from devsynth.methodology.base import Phase
+
+
+@pytest.fixture
+def coordinator_factory():
+    """Create a coordinator factory with mocked dependencies."""
+
+    def factory(max_depth: int = 3) -> EDRRCoordinator:
+        memory_manager = MagicMock(spec=MemoryManager)
+        wsde_team = MagicMock(spec=WSDETeam)
+        code_analyzer = MagicMock(spec=CodeAnalyzer)
+        ast_transformer = MagicMock(spec=AstTransformer)
+        prompt_manager = MagicMock(spec=PromptManager)
+        documentation_manager = MagicMock(spec=DocumentationManager)
+        config = {"edrr": {"max_recursion_depth": max_depth}}
+        return EDRRCoordinator(
+            memory_manager=memory_manager,
+            wsde_team=wsde_team,
+            code_analyzer=code_analyzer,
+            ast_transformer=ast_transformer,
+            prompt_manager=prompt_manager,
+            documentation_manager=documentation_manager,
+            enable_enhanced_logging=True,
+            config=config,
+        )
+
+    return factory
+
+
+@given(max_depth=st.integers(min_value=1, max_value=3))
+@settings(max_examples=5, suppress_health_check=[HealthCheck.function_scoped_fixture])
+@pytest.mark.fast
+def test_micro_cycle_respects_depth_bounds(max_depth: int, coordinator_factory):
+    """Ensure micro cycles stop at the configured recursion depth.
+
+    ReqID: EDRR-RT-001"""
+    coordinator = coordinator_factory(max_depth)
+    with (
+        patch.object(EDRRCoordinator, "start_cycle", lambda self, task: None),
+        patch.object(EDRRCoordinator, "_aggregate_results", lambda self: None),
+        patch.object(
+            EDRRCoordinator, "_invoke_micro_cycle_hooks", lambda *_, **__: None
+        ),
+    ):
+        coordinator.recursion_depth = max_depth - 1
+        micro_cycle = coordinator.create_micro_cycle(
+            {"description": "task"}, parent_phase=Phase.EXPAND
+        )
+        assert micro_cycle.recursion_depth == max_depth
+        coordinator.recursion_depth = max_depth
+        with pytest.raises(EDRRCoordinatorError):
+            coordinator.create_micro_cycle(
+                {"description": "task"}, parent_phase=Phase.EXPAND
+            )
+
+
+@given(complexity_score=st.floats(min_value=0.71, max_value=1.0))
+@settings(max_examples=5, suppress_health_check=[HealthCheck.function_scoped_fixture])
+@pytest.mark.fast
+def test_complexity_threshold_triggers_termination(
+    complexity_score: float, coordinator_factory
+):
+    """Verify recursion terminates when complexity exceeds the threshold.
+
+    ReqID: EDRR-RT-002"""
+    coordinator = coordinator_factory()
+    task = {"description": "complex", "complexity_score": complexity_score}
+    should_terminate, reason = coordinator.should_terminate_recursion(task)
+    assert should_terminate is True
+    assert reason == "complexity threshold"


### PR DESCRIPTION
## Summary
- document recursion invariants and termination criteria for the EDRR coordinator
- add property-based tests asserting recursion depth bounds and complexity termination
- expand recursive coordinator feature scenarios for depth and resource limits

## Testing
- `poetry run pre-commit run --files docs/specifications/edrr-recursion-termination.md tests/unit/application/edrr/test_recursion_termination.py tests/behavior/features/recursive_edrr_coordinator.feature`
- `poetry run devsynth run-tests --speed=fast`
- `poetry run python tests/verify_test_organization.py`
- `poetry run python scripts/verify_test_markers.py` *(fails: verification failed)*
- `poetry run python scripts/verify_requirements_traceability.py`
- `poetry run python scripts/verify_version_sync.py`


------
https://chatgpt.com/codex/tasks/task_e_68a617d5c53483338fc2bbd60dc008b8