### PR TITLE
test: skip LM Studio tests when dependency missing

### DIFF
--- a/tests/integration/general/test_error_handling_at_integration_points.py
+++ b/tests/integration/general/test_error_handling_at_integration_points.py
@@ -12,15 +12,14 @@ from unittest.mock import MagicMock, call, patch
 
 import pytest
 
+pytest.importorskip("lmstudio")
+
 from devsynth.adapters.provider_system import FallbackProvider
 from devsynth.adapters.provider_system import LMStudioProvider as PS_LMStudioProvider
 from devsynth.adapters.provider_system import OpenAIProvider, ProviderError
 from devsynth.application.llm.providers import LMStudioProvider
 
-pytestmark = [
-    pytest.mark.medium,
-    pytest.mark.skipif(LMStudioProvider is None, reason="lmstudio not installed"),
-]
+pytestmark = [pytest.mark.medium]
 from devsynth.application.agents.unified_agent import UnifiedAgent
 from devsynth.application.code_analysis.analyzer import CodeAnalyzer
 from devsynth.application.code_analysis.ast_transformer import AstTransformer

--- a/tests/integration/general/test_lmstudio_provider.py
+++ b/tests/integration/general/test_lmstudio_provider.py
@@ -4,13 +4,12 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+pytest.importorskip("lmstudio")
+
 from devsynth.application.llm.providers import LMStudioProvider
 
 # LMStudio provider integration tests run at medium speed
-pytestmark = [
-    pytest.mark.medium,
-    pytest.mark.skipif(LMStudioProvider is None, reason="lmstudio not installed"),
-]
+pytestmark = [pytest.mark.medium]
 
 
 def _import_provider():

--- a/tests/integration/general/test_provider_system.py
+++ b/tests/integration/general/test_provider_system.py
@@ -12,6 +12,8 @@ from unittest.mock import MagicMock, patch
 import pytest
 import responses
 
+pytest.importorskip("lmstudio")
+
 from devsynth.adapters.provider_system import FallbackProvider
 from devsynth.adapters.provider_system import LMStudioProvider as PS_LMStudioProvider
 from devsynth.adapters.provider_system import (
@@ -25,10 +27,6 @@ from devsynth.adapters.provider_system import (
     get_provider_config,
 )
 from devsynth.application.llm.providers import LMStudioProvider
-
-pytestmark = [
-    pytest.mark.skipif(LMStudioProvider is None, reason="lmstudio not installed")
-]
 
 
 class TestProviderConfig:

--- a/tests/integration/general/test_provider_system_configurations.py
+++ b/tests/integration/general/test_provider_system_configurations.py
@@ -11,6 +11,8 @@ from unittest.mock import MagicMock, patch
 import pytest
 import responses
 
+pytest.importorskip("lmstudio")
+
 from devsynth.adapters.provider_system import FallbackProvider
 from devsynth.adapters.provider_system import LMStudioProvider as PS_LMStudioProvider
 from devsynth.adapters.provider_system import (
@@ -24,10 +26,6 @@ from devsynth.adapters.provider_system import (
     get_provider_config,
 )
 from devsynth.application.llm.providers import LMStudioProvider
-
-pytestmark = [
-    pytest.mark.skipif(LMStudioProvider is None, reason="lmstudio not installed")
-]
 
 
 class TestProviderConfigurations:

--- a/tests/integration/llm/test_lmstudio_streaming.py
+++ b/tests/integration/llm/test_lmstudio_streaming.py
@@ -4,13 +4,12 @@ from unittest.mock import patch
 
 import pytest
 
+pytest.importorskip("lmstudio")
+
 from devsynth.application.llm.providers import LMStudioProvider
 
 # LM Studio streaming tests run at medium speed
-pytestmark = [
-    pytest.mark.medium,
-    pytest.mark.skipif(LMStudioProvider is None, reason="lmstudio not installed"),
-]
+pytestmark = [pytest.mark.medium]
 
 
 def _import_provider():


### PR DESCRIPTION
## Summary
- guard LM Studio integration tests with pytest.importorskip
- ensure optional LM Studio tests skip when dependency not installed

## Testing
- `poetry run pre-commit run --files tests/integration/general/test_error_handling_at_integration_points.py tests/integration/general/test_lmstudio_provider.py tests/integration/general/test_provider_system.py tests/integration/general/test_provider_system_configurations.py tests/integration/llm/test_lmstudio_streaming.py`
- `poetry run devsynth run-tests --speed=fast`
- `poetry run devsynth run-tests --speed=medium` *(killed)*
- `poetry run devsynth run-tests --speed=slow` *(fail: RuntimeError: dependency errors)*
- `poetry run python tests/verify_test_organization.py`
- `poetry run python scripts/verify_test_markers.py`
- `poetry run python scripts/verify_requirements_traceability.py`
- `poetry run python scripts/verify_version_sync.py`


------
https://chatgpt.com/codex/tasks/task_e_68a7b206ef308333ba2d63bf854f29cf