### PR TITLE
test: ensure temporary dummy file cleanup

### DIFF
--- a/tests/unit/general/test_speed_option.py
+++ b/tests/unit/general/test_speed_option.py
@@ -13,6 +13,9 @@ def test_speed_option_recognized():
     repo_root = Path(__file__).resolve().parents[3]
     test_file = repo_root / "tests" / "tmp_speed_dummy.py"
     try:
+        test_file.write_text(
+            "import pytest\n\n@pytest.mark.fast\ndef test_dummy():\n    assert True\n"
+        )
         result = subprocess.run(
             [
                 sys.executable,


### PR DESCRIPTION
## Summary
- create a temporary fast-marked test file in `test_speed_option_recognized`
- remove the temporary file after running the subprocess to avoid residue

## Testing
- `poetry run pre-commit run --files tests/unit/general/test_speed_option.py`
- `poetry run devsynth run-tests --speed=fast` *(fails: ValueError in chromadb import; TypeError in recursion termination tests)*
- `poetry run python tests/verify_test_organization.py`
- `poetry run python scripts/verify_test_markers.py`
- `poetry run python scripts/verify_requirements_traceability.py`
- `poetry run python scripts/verify_version_sync.py`


------
https://chatgpt.com/codex/tasks/task_e_68a78b7c2c588333ad3673f01dd7b695