### PR TITLE
Rename run_tests test function for pytest discovery

### DIFF
--- a/test_markers_report.json
+++ b/test_markers_report.json
@@ -1,46 +1,22 @@
 {
-  "timestamp": "2025-08-21T18:54:39.951390",
+  "timestamp": "2025-08-21T19:21:54.057765",
   "verification": {
     "directory": "tests",
     "total_files": 738,
-    "files_with_issues": 1,
-    "total_test_functions": 2501,
-    "total_markers": 1522,
-    "total_misaligned_markers": 1,
+    "files_with_issues": 0,
+    "total_test_functions": 2502,
+    "total_markers": 1523,
+    "total_misaligned_markers": 0,
     "total_duplicate_markers": 0,
     "total_unrecognized_markers": 0,
     "marker_counts": {
-      "fast": 109,
+      "fast": 110,
       "medium": 1365,
       "slow": 48,
       "isolation": 0
     },
-    "files": {
-      "/workspace/devsynth/tests/unit/testing/test_run_tests_no_xdist_assertions.py": {
-        "file_path": "/workspace/devsynth/tests/unit/testing/test_run_tests_no_xdist_assertions.py",
-        "has_pytest_import": true,
-        "test_functions": 0,
-        "markers": {},
-        "tests_with_markers": 0,
-        "tests_without_markers": 0,
-        "misaligned_markers": [
-          {
-            "line": 5,
-            "marker": "fast",
-            "text": "@pytest.mark.fast"
-          }
-        ],
-        "duplicate_markers": [],
-        "recognized_markers": {},
-        "issues": [
-          {
-            "type": "misaligned_markers",
-            "message": "File has 1 misaligned markers"
-          }
-        ]
-      }
-    },
+    "files": {},
     "subprocess_timeouts": 0,
-    "success": false
+    "success": true
   }
 }

--- a/tests/unit/testing/test_run_tests_no_xdist_assertions.py
+++ b/tests/unit/testing/test_run_tests_no_xdist_assertions.py
@@ -4,7 +4,8 @@ from devsynth.testing.run_tests import TARGET_PATHS, run_tests
 
 
 @pytest.mark.fast
-def run_tests_completes_without_xdist_assertions(tmp_path, monkeypatch):
+def test_run_tests_completes_without_xdist_assertions(tmp_path, monkeypatch):
+    """run_tests completes without INTERNALERROR when run in parallel. ReqID: FR-22"""
     test_file = tmp_path / "test_dummy.py"
     monkeypatch.setitem(TARGET_PATHS, "unit-tests", str(tmp_path))
     success, output = run_tests("unit-tests", ["fast"], parallel=True)


### PR DESCRIPTION
## Summary
- rename run_tests_completes_without_xdist_assertions to test_run_tests_completes_without_xdist_assertions
- regenerate test_markers_report.json after updating test markers

## Testing
- `poetry run pre-commit run --files tests/unit/testing/test_run_tests_no_xdist_assertions.py test_markers_report.json`
- `poetry run devsynth run-tests --speed=fast` *(fails: tests/unit/general/test_speed_option.py::test_speed_option_recognized)*
- `poetry run python tests/verify_test_organization.py`
- `poetry run python scripts/verify_test_markers.py --report`
- `poetry run python scripts/verify_requirements_traceability.py`
- `poetry run python scripts/verify_version_sync.py`


------
https://chatgpt.com/codex/tasks/task_e_68a76edd5bc0833380327d2c6847ec47