### PR TITLE
docs: add dialectical reasoning loop convergence proof

### DIFF
--- a/docs/analysis/dialectical_reasoning_loop_convergence.md
+++ b/docs/analysis/dialectical_reasoning_loop_convergence.md
@@ -1,0 +1,37 @@
+---
+Title: "Dialectical Reasoning Loop Convergence"
+Date: "2025-08-22"
+version: "0.1.0-alpha.1"
+tags:
+  - analysis
+  - methodology
+  - dialectical-reasoning
+status: published
+author: "DevSynth Team"
+last_reviewed: "2025-08-22"
+---
+
+## Socratic Checklist
+- **What is the problem?**
+  The dialectical reasoning loop in `src/devsynth/methodology/edrr/reasoning_loop.py` iterates to synthesize solutions. We must ensure the loop terminates and yields correct results.
+- **What proofs confirm the solution?**
+  We provide a termination proof and cite unit and behavior tests that simulate successful and bounded execution.
+
+## Algorithm Overview
+The loop applies `apply_dialectical_reasoning` up to `max_iterations` times, breaking early when a result reports `status="completed"` or when a `ConsensusError` occurs. Each iteration may update the task with a synthesized solution before the next step.
+
+## Convergence Proof
+Let `i` denote the iteration index starting at 0. The loop condition is `for iteration in range(max_iterations)`, so `i < max_iterations`. At the end of each iteration `i` increments by 1. Therefore `i` can take at most `max_iterations` values. Additionally, if any iteration yields a result with `status="completed"`, the loop breaks immediately. Thus the loop terminates after at most `max_iterations` iterations, establishing convergence.
+
+## Simulation Results
+Unit tests [`tests/unit/methodology/test_dialectical_reasoning_loop.py`](../../tests/unit/methodology/test_dialectical_reasoning_loop.py) confirm three scenarios:
+1. **Completion:** The loop stops when a result marks completion.
+2. **Consensus Failure:** Errors trigger coordinator logging and halt the loop.
+3. **Bounded Iterations:** The loop respects a caller-provided `max_iterations`.
+
+Behavior test [`tests/behavior/test_dialectical_reasoner_termination_behavior.py`](../../tests/behavior/test_dialectical_reasoner_termination_behavior.py) exercises termination in an integration context, validating the same invariants across the orchestration layer.
+
+## References
+- Specification: [`docs/specifications/dialectical_reasoning.md`](../specifications/dialectical_reasoning.md)
+- Implementation: [`src/devsynth/methodology/edrr/reasoning_loop.py`](../../src/devsynth/methodology/edrr/reasoning_loop.py)
+- Tests: [`tests/unit/methodology/test_dialectical_reasoning_loop.py`](../../tests/unit/methodology/test_dialectical_reasoning_loop.py), [`tests/behavior/test_dialectical_reasoner_termination_behavior.py`](../../tests/behavior/test_dialectical_reasoner_termination_behavior.py)

--- a/docs/analysis/index.md
+++ b/docs/analysis/index.md
@@ -36,6 +36,7 @@ This section contains various analysis documents related to the DevSynth project
 - **[Memory Component Algorithmic Analysis](memory_component_analysis.md)**: Invariants and complexity for memory operations.
 - **[EDRR Component Algorithmic Analysis](edrr_component_analysis.md)**: Phase invariants and recovery complexity.
 - **[MVU Component Algorithmic Analysis](mvu_component_analysis.md)**: Atomic rewrite and dashboard overhead.
+- **[Dialectical Reasoning Loop Convergence](dialectical_reasoning_loop_convergence.md)**: Termination proof for the iterative reasoning loop.
 
 ## Related Documentation
 

--- a/docs/documentation_index.md
+++ b/docs/documentation_index.md
@@ -29,6 +29,7 @@ _This index lists all documentation files, their status, and release phase. It i
 | docs/analysis/inventory.md | DevSynth Project Comprehensive Inventory & Analysis | published | analysis |
 | docs/analysis/technical_deep_dive.md | DevSynth Technical Deep Dive Analysis | published | analysis |
 | docs/analysis/wide_sweep_analysis.md | DevSynth Project Wide Sweep Analysis | published | analysis |
+| docs/analysis/dialectical_reasoning_loop_convergence.md | Dialectical Reasoning Loop Convergence | published | analysis |
 | docs/architecture/agent_system.md | DevSynth Agent System Architecture | published | foundation |
 | docs/architecture/cli_webui_mapping.md | CLI to WebUI Command Mapping | draft | foundation |
 | docs/architecture/dialectical_reasoning.md | Dialectical Reasoning System for Requirements Management | published | foundation |

--- a/docs/specifications/dialectical_reasoning.md
+++ b/docs/specifications/dialectical_reasoning.md
@@ -66,3 +66,6 @@ Unit tests under
 ``tests/unit/methodology/test_dialectical_reasoner_termination.py`` and
 ``tests/behavior/test_dialectical_reasoner_termination_behavior.py`` exercise
 these edge cases to confirm termination and complexity bounds.
+
+For a formal convergence argument, see the analysis in
+``docs/analysis/dialectical_reasoning_loop_convergence.md``.


### PR DESCRIPTION
## Summary
- document convergence of the dialectical reasoning loop and reference its specification and tests
- index the new analysis document in docs listings

## Testing
- `poetry run pre-commit run --files docs/analysis/index.md docs/documentation_index.md docs/specifications/dialectical_reasoning.md docs/analysis/dialectical_reasoning_loop_convergence.md`
- `poetry run devsynth run-tests --speed=fast`
- `poetry run python tests/verify_test_organization.py`
- `poetry run python scripts/verify_test_markers.py`
- `poetry run python scripts/verify_requirements_traceability.py`
- `poetry run python scripts/verify_version_sync.py`


------
https://chatgpt.com/codex/tasks/task_e_68a8c4f16ed483338adb97d34b4f40dd