### PR TITLE
test: expand deployment script coverage

### DIFF
--- a/tests/unit/deployment/test_bootstrap_script.py
+++ b/tests/unit/deployment/test_bootstrap_script.py
@@ -1,0 +1,49 @@
+import shutil
+import subprocess
+import tempfile
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[3]
+SCRIPTS_DIR = ROOT / "scripts" / "deployment"
+
+pytestmark = pytest.mark.fast
+
+
+def test_bootstrap_script_rejects_invalid_environment():
+    """bootstrap.sh should reject unknown environments.
+
+    ReqID: DEP-02"""
+    workdir = Path(tempfile.mkdtemp())
+    workdir.chmod(0o755)
+    try:
+        cmd = f"cd '{workdir}' && {SCRIPTS_DIR / 'bootstrap.sh'} invalid"
+        result = subprocess.run(
+            ["su", "nobody", "-s", "/bin/bash", "-c", cmd],
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode != 0
+        assert "Invalid environment" in result.stderr
+    finally:
+        shutil.rmtree(workdir)
+
+
+def test_bootstrap_script_requires_docker():
+    """bootstrap.sh should require docker to be installed.
+
+    ReqID: DEP-03"""
+    workdir = Path(tempfile.mkdtemp())
+    workdir.chmod(0o755)
+    try:
+        cmd = f"cd '{workdir}' && {SCRIPTS_DIR / 'bootstrap.sh'} development"
+        result = subprocess.run(
+            ["su", "nobody", "-s", "/bin/bash", "-c", cmd],
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode != 0
+        assert "Docker is required" in result.stderr
+    finally:
+        shutil.rmtree(workdir)

--- a/tests/unit/deployment/test_health_check_smoke.py
+++ b/tests/unit/deployment/test_health_check_smoke.py
@@ -19,8 +19,16 @@ class _Handler(BaseHTTPRequestHandler):
         self.end_headers()
 
 
+class _FailHandler(BaseHTTPRequestHandler):
+    def do_GET(self):
+        self.send_response(500)
+        self.end_headers()
+
+
 def test_health_check_script_reports_healthy():
-    """health_check.sh should succeed when endpoints return 200."""
+    """health_check.sh should succeed when endpoints return 200.
+
+    ReqID: DEP-02"""
     server = HTTPServer(("127.0.0.1", 0), _Handler)
     port = server.server_address[1]
     thread = threading.Thread(target=server.serve_forever)
@@ -41,6 +49,121 @@ def test_health_check_script_reports_healthy():
         )
         assert result.returncode == 0
         assert "All services are healthy" in result.stdout
+    finally:
+        server.shutdown()
+        thread.join()
+        shutil.rmtree(workdir)
+
+
+def test_health_check_script_rejects_root_user():
+    """health_check.sh should refuse to run as root.
+
+    ReqID: CON-04"""
+    workdir = Path(tempfile.mkdtemp())
+    workdir.chmod(0o755)
+    try:
+        result = subprocess.run(
+            [str(SCRIPTS_DIR / "health_check.sh")],
+            cwd=workdir,
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode != 0
+        assert "Please run this script as a non-root user." in result.stderr
+    finally:
+        shutil.rmtree(workdir)
+
+
+def test_health_check_script_requires_env_file():
+    """health_check.sh should fail when the env file is missing.
+
+    ReqID: DEP-04"""
+    workdir = Path(tempfile.mkdtemp())
+    workdir.chmod(0o755)
+    try:
+        cmd = f"cd '{workdir}' && {SCRIPTS_DIR / 'health_check.sh'}"
+        result = subprocess.run(
+            ["su", "nobody", "-s", "/bin/bash", "-c", cmd],
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode != 0
+        assert "Missing environment file" in result.stderr
+    finally:
+        shutil.rmtree(workdir)
+
+
+def test_health_check_script_requires_strict_permissions():
+    """health_check.sh should enforce 600 permissions on the env file.
+
+    ReqID: CON-04"""
+    workdir = Path(tempfile.mkdtemp())
+    workdir.chmod(0o755)
+    try:
+        env_file = workdir / ".env"
+        env_file.write_text("DEVSYNTH_ENV=testing\n")
+        env_file.chmod(0o644)
+        cmd = f"cd '{workdir}' && {SCRIPTS_DIR / 'health_check.sh'}"
+        result = subprocess.run(
+            ["su", "nobody", "-s", "/bin/bash", "-c", cmd],
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode != 0
+        assert "must have 600 permissions" in result.stderr
+    finally:
+        shutil.rmtree(workdir)
+
+
+def test_health_check_script_rejects_invalid_url():
+    """health_check.sh should validate provided URLs.
+
+    ReqID: DEP-03"""
+    workdir = Path(tempfile.mkdtemp())
+    workdir.chmod(0o755)
+    try:
+        env_file = workdir / ".env"
+        env_file.write_text("DEVSYNTH_ENV=testing\n")
+        env_file.chmod(0o600)
+        cmd = (
+            f"cd '{workdir}' && {SCRIPTS_DIR / 'health_check.sh'} not-a-url"
+            " not-a-url not-a-url"
+        )
+        result = subprocess.run(
+            ["su", "nobody", "-s", "/bin/bash", "-c", cmd],
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode != 0
+        assert "Invalid URL" in result.stderr
+    finally:
+        shutil.rmtree(workdir)
+
+
+def test_health_check_script_fails_on_unhealthy_endpoint():
+    """health_check.sh should report failure when an endpoint is unhealthy.
+
+    ReqID: DEP-01"""
+    server = HTTPServer(("127.0.0.1", 0), _FailHandler)
+    port = server.server_address[1]
+    thread = threading.Thread(target=server.serve_forever)
+    thread.daemon = True
+    thread.start()
+    workdir = Path(tempfile.mkdtemp())
+    workdir.chmod(0o755)
+    try:
+        env_file = workdir / ".env"
+        env_file.write_text("DEVSYNTH_ENV=testing\n")
+        env_file.chmod(0o600)
+        url = f"http://127.0.0.1:{port}"
+        cmd = f"cd '{workdir}' && {SCRIPTS_DIR / 'health_check.sh'} {url} {url} {url}"
+        result = subprocess.run(
+            ["su", "nobody", "-s", "/bin/bash", "-c", cmd],
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode != 0
+        assert f"Health check failed for {url}" in result.stderr
     finally:
         server.shutdown()
         thread.join()


### PR DESCRIPTION
## Summary
- add failure path tests for health_check.sh covering root execution, missing env file, invalid URLs, permission errors, and unhealthy endpoints
- exercise bootstrap.sh validation for unknown environments and missing docker

## Testing
- `poetry run pre-commit run --files tests/unit/deployment/test_health_check_smoke.py tests/unit/deployment/test_bootstrap_script.py`
- `poetry run devsynth run-tests --speed=fast`
- `poetry run python scripts/verify_test_markers.py` *(fails: KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_68a78b9f44a88333b999d23a8887d416