### PR TITLE
chore: capture release prep failures

### DIFF
--- a/dialectical_audit.log
+++ b/dialectical_audit.log
@@ -1,5 +1,10 @@
 {
-  "questions": [],
+  "questions": [
+    "2025-08-22: devsynth run-tests --speed=fast, --speed=medium, and --speed=slow aborted; LMStudioProvider package missing.",
+    "2025-08-22: scripts/verify_test_markers.py interrupted after pytest collection error in tests/behavior/test_agentapi.py.",
+    "2025-08-22: pytest tests/unit/deployment -m fast failed coverage (8.69% < 60%).",
+    "2025-08-22: task release:prep failed; tests/behavior/steps/test_advanced_graph_memory_features_steps.py raised TypeError in TinyDBMemoryAdapter."
+  ],
   "resolved": [
     "Release checklist commands executed 2025-08-20; verify_test_markers.py failed and task command was not found.",
     "Complete memory system integration documented and referenced in code 2025-08-20.",

--- a/issues/release-readiness-v0-1-0-alpha-1.md
+++ b/issues/release-readiness-v0-1-0-alpha-1.md
@@ -1,8 +1,8 @@
 # Release readiness for v0.1.0-alpha.1
 Milestone: 0.1.0-alpha.1
-Status: in progress
+Status: blocked
 Priority: high
-Dependencies: archived/virtualenv-configuration.md, issues/verify-test-markers-script.md, issues/performance-and-scalability-testing.md, docs/release/0.1.0-alpha.1.md
+Dependencies: issues/verify-test-markers-script.md, issues/performance-and-scalability-testing.md, issues/additional-storage-backends.md, issues/devsynth-run-tests-command.md, docs/release/0.1.0-alpha.1.md
 
 ## Problem Statement
 Prerequisites for the first alpha release remain incomplete. The development environment lacks an enforced virtualenv, release automation via `task` is unavailable, and slow tests and marker verification scripts fail or time out. These gaps block tagging `v0.1.0-alpha.1`.
@@ -19,9 +19,11 @@ Prerequisites for the first alpha release remain incomplete. The development env
 - 2025-08-21: Established a Poetry virtual environment and installed development extras; `poetry env info --path` now reports the expected path. Attempted `poetry run devsynth run-tests --speed=fast`, but the command stalled after an `LMStudioProvider` warning, and `scripts/verify_test_markers.py` still runs slowly and was halted after ~150 files.
 - 2025-08-21: Re-ran release checklist; environment provisioning and `pip check` succeeded, but fast tests failed (missing `tests/tmp_speed_dummy.py`). Medium and slow test runs halted after `LMStudioProvider` warnings. `verify_test_markers.py` was interrupted, deployment tests failed coverage, `task release:prep` ended early, and `verify_release_state` reported missing tag `v0.1.0-alpha.1`.
 - 2025-08-22: Archived virtualenv configuration dependency. `poetry run python scripts/verify_release_state.py` reports missing tag `v0.1.0-alpha.1`.
+- 2025-08-22: Re-ran release checklist; `pip check` passed, `devsynth run-tests` for all speeds aborted with missing `LMStudioProvider`, `verify_test_markers.py` halted after collection error, deployment tests failed coverage, and `task release:prep` failed with a `TinyDBMemoryAdapter` TypeError.
 
 ## References
 - docs/release/0.1.0-alpha.1.md
-- archived/virtualenv-configuration.md
 - issues/verify-test-markers-script.md
 - issues/performance-and-scalability-testing.md
+- issues/additional-storage-backends.md
+- issues/devsynth-run-tests-command.md


### PR DESCRIPTION
## Summary
- record outstanding release-prep failures in the dialectical audit log
- mark v0.1.0-alpha.1 release readiness issue as blocked with updated dependencies and progress

## Testing
- `PIP_NO_INDEX=1 poetry run pip check`
- `poetry run pre-commit run --files dialectical_audit.log issues/release-readiness-v0-1-0-alpha-1.md`
- `poetry run python scripts/verify_test_markers.py --changed`
- `poetry run python scripts/verify_requirements_traceability.py`
- `poetry run python scripts/verify_version_sync.py`


------
https://chatgpt.com/codex/tasks/task_e_68a7e50e9fe48333b98e4fcb3f3ace99