### PR TITLE
chore: persist task path and cache in ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,14 +25,20 @@ jobs:
             exit 1
           fi
           echo "Using virtualenv at $venv_path"
+      - name: Cache Task
+        id: cache-task
+        uses: actions/cache@v4
+        with:
+          path: ~/.local/bin/task
+          key: ${{ runner.os }}-task-${{ hashFiles('scripts/install_dev.sh') }}
       - name: Install Task
+        if: steps.cache-task.outputs.cache-hit != 'true'
         run: |
-          if ! command -v task >/dev/null 2>&1; then
-            TASK_BIN_DIR="$HOME/.local/bin"
-            mkdir -p "$TASK_BIN_DIR"
-            curl -sSL https://taskfile.dev/install.sh | bash -s -- -b "$TASK_BIN_DIR"
-            echo "$TASK_BIN_DIR" >> $GITHUB_PATH
-          fi
+          TASK_BIN_DIR="$HOME/.local/bin"
+          mkdir -p "$TASK_BIN_DIR"
+          curl -sSL https://taskfile.dev/install.sh | bash -s -- -b "$TASK_BIN_DIR"
+      - name: Add Task to PATH
+        run: echo "$HOME/.local/bin" >> $GITHUB_PATH
       - name: Verify tooling
         run: |
           poetry env info --path

--- a/docs/plan.md
+++ b/docs/plan.md
@@ -26,6 +26,12 @@ Refer to the [0.1.0-alpha.1 release guide](release/0.1.0-alpha.1.md) for detaile
    poetry env info --path
    task --version
    ```
+   Ensure the Task binary directory persists on your `PATH` for future
+   sessions:
+   ```bash
+   echo 'export PATH="$HOME/.local/bin:$PATH"' >> ~/.profile
+   source ~/.profile
+   ```
 2. **Install dependencies with development and test extras**
    ```bash
    poetry install --with dev --extras tests retrieval chromadb api

--- a/scripts/codex_setup.sh
+++ b/scripts/codex_setup.sh
@@ -9,6 +9,7 @@ set -exo pipefail
 # Ensure pipx is available for installing the CLI. When rerunning offline,
 # skip installation if pipx is already present so the script can proceed
 # without network access.
+PIPX_BIN_DIR="$HOME/.local/bin"
 if ! command -v pipx >/dev/null; then
   if command -v apt-get >/dev/null; then
     for _ in 1 2 3; do
@@ -29,8 +30,13 @@ if ! command -v pipx >/dev/null; then
       echo "[warning] pip install pipx failed" >&2
   fi
 fi
-export PATH="$HOME/.local/bin:$PATH"
+if [[ ":$PATH:" != *":$PIPX_BIN_DIR:"* ]]; then
+  export PATH="$PIPX_BIN_DIR:$PATH"
+fi
 pipx ensurepath
+if [ -w "$HOME/.profile" ] && ! grep -F "$PIPX_BIN_DIR" "$HOME/.profile" >/dev/null 2>&1; then
+  echo "export PATH=\"$PIPX_BIN_DIR:\$PATH\"" >> "$HOME/.profile"
+fi
 
 # Run commands and exit with a clear message on failure
 run_check() {

--- a/scripts/install_dev.sh
+++ b/scripts/install_dev.sh
@@ -23,10 +23,10 @@ else
 fi
 
 # Ensure go-task is available for Taskfile-based workflows
+TASK_BIN_DIR="${HOME}/.local/bin"
+mkdir -p "$TASK_BIN_DIR"
 if ! command -v task >/dev/null 2>&1; then
   echo "[info] task command missing; installing go-task" >&2
-  TASK_BIN_DIR="${HOME}/.local/bin"
-  mkdir -p "$TASK_BIN_DIR"
 
   os=$(uname -s | tr '[:upper:]' '[:lower:]')
   arch=$(uname -m)
@@ -51,8 +51,6 @@ if ! command -v task >/dev/null 2>&1; then
   fi
 
   export PATH="$TASK_BIN_DIR:$PATH"
-  echo "$TASK_BIN_DIR" >> "${GITHUB_PATH:-/dev/null}" 2>/dev/null || true
-
   if ! command -v task >/dev/null 2>&1; then
     echo "[error] task binary not found on PATH after installation" >&2
     exit 1
@@ -62,6 +60,15 @@ if ! command -v task >/dev/null 2>&1; then
     exit 1
   fi
 fi
+
+# Ensure the Task binary directory is on PATH for current and future sessions
+if [[ ":$PATH:" != *":$TASK_BIN_DIR:"* ]]; then
+  export PATH="$TASK_BIN_DIR:$PATH"
+fi
+if [ -w "$HOME/.profile" ] && ! grep -F "$TASK_BIN_DIR" "$HOME/.profile" >/dev/null 2>&1; then
+  echo "export PATH=\"$TASK_BIN_DIR:\$PATH\"" >> "$HOME/.profile"
+fi
+echo "$TASK_BIN_DIR" >> "${GITHUB_PATH:-/dev/null}" 2>/dev/null || true
 
 # Display Task version for debugging and ensure it resolves
 if ! task_version="$(task --version 2>/dev/null)"; then


### PR DESCRIPTION
## Summary
- persist go-task bin directory for local sessions
- cache go-task binary in CI workflow
- document persistent path setup in plan

## Testing
- `poetry run pre-commit run --files scripts/install_dev.sh scripts/codex_setup.sh .github/workflows/ci.yml docs/plan.md`
- `poetry run devsynth run-tests --speed=fast`
- `poetry run python tests/verify_test_organization.py`
- `poetry run python scripts/verify_test_markers.py`
- `poetry run python scripts/verify_requirements_traceability.py docs/requirements_traceability.md`
- `poetry run python scripts/verify_version_sync.py`


------
https://chatgpt.com/codex/tasks/task_e_68bfc14141488333bd0adec0104853e0