### PR TITLE
chore: enforce poetry virtualenv

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,9 +19,7 @@ jobs:
           python -m pip install --upgrade pip
           pip install poetry
           poetry install --with dev,docs
-      - name: Verify Poetry virtualenv
-        run: |
-          venv_path=$(poetry env info --path)
+          venv_path=$(poetry env info --path 2>/dev/null || true)
           if [ -z "$venv_path" ]; then
             echo "Poetry virtualenv path not found" >&2
             exit 1

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,13 +8,12 @@ DevSynth implements agent services under `src/devsynth/` and supporting scripts 
 ## Setup
 
 **How do I prepare my environment?**
-1. Ensure Python 3.12 is active:
+1. Ensure Python 3.12 is active and Poetry created a virtual environment (enforced via the committed `poetry.toml`):
    ```bash
    python --version
    poetry env info --path
    ```
-   Current venv path: `/root/.cache/pypoetry/virtualenvs/devsynth-MeXVnKii-py3.12`
-   If Poetry uses a different interpreter, recreate the environment:
+   If `poetry env info --path` prints nothing or points elsewhere, recreate the environment:
    ```bash
    poetry env use 3.12 && poetry install --with dev --extras tests retrieval chromadb api
    ```

--- a/docs/release/0.1.0-alpha.1.md
+++ b/docs/release/0.1.0-alpha.1.md
@@ -22,6 +22,11 @@ last_reviewed: "2025-08-16"
    ```bash
    poetry install --with dev --extras tests retrieval chromadb api
    ```
+   The repository commits a `poetry.toml` that enforces `virtualenvs.create=true`.
+   Verify the virtual environment path is non-empty:
+   ```bash
+   poetry env info --path
+   ```
 3. Execute repository checks:
    ```bash
    PIP_NO_INDEX=1 poetry run pip check
@@ -105,7 +110,7 @@ After tagging, run `poetry version 0.1.0-alpha.2.dev0` (or appropriate next vers
 
 The following issues were identified during the `0.1.0-alpha.1` release cycle:
 - `poetry run python scripts/verify_test_markers.py` fails due to pytest collection errors in several test modules (e.g., `tests/performance/test_api_benchmarks.py`, `tests/behavior/test_agentapi.py`).
-- Poetry configuration defaults to `virtualenvs.create=false`, causing missing `devsynth` CLI; ensure virtual environments are enabled.
+- A committed `poetry.toml` sets `virtualenvs.create=true` to ensure the `devsynth` CLI is available; verify `poetry env info --path` returns a path.
 - `poetry run python scripts/verify_test_markers.py` takes long to scan 735 files; optimization needed.
 
 ## Looking Ahead

--- a/poetry.toml
+++ b/poetry.toml
@@ -1,0 +1,2 @@
+[virtualenvs]
+create = true

--- a/scripts/install_dev.sh
+++ b/scripts/install_dev.sh
@@ -59,6 +59,13 @@ export PIP_FIND_LINKS="$WHEEL_DIR"
 # Install DevSynth with development and documentation dependencies and required extras
 poetry install --with dev,docs --extras "tests retrieval chromadb api"
 
+# Fail fast if Poetry did not create a virtual environment
+venv_path="$(poetry env info --path 2>/dev/null || true)"
+if [[ -z "$venv_path" ]]; then
+  echo "[error] poetry virtualenv path not found" >&2
+  exit 1
+fi
+
 # Confirm the DevSynth CLI is available
 if ! poetry run devsynth --help >/dev/null 2>&1; then
   echo "[error] devsynth console script not found" >&2


### PR DESCRIPTION
## Summary
- commit local poetry configuration to always create virtualenvs
- fail early in CI and install script when poetry env path is missing
- document the virtualenv requirement in AGENTS and release notes

## Testing
- `poetry run pre-commit run --files .github/workflows/ci.yml AGENTS.md docs/release/0.1.0-alpha.1.md scripts/install_dev.sh poetry.toml`
- `poetry run devsynth run-tests --speed=fast` (failed: file or directory not found)
- `poetry run devsynth run-tests --speed=medium` (killed)
- `poetry run devsynth run-tests --speed=slow` (failed: multiple benchmark errors)
- `poetry run python tests/verify_test_organization.py`
- `poetry run python scripts/verify_test_markers.py` (failed: pytest collection exit code 2)
- `poetry run python scripts/verify_requirements_traceability.py`
- `poetry run python scripts/verify_version_sync.py`


------
https://chatgpt.com/codex/tasks/task_e_68a73afade4083339582dec60e3c37d7