### PR TITLE
chore: verify release workflow

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -194,6 +194,7 @@ tasks:
       - task: build:wheel
       - task: build:sdist
       - task: test:smoke
+      - poetry run python scripts/verify_test_markers.py
       - task: security:audit
       - poetry run python scripts/verify_release_state.py
       - poetry run python scripts/dialectical_audit.py

--- a/docs/release/0.1.0-alpha.1.md
+++ b/docs/release/0.1.0-alpha.1.md
@@ -91,16 +91,18 @@ All Python commands in this guide should be prefixed with `poetry run` to ensure
    task --version
    task release:prep
    ```
-   The `release:prep` task runs `scripts/verify_python_version.py` before building
+   The `release:prep` task runs `scripts/verify_python_version.py`, executes smoke tests,
+   checks test markers via `poetry run python scripts/verify_test_markers.py`, and verifies release
+   readiness with `poetry run python scripts/verify_release_state.py` before building
    distributions. Record all audit questions and their resolutions in `dialectical_audit.log`.
 
-6. Verify the repository is in a release-ready state:
+6. Review release state and audit log (rerun checks if needed):
    ```bash
    poetry run python scripts/verify_release_state.py
    ```
-   Tagging must only occur after this check passes and all audit questions in `dialectical_audit.log` are resolved.
-  Review the log with another contributor before tagging the release.
-  See the [Dialectical Audit Policy](../policies/dialectical_audit.md) for guidance.
+   Tagging must only occur after the release state check passes and all questions in
+   `dialectical_audit.log` are resolved. Review the log with another contributor before tagging
+   the release. See the [Dialectical Audit Policy](../policies/dialectical_audit.md) for guidance.
 
 ## Checklist Results
 


### PR DESCRIPTION
## Summary
- ensure `release:prep` verifies test markers and release state
- document marker check and release-state verification in release guide, including audit resolution before tagging

## Testing
- `poetry env info --path`
- `task --version`
- `PIP_NO_INDEX=1 poetry run pip check`
- `poetry run pre-commit run --files docs/release/0.1.0-alpha.1.md Taskfile.yml`
- `poetry run devsynth run-tests --speed=fast`
- `poetry run devsynth run-tests --speed=medium` *(fails: command hung)*
- `poetry run devsynth run-tests --speed=slow` *(fails: command hung)*
- `poetry run python tests/verify_test_organization.py` *(fails: missing sentinel test)*
- `poetry run python scripts/verify_test_markers.py`
- `poetry run python scripts/verify_requirements_traceability.py`
- `poetry run python scripts/verify_version_sync.py`
- `poetry run pytest tests/unit/deployment -m fast`
- `task release:prep` *(fails: test failure in smoke tests)*
- `poetry run python scripts/verify_release_state.py` *(fails: unresolved audit questions)*


------
https://chatgpt.com/codex/tasks/task_e_68aa547912d88333917dc469f8f39ce9