### PR TITLE
docs: track property marker advisories

### DIFF
--- a/docs/plan.md
+++ b/docs/plan.md
@@ -9,8 +9,9 @@ Executive summary
 - Current state (evidence):
   - Test collection succeeds across a large suite (unit/integration/behavior/property).
   - Fast smoke/unit/integration/behavior profiles run successfully via the CLI.
-  - Speed-marker discipline validated (0 violations).
-  - Property tests (opt-in) reveal 2 failures; must be fixed before release to claim full readiness.
+- Speed-marker discipline validated (0 violations).
+- Property marker verification flags missing @pytest.mark.property in tests/property/test_reasoning_loop_properties.py (2 property_violations).
+- Property tests (opt-in) reveal 2 failures; must be fixed before release to claim full readiness.
   - Diagnostics indicate environment/config gaps for non-test environments (doctor.txt) used by the app; tests succeed due to defaults and gating, but this requires documentation and guardrails.
   - Coverage report artifact (htmlcov) shows 20% from a prior run; targeted property-only run showed 8% and triggered coverage threshold failure. The global pytest.ini threshold is 90%, so any authoritative release run must aggregate full-suite coverage.
 
@@ -20,7 +21,7 @@ Commands executed (audit trail)
 - poetry run devsynth run-tests --target unit-tests --speed=fast --no-parallel --maxfail=1 → Success.
 - poetry run devsynth run-tests --target behavior-tests --speed=fast --smoke --no-parallel --maxfail=1 → Success.
 - poetry run devsynth run-tests --target integration-tests --speed=fast --smoke --no-parallel --maxfail=1 → Success.
-- poetry run python scripts/verify_test_markers.py --report --report-file test_markers_report.json → 0 issues, 0 violations.
+- poetry run python scripts/verify_test_markers.py --report --report-file test_markers_report.json → property marker advisories (2 property_violations) in tests/property/test_reasoning_loop_properties.py.
 - DEVSYNTH_PROPERTY_TESTING=true poetry run pytest tests/property/ -q → 2 failing tests; coverage fail-under triggered (8% on this narrow subset).
 - Environment: Python 3.12.x (pyproject constraint), Poetry 2.1.4; coverage artifacts present under htmlcov/ and coverage.json.
 
@@ -70,6 +71,7 @@ Concrete remediation tasks (actionable specifics)
      - Alternative: Extend the Dummy test double to implement _improve_clarity with a no-op or minimal semantics in tests/helpers/dummies.py (or the appropriate test utility module), ensuring interface compatibility.
   - Re-run: DEVSYNTH_PROPERTY_TESTING=true poetry run pytest tests/property/ -q 2>&1 | tee test_reports/property_tests.log
   - Success criteria: 0 failures; exactly one speed marker per function.
+  3) Tag tests/property/test_reasoning_loop_properties.py::check with @pytest.mark.property and a single speed marker; rerun verify_test_markers to confirm 0 property_violations (Issue: issues/property-marker-advisories-in-reasoning-loop-tests.md).
 - run_tests_cmd coverage uplift (src/devsynth/application/cli/commands/run_tests_cmd.py): add unit tests to cover these branches/behaviors with clear test names:
   - test_smoke_mode_sets_pytest_autoload_off
   - test_no_parallel_maps_to_n0
@@ -258,3 +260,5 @@ Notes and next actions
 - Immediate: Fix the two property test failures; add targeted tests for run_tests_cmd branches; re-generate coverage report and iterate on hotspots below 80% coverage.
 - Short-term: Align docs with current CLI behaviors and ensure issues/ action items are traced to tests.
 - Post-release: Introduce low-throughput GH Actions pipeline as specified and expand nightly coverage runs.
+- verify_test_markers reports missing @pytest.mark.property in tests/property/test_reasoning_loop_properties.py; track under issues/property-marker-advisories-in-reasoning-loop-tests.md and resolve before release.
+- scripts/codex_setup.sh exits early due to version mismatch (project version 0.1.0a1 vs expected 0.1.0-alpha.1); reconcile versioning or adjust the setup script.

--- a/docs/task_notes.md
+++ b/docs/task_notes.md
@@ -110,3 +110,8 @@ Date: 2025-09-08T10:00 Local
 - Smoke test command failed: ModuleNotFoundError: devsynth.
   - `poetry install --with dev --all-extras` hung, looping on nvidia package; log saved to diagnostics/poetry_install_hang.txt; issue poetry-install-nvidia-loop.md opened.
 - Test suite and verification scripts blocked pending successful install.
+Date: 2025-09-09T00:57Z
+- Installed go-task via scripts/install_dev.sh (pre-commit init interrupted but tool now available).
+- scripts/codex_setup.sh failed: Project version 0.1.0a1 does not match 0.1.0-alpha.1.
+- verify_test_markers flagged 2 property_violations in tests/property/test_reasoning_loop_properties.py; issue file opened.
+- Smoke run and marker checks otherwise green.

--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -17,6 +17,7 @@ Instructions: Check off each task when completed. Subtasks are enumerated for cl
 1.5.4 [x] `poetry run devsynth doctor | tee diagnostics/doctor_run.txt`
 1.5.5 [x] `date -u '+%Y-%m-%dT%H:%M:%SZ' | tee diagnostics/run_timestamp_utc.txt`
 1.6 [ ] Investigate `poetry install --with dev --all-extras` hanging on `nvidia/__init__.py` (Issue: poetry-install-nvidia-loop.md).
+1.7 [ ] Resolve scripts/codex_setup.sh version mismatch (project 0.1.0a1 vs expected 0.1.0-alpha.1).
 
 2. Property Tests Remediation (Phase 1)
 2.1 [x] Fix Hypothesis misuse in tests/property/test_requirements_consensus_properties.py:
@@ -25,9 +26,10 @@ Instructions: Check off each task when completed. Subtasks are enumerated for cl
 2.2 [x] Resolve AttributeError for _DummyTeam._improve_clarity:
 2.2.1 [x] Preferred: Update tests to target a public API that internally triggers clarity improvement (e.g., team.improve_clarity(requirement)).
 2.2.2 [x] Alternative: Implement a no-op or minimally semantic _improve_clarity on the Dummy test double to satisfy the expected interface (tests/helpers/dummies.py or equivalent).
-2.3 [x] Ensure each property test has exactly one speed marker plus @pytest.mark.property.
+2.3 [ ] Ensure each property test has exactly one speed marker plus @pytest.mark.property.
 2.4 [x] Re-run property tests: `DEVSYNTH_PROPERTY_TESTING=true poetry run pytest tests/property/ -q` and confirm 0 failures.
 2.5 [x] Add/adjust fixtures as needed to keep property tests isolated and deterministic.
+2.6 [ ] Tag missing @pytest.mark.property in tests/property/test_reasoning_loop_properties.py and re-run `verify_test_markers.py` (Issue: property-marker-advisories-in-reasoning-loop-tests.md).
 
 3. Coverage Uplift — CLI run_tests_cmd Hotspot (Phase 2)
 3.1 [x] Add or extend unit tests for src/devsynth/application/cli/commands/run_tests_cmd.py to cover the following branches/behaviors:

--- a/issues/property-marker-advisories-in-reasoning-loop-tests.md
+++ b/issues/property-marker-advisories-in-reasoning-loop-tests.md
@@ -1,0 +1,16 @@
+Title: Missing property markers in reasoning loop property tests
+Date: 2025-09-09 00:57 UTC
+Status: open
+Affected Area: tests
+Reproduction:
+  - poetry run python scripts/verify_test_markers.py --report --report-file test_markers_report.json
+Exit Code: 0
+Artifacts:
+  - test_markers_report.json
+  - /tmp/markers.log
+Suspected Cause: tests/property/test_reasoning_loop_properties.py::check lacks @pytest.mark.property and a speed marker.
+Next Actions:
+  - [ ] Add required markers to tests/property/test_reasoning_loop_properties.py::check.
+  - [ ] Re-run verify_test_markers.py to confirm 0 property_violations.
+Resolution Evidence:
+  - (pending)


### PR DESCRIPTION
## Summary
- record verify_test_markers advisory about missing `@pytest.mark.property`
- note codex_setup version mismatch for 0.1.0a1 vs 0.1.0-alpha.1
- log iteration notes for environment setup and marker warnings
- add issue to track property-marker remediation

## Testing
- `poetry run devsynth run-tests --smoke --speed=fast --no-parallel --maxfail=1`
- `poetry run python scripts/verify_test_markers.py --report --report-file test_markers_report.json`
- `poetry run pre-commit run --files docs/plan.md docs/tasks.md docs/task_notes.md issues/property-marker-advisories-in-reasoning-loop-tests.md`

------
https://chatgpt.com/codex/tasks/task_e_68bf7a0556788333adac788d2a56d749