### PR TITLE
feat(memory): add tiered cache layers

### DIFF
--- a/dialectical_audit.log
+++ b/dialectical_audit.log
@@ -10,7 +10,6 @@
     "Feature 'Improve deployment automation' has tests but is not documented.",
     "Feature 'Integrate dialectical audit into CI' has tests but is not documented.",
     "Feature 'Multi-Agent Collaboration' has tests but is not documented.",
-    "Feature 'Multi-Layered Memory System' has tests but is not documented.",
     "Feature 'Release state check' has tests but is not documented.",
     "Feature 'Resolve pytest-xdist assertion errors' has tests but is not documented.",
     "Feature 'Review and Reprioritize Open Issues' has tests but is not documented.",
@@ -26,7 +25,6 @@
     "Feature 'Improve deployment automation' is referenced in docs or tests but not in code.",
     "Feature 'Integrate dialectical audit into CI' is referenced in docs or tests but not in code.",
     "Feature 'Multi-Agent Collaboration' is referenced in docs or tests but not in code.",
-    "Feature 'Multi-Layered Memory System' is referenced in docs or tests but not in code.",
     "Feature 'Release state check' is referenced in docs or tests but not in code.",
     "Feature 'Resolve pytest-xdist assertion errors' is referenced in docs or tests but not in code.",
     "Feature 'Review and Reprioritize Open Issues' is referenced in docs or tests but not in code.",
@@ -38,6 +36,7 @@
     "Release checklist commands executed 2025-08-20; verify_test_markers.py failed and task command was not found.",
     "Complete memory system integration documented and referenced in code 2025-08-20.",
     "Finalize dialectical reasoning documented and referenced in code 2025-08-20.",
-    "Release readiness audit 2025-08-20: created issue release-readiness-v0-1-0-alpha-1 to track virtualenv, task command, and test failures."
+    "Release readiness audit 2025-08-20: created issue release-readiness-v0-1-0-alpha-1 to track virtualenv, task command, and test failures.",
+    "Multi-Layered Memory System documented with tiered cache and implemented 2025-08-19."
   ]
 }

--- a/docs/specifications/multi-layered-memory-system-and-tiered-cache-strategy.md
+++ b/docs/specifications/multi-layered-memory-system-and-tiered-cache-strategy.md
@@ -26,10 +26,52 @@ Required metadata fields:
 
 ## Socratic Checklist
 - What is the problem?
+  Fragmented storage and ad hoc caching make it difficult to keep frequently
+  accessed items fast while preserving long‑term knowledge.
 - What proofs confirm the solution?
+  Unit tests and BDD scenarios record hit and miss statistics and verify LRU
+  eviction across cache layers.
 
 ## Motivation
+Efficient retrieval depends on a structured memory hierarchy. Organising items
+into short‑term, episodic and semantic layers backed by a tiered cache keeps
+hot data available without sacrificing persistence.
 
 ## Specification
+- Memory is partitioned by `MemoryType` into short‑term, episodic and semantic
+  stores.
+- A tiered cache fronts these stores. Layers `L1..Ln` use an LRU policy and are
+  checked in order until a value is found.
+- Retrieving an item promotes it to all higher cache layers.
+- `get_cache_stats` reports hit and miss counters for each layer.
+- Cache capacity is configurable; a size of zero disables the layer.
+- Caches may be cleared at runtime without affecting persistent stores.
+
+## Cache Hit Ratio Modeling
+For a cache hierarchy with per‑layer hit ratios `h_i`, the total hit ratio is
+
+\[H = h_1 + (1 - h_1)h_2 + (1 - h_1)(1 - h_2)h_3 + \dots + \prod_{j=1}^{n-1}(1 - h_j)h_n\]
+
+A simple approximation for each layer is `h_i ≈ 1 - e^{-λ_i C_i}`, where `λ_i`
+is the request rate for items mapped to layer `i` and `C_i` its capacity. The
+following Python snippet can simulate hit ratios given a request distribution:
+
+```python
+from random import choices
+
+def simulate_hit_ratio(cache, items, probs, trials=1000):
+    hits = 0
+    for key in choices(items, probs, k=trials):
+        if cache.get(key) is not None:
+            hits += 1
+        else:
+            cache.set(key, key)
+    return hits / trials
+```
 
 ## Acceptance Criteria
+- Storing items with types `CONTEXT`, `TASK_HISTORY` and `KNOWLEDGE` persists
+  them to short‑term, episodic and semantic layers respectively.
+- When caching is enabled, a second retrieval of an item increments cache hit
+  counters.
+- Cache size never exceeds the configured maximum.

--- a/src/devsynth/memory/__init__.py
+++ b/src/devsynth/memory/__init__.py
@@ -1,0 +1,5 @@
+"""Memory utilities with tiered caching."""
+
+from .tiered_cache import CacheStats, MultiLayerCache, MultiLayeredMemorySystem
+
+__all__ = ["MultiLayeredMemorySystem", "MultiLayerCache", "CacheStats"]

--- a/src/devsynth/memory/tiered_cache.py
+++ b/src/devsynth/memory/tiered_cache.py
@@ -1,0 +1,120 @@
+"""Multi-layered memory system with tiered caches."""
+
+from __future__ import annotations
+
+from collections import OrderedDict
+from dataclasses import dataclass, field
+from typing import Any, Dict, Iterable, List, Optional
+from uuid import uuid4
+
+from devsynth.domain.models.memory import MemoryType
+
+
+@dataclass
+class CacheStats:
+    """Cache hit and miss counters."""
+
+    hits: int = 0
+    misses: int = 0
+
+
+class _LRUCache:
+    """Least-recently-used cache layer."""
+
+    def __init__(self, max_size: int):
+        self.max_size = max_size
+        self._store: OrderedDict[str, Any] = OrderedDict()
+
+    def get(self, key: str) -> Optional[Any]:
+        if key not in self._store:
+            return None
+        self._store.move_to_end(key)
+        return self._store[key]
+
+    def set(self, key: str, value: Any) -> None:
+        if key in self._store:
+            self._store.move_to_end(key)
+        self._store[key] = value
+        if len(self._store) > self.max_size:
+            self._store.popitem(last=False)
+
+    def clear(self) -> None:
+        self._store.clear()
+
+
+class MultiLayerCache:
+    """Hierarchy of cache layers checked in order."""
+
+    def __init__(self, sizes: Iterable[int]):
+        self.layers: List[_LRUCache] = [_LRUCache(size) for size in sizes]
+        self.stats: List[CacheStats] = [CacheStats() for _ in self.layers]
+
+    def get(self, key: str) -> Optional[Any]:
+        for index, layer in enumerate(self.layers):
+            value = layer.get(key)
+            if value is not None:
+                self.stats[index].hits += 1
+                for higher in range(index):
+                    self.layers[higher].set(key, value)
+                return value
+            self.stats[index].misses += 1
+        return None
+
+    def set(self, key: str, value: Any) -> None:
+        for layer in self.layers:
+            layer.set(key, value)
+
+    def clear(self) -> None:
+        for layer, stat in zip(self.layers, self.stats):
+            layer.clear()
+            stat.hits = stat.misses = 0
+
+    def get_stats(self) -> List[CacheStats]:
+        return self.stats
+
+
+@dataclass
+class MultiLayeredMemorySystem:
+    """In-memory storage organized by :class:`MemoryType` with a tiered cache."""
+
+    cache_sizes: Iterable[int] = (32, 64, 128)
+    cache: MultiLayerCache = field(init=False)
+    layers: Dict[MemoryType, Dict[str, Any]] = field(
+        default_factory=lambda: {
+            MemoryType.CONTEXT: {},
+            MemoryType.TASK_HISTORY: {},
+            MemoryType.KNOWLEDGE: {},
+        }
+    )
+
+    def __post_init__(self) -> None:
+        self.cache = MultiLayerCache(self.cache_sizes)
+
+    def store(self, content: Any, memory_type: MemoryType) -> str:
+        """Persist *content* under *memory_type* and return its identifier."""
+
+        item_id = str(uuid4())
+        self.layers.setdefault(memory_type, {})[item_id] = content
+        return item_id
+
+    def retrieve(self, item_id: str, memory_type: MemoryType) -> Optional[Any]:
+        """Retrieve *item_id* from cache or persistent layer."""
+
+        key = f"{memory_type.value}:{item_id}"
+        value = self.cache.get(key)
+        if value is not None:
+            return value
+        value = self.layers.get(memory_type, {}).get(item_id)
+        if value is not None:
+            self.cache.set(key, value)
+        return value
+
+    def get_cache_stats(self) -> List[CacheStats]:
+        """Return hit/miss statistics for each cache layer."""
+
+        return self.cache.get_stats()
+
+    def clear_cache(self) -> None:
+        """Remove all cached entries and reset statistics."""
+
+        self.cache.clear()

--- a/tests/behavior/features/multi_layered_memory_system_and_tiered_cache_strategy.feature
+++ b/tests/behavior/features/multi_layered_memory_system_and_tiered_cache_strategy.feature
@@ -1,30 +1,23 @@
 Feature: Multi-Layered Memory System and Tiered Cache Strategy
-  As a [role]
-  I want to [capability]
-  So that [benefit]
+  As a developer
+  I want frequently accessed memory items cached across layers
+  So that subsequent retrievals are fast
 
   Background:
-    Given [common setup step 1]
-    And [common setup step 2]
+    Given a memory system with a cache size of 2
 
-  Scenario: [Scenario 1 Name]
-    Given [precondition 1]
-    When [action 1]
-    Then [expected outcome 1]
-    And [expected outcome 2]
+  @fast @memory
+  Scenario: Second retrieval hits the cache
+    Given I store an item "alpha" in short-term memory
+    When I retrieve "alpha" twice
+    Then the first retrieval results in a cache miss
+    And the second retrieval results in a cache hit
 
-  Scenario: [Scenario 2 Name]
-    Given [precondition 1]
-    When [action 1]
-    Then [expected outcome 1]
-
-  Scenario Outline: [Parameterized Scenario Name]
-    Given [precondition with <parameter>]
-    When [action with <parameter>]
-    Then [expected outcome with <parameter>]
-
-    Examples:
-      | parameter | other_value |
-      | value1    | result1     |
-      | value2    | result2     |
-      | value3    | result3     |
+  @fast @memory
+  Scenario: LRU eviction removes least recently used item
+    Given I store items "alpha" and "beta" in short-term memory
+    And I retrieve "alpha"
+    And I store item "gamma" in short-term memory
+    When I retrieve "beta"
+    Then the retrieval results in a cache miss
+    And the cache contains "gamma"


### PR DESCRIPTION
## Summary
- implement multi-layered memory system with LRU-based tiered cache and stats
- document cache hit ratio formulas and simulation approach
- add BDD scenarios covering cache hits and LRU eviction

## Testing
- `poetry run pre-commit run --files dialectical_audit.log docs/specifications/multi-layered-memory-system-and-tiered-cache-strategy.md tests/behavior/features/multi_layered_memory_system_and_tiered_cache_strategy.feature src/devsynth/memory/__init__.py src/devsynth/memory/tiered_cache.py`
- `poetry run devsynth run-tests --speed=fast`
- `poetry run python tests/verify_test_organization.py`
- `poetry run python scripts/verify_test_markers.py` *(fails: verification failed)*
- `poetry run python scripts/verify_requirements_traceability.py`
- `poetry run python scripts/verify_version_sync.py`

------
https://chatgpt.com/codex/tasks/task_e_68a6812a75648333a4381d67477c6e39