### PR TITLE
feat: add performance benchmarking utilities

### DIFF
--- a/docs/performance/baseline_metrics.json
+++ b/docs/performance/baseline_metrics.json
@@ -1,4 +1,5 @@
 {
   "workload": 100000,
-  "duration_seconds": 0.01119796599999745
+  "duration_seconds": 0.010622779999721388,
+  "throughput_ops_per_s": 9413731.622289343
 }

--- a/docs/performance/performance_and_scalability.md
+++ b/docs/performance/performance_and_scalability.md
@@ -2,7 +2,7 @@
 
 ## Empirical Results
 
-Baseline workload of 100000 operations completed in approximately 0.0112 seconds (≈8.9e6 ops/s).
+Baseline workload of 100000 operations completed in approximately 0.0106 seconds (≈9.4e6 ops/s).
 
 Metrics are stored as JSON entries with `workload`, `duration_seconds`, and `throughput_ops_per_s` fields.
 
@@ -10,9 +10,9 @@ Scalability measurements:
 
 | workload | duration (s) | throughput (ops/s) |
 |---------:|-------------:|-------------------:|
-|   10000  |     0.00106  |      9.40e6        |
-|  100000  |     0.01093  |      9.15e6        |
-| 1000000  |     0.11344  |      8.82e6        |
+|   10000  |     0.00104  |      9.59e6        |
+|  100000  |     0.01103  |      9.06e6        |
+| 1000000  |     0.11658  |      8.58e6        |
 
 ## Scalability Formula
 

--- a/docs/performance/performance_and_scalability_testing.md
+++ b/docs/performance/performance_and_scalability_testing.md
@@ -15,7 +15,7 @@ To generate metrics files directly:
 ```bash
 poetry run python - <<'PY'
 from pathlib import Path
-from devsynth.application.performance import (
+from devsynth.testing.performance import (
     capture_baseline_metrics,
     capture_scalability_metrics,
 )

--- a/docs/performance/scalability_metrics.json
+++ b/docs/performance/scalability_metrics.json
@@ -1,14 +1,17 @@
 [
   {
     "workload": 10000,
-    "duration_seconds": 0.001063993999991908
+    "duration_seconds": 0.0010430009997435263,
+    "throughput_ops_per_s": 9587718.518447246
   },
   {
     "workload": 100000,
-    "duration_seconds": 0.010926303000019288
+    "duration_seconds": 0.011032565999812505,
+    "throughput_ops_per_s": 9064074.486542793
   },
   {
     "workload": 1000000,
-    "duration_seconds": 0.11343649700000924
+    "duration_seconds": 0.11657932800062554,
+    "throughput_ops_per_s": 8577850.097014062
   }
 ]

--- a/src/devsynth/testing/performance.py
+++ b/src/devsynth/testing/performance.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+import json
+import time
+from pathlib import Path
+from typing import Dict, Iterable, List
+
+
+def _run_workload(workload: int) -> None:
+    """Execute a simple CPU-bound workload for benchmarking."""
+    total = 0
+    for i in range(workload):
+        total += i * i
+    return total
+
+
+def capture_baseline_metrics(
+    workload: int, output_path: Path | None = None
+) -> Dict[str, float]:
+    """Capture baseline metrics for a given workload.
+
+    Args:
+        workload: Number of operations to execute.
+        output_path: Optional path to write metrics JSON.
+
+    Returns:
+        Metrics dictionary with workload, duration, and throughput.
+    """
+    start = time.perf_counter()
+    _run_workload(workload)
+    duration = time.perf_counter() - start
+    throughput = workload / duration if duration else 0.0
+    metrics = {
+        "workload": workload,
+        "duration_seconds": duration,
+        "throughput_ops_per_s": throughput,
+    }
+    if output_path is not None:
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        output_path.write_text(json.dumps(metrics, indent=2))
+    return metrics
+
+
+def capture_scalability_metrics(
+    workloads: Iterable[int], output_path: Path | None = None
+) -> List[Dict[str, float]]:
+    """Capture scalability metrics across multiple workloads.
+
+    Args:
+        workloads: Iterable of workload sizes.
+        output_path: Optional path to write metrics JSON list.
+
+    Returns:
+        List of metrics dictionaries for each workload.
+    """
+    results = []
+    for workload in workloads:
+        start = time.perf_counter()
+        _run_workload(workload)
+        duration = time.perf_counter() - start
+        throughput = workload / duration if duration else 0.0
+        results.append(
+            {
+                "workload": workload,
+                "duration_seconds": duration,
+                "throughput_ops_per_s": throughput,
+            }
+        )
+    if output_path is not None:
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        output_path.write_text(json.dumps(results, indent=2))
+    return results
+
+
+__all__ = ["capture_baseline_metrics", "capture_scalability_metrics"]

--- a/tests/behavior/features/performance_and_scalability_testing.feature
+++ b/tests/behavior/features/performance_and_scalability_testing.feature
@@ -20,6 +20,12 @@ Feature: Performance and scalability testing
     Then the metrics file "docs/performance/baseline_metrics.json" includes throughput
 
   @slow
+  Scenario: baseline duration is recorded
+    Given a workload of 100000 operations
+    When the baseline performance task runs
+    Then the metrics file "docs/performance/baseline_metrics.json" includes duration
+
+  @slow
   Scenario Outline: scalability metrics are captured for varying workloads
     Given a workload of <workload> operations
     When the scalability performance task runs
@@ -30,3 +36,15 @@ Feature: Performance and scalability testing
       | 10000    |
       | 100000   |
       | 1000000  |
+
+  @slow
+  Scenario: scalability metrics file is created
+    Given a workload of 100000 operations
+    When the scalability performance task runs
+    Then a metrics file "docs/performance/scalability_metrics.json" is created
+
+  @slow
+  Scenario: scalability throughput is calculated
+    Given a workload of 100000 operations
+    When the scalability performance task runs
+    Then the metrics file "docs/performance/scalability_metrics.json" includes throughput

--- a/tests/behavior/steps/test_performance_and_scalability_steps.py
+++ b/tests/behavior/steps/test_performance_and_scalability_steps.py
@@ -4,7 +4,7 @@ from pathlib import Path
 import pytest
 from pytest_bdd import given, parsers, scenarios, then, when
 
-from devsynth.application.performance import (
+from devsynth.testing.performance import (
     capture_baseline_metrics,
     capture_scalability_metrics,
 )
@@ -87,4 +87,20 @@ def results_include_entry(context, workload):
 @then(parsers.parse('the metrics file "{path}" includes throughput'))
 def metrics_file_includes_throughput(path):
     data = json.loads(Path(path).read_text())
-    assert "throughput_ops_per_s" in data and data["throughput_ops_per_s"] > 0
+    if isinstance(data, list):
+        assert all(
+            entry.get("throughput_ops_per_s", 0) > 0 for entry in data
+        ), "throughput missing for one or more entries"
+    else:
+        assert "throughput_ops_per_s" in data and data["throughput_ops_per_s"] > 0
+
+
+@then(parsers.parse('the metrics file "{path}" includes duration'))
+def metrics_file_includes_duration(path):
+    data = json.loads(Path(path).read_text())
+    if isinstance(data, list):
+        assert all(
+            entry.get("duration_seconds", 0) > 0 for entry in data
+        ), "duration missing for one or more entries"
+    else:
+        assert "duration_seconds" in data and data["duration_seconds"] > 0

--- a/tests/performance/test_performance_metrics.py
+++ b/tests/performance/test_performance_metrics.py
@@ -4,7 +4,7 @@ import time
 
 import pytest
 
-from devsynth.application.performance import (
+from devsynth.testing.performance import (
     capture_baseline_metrics,
     capture_scalability_metrics,
 )


### PR DESCRIPTION
## Summary
- add `devsynth.testing.performance` with baseline and scalability benchmarking helpers
- expand performance BDD specs for baseline and scalability metrics
- persist updated performance metrics and docs

## Testing
- `poetry run pre-commit run --files src/devsynth/testing/performance.py tests/behavior/features/performance_and_scalability_testing.feature tests/behavior/steps/test_performance_and_scalability_steps.py tests/performance/test_performance_metrics.py docs/performance/baseline_metrics.json docs/performance/scalability_metrics.json docs/performance/performance_and_scalability.md docs/performance/performance_and_scalability_testing.md`
- `PYTHONPATH=src poetry run devsynth run-tests --speed=fast`
- `PYTHONPATH=src poetry run python tests/verify_test_organization.py`
- `PYTHONPATH=src poetry run python scripts/verify_test_markers.py`
- `PYTHONPATH=src poetry run python scripts/verify_requirements_traceability.py`
- `PYTHONPATH=src poetry run python scripts/verify_version_sync.py`


------
https://chatgpt.com/codex/tasks/task_e_68a8a2a92a8c83339fd797991a3cda06