### PR TITLE
fix: accept pep440 version in codex setup

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,7 +5,7 @@
 **What is DevSynth?**
 DevSynth implements agent services under `src/devsynth/` and supporting scripts under `scripts/`. It values clarity, collaboration, and dependable automation. For architecture and policy references, see `docs/` and `CONTRIBUTING.md`.
 
-> **NOTE:** All GitHub Actions workflows are temporarily disabled and must be triggered manually via `workflow_dispatch` until the `v0.1.0-alpha.1` tag is created (see `docs/tasks.md` item 10.1).
+> **NOTE:** All GitHub Actions workflows are temporarily disabled and must be triggered manually via `workflow_dispatch` until the `v0.1.0a1` tag is created (see `docs/tasks.md` item 10.1).
 
 ## Setup
 

--- a/docs/release/0.1.0-alpha.1.md
+++ b/docs/release/0.1.0-alpha.1.md
@@ -1,14 +1,14 @@
 ---
-title: "Release Notes: 0.1.0-alpha.1"
+title: "Release Notes: 0.1.0a1"
 date: 2025-08-28
-version: 0.1.0-alpha.1
+version: 0.1.0a1
 status: draft
 last_reviewed: 2025-08-28
 ---
 
-# DevSynth 0.1.0-alpha.1
+# DevSynth 0.1.0a1
 
-This document tracks final checklist updates and artifacts for the 0.1.0‑alpha.1 pre‑release tag.
+This document tracks final checklist updates and artifacts for the 0.1.0a1 pre‑release tag.
 
 ## Summary
 - Focus on CLI stability, provider offline‑by‑default, speed‑marker discipline, and release readiness automation per docs/plan.md.

--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -17,7 +17,7 @@ Instructions: Check off each task when completed. Subtasks are enumerated for cl
 1.5.4 [x] `poetry run devsynth doctor | tee diagnostics/doctor_run.txt`
 1.5.5 [x] `date -u '+%Y-%m-%dT%H:%M:%SZ' | tee diagnostics/run_timestamp_utc.txt`
 1.6 [ ] Investigate `poetry install --with dev --all-extras` hanging on `nvidia/__init__.py` (Issue: poetry-install-nvidia-loop.md).
-1.7 [ ] Resolve scripts/codex_setup.sh version mismatch (project 0.1.0a1 vs expected 0.1.0-alpha.1).
+1.7 [x] Resolve scripts/codex_setup.sh version mismatch (project 0.1.0a1 vs expected 0.1.0-alpha.1).
 
 2. Property Tests Remediation (Phase 1)
 2.1 [x] Fix Hypothesis misuse in tests/property/test_requirements_consensus_properties.py:

--- a/scripts/codex_setup.sh
+++ b/scripts/codex_setup.sh
@@ -75,9 +75,13 @@ poetry env info --path >/dev/null
 echo "DIALECTICAL CHECKPOINT: What dependencies are truly required?"
 echo "DIALECTICAL CHECKPOINT: How do we verify the cache reproduces identical environments?"
 
-EXPECTED_VERSION="0.1.0-alpha.1"
+# Accept either the legacy 0.1.0-alpha.1 notation or the PEP 440-compliant
+# 0.1.0a1 form. Normalize the current version to the latter for comparison so
+# future releases can switch schemes without breaking setup.
+EXPECTED_VERSION="0.1.0a1"
 CURRENT_VERSION="$(poetry version -s)"
-if [[ "$CURRENT_VERSION" != "$EXPECTED_VERSION" ]]; then
+NORMALIZED_VERSION="${CURRENT_VERSION/-alpha./a}"
+if [[ "$NORMALIZED_VERSION" != "$EXPECTED_VERSION" ]]; then
   echo "Project version $CURRENT_VERSION does not match $EXPECTED_VERSION" >&2
   exit 1
 fi


### PR DESCRIPTION
## Summary
- normalize project version in `codex_setup.sh` to accept PEP 440 `0.1.0a1`
- update docs and AGENTS.md for new `v0.1.0a1` tag
- mark task for codex setup version mismatch as complete

## Testing
- `bash scripts/codex_setup.sh` *(fails: tests/behavior/steps/test_alignment_metrics_steps.py::test_collect_metrics_successfully)*
- `poetry run pre-commit run --files scripts/codex_setup.sh AGENTS.md docs/tasks.md docs/release/0.1.0-alpha.1.md`
- `timeout 2m poetry run devsynth run-tests --speed=fast --maxfail=1`
- `poetry run python tests/verify_test_organization.py`
- `poetry run python scripts/verify_test_markers.py`
- `poetry run python scripts/verify_requirements_traceability.py`
- `poetry run python scripts/verify_version_sync.py`


------
https://chatgpt.com/codex/tasks/task_e_68bf7e8dd774833392dcf2714a2dcffa