### PR TITLE
fix(cli): handle missing provider deps gracefully

### DIFF
--- a/src/devsynth/cli.py
+++ b/src/devsynth/cli.py
@@ -49,12 +49,31 @@ def main(argv: list[str] | None = None) -> None:
         result: dict[str, Any] = analyzer.analyze()
         print(json.dumps(result, indent=2))
     else:
-        from devsynth.adapters.cli.typer_adapter import run_cli
+        try:
+            from devsynth.adapters.cli.typer_adapter import run_cli
+        except ModuleNotFoundError as exc:  # pragma: no cover - optional deps
+            from devsynth.application.cli.errors import handle_error
+            from devsynth.interface.cli import CLIUXBridge
+
+            msg = (
+                f"Missing optional dependency: {exc.name}. "
+                "Install the required provider package to enable this feature."
+            )
+            handle_error(CLIUXBridge(), msg)
+            raise SystemExit(1)
+
         from devsynth.application.cli.errors import handle_error
         from devsynth.interface.cli import CLIUXBridge
 
         try:
             run_cli()
+        except ModuleNotFoundError as exc:  # pragma: no cover - optional deps
+            msg = (
+                f"Missing optional dependency: {exc.name}. "
+                "Install the required provider package to enable this feature."
+            )
+            handle_error(CLIUXBridge(), msg)
+            raise SystemExit(1)
         except Exception as err:  # pragma: no cover - defensive
             handle_error(CLIUXBridge(), err)
             raise SystemExit(1)

--- a/tests/behavior/features/devsynth_run_tests_command.feature
+++ b/tests/behavior/features/devsynth_run_tests_command.feature
@@ -1,30 +1,13 @@
 Feature: devsynth run-tests command
-  As a [role]
-  I want to [capability]
-  So that [benefit]
+  Verify the run-tests command handles missing optional dependencies.
 
-  Background:
-    Given [common setup step 1]
-    And [common setup step 2]
+  Scenario: run-tests succeeds without optional LLM providers
+    Given the environment variable "DEVSYNTH_RESOURCE_LMSTUDIO_AVAILABLE" is "false"
+    When I invoke "devsynth run-tests --target unit-tests --speed=fast --no-parallel"
+    Then the command should succeed
 
-  Scenario: [Scenario 1 Name]
-    Given [precondition 1]
-    When [action 1]
-    Then [expected outcome 1]
-    And [expected outcome 2]
-
-  Scenario: [Scenario 2 Name]
-    Given [precondition 1]
-    When [action 1]
-    Then [expected outcome 1]
-
-  Scenario Outline: [Parameterized Scenario Name]
-    Given [precondition with <parameter>]
-    When [action with <parameter>]
-    Then [expected outcome with <parameter>]
-
-    Examples:
-      | parameter | other_value |
-      | value1    | result1     |
-      | value2    | result2     |
-      | value3    | result3     |
+  Scenario: run-tests in parallel skips optional providers
+    Given the environment variable "DEVSYNTH_RESOURCE_LMSTUDIO_AVAILABLE" is "false"
+    When I invoke "devsynth run-tests --target unit-tests --speed=fast"
+    Then the command should succeed
+    And the output should not contain xdist assertions


### PR DESCRIPTION
## Summary
- add explicit ModuleNotFoundError handling in CLI entrypoint for optional LLM provider packages
- expand `devsynth run-tests` feature to cover missing optional dependencies

## Testing
- `poetry run pre-commit run --files src/devsynth/cli.py tests/behavior/features/devsynth_run_tests_command.feature`
- `poetry run devsynth run-tests --target unit-tests --speed=fast`
- `poetry run python tests/verify_test_organization.py`
- `poetry run python scripts/verify_test_markers.py`
- `poetry run python scripts/verify_requirements_traceability.py`
- `poetry run python scripts/verify_version_sync.py`


------
https://chatgpt.com/codex/tasks/task_e_68a78ba433c48333bfeab834dace7a21