### PR TITLE
docs: publish v0.1.0-alpha.1 and document tagging workflow

### DIFF
--- a/docs/release/automation.md
+++ b/docs/release/automation.md
@@ -39,4 +39,12 @@ git tag -a vX.Y.Z -m "DevSynth vX.Y.Z"
 git push origin vX.Y.Z
 ```
 
+Before tagging, set the release note's front matter to `status: "draft"`.
+After creating the tag, update the status to `published` and rerun the
+release-state check:
+
+```bash
+poetry run python scripts/verify_release_state.py
+```
+
 These steps ensure every release includes generated artifacts, a recorded audit, and a signed tag.


### PR DESCRIPTION
## Summary
- publish the `0.1.0-alpha.1` release note now that `v0.1.0-alpha.1` is tagged
- document release-note draft→published workflow in the automation guide

## Testing
- `poetry run pre-commit run --files docs/release/0.1.0-alpha.1.md docs/release/automation.md` *(fails: Command not found: pre-commit)*
- `poetry run devsynth run-tests --speed=fast` *(fails: ModuleNotFoundError: No module named 'devsynth')*
- `poetry run python scripts/verify_test_markers.py` *(fails: ModuleNotFoundError: No module named 'pytest_bdd')*
- `poetry run python scripts/verify_release_state.py`


------
https://chatgpt.com/codex/tasks/task_e_68a78b9728a8833382a64794ced09f5b