### PR TITLE
feat(memory): add S3 storage backend and selection

### DIFF
--- a/docs/specifications/additional-storage-backends.md
+++ b/docs/specifications/additional-storage-backends.md
@@ -24,12 +24,38 @@ Required metadata fields:
 
 # Summary
 
+DevSynth currently persists structured memory through a single TinyDB backend.
+To support deployments that require external or cloud storage, the memory
+system must expose an adapter interface and provide at least one additional
+backend implementation.
+
 ## Socratic Checklist
 - What is the problem?
+  - Memory persistence is tightly coupled to TinyDB and cannot be switched to
+    other services.
 - What proofs confirm the solution?
+  - A pluggable adapter interface and S3-backed implementation verified by
+    integration tests.
 
 ## Motivation
 
+Allow projects to opt into cloud or database storage without changing the
+`MemoryManager` API.  Configuration should determine the backend at runtime so
+tests and examples remain hermetic.
+
 ## Specification
 
+- Introduce a `StorageAdapter` protocol extending the existing `MemoryStore`
+  contract and exposing a `backend_type` attribute used for selection.
+- Implement an `S3MemoryAdapter` using boto3 that stores each `MemoryItem` as a
+  JSON object in an S3 bucket.
+- Extend `MemoryManager` so that when no adapters are supplied it inspects the
+  `memory_store_type` setting and instantiates the matching adapter.  When the
+  value is `s3`, the manager configures the adapter with the bucket name from
+  `s3_bucket_name`.
+
 ## Acceptance Criteria
+
+- Given `DEVSYNTH_MEMORY_STORE=s3` and an available bucket, `MemoryManager`
+  persists and retrieves items using `S3MemoryAdapter`.
+- Documentation describes required environment variables and usage examples.

--- a/docs/user_guides/configuration_reference.md
+++ b/docs/user_guides/configuration_reference.md
@@ -89,6 +89,7 @@ DevSynth supports loading configuration from environment variables. This is espe
 | `SERPER_API_KEY` | `api_keys.serper` | Serper API key for web search |
 | `DEVSYNTH_MEMORY_STORE` | `memory.store_type` | Memory store type |
 | `DEVSYNTH_MEMORY_PATH` | `memory.file_path` | Path for file-based memory store |
+| `DEVSYNTH_S3_BUCKET` | `memory.s3_bucket_name` | S3 bucket for S3 store |
 | `DEVSYNTH_KUZU_DB_PATH` | `memory.kuzu_db_path` | Path for Kuzu |
 | `DEVSYNTH_MAX_CONTEXT_SIZE` | `memory.max_context_size` | Maximum context size |
 | `DEVSYNTH_LOG_LEVEL` | `logging.level` | Log level |
@@ -113,9 +114,8 @@ SERPER_API_KEY=your-serper-api-key
 
 # Memory Configuration
 
-DEVSYNTH_MEMORY_STORE=Kuzu
-DEVSYNTH_MEMORY_PATH=~/.devsynth/memory
-DEVSYNTH_KUZU_DB_PATH=~/.devsynth/memory/Kuzu.db
+DEVSYNTH_MEMORY_STORE=s3
+DEVSYNTH_S3_BUCKET=my-bucket
 
 # Logging
 

--- a/docs/user_guides/user_guide.md
+++ b/docs/user_guides/user_guide.md
@@ -259,7 +259,7 @@ DevSynth can be configured using the `config` command or by editing the configur
 | `endpoint` | LM Studio API endpoint | `http://localhost:1234/v1` | Any valid URL |
 | `openai_api_key` | OpenAI API key for using OpenAI models | None | Valid OpenAI API key |
 | `serper_api_key` | Serper API key for web search functionality | None | Valid Serper API key |
-| `memory_store_type` | Type of memory store to use | `memory` | `memory`, `file`, `Kuzu` |
+| `memory_store_type` | Type of memory store to use | `memory` | `memory`, `file`, `Kuzu`, `s3` |
 
 ### Offline Mode
 
@@ -322,6 +322,7 @@ DevSynth-specific configuration variables use the `DEVSYNTH_` prefix:
 | `DEVSYNTH_MEMORY_STORE` | `memory_store_type` |
 | `DEVSYNTH_MEMORY_PATH` | `memory_file_path` |
 | `DEVSYNTH_KUZU_DB_PATH` | `kuzu_db_path` |
+| `DEVSYNTH_S3_BUCKET` | `s3_bucket_name` |
 | `DEVSYNTH_KUZU_EMBEDDED` | `kuzu_embedded` |
 | `DEVSYNTH_MAX_CONTEXT_SIZE` | `max_context_size` |
 | `DEVSYNTH_CONTEXT_EXPIRATION_DAYS` | `context_expiration_days` |
@@ -381,6 +382,17 @@ The `file` memory store type uses a JSON file for persistent storage. This ensur
 
 devsynth config --key memory_store_type --value file
 devsynth config --key memory_file_path --value /path/to/memory/directory
+```
+
+## S3 Memory Store
+
+The `s3` memory store type persists items to an Amazon S3 bucket. Ensure that
+the bucket exists and credentials are configured for the AWS SDK.
+
+```bash
+# Configure S3 store
+devsynth config --key memory_store_type --value s3
+devsynth config --key s3_bucket_name --value my-bucket
 ```
 
 ## Kuzu Memory Store

--- a/examples/s3_memory_backend_example.py
+++ b/examples/s3_memory_backend_example.py
@@ -1,0 +1,16 @@
+"""Example using the S3 memory backend."""
+
+import os
+
+from devsynth.application.memory.memory_manager import MemoryManager
+from devsynth.domain.models.memory import MemoryType
+
+# Configure backend via environment variables
+os.environ.setdefault("DEVSYNTH_MEMORY_STORE", "s3")
+os.environ.setdefault("DEVSYNTH_S3_BUCKET", "devsynth-example")
+
+# In a real deployment the bucket must already exist and AWS credentials must be
+# configured.  This example focuses on the MemoryManager API.
+manager = MemoryManager()
+item_id = manager.store_with_edrr_phase("example", MemoryType.CODE, "EXPAND")
+print(manager.retrieve(item_id))

--- a/src/devsynth/application/memory/adapters/__init__.py
+++ b/src/devsynth/application/memory/adapters/__init__.py
@@ -1,13 +1,14 @@
-"""
-Memory Adapters Package
+"""Memory Adapters Package
 
 This package provides adapters for different memory storage backends.
 """
+
 from devsynth.logging_setup import DevSynthLogger
 
 from .graph_memory_adapter import GraphMemoryAdapter
-from .vector_memory_adapter import VectorMemoryAdapter
+from .storage_adapter import StorageAdapter
 from .tinydb_memory_adapter import TinyDBMemoryAdapter
+from .vector_memory_adapter import VectorMemoryAdapter
 
 logger = DevSynthLogger(__name__)
 
@@ -17,11 +18,20 @@ except Exception as exc:  # pragma: no cover - missing optional dependency
     KuzuAdapter = None
     logger.warning("KuzuAdapter not available: %s", exc)
 
+try:  # pragma: no cover - optional dependency
+    from .s3_memory_adapter import S3MemoryAdapter
+except Exception as exc:  # pragma: no cover - missing optional dependency
+    S3MemoryAdapter = None
+    logger.warning("S3MemoryAdapter not available: %s", exc)
+
 __all__ = [
-    'GraphMemoryAdapter',
-    'VectorMemoryAdapter',
-    'TinyDBMemoryAdapter',
+    "GraphMemoryAdapter",
+    "VectorMemoryAdapter",
+    "TinyDBMemoryAdapter",
+    "StorageAdapter",
 ]
 
 if KuzuAdapter is not None:
-    __all__.append('KuzuAdapter')
+    __all__.append("KuzuAdapter")
+if S3MemoryAdapter is not None:
+    __all__.append("S3MemoryAdapter")

--- a/src/devsynth/application/memory/adapters/s3_memory_adapter.py
+++ b/src/devsynth/application/memory/adapters/s3_memory_adapter.py
@@ -1,0 +1,135 @@
+"""S3-backed memory adapter."""
+
+from __future__ import annotations
+
+import json
+import uuid
+from typing import Any, Dict, List, Optional
+
+from ....domain.models.memory import MemoryItem, MemoryType
+from ....exceptions import MemoryTransactionError
+from ....logging_setup import DevSynthLogger
+from .storage_adapter import StorageAdapter
+
+try:  # pragma: no cover - optional dependency
+    import boto3
+    from botocore.exceptions import ClientError
+except Exception as exc:  # pragma: no cover - missing optional dependency
+    boto3 = None  # type: ignore[assignment]
+    ClientError = Exception  # type: ignore[misc]
+    _BOTO3_ERROR = exc
+
+logger = DevSynthLogger(__name__)
+
+
+class S3MemoryAdapter(StorageAdapter):
+    """Store memory items in an S3 bucket."""
+
+    backend_type = "s3"
+
+    def __init__(self, bucket: str, client: Any | None = None):
+        if boto3 is None:  # pragma: no cover - defensive
+            raise ImportError("boto3 is required for S3MemoryAdapter") from _BOTO3_ERROR
+        self.bucket = bucket
+        self.client = client or boto3.client("s3")
+
+    # ------------------------------------------------------------------
+    # Core storage operations
+    # ------------------------------------------------------------------
+    def store(self, item: MemoryItem, transaction_id: str | None = None) -> str:
+        if transaction_id is not None:
+            raise MemoryTransactionError(
+                "Transactions are not supported for S3MemoryAdapter",
+                transaction_id=transaction_id,
+                store_type=self.backend_type,
+                operation="store",
+            )
+        if not item.id:
+            item.id = str(uuid.uuid4())
+        data = json.dumps(
+            {
+                "id": item.id,
+                "content": item.content,
+                "memory_type": (
+                    item.memory_type.value
+                    if hasattr(item.memory_type, "value")
+                    else item.memory_type
+                ),
+                "metadata": item.metadata,
+                "created_at": item.created_at.isoformat() if item.created_at else None,
+            }
+        )
+        self.client.put_object(Bucket=self.bucket, Key=item.id, Body=data)
+        return item.id
+
+    def retrieve(self, item_id: str) -> Optional[MemoryItem]:
+        try:
+            obj = self.client.get_object(Bucket=self.bucket, Key=item_id)
+        except ClientError:
+            return None
+        data = json.loads(obj["Body"].read())
+        memory_type = MemoryType(data["memory_type"])
+        return MemoryItem(
+            id=data["id"],
+            content=data["content"],
+            memory_type=memory_type,
+            metadata=data.get("metadata", {}),
+        )
+
+    def search(self, query: Dict[str, Any]) -> List[MemoryItem]:
+        items: List[MemoryItem] = []
+        resp = self.client.list_objects_v2(Bucket=self.bucket)
+        for obj in resp.get("Contents", []):
+            item = self.retrieve(obj["Key"])
+            if not item:
+                continue
+            match = True
+            for key, value in query.items():
+                if key == "type":
+                    if item.memory_type != value:
+                        match = False
+                        break
+                elif item.metadata.get(key) != value:
+                    match = False
+                    break
+            if match:
+                items.append(item)
+        return items
+
+    def delete(self, item_id: str) -> bool:
+        try:
+            self.client.delete_object(Bucket=self.bucket, Key=item_id)
+            return True
+        except ClientError:  # pragma: no cover - defensive
+            return False
+
+    # ------------------------------------------------------------------
+    # Transaction API (unsupported)
+    # ------------------------------------------------------------------
+    def begin_transaction(self) -> str:  # pragma: no cover - simple
+        raise MemoryTransactionError(
+            "Transactions are not supported", store_type=self.backend_type
+        )
+
+    def commit_transaction(
+        self, transaction_id: str
+    ) -> bool:  # pragma: no cover - simple
+        raise MemoryTransactionError(
+            "Transactions are not supported",
+            transaction_id=transaction_id,
+            store_type=self.backend_type,
+        )
+
+    def rollback_transaction(
+        self, transaction_id: str
+    ) -> bool:  # pragma: no cover - simple
+        raise MemoryTransactionError(
+            "Transactions are not supported",
+            transaction_id=transaction_id,
+            store_type=self.backend_type,
+        )
+
+    def is_transaction_active(
+        self, transaction_id: str
+    ) -> bool:  # pragma: no cover - simple
+        return False

--- a/src/devsynth/application/memory/adapters/storage_adapter.py
+++ b/src/devsynth/application/memory/adapters/storage_adapter.py
@@ -1,0 +1,19 @@
+"""Storage adapter protocol for memory backends.
+
+This protocol defines the minimal interface required for storage backends used
+by :class:`~devsynth.application.memory.memory_manager.MemoryManager`.  Each
+backend exposes its ``backend_type`` for configuration-based selection and
+implements the :class:`~devsynth.domain.interfaces.memory.MemoryStore` contract.
+"""
+
+from __future__ import annotations
+
+from typing import Protocol
+
+from ....domain.interfaces.memory import MemoryStore
+
+
+class StorageAdapter(MemoryStore, Protocol):
+    """Protocol implemented by memory storage adapters."""
+
+    backend_type: str

--- a/src/devsynth/application/memory/adapters/tinydb_memory_adapter.py
+++ b/src/devsynth/application/memory/adapters/tinydb_memory_adapter.py
@@ -4,25 +4,31 @@ TinyDB Memory Adapter Module
 This module provides a memory adapter that handles structured data queries
 using TinyDB.
 """
-from typing import Dict, List, Any, Optional
+
 import uuid
 from copy import deepcopy
-from tinydb import TinyDB, Query
+from typing import Any, Dict, List, Optional
+
+from tinydb import Query, TinyDB
 from tinydb.storages import MemoryStorage
+
 from ....domain.models.memory import MemoryItem, MemoryType
-from ....domain.interfaces.memory import MemoryStore
-from ....logging_setup import DevSynthLogger
 from ....exceptions import MemoryTransactionError
+from ....logging_setup import DevSynthLogger
+from .storage_adapter import StorageAdapter
 
 logger = DevSynthLogger(__name__)
 
-class TinyDBMemoryAdapter(MemoryStore):
+
+class TinyDBMemoryAdapter(StorageAdapter):
     """
     TinyDB Memory Adapter handles structured data queries using TinyDB.
 
     It implements the MemoryStore interface and provides additional methods
     for structured data queries.
     """
+
+    backend_type = "tinydb"
 
     def __init__(self, db_path: str = None):
         """
@@ -38,7 +44,7 @@ class TinyDBMemoryAdapter(MemoryStore):
             self.db = TinyDB(db_path)
 
         # Create a table for memory items
-        self.items_table = self.db.table('memory_items')
+        self.items_table = self.db.table("memory_items")
 
         logger.info("TinyDB Memory Adapter initialized")
 
@@ -54,15 +60,15 @@ class TinyDBMemoryAdapter(MemoryStore):
         """
         # Handle both enum and string types for memory_type
         memory_type_value = item.memory_type
-        if hasattr(item.memory_type, 'value'):
+        if hasattr(item.memory_type, "value"):
             memory_type_value = item.memory_type.value
 
         return {
-            'id': item.id,
-            'content': item.content,
-            'memory_type': memory_type_value,
-            'metadata': item.metadata,
-            'created_at': item.created_at.isoformat() if item.created_at else None
+            "id": item.id,
+            "content": item.content,
+            "memory_type": memory_type_value,
+            "metadata": item.metadata,
+            "created_at": item.created_at.isoformat() if item.created_at else None,
         }
 
     def _dict_to_memory_item(self, item_dict: Dict[str, Any]) -> MemoryItem:
@@ -78,11 +84,15 @@ class TinyDBMemoryAdapter(MemoryStore):
         from datetime import datetime
 
         return MemoryItem(
-            id=item_dict['id'],
-            content=item_dict['content'],
-            memory_type=MemoryType(item_dict['memory_type']),
-            metadata=item_dict['metadata'],
-            created_at=datetime.fromisoformat(item_dict['created_at']) if item_dict['created_at'] else None
+            id=item_dict["id"],
+            content=item_dict["content"],
+            memory_type=MemoryType(item_dict["memory_type"]),
+            metadata=item_dict["metadata"],
+            created_at=(
+                datetime.fromisoformat(item_dict["created_at"])
+                if item_dict["created_at"]
+                else None
+            ),
         )
 
     def store(self, item: MemoryItem, transaction_id: str = None) -> str:
@@ -106,14 +116,17 @@ class TinyDBMemoryAdapter(MemoryStore):
         # Check if this operation is part of a transaction
         if transaction_id:
             # Check if this is the active transaction
-            if not hasattr(self, '_transaction_id') or self._transaction_id != transaction_id:
+            if (
+                not hasattr(self, "_transaction_id")
+                or self._transaction_id != transaction_id
+            ):
                 raise MemoryTransactionError(
                     f"Transaction {transaction_id} is not active",
                     transaction_id=transaction_id,
                     store_type="TinyDBMemoryAdapter",
-                    operation="store"
+                    operation="store",
                 )
-                
+
             # Store the item in memory but don't commit to disk yet
             # Check if the item already exists
             existing = self.items_table.get(Query().id == item.id)
@@ -123,8 +136,10 @@ class TinyDBMemoryAdapter(MemoryStore):
             else:
                 # Insert a new item
                 self.items_table.insert(item_dict)
-                
-            logger.info(f"Stored memory item with ID {item.id} in TinyDB Memory Adapter (transaction: {transaction_id})")
+
+            logger.info(
+                f"Stored memory item with ID {item.id} in TinyDB Memory Adapter (transaction: {transaction_id})"
+            )
         else:
             # Not part of a transaction, store normally
             # Check if the item already exists
@@ -135,9 +150,11 @@ class TinyDBMemoryAdapter(MemoryStore):
             else:
                 # Insert a new item
                 self.items_table.insert(item_dict)
-                
-            logger.info(f"Stored memory item with ID {item.id} in TinyDB Memory Adapter")
-            
+
+            logger.info(
+                f"Stored memory item with ID {item.id} in TinyDB Memory Adapter"
+            )
+
         return item.id
 
     def retrieve(self, item_id: str) -> Optional[MemoryItem]:
@@ -172,17 +189,17 @@ class TinyDBMemoryAdapter(MemoryStore):
         for key, value in query.items():
             if key == "type":
                 # Handle memory_type specially
-                condition = (tinydb_query.memory_type == value.value)
+                condition = tinydb_query.memory_type == value.value
             elif key.startswith("metadata."):
                 # Handle nested metadata fields
                 metadata_key = key.split(".", 1)[1]
-                condition = (tinydb_query.metadata[metadata_key] == value)
+                condition = tinydb_query.metadata[metadata_key] == value
             elif key in ["id", "content", "created_at"]:
                 # Handle direct fields
-                condition = (getattr(tinydb_query, key) == value)
+                condition = getattr(tinydb_query, key) == value
             else:
                 # Assume it's a metadata field
-                condition = (tinydb_query.metadata[key] == value)
+                condition = tinydb_query.metadata[key] == value
 
             # Combine conditions with AND
             if query_conditions is None:
@@ -209,32 +226,39 @@ class TinyDBMemoryAdapter(MemoryStore):
 
         Returns:
             True if the item was deleted, False otherwise
-            
+
         Raises:
             MemoryTransactionError: If the transaction is not active
         """
         # Check if this operation is part of a transaction
         if transaction_id:
             # Check if this is the active transaction
-            if not hasattr(self, '_transaction_id') or self._transaction_id != transaction_id:
+            if (
+                not hasattr(self, "_transaction_id")
+                or self._transaction_id != transaction_id
+            ):
                 raise MemoryTransactionError(
                     f"Transaction {transaction_id} is not active",
                     transaction_id=transaction_id,
                     store_type="TinyDBMemoryAdapter",
-                    operation="delete"
+                    operation="delete",
                 )
-                
+
             # Delete the item in memory but don't commit to disk yet
             removed = self.items_table.remove(Query().id == item_id)
             if removed:
-                logger.info(f"Deleted memory item with ID {item_id} from TinyDB Memory Adapter (transaction: {transaction_id})")
+                logger.info(
+                    f"Deleted memory item with ID {item_id} from TinyDB Memory Adapter (transaction: {transaction_id})"
+                )
                 return True
             return False
         else:
             # Not part of a transaction, delete normally
             removed = self.items_table.remove(Query().id == item_id)
             if removed:
-                logger.info(f"Deleted memory item with ID {item_id} from TinyDB Memory Adapter")
+                logger.info(
+                    f"Deleted memory item with ID {item_id} from TinyDB Memory Adapter"
+                )
                 return True
             return False
 
@@ -277,10 +301,10 @@ class TinyDBMemoryAdapter(MemoryStore):
 
         # Build TinyDB query
         tinydb_query = Query()
-        query_conditions = (tinydb_query.memory_type == item_type)
+        query_conditions = tinydb_query.memory_type == item_type
 
         for key, value in search_meta.items():
-            condition = (tinydb_query.metadata[key] == value)
+            condition = tinydb_query.metadata[key] == value
             query_conditions &= condition
 
         results = self.items_table.search(query_conditions)
@@ -296,177 +320,190 @@ class TinyDBMemoryAdapter(MemoryStore):
     def close(self):
         """Close the TinyDB database."""
         self.db.close()
-        
+
     def get_all(self) -> List[MemoryItem]:
         """
         Get all memory items from TinyDB.
-        
+
         Returns:
             A list of all memory items
         """
         results = self.items_table.all()
         return [self._dict_to_memory_item(item_dict) for item_dict in results]
-        
+
     def begin_transaction(self, transaction_id: str) -> str:
         """
         Begin a transaction.
-        
+
         Args:
             transaction_id: The ID of the transaction
-            
+
         Returns:
             The transaction ID
-            
+
         Raises:
             MemoryTransactionError: If the transaction cannot be started
         """
         logger.debug(f"Beginning transaction {transaction_id} in TinyDBMemoryAdapter")
-        
+
         # Store the transaction ID and create a snapshot of the current state
         self._transaction_id = transaction_id
         self._transaction_snapshot = {
             item.id: deepcopy(item) for item in self.get_all()
         }
-        
+
         return transaction_id
-        
+
     def prepare_commit(self, transaction_id: str) -> bool:
         """
         Prepare to commit a transaction.
-        
+
         This is the first phase of a two-phase commit protocol.
-        
+
         Args:
             transaction_id: The ID of the transaction
-            
+
         Returns:
             True if the transaction is prepared for commit
-            
+
         Raises:
             MemoryTransactionError: If the transaction cannot be prepared
         """
-        logger.debug(f"Preparing to commit transaction {transaction_id} in TinyDBMemoryAdapter")
-        
+        logger.debug(
+            f"Preparing to commit transaction {transaction_id} in TinyDBMemoryAdapter"
+        )
+
         # Check if this is the active transaction
-        if not hasattr(self, '_transaction_id') or self._transaction_id != transaction_id:
+        if (
+            not hasattr(self, "_transaction_id")
+            or self._transaction_id != transaction_id
+        ):
             raise MemoryTransactionError(
                 f"Transaction {transaction_id} is not active",
                 transaction_id=transaction_id,
                 store_type="TinyDBMemoryAdapter",
-                operation="prepare_commit"
+                operation="prepare_commit",
             )
-            
+
         # TinyDB doesn't have a native prepare phase, so we just return True
         return True
-        
+
     def commit_transaction(self, transaction_id: str) -> bool:
         """
         Commit a transaction.
-        
+
         Args:
             transaction_id: The ID of the transaction
-            
+
         Returns:
             True if the transaction was committed
-            
+
         Raises:
             MemoryTransactionError: If the transaction cannot be committed
         """
         logger.debug(f"Committing transaction {transaction_id} in TinyDBMemoryAdapter")
-        
+
         # Check if this is the active transaction
-        if not hasattr(self, '_transaction_id') or self._transaction_id != transaction_id:
+        if (
+            not hasattr(self, "_transaction_id")
+            or self._transaction_id != transaction_id
+        ):
             raise MemoryTransactionError(
                 f"Transaction {transaction_id} is not active",
                 transaction_id=transaction_id,
                 store_type="TinyDBMemoryAdapter",
-                operation="commit_transaction"
+                operation="commit_transaction",
             )
-            
+
         # TinyDB doesn't have native transaction support, so we just clear the snapshot
-        if hasattr(self, '_transaction_snapshot'):
-            delattr(self, '_transaction_snapshot')
-            
+        if hasattr(self, "_transaction_snapshot"):
+            delattr(self, "_transaction_snapshot")
+
         # Clear the transaction ID
-        delattr(self, '_transaction_id')
-        
+        delattr(self, "_transaction_id")
+
         return True
-        
+
     def rollback_transaction(self, transaction_id: str) -> bool:
         """
         Rollback a transaction.
-        
+
         Args:
             transaction_id: The ID of the transaction
-            
+
         Returns:
             True if the transaction was rolled back
-            
+
         Raises:
             MemoryTransactionError: If the transaction cannot be rolled back
         """
-        logger.debug(f"Rolling back transaction {transaction_id} in TinyDBMemoryAdapter")
-        
+        logger.debug(
+            f"Rolling back transaction {transaction_id} in TinyDBMemoryAdapter"
+        )
+
         # Check if this is the active transaction
-        if not hasattr(self, '_transaction_id') or self._transaction_id != transaction_id:
+        if (
+            not hasattr(self, "_transaction_id")
+            or self._transaction_id != transaction_id
+        ):
             raise MemoryTransactionError(
                 f"Transaction {transaction_id} is not active",
                 transaction_id=transaction_id,
                 store_type="TinyDBMemoryAdapter",
-                operation="rollback_transaction"
+                operation="rollback_transaction",
             )
-            
+
         # Restore from snapshot if available
-        if hasattr(self, '_transaction_snapshot'):
+        if hasattr(self, "_transaction_snapshot"):
             # Clear the table
             self.items_table.truncate()
-            
+
             # Restore items from snapshot
             for item in self._transaction_snapshot.values():
                 self.store(item)
-                
+
             # Clear the snapshot
-            delattr(self, '_transaction_snapshot')
-            
+            delattr(self, "_transaction_snapshot")
+
         # Clear the transaction ID
-        delattr(self, '_transaction_id')
+        delattr(self, "_transaction_id")
 
         return True
 
     def is_transaction_active(self, transaction_id: str) -> bool:
         """Return True if the given transaction ID is currently active."""
 
-        return hasattr(self, '_transaction_id') and self._transaction_id == transaction_id
+        return (
+            hasattr(self, "_transaction_id") and self._transaction_id == transaction_id
+        )
 
     def snapshot(self) -> Dict[str, MemoryItem]:
         """
         Create a snapshot of the current state.
-        
+
         Returns:
             A dictionary mapping item IDs to memory items
         """
-        return {
-            item.id: deepcopy(item) for item in self.get_all()
-        }
-        
+        return {item.id: deepcopy(item) for item in self.get_all()}
+
     def restore(self, snapshot: Dict[str, MemoryItem]) -> bool:
         """
         Restore from a snapshot.
-        
+
         Args:
             snapshot: A dictionary mapping item IDs to memory items
-            
+
         Returns:
             True if the restore was successful
         """
         if snapshot is None:
             return False
-            
+
         # Clear the table
         self.items_table.truncate()
-        
+
         # Restore items from snapshot
         for item in snapshot.values():
             self.store(item)
-            
+
         return True

--- a/src/devsynth/config/settings.py
+++ b/src/devsynth/config/settings.py
@@ -160,6 +160,9 @@ class Settings(BaseSettings):
             "memory_store_type": lambda s: os.environ.get(
                 "DEVSYNTH_MEMORY_STORE", "memory"
             ),
+            "s3_bucket_name": lambda s: os.environ.get(
+                "DEVSYNTH_S3_BUCKET", s.s3_bucket_name
+            ),
             # Expose configurable Kuzu settings with environment overrides
             "kuzu_db_path": lambda s: os.environ.get(
                 "DEVSYNTH_KUZU_DB_PATH", s.kuzu_db_path
@@ -197,6 +200,9 @@ class Settings(BaseSettings):
     )
     memory_file_path: str = Field(
         default=None, json_schema_extra={"env": "DEVSYNTH_MEMORY_PATH"}
+    )
+    s3_bucket_name: Optional[str] = Field(
+        default=None, json_schema_extra={"env": "DEVSYNTH_S3_BUCKET"}
     )
     kuzu_db_path: Optional[str] = Field(
         default=None, json_schema_extra={"env": "DEVSYNTH_KUZU_DB_PATH"}

--- a/tests/integration/memory/test_s3_backend_selection.py
+++ b/tests/integration/memory/test_s3_backend_selection.py
@@ -1,0 +1,29 @@
+import pytest
+
+from devsynth.application.memory.memory_manager import MemoryManager
+from devsynth.domain.models.memory import MemoryType
+
+pytest.importorskip("boto3")
+pytest.importorskip("moto")
+from moto import mock_s3
+
+
+@pytest.mark.fast
+def test_memory_manager_selects_s3_backend(monkeypatch):
+    """Ensure MemoryManager uses the S3 adapter when configured. ReqID: additional-storage-backends-1"""
+    import boto3
+
+    bucket = "devsynth-test"
+    monkeypatch.setenv("DEVSYNTH_MEMORY_STORE", "s3")
+    monkeypatch.setenv("DEVSYNTH_S3_BUCKET", bucket)
+
+    with mock_s3():
+        client = boto3.client("s3", region_name="us-east-1")
+        client.create_bucket(Bucket=bucket)
+
+        manager = MemoryManager()
+        assert "s3" in manager.adapters
+
+        item_id = manager.store_with_edrr_phase("data", MemoryType.CODE, "EXPAND")
+        retrieved = manager.retrieve(item_id)
+        assert retrieved and retrieved.content == "data"


### PR DESCRIPTION
## Summary
- introduce `StorageAdapter` protocol and S3-backed adapter
- allow `MemoryManager` to auto-select S3 via configuration
- document backend configuration and provide usage example

## Testing
- `poetry run pre-commit run --files docs/specifications/additional-storage-backends.md docs/user_guides/configuration_reference.md docs/user_guides/user_guide.md src/devsynth/application/memory/adapters/__init__.py src/devsynth/application/memory/adapters/tinydb_memory_adapter.py src/devsynth/application/memory/memory_manager.py src/devsynth/config/settings.py examples/s3_memory_backend_example.py src/devsynth/application/memory/adapters/s3_memory_adapter.py src/devsynth/application/memory/adapters/storage_adapter.py tests/integration/memory/test_s3_backend_selection.py`
- `poetry run devsynth run-tests --speed=fast` (fails: ModuleNotFoundError: No module named 'devsynth')
- `poetry run python tests/verify_test_organization.py`
- `poetry run python scripts/verify_test_markers.py`
- `poetry run python scripts/verify_requirements_traceability.py`
- `poetry run python scripts/verify_version_sync.py`


------
https://chatgpt.com/codex/tasks/task_e_68a87c2e2e5083338f7172cacb343ce1