### PR TITLE
chore: run devsynth via poetry and update pre-commit stages

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,7 @@ repos:
   hooks:
     - id: devsynth-align
       name: devsynth align
-      entry: devsynth align --quiet
+      entry: poetry run devsynth align --quiet
       language: system
       pass_filenames: false
     - id: check-frontmatter
@@ -31,7 +31,7 @@ repos:
       entry: python scripts/verify_mvuu_references.py
       language: system
       pass_filenames: false
-      stages: [push]
+      stages: [pre-push]
     - id: verify-requirements-traceability
       name: verify requirements traceability
       entry: poetry run python scripts/verify_requirements_traceability.py
@@ -60,7 +60,7 @@ repos:
       entry: python scripts/policy_audit.py
       language: system
       pass_filenames: false
-      stages: [push]
+      stages: [pre-push]
     - id: commit-message-lint
       name: commit message lint
       description: lint commit messages for MVUU compliance
@@ -73,13 +73,13 @@ repos:
       entry: poetry run bandit -q -r src
       language: system
       pass_filenames: false
-      stages: [push]
+      stages: [pre-push]
     - id: safety
       name: safety vulnerability check
       entry: poetry run safety check --full-report
       language: system
       pass_filenames: false
-      stages: [push]
+      stages: [pre-push]
 - repo: https://github.com/pre-commit/pre-commit-hooks
   rev: v4.4.0
   hooks:


### PR DESCRIPTION
## Summary
- run `devsynth align` through `poetry run`
- replace deprecated `push` stage with `pre-push`

## Testing
- `poetry run pre-commit run --files .pre-commit-config.yaml`
- `poetry run pre-commit run --files README.md`
- `poetry run devsynth run-tests --speed=fast`
- `poetry run python tests/verify_test_organization.py`
- `poetry run python scripts/verify_test_markers.py`
- `poetry run python scripts/verify_requirements_traceability.py`
- `poetry run python scripts/verify_version_sync.py`


------
https://chatgpt.com/codex/tasks/task_e_68a7e4af03e88333bf788c80c2a973c3