### PR TITLE
chore: add phase completion tickets and fix dependencies

### DIFF
--- a/issues/Complete-Sprint-EDRR-integration.md
+++ b/issues/Complete-Sprint-EDRR-integration.md
@@ -3,7 +3,7 @@ Milestone: 0.1.0-alpha.2
 Status: blocked
 
 Priority: high
-Dependencies: [Finalize WSDE/EDRR workflow logic](Finalize-WSDE-EDRR-workflow-logic.md), docs/specifications/complete-sprint-edrr-integration.md, tests/behavior/features/complete_sprint_edrr_integration.feature
+Dependencies: Finalize-WSDE-EDRR-workflow-logic.md, docs/specifications/complete-sprint-edrr-integration.md, tests/behavior/features/complete_sprint_edrr_integration.feature
 
 ## Problem Statement
 Complete Sprint-EDRR integration is not yet implemented, limiting DevSynth's capabilities.

--- a/issues/Critical-recommendations-follow-up.md
+++ b/issues/Critical-recommendations-follow-up.md
@@ -3,7 +3,7 @@ Milestone: 0.1.0-alpha.2
 Status: in progress
 
 Priority: high
-Dependencies: [Implement SDLC security audits](archived/implement-sdlc-security-audits.md), [Resolve remaining dialectical audit questions](archived/Resolve-remaining-dialectical-audit-questions.md), docs/specifications/critical-recommendations-follow-up.md, tests/behavior/features/critical_recommendations_follow_up.feature
+Dependencies: archived/implement-sdlc-security-audits.md, archived/Resolve-remaining-dialectical-audit-questions.md, docs/specifications/critical-recommendations-follow-up.md, tests/behavior/features/critical_recommendations_follow_up.feature
 
 ## Problem Statement
 Critical recommendations follow-up is not yet implemented, limiting DevSynth's capabilities.

--- a/issues/Expand-test-generation-capabilities.md
+++ b/issues/Expand-test-generation-capabilities.md
@@ -3,7 +3,7 @@ Milestone: 0.1.0-alpha.2
 Status: blocked
 
 Priority: high
-Dependencies: [LM Studio mock service for deterministic tests](archived/LM-Studio-mock-service-for-deterministic-tests.md), docs/specifications/expand-test-generation-capabilities.md, tests/behavior/features/expand_test_generation_capabilities.feature
+Dependencies: archived/LM-Studio-mock-service-for-deterministic-tests.md, docs/specifications/expand-test-generation-capabilities.md, tests/behavior/features/expand_test_generation_capabilities.feature
 
 ## Problem Statement
 Expand test generation capabilities is not yet implemented, limiting DevSynth's capabilities.

--- a/issues/Finalize-WSDE-EDRR-workflow-logic.md
+++ b/issues/Finalize-WSDE-EDRR-workflow-logic.md
@@ -3,7 +3,7 @@ Milestone: 0.1.0
 Status: blocked
 
 Priority: low
-Dependencies: Phase 2 completion, [WSDE collaboration test failures](archived/WSDE-collaboration-test-failures.md), docs/specifications/finalize-wsde-edrr-workflow-logic.md, tests/behavior/features/finalize_wsde_edrr_workflow_logic.feature
+Dependencies: Phase-2-completion.md, archived/WSDE-collaboration-test-failures.md, docs/specifications/finalize-wsde-edrr-workflow-logic.md, tests/behavior/features/finalize_wsde_edrr_workflow_logic.feature
 
 ## Problem Statement
 Finalize WSDE/EDRR workflow logic is not yet implemented, limiting DevSynth's capabilities.

--- a/issues/Finalize-dialectical-reasoning.md
+++ b/issues/Finalize-dialectical-reasoning.md
@@ -3,7 +3,7 @@ Milestone: 0.1.0
 Status: in progress
 
 Priority: low
-Dependencies: Phase 2 completion, [Resolve remaining dialectical audit questions](archived/Resolve-remaining-dialectical-audit-questions.md), docs/specifications/finalize-dialectical-reasoning.md, tests/behavior/features/finalize_dialectical_reasoning.feature
+Dependencies: Phase-2-completion.md, archived/Resolve-remaining-dialectical-audit-questions.md, docs/specifications/finalize-dialectical-reasoning.md, tests/behavior/features/finalize_dialectical_reasoning.feature
 
 ## Problem Statement
 Finalize dialectical reasoning is not yet implemented, limiting DevSynth's capabilities.

--- a/issues/Integrate-dialectical-audit-into-CI.md
+++ b/issues/Integrate-dialectical-audit-into-CI.md
@@ -2,7 +2,7 @@
 Milestone: 0.1.0
 Status: open
 Priority: low
-Dependencies: Phase 2 completion, docs/specifications/integrate-dialectical-audit-into-ci.md, tests/behavior/features/integrate_dialectical_audit_into_ci.feature
+Dependencies: Phase-2-completion.md, docs/specifications/integrate-dialectical-audit-into-ci.md, tests/behavior/features/integrate_dialectical_audit_into_ci.feature
 
 ## Problem Statement
 Integrate dialectical audit into CI is not yet implemented, limiting DevSynth's capabilities.

--- a/issues/Phase-1-completion.md
+++ b/issues/Phase-1-completion.md
@@ -1,0 +1,19 @@
+# Phase 1 completion
+Milestone: 0.1.0-beta.1
+Status: in progress
+Priority: high
+Dependencies:
+
+## Problem Statement
+Downstream tickets reference Phase 1 completion, but no tracking issue exists to coordinate the milestone.
+
+## Action Plan
+- Define deliverables for Phase 1.
+- Monitor dependent tickets until all objectives are met.
+- Archive this ticket once Phase 1 goals are satisfied.
+
+## Progress
+- 2025-02-22: Ticket created to anchor Phase 1 milestone dependencies.
+
+## References
+-

--- a/issues/Phase-2-completion.md
+++ b/issues/Phase-2-completion.md
@@ -1,0 +1,19 @@
+# Phase 2 completion
+Milestone: 0.1.0
+Status: in progress
+Priority: high
+Dependencies: Phase-1-completion.md
+
+## Problem Statement
+Phase 2 work depends on a dedicated milestone issue, but none exists.
+
+## Action Plan
+- Enumerate Phase 2 deliverables and blockers.
+- Ensure Phase-1-completion.md is archived before closing this ticket.
+- Archive this ticket when Phase 2 goals are achieved.
+
+## Progress
+- 2025-02-22: Ticket created to manage Phase 2 milestone.
+
+## References
+-

--- a/issues/Phase-3-completion.md
+++ b/issues/Phase-3-completion.md
@@ -1,0 +1,19 @@
+# Phase 3 completion
+Milestone: 0.1.1
+Status: in progress
+Priority: high
+Dependencies: Phase-2-completion.md
+
+## Problem Statement
+Later features rely on the completion of Phase 3, but there is no central issue to track this milestone.
+
+## Action Plan
+- Detail Phase 3 deliverables and outstanding work.
+- Verify Phase-2-completion.md is archived before closing.
+- Archive this ticket once Phase 3 goals are met.
+
+## Progress
+- 2025-02-22: Ticket created to serve as the Phase 3 milestone anchor.
+
+## References
+-

--- a/issues/Resolve-pytest-xdist-assertion-errors.md
+++ b/issues/Resolve-pytest-xdist-assertion-errors.md
@@ -2,7 +2,7 @@
 Milestone: 0.1.0-alpha.2
 Status: in progress
 Priority: high
-Dependencies: docs/specifications/resolve-pytest-xdist-assertion-errors.md, tests/behavior/features/resolve_pytest_xdist_assertion_errors.feature, devsynth-run-tests-command.md
+Dependencies: docs/specifications/resolve-pytest-xdist-assertion-errors.md, tests/behavior/features/resolve_pytest_xdist_assertion_errors.feature, archived/devsynth-run-tests-command.md
 
 ## Problem Statement
 Resolve pytest-xdist assertion errors is not yet implemented, limiting DevSynth's capabilities. Running `devsynth run-tests` across speed categories triggers internal pytest-xdist assertion errors, preventing full suite completion.

--- a/issues/agent-api-health-and-metrics.md
+++ b/issues/agent-api-health-and-metrics.md
@@ -2,7 +2,7 @@
 Milestone: 0.1.1
 Status: in progress
 Priority: low
-Dependencies: Phase 3 completion, docs/specifications/agent-api-health-and-metrics.md, tests/behavior/features/agent_api_health_and_metrics.feature
+Dependencies: Phase-3-completion.md, docs/specifications/agent-api-health-and-metrics.md, tests/behavior/features/agent_api_health_and_metrics.feature
 
 ## Problem Statement
 The agent API lacks dedicated health checks and runtime metrics. Without

--- a/issues/alignment-metrics-command.md
+++ b/issues/alignment-metrics-command.md
@@ -2,7 +2,7 @@
 Milestone: 0.1.1
 Status: in progress
 Priority: low
-Dependencies: Phase 3 completion, docs/specifications/alignment-metrics-command.md, tests/behavior/features/alignment_metrics_command.feature
+Dependencies: Phase-3-completion.md, docs/specifications/alignment-metrics-command.md, tests/behavior/features/alignment_metrics_command.feature
 
 ## Problem Statement
 Alignment Metrics Command is not yet implemented, limiting DevSynth's capabilities.

--- a/issues/ast-based-code-analysis-and-transformation.md
+++ b/issues/ast-based-code-analysis-and-transformation.md
@@ -2,7 +2,7 @@
 Milestone: 0.1.0-beta.1
 Status: in progress
 Priority: medium
-Dependencies: Phase 1 completion, docs/specifications/ast-based-code-analysis-and-transformation.md, tests/behavior/features/ast_based_code_analysis_and_transformation.feature
+Dependencies: Phase-1-completion.md, docs/specifications/ast-based-code-analysis-and-transformation.md, tests/behavior/features/ast_based_code_analysis_and_transformation.feature
 
 ## Problem Statement
 AST-Based Code Analysis and Transformation is not yet implemented, limiting DevSynth's capabilities.

--- a/issues/code-analysis.md
+++ b/issues/code-analysis.md
@@ -2,7 +2,7 @@
 Milestone: 0.1.0-beta.1
 Status: in progress
 Priority: medium
-Dependencies: Phase 1 completion, docs/specifications/code-analysis.md, tests/behavior/features/code_analysis.feature
+Dependencies: Phase-1-completion.md, docs/specifications/code-analysis.md, tests/behavior/features/code_analysis.feature
 
 ## Problem Statement
 Code Analysis is not yet implemented, limiting DevSynth's capabilities.

--- a/issues/code-generation.md
+++ b/issues/code-generation.md
@@ -2,7 +2,7 @@
 Milestone: 0.1.0-beta.1
 Status: in progress
 Priority: medium
-Dependencies: Phase 1 completion, docs/specifications/code-generation.md, tests/behavior/features/code_generation.feature
+Dependencies: Phase-1-completion.md, docs/specifications/code-generation.md, tests/behavior/features/code_generation.feature
 
 ## Problem Statement
 Code Generation is not yet implemented, limiting DevSynth's capabilities.

--- a/issues/consensus-building.md
+++ b/issues/consensus-building.md
@@ -2,7 +2,7 @@
 Milestone: 0.1.0
 Status: in progress
 Priority: low
-Dependencies: Phase 2 completion, docs/specifications/consensus-building.md, tests/behavior/features/consensus_building.feature
+Dependencies: Phase-2-completion.md, docs/specifications/consensus-building.md, tests/behavior/features/consensus_building.feature
 
 ## Problem Statement
 Consensus Building is not yet implemented, limiting DevSynth's capabilities.

--- a/issues/delegating-tasks-with-consensus-voting.md
+++ b/issues/delegating-tasks-with-consensus-voting.md
@@ -2,7 +2,7 @@
 Milestone: 0.1.0
 Status: in progress
 Priority: low
-Dependencies: Phase 2 completion, docs/specifications/delegating-tasks-with-consensus-voting.md, tests/behavior/features/delegating_tasks_with_consensus_voting.feature
+Dependencies: Phase-2-completion.md, docs/specifications/delegating-tasks-with-consensus-voting.md, tests/behavior/features/delegating_tasks_with_consensus_voting.feature
 
 ## Problem Statement
 Delegating tasks with consensus voting is not yet implemented, limiting DevSynth's capabilities.

--- a/issues/edrr-coordinator.md
+++ b/issues/edrr-coordinator.md
@@ -2,7 +2,7 @@
 Milestone: 0.1.0
 Status: in progress
 Priority: low
-Dependencies: Phase 2 completion, docs/specifications/edrr-coordinator.md, tests/behavior/features/edrr_coordinator.feature
+Dependencies: Phase-2-completion.md, docs/specifications/edrr-coordinator.md, tests/behavior/features/edrr_coordinator.feature
 
 ## Problem Statement
 EDRR Coordinator is not yet implemented, limiting DevSynth's capabilities.

--- a/issues/interactive-requirements-flow-webui.md
+++ b/issues/interactive-requirements-flow-webui.md
@@ -2,7 +2,7 @@
 Milestone: 0.1.0-beta.1
 Status: in progress
 Priority: medium
-Dependencies: Phase 1 completion, docs/specifications/interactive-requirements-flow-webui.md, tests/behavior/features/interactive_requirements_flow_webui.feature
+Dependencies: Phase-1-completion.md, docs/specifications/interactive-requirements-flow-webui.md, tests/behavior/features/interactive_requirements_flow_webui.feature
 
 ## Problem Statement
 Interactive Requirements Flow WebUI is not yet implemented, limiting DevSynth's capabilities.

--- a/issues/multi-agent-collaboration.md
+++ b/issues/multi-agent-collaboration.md
@@ -2,7 +2,7 @@
 Milestone: 0.1.0
 Status: in progress
 Priority: low
-Dependencies: Phase 2 completion, docs/specifications/multi-agent-collaboration.md, tests/behavior/features/multi_agent_collaboration.feature
+Dependencies: Phase-2-completion.md, docs/specifications/multi-agent-collaboration.md, tests/behavior/features/multi_agent_collaboration.feature
 
 ## Problem Statement
 Multi-Agent Collaboration is not yet implemented, limiting DevSynth's capabilities.

--- a/issues/multi-agent-task-delegation.md
+++ b/issues/multi-agent-task-delegation.md
@@ -2,7 +2,7 @@
 Milestone: 0.1.0
 Status: in progress
 Priority: low
-Dependencies: Phase 2 completion, docs/specifications/multi-agent-task-delegation.md, tests/behavior/features/multi_agent_task_delegation.feature
+Dependencies: Phase-2-completion.md, docs/specifications/multi-agent-task-delegation.md, tests/behavior/features/multi_agent_task_delegation.feature
 
 ## Problem Statement
 Multi-agent task delegation is not yet implemented, limiting DevSynth's capabilities.

--- a/issues/multi-disciplinary-dialectical-reasoning.md
+++ b/issues/multi-disciplinary-dialectical-reasoning.md
@@ -2,7 +2,7 @@
 Milestone: 0.1.0
 Status: in progress
 Priority: low
-Dependencies: Phase 2 completion, docs/specifications/multi-disciplinary-dialectical-reasoning.md, tests/behavior/features/dialectical_reasoning/multi_disciplinary_dialectical_reasoning.feature, tests/behavior/features/multi_disciplinary_dialectical_reasoning.feature
+Dependencies: Phase-2-completion.md, docs/specifications/multi-disciplinary-dialectical-reasoning.md, tests/behavior/features/dialectical_reasoning/multi_disciplinary_dialectical_reasoning.feature, tests/behavior/features/multi_disciplinary_dialectical_reasoning.feature
 
 ## Problem Statement
 Multi-disciplinary Dialectical Reasoning is not yet implemented, limiting DevSynth's capabilities.

--- a/issues/non-hierarchical-collaboration.md
+++ b/issues/non-hierarchical-collaboration.md
@@ -2,7 +2,7 @@
 Milestone: 0.1.0
 Status: in progress
 Priority: low
-Dependencies: Phase 2 completion, docs/specifications/non-hierarchical-collaboration.md, tests/behavior/features/non_hierarchical_collaboration.feature
+Dependencies: Phase-2-completion.md, docs/specifications/non-hierarchical-collaboration.md, tests/behavior/features/non_hierarchical_collaboration.feature
 
 ## Problem Statement
 Non-Hierarchical Collaboration is not yet implemented, limiting DevSynth's capabilities.

--- a/issues/project-state-analysis.md
+++ b/issues/project-state-analysis.md
@@ -2,7 +2,7 @@
 Milestone: 0.1.0-beta.1
 Status: in progress
 Priority: medium
-Dependencies: Phase 1 completion, tests/behavior/features/general/project_state_analyzer.feature, docs/specifications/project-state-analysis.md, tests/behavior/features/project_state_analysis.feature
+Dependencies: Phase-1-completion.md, tests/behavior/features/general/project_state_analyzer.feature, docs/specifications/project-state-analysis.md, tests/behavior/features/project_state_analysis.feature
 
 ## Problem Statement
 Project State Analysis is not yet implemented, limiting DevSynth's capabilities.

--- a/issues/promise-system-capability-management.md
+++ b/issues/promise-system-capability-management.md
@@ -2,7 +2,7 @@
 Milestone: 0.1.0
 Status: in progress
 Priority: low
-Dependencies: Phase 2 completion, docs/specifications/promise-system-capability-management.md, tests/behavior/features/promise_system_capability_management.feature
+Dependencies: Phase-2-completion.md, docs/specifications/promise-system-capability-management.md, tests/behavior/features/promise_system_capability_management.feature
 
 ## Problem Statement
 Promise System Capability Management is not yet implemented, limiting DevSynth's capabilities.

--- a/issues/prompt-management-with-dpsy-ai.md
+++ b/issues/prompt-management-with-dpsy-ai.md
@@ -2,7 +2,7 @@
 Milestone: 0.1.0
 Status: in progress
 Priority: low
-Dependencies: Phase 2 completion, docs/specifications/prompt-management-with-dpsy-ai.md, tests/behavior/features/prompt_management_with_dpsy_ai.feature
+Dependencies: Phase-2-completion.md, docs/specifications/prompt-management-with-dpsy-ai.md, tests/behavior/features/prompt_management_with_dpsy_ai.feature
 
 ## Problem Statement
 Prompt Management with DPSy-AI is not yet implemented, limiting DevSynth's capabilities.

--- a/issues/recursive-edrr-coordinator.md
+++ b/issues/recursive-edrr-coordinator.md
@@ -2,7 +2,7 @@
 Milestone: 0.1.0
 Status: in progress
 Priority: low
-Dependencies: Phase 2 completion, docs/specifications/recursive-edrr-coordinator.md, tests/behavior/features/recursive_edrr_coordinator.feature
+Dependencies: Phase-2-completion.md, docs/specifications/recursive-edrr-coordinator.md, tests/behavior/features/recursive_edrr_coordinator.feature
 
 ## Problem Statement
 Recursive EDRR Coordinator is not yet implemented, limiting DevSynth's capabilities.

--- a/issues/requirement-analysis.md
+++ b/issues/requirement-analysis.md
@@ -2,7 +2,7 @@
 Milestone: 0.1.0-beta.1
 Status: in progress
 Priority: medium
-Dependencies: Phase 1 completion, docs/specifications/requirement-analysis.md, tests/behavior/features/requirement_analysis.feature
+Dependencies: Phase-1-completion.md, docs/specifications/requirement-analysis.md, tests/behavior/features/requirement_analysis.feature
 
 ## Problem Statement
 Requirement Analysis is not yet implemented, limiting DevSynth's capabilities.

--- a/issues/requirements-wizard-navigation.md
+++ b/issues/requirements-wizard-navigation.md
@@ -2,7 +2,7 @@
 Milestone: 0.1.0-beta.1
 Status: in progress
 Priority: medium
-Dependencies: Phase 1 completion, docs/specifications/requirements-wizard-navigation.md, tests/behavior/features/requirements_wizard_navigation.feature
+Dependencies: Phase-1-completion.md, docs/specifications/requirements-wizard-navigation.md, tests/behavior/features/requirements_wizard_navigation.feature
 
 ## Problem Statement
 Requirements Wizard Navigation is not yet implemented, limiting DevSynth's capabilities.

--- a/issues/self-analysis.md
+++ b/issues/self-analysis.md
@@ -2,7 +2,7 @@
 Milestone: 0.1.0-beta.1
 Status: in progress
 Priority: medium
-Dependencies: Phase 1 completion, docs/specifications/self-analysis.md, tests/behavior/features/self_analysis.feature
+Dependencies: Phase-1-completion.md, docs/specifications/self-analysis.md, tests/behavior/features/self_analysis.feature
 
 ## Problem Statement
 Self Analysis is not yet implemented, limiting DevSynth's capabilities.

--- a/issues/shared-uxbridge-across-cli-and-webui.md
+++ b/issues/shared-uxbridge-across-cli-and-webui.md
@@ -2,7 +2,7 @@
 Milestone: 0.1.0-beta.1
 Status: in progress
 Priority: medium
-Dependencies: Phase 1 completion, docs/specifications/shared-uxbridge-across-cli-and-webui.md, tests/behavior/features/shared_uxbridge_across_cli_and_webui.feature
+Dependencies: Phase-1-completion.md, docs/specifications/shared-uxbridge-across-cli-and-webui.md, tests/behavior/features/shared_uxbridge_across_cli_and_webui.feature
 
 ## Problem Statement
 Shared UXBridge across CLI and WebUI is not yet implemented, limiting DevSynth's capabilities.

--- a/issues/streamlit-webui-navigation.md
+++ b/issues/streamlit-webui-navigation.md
@@ -2,7 +2,7 @@
 Milestone: 0.1.0-beta.1
 Status: in progress
 Priority: medium
-Dependencies: Phase 1 completion, docs/specifications/streamlit-webui-navigation.md, tests/behavior/features/streamlit_webui_navigation.feature
+Dependencies: Phase-1-completion.md, docs/specifications/streamlit-webui-navigation.md, tests/behavior/features/streamlit_webui_navigation.feature
 
 ## Problem Statement
 Streamlit WebUI Navigation is not yet implemented, limiting DevSynth's capabilities.

--- a/issues/test-metrics.md
+++ b/issues/test-metrics.md
@@ -2,7 +2,7 @@
 Milestone: 0.1.1
 Status: in progress
 Priority: low
-Dependencies: Phase 3 completion, docs/specifications/test-metrics.md, tests/behavior/features/test_metrics.feature
+Dependencies: Phase-3-completion.md, docs/specifications/test-metrics.md, tests/behavior/features/test_metrics.feature
 
 ## Problem Statement
 Test Metrics is not yet implemented, limiting DevSynth's capabilities.

--- a/issues/user-authentication.md
+++ b/issues/user-authentication.md
@@ -2,7 +2,7 @@
 Milestone: 0.1.1
 Status: in progress
 Priority: low
-Dependencies: Phase 3 completion, docs/specifications/user-authentication.md, tests/behavior/features/user_authentication.feature
+Dependencies: Phase-3-completion.md, docs/specifications/user-authentication.md, tests/behavior/features/user_authentication.feature
 
 ## Problem Statement
 User Authentication is not yet implemented, limiting DevSynth's capabilities.

--- a/issues/uxbridge-interface.md
+++ b/issues/uxbridge-interface.md
@@ -2,7 +2,7 @@
 Milestone: 0.1.0-beta.1
 Status: in progress
 Priority: medium
-Dependencies: Phase 1 completion, docs/specifications/uxbridge-interface.md, tests/behavior/features/uxbridge_interface.feature
+Dependencies: Phase-1-completion.md, docs/specifications/uxbridge-interface.md, tests/behavior/features/uxbridge_interface.feature
 
 ## Problem Statement
 UXBridge Interface is not yet implemented, limiting DevSynth's capabilities.

--- a/issues/web-application-generation.md
+++ b/issues/web-application-generation.md
@@ -2,7 +2,7 @@
 Milestone: 0.1.0-beta.1
 Status: in progress
 Priority: medium
-Dependencies: Phase 1 completion, docs/specifications/web-application-generation.md, tests/behavior/features/web_application_generation.feature
+Dependencies: Phase-1-completion.md, docs/specifications/web-application-generation.md, tests/behavior/features/web_application_generation.feature
 
 ## Problem Statement
 Web Application Generation is not yet implemented, limiting DevSynth's capabilities.

--- a/issues/webui-alignment-metrics-page.md
+++ b/issues/webui-alignment-metrics-page.md
@@ -2,7 +2,7 @@
 Milestone: 0.1.1
 Status: in progress
 Priority: low
-Dependencies: Phase 3 completion, docs/specifications/webui-alignment-metrics-page.md, tests/behavior/features/webui_alignment_metrics_page.feature
+Dependencies: Phase-3-completion.md, docs/specifications/webui-alignment-metrics-page.md, tests/behavior/features/webui_alignment_metrics_page.feature
 
 ## Problem Statement
 WebUI Alignment Metrics Page is not yet implemented, limiting DevSynth's capabilities.

--- a/issues/webui-analysis-page.md
+++ b/issues/webui-analysis-page.md
@@ -2,7 +2,7 @@
 Milestone: 0.1.0-beta.1
 Status: in progress
 Priority: medium
-Dependencies: Phase 1 completion, docs/specifications/webui-analysis-page.md, tests/behavior/features/webui_analysis_page.feature
+Dependencies: Phase-1-completion.md, docs/specifications/webui-analysis-page.md, tests/behavior/features/webui_analysis_page.feature
 
 ## Problem Statement
 WebUI Analysis Page is not yet implemented, limiting DevSynth's capabilities.

--- a/issues/webui-apispec-page.md
+++ b/issues/webui-apispec-page.md
@@ -2,7 +2,7 @@
 Milestone: 0.1.0-beta.1
 Status: in progress
 Priority: medium
-Dependencies: Phase 1 completion, docs/specifications/webui-apispec-page.md, tests/behavior/features/webui_apispec_page.feature
+Dependencies: Phase-1-completion.md, docs/specifications/webui-apispec-page.md, tests/behavior/features/webui_apispec_page.feature
 
 ## Problem Statement
 WebUI APISpec Page is not yet implemented, limiting DevSynth's capabilities.

--- a/issues/webui-command-execution.md
+++ b/issues/webui-command-execution.md
@@ -2,7 +2,7 @@
 Milestone: 0.1.0-beta.1
 Status: in progress
 Priority: medium
-Dependencies: Phase 1 completion, docs/specifications/webui-command-execution.md, tests/behavior/features/webui_command_execution.feature
+Dependencies: Phase-1-completion.md, docs/specifications/webui-command-execution.md, tests/behavior/features/webui_command_execution.feature
 
 ## Problem Statement
 WebUI Command Execution is not yet implemented, limiting DevSynth's capabilities.

--- a/issues/webui-configuration-page.md
+++ b/issues/webui-configuration-page.md
@@ -2,7 +2,7 @@
 Milestone: 0.1.0-beta.1
 Status: in progress
 Priority: medium
-Dependencies: Phase 1 completion, docs/specifications/webui-configuration-page.md, tests/behavior/features/webui_configuration_page.feature
+Dependencies: Phase-1-completion.md, docs/specifications/webui-configuration-page.md, tests/behavior/features/webui_configuration_page.feature
 
 ## Problem Statement
 WebUI Configuration Page is not yet implemented, limiting DevSynth's capabilities.

--- a/issues/webui-dbschema-page.md
+++ b/issues/webui-dbschema-page.md
@@ -2,7 +2,7 @@
 Milestone: 0.1.0-beta.1
 Status: in progress
 Priority: medium
-Dependencies: Phase 1 completion, docs/specifications/webui-dbschema-page.md, tests/behavior/features/webui_dbschema_page.feature
+Dependencies: Phase-1-completion.md, docs/specifications/webui-dbschema-page.md, tests/behavior/features/webui_dbschema_page.feature
 
 ## Problem Statement
 WebUI DBSchema Page is not yet implemented, limiting DevSynth's capabilities.

--- a/issues/webui-diagnostics-page.md
+++ b/issues/webui-diagnostics-page.md
@@ -2,7 +2,7 @@
 Milestone: 0.1.0-beta.1
 Status: in progress
 Priority: medium
-Dependencies: Phase 1 completion, docs/specifications/webui-diagnostics-page.md, tests/behavior/features/webui_diagnostics_page.feature
+Dependencies: Phase-1-completion.md, docs/specifications/webui-diagnostics-page.md, tests/behavior/features/webui_diagnostics_page.feature
 
 ## Problem Statement
 WebUI Diagnostics Page is not yet implemented, limiting DevSynth's capabilities.

--- a/issues/webui-docs-generation-page.md
+++ b/issues/webui-docs-generation-page.md
@@ -2,7 +2,7 @@
 Milestone: 0.1.0-beta.1
 Status: in progress
 Priority: medium
-Dependencies: Phase 1 completion, docs/specifications/webui-docs-generation-page.md, tests/behavior/features/webui_docs_generation_page.feature
+Dependencies: Phase-1-completion.md, docs/specifications/webui-docs-generation-page.md, tests/behavior/features/webui_docs_generation_page.feature
 
 ## Problem Statement
 WebUI Docs Generation Page is not yet implemented, limiting DevSynth's capabilities.

--- a/issues/webui-doctor.md
+++ b/issues/webui-doctor.md
@@ -2,7 +2,7 @@
 Milestone: 0.1.0-beta.1
 Status: in progress
 Priority: medium
-Dependencies: Phase 1 completion, docs/specifications/webui-doctor.md, tests/behavior/features/webui_doctor.feature
+Dependencies: Phase-1-completion.md, docs/specifications/webui-doctor.md, tests/behavior/features/webui_doctor.feature
 
 ## Problem Statement
 WebUI Doctor is not yet implemented, limiting DevSynth's capabilities.

--- a/issues/webui-gather-wizard.md
+++ b/issues/webui-gather-wizard.md
@@ -2,7 +2,7 @@
 Milestone: 0.1.0-beta.1
 Status: in progress
 Priority: medium
-Dependencies: Phase 1 completion, docs/specifications/webui-gather-wizard.md, tests/behavior/features/webui_gather_wizard.feature
+Dependencies: Phase-1-completion.md, docs/specifications/webui-gather-wizard.md, tests/behavior/features/webui_gather_wizard.feature
 
 ## Problem Statement
 WebUI Gather Wizard is not yet implemented, limiting DevSynth's capabilities.

--- a/issues/webui-ingestion-page.md
+++ b/issues/webui-ingestion-page.md
@@ -2,7 +2,7 @@
 Milestone: 0.1.0-beta.1
 Status: in progress
 Priority: medium
-Dependencies: Phase 1 completion, docs/specifications/webui-ingestion-page.md, tests/behavior/features/webui_ingestion_page.feature
+Dependencies: Phase-1-completion.md, docs/specifications/webui-ingestion-page.md, tests/behavior/features/webui_ingestion_page.feature
 
 ## Problem Statement
 WebUI Ingestion Page is not yet implemented, limiting DevSynth's capabilities.

--- a/issues/webui-inspect-config-page.md
+++ b/issues/webui-inspect-config-page.md
@@ -2,7 +2,7 @@
 Milestone: 0.1.0-beta.1
 Status: in progress
 Priority: medium
-Dependencies: Phase 1 completion, docs/specifications/webui-inspect-config-page.md, tests/behavior/features/webui_inspect_config_page.feature
+Dependencies: Phase-1-completion.md, docs/specifications/webui-inspect-config-page.md, tests/behavior/features/webui_inspect_config_page.feature
 
 ## Problem Statement
 WebUI Inspect Config Page is not yet implemented, limiting DevSynth's capabilities.

--- a/issues/webui-integration.md
+++ b/issues/webui-integration.md
@@ -2,7 +2,7 @@
 Milestone: 0.1.0-beta.1
 Status: in progress
 Priority: medium
-Dependencies: Phase 1 completion, docs/specifications/webui-integration.md, tests/behavior/features/webui_integration.feature
+Dependencies: Phase-1-completion.md, docs/specifications/webui-integration.md, tests/behavior/features/webui_integration.feature
 
 ## Problem Statement
 WebUI Integration is not yet implemented, limiting DevSynth's capabilities.

--- a/issues/webui-navigation-and-prompts.md
+++ b/issues/webui-navigation-and-prompts.md
@@ -2,7 +2,7 @@
 Milestone: 0.1.0-beta.1
 Status: in progress
 Priority: medium
-Dependencies: Phase 1 completion, docs/specifications/webui-navigation-and-prompts.md, tests/behavior/features/webui_navigation_and_prompts.feature
+Dependencies: Phase-1-completion.md, docs/specifications/webui-navigation-and-prompts.md, tests/behavior/features/webui_navigation_and_prompts.feature
 
 ## Problem Statement
 WebUI Navigation and Prompts is not yet implemented, limiting DevSynth's capabilities.

--- a/issues/webui-onboarding-flow.md
+++ b/issues/webui-onboarding-flow.md
@@ -2,7 +2,7 @@
 Milestone: 0.1.0-beta.1
 Status: in progress
 Priority: medium
-Dependencies: Phase 1 completion, docs/specifications/webui-onboarding-flow.md, tests/behavior/features/webui_onboarding_flow.feature
+Dependencies: Phase-1-completion.md, docs/specifications/webui-onboarding-flow.md, tests/behavior/features/webui_onboarding_flow.feature
 
 ## Problem Statement
 WebUI Onboarding Flow is not yet implemented, limiting DevSynth's capabilities.

--- a/issues/webui-refactor-page.md
+++ b/issues/webui-refactor-page.md
@@ -2,7 +2,7 @@
 Milestone: 0.1.0-beta.1
 Status: in progress
 Priority: medium
-Dependencies: Phase 1 completion, docs/specifications/webui-refactor-page.md, tests/behavior/features/webui_refactor_page.feature
+Dependencies: Phase-1-completion.md, docs/specifications/webui-refactor-page.md, tests/behavior/features/webui_refactor_page.feature
 
 ## Problem Statement
 WebUI Refactor Page is not yet implemented, limiting DevSynth's capabilities.

--- a/issues/webui-requirements-wizard-with-wizardstate.md
+++ b/issues/webui-requirements-wizard-with-wizardstate.md
@@ -2,7 +2,7 @@
 Milestone: 0.1.0-beta.1
 Status: in progress
 Priority: medium
-Dependencies: Phase 1 completion, docs/specifications/webui-requirements-wizard-with-wizardstate.md, tests/behavior/features/webui_requirements_wizard_with_wizardstate.feature
+Dependencies: Phase-1-completion.md, docs/specifications/webui-requirements-wizard-with-wizardstate.md, tests/behavior/features/webui_requirements_wizard_with_wizardstate.feature
 
 ## Problem Statement
 WebUI Requirements Wizard with WizardState is not yet implemented, limiting DevSynth's capabilities.

--- a/issues/webui-serve-page.md
+++ b/issues/webui-serve-page.md
@@ -2,7 +2,7 @@
 Milestone: 0.1.0-beta.1
 Status: in progress
 Priority: medium
-Dependencies: Phase 1 completion, docs/specifications/webui-serve-page.md, tests/behavior/features/webui_serve_page.feature
+Dependencies: Phase-1-completion.md, docs/specifications/webui-serve-page.md, tests/behavior/features/webui_serve_page.feature
 
 ## Problem Statement
 WebUI Serve Page is not yet implemented, limiting DevSynth's capabilities.

--- a/issues/webui-specification-editor-extended.md
+++ b/issues/webui-specification-editor-extended.md
@@ -2,7 +2,7 @@
 Milestone: 0.1.0-beta.1
 Status: in progress
 Priority: medium
-Dependencies: Phase 1 completion, docs/specifications/webui-specification-editor-extended.md, tests/behavior/features/webui_specification_editor_extended.feature
+Dependencies: Phase-1-completion.md, docs/specifications/webui-specification-editor-extended.md, tests/behavior/features/webui_specification_editor_extended.feature
 
 ## Problem Statement
 WebUI Specification Editor Extended is not yet implemented, limiting DevSynth's capabilities.

--- a/issues/webui-specification-editor.md
+++ b/issues/webui-specification-editor.md
@@ -2,7 +2,7 @@
 Milestone: 0.1.0-beta.1
 Status: in progress
 Priority: medium
-Dependencies: Phase 1 completion, docs/specifications/webui-specification-editor.md, tests/behavior/features/webui_specification_editor.feature
+Dependencies: Phase-1-completion.md, docs/specifications/webui-specification-editor.md, tests/behavior/features/webui_specification_editor.feature
 
 ## Problem Statement
 WebUI Specification Editor is not yet implemented, limiting DevSynth's capabilities.

--- a/issues/webui-synthesis-page.md
+++ b/issues/webui-synthesis-page.md
@@ -2,7 +2,7 @@
 Milestone: 0.1.0-beta.1
 Status: in progress
 Priority: medium
-Dependencies: Phase 1 completion, docs/specifications/webui-synthesis-page.md, tests/behavior/features/webui_synthesis_page.feature
+Dependencies: Phase-1-completion.md, docs/specifications/webui-synthesis-page.md, tests/behavior/features/webui_synthesis_page.feature
 
 ## Problem Statement
 WebUI Synthesis Page is not yet implemented, limiting DevSynth's capabilities.

--- a/issues/webui-test-metrics-page.md
+++ b/issues/webui-test-metrics-page.md
@@ -2,7 +2,7 @@
 Milestone: 0.1.1
 Status: in progress
 Priority: low
-Dependencies: Phase 3 completion, docs/specifications/webui-test-metrics-page.md, tests/behavior/features/webui_test_metrics_page.feature
+Dependencies: Phase-3-completion.md, docs/specifications/webui-test-metrics-page.md, tests/behavior/features/webui_test_metrics_page.feature
 
 ## Problem Statement
 WebUI Test Metrics Page is not yet implemented, limiting DevSynth's capabilities.

--- a/issues/webui-validate-manifest-page.md
+++ b/issues/webui-validate-manifest-page.md
@@ -2,7 +2,7 @@
 Milestone: 0.1.0-beta.1
 Status: in progress
 Priority: medium
-Dependencies: Phase 1 completion, docs/specifications/webui-validate-manifest-page.md, tests/behavior/features/webui_validate_manifest_page.feature
+Dependencies: Phase-1-completion.md, docs/specifications/webui-validate-manifest-page.md, tests/behavior/features/webui_validate_manifest_page.feature
 
 ## Problem Statement
 WebUI Validate Manifest Page is not yet implemented, limiting DevSynth's capabilities.

--- a/issues/webui-validate-metadata-page.md
+++ b/issues/webui-validate-metadata-page.md
@@ -2,7 +2,7 @@
 Milestone: 0.1.0-beta.1
 Status: in progress
 Priority: medium
-Dependencies: Phase 1 completion, docs/specifications/webui-validate-metadata-page.md, tests/behavior/features/webui_validate_metadata_page.feature
+Dependencies: Phase-1-completion.md, docs/specifications/webui-validate-metadata-page.md, tests/behavior/features/webui_validate_metadata_page.feature
 
 ## Problem Statement
 WebUI Validate Metadata Page is not yet implemented, limiting DevSynth's capabilities.

--- a/issues/webui-webapp-page.md
+++ b/issues/webui-webapp-page.md
@@ -2,7 +2,7 @@
 Milestone: 0.1.0-beta.1
 Status: in progress
 Priority: medium
-Dependencies: Phase 1 completion, docs/specifications/webui-webapp-page.md, tests/behavior/features/webui_webapp_page.feature
+Dependencies: Phase-1-completion.md, docs/specifications/webui-webapp-page.md, tests/behavior/features/webui_webapp_page.feature
 
 ## Problem Statement
 WebUI WebApp Page is not yet implemented, limiting DevSynth's capabilities.

--- a/issues/wsde-agent-model-refinement.md
+++ b/issues/wsde-agent-model-refinement.md
@@ -2,7 +2,7 @@
 Milestone: 0.1.0
 Status: in progress
 Priority: low
-Dependencies: Phase 2 completion, docs/specifications/wsde-agent-model-refinement.md, tests/behavior/features/wsde_agent_model_refinement.feature
+Dependencies: Phase-2-completion.md, docs/specifications/wsde-agent-model-refinement.md, tests/behavior/features/wsde_agent_model_refinement.feature
 
 ## Problem Statement
 WSDE Agent Model Refinement is not yet implemented, limiting DevSynth's capabilities.

--- a/issues/wsde-message-passing-and-peer-review.md
+++ b/issues/wsde-message-passing-and-peer-review.md
@@ -2,7 +2,7 @@
 Milestone: 0.1.0
 Status: in progress
 Priority: low
-Dependencies: Phase 2 completion, docs/specifications/wsde-message-passing-and-peer-review.md, tests/behavior/features/wsde_message_passing_and_peer_review.feature
+Dependencies: Phase-2-completion.md, docs/specifications/wsde-message-passing-and-peer-review.md, tests/behavior/features/wsde_message_passing_and_peer_review.feature
 
 ## Problem Statement
 WSDE Message Passing and Peer Review is not yet implemented, limiting DevSynth's capabilities.

--- a/issues/wsde-model-and-memory-system-integration.md
+++ b/issues/wsde-model-and-memory-system-integration.md
@@ -2,7 +2,7 @@
 Milestone: 0.1.0
 Status: in progress
 Priority: low
-Dependencies: Phase 2 completion, docs/specifications/wsde-model-and-memory-system-integration.md, tests/behavior/features/wsde_model_and_memory_system_integration.feature
+Dependencies: Phase-2-completion.md, docs/specifications/wsde-model-and-memory-system-integration.md, tests/behavior/features/wsde_model_and_memory_system_integration.feature
 
 ## Problem Statement
 WSDE Model and Memory System Integration is not yet implemented, limiting DevSynth's capabilities.

--- a/issues/wsde-peer-review-workflow.md
+++ b/issues/wsde-peer-review-workflow.md
@@ -2,7 +2,7 @@
 Milestone: 0.1.0
 Status: in progress
 Priority: low
-Dependencies: Phase 2 completion, docs/specifications/wsde-peer-review-workflow.md, tests/behavior/features/wsde_peer_review_workflow.feature
+Dependencies: Phase-2-completion.md, docs/specifications/wsde-peer-review-workflow.md, tests/behavior/features/wsde_peer_review_workflow.feature
 
 ## Problem Statement
 WSDE Peer Review Workflow is not yet implemented, limiting DevSynth's capabilities.

--- a/issues/wsde-voting-mechanisms-for-critical-decisions.md
+++ b/issues/wsde-voting-mechanisms-for-critical-decisions.md
@@ -2,7 +2,7 @@
 Milestone: 0.1.0
 Status: in progress
 Priority: low
-Dependencies: Phase 2 completion, docs/specifications/wsde-voting-mechanisms-for-critical-decisions.md, tests/behavior/features/wsde_voting_mechanisms_for_critical_decisions.feature
+Dependencies: Phase-2-completion.md, docs/specifications/wsde-voting-mechanisms-for-critical-decisions.md, tests/behavior/features/wsde_voting_mechanisms_for_critical_decisions.feature
 
 ## Problem Statement
 WSDE Voting Mechanisms for Critical Decisions is not yet implemented, limiting DevSynth's capabilities.


### PR DESCRIPTION
## Summary
- add Phase 1/2/3 completion milestone tickets
- standardize issue dependency references and fix missing archived path

## Testing
- `poetry run pre-commit run --files $(git status --short | awk '{print $2}')`
- `poetry run devsynth run-tests --speed=fast`
- `poetry run python tests/verify_test_organization.py`
- `poetry run python scripts/verify_test_markers.py`
- `poetry run python scripts/verify_requirements_traceability.py`
- `poetry run python scripts/verify_version_sync.py`


------
https://chatgpt.com/codex/tasks/task_e_68a8d153c8d083339ef8d237362ffa3e