### PR TITLE
feat: guard optional providers in run-tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -389,6 +389,9 @@ poetry run devsynth run-tests
 poetry run devsynth run-tests --maxfail 1  # optional early exit
 ```
 
+Optional provider tests such as LM Studio are disabled unless explicitly
+enabled. Set `DEVSYNTH_RESOURCE_LMSTUDIO_AVAILABLE=true` to opt in.
+
 The legacy `scripts/run_all_tests.py` wrapper remains for backward compatibility but will be removed in a future release.
 
 ### Updating the coverage badge

--- a/docs/developer_guides/testing.md
+++ b/docs/developer_guides/testing.md
@@ -288,8 +288,9 @@ poetry run pytest -q
 Always run tests with `poetry run devsynth run-tests --speed=<cat>`. Use `--maxfail <n>` to exit after a set number of failures. If `pytest` reports missing packages, run `poetry install` to restore them.
 
 The `devsynth run-tests` command disables optional provider tests by default so
-missing services won't stall the suite. For example, LM Studio tests are
-skipped unless explicitly enabled:
+missing services won't stall the suite. It sets
+`DEVSYNTH_RESOURCE_LMSTUDIO_AVAILABLE=false` unless you override it, so LM
+Studio tests are skipped unless explicitly enabled:
 
 ```bash
 poetry run devsynth run-tests --speed=fast  # LM Studio tests skipped

--- a/src/devsynth/application/cli/commands/run_tests_cmd.py
+++ b/src/devsynth/application/cli/commands/run_tests_cmd.py
@@ -45,17 +45,21 @@ def _parse_feature_options(values: List[str]) -> Dict[str, bool]:
     return result
 
 
+OPTIONAL_PROVIDER_ENV_VARS = ["DEVSYNTH_RESOURCE_LMSTUDIO_AVAILABLE"]
+
+
 def _configure_optional_providers() -> None:
     """Disable tests for missing optional providers.
 
     Some test suites depend on services like LM Studio. When those services or
-    their Python packages aren't available, running the tests can hang while
-    the runner waits for an unavailable resource. We default these optional
-    resources to "false" unless explicitly enabled by the user to ensure the
+    their Python packages aren't available, running the tests can hang while the
+    runner waits for an unavailable resource. We default these optional
+    resources to ``false`` unless explicitly enabled by the user to ensure the
     corresponding tests are skipped rather than stalling the run.
     """
 
-    os.environ.setdefault("DEVSYNTH_RESOURCE_LMSTUDIO_AVAILABLE", "false")
+    for env_var in OPTIONAL_PROVIDER_ENV_VARS:
+        os.environ.setdefault(env_var, "false")
 
 
 def run_tests_cmd(

--- a/tests/behavior/features/devsynth_run_tests_command.feature
+++ b/tests/behavior/features/devsynth_run_tests_command.feature
@@ -1,8 +1,8 @@
 Feature: devsynth run-tests command
   Verify the run-tests command handles missing optional dependencies.
 
-  Scenario: run-tests succeeds without optional LLM providers
-    Given the environment variable "DEVSYNTH_RESOURCE_LMSTUDIO_AVAILABLE" is "false"
+  Scenario: run-tests defaults to skipping optional LM Studio tests
+    Given the environment variable "DEVSYNTH_RESOURCE_LMSTUDIO_AVAILABLE" is unset
     When I invoke "devsynth run-tests --target unit-tests --speed=fast --no-parallel"
     Then the command should succeed
 

--- a/tests/behavior/steps/test_run_tests_steps.py
+++ b/tests/behavior/steps/test_run_tests_steps.py
@@ -20,6 +20,12 @@ def set_env(name: str, value: str, monkeypatch) -> None:
     monkeypatch.setenv(name, value)
 
 
+@given(parsers.parse('the environment variable "{name}" is unset'))
+def unset_env(name: str, monkeypatch) -> None:
+    """Remove an environment variable for the command invocation."""
+    monkeypatch.delenv(name, raising=False)
+
+
 @when('I invoke "devsynth run-tests --target unit-tests --speed=fast --no-parallel"')
 def invoke_run_tests(command_result: Dict[str, str]) -> None:
     env = os.environ.copy()


### PR DESCRIPTION
## Summary
- default optional providers like LM Studio to disabled in `devsynth run-tests`
- cover run-tests fallback behavior in BDD scenario
- document run-tests optional provider usage and fallback

## Testing
- `poetry run pre-commit run --files README.md docs/developer_guides/testing.md src/devsynth/application/cli/commands/run_tests_cmd.py tests/behavior/features/devsynth_run_tests_command.feature tests/behavior/steps/test_run_tests_steps.py`
- `poetry run devsynth run-tests --target unit-tests --speed=fast --no-parallel` *(fails: Required test coverage of 60% not reached)*
- `poetry run python tests/verify_test_organization.py`
- `poetry run python scripts/verify_test_markers.py`
- `poetry run python scripts/verify_requirements_traceability.py`
- `poetry run python scripts/verify_version_sync.py`


------
https://chatgpt.com/codex/tasks/task_e_68a87c27853c833399f21a13d6157e9c