### PR TITLE
chore: enforce codex setup runtime limits

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,7 +20,7 @@ DevSynth implements agent services under `src/devsynth/` and supporting scripts 
 2. Provision the environment:
    ```bash
    bash scripts/install_dev.sh      # general setup (auto-installs go-task)
-   bash scripts/codex_setup.sh      # Codex agents
+    bash scripts/codex_setup.sh      # Codex agents (finishes <15m, warns >10m)
    task --version                   # verify Taskfile is available
    ```
    The install script downloads `go-task` to `$HOME/.local/bin` and adds it to

--- a/scripts/codex_setup.sh
+++ b/scripts/codex_setup.sh
@@ -1,8 +1,14 @@
 #!/usr/bin/env bash
 set -exo pipefail
 
+START_TIME=$(date +%s)
+MAX_SECONDS=$((15 * 60))
+WARN_SECONDS=$((10 * 60))
+
 # NOTE: This script provisions the Codex testing environment only. It is not
-# intended for regular development setup.
+# intended for regular development setup. To keep the ephemeral workspace
+# responsive, it targets completion in under 10 minutes and fails if it
+# exceeds 15 minutes.
 # See AGENTS.md for repository instructions; only AGENTS.md and this file should
 # reference AGENTS guidelines or `codex_setup.sh`.
 
@@ -231,9 +237,10 @@ fi
 poetry run pytest tests/behavior/steps/test_alignment_metrics_steps.py --maxfail=1
 
 # Use the CLI to run a fast, non-interactive test sweep. The timeout prevents
-# hangs while the log aids in diagnosing failures.
+# hangs while the log aids in diagnosing failures. Keeping this step under
+# ten minutes helps the overall setup stay within the target runtime.
 # What evidence shows the CLI can run tests non-interactively?
-timeout 15m poetry run devsynth run-tests --speed=fast | tee devsynth_cli_tests.log
+timeout 10m poetry run devsynth run-tests --speed=fast | tee devsynth_cli_tests.log
 
 # Run the dialectical audit and surface any unanswered questions.
 poetry run python scripts/dialectical_audit.py || true
@@ -259,3 +266,13 @@ run_check "Security audit" DEVSYNTH_PRE_DEPLOY_APPROVED=true poetry run python s
 
 # Cleanup any failure marker if the setup completes successfully
 [ -f CODEX_ENVIRONMENT_SETUP_FAILED ] && rm CODEX_ENVIRONMENT_SETUP_FAILED
+
+END_TIME=$(date +%s)
+ELAPSED=$((END_TIME - START_TIME))
+echo "codex_setup completed in ${ELAPSED}s"
+if (( ELAPSED > MAX_SECONDS )); then
+  echo "codex_setup exceeded ${MAX_SECONDS}s limit" >&2
+  exit 1
+elif (( ELAPSED > WARN_SECONDS )); then
+  echo "[warning] codex_setup exceeded ${WARN_SECONDS}s target" >&2
+fi


### PR DESCRIPTION
## Summary
- ensure codex_setup.sh warns at 10m and fails after 15m
- shorten CLI test sweep to 10m
- document runtime expectation in AGENTS.md

## Testing
- `poetry run pre-commit run --files AGENTS.md scripts/codex_setup.sh`
- `poetry run devsynth run-tests --speed=fast` *(no output produced)*
- `poetry run python tests/verify_test_organization.py`
- `poetry run python scripts/verify_test_markers.py`
- `poetry run python scripts/verify_requirements_traceability.py`
- `poetry run python scripts/verify_version_sync.py`


------
https://chatgpt.com/codex/tasks/task_e_68af46e146dc8333b34cfb13034ebede