### PR TITLE
feat: add performance scalability benchmarks

### DIFF
--- a/docs/performance/performance_and_scalability_testing.md
+++ b/docs/performance/performance_and_scalability_testing.md
@@ -1,0 +1,39 @@
+# Performance and Scalability Testing
+
+DevSynth captures repeatable benchmarks for core operations. This guide explains how to run the benchmarks and interpret their results.
+
+## Running the benchmarks
+
+Use the `pytest-benchmark` plugin to execute the baseline and scalability tests:
+
+```bash
+poetry run pytest tests/performance/test_performance_metrics.py
+```
+
+To generate metrics files directly:
+
+```bash
+poetry run python - <<'PY'
+from pathlib import Path
+from devsynth.application.performance import (
+    capture_baseline_metrics,
+    capture_scalability_metrics,
+)
+
+capture_baseline_metrics(100000, output_path=Path("docs/performance/baseline_metrics.json"))
+capture_scalability_metrics(
+    [10000, 100000, 1000000],
+    output_path=Path("docs/performance/scalability_metrics.json"),
+)
+PY
+```
+
+## Interpreting results
+
+Each metrics file stores:
+
+- `workload`: number of operations executed
+- `duration_seconds`: elapsed wall-clock time
+- `throughput_ops_per_s`: operations per second
+
+Higher throughput indicates better performance. Compare metrics across commits to detect regressions or scalability issues.

--- a/src/devsynth/application/performance/__init__.py
+++ b/src/devsynth/application/performance/__init__.py
@@ -3,15 +3,17 @@
 from __future__ import annotations
 
 import json
+import time
 from pathlib import Path
 from typing import Dict, Iterable, List
 
-OPS_PER_SECOND = 9_000_000
 
-
-def _simulate_duration(workload: int, ops_per_second: float = OPS_PER_SECOND) -> float:
-    """Return a deterministic duration for the workload."""
-    return workload / ops_per_second
+def _run_workload(workload: int) -> None:
+    """Execute a CPU-bound workload to benchmark."""
+    total = 0
+    for i in range(workload):
+        total += i * i
+    return total
 
 
 def capture_baseline_metrics(
@@ -20,13 +22,15 @@ def capture_baseline_metrics(
     """Capture baseline metrics for a workload.
 
     Args:
-        workload: Number of operations to simulate.
+        workload: Number of operations to execute.
         output_path: Optional path to write the metrics JSON.
 
     Returns:
         Metrics dictionary with workload, duration, and throughput.
     """
-    duration = _simulate_duration(workload)
+    start = time.perf_counter()
+    _run_workload(workload)
+    duration = time.perf_counter() - start
     throughput = workload / duration if duration else 0.0
     metrics = {
         "workload": workload,
@@ -53,7 +57,9 @@ def capture_scalability_metrics(
     """
     results = []
     for workload in workloads:
-        duration = _simulate_duration(workload)
+        start = time.perf_counter()
+        _run_workload(workload)
+        duration = time.perf_counter() - start
         throughput = workload / duration if duration else 0.0
         results.append(
             {

--- a/tests/performance/test_performance_metrics.py
+++ b/tests/performance/test_performance_metrics.py
@@ -1,0 +1,33 @@
+"""Stress tests for performance metrics. ReqID: PERF-05"""
+
+import time
+
+import pytest
+
+from devsynth.application.performance import (
+    capture_baseline_metrics,
+    capture_scalability_metrics,
+)
+
+
+@pytest.mark.slow
+def test_baseline_metrics(tmp_path):
+    """Baseline metrics include throughput. ReqID: PERF-05"""
+    path = tmp_path / "baseline.json"
+    start = time.perf_counter()
+    result = capture_baseline_metrics(100000, output_path=path)
+    elapsed = time.perf_counter() - start
+    assert result["throughput_ops_per_s"] > 0
+    assert elapsed >= result["duration_seconds"]
+
+
+@pytest.mark.slow
+def test_scalability_metrics(tmp_path):
+    """Scalability metrics cover multiple workloads. ReqID: PERF-05"""
+    path = tmp_path / "scalability.json"
+    workloads = [10000, 100000, 1000000]
+    start = time.perf_counter()
+    results = capture_scalability_metrics(workloads, output_path=path)
+    elapsed = time.perf_counter() - start
+    assert len(results) == len(workloads)
+    assert elapsed >= max(r["duration_seconds"] for r in results)


### PR DESCRIPTION
## Summary
- measure baseline and scalability workloads with runtime metrics
- add stress tests for throughput and multi workload metrics
- document running and interpreting performance benchmarks

## Testing
- `poetry run pre-commit run --files src/devsynth/application/performance/__init__.py docs/performance/performance_and_scalability_testing.md tests/performance/test_performance_metrics.py`
- `poetry run devsynth run-tests --target behavior-tests --speed=slow`
- `poetry run pytest tests/performance/test_performance_metrics.py tests/behavior/steps/test_performance_and_scalability_steps.py -m "slow" --cov=src/devsynth --cov-report=term-missing --cov-fail-under=0`
- `poetry run python tests/verify_test_organization.py`
- `poetry run python scripts/verify_test_markers.py`
- `poetry run python scripts/verify_requirements_traceability.py`
- `poetry run python scripts/verify_version_sync.py`


------
https://chatgpt.com/codex/tasks/task_e_68a87c358cf8833385f40caa774f06e9