### PR TITLE
test: mark reasoning loop property checks

### DIFF
--- a/issues/archived/property-marker-advisories-in-reasoning-loop-tests.md
+++ b/issues/archived/property-marker-advisories-in-reasoning-loop-tests.md
@@ -1,6 +1,6 @@
 Title: Missing property markers in reasoning loop property tests
 Date: 2025-09-09 00:57 UTC
-Status: open
+Status: closed
 Affected Area: tests
 Reproduction:
   - poetry run python scripts/verify_test_markers.py --report --report-file test_markers_report.json
@@ -10,7 +10,7 @@ Artifacts:
   - /tmp/markers.log
 Suspected Cause: tests/property/test_reasoning_loop_properties.py::check lacks @pytest.mark.property and a speed marker.
 Next Actions:
-  - [ ] Add required markers to tests/property/test_reasoning_loop_properties.py::check.
-  - [ ] Re-run verify_test_markers.py to confirm 0 property_violations.
+  - [x] Add required markers to tests/property/test_reasoning_loop_properties.py::check.
+  - [x] Re-run verify_test_markers.py to confirm 0 property_violations.
 Resolution Evidence:
-  - (pending)
+  - `poetry run python scripts/verify_test_markers.py` reported 0 property_violations.

--- a/tests/property/test_reasoning_loop_properties.py
+++ b/tests/property/test_reasoning_loop_properties.py
@@ -1,13 +1,15 @@
 """Property-based tests for the reasoning loop convergence. ReqID: DRL-001"""
 
-import pytest
-
-pytest.importorskip("hypothesis")
 import importlib
 from unittest.mock import MagicMock
 
-from hypothesis import given
-from hypothesis import strategies as st
+import pytest
+
+try:
+    from hypothesis import given
+    from hypothesis import strategies as st
+except ImportError:  # pragma: no cover
+    pytest.skip("hypothesis not available", allow_module_level=True)
 
 reasoning_loop_module = importlib.import_module(
     "devsynth.methodology.edrr.reasoning_loop"
@@ -19,6 +21,8 @@ reasoning_loop_module = importlib.import_module(
 def test_reasoning_loop_stops_on_completion(monkeypatch):
     """Loop halts on the first completed status. ReqID: DRL-001"""
 
+    @pytest.mark.property
+    @pytest.mark.medium
     @given(
         st.lists(st.sampled_from(["in_progress", "completed"]), min_size=1, max_size=5)
     )
@@ -61,6 +65,8 @@ def test_reasoning_loop_stops_on_completion(monkeypatch):
 def test_reasoning_loop_respects_max_iterations(monkeypatch):
     """Loop runs at most max_iterations times. ReqID: DRL-001"""
 
+    @pytest.mark.property
+    @pytest.mark.medium
     @given(st.integers(min_value=1, max_value=5))
     def check(max_iterations):
         def fake_apply(team, task, critic, memory):


### PR DESCRIPTION
## Summary
- ensure reasoning loop property tests' inner checks carry property and speed markers
- archive resolved marker advisory issue

## Testing
- `poetry run pre-commit run --files tests/property/test_reasoning_loop_properties.py issues/archived/property-marker-advisories-in-reasoning-loop-tests.md`
- `DEVSYNTH_PROPERTY_TESTING=1 poetry run pytest tests/property/test_reasoning_loop_properties.py -m medium -q --no-cov`
- `poetry run python scripts/verify_test_markers.py`


------
https://chatgpt.com/codex/tasks/task_e_68bf7e95da2c8333ba8dc27fb83e95e9