### PR TITLE
docs: track release readiness blockers

### DIFF
--- a/dialectical_audit.log
+++ b/dialectical_audit.log
@@ -37,6 +37,7 @@
   "resolved": [
     "Release checklist commands executed 2025-08-20; verify_test_markers.py failed and task command was not found.",
     "Complete memory system integration documented and referenced in code 2025-08-20.",
-    "Finalize dialectical reasoning documented and referenced in code 2025-08-20."
+    "Finalize dialectical reasoning documented and referenced in code 2025-08-20.",
+    "Release readiness audit 2025-08-20: created issue release-readiness-v0-1-0-alpha-1 to track virtualenv, task command, and test failures."
   ]
 }

--- a/issues/release-readiness-v0-1-0-alpha-1.md
+++ b/issues/release-readiness-v0-1-0-alpha-1.md
@@ -1,0 +1,24 @@
+# Release readiness for v0.1.0-alpha.1
+Milestone: 0.1.0-alpha.1
+Status: open
+Priority: high
+Dependencies: issues/virtualenv-configuration.md, issues/verify-test-markers-script.md, issues/performance-and-scalability-testing.md, docs/release/0.1.0-alpha.1.md
+
+## Problem Statement
+Prerequisites for the first alpha release remain incomplete. The development environment lacks an enforced virtualenv, release automation via `task` is unavailable, and slow tests and marker verification scripts fail or time out. These gaps block tagging `v0.1.0-alpha.1`.
+
+## Action Plan
+- Ensure Poetry-managed virtual environments are enabled and documented.
+- Install and wire up `go-task` so `task release:prep` works in CI and locally.
+- Fix failing slow tests or mark benchmarks as optional to keep the suite green.
+- Optimize or stub `scripts/verify_test_markers.py` to finish within reasonable time.
+- Re-run the full release checklist in `docs/release/0.1.0-alpha.1.md` once blockers are resolved.
+
+## Progress
+- 2025-08-20: Initial audit captured missing virtualenv, absent `task` command, slow-test failures, and stalled marker verification.
+
+## References
+- docs/release/0.1.0-alpha.1.md
+- issues/virtualenv-configuration.md
+- issues/verify-test-markers-script.md
+- issues/performance-and-scalability-testing.md

--- a/issues/virtualenv-configuration.md
+++ b/issues/virtualenv-configuration.md
@@ -14,6 +14,7 @@ Developers run commands in the global Python environment because `poetry` is con
 
 ## Progress
 - 2025-08-20: Identified missing virtualenv after failing to run `devsynth` tests.
+- 2025-08-20: `poetry env info --path` produced no output even after `poetry install`, confirming virtualenv remains disabled.
 
 ## References
 - docs/release/0.1.0-alpha.1.md


### PR DESCRIPTION
## Summary
- track outstanding blockers for v0.1.0-alpha.1 in new issue file
- document lack of active virtualenv in virtualenv enforcement issue
- note release readiness audit in dialectical log

## Testing
- `poetry run devsynth run-tests --speed=fast`
- `poetry run devsynth run-tests --speed=medium` *(killed)*
- `poetry run devsynth run-tests --speed=slow`
- `poetry run python tests/verify_test_organization.py`
- `poetry run python scripts/verify_test_markers.py` *(timeout, interrupted)*
- `poetry run python scripts/verify_requirements_traceability.py`
- `poetry run python scripts/verify_version_sync.py`
- `poetry run pre-commit run --files dialectical_audit.log issues/virtualenv-configuration.md issues/release-readiness-v0-1-0-alpha-1.md`


------
https://chatgpt.com/codex/tasks/task_e_68a654ef6d888333ba11062ca2f95266