### PR TITLE
fix: harden TinyDB transaction lifecycle

### DIFF
--- a/dialectical_audit.log
+++ b/dialectical_audit.log
@@ -2,7 +2,6 @@
   "questions": [
     "2025-08-22: devsynth run-tests --speed=fast, --speed=medium, and --speed=slow aborted; LMStudioProvider package missing.",
     "2025-08-22: scripts/verify_test_markers.py interrupted after pytest collection error in tests/behavior/test_agentapi.py.",
-    "2025-08-22: task release:prep failed; tests/behavior/steps/test_advanced_graph_memory_features_steps.py raised TypeError in TinyDBMemoryAdapter."
   ],
   "resolved": [
     "Release checklist commands executed 2025-08-20; verify_test_markers.py failed and task command was not found.",


### PR DESCRIPTION
## Summary
- ensure TinyDB adapter auto-generates item IDs and validates commit/rollback phases
- cover implicit transaction commits in regression tests
- clear resolved TinyDB question from dialectical audit log

## Testing
- `PYTHONPATH=src poetry run pytest tests/behavior/steps/test_advanced_graph_memory_features_steps.py::test_integrate_with_another_memory_store -q`
- `PYTHONPATH=src poetry run pytest tests/unit/application/memory/test_memory_adapters_regression.py::test_tinydb_transaction_optional_id -q`
- `PYTHONPATH=src poetry run python tests/verify_test_organization.py`
- `PYTHONPATH=src poetry run python scripts/verify_test_markers.py`
- `PYTHONPATH=src poetry run python scripts/verify_requirements_traceability.py`
- `PYTHONPATH=src poetry run python scripts/verify_version_sync.py`
- `PYTHONPATH=src poetry run devsynth run-tests --speed=fast` *(fails: LMStudioProvider requires optional dependency)*

------
https://chatgpt.com/codex/tasks/task_e_68a8a28134208333882258059cbbb903