### PR TITLE
test: ensure property tests include speed and issue markers

### DIFF
--- a/tests/property/test_core_values_properties.py
+++ b/tests/property/test_core_values_properties.py
@@ -1,10 +1,15 @@
-"""Property-based tests for CoreValues utilities. ReqID: FR-87"""
+"""Property-based tests for CoreValues utilities.
+
+Issue: issues/Finalize-dialectical-reasoning.md ReqID: FR-87
+"""
 
 import pytest
 
-pytest.importorskip("hypothesis")
-from hypothesis import assume, given
-from hypothesis import strategies as st
+try:
+    from hypothesis import assume, given
+    from hypothesis import strategies as st
+except ImportError:  # pragma: no cover
+    pytest.skip("hypothesis not available", allow_module_level=True)
 
 from devsynth.core.values import CoreValues, find_value_conflicts
 
@@ -13,7 +18,10 @@ from devsynth.core.values import CoreValues, find_value_conflicts
 @given(st.lists(st.text(min_size=1).filter(lambda s: s.strip()), max_size=10))
 @pytest.mark.medium
 def test_update_values_deduplicates(values):
-    """update_values should keep the first occurrence of each value. ReqID: FR-87"""
+    """update_values should keep the first occurrence of each value.
+
+    Issue: issues/Finalize-dialectical-reasoning.md ReqID: FR-87
+    """
     cv = CoreValues()
     cv.update_values(values)
     expected = [v.strip() for v in dict.fromkeys(values) if v.strip()]
@@ -24,7 +32,10 @@ def test_update_values_deduplicates(values):
 @given(st.text())
 @pytest.mark.medium
 def test_find_value_conflicts_no_negation(text):
-    """find_value_conflicts returns empty when no negation tokens appear. ReqID: FR-87"""
+    """find_value_conflicts returns empty when no negation tokens appear.
+
+    Issue: issues/Finalize-dialectical-reasoning.md ReqID: FR-87
+    """
     cv = CoreValues(["safety"])
     lower = text.lower()
     assume("not safety" not in lower and "no safety" not in lower)

--- a/tests/property/test_memory_adapter_properties.py
+++ b/tests/property/test_memory_adapter_properties.py
@@ -1,10 +1,15 @@
-"""Property tests for MemorySystemAdapter operations. ReqID: HMA-001, HMA-002"""
+"""Property tests for MemorySystemAdapter operations.
+
+Issue: issues/memory-adapter-integration.md ReqID: HMA-001, HMA-002
+"""
 
 import pytest
 
-pytest.importorskip("hypothesis")
-from hypothesis import given
-from hypothesis import strategies as st
+try:
+    from hypothesis import given
+    from hypothesis import strategies as st
+except ImportError:  # pragma: no cover
+    pytest.skip("hypothesis not available", allow_module_level=True)
 
 from devsynth.adapters.memory.memory_adapter import MemorySystemAdapter
 from devsynth.domain.models.memory import MemoryItem, MemoryType
@@ -14,7 +19,10 @@ from devsynth.domain.models.memory import MemoryItem, MemoryType
 @given(st.text())
 @pytest.mark.medium
 def test_store_and_retrieve_round_trip(content):
-    """Stored items are retrievable with identical content. ReqID: HMA-001"""
+    """Stored items are retrievable with identical content.
+
+    Issue: issues/memory-adapter-integration.md ReqID: HMA-001
+    """
     adapter = MemorySystemAdapter.create_for_testing()
     item = MemoryItem(id="", content=content, memory_type=MemoryType.SHORT_TERM)
     item_id = adapter.write(item)
@@ -27,7 +35,10 @@ def test_store_and_retrieve_round_trip(content):
 @given(st.lists(st.text(), min_size=1, max_size=5))
 @pytest.mark.medium
 def test_search_without_filters_returns_all(contents):
-    """Unfiltered search returns all stored items. ReqID: HMA-002"""
+    """Unfiltered search returns all stored items.
+
+    Issue: issues/memory-adapter-integration.md ReqID: HMA-002
+    """
     adapter = MemorySystemAdapter.create_for_testing()
     for text in contents:
         adapter.write(

--- a/tests/property/test_reasoning_loop_properties.py
+++ b/tests/property/test_reasoning_loop_properties.py
@@ -1,4 +1,7 @@
-"""Property-based tests for the reasoning loop convergence. ReqID: DRL-001"""
+"""Property-based tests for the reasoning loop convergence.
+
+Issue: issues/Finalize-dialectical-reasoning.md ReqID: DRL-001
+"""
 
 import importlib
 from unittest.mock import MagicMock
@@ -19,10 +22,11 @@ reasoning_loop_module = importlib.import_module(
 @pytest.mark.property
 @pytest.mark.medium
 def test_reasoning_loop_stops_on_completion(monkeypatch):
-    """Loop halts on the first completed status. ReqID: DRL-001"""
+    """Loop halts on the first completed status.
 
-    @pytest.mark.property
-    @pytest.mark.medium
+    Issue: issues/Finalize-dialectical-reasoning.md ReqID: DRL-001
+    """
+
     @given(
         st.lists(st.sampled_from(["in_progress", "completed"]), min_size=1, max_size=5)
     )
@@ -63,10 +67,11 @@ def test_reasoning_loop_stops_on_completion(monkeypatch):
 @pytest.mark.property
 @pytest.mark.medium
 def test_reasoning_loop_respects_max_iterations(monkeypatch):
-    """Loop runs at most max_iterations times. ReqID: DRL-001"""
+    """Loop runs at most max_iterations times.
 
-    @pytest.mark.property
-    @pytest.mark.medium
+    Issue: issues/Finalize-dialectical-reasoning.md ReqID: DRL-001
+    """
+
     @given(st.integers(min_value=1, max_value=5))
     def check(max_iterations):
         def fake_apply(team, task, critic, memory):

--- a/tests/property/test_requirements_consensus_properties.py
+++ b/tests/property/test_requirements_consensus_properties.py
@@ -1,5 +1,10 @@
+"""Property-based tests for requirement consensus utilities.
+
+Issue: issues/Finalize-dialectical-reasoning.md ReqID: DRL-001
+"""
+
 import time
-from typing import Any, Dict
+from typing import Any
 
 import pytest
 from hypothesis import given, settings
@@ -17,7 +22,10 @@ from .strategies import consensus_outcome_strategy, requirement_strategy
 @settings(deadline=300)  # 300ms per example to keep CI stable
 @given(req=requirement_strategy())
 def test_requirement_update_timestamp_is_monotonic(req: Requirement):
-    # Act: perform an update and verify updated_at does not go backwards
+    """Updating a requirement should not regress its timestamp.
+
+    Issue: issues/Finalize-dialectical-reasoning.md ReqID: DRL-001
+    """
     before = req.updated_at
     req.update(title=req.title + "!")
     after = req.updated_at
@@ -61,6 +69,10 @@ class _DummyTeam(WSDETeam):
 @given(thesis_content=st.text(min_size=5, max_size=80))
 @pytest.mark.no_network
 def test_dialectical_reasoning_returns_expected_shape_quickly(thesis_content: str):
+    """dialectical reasoning yields expected keys quickly.
+
+    Issue: issues/Finalize-dialectical-reasoning.md ReqID: DRL-001
+    """
     team = _DummyTeam()
     task: dict[str, Any] = {
         "solution": {"content": thesis_content, "code": "x=1\nprint(x)"}
@@ -96,7 +108,10 @@ def test_dialectical_reasoning_returns_expected_shape_quickly(thesis_content: st
 @settings(max_examples=5, deadline=300)
 @given(outcome=consensus_outcome_strategy())
 def test_generated_consensus_outcome_has_expected_keys(outcome: dict[str, Any]):
-    # Verify required keys exist and have expected types
+    """Generated consensus outcomes provide required keys.
+
+    Issue: issues/Finalize-dialectical-reasoning.md ReqID: DRL-001
+    """
     for key in (
         "id",
         "task_id",

--- a/tests/property/test_run_tests_sanitize_properties.py
+++ b/tests/property/test_run_tests_sanitize_properties.py
@@ -1,10 +1,15 @@
-"""Property-based tests for _sanitize_node_ids behavior. ReqID: FR-09"""
+"""Property-based tests for _sanitize_node_ids behavior.
+
+Issue: issues/Expand-test-generation-capabilities.md ReqID: FR-09
+"""
 
 import pytest
 
-pytest.importorskip("hypothesis")
-from hypothesis import given
-from hypothesis import strategies as st
+try:
+    from hypothesis import given
+    from hypothesis import strategies as st
+except ImportError:  # pragma: no cover
+    pytest.skip("hypothesis not available", allow_module_level=True)
 
 from devsynth.testing.run_tests import _sanitize_node_ids
 
@@ -32,6 +37,10 @@ def _with_optional_line_suffix(s: str) -> str:
 )
 @pytest.mark.medium
 def test_sanitize_strips_trailing_line_when_no_function(ids):
+    """Strip trailing line numbers when no function part is present.
+
+    Issue: issues/Expand-test-generation-capabilities.md ReqID: FR-09
+    """
     # Build inputs: ensure no '::' present in base strings
     raw = [f"tests/unit/{s}" if not s.startswith("tests/") else s for s in ids]
     out = _sanitize_node_ids(raw)

--- a/tests/property/test_tiered_cache_properties.py
+++ b/tests/property/test_tiered_cache_properties.py
@@ -1,10 +1,15 @@
-"""Property-based tests for tiered cache integration. ReqID: HMA-003"""
+"""Property-based tests for tiered cache integration.
+
+Issue: issues/multi-layered-memory-system.md ReqID: HMA-003, HMA-004
+"""
 
 import pytest
 
-pytest.importorskip("hypothesis")
-from hypothesis import given
-from hypothesis import strategies as st
+try:
+    from hypothesis import given
+    from hypothesis import strategies as st
+except ImportError:  # pragma: no cover
+    pytest.skip("hypothesis not available", allow_module_level=True)
 
 from devsynth.adapters.memory.memory_adapter import MemorySystemAdapter
 from devsynth.domain.models.memory import MemoryItem, MemoryType
@@ -14,7 +19,10 @@ from devsynth.domain.models.memory import MemoryItem, MemoryType
 @given(st.text())
 @pytest.mark.medium
 def test_second_read_hits_cache(content):
-    """Second read of an item results in a cache hit. ReqID: HMA-003"""
+    """Second read of an item results in a cache hit.
+
+    Issue: issues/multi-layered-memory-system.md ReqID: HMA-003
+    """
     adapter = MemorySystemAdapter.create_for_testing()
     adapter.enable_tiered_cache(max_size=5)
     item = MemoryItem(id="", content=content, memory_type=MemoryType.SHORT_TERM)
@@ -29,7 +37,10 @@ def test_second_read_hits_cache(content):
 @given(st.lists(st.text(), min_size=1, max_size=20))
 @pytest.mark.medium
 def test_cache_never_exceeds_max_size(contents):
-    """Cache size stays within limit regardless of inputs. ReqID: HMA-004"""
+    """Cache size stays within limit regardless of inputs.
+
+    Issue: issues/multi-layered-memory-system.md ReqID: HMA-004
+    """
     adapter = MemorySystemAdapter.create_for_testing()
     adapter.enable_tiered_cache(max_size=5)
     ids = []


### PR DESCRIPTION
## Summary
- add issue references and single speed markers to property tests
- normalize hypothesis imports and remove nested markers

## Testing
- `poetry run pre-commit run --files tests/property/test_core_values_properties.py tests/property/test_memory_adapter_properties.py tests/property/test_reasoning_loop_properties.py tests/property/test_requirements_consensus_properties.py tests/property/test_run_tests_sanitize_properties.py tests/property/test_tiered_cache_properties.py`
- `poetry run python tests/verify_test_organization.py`
- `poetry run python scripts/verify_test_markers.py --report`
- `poetry run python scripts/verify_requirements_traceability.py`
- `poetry run python scripts/verify_version_sync.py`
- `poetry run python scripts/verify_issue_references.py`
- `poetry run devsynth run-tests --speed fast` *(fails: no output)*
- `poetry run devsynth run-tests --speed medium` *(fails: no output)*

------
https://chatgpt.com/codex/tasks/task_e_68bf911ace3c8333b309045abe16caf4