### PR TITLE
feat(memory): add graph traversal and persistence

### DIFF
--- a/docs/specifications/advanced-graph-memory-features.md
+++ b/docs/specifications/advanced-graph-memory-features.md
@@ -26,10 +26,53 @@ Required metadata fields:
 
 ## Socratic Checklist
 - What is the problem?
+  The graph memory system stores items as RDF triples but lacks explicit
+  traversal capabilities and documented guarantees that nodes and links
+  persist across adapter restarts.
 - What proofs confirm the solution?
+  Behavioural tests traverse stored relationships and reload the adapter to
+  verify that previously persisted nodes and links remain accessible.
 
 ## Motivation
 
+Agents reason over relationships between memories.  Without a bounded
+traversal mechanism and durable graph storage, agents cannot reliably follow
+chains of related items or resume reasoning after a restart.  Providing a
+documented traversal API with persistence guarantees enables richer memory
+queries and long‑lived reasoning across all supported backends.
+
 ## Specification
 
+- Add a `traverse_graph(start_id, max_depth)` method to
+  `GraphMemoryAdapter`.  The method performs a breadth‑first search over
+  `devsynth:relatedTo` links, returning the set of reachable node IDs up to
+  the specified depth.
+- Persist nodes and relationships to `graph_memory.ttl` whenever items or
+  links are stored.  On initialization the adapter loads the file if it
+  exists, ensuring all nodes and `relatedTo` edges survive process restarts.
+- Expose traversal and persistence behaviours through behaviour‑driven tests
+  exercising graph traversal, reload cycles, and integration with other
+  memory stores.
+
+### Termination reasoning
+
+The traversal algorithm employs breadth‑first search with an explicit depth
+limit and a visited set.  Each iteration processes only unvisited nodes and
+decrements the remaining depth, guaranteeing termination for any finite
+graph and preventing cycles from causing infinite loops.
+
 ## Acceptance Criteria
+
+- `GraphMemoryAdapter.traverse_graph` returns all nodes reachable within the
+  requested depth and excludes the starting node.
+- Reloading the adapter from a previously persisted graph reproduces all
+  stored nodes and `relatedTo` links.
+- Behavioural tests cover traversal and persistence across TinyDB and
+  ChromaDB backends and pass under the `fast` marker.
+
+## Proofs
+
+- `advanced_graph_memory_features.feature` scenarios demonstrate traversal
+  from an initial node through multiple hops and verify persistence after
+  adapter reload.
+- Unit and integration tests execute without errors for all memory backends.

--- a/tests/behavior/features/general/advanced_graph_memory_features.feature
+++ b/tests/behavior/features/general/advanced_graph_memory_features.feature
@@ -54,3 +54,17 @@ Feature: Advanced Graph Memory Features
     When I integrate the GraphMemoryAdapter with the ChromaDBVectorStore in "bidirectional" mode
     Then memory items with vectors should be properly synchronized between stores
     And I should be able to perform vector similarity searches on both stores
+
+  @fast
+  Scenario: Traverse related memory items
+    Given I have a GraphMemoryAdapter with RDFLibStore integration
+    And I have stored related memory items
+    When I traverse the graph starting from "node1" up to depth 2
+    Then the traversal result should include "node2,node3"
+
+  @fast
+  Scenario: Persist nodes and links across sessions
+    Given I have a GraphMemoryAdapter with RDFLibStore integration
+    And I have stored related memory items
+    When I save and reload the GraphMemoryAdapter
+    Then traversing from "node1" to depth 2 should return "node2,node3"


### PR DESCRIPTION
## Summary
- document advanced graph traversal and persistence requirements
- add `traverse_graph` to `GraphMemoryAdapter`
- test graph traversal and link persistence across memory stores

## Testing
- `poetry run pre-commit run --files docs/specifications/advanced-graph-memory-features.md src/devsynth/application/memory/adapters/graph_memory_adapter.py tests/behavior/features/general/advanced_graph_memory_features.feature tests/behavior/steps/test_advanced_graph_memory_features_steps.py`
- `poetry run devsynth run-tests --speed=fast`
- `poetry run python tests/verify_test_organization.py`
- `poetry run python scripts/verify_test_markers.py`
- `poetry run python scripts/verify_requirements_traceability.py`
- `poetry run python scripts/verify_version_sync.py`


------
https://chatgpt.com/codex/tasks/task_e_68a8aae5362083339711991bbe75eb8c