### PR TITLE
chore: reinforce Taskfile setup checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,8 @@ Provision the development environment by running the environment provisioning sc
 bash scripts/install_dev.sh
 ```
 
+> **Note:** Run this script **before** invoking any Taskfile commands to ensure the `task` runner is installed and ready.
+
 ## Installation
 
 You can install DevSynth in a few different ways:

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -8,6 +8,14 @@ vars:
   MKDOCS_ADDR: 127.0.0.1
 
 tasks:
+  default:
+    desc: Verify task availability
+    cmds:
+      - |
+        if ! task --version >/dev/null 2>&1; then
+          echo "[error] task command unavailable; run bash scripts/install_dev.sh" >&2
+          exit 1
+        fi
   # Environment setup tasks
   setup:
     desc: Install all dependencies

--- a/docs/release/0.1.0-alpha.1.md
+++ b/docs/release/0.1.0-alpha.1.md
@@ -22,6 +22,8 @@ poetry env info --path
 task --version
 ```
 
+Run `bash scripts/install_dev.sh` **before** using any `task` targets; it installs and validates the runner.
+
 This ensures Taskfile targets are available and Poetry manages a virtual environment during release preparation.
 The provisioning script now validates both commands, exiting early if either check fails.
 
@@ -57,7 +59,7 @@ The provisioning script now validates both commands, exiting early if either che
    ```bash
    poetry run pytest tests/unit/deployment -m fast
    ```
-5. Prepare release artifacts with Taskfile and run the dialectical audit:
+5. Prepare release artifacts with Taskfile and run the dialectical audit (rerun `bash scripts/install_dev.sh` first if `task --version` fails):
    ```bash
    task --version
    task release:prep

--- a/scripts/install_dev.sh
+++ b/scripts/install_dev.sh
@@ -7,7 +7,7 @@ mkdir -p "$WHEEL_DIR"
 
 # Ensure go-task is available for Taskfile-based workflows
 if ! command -v task >/dev/null 2>&1; then
-  echo "[info] installing go-task"
+  echo "[warning] task command missing; installing go-task. Re-run scripts/install_dev.sh after installation." >&2
   TASK_BIN_DIR="${HOME}/.local/bin"
   mkdir -p "$TASK_BIN_DIR"
 
@@ -22,11 +22,12 @@ if ! command -v task >/dev/null 2>&1; then
 
   export PATH="$TASK_BIN_DIR:$PATH"
   echo "$TASK_BIN_DIR" >> "${GITHUB_PATH:-/dev/null}" 2>/dev/null || true
-fi
 
-# Ensure the task binary is available after installation
-if ! command -v task >/dev/null 2>&1; then
-  echo "[error] task binary not found on PATH after installation" >&2
+  if ! command -v task >/dev/null 2>&1; then
+    echo "[error] task binary not found on PATH after installation. Install it manually and re-run scripts/install_dev.sh." >&2
+  else
+    echo "[info] task installed; please re-run scripts/install_dev.sh to finish setup." >&2
+  fi
   exit 1
 fi
 


### PR DESCRIPTION
## Summary
- highlight running `scripts/install_dev.sh` before any Taskfile usage
- warn and exit early when `task` is missing during provisioning
- add default Taskfile target verifying `task --version`

## Testing
- `poetry run pre-commit run --files README.md Taskfile.yml docs/release/0.1.0-alpha.1.md scripts/install_dev.sh`
- `poetry run devsynth run-tests --speed=fast`
- `poetry run python tests/verify_test_organization.py`
- `poetry run python scripts/verify_test_markers.py`
- `poetry run python scripts/verify_requirements_traceability.py`
- `poetry run python scripts/verify_version_sync.py`


------
https://chatgpt.com/codex/tasks/task_e_68a8a2ade1d483338ce15bb396f84abc