### PR TITLE
docs: reopen test tasks and refresh plan

### DIFF
--- a/docs/plan.md
+++ b/docs/plan.md
@@ -7,15 +7,15 @@ Prepare DevSynth for the v0.1.0-alpha.1 release.
 - Python 3.12 environment with Poetry-managed virtualenv.
 - `go-task` installed; `task --version` returns 3.44.1.
 - Fast tests succeed (162 passed, 27 skipped).
-- `scripts/verify_test_markers.py` now scans changed files without marker issues.
+- `scripts/verify_test_markers.py` reports zero test files; marker enforcement pending.
 - Medium test run surfaced numerous missing step definitions and a failing AST workflow test; suite still red.
 - Specifications now contain "What proofs confirm the solution?" sections linked to BDD features.
 - Release readiness remains blocked by failing medium tests and unverified slow tests.
 
 ## Next Steps
-1. Follow the release checklist below to finalize environment setup.
-2. Stub or implement missing BDD steps so medium suite completes.
-3. After medium tests pass, execute slow suite and address remaining failures.
+1. Investigate why `scripts/verify_test_markers.py` reports no test files and restore marker validation.
+2. Resolve missing BDD steps and pytest-xdist errors so the medium suite completes, then re-run the slow suite.
+3. After test suites and marker checks pass, follow the release checklist to finalize the release.
 
 ## Release Checklist
 Refer to the [0.1.0-alpha.1 release guide](release/0.1.0-alpha.1.md) for detailed commands:

--- a/docs/task_notes.md
+++ b/docs/task_notes.md
@@ -1,26 +1,4 @@
-2025-09-08:
-- Environment lacked `task`; ran scripts/install_dev.sh to install v3.44.1.
-- Executed `poetry install --with dev --extras "tests retrieval chromadb api"` to fix missing `devsynth` module.
-- Restored missing sentinel test `tests/test_speed_dummy.py` to satisfy organization checks.
-- Fast tests now pass; verify scripts succeed.
-- Outstanding: validate medium/slow tests and resolve pytest-xdist errors.
-2025-09-09:
-- `task` command missing again; reinstalled via scripts/install_dev.sh (v3.44.1).
-- Fast tests pass (162 passed, 27 skipped); `scripts/verify_test_markers.py` reports zero test files.
-- Release readiness still blocked by unresolved pytest-xdist errors and unverified medium/slow tests.
-2025-09-10:
-- Reinstalled go-task via scripts/install_dev.sh; confirmed `task --version` outputs v3.44.1.
-- Dependency installation was interrupted, so additional verification steps remain.
-
-2025-09-11:
-- Re-executed `poetry install --with dev --extras "tests retrieval chromadb api"` and confirmed CLI with `poetry run devsynth --help`.
-- Fast tests pass (162 passed, 27 skipped); verification scripts succeeded.
-
-2025-09-12:
-- Added release checklist to plan and marked task 1.4 complete.
-2025-09-13:
-- `poetry run devsynth run-tests --target unit-tests --speed=medium` reported 66 failures but no pytest-xdist assertion errors; `--speed=slow` found no tests.
-- Marked task 1.5 complete.
-2025-09-14:
-- Attempted medium suite after stubbing missing BDD steps; residual failures persist (ChromaDB integration, AST workflow).
-- `scripts/verify_test_markers.py` run on changed files; no marker issues detected.
+2025-09-15:
+- Reopened task 1.5 to confirm medium and slow test suites run without pytest-xdist errors.
+- Reopened task 6.4 after `scripts/verify_test_markers.py` reported zero test files.
+- Updated release plan and tasks to track these outstanding issues.

--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -5,8 +5,8 @@
 - [x] 1.2 Ensure devsynth package installed and fast tests pass.
 - [x] 1.3 Audit outstanding release-blocking issues.
 - [x] 1.4 Document full release checklist and environment setup.
-- [x] 1.5 Verify medium and slow test suites run without pytest-xdist errors.
+- [ ] 1.5 Verify medium and slow test suites run without pytest-xdist errors.
 
 ## 6. Testing and Coverage
 - [x] 6.3 Ensure coverage outputs (`htmlcov/`, `coverage.json`) are generated and excluded from version control.
-- [x] 6.4 Investigate why `scripts/verify_test_markers.py` finds no test files.
+- [ ] 6.4 Investigate why `scripts/verify_test_markers.py` finds no test files.


### PR DESCRIPTION
## Summary
- Reopen tasks 1.5 and 6.4 to track medium/slow test verification and marker investigation
- Update plan's status and next steps to focus on marker validation and clearing test suite issues
- Trim stale task notes and log reopened work

## Testing
- `poetry run pre-commit run --files docs/tasks.md docs/plan.md docs/task_notes.md`
- `poetry run devsynth run-tests --speed=fast`
- `poetry run python scripts/verify_test_markers.py`


------
https://chatgpt.com/codex/tasks/task_e_68bfc111f5d0833390352c9b5abdeb91