### PR TITLE
feat: justify dialectical termination with tests

### DIFF
--- a/dialectical_audit.log
+++ b/dialectical_audit.log
@@ -22,6 +22,7 @@
     "Feature 'User Authentication' documented and referenced in code 2025-08-21.",
     "Feature 'Version bump script' documented and referenced in code 2025-08-21.",
     "Development environment virtualenv enforcement documented 2025-08-21.",
-    "Release checklist re-run 2025-08-21: environment setup and pip check succeeded; fast tests failed (missing tests/tmp_speed_dummy.py); medium and slow test runs terminated after LMStudioProvider warnings; marker verification interrupted; deployment tests failed coverage; release prep interrupted; release state check reported missing tag."
+    "Release checklist re-run 2025-08-21: environment setup and pip check succeeded; fast tests failed (missing tests/tmp_speed_dummy.py); medium and slow test runs terminated after LMStudioProvider warnings; marker verification interrupted; deployment tests failed coverage; release prep interrupted; release state check reported missing tag.",
+    "Termination proof for dialectical reasoner hooks documented and tests added 2025-08-21."
   ]
 }

--- a/docs/release/0.1.0-alpha.1.md
+++ b/docs/release/0.1.0-alpha.1.md
@@ -119,6 +119,12 @@ After tagging, run `poetry version 0.1.0-alpha.2.dev0` (or appropriate next vers
 - `PIP_NO_INDEX=1 poetry run pip check` succeeds in offline mode.
 - `poetry run devsynth run-tests --speed=fast` completes without unexpected failures.
 
+## Audit Compliance
+
+Termination analysis for the dialectical reasoning hooks is documented in the
+[specification](../specifications/dialectical_reasoning.md#termination),
+demonstrating adherence to the dialectical audit policy.
+
 ## Known P1 Issues and Test Gaps
 
 The following issues were identified during the `0.1.0-alpha.1` release cycle:

--- a/docs/specifications/dialectical_reasoning.md
+++ b/docs/specifications/dialectical_reasoning.md
@@ -28,3 +28,24 @@ The dialectical reasoner exposes evaluation hooks. Registered callbacks receive 
 - Unit test: a hook receives the reasoning and consensus flag when evaluation succeeds.
 - Unit test: hook exceptions are logged without interrupting evaluation.
 - Unit test: a hook runs when consensus is not reached and receives ``False``.
+
+## Termination
+
+Let ``n`` be the number of registered evaluation hooks. After producing a
+``DialecticalReasoning`` result, the service iterates through this finite set of
+hooks exactly once. If ``T_i`` bounds the execution time of the ``i``\ th hook,
+then the total additional work is ``\sum_{i=1}^n T_i``. Because ``n`` is finite
+and hooks cannot register new hooks during iteration, the evaluation loop is
+guaranteed to terminate.
+
+### Simulation
+
+The snippet below demonstrates termination even for a large number of hooks::
+
+    for _ in range(1000):
+        service.register_evaluation_hook(lambda r, c: None)
+    service.evaluate_change(change)  # completes in O(n)
+
+Unit tests under
+``tests/unit/methodology/test_dialectical_reasoner_termination.py`` exercise
+these edge cases to confirm termination.

--- a/tests/unit/methodology/test_dialectical_reasoner_termination.py
+++ b/tests/unit/methodology/test_dialectical_reasoner_termination.py
@@ -1,0 +1,52 @@
+from uuid import uuid4
+
+import pytest
+
+from devsynth.domain.models.requirement import RequirementChange
+from tests.unit.methodology.test_dialectical_reasoner_hooks import _build_service
+
+
+@pytest.mark.fast
+def test_evaluation_terminates_with_many_hooks():
+    """Evaluation terminates with many hooks.
+
+    ReqID: dialectical_reasoning-termination"""
+
+    service = _build_service("yes")
+    change = RequirementChange(requirement_id=uuid4(), created_by="user")
+    count = 0
+
+    def hook(_, __):
+        nonlocal count
+        count += 1
+
+    for _ in range(1000):
+        service.register_evaluation_hook(hook)
+
+    service.evaluate_change(change)
+
+    assert count == 1000
+
+
+@pytest.mark.fast
+def test_hooks_continue_after_exception():
+    """Subsequent hooks run after an exception.
+
+    ReqID: dialectical_reasoning-termination"""
+
+    service = _build_service("yes")
+    change = RequirementChange(requirement_id=uuid4(), created_by="user")
+    calls = []
+
+    def bad_hook(_, __):
+        raise RuntimeError("boom")
+
+    def good_hook(_, __):
+        calls.append("good")
+
+    service.register_evaluation_hook(bad_hook)
+    service.register_evaluation_hook(good_hook)
+
+    service.evaluate_change(change)
+
+    assert calls == ["good"]


### PR DESCRIPTION
## Summary
- justify dialectical reasoner termination with a bounded loop and illustrative simulation
- cross-reference termination analysis in the release notes for audit compliance and log its resolution
- add unit tests for many hooks and post-exception execution

## Testing
- `python --version`
- `poetry env info --path`
- `task --version` *(fails: command not found)*
- `poetry run pre-commit run --files docs/specifications/dialectical_reasoning.md docs/release/0.1.0-alpha.1.md tests/unit/methodology/test_dialectical_reasoner_termination.py dialectical_audit.log`
- `poetry run devsynth run-tests --speed=fast`
- `poetry run python tests/verify_test_organization.py`
- `poetry run python scripts/verify_test_markers.py`
- `poetry run python scripts/verify_requirements_traceability.py`
- `poetry run python scripts/verify_version_sync.py`


------
https://chatgpt.com/codex/tasks/task_e_68a7b21045cc8333ba2c607852689bbc