### PR TITLE
test: skip LMStudio tests when provider missing

### DIFF
--- a/tests/integration/general/test_error_handling_at_integration_points.py
+++ b/tests/integration/general/test_error_handling_at_integration_points.py
@@ -19,7 +19,7 @@ from devsynth.adapters.provider_system import LMStudioProvider as PS_LMStudioPro
 from devsynth.adapters.provider_system import OpenAIProvider, ProviderError
 from devsynth.application.llm.providers import LMStudioProvider
 
-pytestmark = [pytest.mark.medium]
+pytestmark = [pytest.mark.requires_resource("lmstudio"), pytest.mark.medium]
 from devsynth.application.agents.unified_agent import UnifiedAgent
 from devsynth.application.code_analysis.analyzer import CodeAnalyzer
 from devsynth.application.code_analysis.ast_transformer import AstTransformer

--- a/tests/integration/general/test_lmstudio_provider.py
+++ b/tests/integration/general/test_lmstudio_provider.py
@@ -9,7 +9,7 @@ pytest.importorskip("lmstudio")
 from devsynth.application.llm.providers import LMStudioProvider
 
 # LMStudio provider integration tests run at medium speed
-pytestmark = [pytest.mark.medium]
+pytestmark = [pytest.mark.requires_resource("lmstudio"), pytest.mark.medium]
 
 
 def _import_provider():

--- a/tests/integration/general/test_provider_system.py
+++ b/tests/integration/general/test_provider_system.py
@@ -28,6 +28,8 @@ from devsynth.adapters.provider_system import (
 )
 from devsynth.application.llm.providers import LMStudioProvider
 
+pytestmark = [pytest.mark.requires_resource("lmstudio")]
+
 
 class TestProviderConfig:
     """Test provider configuration loading.

--- a/tests/integration/general/test_provider_system_configurations.py
+++ b/tests/integration/general/test_provider_system_configurations.py
@@ -27,6 +27,8 @@ from devsynth.adapters.provider_system import (
 )
 from devsynth.application.llm.providers import LMStudioProvider
 
+pytestmark = [pytest.mark.requires_resource("lmstudio")]
+
 
 class TestProviderConfigurations:
     """Test the provider system with different LLM configurations.

--- a/tests/integration/llm/test_lmstudio_streaming.py
+++ b/tests/integration/llm/test_lmstudio_streaming.py
@@ -9,7 +9,7 @@ pytest.importorskip("lmstudio")
 from devsynth.application.llm.providers import LMStudioProvider
 
 # LM Studio streaming tests run at medium speed
-pytestmark = [pytest.mark.medium]
+pytestmark = [pytest.mark.requires_resource("lmstudio"), pytest.mark.medium]
 
 
 def _import_provider():

--- a/tests/unit/adapters/providers/test_embeddings.py
+++ b/tests/unit/adapters/providers/test_embeddings.py
@@ -14,6 +14,8 @@ from devsynth.adapters.provider_system import (
 
 pytest.importorskip("lmstudio")
 
+pytestmark = [pytest.mark.requires_resource("lmstudio")]
+
 
 @pytest.mark.medium
 def test_openai_provider_embed_calls_api_succeeds():

--- a/tests/unit/adapters/providers/test_provider_factory.py
+++ b/tests/unit/adapters/providers/test_provider_factory.py
@@ -2,7 +2,11 @@ import pytest
 
 pytest.importorskip("lmstudio")
 
-pytestmark = [pytest.mark.memory_intensive, pytest.mark.medium]
+pytestmark = [
+    pytest.mark.requires_resource("lmstudio"),
+    pytest.mark.memory_intensive,
+    pytest.mark.medium,
+]
 
 from devsynth.adapters.providers.provider_factory import (
     LMStudioProvider,

--- a/tests/unit/adapters/test_provider_factory.py
+++ b/tests/unit/adapters/test_provider_factory.py
@@ -12,6 +12,8 @@ from devsynth.adapters.provider_system import (
 
 pytest.importorskip("lmstudio")
 
+pytestmark = [pytest.mark.requires_resource("lmstudio")]
+
 
 @pytest.mark.medium
 def test_create_provider_env_fallback_has_expected(monkeypatch, caplog):

--- a/tests/unit/adapters/test_provider_factory_env_vars.py
+++ b/tests/unit/adapters/test_provider_factory_env_vars.py
@@ -9,6 +9,8 @@ from devsynth.adapters.provider_system import (
 
 pytest.importorskip("lmstudio")
 
+pytestmark = [pytest.mark.requires_resource("lmstudio")]
+
 
 @pytest.mark.medium
 def test_env_provider_openai_succeeds(monkeypatch):

--- a/tests/unit/adapters/test_provider_system.py
+++ b/tests/unit/adapters/test_provider_system.py
@@ -21,7 +21,10 @@ from devsynth.fallback import retry_with_exponential_backoff
 
 pytest.importorskip("lmstudio")
 
-pytestmark = [pytest.mark.memory_intensive]
+pytestmark = [
+    pytest.mark.requires_resource("lmstudio"),
+    pytest.mark.memory_intensive,
+]
 
 
 @pytest.mark.medium


### PR DESCRIPTION
## Summary
- default LM Studio resource flag to false when `lmstudio` package is absent
- guard LM Studio tests with `requires_resource("lmstudio")`

## Testing
- `poetry run pre-commit run --files src/devsynth/application/cli/commands/run_tests_cmd.py tests/integration/general/test_error_handling_at_integration_points.py tests/integration/general/test_lmstudio_provider.py tests/integration/general/test_provider_system.py tests/integration/general/test_provider_system_configurations.py tests/integration/llm/test_lmstudio_streaming.py tests/unit/adapters/providers/test_embeddings.py tests/unit/adapters/providers/test_provider_factory.py tests/unit/adapters/test_provider_factory.py tests/unit/adapters/test_provider_factory_env_vars.py tests/unit/adapters/test_provider_system.py`
- `poetry run pytest tests/behavior/features/devsynth_run_tests_command.feature` *(fails: not found: /workspace/devsynth/tests/behavior/features/devsynth_run_tests_command.feature)*
- `poetry run devsynth run-tests --speed=fast`
- `poetry run python tests/verify_test_organization.py`
- `poetry run python scripts/verify_test_markers.py`
- `poetry run python scripts/verify_requirements_traceability.py`
- `poetry run python scripts/verify_version_sync.py`


------
https://chatgpt.com/codex/tasks/task_e_68a8a23727fc83338e036b72b1e4df28