### PR TITLE
docs: log release checklist rerun

### DIFF
--- a/dialectical_audit.log
+++ b/dialectical_audit.log
@@ -21,6 +21,7 @@
     "Feature 'Review and Reprioritize Open Issues' documented and referenced in code 2025-08-21.",
     "Feature 'User Authentication' documented and referenced in code 2025-08-21.",
     "Feature 'Version bump script' documented and referenced in code 2025-08-21.",
-    "Development environment virtualenv enforcement documented 2025-08-21."
+    "Development environment virtualenv enforcement documented 2025-08-21.",
+    "Release checklist re-run 2025-08-21: environment setup and pip check succeeded; fast tests failed (missing tests/tmp_speed_dummy.py); medium and slow test runs terminated after LMStudioProvider warnings; marker verification interrupted; deployment tests failed coverage; release prep interrupted; release state check reported missing tag."
   ]
 }

--- a/issues/release-readiness-v0-1-0-alpha-1.md
+++ b/issues/release-readiness-v0-1-0-alpha-1.md
@@ -17,6 +17,7 @@ Prerequisites for the first alpha release remain incomplete. The development env
 ## Progress
 - 2025-08-20: Initial audit captured missing virtualenv, absent `task` command, slow-test failures, and stalled marker verification.
 - 2025-08-21: Established a Poetry virtual environment and installed development extras; `poetry env info --path` now reports the expected path. Attempted `poetry run devsynth run-tests --speed=fast`, but the command stalled after an `LMStudioProvider` warning, and `scripts/verify_test_markers.py` still runs slowly and was halted after ~150 files.
+- 2025-08-21: Re-ran release checklist; environment provisioning and `pip check` succeeded, but fast tests failed (missing `tests/tmp_speed_dummy.py`). Medium and slow test runs halted after `LMStudioProvider` warnings. `verify_test_markers.py` was interrupted, deployment tests failed coverage, `task release:prep` ended early, and `verify_release_state` reported missing tag `v0.1.0-alpha.1`.
 
 ## References
 - docs/release/0.1.0-alpha.1.md


### PR DESCRIPTION
## Summary
- record the latest release-checklist rerun in dialectical audit log
- update release readiness issue with current checklist results

## Testing
- `PIP_NO_INDEX=1 poetry run pip check`
- `poetry run devsynth run-tests --speed=fast` *(fails: tests/tmp_speed_dummy.py missing)*
- `timeout 30 poetry run devsynth run-tests --speed=medium` *(incomplete: LMStudioProvider warning)*
- `timeout 30 poetry run devsynth run-tests --speed=slow` *(incomplete: LMStudioProvider warning)*
- `poetry run python tests/verify_test_organization.py`
- `poetry run python scripts/verify_test_markers.py` *(interrupted: KeyboardInterrupt)*
- `poetry run python scripts/verify_requirements_traceability.py`
- `poetry run python scripts/verify_version_sync.py`
- `poetry run pytest tests/unit/deployment -m fast`
- `task release:prep` *(interrupted: KeyboardInterrupt)*
- `poetry run python scripts/verify_release_state.py`
- `poetry run pre-commit run --files dialectical_audit.log issues/release-readiness-v0-1-0-alpha-1.md`


------
https://chatgpt.com/codex/tasks/task_e_68a7738948c88333a54ea0c06994bd5c