### PR TITLE
feat(memory): support environment-based storage adapter selection

### DIFF
--- a/docs/specifications/additional-storage-backends.md
+++ b/docs/specifications/additional-storage-backends.md
@@ -54,6 +54,13 @@ tests and examples remain hermetic.
   value is `s3`, the manager configures the adapter with the bucket name from
   `s3_bucket_name`.
 
+## Required Environment Variables
+
+- `DEVSYNTH_MEMORY_STORE` – selects the backend (`s3` enables the S3 adapter).
+- `DEVSYNTH_S3_BUCKET` – name of the bucket for persisted items.
+- Standard AWS credentials (`AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, and
+  optionally `AWS_DEFAULT_REGION`) so boto3 can authenticate.
+
 ## Acceptance Criteria
 
 - Given `DEVSYNTH_MEMORY_STORE=s3` and an available bucket, `MemoryManager`

--- a/src/devsynth/application/memory/adapters/storage_adapter.py
+++ b/src/devsynth/application/memory/adapters/storage_adapter.py
@@ -8,12 +8,17 @@ implements the :class:`~devsynth.domain.interfaces.memory.MemoryStore` contract.
 
 from __future__ import annotations
 
-from typing import Protocol
+from typing import ClassVar, Protocol
 
 from ....domain.interfaces.memory import MemoryStore
 
 
 class StorageAdapter(MemoryStore, Protocol):
-    """Protocol implemented by memory storage adapters."""
+    """Protocol implemented by memory storage adapters.
 
-    backend_type: str
+    Adapters expose a class-level :attr:`backend_type` used by
+    :class:`~devsynth.application.memory.memory_manager.MemoryManager` to select
+    the appropriate backend at runtime.
+    """
+
+    backend_type: ClassVar[str]

--- a/src/devsynth/application/memory/memory_manager.py
+++ b/src/devsynth/application/memory/memory_manager.py
@@ -6,6 +6,7 @@ allowing for efficient querying of different types of memory and tagging
 items with EDRR phases.
 """
 
+import os
 from functools import lru_cache
 from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 
@@ -58,9 +59,15 @@ class MemoryManager:
         """
         if adapters is None:
             settings = get_settings()
-            store_type = getattr(settings, "memory_store_type", "tinydb").lower()
+            store_type = os.getenv(
+                "DEVSYNTH_MEMORY_STORE",
+                getattr(settings, "memory_store_type", "tinydb"),
+            ).lower()
             if store_type == "s3" and S3MemoryAdapter is not None:
-                bucket = getattr(settings, "s3_bucket_name", "devsynth-memory")
+                bucket = os.getenv(
+                    "DEVSYNTH_S3_BUCKET",
+                    getattr(settings, "s3_bucket_name", "devsynth-memory"),
+                )
                 try:
                     adapter = S3MemoryAdapter(bucket)
                     self.adapters = {"s3": adapter}

--- a/tests/behavior/features/additional_storage_backends.feature
+++ b/tests/behavior/features/additional_storage_backends.feature
@@ -1,30 +1,8 @@
 Feature: Additional Storage Backends
-  As a [role]
-  I want to [capability]
-  So that [benefit]
+  The memory system selects a storage backend based on configuration.
 
-  Background:
-    Given [common setup step 1]
-    And [common setup step 2]
-
-  Scenario: [Scenario 1 Name]
-    Given [precondition 1]
-    When [action 1]
-    Then [expected outcome 1]
-    And [expected outcome 2]
-
-  Scenario: [Scenario 2 Name]
-    Given [precondition 1]
-    When [action 1]
-    Then [expected outcome 1]
-
-  Scenario Outline: [Parameterized Scenario Name]
-    Given [precondition with <parameter>]
-    When [action with <parameter>]
-    Then [expected outcome with <parameter>]
-
-    Examples:
-      | parameter | other_value |
-      | value1    | result1     |
-      | value2    | result2     |
-      | value3    | result3     |
+  Scenario: S3 backend selected via environment variables
+    Given the environment variable "DEVSYNTH_MEMORY_STORE" is "s3"
+    And the environment variable "DEVSYNTH_S3_BUCKET" points to an existing bucket
+    When the MemoryManager stores "data" as CODE memory
+    Then the item can be retrieved with content "data"


### PR DESCRIPTION
## Summary
- define `StorageAdapter` protocol with `backend_type`
- let `MemoryManager` choose S3 or TinyDB adapters via `DEVSYNTH_MEMORY_STORE`
- document S3 environment variables and add corresponding feature spec

## Testing
- `poetry run pre-commit run --files docs/specifications/additional-storage-backends.md src/devsynth/application/memory/adapters/storage_adapter.py src/devsynth/application/memory/memory_manager.py tests/behavior/features/additional_storage_backends.feature`
- `poetry run devsynth run-tests --speed=fast`
- `poetry run python tests/verify_test_organization.py`
- `poetry run python scripts/verify_test_markers.py`
- `poetry run python scripts/verify_requirements_traceability.py`
- `poetry run python scripts/verify_version_sync.py`


------
https://chatgpt.com/codex/tasks/task_e_68a8a29ea1c883339e69adb65c9b2581