### PR TITLE
fix: guard LM Studio tests and clarify provider availability

### DIFF
--- a/docs/developer_guides/testing.md
+++ b/docs/developer_guides/testing.md
@@ -466,6 +466,9 @@ variables like `DEVSYNTH_RESOURCE_LMSTUDIO_AVAILABLE` and
 resources enabled:
 
 ```bash
+# Install LM Studio optional dependency and start the server
+poetry install --extras lmstudio
+# (start LM Studio in API mode before running tests)
 
 # Provide an OpenAI API key
 

--- a/src/devsynth/adapters/provider_system.py
+++ b/src/devsynth/adapters/provider_system.py
@@ -936,8 +936,12 @@ class LMStudioProvider(BaseProvider):
                 on_retry=self._emit_retry_telemetry,
             )(_api_call)()
         except requests.exceptions.RequestException as e:
-            logger.error(f"LM Studio API error: {e}")
-            raise ProviderError(f"LM Studio API error: {e}")
+            msg = (
+                f"LM Studio endpoint {self.endpoint} is unreachable. "
+                "Ensure the server is running."
+            )
+            logger.error("%s: %s", msg, e)
+            raise ProviderError(msg) from e
 
     async def acomplete(
         self,
@@ -1043,16 +1047,20 @@ class LMStudioProvider(BaseProvider):
                     await asyncio.sleep(delay)
 
             # If we've exhausted all retries, raise the last exception
-            logger.error(
-                f"LM Studio API error after {max_retries} retries: {last_exception}"
+            msg = (
+                f"LM Studio endpoint {self.endpoint} is unreachable after {max_retries} "
+                f"retries: {last_exception}"
             )
-            raise ProviderError(
-                f"LM Studio API error after {max_retries} retries: {last_exception}"
-            )
+            logger.error(msg)
+            raise ProviderError(msg)
 
         except httpx.HTTPError as e:
-            logger.error(f"LM Studio API error: {e}")
-            raise ProviderError(f"LM Studio API error: {e}")
+            msg = (
+                f"LM Studio endpoint {self.endpoint} is unreachable. "
+                "Ensure the server is running."
+            )
+            logger.error("%s: %s", msg, e)
+            raise ProviderError(msg) from e
 
     def complete_with_context(
         self,
@@ -1130,8 +1138,12 @@ class LMStudioProvider(BaseProvider):
                 on_retry=self._emit_retry_telemetry,
             )(_api_call)()
         except requests.exceptions.RequestException as e:
-            logger.error(f"LM Studio embedding API error: {e}")
-            raise ProviderError(f"LM Studio embedding API error: {e}")
+            msg = (
+                f"LM Studio endpoint {self.endpoint} is unreachable. "
+                "Ensure the server is running."
+            )
+            logger.error("%s: %s", msg, e)
+            raise ProviderError(msg) from e
 
     async def aembed(self, text: Union[str, List[str]]) -> List[List[float]]:
         """Asynchronously generate embeddings using the LM Studio API."""
@@ -1200,16 +1212,20 @@ class LMStudioProvider(BaseProvider):
                     await asyncio.sleep(delay)
 
             # If we've exhausted all retries, raise the last exception
-            logger.error(
-                f"LM Studio embedding API error after {max_retries} retries: {last_exception}"
+            msg = (
+                f"LM Studio endpoint {self.endpoint} is unreachable after {max_retries} "
+                f"retries: {last_exception}"
             )
-            raise ProviderError(
-                f"LM Studio embedding API error after {max_retries} retries: {last_exception}"
-            )
+            logger.error(msg)
+            raise ProviderError(msg)
 
         except httpx.HTTPError as e:
-            logger.error(f"LM Studio embedding API error: {e}")
-            raise ProviderError(f"LM Studio embedding API error: {e}")
+            msg = (
+                f"LM Studio endpoint {self.endpoint} is unreachable. "
+                "Ensure the server is running."
+            )
+            logger.error("%s: %s", msg, e)
+            raise ProviderError(msg) from e
 
 
 class FallbackProvider(BaseProvider):

--- a/src/devsynth/application/llm/providers.py
+++ b/src/devsynth/application/llm/providers.py
@@ -1,12 +1,15 @@
-from typing import Any, Dict, List, Optional
-import httpx
-from ...domain.interfaces.llm import LLMProvider, LLMProviderFactory
 import os
-from devsynth.core.config_loader import load_config
+from typing import Any, Dict, List, Optional
+
+import httpx
+
 from devsynth.config import get_llm_settings
+from devsynth.core.config_loader import load_config
 
 # Create a logger for this module
 from devsynth.logging_setup import DevSynthLogger
+
+from ...domain.interfaces.llm import LLMProvider, LLMProviderFactory
 
 logger = DevSynthLogger(__name__)
 from devsynth.exceptions import DevSynthError
@@ -178,6 +181,10 @@ class SimpleLLMProviderFactory(LLMProviderFactory):
     ) -> LLMProvider:
         """Create an LLM provider of the specified type."""
         if provider_type not in self.provider_types:
+            if provider_type == "lmstudio":
+                raise ValidationError(
+                    "LMStudio provider is unavailable. Install the 'lmstudio' package to enable this provider."
+                )
             raise ValidationError(f"Unknown provider type: {provider_type}")
 
         provider_class = self.provider_types[provider_type]
@@ -209,9 +216,9 @@ try:  # pragma: no cover - optional dependency
 except ImportError as exc:  # pragma: no cover - fallback path
     LMStudioProvider = None
     logger.warning("LMStudioProvider not available: %s", exc)
-from .openai_provider import OpenAIProvider
 from .local_provider import LocalProvider
 from .offline_provider import OfflineProvider
+from .openai_provider import OpenAIProvider
 
 # Create factory instance
 factory = SimpleLLMProviderFactory()

--- a/tests/unit/application/llm/test_import_without_lmstudio.py
+++ b/tests/unit/application/llm/test_import_without_lmstudio.py
@@ -7,7 +7,9 @@ import pytest
 
 @pytest.mark.medium
 def test_import_lmstudio_provider_without_lmstudio_succeeds(monkeypatch):
-    """Importing providers should succeed without lmstudio installed."""
+    """Importing providers should succeed without lmstudio installed.
+
+    ReqID: LMSTUDIO-2"""
     sys.modules.pop("devsynth.application.llm.providers", None)
     sys.modules.pop("devsynth.application.llm.lmstudio_provider", None)
     sys.modules.pop("lmstudio", None)
@@ -22,3 +24,26 @@ def test_import_lmstudio_provider_without_lmstudio_succeeds(monkeypatch):
     providers = importlib.import_module("devsynth.application.llm.providers")
     assert providers.LMStudioProvider is None
     assert "lmstudio" not in providers.factory.provider_types
+
+
+@pytest.mark.medium
+def test_factory_missing_lmstudio_provider_raises_clear_error(monkeypatch):
+    """Requesting LM Studio provider without SDK yields a helpful error.
+
+    ReqID: LMSTUDIO-3"""
+    sys.modules.pop("devsynth.application.llm.providers", None)
+    sys.modules.pop("devsynth.application.llm.lmstudio_provider", None)
+    sys.modules.pop("lmstudio", None)
+    real_import = builtins.__import__
+
+    def fake_import(name, globals=None, locals=None, fromlist=(), level=0):
+        if name.startswith("lmstudio"):
+            raise ImportError("No module named 'lmstudio'")
+        return real_import(name, globals, locals, fromlist, level)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+    providers = importlib.import_module("devsynth.application.llm.providers")
+    with pytest.raises(
+        providers.ValidationError, match="LMStudio provider is unavailable"
+    ):
+        providers.factory.create_provider("lmstudio")

--- a/tests/unit/general/test_lmstudio_service.py
+++ b/tests/unit/general/test_lmstudio_service.py
@@ -2,9 +2,13 @@ from __future__ import annotations
 
 import pytest
 
-pytestmark = [pytest.mark.fast]
+pytest.importorskip("lmstudio")
+
+pytestmark = [pytest.mark.fast, pytest.mark.requires_resource("lmstudio")]
 
 
 def test_lmstudio_mock_fixture_returns_base_url(lmstudio_mock):
-    """Ensure the mock service fixture provides a usable base URL."""
+    """Ensure the mock service fixture provides a usable base URL.
+
+    ReqID: LMSTUDIO-1"""
     assert lmstudio_mock.base_url


### PR DESCRIPTION
## Summary
- skip LM Studio service tests when SDK is missing
- raise explicit errors when LM Studio provider is unavailable
- document optional LM Studio setup for test runs

## Testing
- `poetry run pre-commit run --files src/devsynth/adapters/provider_system.py src/devsynth/application/llm/providers.py tests/unit/general/test_lmstudio_service.py tests/unit/application/llm/test_import_without_lmstudio.py docs/developer_guides/testing.md`
- `PYTEST_ADDOPTS="--no-cov" poetry run pytest tests/unit/general/test_lmstudio_service.py tests/unit/application/llm/test_import_without_lmstudio.py -q`
- `poetry run python tests/verify_test_organization.py`
- `poetry run python scripts/verify_test_markers.py`
- `poetry run python scripts/verify_requirements_traceability.py`
- `poetry run python scripts/verify_version_sync.py`


------
https://chatgpt.com/codex/tasks/task_e_68a87c39ab088333b7c30ef78785b31d