### PR TITLE
fix: allow TinyDB transactions without explicit ids

### DIFF
--- a/dialectical_audit.log
+++ b/dialectical_audit.log
@@ -29,5 +29,7 @@
     "Release checklist re-run 2025-08-21: environment setup and pip check succeeded; fast tests failed (missing tests/tmp_speed_dummy.py); medium and slow test runs terminated after LMStudioProvider warnings; marker verification interrupted; deployment tests failed coverage; release prep interrupted; release state check reported missing tag.",
     "Termination proof for dialectical reasoner hooks documented and tests added 2025-08-21.",
     "2025-08-22: tests/unit/deployment coverage improved to 100% with security hardening tests."
+    ,
+    "2025-08-22: TinyDBMemoryAdapter transaction lifecycle fixed to auto-generate IDs; regression test added."
   ]
 }

--- a/tests/unit/application/memory/test_memory_adapters_regression.py
+++ b/tests/unit/application/memory/test_memory_adapters_regression.py
@@ -16,6 +16,7 @@ from devsynth.exceptions import MemoryTransactionError
 @pytest.mark.parametrize("adapter_cls", [TinyDBMemoryAdapter, GraphMemoryAdapter])
 @pytest.mark.medium
 def test_store_retrieve_search_update(adapter_cls, tmp_path):
+    """ReqID: FR-44"""
     if adapter_cls is GraphMemoryAdapter:
         adapter = adapter_cls(base_path=tmp_path)
     else:
@@ -40,6 +41,7 @@ def test_store_retrieve_search_update(adapter_cls, tmp_path):
 
 @pytest.mark.medium
 def test_vector_adapter_operations():
+    """ReqID: FR-47"""
     adapter = VectorMemoryAdapter()
     vector = MemoryVector(
         id="", content="doc", embedding=[0.1, 0.2, 0.3], metadata={"kind": "test"}
@@ -54,7 +56,10 @@ def test_vector_adapter_operations():
 
 @pytest.mark.medium
 def test_tinydb_adapter_transaction_support(tmp_path):
-    """Test transaction support in TinyDBMemoryAdapter."""
+    """Test transaction support in TinyDBMemoryAdapter.
+
+    ReqID: FR-44
+    """
     adapter = TinyDBMemoryAdapter(db_path=str(tmp_path / "db.json"))
     item1 = MemoryItem(
         id="test1",
@@ -68,8 +73,9 @@ def test_tinydb_adapter_transaction_support(tmp_path):
         memory_type=MemoryType.KNOWLEDGE,
         metadata={"tag": "transaction_test"},
     )
-    transaction_id = adapter.begin_transaction("tx1")
-    assert transaction_id == "tx1"
+    transaction_id = adapter.begin_transaction()
+    # Should auto-generate an identifier when none is provided
+    assert isinstance(transaction_id, str) and transaction_id
     adapter.store(item1, transaction_id=transaction_id)
     retrieved = adapter.retrieve(item1.id)
     assert retrieved is not None


### PR DESCRIPTION
## Summary
- allow `TinyDBMemoryAdapter.begin_transaction` to auto-generate IDs and guard against nested transactions
- add regression coverage for TinyDB transaction lifecycle
- record transaction fix in dialectical audit log

## Testing
- `poetry run pre-commit run --files src/devsynth/application/memory/adapters/tinydb_memory_adapter.py tests/unit/application/memory/test_memory_adapters_regression.py dialectical_audit.log`
- `poetry run pytest tests/unit/application/memory/test_memory_adapters_regression.py::test_tinydb_adapter_transaction_support --cov-fail-under=0 -vv`
- `poetry run python tests/verify_test_organization.py`
- `poetry run python scripts/verify_test_markers.py`
- `poetry run python scripts/verify_requirements_traceability.py`
- `poetry run python scripts/verify_version_sync.py`
- `poetry run devsynth run-tests --speed=fast` *(fails: LMStudioProvider not available)*
- `poetry run devsynth run-tests --speed=medium` *(fails: LMStudioProvider not available)*

------
https://chatgpt.com/codex/tasks/task_e_68a8987b7ca08333a31366e4f04fc5c9