### PR TITLE
docs: log virtualenv requirement and test gaps

### DIFF
--- a/dialectical_audit.log
+++ b/dialectical_audit.log
@@ -31,7 +31,8 @@
     "Feature 'Resolve pytest-xdist assertion errors' is referenced in docs or tests but not in code.",
     "Feature 'Review and Reprioritize Open Issues' is referenced in docs or tests but not in code.",
     "Feature 'User Authentication' is referenced in docs or tests but not in code.",
-    "Feature 'Version bump script' is referenced in docs or tests but not in code."
+    "Feature 'Version bump script' is referenced in docs or tests but not in code.",
+    "Development environment lacks enforced virtualenv, leading to inconsistent tooling."
   ],
   "resolved": [
     "Release checklist commands executed 2025-08-20; verify_test_markers.py failed and task command was not found.",

--- a/docs/release/0.1.0-alpha.1.md
+++ b/docs/release/0.1.0-alpha.1.md
@@ -105,6 +105,8 @@ After tagging, run `poetry version 0.1.0-alpha.2.dev0` (or appropriate next vers
 The following issues were identified during the `0.1.0-alpha.1` release cycle:
 - `poetry run python scripts/verify_test_markers.py` fails due to pytest collection errors in several test modules (e.g., `tests/performance/test_api_benchmarks.py`, `tests/behavior/test_agentapi.py`).
 - `task --version` reports `command not found`, preventing `poetry run task release:prep` from preparing release artifacts.
+- Poetry configuration defaults to `virtualenvs.create=false`, causing missing `devsynth` CLI; ensure virtual environments are enabled.
+- `poetry run python scripts/verify_test_markers.py` takes long to scan 735 files; optimization needed.
 
 ## Looking Ahead
 

--- a/issues/project-state-analysis.md
+++ b/issues/project-state-analysis.md
@@ -17,6 +17,7 @@ Project State Analysis is not yet implemented, limiting DevSynth's capabilities.
 ## Progress
 - 2025-02-19: extracted from dialectical audit backlog.
 - 2025-08-19: implemented initial project state analysis function and BDD test.
+- 2025-08-20: Verified baseline tests; verify_test_markers script requires optimization.
 
 ## References
 - Specification: docs/specifications/project-state-analysis.md

--- a/issues/virtualenv-configuration.md
+++ b/issues/virtualenv-configuration.md
@@ -1,0 +1,19 @@
+# Virtualenv configuration enforcement
+Milestone: 0.1.0
+Status: open
+Priority: medium
+Dependencies: docs/release/0.1.0-alpha.1.md
+
+## Problem Statement
+Developers run commands in the global Python environment because `poetry` is configured with `virtualenvs.create=false`. This leads to inconsistent dependency resolution and missing console scripts such as `devsynth`.
+
+## Action Plan
+- Document the requirement to enable Poetry-managed virtual environments.
+- Update setup scripts to enforce `poetry config virtualenvs.create true`.
+- Verify `poetry env info --path` in CI to ensure the virtual environment is active.
+
+## Progress
+- 2025-08-20: Identified missing virtualenv after failing to run `devsynth` tests.
+
+## References
+- docs/release/0.1.0-alpha.1.md


### PR DESCRIPTION
## Summary
- note missing Poetry virtualenv setup in dialectical audit log
- capture test-marker performance issue in release notes
- track project-state test progress and add virtualenv configuration ticket

## Testing
- `poetry run devsynth run-tests --speed=fast`
- `poetry run python tests/verify_test_organization.py`
- `poetry run pre-commit run --files issues/virtualenv-configuration.md issues/project-state-analysis.md docs/release/0.1.0-alpha.1.md dialectical_audit.log`
- `poetry run python scripts/verify_requirements_traceability.py`
- `poetry run python scripts/verify_version_sync.py`
- `poetry run python scripts/verify_test_markers.py` *(failed: KeyboardInterrupt)*


------
https://chatgpt.com/codex/tasks/task_e_68a651643b148333a95e3e6b73c1867b