### PR TITLE
feat: enhance run-tests command options

### DIFF
--- a/docs/specifications/devsynth-run-tests-command.md
+++ b/docs/specifications/devsynth-run-tests-command.md
@@ -4,32 +4,29 @@ date: 2025-08-19
 last_reviewed: 2025-08-19
 status: draft
 tags:
-
-- specification
-
+  - specification
 title: devsynth run-tests command
 version: 0.1.0-alpha.1
 ---
 
-<!--
-Required metadata fields:
-- author: document author
-- date: creation date
-- last_reviewed: last review date
-- status: draft | review | published
-- tags: search keywords
-- title: short descriptive name
-- version: specification version
--->
-
 # Summary
+Enhances `devsynth run-tests` with flags to control parallelism, batching, and feature toggles.
 
 ## Socratic Checklist
-- What is the problem?
-- What proofs confirm the solution?
+- **What is the problem?** Developers lacked fine-grained control over test execution; optional providers could stall runs, large suites overwhelmed resources, and conditional features were hard to toggle.
+- **What proofs confirm the solution?** Behavior tests invoke the command with `--no-parallel`, `--segment`, and `--feature` options; unit tests verify feature flag parsing.
 
 ## Motivation
+Reliable test runs require bypassing unavailable providers, splitting large suites, and enabling optional features via environment flags.
 
 ## Specification
+- `--no-parallel` disables `pytest-xdist` so tests run sequentially.
+- `--segment` runs tests in batches; `--segment-size` sets batch size (default 50).
+- `--feature NAME[=BOOLEAN]` sets `DEVSYNTH_FEATURE_<NAME>` to `true` or `false` for the test process.
+- Optional providers are disabled by default unless their `DEVSYNTH_RESOURCE_*` variables are explicitly set.
 
 ## Acceptance Criteria
+- `devsynth run-tests --target unit-tests --speed=fast --no-parallel` completes without waiting on optional providers.
+- `devsynth run-tests --target unit-tests --speed=fast --no-parallel --segment --segment-size=1` executes tests in batches of one.
+- `devsynth run-tests --target unit-tests --speed=fast --no-parallel --feature demo=false` sets `DEVSYNTH_FEATURE_DEMO=false` during test execution.
+- Invocations without `--no-parallel` run tests in parallel while still skipping optional providers.

--- a/src/devsynth/application/cli/commands/run_tests_cmd.py
+++ b/src/devsynth/application/cli/commands/run_tests_cmd.py
@@ -104,7 +104,10 @@ def run_tests_cmd(
     speed_categories = speeds or None
     feature_map = _parse_feature_options(features)
     if feature_map:
-        logger.debug("Feature flags: %s", feature_map)
+        for name, enabled in feature_map.items():
+            env_var = f"DEVSYNTH_FEATURE_{name.upper()}"
+            os.environ[env_var] = "true" if enabled else "false"
+        logger.info("Feature flags: %s", feature_map)
 
     success, output = run_tests(
         target,

--- a/tests/behavior/features/devsynth_run_tests_command.feature
+++ b/tests/behavior/features/devsynth_run_tests_command.feature
@@ -11,3 +11,13 @@ Feature: devsynth run-tests command
     When I invoke "devsynth run-tests --target unit-tests --speed=fast"
     Then the command should succeed
     And the output should not contain xdist assertions
+
+  Scenario: run-tests can segment execution
+    Given the environment variable "DEVSYNTH_RESOURCE_LMSTUDIO_AVAILABLE" is "false"
+    When I invoke "devsynth run-tests --target unit-tests --speed=fast --no-parallel --segment --segment-size=1"
+    Then the command should succeed
+
+  Scenario: run-tests accepts feature flags
+    Given the environment variable "DEVSYNTH_RESOURCE_LMSTUDIO_AVAILABLE" is "false"
+    When I invoke "devsynth run-tests --target unit-tests --speed=fast --no-parallel --feature experimental"
+    Then the command should succeed

--- a/tests/behavior/steps/test_run_tests_steps.py
+++ b/tests/behavior/steps/test_run_tests_steps.py
@@ -66,6 +66,55 @@ def invoke_run_tests_parallel(command_result: Dict[str, str]) -> None:
 
 
 @when(
+    'I invoke "devsynth run-tests --target unit-tests --speed=fast --no-parallel --segment --segment-size=1"'
+)
+def invoke_run_tests_segment(command_result: Dict[str, str]) -> None:
+    env = os.environ.copy()
+    env.setdefault("DEVSYNTH_NO_FILE_LOGGING", "1")
+    env.setdefault("DEVSYNTH_RESOURCE_LMSTUDIO_AVAILABLE", "false")
+    cmd = [
+        "poetry",
+        "run",
+        "devsynth",
+        "run-tests",
+        "--target",
+        "unit-tests",
+        "--speed=fast",
+        "--no-parallel",
+        "--segment",
+        "--segment-size",
+        "1",
+    ]
+    result = subprocess.run(cmd, capture_output=True, text=True, env=env)
+    command_result["exit_code"] = result.returncode
+    command_result["output"] = result.stdout + result.stderr
+
+
+@when(
+    'I invoke "devsynth run-tests --target unit-tests --speed=fast --no-parallel --feature experimental"'
+)
+def invoke_run_tests_feature(command_result: Dict[str, str]) -> None:
+    env = os.environ.copy()
+    env.setdefault("DEVSYNTH_NO_FILE_LOGGING", "1")
+    env.setdefault("DEVSYNTH_RESOURCE_LMSTUDIO_AVAILABLE", "false")
+    cmd = [
+        "poetry",
+        "run",
+        "devsynth",
+        "run-tests",
+        "--target",
+        "unit-tests",
+        "--speed=fast",
+        "--no-parallel",
+        "--feature",
+        "experimental",
+    ]
+    result = subprocess.run(cmd, capture_output=True, text=True, env=env)
+    command_result["exit_code"] = result.returncode
+    command_result["output"] = result.stdout + result.stderr
+
+
+@when(
     'I invoke "devsynth run-tests --target unit-tests --speed=fast --no-parallel --maxfail=1"'
 )
 def invoke_run_tests_maxfail(command_result: Dict[str, str]) -> None:


### PR DESCRIPTION
## Summary
- document run-tests CLI options for parallel control, segmenting, and feature flags
- add behavior tests for segmenting, --no-parallel, and feature flag usage
- support feature flags via environment variables in run-tests command

## Testing
- `poetry run pre-commit run --files docs/specifications/devsynth-run-tests-command.md src/devsynth/application/cli/commands/run_tests_cmd.py tests/behavior/features/devsynth_run_tests_command.feature tests/behavior/steps/test_run_tests_steps.py`
- `PYTEST_ADDOPTS="--cov-fail-under=0" poetry run devsynth run-tests --target unit-tests --speed=fast --no-parallel` *(fails: test_speed_option_recognized)*
- `poetry run python scripts/verify_test_markers.py`


------
https://chatgpt.com/codex/tasks/task_e_68a8a2877f7c8333927cb8c13f5c017a