### PR TITLE
docs: track property marker advisories and environment status

### DIFF
--- a/docs/plan.md
+++ b/docs/plan.md
@@ -2,7 +2,7 @@
 
 Version: 2025-09-07
 Owner: DevSynth Team (maintainers)
-Status: Execution in progress; plan updated with new environment blocker (2025-09-08)
+Status: Execution in progress; install loop closed (2025-09-09); property marker advisories remain
 
 Executive summary
 - Goal: Reach and sustain >90% coverage with a well‑functioning, reliable test suite across unit, integration, behavior, and property tests for the 0.1.0a1 release, with strict marker discipline and resource gating.
@@ -10,8 +10,8 @@ Executive summary
   - Test collection succeeds across a large suite (unit/integration/behavior/property).
   - Fast smoke/unit/integration/behavior profiles run successfully via the CLI.
 - Speed-marker discipline validated (0 violations).
-- Property marker verification flags missing @pytest.mark.property in tests/property/test_reasoning_loop_properties.py (2 property_violations).
-- Property tests (opt-in) reveal 2 failures; must be fixed before release to claim full readiness.
+ - Property marker verification flags missing @pytest.mark.property in tests/property/test_reasoning_loop_properties.py (2 property_violations).
+ - Property tests (opt-in) reveal 2 failures; must be fixed before release to claim full readiness.
   - Diagnostics indicate environment/config gaps for non-test environments (doctor.txt) used by the app; tests succeed due to defaults and gating, but this requires documentation and guardrails.
   - Coverage report artifact (htmlcov) shows 20% from a prior run; targeted property-only run showed 8% and triggered coverage threshold failure. The global pytest.ini threshold is 90%, so any authoritative release run must aggregate full-suite coverage.
 
@@ -21,8 +21,8 @@ Commands executed (audit trail)
 - poetry run devsynth run-tests --target unit-tests --speed=fast --no-parallel --maxfail=1 → Success.
 - poetry run devsynth run-tests --target behavior-tests --speed=fast --smoke --no-parallel --maxfail=1 → Success.
 - poetry run devsynth run-tests --target integration-tests --speed=fast --smoke --no-parallel --maxfail=1 → Success.
-- poetry run python scripts/verify_test_markers.py --report --report-file test_markers_report.json → property marker advisories (2 property_violations) in tests/property/test_reasoning_loop_properties.py.
-- DEVSYNTH_PROPERTY_TESTING=true poetry run pytest tests/property/ -q → 2 failing tests; coverage fail-under triggered (8% on this narrow subset).
+ - poetry run python scripts/verify_test_markers.py --report --report-file test_markers_report.json → property marker advisories (2 property_violations) in tests/property/test_reasoning_loop_properties.py.
+ - DEVSYNTH_PROPERTY_TESTING=true poetry run pytest tests/property/ -q → 2 failing tests; coverage fail-under triggered (8% on this narrow subset).
 - Environment: Python 3.12.x (pyproject constraint), Poetry 2.1.4; coverage artifacts present under htmlcov/ and coverage.json.
 
 Environment snapshot and reproducibility (authoritative)
@@ -71,7 +71,7 @@ Concrete remediation tasks (actionable specifics)
      - Alternative: Extend the Dummy test double to implement _improve_clarity with a no-op or minimal semantics in tests/helpers/dummies.py (or the appropriate test utility module), ensuring interface compatibility.
   - Re-run: DEVSYNTH_PROPERTY_TESTING=true poetry run pytest tests/property/ -q 2>&1 | tee test_reports/property_tests.log
   - Success criteria: 0 failures; exactly one speed marker per function.
-  3) Tag tests/property/test_reasoning_loop_properties.py::check with @pytest.mark.property and a single speed marker; rerun verify_test_markers to confirm 0 property_violations (Issue: issues/property-marker-advisories-in-reasoning-loop-tests.md).
+   3) Tag tests/property/test_reasoning_loop_properties.py::check with @pytest.mark.property and a single speed marker; rerun verify_test_markers to confirm 0 property_violations (Issue: issues/property-marker-advisories-in-reasoning-loop-tests.md).
 - run_tests_cmd coverage uplift (src/devsynth/application/cli/commands/run_tests_cmd.py): add unit tests to cover these branches/behaviors with clear test names:
   - test_smoke_mode_sets_pytest_autoload_off
   - test_no_parallel_maps_to_n0
@@ -104,7 +104,7 @@ Critical evaluation of current tests (dialectical + Socratic)
   - AttributeError: _DummyTeam lacks _improve_clarity → either the dummy must implement this method or tests need to call a public interface the dummy supports.
 - Coverage hotspots: Historical diagnostics and htmlcov show low coverage in src/devsynth/application/cli/commands/run_tests_cmd.py (~14–15%), and other adapter-heavy modules show very low coverage in artifacts. Need targeted tests or broaden integration coverage.
 - Environment/config: diagnostics/doctor.txt lists many missing env vars across environments; while tests pass due to default stubbing, release QA should include doctor sanity checks and documented defaults.
-- Installation: `poetry install --with dev --all-extras` hangs repeatedly on `nvidia/__init__.py`, leaving the environment incomplete (see issues/poetry-install-nvidia-loop.md).
+- Installation: earlier hang on `poetry install --with dev --all-extras` (nvidia/__init__.py) resolved per issues/poetry-install-nvidia-loop.md (closed).
 - Potential mismatch between pytest.ini fail-under=90 and how contributors run focused subsets; dev tooling must aggregate coverage or provide guidance on running complete profiles locally.
 
 Standards and constraints reaffirmed

--- a/docs/task_notes.md
+++ b/docs/task_notes.md
@@ -118,3 +118,10 @@ Date: 2025-09-09T00:57Z
 Date: 2025-09-09T02:31Z
 - Ran scripts/install_dev.sh; go-task 3.44.1 installed under \$HOME/.local/bin.
 - Confirmed `task --version` outputs 3.44.1 in a new shell.
+Date: 2025-09-09T03:17Z
+- Verified Python 3.12.10 and poetry env path /root/.cache/pypoetry/virtualenvs/devsynth-MeXVnKii-py3.12.
+- Re-ran scripts/install_dev.sh; task --version 3.44.1.
+- verify_test_markers reports property advisories for tests/property/test_reasoning_loop_properties.py::check; issue property-marker-advisories-in-reasoning-loop-tests.md opened.
+- Updated docs/plan.md and docs/tasks.md (1.6, 10.1 marked complete; property-marker tasks remain open).
+- Confirmed .github workflows are workflow_dispatch-only.
+- Next: address property markers (tasks 2.3/2.6), coverage threshold (6.3), and acceptance criteria tasks (13.*).

--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -16,7 +16,7 @@ Instructions: Check off each task when completed. Subtasks are enumerated for cl
 1.5.3 [x] `poetry run pip freeze | tee diagnostics/pip_freeze.txt`
 1.5.4 [x] `poetry run devsynth doctor | tee diagnostics/doctor_run.txt`
 1.5.5 [x] `date -u '+%Y-%m-%dT%H:%M:%SZ' | tee diagnostics/run_timestamp_utc.txt`
-1.6 [ ] Investigate `poetry install --with dev --all-extras` hanging on `nvidia/__init__.py` (Issue: poetry-install-nvidia-loop.md).
+1.6 [x] Investigate `poetry install --with dev --all-extras` hanging on `nvidia/__init__.py` (Issue: poetry-install-nvidia-loop.md).
 1.7 [x] Resolve scripts/codex_setup.sh version mismatch (project 0.1.0a1 vs expected 0.1.0-alpha.1).
 
 2. Property Tests Remediation (Phase 1)
@@ -88,7 +88,7 @@ Instructions: Check off each task when completed. Subtasks are enumerated for cl
 9.4 [x] Add guidance to always aggregate coverage for readiness claims, avoiding narrow subset runs.
 
 10. Release Preparation and CI/CD Strategy (Phase 6)
-10.1 [ ] Keep GitHub Actions disabled until 0.1.0a1 is tagged.
+10.1 [x] Keep GitHub Actions disabled until 0.1.0a1 is tagged.
 10.2 [x] After release, enable low-throughput workflows with concurrency control:
 10.2.1 [x] Add smoke job (fast, --no-parallel, PYTEST_DISABLE_PLUGIN_AUTOLOAD=1).
 10.2.2 [x] Add unit+integration job (fast+medium) without xdist.

--- a/issues/property-marker-advisories-in-reasoning-loop-tests.md
+++ b/issues/property-marker-advisories-in-reasoning-loop-tests.md
@@ -1,0 +1,17 @@
+---
+Title: property marker advisories in reasoning loop tests
+Date: 2025-09-09
+Status: open
+Affected Area: tests
+Reproduction:
+  - poetry run python scripts/verify_test_markers.py --report --report-file test_markers_report.json
+Exit Code: 0
+Artifacts:
+  - test_markers_report.json
+Suspected Cause: tests/property/test_reasoning_loop_properties.py lacked @pytest.mark.property, causing verify_test_markers warnings.
+Next Actions:
+  - [ ] add missing marker and single speed marker
+  - [ ] re-run verify_test_markers
+Resolution Evidence:
+  - pending
+---


### PR DESCRIPTION
## Summary
- note unresolved property markers and property test failures in release plan
- document environment status and open marker follow-up in task notes and tasks checklist
- add issue record for property marker advisories in reasoning loop tests

## Testing
- `poetry run pre-commit run --files docs/plan.md docs/task_notes.md docs/tasks.md issues/property-marker-advisories-in-reasoning-loop-tests.md`
- `poetry run devsynth run-tests --smoke --speed=fast --no-parallel --maxfail=1`
- `poetry run python tests/verify_test_organization.py`
- `poetry run python scripts/verify_test_markers.py`
- `poetry run python scripts/verify_requirements_traceability.py`
- `poetry run python scripts/verify_version_sync.py`


------
https://chatgpt.com/codex/tasks/task_e_68bf9ba7aac88333b4dd6e6562cad52d