### PR TITLE
docs: add tiered cache termination proof

### DIFF
--- a/docs/analysis/tiered_cache_termination_proof.md
+++ b/docs/analysis/tiered_cache_termination_proof.md
@@ -1,0 +1,44 @@
+---
+title: "Tiered Cache Termination Proof"
+date: "2025-08-24"
+version: "0.1.0-alpha.1"
+tags:
+  - analysis
+  - caching
+status: "draft"
+author: "DevSynth Team"
+last_reviewed: "2025-08-24"
+---
+<div class="breadcrumbs">
+<a href="../index.md">Documentation</a> &gt; <a href="index.md">Analysis</a> &gt; Tiered Cache Termination Proof
+</div>
+
+# Tiered Cache Termination Proof
+
+## Overview
+The `TieredCache` provides an LRU eviction strategy with a fixed maximum size. We show that its operations complete after a finite number of steps and outline how to benchmark their performance.
+
+## Termination Proof
+Let `C` be a cache with bound `max_size = M`.
+
+- `put(key, value)` performs at most three constant-time steps:
+  1. Update and promote if `key` exists.
+  2. Evict the least recently used key if the cache already holds `M` entries.
+  3. Insert the new entry.
+  Each step touches at most one element, so the function terminates in \(O(1)\).
+- `get(key)` looks up `key` in a dictionary and optionally promotes it to most-recently-used. Both actions are constant time, so the call terminates.
+- `remove(key)` deletes at most one entry, again bounded by \(O(1)\).
+
+Because every loop iterates over at most `M` elements, all operations terminate.
+
+## Simulation Plan
+Benchmark `put` and `get` latency with the existing performance test:
+
+```bash
+poetry run devsynth run-tests --speed=slow --target tests/performance/test_cache_benchmarks.py
+```
+
+## References
+- [Specification: Tiered Cache Validation](../specifications/tiered-cache-validation.md)
+- [Issue: Multi-Layered Memory System](../../issues/multi-layered-memory-system.md)
+- [Test: tests/unit/application/memory/test_tiered_cache_termination.py](../../tests/unit/application/memory/test_tiered_cache_termination.py)

--- a/docs/specifications/tiered-cache-validation.md
+++ b/docs/specifications/tiered-cache-validation.md
@@ -25,11 +25,20 @@ Required metadata fields:
 
 ## Socratic Checklist
 - What is the problem?
+  The tiered cache lacks a formal argument that its eviction loop terminates
+  and preserves the configured bound.
 - What proofs confirm the solution?
+  The termination proof in
+  [`docs/analysis/tiered_cache_termination_proof.md`](../analysis/tiered_cache_termination_proof.md)
+  establishes that each operation touches at most `max_size` entries, and
+  [`tests/unit/application/memory/test_tiered_cache_termination.py`](../../tests/unit/application/memory/test_tiered_cache_termination.py)
+  validates the bound.
 
 ## Motivation
 
 ## What proofs confirm the solution?
+- Analysis: [`Tiered Cache Termination Proof`](../analysis/tiered_cache_termination_proof.md)
+- Unit test: [`test_tiered_cache_termination.py`](../../tests/unit/application/memory/test_tiered_cache_termination.py)
 - Pending BDD scenarios will verify termination and expected outcomes.
 - Finite state transitions and bounded loops guarantee termination.
 
@@ -45,3 +54,8 @@ A tiered cache improves read performance, but only if it consistently evicts the
 - Cache size never exceeds `max_size` during any access sequence.
 - After exceeding capacity, the evicted key is the one least recently accessed.
 - Hit and miss counters reflect observed cache behavior.
+
+## References
+
+- [Analysis: Tiered Cache Termination Proof](../analysis/tiered_cache_termination_proof.md)
+- [Issue: Multi-Layered Memory System](../../issues/multi-layered-memory-system.md)

--- a/issues/multi-layered-memory-system.md
+++ b/issues/multi-layered-memory-system.md
@@ -26,3 +26,4 @@ Multi-Layered Memory System is not yet implemented, limiting DevSynth's capabili
 - BDD Feature: tests/behavior/features/multi_layered_memory_system.feature
 - BDD Feature: tests/behavior/features/multi_layered_memory_system_and_tiered_cache_strategy.feature
 - Proof: see 'What proofs confirm the solution?' in [docs/specifications/multi-layered-memory-system.md](../docs/specifications/multi-layered-memory-system.md) and scenarios in [tests/behavior/features/multi_layered_memory_system.feature](../tests/behavior/features/multi_layered_memory_system.feature).
+- Analysis: [docs/analysis/tiered_cache_termination_proof.md](../docs/analysis/tiered_cache_termination_proof.md)

--- a/tests/unit/application/memory/test_tiered_cache_termination.py
+++ b/tests/unit/application/memory/test_tiered_cache_termination.py
@@ -1,0 +1,13 @@
+import pytest
+
+from devsynth.application.memory.tiered_cache import TieredCache
+
+
+@pytest.mark.unit
+@pytest.mark.fast
+def test_eviction_loop_terminates() -> None:
+    """Eviction loop terminates and bounds cache size. ReqID: TCV-003"""
+    cache = TieredCache(max_size=3)
+    for i in range(10):
+        cache.put(f"k{i}", i)
+    assert len(cache.get_keys()) == 3


### PR DESCRIPTION
## Summary
- document TieredCache termination and benchmarking approach
- cross-reference tiered cache analysis from spec and issue
- test eviction loop stays within configured bounds

## Testing
- `poetry run pre-commit run --files docs/analysis/tiered_cache_termination_proof.md docs/specifications/tiered-cache-validation.md issues/multi-layered-memory-system.md tests/unit/application/memory/test_tiered_cache_termination.py`
- `poetry run devsynth run-tests --speed=fast --target unit-tests` *(no tests collected)*
- `poetry run pytest tests/unit/application/memory/test_tiered_cache_termination.py -m fast --cov=src/devsynth --cov-report=term --cov-fail-under=0 -vv`
- `poetry run python tests/verify_test_organization.py`
- `poetry run python scripts/verify_test_markers.py`
- `poetry run python scripts/verify_requirements_traceability.py`
- `poetry run python scripts/verify_version_sync.py`


------
https://chatgpt.com/codex/tasks/task_e_68c1af2ab4b48333aba0c12cf867c139