### PR TITLE
docs: add layered cache analysis

### DIFF
--- a/docs/analysis/layered_cache.md
+++ b/docs/analysis/layered_cache.md
@@ -1,0 +1,31 @@
+---
+title: "Layered Cache Analysis"
+date: "2025-08-23"
+version: "0.1.0-alpha.1"
+tags:
+  - "analysis"
+  - "caching"
+status: "draft"
+author: "DevSynth Team"
+last_reviewed: "2025-08-23"
+---
+<div class="breadcrumbs">
+<a href="../index.md">Documentation</a> &gt; <a href="index.md">Analysis</a> &gt; Layered Cache Analysis
+</div>
+
+# Layered Cache Analysis
+
+## Complexity
+- **Set:** \(O(L)\) where *L* is the number of layers because writes propagate to each tier.
+- **Get:** Worst-case \(O(L)\) when the item resides in the deepest layer; promotions add constant overhead per hop.
+
+## Hit-Rate Formulae
+Let \(A\) denote total accesses and \(H_i\) the hits served by layer *i* (0-indexed).
+- **Overall hit rate:** \(\frac{\sum_i H_i}{A}\).
+- **Per-layer hit rate:** \(\frac{H_i}{A}\).
+
+## Assumptions
+- Access patterns are independent and identically distributed.
+- Promotion copies items to all preceding layers upon access.
+- Cache layers are dictionary-backed with \(O(1)\) lookups and writes.
+- Eviction policies are not modeled in this analysis.

--- a/src/devsynth/memory/layered_cache.py
+++ b/src/devsynth/memory/layered_cache.py
@@ -1,4 +1,8 @@
-"""Multi-layered memory system with tiered cache strategy."""
+"""Multi-layered memory system with tiered cache strategy.
+
+See :doc:`docs/analysis/layered_cache.md` for complexity and hit-rate
+derivations.
+"""
 
 from __future__ import annotations
 

--- a/tests/performance/test_layered_cache_bench.py
+++ b/tests/performance/test_layered_cache_bench.py
@@ -1,0 +1,19 @@
+"""Benchmarks for layered cache promotion. ReqID: PERF-04"""
+
+import pytest
+
+from devsynth.memory.layered_cache import DictCacheLayer, MultiLayeredMemory
+
+
+@pytest.mark.slow
+def test_layered_cache_promotion_benchmark(benchmark):
+    """Benchmark promoting an item from a lower layer. ReqID: PERF-04"""
+    layers = [DictCacheLayer(), DictCacheLayer()]
+    memory = MultiLayeredMemory(layers)
+    layers[1].set("x", 1)
+
+    def fetch_with_promotion() -> int:
+        layers[0].store.pop("x", None)
+        return memory.get("x")
+
+    benchmark(fetch_with_promotion)


### PR DESCRIPTION
## Summary
- analyze layered cache complexity, hit-rate formulas, and modeling assumptions
- benchmark layered cache promotion behavior
- link layered cache implementation to supporting analysis docs

## Testing
- `poetry run pre-commit run --files docs/analysis/layered_cache.md src/devsynth/memory/layered_cache.py tests/performance/test_layered_cache_bench.py`
- `poetry run devsynth run-tests --speed=slow` *(fails: RuntimeError: dearpygui is required; multiple benchmark errors)*
- `poetry run python tests/verify_test_organization.py`
- `poetry run python scripts/verify_test_markers.py` *(fails: verification failed)*
- `poetry run python scripts/verify_requirements_traceability.py`
- `poetry run python scripts/verify_version_sync.py`

------
https://chatgpt.com/codex/tasks/task_e_68a73b5c9e348333883121384d5a484a