### PR TITLE
docs: log guardrail scan results

### DIFF
--- a/diagnostics/bandit_2025-09-10_run2.txt
+++ b/diagnostics/bandit_2025-09-10_run2.txt
@@ -1,0 +1,1993 @@
+[main]	INFO	profile include tests: None
+[main]	INFO	profile exclude tests: None
+[main]	INFO	cli include tests: None
+[main]	INFO	cli exclude tests: None
+[main]	INFO	running on Python 3.12.10
+Working... ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:08
+Run started:2025-09-10 18:12:38.016484
+
+Test results:
+>> Issue: [B110:try_except_pass] Try, Except, Pass detected.
+   Severity: Low   Confidence: High
+   CWE: CWE-703 (https://cwe.mitre.org/data/definitions/703.html)
+   More Info: https://bandit.readthedocs.io/en/1.8.6/plugins/b110_try_except_pass.html
+   Location: src/devsynth/__init__.py:52:4
+51	        return module
+52	    except Exception:
+53	        pass
+54
+
+--------------------------------------------------
+>> Issue: [B110:try_except_pass] Try, Except, Pass detected.
+   Severity: Low   Confidence: High
+   CWE: CWE-703 (https://cwe.mitre.org/data/definitions/703.html)
+   More Info: https://bandit.readthedocs.io/en/1.8.6/plugins/b110_try_except_pass.html
+   Location: src/devsynth/__init__.py:73:8
+72	            importlib.import_module(module)
+73	        except Exception:  # pragma: no cover - ignore if unavailable
+74	            pass
+
+--------------------------------------------------
+>> Issue: [B110:try_except_pass] Try, Except, Pass detected.
+   Severity: Low   Confidence: High
+   CWE: CWE-703 (https://cwe.mitre.org/data/definitions/703.html)
+   More Info: https://bandit.readthedocs.io/en/1.8.6/plugins/b110_try_except_pass.html
+   Location: src/devsynth/adapters/chromadb_memory_store.py:257:8
+256	            self.close()
+257	        except Exception:  # pragma: no cover - defensive
+258	            pass
+259
+
+--------------------------------------------------
+>> Issue: [B604:any_other_function_with_shell_equals_true] Function call with shell=True parameter identified, possible security issue.
+   Severity: Medium   Confidence: Low
+   CWE: CWE-78 (https://cwe.mitre.org/data/definitions/78.html)
+   More Info: https://bandit.readthedocs.io/en/1.8.6/plugins/b604_any_other_function_with_shell_equals_true.html
+   Location: src/devsynth/adapters/cli/typer_adapter.py:79:13
+78	    script = typer_completion.get_completion_script(
+79	        prog_name=prog_name, complete_var=complete_var, shell=shell_name
+80	    )
+81	    progress.update(status="script generated", advance=1)
+82
+
+--------------------------------------------------
+>> Issue: [B604:any_other_function_with_shell_equals_true] Function call with shell=True parameter identified, possible security issue.
+   Severity: Medium   Confidence: Low
+   CWE: CWE-78 (https://cwe.mitre.org/data/definitions/78.html)
+   More Info: https://bandit.readthedocs.io/en/1.8.6/plugins/b604_any_other_function_with_shell_equals_true.html
+   Location: src/devsynth/adapters/cli/typer_adapter.py:86:29
+85	            _, target_path = typer_completion.install(
+86	                shell=shell_name, prog_name=prog_name, complete_var=complete_var
+87	            )
+88	        else:
+89	            target_path = path
+
+--------------------------------------------------
+>> Issue: [B604:any_other_function_with_shell_equals_true] Function call with shell=True parameter identified, possible security issue.
+   Severity: Medium   Confidence: Low
+   CWE: CWE-78 (https://cwe.mitre.org/data/definitions/78.html)
+   More Info: https://bandit.readthedocs.io/en/1.8.6/plugins/b604_any_other_function_with_shell_equals_true.html
+   Location: src/devsynth/adapters/cli/typer_adapter.py:293:8
+292	    ) -> None:
+293	        completion_cmd(shell=shell, install=install, path=path)
+294
+
+--------------------------------------------------
+>> Issue: [B110:try_except_pass] Try, Except, Pass detected.
+   Severity: Low   Confidence: High
+   CWE: CWE-703 (https://cwe.mitre.org/data/definitions/703.html)
+   More Info: https://bandit.readthedocs.io/en/1.8.6/plugins/b110_try_except_pass.html
+   Location: src/devsynth/adapters/cli/typer_adapter.py:352:16
+351	                    configure_logging(log_level=chosen_level)
+352	                except Exception:
+353	                    # Do not crash CLI due to logging issues
+354	                    pass
+355
+
+--------------------------------------------------
+>> Issue: [B110:try_except_pass] Try, Except, Pass detected.
+   Severity: Low   Confidence: High
+   CWE: CWE-703 (https://cwe.mitre.org/data/definitions/703.html)
+   More Info: https://bandit.readthedocs.io/en/1.8.6/plugins/b110_try_except_pass.html
+   Location: src/devsynth/adapters/cli/typer_adapter.py:384:8
+383	            app._add_completion()  # type: ignore[attr-defined]
+384	        except Exception:
+385	            pass
+386	    return app
+
+--------------------------------------------------
+>> Issue: [B113:request_without_timeout] Call to requests without timeout
+   Severity: Medium   Confidence: Low
+   CWE: CWE-400 (https://cwe.mitre.org/data/definitions/400.html)
+   More Info: https://bandit.readthedocs.io/en/1.8.6/plugins/b113_request_without_timeout.html
+   Location: src/devsynth/adapters/github_project.py:30:19
+29	        """Execute a GraphQL query against the GitHub API."""
+30	        response = requests.post(
+31	            self._endpoint,
+32	            json={"query": query, "variables": variables},
+33	            headers=self._headers,
+34	        )
+35	        response.raise_for_status()
+
+--------------------------------------------------
+>> Issue: [B110:try_except_pass] Try, Except, Pass detected.
+   Severity: Low   Confidence: High
+   CWE: CWE-703 (https://cwe.mitre.org/data/definitions/703.html)
+   More Info: https://bandit.readthedocs.io/en/1.8.6/plugins/b110_try_except_pass.html
+   Location: src/devsynth/adapters/memory/sync_manager.py:97:12
+96	                cls.__abstractmethods__ = frozenset()
+97	            except Exception:
+98	                pass
+99
+
+--------------------------------------------------
+>> Issue: [B110:try_except_pass] Try, Except, Pass detected.
+   Severity: Low   Confidence: High
+   CWE: CWE-703 (https://cwe.mitre.org/data/definitions/703.html)
+   More Info: https://bandit.readthedocs.io/en/1.8.6/plugins/b110_try_except_pass.html
+   Location: src/devsynth/adapters/memory/sync_manager.py:200:16
+199	                    close()
+200	                except Exception:
+201	                    pass
+202	        # The Kuzu memory store uses a custom cleanup helper
+
+--------------------------------------------------
+>> Issue: [B110:try_except_pass] Try, Except, Pass detected.
+   Severity: Low   Confidence: High
+   CWE: CWE-703 (https://cwe.mitre.org/data/definitions/703.html)
+   More Info: https://bandit.readthedocs.io/en/1.8.6/plugins/b110_try_except_pass.html
+   Location: src/devsynth/adapters/memory/sync_manager.py:206:12
+205	                self.kuzu.cleanup()
+206	            except Exception:
+207	                pass
+
+--------------------------------------------------
+>> Issue: [B403:blacklist] Consider possible security implications associated with pickle module.
+   Severity: Low   Confidence: High
+   CWE: CWE-502 (https://cwe.mitre.org/data/definitions/502.html)
+   More Info: https://bandit.readthedocs.io/en/1.8.6/blacklists/blacklist_imports.html#b403-import-pickle
+   Location: src/devsynth/adapters/orchestration/langgraph_adapter.py:7:0
+6	import os
+7	import pickle
+8	from dataclasses import asdict, dataclass, field
+
+--------------------------------------------------
+>> Issue: [B301:blacklist] Pickle and modules that wrap it can be unsafe when used to deserialize untrusted data, possible security issue.
+   Severity: Medium   Confidence: High
+   CWE: CWE-502 (https://cwe.mitre.org/data/definitions/502.html)
+   More Info: https://bandit.readthedocs.io/en/1.8.6/blacklists/blacklist_calls.html#b301-pickle
+   Location: src/devsynth/adapters/orchestration/langgraph_adapter.py:128:23
+127	            with open(path, "rb") as f:
+128	                return pickle.load(f)
+129	        return None
+
+--------------------------------------------------
+>> Issue: [B110:try_except_pass] Try, Except, Pass detected.
+   Severity: Low   Confidence: High
+   CWE: CWE-703 (https://cwe.mitre.org/data/definitions/703.html)
+   More Info: https://bandit.readthedocs.io/en/1.8.6/plugins/b110_try_except_pass.html
+   Location: src/devsynth/adapters/orchestration/langgraph_adapter.py:265:16
+264	                    )
+265	                except Exception:
+266	                    pass
+267
+
+--------------------------------------------------
+>> Issue: [B110:try_except_pass] Try, Except, Pass detected.
+   Severity: Low   Confidence: High
+   CWE: CWE-703 (https://cwe.mitre.org/data/definitions/703.html)
+   More Info: https://bandit.readthedocs.io/en/1.8.6/plugins/b110_try_except_pass.html
+   Location: src/devsynth/adapters/orchestration/langgraph_adapter.py:293:24
+292	                            )
+293	                        except Exception:
+294	                            pass
+295	                    return state
+
+--------------------------------------------------
+>> Issue: [B301:blacklist] Pickle and modules that wrap it can be unsafe when used to deserialize untrusted data, possible security issue.
+   Severity: Medium   Confidence: High
+   CWE: CWE-502 (https://cwe.mitre.org/data/definitions/502.html)
+   More Info: https://bandit.readthedocs.io/en/1.8.6/blacklists/blacklist_calls.html#b301-pickle
+   Location: src/devsynth/adapters/orchestration/langgraph_adapter.py:460:15
+459	            data = data.encode("utf-8")
+460	        return pickle.loads(data)
+461
+
+--------------------------------------------------
+>> Issue: [B403:blacklist] Consider possible security implications associated with pickle module.
+   Severity: Low   Confidence: High
+   CWE: CWE-502 (https://cwe.mitre.org/data/definitions/502.html)
+   More Info: https://bandit.readthedocs.io/en/1.8.6/blacklists/blacklist_imports.html#b403-import-pickle
+   Location: src/devsynth/adapters/orchestration/langgraph_adapter.py:483:12
+482	        if "pytest" in sys.modules:
+483	            import pickle
+484
+
+--------------------------------------------------
+>> Issue: [B113:request_without_timeout] Call to requests without timeout
+   Severity: Medium   Confidence: Low
+   CWE: CWE-400 (https://cwe.mitre.org/data/definitions/400.html)
+   More Info: https://bandit.readthedocs.io/en/1.8.6/plugins/b113_request_without_timeout.html
+   Location: src/devsynth/adapters/provider_system.py:679:23
+678
+679	            response = requests.post(
+680	                url,
+681	                headers=self.headers,
+682	                json=payload,
+683	                **self.tls_config.as_requests_kwargs(),
+684	            )
+685	            response.raise_for_status()
+
+--------------------------------------------------
+>> Issue: [B311:blacklist] Standard pseudo-random generators are not suitable for security/cryptographic purposes.
+   Severity: Low   Confidence: High
+   CWE: CWE-330 (https://cwe.mitre.org/data/definitions/330.html)
+   More Info: https://bandit.readthedocs.io/en/1.8.6/blacklists/blacklist_calls.html#b311-random
+   Location: src/devsynth/adapters/provider_system.py:811:47
+810
+811	                        delay = delay * (0.5 + random.random())
+812
+
+--------------------------------------------------
+>> Issue: [B113:request_without_timeout] Call to requests without timeout
+   Severity: Medium   Confidence: Low
+   CWE: CWE-400 (https://cwe.mitre.org/data/definitions/400.html)
+   More Info: https://bandit.readthedocs.io/en/1.8.6/plugins/b113_request_without_timeout.html
+   Location: src/devsynth/adapters/provider_system.py:877:23
+876
+877	            response = requests.post(
+878	                url,
+879	                headers=self.headers,
+880	                json=payload,
+881	                **self.tls_config.as_requests_kwargs(),
+882	            )
+883	            response.raise_for_status()
+
+--------------------------------------------------
+>> Issue: [B311:blacklist] Standard pseudo-random generators are not suitable for security/cryptographic purposes.
+   Severity: Low   Confidence: High
+   CWE: CWE-330 (https://cwe.mitre.org/data/definitions/330.html)
+   More Info: https://bandit.readthedocs.io/en/1.8.6/blacklists/blacklist_calls.html#b311-random
+   Location: src/devsynth/adapters/provider_system.py:979:47
+978
+979	                        delay = delay * (0.5 + random.random())
+980
+
+--------------------------------------------------
+>> Issue: [B113:request_without_timeout] Call to requests without timeout
+   Severity: Medium   Confidence: Low
+   CWE: CWE-400 (https://cwe.mitre.org/data/definitions/400.html)
+   More Info: https://bandit.readthedocs.io/en/1.8.6/plugins/b113_request_without_timeout.html
+   Location: src/devsynth/adapters/provider_system.py:1132:23
+1131
+1132	            response = requests.post(
+1133	                url,
+1134	                headers=self.headers,
+1135	                json=payload,
+1136	                **self.tls_config.as_requests_kwargs(),
+1137	            )
+1138	            response.raise_for_status()
+
+--------------------------------------------------
+>> Issue: [B311:blacklist] Standard pseudo-random generators are not suitable for security/cryptographic purposes.
+   Severity: Low   Confidence: High
+   CWE: CWE-330 (https://cwe.mitre.org/data/definitions/330.html)
+   More Info: https://bandit.readthedocs.io/en/1.8.6/blacklists/blacklist_calls.html#b311-random
+   Location: src/devsynth/adapters/provider_system.py:1275:47
+1274
+1275	                        delay = delay * (0.5 + random.random())
+1276
+
+--------------------------------------------------
+>> Issue: [B113:request_without_timeout] Call to requests without timeout
+   Severity: Medium   Confidence: Low
+   CWE: CWE-400 (https://cwe.mitre.org/data/definitions/400.html)
+   More Info: https://bandit.readthedocs.io/en/1.8.6/plugins/b113_request_without_timeout.html
+   Location: src/devsynth/adapters/provider_system.py:1342:23
+1341
+1342	            response = requests.post(
+1343	                url,
+1344	                headers=self.headers,
+1345	                json=payload,
+1346	                **self.tls_config.as_requests_kwargs(),
+1347	            )
+1348	            response.raise_for_status()
+
+--------------------------------------------------
+>> Issue: [B311:blacklist] Standard pseudo-random generators are not suitable for security/cryptographic purposes.
+   Severity: Low   Confidence: High
+   CWE: CWE-330 (https://cwe.mitre.org/data/definitions/330.html)
+   More Info: https://bandit.readthedocs.io/en/1.8.6/blacklists/blacklist_calls.html#b311-random
+   Location: src/devsynth/adapters/provider_system.py:1440:47
+1439
+1440	                        delay = delay * (0.5 + random.random())
+1441
+
+--------------------------------------------------
+>> Issue: [B404:blacklist] Consider possible security implications associated with the subprocess module.
+   Severity: Low   Confidence: High
+   CWE: CWE-78 (https://cwe.mitre.org/data/definitions/78.html)
+   More Info: https://bandit.readthedocs.io/en/1.8.6/blacklists/blacklist_imports.html#b404-import-subprocess
+   Location: src/devsynth/agents/sandbox.py:6:0
+5	import builtins
+6	import subprocess
+7	from contextlib import ContextDecorator
+
+--------------------------------------------------
+>> Issue: [B404:blacklist] Consider possible security implications associated with the subprocess module.
+   Severity: Low   Confidence: High
+   CWE: CWE-78 (https://cwe.mitre.org/data/definitions/78.html)
+   More Info: https://bandit.readthedocs.io/en/1.8.6/blacklists/blacklist_imports.html#b404-import-subprocess
+   Location: src/devsynth/application/agents/test.py:5:0
+4	import re
+5	import subprocess
+6	import sys
+
+--------------------------------------------------
+>> Issue: [B603:subprocess_without_shell_equals_true] subprocess call - check for execution of untrusted input.
+   Severity: Low   Confidence: High
+   CWE: CWE-78 (https://cwe.mitre.org/data/definitions/78.html)
+   More Info: https://bandit.readthedocs.io/en/1.8.6/plugins/b603_subprocess_without_shell_equals_true.html
+   Location: src/devsynth/application/agents/test.py:127:17
+126
+127	        result = subprocess.run(
+128	            [sys.executable, "-m", "pytest", "-q"],
+129	            cwd=str(directory),
+130	            env=env,
+131	            capture_output=True,
+132	            text=True,
+133	        )
+134	        output = result.stdout + result.stderr
+
+--------------------------------------------------
+>> Issue: [B112:try_except_continue] Try, Except, Continue detected.
+   Severity: Low   Confidence: High
+   CWE: CWE-703 (https://cwe.mitre.org/data/definitions/703.html)
+   More Info: https://bandit.readthedocs.io/en/1.8.6/plugins/b112_try_except_continue.html
+   Location: src/devsynth/application/agents/wsde_memory_integration.py:189:24
+188	                                break
+189	                        except Exception:
+190	                            continue
+191	                for item in items:
+
+--------------------------------------------------
+>> Issue: [B404:blacklist] Consider possible security implications associated with the subprocess module.
+   Severity: Low   Confidence: High
+   CWE: CWE-78 (https://cwe.mitre.org/data/definitions/78.html)
+   More Info: https://bandit.readthedocs.io/en/1.8.6/blacklists/blacklist_imports.html#b404-import-subprocess
+   Location: src/devsynth/application/cli/commands/completion_cmd.py:9:0
+8	import shutil
+9	import subprocess
+10	import sys
+
+--------------------------------------------------
+>> Issue: [B607:start_process_with_partial_path] Starting a process with a partial executable path
+   Severity: Low   Confidence: High
+   CWE: CWE-78 (https://cwe.mitre.org/data/definitions/78.html)
+   More Info: https://bandit.readthedocs.io/en/1.8.6/plugins/b607_start_process_with_partial_path.html
+   Location: src/devsynth/application/cli/commands/completion_cmd.py:90:25
+89	            try:
+90	                result = subprocess.run(
+91	                    ["brew", "--prefix"], capture_output=True, text=True, check=False
+92	                )
+93	                if result.returncode == 0:
+
+--------------------------------------------------
+>> Issue: [B603:subprocess_without_shell_equals_true] subprocess call - check for execution of untrusted input.
+   Severity: Low   Confidence: High
+   CWE: CWE-78 (https://cwe.mitre.org/data/definitions/78.html)
+   More Info: https://bandit.readthedocs.io/en/1.8.6/plugins/b603_subprocess_without_shell_equals_true.html
+   Location: src/devsynth/application/cli/commands/completion_cmd.py:90:25
+89	            try:
+90	                result = subprocess.run(
+91	                    ["brew", "--prefix"], capture_output=True, text=True, check=False
+92	                )
+93	                if result.returncode == 0:
+
+--------------------------------------------------
+>> Issue: [B101:assert_used] Use of assert detected. The enclosed code will be removed when compiling to optimised byte code.
+   Severity: Low   Confidence: High
+   CWE: CWE-703 (https://cwe.mitre.org/data/definitions/703.html)
+   More Info: https://bandit.readthedocs.io/en/1.8.6/plugins/b101_assert_used.html
+   Location: src/devsynth/application/cli/commands/doctor_cmd.py:155:8
+154	        module = importlib.util.module_from_spec(spec)  # type: ignore
+155	        assert spec and spec.loader
+156	        spec.loader.exec_module(module)  # type: ignore
+
+--------------------------------------------------
+>> Issue: [B404:blacklist] Consider possible security implications associated with the subprocess module.
+   Severity: Low   Confidence: High
+   CWE: CWE-78 (https://cwe.mitre.org/data/definitions/78.html)
+   More Info: https://bandit.readthedocs.io/en/1.8.6/blacklists/blacklist_imports.html#b404-import-subprocess
+   Location: src/devsynth/application/cli/commands/mvu_exec_cmd.py:7:0
+6
+7	import subprocess
+8	from typing import List, Optional
+
+--------------------------------------------------
+>> Issue: [B603:subprocess_without_shell_equals_true] subprocess call - check for execution of untrusted input.
+   Severity: Low   Confidence: High
+   CWE: CWE-78 (https://cwe.mitre.org/data/definitions/78.html)
+   More Info: https://bandit.readthedocs.io/en/1.8.6/plugins/b603_subprocess_without_shell_equals_true.html
+   Location: src/devsynth/application/cli/commands/mvu_exec_cmd.py:30:16
+29	    logger.debug("Executing MVU command: %s", command)
+30	    completed = subprocess.run(command, capture_output=True, text=True)
+31	    output = (completed.stdout or "") + (completed.stderr or "")
+
+--------------------------------------------------
+>> Issue: [B404:blacklist] Consider possible security implications associated with the subprocess module.
+   Severity: Low   Confidence: High
+   CWE: CWE-78 (https://cwe.mitre.org/data/definitions/78.html)
+   More Info: https://bandit.readthedocs.io/en/1.8.6/blacklists/blacklist_imports.html#b404-import-subprocess
+   Location: src/devsynth/application/cli/commands/mvuu_dashboard_cmd.py:11:0
+10	import argparse
+11	import subprocess
+12	import sys
+
+--------------------------------------------------
+>> Issue: [B607:start_process_with_partial_path] Starting a process with a partial executable path
+   Severity: Low   Confidence: High
+   CWE: CWE-78 (https://cwe.mitre.org/data/definitions/78.html)
+   More Info: https://bandit.readthedocs.io/en/1.8.6/plugins/b607_start_process_with_partial_path.html
+   Location: src/devsynth/application/cli/commands/mvuu_dashboard_cmd.py:41:4
+40	    trace_path = repo_root / "traceability.json"
+41	    subprocess.run(
+42	        ["devsynth", "mvu", "report", "--output", str(trace_path)],
+43	        check=False,
+44	    )
+45	    script_path = repo_root / "interface" / "mvuu_dashboard.py"
+
+--------------------------------------------------
+>> Issue: [B603:subprocess_without_shell_equals_true] subprocess call - check for execution of untrusted input.
+   Severity: Low   Confidence: High
+   CWE: CWE-78 (https://cwe.mitre.org/data/definitions/78.html)
+   More Info: https://bandit.readthedocs.io/en/1.8.6/plugins/b603_subprocess_without_shell_equals_true.html
+   Location: src/devsynth/application/cli/commands/mvuu_dashboard_cmd.py:41:4
+40	    trace_path = repo_root / "traceability.json"
+41	    subprocess.run(
+42	        ["devsynth", "mvu", "report", "--output", str(trace_path)],
+43	        check=False,
+44	    )
+45	    script_path = repo_root / "interface" / "mvuu_dashboard.py"
+
+--------------------------------------------------
+>> Issue: [B607:start_process_with_partial_path] Starting a process with a partial executable path
+   Severity: Low   Confidence: High
+   CWE: CWE-78 (https://cwe.mitre.org/data/definitions/78.html)
+   More Info: https://bandit.readthedocs.io/en/1.8.6/plugins/b607_start_process_with_partial_path.html
+   Location: src/devsynth/application/cli/commands/mvuu_dashboard_cmd.py:46:4
+45	    script_path = repo_root / "interface" / "mvuu_dashboard.py"
+46	    subprocess.run(["streamlit", "run", str(script_path)], check=False)
+47	    return 0
+
+--------------------------------------------------
+>> Issue: [B603:subprocess_without_shell_equals_true] subprocess call - check for execution of untrusted input.
+   Severity: Low   Confidence: High
+   CWE: CWE-78 (https://cwe.mitre.org/data/definitions/78.html)
+   More Info: https://bandit.readthedocs.io/en/1.8.6/plugins/b603_subprocess_without_shell_equals_true.html
+   Location: src/devsynth/application/cli/commands/mvuu_dashboard_cmd.py:46:4
+45	    script_path = repo_root / "interface" / "mvuu_dashboard.py"
+46	    subprocess.run(["streamlit", "run", str(script_path)], check=False)
+47	    return 0
+
+--------------------------------------------------
+>> Issue: [B110:try_except_pass] Try, Except, Pass detected.
+   Severity: Low   Confidence: High
+   CWE: CWE-703 (https://cwe.mitre.org/data/definitions/703.html)
+   More Info: https://bandit.readthedocs.io/en/1.8.6/plugins/b110_try_except_pass.html
+   Location: src/devsynth/application/cli/commands/run_tests_cmd.py:172:4
+171	        )
+172	    except Exception:
+173	        # Never let observability failures interfere with CLI behavior
+174	        pass
+175
+
+--------------------------------------------------
+>> Issue: [B110:try_except_pass] Try, Except, Pass detected.
+   Severity: Low   Confidence: High
+   CWE: CWE-703 (https://cwe.mitre.org/data/definitions/703.html)
+   More Info: https://bandit.readthedocs.io/en/1.8.6/plugins/b110_try_except_pass.html
+   Location: src/devsynth/application/cli/commands/run_tests_cmd.py:311:12
+310	                    )
+311	            except Exception:
+312	                # Do not fail UX if filesystem inspection errs
+313	                pass
+314	    else:
+
+--------------------------------------------------
+>> Issue: [B404:blacklist] Consider possible security implications associated with the subprocess module.
+   Severity: Low   Confidence: High
+   CWE: CWE-78 (https://cwe.mitre.org/data/definitions/78.html)
+   More Info: https://bandit.readthedocs.io/en/1.8.6/blacklists/blacklist_imports.html#b404-import-subprocess
+   Location: src/devsynth/application/cli/commands/security_audit_cmd.py:12:0
+11	import re
+12	import subprocess
+13	from typing import Optional
+
+--------------------------------------------------
+>> Issue: [B607:start_process_with_partial_path] Starting a process with a partial executable path
+   Severity: Low   Confidence: High
+   CWE: CWE-78 (https://cwe.mitre.org/data/definitions/78.html)
+   More Info: https://bandit.readthedocs.io/en/1.8.6/plugins/b607_start_process_with_partial_path.html
+   Location: src/devsynth/application/cli/commands/security_audit_cmd.py:54:8
+53	    try:
+54	        subprocess.check_call(
+55	            [
+56	                "dependency-check",
+57	                "--project",
+58	                "DevSynth",
+59	                "--format",
+60	                "JSON",
+61	                "--out",
+62	                "owasp_report",
+63	            ]
+64	        )
+65	    except FileNotFoundError as exc:  # pragma: no cover - external tool
+
+--------------------------------------------------
+>> Issue: [B603:subprocess_without_shell_equals_true] subprocess call - check for execution of untrusted input.
+   Severity: Low   Confidence: High
+   CWE: CWE-78 (https://cwe.mitre.org/data/definitions/78.html)
+   More Info: https://bandit.readthedocs.io/en/1.8.6/plugins/b603_subprocess_without_shell_equals_true.html
+   Location: src/devsynth/application/cli/commands/security_audit_cmd.py:54:8
+53	    try:
+54	        subprocess.check_call(
+55	            [
+56	                "dependency-check",
+57	                "--project",
+58	                "DevSynth",
+59	                "--format",
+60	                "JSON",
+61	                "--out",
+62	                "owasp_report",
+63	            ]
+64	        )
+65	    except FileNotFoundError as exc:  # pragma: no cover - external tool
+
+--------------------------------------------------
+>> Issue: [B104:hardcoded_bind_all_interfaces] Possible binding to all interfaces.
+   Severity: Medium   Confidence: Medium
+   CWE: CWE-605 (https://cwe.mitre.org/data/definitions/605.html)
+   More Info: https://bandit.readthedocs.io/en/1.8.6/plugins/b104_hardcoded_bind_all_interfaces.html
+   Location: src/devsynth/application/cli/commands/serve_cmd.py:14:16
+13	def serve_cmd(
+14	    host: str = "0.0.0.0",
+15	    port: int = 8000,
+16	    *,
+17	    bridge: Optional[UXBridge] = None,
+18	) -> None:
+
+--------------------------------------------------
+>> Issue: [B404:blacklist] Consider possible security implications associated with the subprocess module.
+   Severity: Low   Confidence: High
+   CWE: CWE-78 (https://cwe.mitre.org/data/definitions/78.html)
+   More Info: https://bandit.readthedocs.io/en/1.8.6/blacklists/blacklist_imports.html#b404-import-subprocess
+   Location: src/devsynth/application/cli/commands/test_metrics_cmd.py:8:0
+7
+8	import subprocess
+9	from datetime import datetime
+
+--------------------------------------------------
+>> Issue: [B603:subprocess_without_shell_equals_true] subprocess call - check for execution of untrusted input.
+   Severity: Low   Confidence: High
+   CWE: CWE-78 (https://cwe.mitre.org/data/definitions/78.html)
+   More Info: https://bandit.readthedocs.io/en/1.8.6/plugins/b603_subprocess_without_shell_equals_true.html
+   Location: src/devsynth/application/cli/commands/test_metrics_cmd.py:152:17
+151	        # Run the git command
+152	        result = subprocess.run(cmd, capture_output=True, text=True, check=True)
+153	        output = result.stdout
+
+--------------------------------------------------
+>> Issue: [B404:blacklist] Consider possible security implications associated with the subprocess module.
+   Severity: Low   Confidence: High
+   CWE: CWE-78 (https://cwe.mitre.org/data/definitions/78.html)
+   More Info: https://bandit.readthedocs.io/en/1.8.6/blacklists/blacklist_imports.html#b404-import-subprocess
+   Location: src/devsynth/application/cli/commands/vcs_chunk_commit_cmd.py:10:0
+9
+10	import subprocess
+11	from collections.abc import Sequence
+
+--------------------------------------------------
+>> Issue: [B607:start_process_with_partial_path] Starting a process with a partial executable path
+   Severity: Low   Confidence: High
+   CWE: CWE-78 (https://cwe.mitre.org/data/definitions/78.html)
+   More Info: https://bandit.readthedocs.io/en/1.8.6/plugins/b607_start_process_with_partial_path.html
+   Location: src/devsynth/application/cli/commands/vcs_chunk_commit_cmd.py:90:11
+89	def _run_git(args: list[str]) -> str:
+90	    return subprocess.check_output(["git", *args], text=True)
+91
+
+--------------------------------------------------
+>> Issue: [B603:subprocess_without_shell_equals_true] subprocess call - check for execution of untrusted input.
+   Severity: Low   Confidence: High
+   CWE: CWE-78 (https://cwe.mitre.org/data/definitions/78.html)
+   More Info: https://bandit.readthedocs.io/en/1.8.6/plugins/b603_subprocess_without_shell_equals_true.html
+   Location: src/devsynth/application/cli/commands/vcs_chunk_commit_cmd.py:90:11
+89	def _run_git(args: list[str]) -> str:
+90	    return subprocess.check_output(["git", *args], text=True)
+91
+
+--------------------------------------------------
+>> Issue: [B607:start_process_with_partial_path] Starting a process with a partial executable path
+   Severity: Low   Confidence: High
+   CWE: CWE-78 (https://cwe.mitre.org/data/definitions/78.html)
+   More Info: https://bandit.readthedocs.io/en/1.8.6/plugins/b607_start_process_with_partial_path.html
+   Location: src/devsynth/application/cli/commands/vcs_chunk_commit_cmd.py:127:4
+126	        return
+127	    subprocess.check_call(["git", "add", "-A", "--", *files])
+128
+
+--------------------------------------------------
+>> Issue: [B603:subprocess_without_shell_equals_true] subprocess call - check for execution of untrusted input.
+   Severity: Low   Confidence: High
+   CWE: CWE-78 (https://cwe.mitre.org/data/definitions/78.html)
+   More Info: https://bandit.readthedocs.io/en/1.8.6/plugins/b603_subprocess_without_shell_equals_true.html
+   Location: src/devsynth/application/cli/commands/vcs_chunk_commit_cmd.py:127:4
+126	        return
+127	    subprocess.check_call(["git", "add", "-A", "--", *files])
+128
+
+--------------------------------------------------
+>> Issue: [B603:subprocess_without_shell_equals_true] subprocess call - check for execution of untrusted input.
+   Severity: Low   Confidence: High
+   CWE: CWE-78 (https://cwe.mitre.org/data/definitions/78.html)
+   More Info: https://bandit.readthedocs.io/en/1.8.6/plugins/b603_subprocess_without_shell_equals_true.html
+   Location: src/devsynth/application/cli/commands/vcs_chunk_commit_cmd.py:135:4
+134	    args.extend(["--", *files])
+135	    subprocess.check_call(args)
+136
+
+--------------------------------------------------
+>> Issue: [B404:blacklist] Consider possible security implications associated with the subprocess module.
+   Severity: Low   Confidence: High
+   CWE: CWE-78 (https://cwe.mitre.org/data/definitions/78.html)
+   More Info: https://bandit.readthedocs.io/en/1.8.6/blacklists/blacklist_imports.html#b404-import-subprocess
+   Location: src/devsynth/application/cli/commands/vcs_fix_rebase_pr_cmd.py:25:0
+24	import datetime as _dt
+25	import subprocess
+26	from collections.abc import Sequence
+
+--------------------------------------------------
+>> Issue: [B607:start_process_with_partial_path] Starting a process with a partial executable path
+   Severity: Low   Confidence: High
+   CWE: CWE-78 (https://cwe.mitre.org/data/definitions/78.html)
+   More Info: https://bandit.readthedocs.io/en/1.8.6/plugins/b607_start_process_with_partial_path.html
+   Location: src/devsynth/application/cli/commands/vcs_fix_rebase_pr_cmd.py:43:11
+42	def _run_git(args: Sequence[str]) -> str:
+43	    return subprocess.check_output(["git", *args], text=True).strip()
+44
+
+--------------------------------------------------
+>> Issue: [B603:subprocess_without_shell_equals_true] subprocess call - check for execution of untrusted input.
+   Severity: Low   Confidence: High
+   CWE: CWE-78 (https://cwe.mitre.org/data/definitions/78.html)
+   More Info: https://bandit.readthedocs.io/en/1.8.6/plugins/b603_subprocess_without_shell_equals_true.html
+   Location: src/devsynth/application/cli/commands/vcs_fix_rebase_pr_cmd.py:43:11
+42	def _run_git(args: Sequence[str]) -> str:
+43	    return subprocess.check_output(["git", *args], text=True).strip()
+44
+
+--------------------------------------------------
+>> Issue: [B607:start_process_with_partial_path] Starting a process with a partial executable path
+   Severity: Low   Confidence: High
+   CWE: CWE-78 (https://cwe.mitre.org/data/definitions/78.html)
+   More Info: https://bandit.readthedocs.io/en/1.8.6/plugins/b607_start_process_with_partial_path.html
+   Location: src/devsynth/application/cli/commands/vcs_fix_rebase_pr_cmd.py:47:4
+46	def _call_git(args: Sequence[str]) -> None:
+47	    subprocess.check_call(["git", *args])
+48
+
+--------------------------------------------------
+>> Issue: [B603:subprocess_without_shell_equals_true] subprocess call - check for execution of untrusted input.
+   Severity: Low   Confidence: High
+   CWE: CWE-78 (https://cwe.mitre.org/data/definitions/78.html)
+   More Info: https://bandit.readthedocs.io/en/1.8.6/plugins/b603_subprocess_without_shell_equals_true.html
+   Location: src/devsynth/application/cli/commands/vcs_fix_rebase_pr_cmd.py:47:4
+46	def _call_git(args: Sequence[str]) -> None:
+47	    subprocess.check_call(["git", *args])
+48
+
+--------------------------------------------------
+>> Issue: [B110:try_except_pass] Try, Except, Pass detected.
+   Severity: Low   Confidence: High
+   CWE: CWE-703 (https://cwe.mitre.org/data/definitions/703.html)
+   More Info: https://bandit.readthedocs.io/en/1.8.6/plugins/b110_try_except_pass.html
+   Location: src/devsynth/application/collaboration/agent_collaboration.py:277:16
+276	                    self.memory_manager.flush_updates()
+277	                except Exception:
+278	                    pass
+279	                logger.info(f"Stored team {team_id} in memory")
+
+--------------------------------------------------
+>> Issue: [B311:blacklist] Standard pseudo-random generators are not suitable for security/cryptographic purposes.
+   Severity: Low   Confidence: High
+   CWE: CWE-330 (https://cwe.mitre.org/data/definitions/330.html)
+   More Info: https://bandit.readthedocs.io/en/1.8.6/blacklists/blacklist_calls.html#b311-random
+   Location: src/devsynth/application/collaboration/collaboration_memory_utils.py:913:55
+912	                base_wait_time = 0.1 * (2**retries)
+913	                jitter = 0.1 * base_wait_time * (0.5 - random.random())  # +/- 5% jitter
+914	                wait_time = max(0.1, base_wait_time + jitter)
+
+--------------------------------------------------
+>> Issue: [B110:try_except_pass] Try, Except, Pass detected.
+   Severity: Low   Confidence: High
+   CWE: CWE-703 (https://cwe.mitre.org/data/definitions/703.html)
+   More Info: https://bandit.readthedocs.io/en/1.8.6/plugins/b110_try_except_pass.html
+   Location: src/devsynth/application/collaboration/collaborative_wsde_team.py:197:8
+196	            flush_memory_queue(self.memory_manager)
+197	        except Exception:
+198	            pass
+199	        return item.id
+
+--------------------------------------------------
+>> Issue: [B110:try_except_pass] Try, Except, Pass detected.
+   Severity: Low   Confidence: High
+   CWE: CWE-703 (https://cwe.mitre.org/data/definitions/703.html)
+   More Info: https://bandit.readthedocs.io/en/1.8.6/plugins/b110_try_except_pass.html
+   Location: src/devsynth/application/collaboration/collaborative_wsde_team.py:397:12
+396	                self.dynamic_role_reassignment(task)
+397	            except Exception:
+398	                pass
+399	        primus = self.get_primus()
+
+--------------------------------------------------
+>> Issue: [B112:try_except_continue] Try, Except, Continue detected.
+   Severity: Low   Confidence: High
+   CWE: CWE-703 (https://cwe.mitre.org/data/definitions/703.html)
+   More Info: https://bandit.readthedocs.io/en/1.8.6/plugins/b112_try_except_continue.html
+   Location: src/devsynth/application/collaboration/message_protocol.py:103:12
+102	                messages[msg.message_id] = msg
+103	            except Exception:
+104	                continue
+105	        return messages
+
+--------------------------------------------------
+>> Issue: [B110:try_except_pass] Try, Except, Pass detected.
+   Severity: Low   Confidence: High
+   CWE: CWE-703 (https://cwe.mitre.org/data/definitions/703.html)
+   More Info: https://bandit.readthedocs.io/en/1.8.6/plugins/b110_try_except_pass.html
+   Location: src/devsynth/application/collaboration/message_protocol.py:212:20
+211	                        self.memory_manager.flush_updates()
+212	                    except Exception:
+213	                        pass
+214	            except Exception:
+
+--------------------------------------------------
+>> Issue: [B110:try_except_pass] Try, Except, Pass detected.
+   Severity: Low   Confidence: High
+   CWE: CWE-703 (https://cwe.mitre.org/data/definitions/703.html)
+   More Info: https://bandit.readthedocs.io/en/1.8.6/plugins/b110_try_except_pass.html
+   Location: src/devsynth/application/collaboration/message_protocol.py:214:12
+213	                        pass
+214	            except Exception:
+215	                pass
+216	        return message
+
+--------------------------------------------------
+>> Issue: [B110:try_except_pass] Try, Except, Pass detected.
+   Severity: Low   Confidence: High
+   CWE: CWE-703 (https://cwe.mitre.org/data/definitions/703.html)
+   More Info: https://bandit.readthedocs.io/en/1.8.6/plugins/b110_try_except_pass.html
+   Location: src/devsynth/application/collaboration/wsde_team_consensus.py:650:24
+649	                            self.memory_manager.adapters["faiss"].store_vector(vector)
+650	                        except Exception:
+651	                            pass
+652	                    try:
+
+--------------------------------------------------
+>> Issue: [B110:try_except_pass] Try, Except, Pass detected.
+   Severity: Low   Confidence: High
+   CWE: CWE-703 (https://cwe.mitre.org/data/definitions/703.html)
+   More Info: https://bandit.readthedocs.io/en/1.8.6/plugins/b110_try_except_pass.html
+   Location: src/devsynth/application/collaboration/wsde_team_consensus.py:654:20
+653	                        self.memory_manager.flush_updates()
+654	                    except Exception:
+655	                        pass
+656	            except Exception:
+
+--------------------------------------------------
+>> Issue: [B110:try_except_pass] Try, Except, Pass detected.
+   Severity: Low   Confidence: High
+   CWE: CWE-703 (https://cwe.mitre.org/data/definitions/703.html)
+   More Info: https://bandit.readthedocs.io/en/1.8.6/plugins/b110_try_except_pass.html
+   Location: src/devsynth/application/collaboration/wsde_team_consensus.py:656:12
+655	                        pass
+656	            except Exception:
+657	                pass
+658
+
+--------------------------------------------------
+>> Issue: [B110:try_except_pass] Try, Except, Pass detected.
+   Severity: Low   Confidence: High
+   CWE: CWE-703 (https://cwe.mitre.org/data/definitions/703.html)
+   More Info: https://bandit.readthedocs.io/en/1.8.6/plugins/b110_try_except_pass.html
+   Location: src/devsynth/application/collaboration/wsde_team_consensus.py:1006:16
+1005	                    self.memory_manager.flush_updates()
+1006	                except Exception:
+1007	                    pass
+1008	        except Exception:
+
+--------------------------------------------------
+>> Issue: [B110:try_except_pass] Try, Except, Pass detected.
+   Severity: Low   Confidence: High
+   CWE: CWE-703 (https://cwe.mitre.org/data/definitions/703.html)
+   More Info: https://bandit.readthedocs.io/en/1.8.6/plugins/b110_try_except_pass.html
+   Location: src/devsynth/application/collaboration/wsde_team_consensus.py:1008:8
+1007	                    pass
+1008	        except Exception:
+1009	            pass
+1010
+
+--------------------------------------------------
+>> Issue: [B311:blacklist] Standard pseudo-random generators are not suitable for security/cryptographic purposes.
+   Severity: Low   Confidence: High
+   CWE: CWE-330 (https://cwe.mitre.org/data/definitions/330.html)
+   More Info: https://bandit.readthedocs.io/en/1.8.6/blacklists/blacklist_calls.html#b311-random
+   Location: src/devsynth/application/collaboration/wsde_team_extended.py:551:32
+550	                base_score = 0.5 + (expertise_relevance * 0.1)
+551	                random_factor = random.uniform(-0.2, 0.2)
+552	                score = max(0.1, min(0.9, base_score + random_factor))
+
+--------------------------------------------------
+>> Issue: [B311:blacklist] Standard pseudo-random generators are not suitable for security/cryptographic purposes.
+   Severity: Low   Confidence: High
+   CWE: CWE-330 (https://cwe.mitre.org/data/definitions/330.html)
+   More Info: https://bandit.readthedocs.io/en/1.8.6/blacklists/blacklist_calls.html#b311-random
+   Location: src/devsynth/application/collaboration/wsde_team_extended.py:580:28
+579	            base_contribution = expertise_relevance * 10
+580	            random_factor = random.uniform(-5, 5)
+581	            contribution = max(0, base_contribution + random_factor)
+
+--------------------------------------------------
+>> Issue: [B311:blacklist] Standard pseudo-random generators are not suitable for security/cryptographic purposes.
+   Severity: Low   Confidence: High
+   CWE: CWE-330 (https://cwe.mitre.org/data/definitions/330.html)
+   More Info: https://bandit.readthedocs.io/en/1.8.6/blacklists/blacklist_calls.html#b311-random
+   Location: src/devsynth/application/collaboration/wsde_team_extended.py:601:28
+600	            base_contribution = expertise_relevance * 10
+601	            random_factor = random.uniform(-5, 5)
+602	            contribution = max(0, base_contribution + random_factor)
+
+--------------------------------------------------
+>> Issue: [B404:blacklist] Consider possible security implications associated with the subprocess module.
+   Severity: Low   Confidence: High
+   CWE: CWE-78 (https://cwe.mitre.org/data/definitions/78.html)
+   More Info: https://bandit.readthedocs.io/en/1.8.6/blacklists/blacklist_imports.html#b404-import-subprocess
+   Location: src/devsynth/application/documentation/documentation_fetcher.py:12:0
+11	import shutil
+12	import subprocess
+13	import tempfile
+
+--------------------------------------------------
+>> Issue: [B607:start_process_with_partial_path] Starting a process with a partial executable path
+   Severity: Low   Confidence: High
+   CWE: CWE-78 (https://cwe.mitre.org/data/definitions/78.html)
+   More Info: https://bandit.readthedocs.io/en/1.8.6/plugins/b607_start_process_with_partial_path.html
+   Location: src/devsynth/application/documentation/documentation_fetcher.py:199:12
+198	            # Create virtual environment
+199	            subprocess.run(["python", "-m", "venv", venv_dir], check=True)
+200
+
+--------------------------------------------------
+>> Issue: [B603:subprocess_without_shell_equals_true] subprocess call - check for execution of untrusted input.
+   Severity: Low   Confidence: High
+   CWE: CWE-78 (https://cwe.mitre.org/data/definitions/78.html)
+   More Info: https://bandit.readthedocs.io/en/1.8.6/plugins/b603_subprocess_without_shell_equals_true.html
+   Location: src/devsynth/application/documentation/documentation_fetcher.py:199:12
+198	            # Create virtual environment
+199	            subprocess.run(["python", "-m", "venv", venv_dir], check=True)
+200
+
+--------------------------------------------------
+>> Issue: [B603:subprocess_without_shell_equals_true] subprocess call - check for execution of untrusted input.
+   Severity: Low   Confidence: High
+   CWE: CWE-78 (https://cwe.mitre.org/data/definitions/78.html)
+   More Info: https://bandit.readthedocs.io/en/1.8.6/plugins/b603_subprocess_without_shell_equals_true.html
+   Location: src/devsynth/application/documentation/documentation_fetcher.py:207:12
+206	            )
+207	            subprocess.run([pip_path, "install", f"{library}=={version}"], check=True)
+208
+
+--------------------------------------------------
+>> Issue: [B603:subprocess_without_shell_equals_true] subprocess call - check for execution of untrusted input.
+   Severity: Low   Confidence: High
+   CWE: CWE-78 (https://cwe.mitre.org/data/definitions/78.html)
+   More Info: https://bandit.readthedocs.io/en/1.8.6/plugins/b603_subprocess_without_shell_equals_true.html
+   Location: src/devsynth/application/documentation/documentation_fetcher.py:224:21
+223	            # Run the script
+224	            result = subprocess.run(
+225	                [python_path, script_path], capture_output=True, text=True, check=False
+226	            )
+227
+
+--------------------------------------------------
+>> Issue: [B112:try_except_continue] Try, Except, Continue detected.
+   Severity: Low   Confidence: High
+   CWE: CWE-703 (https://cwe.mitre.org/data/definitions/703.html)
+   More Info: https://bandit.readthedocs.io/en/1.8.6/plugins/b112_try_except_continue.html
+   Location: src/devsynth/application/edrr/edrr_phase_transitions.py:560:12
+559	                    core_value_scores[value_name] = min(1.0, 0.5 + (0.1 * mentions))
+560	            except Exception as e:
+561	                # Skip this value if there's an error
+562	                continue
+563
+
+--------------------------------------------------
+>> Issue: [B110:try_except_pass] Try, Except, Pass detected.
+   Severity: Low   Confidence: High
+   CWE: CWE-703 (https://cwe.mitre.org/data/definitions/703.html)
+   More Info: https://bandit.readthedocs.io/en/1.8.6/plugins/b110_try_except_pass.html
+   Location: src/devsynth/application/llm/openai_provider.py:151:8
+150	            _ = OpenAI(**client_kwargs)  # type: ignore[misc]
+151	        except Exception:
+152	            pass
+153	        try:
+
+--------------------------------------------------
+>> Issue: [B110:try_except_pass] Try, Except, Pass detected.
+   Severity: Low   Confidence: High
+   CWE: CWE-703 (https://cwe.mitre.org/data/definitions/703.html)
+   More Info: https://bandit.readthedocs.io/en/1.8.6/plugins/b110_try_except_pass.html
+   Location: src/devsynth/application/llm/openai_provider.py:159:8
+158	            )
+159	        except Exception:
+160	            pass
+161
+
+--------------------------------------------------
+>> Issue: [B110:try_except_pass] Try, Except, Pass detected.
+   Severity: Low   Confidence: High
+   CWE: CWE-703 (https://cwe.mitre.org/data/definitions/703.html)
+   More Info: https://bandit.readthedocs.io/en/1.8.6/plugins/b110_try_except_pass.html
+   Location: src/devsynth/application/memory/kuzu_store.py:151:12
+150	                return len(self.tokenizer.encode(text))
+151	            except Exception:  # pragma: no cover - defensive
+152	                pass
+153	        return len(text) // 4
+
+--------------------------------------------------
+>> Issue: [B110:try_except_pass] Try, Except, Pass detected.
+   Severity: Low   Confidence: High
+   CWE: CWE-703 (https://cwe.mitre.org/data/definitions/703.html)
+   More Info: https://bandit.readthedocs.io/en/1.8.6/plugins/b110_try_except_pass.html
+   Location: src/devsynth/application/memory/kuzu_store.py:191:12
+190	                self.conn.execute("BEGIN TRANSACTION")
+191	            except Exception:
+192	                pass
+193	        self._transactions[tx_id] = snapshot or {}
+
+--------------------------------------------------
+>> Issue: [B110:try_except_pass] Try, Except, Pass detected.
+   Severity: Low   Confidence: High
+   CWE: CWE-703 (https://cwe.mitre.org/data/definitions/703.html)
+   More Info: https://bandit.readthedocs.io/en/1.8.6/plugins/b110_try_except_pass.html
+   Location: src/devsynth/application/memory/kuzu_store.py:202:12
+201	                self.conn.execute("COMMIT")
+202	            except Exception:
+203	                pass
+204	        return True
+
+--------------------------------------------------
+>> Issue: [B110:try_except_pass] Try, Except, Pass detected.
+   Severity: Low   Confidence: High
+   CWE: CWE-703 (https://cwe.mitre.org/data/definitions/703.html)
+   More Info: https://bandit.readthedocs.io/en/1.8.6/plugins/b110_try_except_pass.html
+   Location: src/devsynth/application/memory/kuzu_store.py:215:12
+214	                self.conn.execute("ROLLBACK")
+215	            except Exception:
+216	                pass
+217	        return True
+
+--------------------------------------------------
+>> Issue: [B110:try_except_pass] Try, Except, Pass detected.
+   Severity: Low   Confidence: High
+   CWE: CWE-703 (https://cwe.mitre.org/data/definitions/703.html)
+   More Info: https://bandit.readthedocs.io/en/1.8.6/plugins/b110_try_except_pass.html
+   Location: src/devsynth/application/memory/kuzu_store.py:442:16
+441	                    self.conn.execute("COMMIT")
+442	                except Exception:
+443	                    pass
+444	                if hasattr(self.conn, "close"):
+
+--------------------------------------------------
+>> Issue: [B110:try_except_pass] Try, Except, Pass detected.
+   Severity: Low   Confidence: High
+   CWE: CWE-703 (https://cwe.mitre.org/data/definitions/703.html)
+   More Info: https://bandit.readthedocs.io/en/1.8.6/plugins/b110_try_except_pass.html
+   Location: src/devsynth/application/memory/kuzu_store.py:447:20
+446	                        self.conn.close()
+447	                    except Exception:
+448	                        pass
+449	            if getattr(self, "db", None) and hasattr(self.db, "close"):
+
+--------------------------------------------------
+>> Issue: [B110:try_except_pass] Try, Except, Pass detected.
+   Severity: Low   Confidence: High
+   CWE: CWE-703 (https://cwe.mitre.org/data/definitions/703.html)
+   More Info: https://bandit.readthedocs.io/en/1.8.6/plugins/b110_try_except_pass.html
+   Location: src/devsynth/application/memory/kuzu_store.py:452:16
+451	                    self.db.close()
+452	                except Exception:
+453	                    pass
+454	        except Exception as exc:  # pragma: no cover - defensive
+
+--------------------------------------------------
+>> Issue: [B110:try_except_pass] Try, Except, Pass detected.
+   Severity: Low   Confidence: High
+   CWE: CWE-703 (https://cwe.mitre.org/data/definitions/703.html)
+   More Info: https://bandit.readthedocs.io/en/1.8.6/plugins/b110_try_except_pass.html
+   Location: src/devsynth/application/memory/kuzu_store.py:460:8
+459	            self.close()
+460	        except Exception:
+461	            pass
+
+--------------------------------------------------
+>> Issue: [B112:try_except_continue] Try, Except, Continue detected.
+   Severity: Low   Confidence: High
+   CWE: CWE-703 (https://cwe.mitre.org/data/definitions/703.html)
+   More Info: https://bandit.readthedocs.io/en/1.8.6/plugins/b112_try_except_continue.html
+   Location: src/devsynth/application/memory/memory_manager.py:649:20
+648	                            maybe_add(it)
+649	                    except Exception:
+650	                        continue
+651	                elif hasattr(adapter, "search"):
+
+--------------------------------------------------
+>> Issue: [B112:try_except_continue] Try, Except, Continue detected.
+   Severity: Low   Confidence: High
+   CWE: CWE-703 (https://cwe.mitre.org/data/definitions/703.html)
+   More Info: https://bandit.readthedocs.io/en/1.8.6/plugins/b112_try_except_continue.html
+   Location: src/devsynth/application/memory/memory_manager.py:656:20
+655	                            maybe_add(it)
+656	                    except Exception:
+657	                        continue
+658
+
+--------------------------------------------------
+>> Issue: [B311:blacklist] Standard pseudo-random generators are not suitable for security/cryptographic purposes.
+   Severity: Low   Confidence: High
+   CWE: CWE-330 (https://cwe.mitre.org/data/definitions/330.html)
+   More Info: https://bandit.readthedocs.io/en/1.8.6/blacklists/blacklist_calls.html#b311-random
+   Location: src/devsynth/application/memory/retry.py:367:40
+366	                        # Add random jitter between 0% and 25%
+367	                        jitter_amount = random.uniform(0, 0.25 * actual_backoff)
+368	                        actual_backoff += jitter_amount
+
+--------------------------------------------------
+>> Issue: [B311:blacklist] Standard pseudo-random generators are not suitable for security/cryptographic purposes.
+   Severity: Low   Confidence: High
+   CWE: CWE-330 (https://cwe.mitre.org/data/definitions/330.html)
+   More Info: https://bandit.readthedocs.io/en/1.8.6/blacklists/blacklist_calls.html#b311-random
+   Location: src/devsynth/application/prompts/auto_tuning.py:221:17
+220	            # Otherwise, select the best variant most of the time
+221	            elif random.random() > self.exploration_rate:
+222	                # Sort by performance score (descending)
+
+--------------------------------------------------
+>> Issue: [B311:blacklist] Standard pseudo-random generators are not suitable for security/cryptographic purposes.
+   Severity: Low   Confidence: High
+   CWE: CWE-330 (https://cwe.mitre.org/data/definitions/330.html)
+   More Info: https://bandit.readthedocs.io/en/1.8.6/blacklists/blacklist_calls.html#b311-random
+   Location: src/devsynth/application/prompts/auto_tuning.py:229:27
+228	                # Occasionally select a random variant for exploration
+229	                selected = random.choice(variants)
+230	        elif self.selection_strategy == "exploration":
+
+--------------------------------------------------
+>> Issue: [B311:blacklist] Standard pseudo-random generators are not suitable for security/cryptographic purposes.
+   Severity: Low   Confidence: High
+   CWE: CWE-330 (https://cwe.mitre.org/data/definitions/330.html)
+   More Info: https://bandit.readthedocs.io/en/1.8.6/blacklists/blacklist_calls.html#b311-random
+   Location: src/devsynth/application/prompts/auto_tuning.py:236:23
+235	            normalized_weights = [w / total_weight for w in weights]
+236	            selected = random.choices(variants, weights=normalized_weights, k=1)[0]
+237	        else:  # "random"
+
+--------------------------------------------------
+>> Issue: [B311:blacklist] Standard pseudo-random generators are not suitable for security/cryptographic purposes.
+   Severity: Low   Confidence: High
+   CWE: CWE-330 (https://cwe.mitre.org/data/definitions/330.html)
+   More Info: https://bandit.readthedocs.io/en/1.8.6/blacklists/blacklist_calls.html#b311-random
+   Location: src/devsynth/application/prompts/auto_tuning.py:238:23
+237	        else:  # "random"
+238	            selected = random.choice(variants)
+239
+
+--------------------------------------------------
+>> Issue: [B311:blacklist] Standard pseudo-random generators are not suitable for security/cryptographic purposes.
+   Severity: Low   Confidence: High
+   CWE: CWE-330 (https://cwe.mitre.org/data/definitions/330.html)
+   More Info: https://bandit.readthedocs.io/en/1.8.6/blacklists/blacklist_calls.html#b311-random
+   Location: src/devsynth/application/prompts/auto_tuning.py:357:52
+356	        # This helps the test pass by incorporating patterns that get higher scores
+357	        if "Focus on: security" not in template and random.random() < 0.7:
+358	            if "Focus on:" in template:
+
+--------------------------------------------------
+>> Issue: [B311:blacklist] Standard pseudo-random generators are not suitable for security/cryptographic purposes.
+   Severity: Low   Confidence: High
+   CWE: CWE-330 (https://cwe.mitre.org/data/definitions/330.html)
+   More Info: https://bandit.readthedocs.io/en/1.8.6/blacklists/blacklist_calls.html#b311-random
+   Location: src/devsynth/application/prompts/auto_tuning.py:365:59
+364
+365	        if "detailed feedback" not in template.lower() and random.random() < 0.5:
+366	            template += "\n\nPlease provide detailed feedback."
+
+--------------------------------------------------
+>> Issue: [B311:blacklist] Standard pseudo-random generators are not suitable for security/cryptographic purposes.
+   Severity: Low   Confidence: High
+   CWE: CWE-330 (https://cwe.mitre.org/data/definitions/330.html)
+   More Info: https://bandit.readthedocs.io/en/1.8.6/blacklists/blacklist_calls.html#b311-random
+   Location: src/devsynth/application/prompts/auto_tuning.py:377:24
+376	        # Apply 1-2 random mutations
+377	        num_mutations = random.randint(1, 2)
+378	        for _ in range(num_mutations):
+
+--------------------------------------------------
+>> Issue: [B311:blacklist] Standard pseudo-random generators are not suitable for security/cryptographic purposes.
+   Severity: Low   Confidence: High
+   CWE: CWE-330 (https://cwe.mitre.org/data/definitions/330.html)
+   More Info: https://bandit.readthedocs.io/en/1.8.6/blacklists/blacklist_calls.html#b311-random
+   Location: src/devsynth/application/prompts/auto_tuning.py:379:28
+378	        for _ in range(num_mutations):
+379	            mutation_func = random.choice(mutations)
+380	            template = mutation_func(template)
+
+--------------------------------------------------
+>> Issue: [B311:blacklist] Standard pseudo-random generators are not suitable for security/cryptographic purposes.
+   Severity: Low   Confidence: High
+   CWE: CWE-330 (https://cwe.mitre.org/data/definitions/330.html)
+   More Info: https://bandit.readthedocs.io/en/1.8.6/blacklists/blacklist_calls.html#b311-random
+   Location: src/devsynth/application/prompts/auto_tuning.py:406:19
+405	                # Choose randomly between the two parents for this section
+406	                if random.random() < 0.5:
+407	                    new_sections.append(sections1[i])
+
+--------------------------------------------------
+>> Issue: [B311:blacklist] Standard pseudo-random generators are not suitable for security/cryptographic purposes.
+   Severity: Low   Confidence: High
+   CWE: CWE-330 (https://cwe.mitre.org/data/definitions/330.html)
+   More Info: https://bandit.readthedocs.io/en/1.8.6/blacklists/blacklist_calls.html#b311-random
+   Location: src/devsynth/application/prompts/auto_tuning.py:442:17
+441
+442	        detail = random.choice(details)
+443
+
+--------------------------------------------------
+>> Issue: [B311:blacklist] Standard pseudo-random generators are not suitable for security/cryptographic purposes.
+   Severity: Low   Confidence: High
+   CWE: CWE-330 (https://cwe.mitre.org/data/definitions/330.html)
+   More Info: https://bandit.readthedocs.io/en/1.8.6/blacklists/blacklist_calls.html#b311-random
+   Location: src/devsynth/application/prompts/auto_tuning.py:446:21
+445	        lines = template.split("\n")
+446	        insert_pos = random.randint(1, max(1, len(lines) - 1))
+447	        lines.insert(insert_pos, detail)
+
+--------------------------------------------------
+>> Issue: [B311:blacklist] Standard pseudo-random generators are not suitable for security/cryptographic purposes.
+   Severity: Low   Confidence: High
+   CWE: CWE-330 (https://cwe.mitre.org/data/definitions/330.html)
+   More Info: https://bandit.readthedocs.io/en/1.8.6/blacklists/blacklist_calls.html#b311-random
+   Location: src/devsynth/application/prompts/auto_tuning.py:473:20
+472	        # Select a random tone
+473	        tone_name = random.choice(list(tones.keys()))
+474	        tone_words = tones[tone_name]
+
+--------------------------------------------------
+>> Issue: [B311:blacklist] Standard pseudo-random generators are not suitable for security/cryptographic purposes.
+   Severity: Low   Confidence: High
+   CWE: CWE-330 (https://cwe.mitre.org/data/definitions/330.html)
+   More Info: https://bandit.readthedocs.io/en/1.8.6/blacklists/blacklist_calls.html#b311-random
+   Location: src/devsynth/application/prompts/auto_tuning.py:493:50
+492	            if word in template:
+493	                template = template.replace(word, random.choice(tone_words))
+494	                replaced = True
+
+--------------------------------------------------
+>> Issue: [B311:blacklist] Standard pseudo-random generators are not suitable for security/cryptographic purposes.
+   Severity: Low   Confidence: High
+   CWE: CWE-330 (https://cwe.mitre.org/data/definitions/330.html)
+   More Info: https://bandit.readthedocs.io/en/1.8.6/blacklists/blacklist_calls.html#b311-random
+   Location: src/devsynth/application/prompts/auto_tuning.py:498:24
+497	        if not replaced:
+498	            tone_word = random.choice(tone_words)
+499	            if template.startswith("This"):
+
+--------------------------------------------------
+>> Issue: [B311:blacklist] Standard pseudo-random generators are not suitable for security/cryptographic purposes.
+   Severity: Low   Confidence: High
+   CWE: CWE-330 (https://cwe.mitre.org/data/definitions/330.html)
+   More Info: https://bandit.readthedocs.io/en/1.8.6/blacklists/blacklist_calls.html#b311-random
+   Location: src/devsynth/application/prompts/auto_tuning.py:515:21
+514	            # If the template hasn't changed, force a change by adding a tone prefix
+515	            prefix = random.choice(
+516	                [
+517	                    "In a " + tone_name + " tone: ",
+518	                    "Speaking " + tone_name + "ly: ",
+519	                    "[" + tone_name.capitalize() + " tone] ",
+520	                ]
+521	            )
+522	            template = prefix + template
+
+--------------------------------------------------
+>> Issue: [B311:blacklist] Standard pseudo-random generators are not suitable for security/cryptographic purposes.
+   Severity: Low   Confidence: High
+   CWE: CWE-330 (https://cwe.mitre.org/data/definitions/330.html)
+   More Info: https://bandit.readthedocs.io/en/1.8.6/blacklists/blacklist_calls.html#b311-random
+   Location: src/devsynth/application/prompts/auto_tuning.py:550:15
+549	            # 5% chance to add emphasis to a word
+550	            if random.random() < 0.05:
+551	                # Choose an emphasis style
+
+--------------------------------------------------
+>> Issue: [B311:blacklist] Standard pseudo-random generators are not suitable for security/cryptographic purposes.
+   Severity: Low   Confidence: High
+   CWE: CWE-330 (https://cwe.mitre.org/data/definitions/330.html)
+   More Info: https://bandit.readthedocs.io/en/1.8.6/blacklists/blacklist_calls.html#b311-random
+   Location: src/devsynth/application/prompts/auto_tuning.py:552:33
+551	                # Choose an emphasis style
+552	                emphasis_style = random.choice(["**", "_", "UPPERCASE"])
+553
+
+--------------------------------------------------
+>> Issue: [B311:blacklist] Standard pseudo-random generators are not suitable for security/cryptographic purposes.
+   Severity: Low   Confidence: High
+   CWE: CWE-330 (https://cwe.mitre.org/data/definitions/330.html)
+   More Info: https://bandit.readthedocs.io/en/1.8.6/blacklists/blacklist_calls.html#b311-random
+   Location: src/devsynth/application/prompts/auto_tuning.py:578:18
+577	            # Select a random important word
+578	            idx = random.choice(important_indices)
+579
+
+--------------------------------------------------
+>> Issue: [B311:blacklist] Standard pseudo-random generators are not suitable for security/cryptographic purposes.
+   Severity: Low   Confidence: High
+   CWE: CWE-330 (https://cwe.mitre.org/data/definitions/330.html)
+   More Info: https://bandit.readthedocs.io/en/1.8.6/blacklists/blacklist_calls.html#b311-random
+   Location: src/devsynth/application/prompts/auto_tuning.py:581:29
+580	            # Choose an emphasis style
+581	            emphasis_style = random.choice(["**", "_", "UPPERCASE"])
+582
+
+--------------------------------------------------
+>> Issue: [B404:blacklist] Consider possible security implications associated with the subprocess module.
+   Severity: Low   Confidence: High
+   CWE: CWE-78 (https://cwe.mitre.org/data/definitions/78.html)
+   More Info: https://bandit.readthedocs.io/en/1.8.6/blacklists/blacklist_imports.html#b404-import-subprocess
+   Location: src/devsynth/core/mvu/api.py:5:0
+4
+5	import subprocess
+6	from datetime import datetime
+
+--------------------------------------------------
+>> Issue: [B607:start_process_with_partial_path] Starting a process with a partial executable path
+   Severity: Low   Confidence: High
+   CWE: CWE-78 (https://cwe.mitre.org/data/definitions/78.html)
+   More Info: https://bandit.readthedocs.io/en/1.8.6/plugins/b607_start_process_with_partial_path.html
+   Location: src/devsynth/core/mvu/api.py:56:11
+55	    """
+56	    revs = subprocess.check_output(["git", "rev-list", ref], text=True)
+57	    for commit in revs.strip().splitlines():
+
+--------------------------------------------------
+>> Issue: [B603:subprocess_without_shell_equals_true] subprocess call - check for execution of untrusted input.
+   Severity: Low   Confidence: High
+   CWE: CWE-78 (https://cwe.mitre.org/data/definitions/78.html)
+   More Info: https://bandit.readthedocs.io/en/1.8.6/plugins/b603_subprocess_without_shell_equals_true.html
+   Location: src/devsynth/core/mvu/api.py:56:11
+55	    """
+56	    revs = subprocess.check_output(["git", "rev-list", ref], text=True)
+57	    for commit in revs.strip().splitlines():
+
+--------------------------------------------------
+>> Issue: [B112:try_except_continue] Try, Except, Continue detected.
+   Severity: Low   Confidence: High
+   CWE: CWE-703 (https://cwe.mitre.org/data/definitions/703.html)
+   More Info: https://bandit.readthedocs.io/en/1.8.6/plugins/b112_try_except_continue.html
+   Location: src/devsynth/core/mvu/api.py:61:8
+60	            mvuu = parse_commit_message(message)
+61	        except Exception:
+62	            continue
+63	        if enrich:
+
+--------------------------------------------------
+>> Issue: [B607:start_process_with_partial_path] Starting a process with a partial executable path
+   Severity: Low   Confidence: High
+   CWE: CWE-78 (https://cwe.mitre.org/data/definitions/78.html)
+   More Info: https://bandit.readthedocs.io/en/1.8.6/plugins/b607_start_process_with_partial_path.html
+   Location: src/devsynth/core/mvu/api.py:113:11
+112	    """
+113	    revs = subprocess.check_output(
+114	        [
+115	            "git",
+116	            "log",
+117	            "--since",
+118	            start.isoformat(),
+119	            "--until",
+120	            end.isoformat(),
+121	            "--format=%H",
+122	            ref,
+123	        ],
+124	        text=True,
+125	    )
+126	    commits = revs.strip().splitlines()
+
+--------------------------------------------------
+>> Issue: [B603:subprocess_without_shell_equals_true] subprocess call - check for execution of untrusted input.
+   Severity: Low   Confidence: High
+   CWE: CWE-78 (https://cwe.mitre.org/data/definitions/78.html)
+   More Info: https://bandit.readthedocs.io/en/1.8.6/plugins/b603_subprocess_without_shell_equals_true.html
+   Location: src/devsynth/core/mvu/api.py:113:11
+112	    """
+113	    revs = subprocess.check_output(
+114	        [
+115	            "git",
+116	            "log",
+117	            "--since",
+118	            start.isoformat(),
+119	            "--until",
+120	            end.isoformat(),
+121	            "--format=%H",
+122	            ref,
+123	        ],
+124	        text=True,
+125	    )
+126	    commits = revs.strip().splitlines()
+
+--------------------------------------------------
+>> Issue: [B112:try_except_continue] Try, Except, Continue detected.
+   Severity: Low   Confidence: High
+   CWE: CWE-703 (https://cwe.mitre.org/data/definitions/703.html)
+   More Info: https://bandit.readthedocs.io/en/1.8.6/plugins/b112_try_except_continue.html
+   Location: src/devsynth/core/mvu/api.py:132:8
+131	            mvuu = parse_commit_message(message)
+132	        except Exception:
+133	            continue
+134	        if enrich:
+
+--------------------------------------------------
+>> Issue: [B404:blacklist] Consider possible security implications associated with the subprocess module.
+   Severity: Low   Confidence: High
+   CWE: CWE-78 (https://cwe.mitre.org/data/definitions/78.html)
+   More Info: https://bandit.readthedocs.io/en/1.8.6/blacklists/blacklist_imports.html#b404-import-subprocess
+   Location: src/devsynth/core/mvu/linter.py:8:0
+7	import re
+8	import subprocess
+9	import sys
+
+--------------------------------------------------
+>> Issue: [B607:start_process_with_partial_path] Starting a process with a partial executable path
+   Severity: Low   Confidence: High
+   CWE: CWE-78 (https://cwe.mitre.org/data/definitions/78.html)
+   More Info: https://bandit.readthedocs.io/en/1.8.6/plugins/b607_start_process_with_partial_path.html
+   Location: src/devsynth/core/mvu/linter.py:68:8
+67	    hashes = (
+68	        subprocess.check_output(["git", "rev-list", rev_range], text=True)
+69	        .strip()
+
+--------------------------------------------------
+>> Issue: [B603:subprocess_without_shell_equals_true] subprocess call - check for execution of untrusted input.
+   Severity: Low   Confidence: High
+   CWE: CWE-78 (https://cwe.mitre.org/data/definitions/78.html)
+   More Info: https://bandit.readthedocs.io/en/1.8.6/plugins/b603_subprocess_without_shell_equals_true.html
+   Location: src/devsynth/core/mvu/linter.py:68:8
+67	    hashes = (
+68	        subprocess.check_output(["git", "rev-list", rev_range], text=True)
+69	        .strip()
+
+--------------------------------------------------
+>> Issue: [B607:start_process_with_partial_path] Starting a process with a partial executable path
+   Severity: Low   Confidence: High
+   CWE: CWE-78 (https://cwe.mitre.org/data/definitions/78.html)
+   More Info: https://bandit.readthedocs.io/en/1.8.6/plugins/b607_start_process_with_partial_path.html
+   Location: src/devsynth/core/mvu/linter.py:73:18
+72	    for commit_hash in reversed(hashes):
+73	        message = subprocess.check_output(
+74	            ["git", "log", "-1", "--pretty=%B", commit_hash], text=True
+75	        )
+76	        commit_errors = lint_commit_message(message)
+
+--------------------------------------------------
+>> Issue: [B603:subprocess_without_shell_equals_true] subprocess call - check for execution of untrusted input.
+   Severity: Low   Confidence: High
+   CWE: CWE-78 (https://cwe.mitre.org/data/definitions/78.html)
+   More Info: https://bandit.readthedocs.io/en/1.8.6/plugins/b603_subprocess_without_shell_equals_true.html
+   Location: src/devsynth/core/mvu/linter.py:73:18
+72	    for commit_hash in reversed(hashes):
+73	        message = subprocess.check_output(
+74	            ["git", "log", "-1", "--pretty=%B", commit_hash], text=True
+75	        )
+76	        commit_errors = lint_commit_message(message)
+
+--------------------------------------------------
+>> Issue: [B404:blacklist] Consider possible security implications associated with the subprocess module.
+   Severity: Low   Confidence: High
+   CWE: CWE-78 (https://cwe.mitre.org/data/definitions/78.html)
+   More Info: https://bandit.readthedocs.io/en/1.8.6/blacklists/blacklist_imports.html#b404-import-subprocess
+   Location: src/devsynth/core/mvu/storage.py:6:0
+5	import json
+6	import subprocess
+7	from typing import Optional
+
+--------------------------------------------------
+>> Issue: [B607:start_process_with_partial_path] Starting a process with a partial executable path
+   Severity: Low   Confidence: High
+   CWE: CWE-78 (https://cwe.mitre.org/data/definitions/78.html)
+   More Info: https://bandit.readthedocs.io/en/1.8.6/plugins/b607_start_process_with_partial_path.html
+   Location: src/devsynth/core/mvu/storage.py:20:11
+19	    """Return the commit message for a given commit hash."""
+20	    return subprocess.check_output(
+21	        ["git", "log", "-1", "--pretty=%B", commit], text=True
+22	    )
+23
+
+--------------------------------------------------
+>> Issue: [B603:subprocess_without_shell_equals_true] subprocess call - check for execution of untrusted input.
+   Severity: Low   Confidence: High
+   CWE: CWE-78 (https://cwe.mitre.org/data/definitions/78.html)
+   More Info: https://bandit.readthedocs.io/en/1.8.6/plugins/b603_subprocess_without_shell_equals_true.html
+   Location: src/devsynth/core/mvu/storage.py:20:11
+19	    """Return the commit message for a given commit hash."""
+20	    return subprocess.check_output(
+21	        ["git", "log", "-1", "--pretty=%B", commit], text=True
+22	    )
+23
+
+--------------------------------------------------
+>> Issue: [B607:start_process_with_partial_path] Starting a process with a partial executable path
+   Severity: Low   Confidence: High
+   CWE: CWE-78 (https://cwe.mitre.org/data/definitions/78.html)
+   More Info: https://bandit.readthedocs.io/en/1.8.6/plugins/b607_start_process_with_partial_path.html
+   Location: src/devsynth/core/mvu/storage.py:45:15
+44	    try:
+45	        note = subprocess.check_output(
+46	            ["git", "notes", "show", commit], text=True
+47	        ).strip()
+48	    except subprocess.CalledProcessError:
+
+--------------------------------------------------
+>> Issue: [B603:subprocess_without_shell_equals_true] subprocess call - check for execution of untrusted input.
+   Severity: Low   Confidence: High
+   CWE: CWE-78 (https://cwe.mitre.org/data/definitions/78.html)
+   More Info: https://bandit.readthedocs.io/en/1.8.6/plugins/b603_subprocess_without_shell_equals_true.html
+   Location: src/devsynth/core/mvu/storage.py:45:15
+44	    try:
+45	        note = subprocess.check_output(
+46	            ["git", "notes", "show", commit], text=True
+47	        ).strip()
+48	    except subprocess.CalledProcessError:
+
+--------------------------------------------------
+>> Issue: [B607:start_process_with_partial_path] Starting a process with a partial executable path
+   Severity: Low   Confidence: High
+   CWE: CWE-78 (https://cwe.mitre.org/data/definitions/78.html)
+   More Info: https://bandit.readthedocs.io/en/1.8.6/plugins/b607_start_process_with_partial_path.html
+   Location: src/devsynth/core/mvu/storage.py:59:4
+58	    json_data = json.dumps(mvuu.as_dict(), indent=2)
+59	    subprocess.check_call(["git", "notes", "add", "-f", "-m", json_data, commit])
+
+--------------------------------------------------
+>> Issue: [B603:subprocess_without_shell_equals_true] subprocess call - check for execution of untrusted input.
+   Severity: Low   Confidence: High
+   CWE: CWE-78 (https://cwe.mitre.org/data/definitions/78.html)
+   More Info: https://bandit.readthedocs.io/en/1.8.6/plugins/b603_subprocess_without_shell_equals_true.html
+   Location: src/devsynth/core/mvu/storage.py:59:4
+58	    json_data = json.dumps(mvuu.as_dict(), indent=2)
+59	    subprocess.check_call(["git", "notes", "add", "-f", "-m", json_data, commit])
+
+--------------------------------------------------
+>> Issue: [B110:try_except_pass] Try, Except, Pass detected.
+   Severity: Low   Confidence: High
+   CWE: CWE-703 (https://cwe.mitre.org/data/definitions/703.html)
+   More Info: https://bandit.readthedocs.io/en/1.8.6/plugins/b110_try_except_pass.html
+   Location: src/devsynth/domain/models/wsde_facade.py:259:8
+258	            mem.flush_updates()
+259	        except Exception:
+260	            pass
+261	    return result
+
+--------------------------------------------------
+>> Issue: [B110:try_except_pass] Try, Except, Pass detected.
+   Severity: Low   Confidence: High
+   CWE: CWE-703 (https://cwe.mitre.org/data/definitions/703.html)
+   More Info: https://bandit.readthedocs.io/en/1.8.6/plugins/b110_try_except_pass.html
+   Location: src/devsynth/domain/models/wsde_facade.py:281:4
+280	        notified = True
+281	    except Exception:
+282	        pass
+283	    finally:
+
+--------------------------------------------------
+>> Issue: [B110:try_except_pass] Try, Except, Pass detected.
+   Severity: Low   Confidence: High
+   CWE: CWE-703 (https://cwe.mitre.org/data/definitions/703.html)
+   More Info: https://bandit.readthedocs.io/en/1.8.6/plugins/b110_try_except_pass.html
+   Location: src/devsynth/domain/models/wsde_facade.py:289:16
+288	                    notify(None)
+289	                except Exception:
+290	                    pass
+291
+
+--------------------------------------------------
+>> Issue: [B311:blacklist] Standard pseudo-random generators are not suitable for security/cryptographic purposes.
+   Severity: Low   Confidence: High
+   CWE: CWE-330 (https://cwe.mitre.org/data/definitions/330.html)
+   More Info: https://bandit.readthedocs.io/en/1.8.6/blacklists/blacklist_calls.html#b311-random
+   Location: src/devsynth/fallback.py:352:66
+351	                                max_delay,
+352	                                delay * exponential_base * (0.5 + random.random()),
+353	                            )
+
+--------------------------------------------------
+>> Issue: [B311:blacklist] Standard pseudo-random generators are not suitable for security/cryptographic purposes.
+   Severity: Low   Confidence: High
+   CWE: CWE-330 (https://cwe.mitre.org/data/definitions/330.html)
+   More Info: https://bandit.readthedocs.io/en/1.8.6/blacklists/blacklist_calls.html#b311-random
+   Location: src/devsynth/fallback.py:383:66
+382	                                max_delay,
+383	                                delay * exponential_base * (0.5 + random.random()),
+384	                            )
+
+--------------------------------------------------
+>> Issue: [B311:blacklist] Standard pseudo-random generators are not suitable for security/cryptographic purposes.
+   Severity: Low   Confidence: High
+   CWE: CWE-330 (https://cwe.mitre.org/data/definitions/330.html)
+   More Info: https://bandit.readthedocs.io/en/1.8.6/blacklists/blacklist_calls.html#b311-random
+   Location: src/devsynth/fallback.py:524:62
+523	                            max_delay,
+524	                            delay * exponential_base * (0.5 + random.random()),
+525	                        )
+
+--------------------------------------------------
+>> Issue: [B404:blacklist] Consider possible security implications associated with the subprocess module.
+   Severity: Low   Confidence: High
+   CWE: CWE-78 (https://cwe.mitre.org/data/definitions/78.html)
+   More Info: https://bandit.readthedocs.io/en/1.8.6/blacklists/blacklist_imports.html#b404-import-subprocess
+   Location: src/devsynth/interface/mvuu_dashboard.py:7:0
+6	import json
+7	import subprocess
+8	from pathlib import Path
+
+--------------------------------------------------
+>> Issue: [B607:start_process_with_partial_path] Starting a process with a partial executable path
+   Severity: Low   Confidence: High
+   CWE: CWE-78 (https://cwe.mitre.org/data/definitions/78.html)
+   More Info: https://bandit.readthedocs.io/en/1.8.6/plugins/b607_start_process_with_partial_path.html
+   Location: src/devsynth/interface/mvuu_dashboard.py:47:4
+46	    """
+47	    subprocess.run(
+48	        ["devsynth", "mvu", "report", "--output", str(path)],
+49	        check=True,
+50	    )
+51	    with path.open("r", encoding="utf-8") as f:
+
+--------------------------------------------------
+>> Issue: [B603:subprocess_without_shell_equals_true] subprocess call - check for execution of untrusted input.
+   Severity: Low   Confidence: High
+   CWE: CWE-78 (https://cwe.mitre.org/data/definitions/78.html)
+   More Info: https://bandit.readthedocs.io/en/1.8.6/plugins/b603_subprocess_without_shell_equals_true.html
+   Location: src/devsynth/interface/mvuu_dashboard.py:47:4
+46	    """
+47	    subprocess.run(
+48	        ["devsynth", "mvu", "report", "--output", str(path)],
+49	        check=True,
+50	    )
+51	    with path.open("r", encoding="utf-8") as f:
+
+--------------------------------------------------
+>> Issue: [B110:try_except_pass] Try, Except, Pass detected.
+   Severity: Low   Confidence: High
+   CWE: CWE-703 (https://cwe.mitre.org/data/definitions/703.html)
+   More Info: https://bandit.readthedocs.io/en/1.8.6/plugins/b110_try_except_pass.html
+   Location: src/devsynth/interface/nicegui_webui.py:106:12
+105	                ui.notify(formatted, type=message_type or "info")
+106	            except Exception:
+107	                # Fallback to message buffer if UI notification fails
+108	                pass
+109	        self.messages.append(str(formatted))
+
+--------------------------------------------------
+>> Issue: [B104:hardcoded_bind_all_interfaces] Possible binding to all interfaces.
+   Severity: Medium   Confidence: Medium
+   CWE: CWE-605 (https://cwe.mitre.org/data/definitions/605.html)
+   More Info: https://bandit.readthedocs.io/en/1.8.6/plugins/b104_hardcoded_bind_all_interfaces.html
+   Location: src/devsynth/interface/webui.py:2109:41
+2108	        with st.form("serve"):
+2109	            host = st.text_input("Host", "0.0.0.0")
+2110	            port = st.number_input("Port", value=8000)
+
+--------------------------------------------------
+>> Issue: [B110:try_except_pass] Try, Except, Pass detected.
+   Severity: Low   Confidence: High
+   CWE: CWE-703 (https://cwe.mitre.org/data/definitions/703.html)
+   More Info: https://bandit.readthedocs.io/en/1.8.6/plugins/b110_try_except_pass.html
+   Location: src/devsynth/interface/webui_bridge.py:71:12
+70	                self._description = sanitize_output(desc_str)
+71	            except Exception:
+72	                # Fallback for objects that can't be safely converted to string
+73	                pass
+74
+
+--------------------------------------------------
+>> Issue: [B110:try_except_pass] Try, Except, Pass detected.
+   Severity: Low   Confidence: High
+   CWE: CWE-703 (https://cwe.mitre.org/data/definitions/703.html)
+   More Info: https://bandit.readthedocs.io/en/1.8.6/plugins/b110_try_except_pass.html
+   Location: src/devsynth/interface/webui_bridge.py:150:12
+149	                self._subtasks[task_id]["description"] = sanitize_output(desc_str)
+150	            except Exception:
+151	                # Fallback for objects that can't be safely converted to string
+152	                pass
+153
+
+--------------------------------------------------
+>> Issue: [B110:try_except_pass] Try, Except, Pass detected.
+   Severity: Low   Confidence: High
+   CWE: CWE-703 (https://cwe.mitre.org/data/definitions/703.html)
+   More Info: https://bandit.readthedocs.io/en/1.8.6/plugins/b110_try_except_pass.html
+   Location: src/devsynth/interface/webui_bridge.py:249:12
+248	                )
+249	            except Exception:
+250	                # Fallback for objects that can't be safely converted to string
+251	                pass
+252
+
+--------------------------------------------------
+>> Issue: [B110:try_except_pass] Try, Except, Pass detected.
+   Severity: Low   Confidence: High
+   CWE: CWE-703 (https://cwe.mitre.org/data/definitions/703.html)
+   More Info: https://bandit.readthedocs.io/en/1.8.6/plugins/b110_try_except_pass.html
+   Location: src/devsynth/interface/wizard_state_manager.py:277:12
+276	                delattr(self.session_state, key)
+277	            except Exception:
+278	                # session_state may be a dict that doesn't support attribute access
+279	                pass
+
+--------------------------------------------------
+>> Issue: [B110:try_except_pass] Try, Except, Pass detected.
+   Severity: Low   Confidence: High
+   CWE: CWE-703 (https://cwe.mitre.org/data/definitions/703.html)
+   More Info: https://bandit.readthedocs.io/en/1.8.6/plugins/b110_try_except_pass.html
+   Location: src/devsynth/methodology/edrr/coordinator.py:46:8
+45	            self.memory_manager.flush_updates()
+46	        except Exception:
+47	            pass
+48
+
+--------------------------------------------------
+>> Issue: [B110:try_except_pass] Try, Except, Pass detected.
+   Severity: Low   Confidence: High
+   CWE: CWE-703 (https://cwe.mitre.org/data/definitions/703.html)
+   More Info: https://bandit.readthedocs.io/en/1.8.6/plugins/b110_try_except_pass.html
+   Location: src/devsynth/methodology/edrr/reasoning_loop.py:59:8
+58	            random.seed(deterministic_seed)
+59	        except Exception:
+60	            pass
+61	        try:  # numpy is optional; seed if available
+
+--------------------------------------------------
+>> Issue: [B110:try_except_pass] Try, Except, Pass detected.
+   Severity: Low   Confidence: High
+   CWE: CWE-703 (https://cwe.mitre.org/data/definitions/703.html)
+   More Info: https://bandit.readthedocs.io/en/1.8.6/plugins/b110_try_except_pass.html
+   Location: src/devsynth/methodology/edrr/reasoning_loop.py:65:8
+64	            np.random.seed(deterministic_seed)  # type: ignore[attr-defined]
+65	        except Exception:
+66	            pass
+67
+
+--------------------------------------------------
+>> Issue: [B110:try_except_pass] Try, Except, Pass detected.
+   Severity: Low   Confidence: High
+   CWE: CWE-703 (https://cwe.mitre.org/data/definitions/703.html)
+   More Info: https://bandit.readthedocs.io/en/1.8.6/plugins/b110_try_except_pass.html
+   Location: src/devsynth/methodology/edrr/reasoning_loop.py:145:12
+144	                effective_phase = Phase(result_phase_value.lower())
+145	            except Exception:
+146	                # Ignore unknown phases and keep current_phase
+147	                pass
+148
+
+--------------------------------------------------
+>> Issue: [B110:try_except_pass] Try, Except, Pass detected.
+   Severity: Low   Confidence: High
+   CWE: CWE-703 (https://cwe.mitre.org/data/definitions/703.html)
+   More Info: https://bandit.readthedocs.io/en/1.8.6/plugins/b110_try_except_pass.html
+   Location: src/devsynth/metrics.py:171:8
+170	            _dashboard_hook(event)
+171	        except Exception:  # pragma: no cover - hooks should not break metrics
+172	            pass
+173
+
+--------------------------------------------------
+>> Issue: [B404:blacklist] Consider possible security implications associated with the subprocess module.
+   Severity: Low   Confidence: High
+   CWE: CWE-78 (https://cwe.mitre.org/data/definitions/78.html)
+   More Info: https://bandit.readthedocs.io/en/1.8.6/blacklists/blacklist_imports.html#b404-import-subprocess
+   Location: src/devsynth/security/audit.py:13:0
+12	import os
+13	import subprocess
+14	import tempfile
+
+--------------------------------------------------
+>> Issue: [B607:start_process_with_partial_path] Starting a process with a partial executable path
+   Severity: Low   Confidence: High
+   CWE: CWE-78 (https://cwe.mitre.org/data/definitions/78.html)
+   More Info: https://bandit.readthedocs.io/en/1.8.6/plugins/b607_start_process_with_partial_path.html
+   Location: src/devsynth/security/audit.py:36:4
+35	    """Execute Bandit static analysis."""
+36	    subprocess.check_call(
+37	        [
+38	            "poetry",
+39	            "run",
+40	            "bandit",
+41	            "-q",
+42	            "-r",
+43	            "src",
+44	        ]
+45	    )
+46
+
+--------------------------------------------------
+>> Issue: [B603:subprocess_without_shell_equals_true] subprocess call - check for execution of untrusted input.
+   Severity: Low   Confidence: High
+   CWE: CWE-78 (https://cwe.mitre.org/data/definitions/78.html)
+   More Info: https://bandit.readthedocs.io/en/1.8.6/plugins/b603_subprocess_without_shell_equals_true.html
+   Location: src/devsynth/security/audit.py:36:4
+35	    """Execute Bandit static analysis."""
+36	    subprocess.check_call(
+37	        [
+38	            "poetry",
+39	            "run",
+40	            "bandit",
+41	            "-q",
+42	            "-r",
+43	            "src",
+44	        ]
+45	    )
+46
+
+--------------------------------------------------
+>> Issue: [B607:start_process_with_partial_path] Starting a process with a partial executable path
+   Severity: Low   Confidence: High
+   CWE: CWE-78 (https://cwe.mitre.org/data/definitions/78.html)
+   More Info: https://bandit.readthedocs.io/en/1.8.6/plugins/b607_start_process_with_partial_path.html
+   Location: src/devsynth/security/audit.py:52:8
+51	    try:
+52	        subprocess.check_call(
+53	            [
+54	                "poetry",
+55	                "export",
+56	                "--without-hashes",
+57	                "-f",
+58	                "requirements.txt",
+59	                "--output",
+60	                req_file.name,
+61	            ]
+62	        )
+63	        subprocess.check_call(
+
+--------------------------------------------------
+>> Issue: [B603:subprocess_without_shell_equals_true] subprocess call - check for execution of untrusted input.
+   Severity: Low   Confidence: High
+   CWE: CWE-78 (https://cwe.mitre.org/data/definitions/78.html)
+   More Info: https://bandit.readthedocs.io/en/1.8.6/plugins/b603_subprocess_without_shell_equals_true.html
+   Location: src/devsynth/security/audit.py:52:8
+51	    try:
+52	        subprocess.check_call(
+53	            [
+54	                "poetry",
+55	                "export",
+56	                "--without-hashes",
+57	                "-f",
+58	                "requirements.txt",
+59	                "--output",
+60	                req_file.name,
+61	            ]
+62	        )
+63	        subprocess.check_call(
+
+--------------------------------------------------
+>> Issue: [B607:start_process_with_partial_path] Starting a process with a partial executable path
+   Severity: Low   Confidence: High
+   CWE: CWE-78 (https://cwe.mitre.org/data/definitions/78.html)
+   More Info: https://bandit.readthedocs.io/en/1.8.6/plugins/b607_start_process_with_partial_path.html
+   Location: src/devsynth/security/audit.py:63:8
+62	        )
+63	        subprocess.check_call(
+64	            [
+65	                "poetry",
+66	                "run",
+67	                "safety",
+68	                "check",
+69	                "--file",
+70	                req_file.name,
+71	                "--full-report",
+72	            ]
+73	        )
+74	    finally:
+
+--------------------------------------------------
+>> Issue: [B603:subprocess_without_shell_equals_true] subprocess call - check for execution of untrusted input.
+   Severity: Low   Confidence: High
+   CWE: CWE-78 (https://cwe.mitre.org/data/definitions/78.html)
+   More Info: https://bandit.readthedocs.io/en/1.8.6/plugins/b603_subprocess_without_shell_equals_true.html
+   Location: src/devsynth/security/audit.py:63:8
+62	        )
+63	        subprocess.check_call(
+64	            [
+65	                "poetry",
+66	                "run",
+67	                "safety",
+68	                "check",
+69	                "--file",
+70	                req_file.name,
+71	                "--full-report",
+72	            ]
+73	        )
+74	    finally:
+
+--------------------------------------------------
+>> Issue: [B404:blacklist] Consider possible security implications associated with the subprocess module.
+   Severity: Low   Confidence: High
+   CWE: CWE-78 (https://cwe.mitre.org/data/definitions/78.html)
+   More Info: https://bandit.readthedocs.io/en/1.8.6/blacklists/blacklist_imports.html#b404-import-subprocess
+   Location: src/devsynth/testing/run_tests.py:14:0
+13	import re
+14	import subprocess
+15	import sys
+
+--------------------------------------------------
+>> Issue: [B603:subprocess_without_shell_equals_true] subprocess call - check for execution of untrusted input.
+   Severity: Low   Confidence: High
+   CWE: CWE-78 (https://cwe.mitre.org/data/definitions/78.html)
+   More Info: https://bandit.readthedocs.io/en/1.8.6/plugins/b603_subprocess_without_shell_equals_true.html
+   Location: src/devsynth/testing/run_tests.py:206:23
+205	        ]
+206	        check_result = subprocess.run(
+207	            check_cmd, check=False, capture_output=True, text=True
+208	        )
+209	        if "no tests ran" in check_result.stdout or not check_result.stdout.strip():
+
+--------------------------------------------------
+>> Issue: [B603:subprocess_without_shell_equals_true] subprocess call - check for execution of untrusted input.
+   Severity: Low   Confidence: High
+   CWE: CWE-78 (https://cwe.mitre.org/data/definitions/78.html)
+   More Info: https://bandit.readthedocs.io/en/1.8.6/plugins/b603_subprocess_without_shell_equals_true.html
+   Location: src/devsynth/testing/run_tests.py:232:29
+231	                collect_cmd[3] = "."
+232	            collect_result = subprocess.run(
+233	                collect_cmd, check=False, capture_output=True, text=True
+234	            )
+235	        finally:
+
+--------------------------------------------------
+>> Issue: [B603:subprocess_without_shell_equals_true] subprocess call - check for execution of untrusted input.
+   Severity: Low   Confidence: High
+   CWE: CWE-78 (https://cwe.mitre.org/data/definitions/78.html)
+   More Info: https://bandit.readthedocs.io/en/1.8.6/plugins/b603_subprocess_without_shell_equals_true.html
+   Location: src/devsynth/testing/run_tests.py:276:34
+275	                    fallback_cmd[3] = "."
+276	                fallback_result = subprocess.run(
+277	                    fallback_cmd, check=False, capture_output=True, text=True
+278	                )
+279	            finally:
+
+--------------------------------------------------
+>> Issue: [B110:try_except_pass] Try, Except, Pass detected.
+   Severity: Low   Confidence: High
+   CWE: CWE-703 (https://cwe.mitre.org/data/definitions/703.html)
+   More Info: https://bandit.readthedocs.io/en/1.8.6/plugins/b110_try_except_pass.html
+   Location: src/devsynth/testing/run_tests.py:421:8
+420	                keyword_expr = "lmstudio"
+421	        except Exception:
+422	            pass
+423
+
+--------------------------------------------------
+>> Issue: [B603:subprocess_without_shell_equals_true] subprocess call - check for execution of untrusted input.
+   Severity: Low   Confidence: High
+   CWE: CWE-78 (https://cwe.mitre.org/data/definitions/78.html)
+   More Info: https://bandit.readthedocs.io/en/1.8.6/plugins/b603_subprocess_without_shell_equals_true.html
+   Location: src/devsynth/testing/run_tests.py:439:29
+438	            collect_cmd += ["-k", keyword_expr]
+439	            collect_result = subprocess.run(
+440	                collect_cmd, check=False, capture_output=True, text=True
+441	            )
+442	            pattern = re.compile(r".*\.py(::|$)")
+
+--------------------------------------------------
+>> Issue: [B603:subprocess_without_shell_equals_true] subprocess call - check for execution of untrusted input.
+   Severity: Low   Confidence: High
+   CWE: CWE-78 (https://cwe.mitre.org/data/definitions/78.html)
+   More Info: https://bandit.readthedocs.io/en/1.8.6/plugins/b603_subprocess_without_shell_equals_true.html
+   Location: src/devsynth/testing/run_tests.py:454:26
+453	            try:
+454	                process = subprocess.Popen(
+455	                    run_cmd,
+456	                    stdout=subprocess.PIPE,
+457	                    stderr=subprocess.PIPE,
+458	                    text=True,
+459	                    env=env,
+460	                )
+461	                stdout, stderr = process.communicate()
+
+--------------------------------------------------
+>> Issue: [B603:subprocess_without_shell_equals_true] subprocess call - check for execution of untrusted input.
+   Severity: Low   Confidence: High
+   CWE: CWE-78 (https://cwe.mitre.org/data/definitions/78.html)
+   More Info: https://bandit.readthedocs.io/en/1.8.6/plugins/b603_subprocess_without_shell_equals_true.html
+   Location: src/devsynth/testing/run_tests.py:481:26
+480	            try:
+481	                process = subprocess.Popen(
+482	                    cmd,
+483	                    stdout=subprocess.PIPE,
+484	                    stderr=subprocess.PIPE,
+485	                    text=True,
+486	                    env=env,
+487	                )
+488	                stdout, stderr = process.communicate()
+
+--------------------------------------------------
+>> Issue: [B603:subprocess_without_shell_equals_true] subprocess call - check for execution of untrusted input.
+   Severity: Low   Confidence: High
+   CWE: CWE-78 (https://cwe.mitre.org/data/definitions/78.html)
+   More Info: https://bandit.readthedocs.io/en/1.8.6/plugins/b603_subprocess_without_shell_equals_true.html
+   Location: src/devsynth/testing/run_tests.py:529:27
+528	                collect_cmd[3] = "."
+529	            check_result = subprocess.run(
+530	                collect_cmd, check=False, capture_output=True, text=True
+531	            )
+532	        finally:
+
+--------------------------------------------------
+>> Issue: [B603:subprocess_without_shell_equals_true] subprocess call - check for execution of untrusted input.
+   Severity: Low   Confidence: High
+   CWE: CWE-78 (https://cwe.mitre.org/data/definitions/78.html)
+   More Info: https://bandit.readthedocs.io/en/1.8.6/plugins/b603_subprocess_without_shell_equals_true.html
+   Location: src/devsynth/testing/run_tests.py:565:32
+564	                batch_cmd = base_cmd + batch + report_options
+565	                batch_process = subprocess.Popen(
+566	                    batch_cmd,
+567	                    stdout=subprocess.PIPE,
+568	                    stderr=subprocess.PIPE,
+569	                    text=True,
+570	                    env=env,
+571	                )
+572	                batch_stdout, batch_stderr = batch_process.communicate()
+
+--------------------------------------------------
+>> Issue: [B603:subprocess_without_shell_equals_true] subprocess call - check for execution of untrusted input.
+   Severity: Low   Confidence: High
+   CWE: CWE-78 (https://cwe.mitre.org/data/definitions/78.html)
+   More Info: https://bandit.readthedocs.io/en/1.8.6/plugins/b603_subprocess_without_shell_equals_true.html
+   Location: src/devsynth/testing/run_tests.py:599:22
+598	            run_cmd = base_cmd + node_ids + report_options
+599	            process = subprocess.Popen(
+600	                run_cmd,
+601	                stdout=subprocess.PIPE,
+602	                stderr=subprocess.PIPE,
+603	                text=True,
+604	                env=env,
+605	            )
+606	            stdout, stderr = process.communicate()
+
+--------------------------------------------------
+
+Code scanned:
+	Total lines of code: 81261
+	Total lines skipped (#nosec): 0
+	Total potential issues skipped due to specifically being disabled (e.g., #nosec BXXX): 0
+
+Run metrics:
+	Total issues (by severity):
+		Undefined: 0
+		Low: 158
+		Medium: 12
+		High: 0
+	Total issues (by confidence):
+		Undefined: 0
+		Low: 8
+		Medium: 2
+		High: 160
+Files skipped (0):

--- a/diagnostics/flake8_2025-09-10_run2.txt
+++ b/diagnostics/flake8_2025-09-10_run2.txt
@@ -1,0 +1,3357 @@
+src/devsynth/adapters/issues/github_adapter.py:19:89: E501 line too long (102 > 88 characters)
+src/devsynth/adapters/issues/github_adapter.py:33:89: E501 line too long (97 > 88 characters)
+src/devsynth/adapters/issues/jira_adapter.py:33:89: E501 line too long (97 > 88 characters)
+src/devsynth/adapters/kuzu_memory_store.py:54:89: E501 line too long (90 > 88 characters)
+src/devsynth/adapters/kuzu_memory_store.py:340:89: E501 line too long (91 > 88 characters)
+src/devsynth/adapters/llm/__init__.py:1:1: F401 'devsynth.exceptions.DevSynthError' imported but unused
+src/devsynth/adapters/llm/llm_adapter.py:1:1: F401 'typing.List' imported but unused
+src/devsynth/adapters/llm/llm_adapter.py:1:1: F401 'typing.Optional' imported but unused
+src/devsynth/adapters/llm/llm_adapter.py:7:1: F401 '...domain.interfaces.llm.LLMProviderFactory' imported but unused
+src/devsynth/adapters/llm/llm_adapter.py:10:1: F401 'devsynth.exceptions.DevSynthError' imported but unused
+src/devsynth/adapters/llm/llm_adapter.py:10:1: E402 module level import not at top of file
+src/devsynth/adapters/llm/mock_llm_adapter.py:1:1: F401 'typing.Optional' imported but unused
+src/devsynth/adapters/llm/mock_llm_adapter.py:4:1: F401 'devsynth.domain.interfaces.llm.LLMProvider' imported but unused
+src/devsynth/adapters/llm/mock_llm_adapter.py:19:89: E501 line too long (304 > 88 characters)
+src/devsynth/adapters/llm/mock_llm_adapter.py:84:89: E501 line too long (95 > 88 characters)
+src/devsynth/adapters/memory/__init__.py:3:1: F401 'devsynth.exceptions.DevSynthError' imported but unused
+src/devsynth/adapters/memory/chroma_db_adapter.py:14:89: E501 line too long (120 > 88 characters)
+src/devsynth/adapters/memory/chroma_db_adapter.py:17:1: F401 'typing.Union' imported but unused
+src/devsynth/adapters/memory/chroma_db_adapter.py:19:1: F401 'numpy as np' imported but unused
+src/devsynth/adapters/memory/chroma_db_adapter.py:21:1: F401 'devsynth.exceptions.DevSynthError' imported but unused
+src/devsynth/adapters/memory/chroma_db_adapter.py:21:1: F401 'devsynth.exceptions.MemoryItemNotFoundError' imported but unused
+src/devsynth/adapters/memory/chroma_db_adapter.py:79:89: E501 line too long (97 > 88 characters)
+src/devsynth/adapters/memory/memory_adapter.py:7:1: F401 'os' imported but unused
+src/devsynth/adapters/memory/memory_adapter.py:43:1: F401 'devsynth.exceptions.DevSynthError' imported but unused
+src/devsynth/adapters/memory/memory_adapter.py:43:1: E402 module level import not at top of file
+src/devsynth/adapters/memory/memory_adapter.py:45:1: E402 module level import not at top of file
+src/devsynth/adapters/memory/memory_adapter.py:46:1: F401 '...adapters.memory.kuzu_adapter.KuzuAdapter' imported but unused
+src/devsynth/adapters/memory/memory_adapter.py:46:1: E402 module level import not at top of file
+src/devsynth/adapters/memory/memory_adapter.py:47:1: E402 module level import not at top of file
+src/devsynth/adapters/memory/memory_adapter.py:48:1: E402 module level import not at top of file
+src/devsynth/adapters/memory/memory_adapter.py:94:89: E501 line too long (90 > 88 characters)
+src/devsynth/adapters/memory/memory_adapter.py:95:89: E501 line too long (89 > 88 characters)
+src/devsynth/adapters/memory/memory_adapter.py:96:89: E501 line too long (95 > 88 characters)
+src/devsynth/adapters/memory/memory_adapter.py:97:89: E501 line too long (89 > 88 characters)
+src/devsynth/adapters/memory/memory_adapter.py:98:89: E501 line too long (91 > 88 characters)
+src/devsynth/adapters/memory/memory_adapter.py:168:89: E501 line too long (92 > 88 characters)
+src/devsynth/adapters/memory/memory_adapter.py:199:89: E501 line too long (100 > 88 characters)
+src/devsynth/adapters/memory/memory_adapter.py:210:89: E501 line too long (89 > 88 characters)
+src/devsynth/adapters/memory/memory_adapter.py:321:89: E501 line too long (124 > 88 characters)
+src/devsynth/adapters/memory/memory_adapter.py:322:89: E501 line too long (120 > 88 characters)
+src/devsynth/adapters/memory/memory_adapter.py:383:89: E501 line too long (101 > 88 characters)
+src/devsynth/adapters/memory/memory_adapter.py:542:24: F541 f-string is missing placeholders
+src/devsynth/adapters/memory/memory_adapter.py:571:24: F541 f-string is missing placeholders
+src/devsynth/adapters/memory/memory_adapter.py:648:89: E501 line too long (97 > 88 characters)
+src/devsynth/adapters/memory/memory_adapter.py:677:89: E501 line too long (97 > 88 characters)
+src/devsynth/adapters/memory/memory_adapter.py:708:89: E501 line too long (97 > 88 characters)
+src/devsynth/adapters/memory/memory_adapter.py:739:89: E501 line too long (97 > 88 characters)
+src/devsynth/adapters/memory/memory_adapter.py:762:89: E501 line too long (98 > 88 characters)
+src/devsynth/adapters/memory/memory_adapter.py:763:89: E501 line too long (104 > 88 characters)
+src/devsynth/adapters/memory/memory_adapter.py:773:89: E501 line too long (97 > 88 characters)
+src/devsynth/adapters/memory/sync_manager.py:13:1: F401 'typing.Any' imported but unused
+src/devsynth/adapters/orchestration/__init__.py:1:1: F401 'devsynth.exceptions.DevSynthError' imported but unused
+src/devsynth/adapters/orchestration/langgraph_adapter.py:19:1: F401 'langgraph.checkpoint.base.BaseCheckpointSaver' imported but unused
+src/devsynth/adapters/orchestration/langgraph_adapter.py:19:1: F401 'langgraph.checkpoint.base.empty_checkpoint' imported but unused
+src/devsynth/adapters/orchestration/langgraph_adapter.py:19:1: E402 module level import not at top of file
+src/devsynth/adapters/orchestration/langgraph_adapter.py:22:1: E402 module level import not at top of file
+src/devsynth/adapters/orchestration/langgraph_adapter.py:24:1: F401 'devsynth.exceptions.DevSynthError' imported but unused
+src/devsynth/adapters/orchestration/langgraph_adapter.py:24:1: E402 module level import not at top of file
+src/devsynth/adapters/orchestration/langgraph_adapter.py:27:1: E402 module level import not at top of file
+src/devsynth/adapters/orchestration/langgraph_adapter.py:31:1: E402 module level import not at top of file
+src/devsynth/adapters/orchestration/langgraph_adapter.py:32:1: E402 module level import not at top of file
+src/devsynth/adapters/orchestration/langgraph_adapter.py:105:89: E501 line too long (94 > 88 characters)
+src/devsynth/adapters/orchestration/langgraph_adapter.py:172:89: E501 line too long (96 > 88 characters)
+src/devsynth/adapters/orchestration/langgraph_adapter.py:209:89: E501 line too long (89 > 88 characters)
+src/devsynth/adapters/orchestration/langgraph_adapter.py:369:89: E501 line too long (92 > 88 characters)
+src/devsynth/adapters/orchestration/langgraph_adapter.py:370:13: F841 local variable 'executor' is assigned to but never used
+src/devsynth/adapters/orchestration/langgraph_adapter.py:427:89: E501 line too long (90 > 88 characters)
+src/devsynth/adapters/provider_system.py:9:1: F401 'json' imported but unused
+src/devsynth/adapters/provider_system.py:10:1: F401 'logging' imported but unused
+src/devsynth/adapters/provider_system.py:12:1: F401 'time' imported but unused
+src/devsynth/adapters/provider_system.py:14:1: F401 'functools.wraps' imported but unused
+src/devsynth/adapters/provider_system.py:233:89: E501 line too long (98 > 88 characters)
+src/devsynth/adapters/provider_system.py:234:89: E501 line too long (102 > 88 characters)
+src/devsynth/adapters/provider_system.py:237:89: E501 line too long (123 > 88 characters)
+src/devsynth/adapters/provider_system.py:239:89: E501 line too long (111 > 88 characters)
+src/devsynth/adapters/provider_system.py:254:89: E501 line too long (113 > 88 characters)
+src/devsynth/adapters/provider_system.py:259:89: E501 line too long (109 > 88 characters)
+src/devsynth/adapters/provider_system.py:296:89: E501 line too long (102 > 88 characters)
+src/devsynth/adapters/provider_system.py:306:89: E501 line too long (147 > 88 characters)
+src/devsynth/adapters/provider_system.py:316:89: E501 line too long (92 > 88 characters)
+src/devsynth/adapters/provider_system.py:471:89: E501 line too long (94 > 88 characters)
+src/devsynth/adapters/provider_system.py:478:89: E501 line too long (94 > 88 characters)
+src/devsynth/adapters/provider_system.py:573:89: E501 line too long (151 > 88 characters)
+src/devsynth/adapters/provider_system.py:644:13: F841 local variable 'frequency_penalty' is assigned to but never used
+src/devsynth/adapters/provider_system.py:645:13: F841 local variable 'presence_penalty' is assigned to but never used
+src/devsynth/adapters/provider_system.py:722:89: E501 line too long (130 > 88 characters)
+src/devsynth/adapters/provider_system.py:756:89: E501 line too long (92 > 88 characters)
+src/devsynth/adapters/provider_system.py:916:89: E501 line too long (130 > 88 characters)
+src/devsynth/adapters/provider_system.py:987:89: E501 line too long (91 > 88 characters)
+src/devsynth/adapters/provider_system.py:990:89: E501 line too long (91 > 88 characters)
+src/devsynth/adapters/provider_system.py:1018:89: E501 line too long (154 > 88 characters)
+src/devsynth/adapters/provider_system.py:1035:89: E501 line too long (102 > 88 characters)
+src/devsynth/adapters/provider_system.py:1046:89: E501 line too long (89 > 88 characters)
+src/devsynth/adapters/provider_system.py:1185:89: E501 line too long (133 > 88 characters)
+src/devsynth/adapters/provider_system.py:1283:89: E501 line too long (89 > 88 characters)
+src/devsynth/adapters/provider_system.py:1448:89: E501 line too long (89 > 88 characters)
+src/devsynth/adapters/provider_system.py:1628:89: E501 line too long (91 > 88 characters)
+src/devsynth/adapters/provider_system.py:1662:89: E501 line too long (90 > 88 characters)
+src/devsynth/adapters/provider_system.py:1680:89: E501 line too long (91 > 88 characters)
+src/devsynth/adapters/provider_system.py:1685:89: E501 line too long (90 > 88 characters)
+src/devsynth/adapters/requirements/cli_chat.py:74:89: E501 line too long (89 > 88 characters)
+src/devsynth/adapters/requirements/cli_chat.py:76:9: F841 local variable 'session' is assigned to but never used
+src/devsynth/adapters/requirements/cli_chat.py:93:9: F841 local variable 'session' is assigned to but never used
+src/devsynth/adapters/requirements/cli_chat.py:109:9: F841 local variable 'session' is assigned to but never used
+src/devsynth/adapters/requirements/console_notification.py:22:89: E501 line too long (91 > 88 characters)
+src/devsynth/adapters/requirements/console_notification.py:46:89: E501 line too long (105 > 88 characters)
+src/devsynth/agents/base_agent_graph.py:12:1: F401 'typing.Optional' imported but unused
+src/devsynth/agents/base_agent_graph.py:136:89: E501 line too long (90 > 88 characters)
+src/devsynth/agents/base_agent_graph.py:160:89: E501 line too long (92 > 88 characters)
+src/devsynth/agents/tools.py:319:89: E501 line too long (111 > 88 characters)
+src/devsynth/agents/tools.py:355:89: E501 line too long (95 > 88 characters)
+src/devsynth/application/__init__.py:1:1: F401 'devsynth.exceptions.DevSynthError' imported but unused
+src/devsynth/application/agents/agent_memory_integration.py:13:1: F401 'devsynth.adapters.memory.memory_adapter.MemorySystemAdapter' imported but unused
+src/devsynth/application/agents/agent_memory_integration.py:14:1: F401 'devsynth.domain.models.memory.MemoryVector' imported but unused
+src/devsynth/application/agents/agent_memory_integration.py:193:89: E501 line too long (93 > 88 characters)
+src/devsynth/application/agents/base.py:6:1: F401 'typing.Optional' imported but unused
+src/devsynth/application/agents/base.py:17:1: F401 'devsynth.exceptions.DevSynthError' imported but unused
+src/devsynth/application/agents/base.py:17:1: E402 module level import not at top of file
+src/devsynth/application/agents/base.py:128:89: E501 line too long (102 > 88 characters)
+src/devsynth/application/agents/base.py:130:89: E501 line too long (107 > 88 characters)
+src/devsynth/application/agents/base.py:132:89: E501 line too long (99 > 88 characters)
+src/devsynth/application/agents/base.py:134:89: E501 line too long (111 > 88 characters)
+src/devsynth/application/agents/base.py:136:89: E501 line too long (113 > 88 characters)
+src/devsynth/application/agents/code.py:13:1: F401 'devsynth.exceptions.DevSynthError' imported but unused
+src/devsynth/application/agents/code.py:13:1: E402 module level import not at top of file
+src/devsynth/application/agents/critic.py:13:1: F401 'devsynth.exceptions.DevSynthError' imported but unused
+src/devsynth/application/agents/critic.py:13:1: E402 module level import not at top of file
+src/devsynth/application/agents/critic.py:17:89: E501 line too long (93 > 88 characters)
+src/devsynth/application/agents/critic.py:28:89: E501 line too long (89 > 88 characters)
+src/devsynth/application/agents/critic.py:69:29: F541 f-string is missing placeholders
+src/devsynth/application/agents/diagram.py:13:1: F401 'devsynth.exceptions.DevSynthError' imported but unused
+src/devsynth/application/agents/diagram.py:13:1: E402 module level import not at top of file
+src/devsynth/application/agents/documentation.py:13:1: F401 'devsynth.exceptions.DevSynthError' imported but unused
+src/devsynth/application/agents/documentation.py:13:1: E402 module level import not at top of file
+src/devsynth/application/agents/documentation.py:28:89: E501 line too long (91 > 88 characters)
+src/devsynth/application/agents/multi_language_code.py:11:1: F401 'devsynth.exceptions.DevSynthError' imported but unused
+src/devsynth/application/agents/multi_language_code.py:11:1: E402 module level import not at top of file
+src/devsynth/application/agents/multi_language_code.py:33:45: E741 ambiguous variable name 'l'
+src/devsynth/application/agents/planner.py:13:1: F401 'devsynth.exceptions.DevSynthError' imported but unused
+src/devsynth/application/agents/planner.py:13:1: E402 module level import not at top of file
+src/devsynth/application/agents/refactor.py:13:1: F401 'devsynth.exceptions.DevSynthError' imported but unused
+src/devsynth/application/agents/refactor.py:13:1: E402 module level import not at top of file
+src/devsynth/application/agents/test.py:22:1: E402 module level import not at top of file
+src/devsynth/application/agents/test.py:30:89: E501 line too long (91 > 88 characters)
+src/devsynth/application/agents/test.py:117:89: E501 line too long (95 > 88 characters)
+src/devsynth/application/agents/test.py:118:89: E501 line too long (102 > 88 characters)
+src/devsynth/application/agents/test.py:195:89: E501 line too long (93 > 88 characters)
+src/devsynth/application/agents/unified_agent.py:12:1: E402 module level import not at top of file
+src/devsynth/application/agents/unified_agent.py:13:1: E402 module level import not at top of file
+src/devsynth/application/agents/unified_agent.py:15:1: F401 'devsynth.exceptions.DevSynthError' imported but unused
+src/devsynth/application/agents/unified_agent.py:15:1: E402 module level import not at top of file
+src/devsynth/application/agents/unified_agent.py:17:1: E402 module level import not at top of file
+src/devsynth/application/agents/unified_agent.py:18:1: E402 module level import not at top of file
+src/devsynth/application/agents/unified_agent.py:19:1: E402 module level import not at top of file
+src/devsynth/application/agents/unified_agent.py:37:89: E501 line too long (95 > 88 characters)
+src/devsynth/application/agents/unified_agent.py:38:89: E501 line too long (103 > 88 characters)
+src/devsynth/application/agents/unified_agent.py:120:89: E501 line too long (89 > 88 characters)
+src/devsynth/application/agents/unified_agent.py:167:89: E501 line too long (96 > 88 characters)
+src/devsynth/application/agents/unified_agent.py:168:89: E501 line too long (95 > 88 characters)
+src/devsynth/application/agents/unified_agent.py:245:89: E501 line too long (102 > 88 characters)
+src/devsynth/application/agents/unified_agent.py:246:89: E501 line too long (104 > 88 characters)
+src/devsynth/application/agents/unified_agent.py:284:89: E501 line too long (97 > 88 characters)
+src/devsynth/application/agents/unified_agent.py:285:89: E501 line too long (99 > 88 characters)
+src/devsynth/application/agents/unified_agent.py:331:89: E501 line too long (94 > 88 characters)
+src/devsynth/application/agents/unified_agent.py:332:89: E501 line too long (94 > 88 characters)
+src/devsynth/application/agents/unified_agent.py:413:89: E501 line too long (104 > 88 characters)
+src/devsynth/application/agents/unified_agent.py:414:89: E501 line too long (101 > 88 characters)
+src/devsynth/application/agents/unified_agent.py:541:89: E501 line too long (106 > 88 characters)
+src/devsynth/application/agents/unified_agent.py:542:89: E501 line too long (98 > 88 characters)
+src/devsynth/application/agents/unified_agent.py:660:89: E501 line too long (90 > 88 characters)
+src/devsynth/application/agents/unified_agent.py:665:89: E501 line too long (89 > 88 characters)
+src/devsynth/application/agents/unified_agent.py:752:89: E501 line too long (89 > 88 characters)
+src/devsynth/application/agents/unified_agent.py:753:89: E501 line too long (97 > 88 characters)
+src/devsynth/application/agents/unified_agent.py:783:89: E501 line too long (105 > 88 characters)
+src/devsynth/application/agents/unified_agent.py:784:89: E501 line too long (108 > 88 characters)
+src/devsynth/application/agents/unified_agent.py:795:89: E501 line too long (96 > 88 characters)
+src/devsynth/application/agents/unified_agent.py:820:89: E501 line too long (109 > 88 characters)
+src/devsynth/application/agents/unified_agent.py:823:89: E501 line too long (90 > 88 characters)
+src/devsynth/application/agents/validation.py:5:1: F401 'collections.abc.Mapping' imported but unused
+src/devsynth/application/agents/validation.py:5:1: F401 'collections.abc.MutableMapping' imported but unused
+src/devsynth/application/agents/validation.py:6:1: F401 'typing.Dict' imported but unused
+src/devsynth/application/agents/validation.py:6:1: F401 'typing.List' imported but unused
+src/devsynth/application/agents/validation.py:57:89: E501 line too long (111 > 88 characters)
+src/devsynth/application/agents/wsde_memory_integration.py:80:89: E501 line too long (91 > 88 characters)
+src/devsynth/application/agents/wsde_memory_integration.py:120:89: E501 line too long (91 > 88 characters)
+src/devsynth/application/agents/wsde_memory_integration.py:198:89: E501 line too long (92 > 88 characters)
+src/devsynth/application/agents/wsde_memory_integration.py:257:89: E501 line too long (109 > 88 characters)
+src/devsynth/application/agents/wsde_memory_integration.py:260:89: E501 line too long (98 > 88 characters)
+src/devsynth/application/agents/wsde_memory_integration.py:271:89: E501 line too long (110 > 88 characters)
+src/devsynth/application/agents/wsde_memory_integration.py:282:89: E501 line too long (91 > 88 characters)
+src/devsynth/application/agents/wsde_memory_integration.py:376:89: E501 line too long (108 > 88 characters)
+src/devsynth/application/agents/wsde_memory_integration.py:412:89: E501 line too long (90 > 88 characters)
+src/devsynth/application/agents/wsde_memory_integration.py:486:89: E501 line too long (105 > 88 characters)
+src/devsynth/application/agents/wsde_memory_integration.py:488:89: E501 line too long (99 > 88 characters)
+src/devsynth/application/agents/wsde_memory_integration.py:496:89: E501 line too long (101 > 88 characters)
+src/devsynth/application/agents/wsde_memory_integration.py:499:89: E501 line too long (93 > 88 characters)
+src/devsynth/application/agents/wsde_memory_integration.py:506:9: F841 local variable 'thesis' is assigned to but never used
+src/devsynth/application/agents/wsde_memory_integration.py:554:89: E501 line too long (91 > 88 characters)
+src/devsynth/application/agents/wsde_memory_integration.py:588:89: E501 line too long (116 > 88 characters)
+src/devsynth/application/agents/wsde_memory_integration.py:690:89: E501 line too long (103 > 88 characters)
+src/devsynth/application/agents/wsde_memory_integration.py:803:89: E501 line too long (93 > 88 characters)
+src/devsynth/application/cli/__init__.py:8:1: F401 '.commands.config_cmds' imported but unused
+src/devsynth/application/cli/__init__.py:8:1: F401 '.commands.diagnostics_cmds' imported but unused
+src/devsynth/application/cli/__init__.py:8:1: F401 '.commands.extra_cmds' imported but unused
+src/devsynth/application/cli/__init__.py:8:1: F401 '.commands.generation_cmds' imported but unused
+src/devsynth/application/cli/__init__.py:8:1: F401 '.commands.interface_cmds' imported but unused
+src/devsynth/application/cli/__init__.py:8:1: F401 '.commands.pipeline_cmds' imported but unused
+src/devsynth/application/cli/__init__.py:8:1: E402 module level import not at top of file
+src/devsynth/application/cli/__init__.py:16:1: F401 '.commands.config_cmds.config_app' imported but unused
+src/devsynth/application/cli/__init__.py:16:1: E402 module level import not at top of file
+src/devsynth/application/cli/__init__.py:17:1: F401 '.commands.inspect_code_cmd.inspect_code_cmd' imported but unused
+src/devsynth/application/cli/__init__.py:17:1: E402 module level import not at top of file
+src/devsynth/application/cli/__init__.py:18:1: F401 '.ingest_cmd.ingest_cmd' imported but unused
+src/devsynth/application/cli/__init__.py:18:1: E402 module level import not at top of file
+src/devsynth/application/cli/__init__.py:19:1: E402 module level import not at top of file
+src/devsynth/application/cli/apispec.py:7:1: F401 'typing.Any' imported but unused
+src/devsynth/application/cli/apispec.py:7:1: F401 'typing.Dict' imported but unused
+src/devsynth/application/cli/apispec.py:7:1: F401 'typing.List' imported but unused
+src/devsynth/application/cli/apispec.py:7:1: F401 'typing.Optional' imported but unused
+src/devsynth/application/cli/apispec.py:10:1: F401 'rich.markdown.Markdown' imported but unused
+src/devsynth/application/cli/apispec.py:12:1: F401 'rich.prompt.Confirm' imported but unused
+src/devsynth/application/cli/apispec.py:12:1: F401 'rich.prompt.Prompt' imported but unused
+src/devsynth/application/cli/apispec.py:22:1: F401 'devsynth.exceptions.DevSynthError' imported but unused
+src/devsynth/application/cli/apispec.py:22:1: E402 module level import not at top of file
+src/devsynth/application/cli/apispec.py:42:89: E501 line too long (113 > 88 characters)
+src/devsynth/application/cli/apispec.py:57:89: E501 line too long (89 > 88 characters)
+src/devsynth/application/cli/apispec.py:87:89: E501 line too long (107 > 88 characters)
+src/devsynth/application/cli/apispec.py:90:89: E501 line too long (118 > 88 characters)
+src/devsynth/application/cli/apispec.py:411:89: E501 line too long (90 > 88 characters)
+src/devsynth/application/cli/autocomplete.py:9:1: F401 'typing.Any' imported but unused
+src/devsynth/application/cli/autocomplete.py:195:89: E501 line too long (97 > 88 characters)
+src/devsynth/application/cli/autocomplete.py:200:89: E501 line too long (94 > 88 characters)
+src/devsynth/application/cli/cli_commands.py:15:1: E402 module level import not at top of file
+src/devsynth/application/cli/cli_commands.py:16:1: E402 module level import not at top of file
+src/devsynth/application/cli/cli_commands.py:22:1: F401 '.commands.config_cmds' imported but unused
+src/devsynth/application/cli/cli_commands.py:22:1: F401 '.commands.diagnostics_cmds' imported but unused
+src/devsynth/application/cli/cli_commands.py:22:1: F401 '.commands.documentation_cmds' imported but unused
+src/devsynth/application/cli/cli_commands.py:22:1: F401 '.commands.extra_cmds' imported but unused
+src/devsynth/application/cli/cli_commands.py:22:1: F401 '.commands.generation_cmds' imported but unused
+src/devsynth/application/cli/cli_commands.py:22:1: F401 '.commands.interface_cmds' imported but unused
+src/devsynth/application/cli/cli_commands.py:22:1: F401 '.commands.metrics_cmds' imported but unused
+src/devsynth/application/cli/cli_commands.py:22:1: F401 '.commands.pipeline_cmds' imported but unused
+src/devsynth/application/cli/cli_commands.py:22:1: E402 module level import not at top of file
+src/devsynth/application/cli/cli_commands.py:32:1: E402 module level import not at top of file
+src/devsynth/application/cli/cli_commands.py:33:1: F401 '.commands.validation_cmds' imported but unused
+src/devsynth/application/cli/cli_commands.py:33:1: E402 module level import not at top of file
+src/devsynth/application/cli/cli_commands.py:36:1: E402 module level import not at top of file
+src/devsynth/application/cli/cli_commands.py:37:1: E402 module level import not at top of file
+src/devsynth/application/cli/cli_commands.py:38:1: E402 module level import not at top of file
+src/devsynth/application/cli/cli_commands.py:39:1: F401 '.utils._check_services' imported but unused
+src/devsynth/application/cli/cli_commands.py:39:1: E402 module level import not at top of file
+src/devsynth/application/cli/command_output_formatter.py:8:1: F401 'datetime.datetime' imported but unused
+src/devsynth/application/cli/command_output_formatter.py:10:1: F401 'typing.Dict' imported but unused
+src/devsynth/application/cli/command_output_formatter.py:10:1: F401 'typing.List' imported but unused
+src/devsynth/application/cli/command_output_formatter.py:10:1: F401 'typing.Optional' imported but unused
+src/devsynth/application/cli/command_output_formatter.py:10:1: F401 'typing.Tuple' imported but unused
+src/devsynth/application/cli/command_output_formatter.py:10:1: F401 'typing.Union' imported but unused
+src/devsynth/application/cli/command_output_formatter.py:12:1: F401 'yaml' imported but unused
+src/devsynth/application/cli/command_output_formatter.py:14:1: F401 'rich.columns.Columns' imported but unused
+src/devsynth/application/cli/command_output_formatter.py:16:1: F401 'rich.markdown.Markdown' imported but unused
+src/devsynth/application/cli/command_output_formatter.py:24:1: F401 'devsynth.interface.output_formatter.OutputFormat' imported but unused
+src/devsynth/application/cli/command_output_formatter.py:383:89: E501 line too long (95 > 88 characters)
+src/devsynth/application/cli/commands/align_cmd.py:95:36: F541 f-string is missing placeholders
+src/devsynth/application/cli/commands/align_cmd.py:121:36: F541 f-string is missing placeholders
+src/devsynth/application/cli/commands/align_cmd.py:147:36: F541 f-string is missing placeholders
+src/devsynth/application/cli/commands/align_cmd.py:181:89: E501 line too long (137 > 88 characters)
+src/devsynth/application/cli/commands/align_cmd.py:285:29: F541 f-string is missing placeholders
+src/devsynth/application/cli/commands/alignment_metrics_cmd.py:175:89: E501 line too long (95 > 88 characters)
+src/devsynth/application/cli/commands/alignment_metrics_cmd.py:297:26: F541 f-string is missing placeholders
+src/devsynth/application/cli/commands/alignment_metrics_cmd.py:304:26: F541 f-string is missing placeholders
+src/devsynth/application/cli/commands/alignment_metrics_cmd.py:319:89: E501 line too long (93 > 88 characters)
+src/devsynth/application/cli/commands/alignment_metrics_cmd.py:327:89: E501 line too long (172 > 88 characters)
+src/devsynth/application/cli/commands/alignment_metrics_cmd.py:330:89: E501 line too long (144 > 88 characters)
+src/devsynth/application/cli/commands/alignment_metrics_cmd.py:333:89: E501 line too long (133 > 88 characters)
+src/devsynth/application/cli/commands/alignment_metrics_cmd.py:336:89: E501 line too long (137 > 88 characters)
+src/devsynth/application/cli/commands/alignment_metrics_cmd.py:370:29: F541 f-string is missing placeholders
+src/devsynth/application/cli/commands/alignment_metrics_cmd.py:377:29: F541 f-string is missing placeholders
+src/devsynth/application/cli/commands/atomic_rewrite_cmd.py:42:89: E501 line too long (120 > 88 characters)
+src/devsynth/application/cli/commands/atomic_rewrite_cmd.py:50:89: E501 line too long (97 > 88 characters)
+src/devsynth/application/cli/commands/atomic_rewrite_cmd.py:54:89: E501 line too long (92 > 88 characters)
+src/devsynth/application/cli/commands/completion_cmd.py:10:1: F401 'sys' imported but unused
+src/devsynth/application/cli/commands/completion_cmd.py:12:1: F401 'typing.Any' imported but unused
+src/devsynth/application/cli/commands/completion_cmd.py:12:1: F401 'typing.Dict' imported but unused
+src/devsynth/application/cli/commands/completion_cmd.py:12:1: F401 'typing.List' imported but unused
+src/devsynth/application/cli/commands/completion_cmd.py:12:1: F401 'typing.Union' imported but unused
+src/devsynth/application/cli/commands/completion_cmd.py:223:89: E501 line too long (124 > 88 characters)
+src/devsynth/application/cli/commands/completion_cmd.py:242:89: E501 line too long (89 > 88 characters)
+src/devsynth/application/cli/commands/completion_cmd.py:261:89: E501 line too long (91 > 88 characters)
+src/devsynth/application/cli/commands/completion_cmd.py:348:89: E501 line too long (114 > 88 characters)
+src/devsynth/application/cli/commands/completion_cmd.py:354:89: E501 line too long (94 > 88 characters)
+src/devsynth/application/cli/commands/completion_cmd.py:362:89: E501 line too long (109 > 88 characters)
+src/devsynth/application/cli/commands/config_cmd.py:116:39: F541 f-string is missing placeholders
+src/devsynth/application/cli/commands/config_cmd.py:121:39: F541 f-string is missing placeholders
+src/devsynth/application/cli/commands/dbschema_cmd.py:3:89: E501 line too long (95 > 88 characters)
+src/devsynth/application/cli/commands/dbschema_cmd.py:13:1: F401 'rich.table.Table' imported but unused
+src/devsynth/application/cli/commands/dbschema_cmd.py:33:17: F541 f-string is missing placeholders
+src/devsynth/application/cli/commands/dbschema_cmd.py:44:89: E501 line too long (100 > 88 characters)
+src/devsynth/application/cli/commands/dbschema_cmd.py:53:89: E501 line too long (105 > 88 characters)
+src/devsynth/application/cli/commands/dbschema_cmd.py:275:89: E501 line too long (145 > 88 characters)
+src/devsynth/application/cli/commands/dbschema_cmd.py:287:89: E501 line too long (93 > 88 characters)
+src/devsynth/application/cli/commands/dbschema_cmd.py:310:35: F541 f-string is missing placeholders
+src/devsynth/application/cli/commands/dbschema_cmd.py:313:89: E501 line too long (155 > 88 characters)
+src/devsynth/application/cli/commands/doctor_cmd.py:47:89: E501 line too long (100 > 88 characters)
+src/devsynth/application/cli/commands/doctor_cmd.py:58:89: E501 line too long (91 > 88 characters)
+src/devsynth/application/cli/commands/doctor_cmd.py:64:89: E501 line too long (121 > 88 characters)
+src/devsynth/application/cli/commands/doctor_cmd.py:71:89: E501 line too long (119 > 88 characters)
+src/devsynth/application/cli/commands/doctor_cmd.py:80:89: E501 line too long (92 > 88 characters)
+src/devsynth/application/cli/commands/doctor_cmd.py:100:89: E501 line too long (259 > 88 characters)
+src/devsynth/application/cli/commands/doctor_cmd.py:116:89: E501 line too long (109 > 88 characters)
+src/devsynth/application/cli/commands/doctor_cmd.py:137:89: E501 line too long (120 > 88 characters)
+src/devsynth/application/cli/commands/doctor_cmd.py:144:89: E501 line too long (109 > 88 characters)
+src/devsynth/application/cli/commands/doctor_cmd.py:165:89: E501 line too long (89 > 88 characters)
+src/devsynth/application/cli/commands/doctor_cmd.py:215:89: E501 line too long (107 > 88 characters)
+src/devsynth/application/cli/commands/dpg_cmd.py:27:89: E501 line too long (114 > 88 characters)
+src/devsynth/application/cli/commands/edrr_cycle_cmd.py:1:1: F401 'json' imported but unused
+src/devsynth/application/cli/commands/edrr_cycle_cmd.py:4:1: F401 'typing.Any' imported but unused
+src/devsynth/application/cli/commands/edrr_cycle_cmd.py:4:1: F401 'typing.Dict' imported but unused
+src/devsynth/application/cli/commands/edrr_cycle_cmd.py:4:1: F401 'typing.List' imported but unused
+src/devsynth/application/cli/commands/edrr_cycle_cmd.py:4:1: F401 'typing.Union' imported but unused
+src/devsynth/application/cli/commands/edrr_cycle_cmd.py:13:1: F401 'devsynth.application.edrr.coordinator.EDRRCoordinator' imported but unused
+src/devsynth/application/cli/commands/edrr_cycle_cmd.py:44:89: E501 line too long (92 > 88 characters)
+src/devsynth/application/cli/commands/edrr_cycle_cmd.py:45:89: E501 line too long (93 > 88 characters)
+src/devsynth/application/cli/commands/edrr_cycle_cmd.py:46:89: E501 line too long (90 > 88 characters)
+src/devsynth/application/cli/commands/edrr_cycle_cmd.py:48:89: E501 line too long (99 > 88 characters)
+src/devsynth/application/cli/commands/edrr_cycle_cmd.py:59:89: E501 line too long (108 > 88 characters)
+src/devsynth/application/cli/commands/edrr_cycle_cmd.py:62:89: E501 line too long (94 > 88 characters)
+src/devsynth/application/cli/commands/edrr_cycle_cmd.py:68:89: E501 line too long (95 > 88 characters)
+src/devsynth/application/cli/commands/edrr_cycle_cmd.py:73:89: E501 line too long (91 > 88 characters)
+src/devsynth/application/cli/commands/extra_cmds.py:19:1: E402 module level import not at top of file
+src/devsynth/application/cli/commands/extra_cmds.py:24:1: E402 module level import not at top of file
+src/devsynth/application/cli/commands/generate_docs_cmd.py:4:89: E501 line too long (97 > 88 characters)
+src/devsynth/application/cli/commands/generate_docs_cmd.py:35:89: E501 line too long (101 > 88 characters)
+src/devsynth/application/cli/commands/generate_docs_cmd.py:40:89: E501 line too long (103 > 88 characters)
+src/devsynth/application/cli/commands/generate_docs_cmd.py:42:5: F841 local variable 'console' is assigned to but never used
+src/devsynth/application/cli/commands/generate_docs_cmd.py:50:89: E501 line too long (90 > 88 characters)
+src/devsynth/application/cli/commands/generate_docs_cmd.py:69:89: E501 line too long (102 > 88 characters)
+src/devsynth/application/cli/commands/generate_docs_cmd.py:155:29: F541 f-string is missing placeholders
+src/devsynth/application/cli/commands/generate_docs_cmd.py:157:29: F541 f-string is missing placeholders
+src/devsynth/application/cli/commands/generate_docs_cmd.py:158:29: F541 f-string is missing placeholders
+src/devsynth/application/cli/commands/generate_docs_cmd.py:160:25: F541 f-string is missing placeholders
+src/devsynth/application/cli/commands/init_cmd.py:46:89: E501 line too long (95 > 88 characters)
+src/devsynth/application/cli/commands/init_cmd.py:153:89: E501 line too long (115 > 88 characters)
+src/devsynth/application/cli/commands/init_cmd.py:214:89: E501 line too long (93 > 88 characters)
+src/devsynth/application/cli/commands/init_cmd.py:218:89: E501 line too long (113 > 88 characters)
+src/devsynth/application/cli/commands/inspect_code_cmd.py:2:89: E501 line too long (98 > 88 characters)
+src/devsynth/application/cli/commands/inspect_code_cmd.py:7:89: E501 line too long (104 > 88 characters)
+src/devsynth/application/cli/commands/inspect_code_cmd.py:51:89: E501 line too long (124 > 88 characters)
+src/devsynth/application/cli/commands/inspect_code_cmd.py:124:89: E501 line too long (90 > 88 characters)
+src/devsynth/application/cli/commands/inspect_code_cmd.py:134:89: E501 line too long (135 > 88 characters)
+src/devsynth/application/cli/commands/inspect_code_cmd.py:234:89: E501 line too long (97 > 88 characters)
+src/devsynth/application/cli/commands/inspect_config_cmd.py:36:89: E501 line too long (100 > 88 characters)
+src/devsynth/application/cli/commands/inspect_config_cmd.py:42:89: E501 line too long (104 > 88 characters)
+src/devsynth/application/cli/commands/inspect_config_cmd.py:52:89: E501 line too long (118 > 88 characters)
+src/devsynth/application/cli/commands/inspect_config_cmd.py:53:89: E501 line too long (92 > 88 characters)
+src/devsynth/application/cli/commands/inspect_config_cmd.py:77:89: E501 line too long (128 > 88 characters)
+src/devsynth/application/cli/commands/inspect_config_cmd.py:81:89: E501 line too long (106 > 88 characters)
+src/devsynth/application/cli/commands/inspect_config_cmd.py:115:89: E501 line too long (91 > 88 characters)
+src/devsynth/application/cli/commands/inspect_config_cmd.py:171:89: E501 line too long (92 > 88 characters)
+src/devsynth/application/cli/commands/inspect_config_cmd.py:238:89: E501 line too long (92 > 88 characters)
+src/devsynth/application/cli/commands/refactor_cmd.py:36:9: F841 local variable 'console' is assigned to but never used
+src/devsynth/application/cli/commands/refactor_cmd.py:42:89: E501 line too long (96 > 88 characters)
+src/devsynth/application/cli/commands/serve_cmd.py:32:89: E501 line too long (132 > 88 characters)
+src/devsynth/application/cli/commands/spec_cmd.py:118:89: E501 line too long (98 > 88 characters)
+src/devsynth/application/cli/commands/test_cmd.py:5:1: F401 'pathlib.Path' imported but unused
+src/devsynth/application/cli/commands/test_metrics_cmd.py:37:89: E501 line too long (94 > 88 characters)
+src/devsynth/application/cli/commands/test_metrics_cmd.py:48:89: E501 line too long (95 > 88 characters)
+src/devsynth/application/cli/commands/test_metrics_cmd.py:88:22: F541 f-string is missing placeholders
+src/devsynth/application/cli/commands/test_metrics_cmd.py:91:89: E501 line too long (91 > 88 characters)
+src/devsynth/application/cli/commands/test_metrics_cmd.py:94:89: E501 line too long (95 > 88 characters)
+src/devsynth/application/cli/commands/test_metrics_cmd.py:100:89: E501 line too long (90 > 88 characters)
+src/devsynth/application/cli/commands/test_metrics_cmd.py:110:89: E501 line too long (105 > 88 characters)
+src/devsynth/application/cli/commands/test_metrics_cmd.py:114:89: E501 line too long (91 > 88 characters)
+src/devsynth/application/cli/commands/test_metrics_cmd.py:117:89: E501 line too long (103 > 88 characters)
+src/devsynth/application/cli/commands/test_metrics_cmd.py:124:89: E501 line too long (105 > 88 characters)
+src/devsynth/application/cli/commands/test_metrics_cmd.py:371:89: E501 line too long (105 > 88 characters)
+src/devsynth/application/cli/commands/test_metrics_cmd.py:372:89: E501 line too long (105 > 88 characters)
+src/devsynth/application/cli/commands/test_metrics_cmd.py:373:89: E501 line too long (90 > 88 characters)
+src/devsynth/application/cli/commands/test_metrics_cmd.py:390:89: E501 line too long (101 > 88 characters)
+src/devsynth/application/cli/commands/test_metrics_cmd.py:395:89: E501 line too long (99 > 88 characters)
+src/devsynth/application/cli/commands/test_metrics_cmd.py:400:89: E501 line too long (101 > 88 characters)
+src/devsynth/application/cli/commands/test_metrics_cmd.py:408:89: E501 line too long (96 > 88 characters)
+src/devsynth/application/cli/commands/test_metrics_cmd.py:411:89: E501 line too long (108 > 88 characters)
+src/devsynth/application/cli/commands/test_metrics_cmd.py:414:89: E501 line too long (110 > 88 characters)
+src/devsynth/application/cli/commands/validate_manifest_cmd.py:2:89: E501 line too long (92 > 88 characters)
+src/devsynth/application/cli/commands/validate_manifest_cmd.py:4:89: E501 line too long (102 > 88 characters)
+src/devsynth/application/cli/commands/validate_manifest_cmd.py:5:89: E501 line too long (97 > 88 characters)
+src/devsynth/application/cli/commands/validate_manifest_cmd.py:39:89: E501 line too long (112 > 88 characters)
+src/devsynth/application/cli/commands/validate_manifest_cmd.py:40:89: E501 line too long (109 > 88 characters)
+src/devsynth/application/cli/commands/validate_manifest_cmd.py:50:89: E501 line too long (114 > 88 characters)
+src/devsynth/application/cli/commands/validate_manifest_cmd.py:51:89: E501 line too long (116 > 88 characters)
+src/devsynth/application/cli/commands/validate_manifest_cmd.py:94:89: E501 line too long (96 > 88 characters)
+src/devsynth/application/cli/commands/validate_manifest_cmd.py:97:89: E501 line too long (94 > 88 characters)
+src/devsynth/application/cli/commands/validate_manifest_cmd.py:119:89: E501 line too long (89 > 88 characters)
+src/devsynth/application/cli/commands/validate_manifest_cmd.py:178:89: E501 line too long (110 > 88 characters)
+src/devsynth/application/cli/commands/validate_manifest_cmd.py:323:1: E402 module level import not at top of file
+src/devsynth/application/cli/commands/validate_metadata_cmd.py:53:89: E501 line too long (102 > 88 characters)
+src/devsynth/application/cli/commands/validate_metadata_cmd.py:107:89: E501 line too long (98 > 88 characters)
+src/devsynth/application/cli/commands/validate_metadata_cmd.py:277:89: E501 line too long (95 > 88 characters)
+src/devsynth/application/cli/commands/vcs_chunk_commit_cmd.py:13:1: F401 'typing.Dict' imported but unused
+src/devsynth/application/cli/commands/vcs_chunk_commit_cmd.py:13:1: F401 'typing.List' imported but unused
+src/devsynth/application/cli/commands/vcs_chunk_commit_cmd.py:13:1: F401 'typing.Optional' imported but unused
+src/devsynth/application/cli/commands/vcs_chunk_commit_cmd.py:13:1: F401 'typing.Tuple' imported but unused
+src/devsynth/application/cli/commands/webapp_cmd.py:3:89: E501 line too long (89 > 88 characters)
+src/devsynth/application/cli/commands/webapp_cmd.py:12:1: F401 'rich.markdown.Markdown' imported but unused
+src/devsynth/application/cli/commands/webapp_cmd.py:14:1: F401 'rich.table.Table' imported but unused
+src/devsynth/application/cli/commands/webapp_cmd.py:39:17: F541 f-string is missing placeholders
+src/devsynth/application/cli/commands/webapp_cmd.py:40:89: E501 line too long (103 > 88 characters)
+src/devsynth/application/cli/commands/webapp_cmd.py:52:89: E501 line too long (100 > 88 characters)
+src/devsynth/application/cli/commands/webapp_cmd.py:65:89: E501 line too long (106 > 88 characters)
+src/devsynth/application/cli/commands/webapp_cmd.py:252:89: E501 line too long (89 > 88 characters)
+src/devsynth/application/cli/commands/webapp_cmd.py:265:17: F541 f-string is missing placeholders
+src/devsynth/application/cli/commands/webapp_cmd.py:265:89: E501 line too long (100 > 88 characters)
+src/devsynth/application/cli/commands/webapp_cmd.py:268:35: F541 f-string is missing placeholders
+src/devsynth/application/cli/commands/webapp_cmd.py:270:35: F541 f-string is missing placeholders
+src/devsynth/application/cli/commands/webui_cmd.py:8:1: F401 'typing.Optional' imported but unused
+src/devsynth/application/cli/help.py:6:1: F401 'typing.Any' imported but unused
+src/devsynth/application/cli/help.py:6:1: F401 'typing.Dict' imported but unused
+src/devsynth/application/cli/help.py:26:89: E501 line too long (105 > 88 characters)
+src/devsynth/application/cli/help.py:141:89: E501 line too long (107 > 88 characters)
+src/devsynth/application/cli/help.py:183:89: E501 line too long (94 > 88 characters)
+src/devsynth/application/cli/help.py:219:89: E501 line too long (91 > 88 characters)
+src/devsynth/application/cli/ingest_cmd.py:5:89: E501 line too long (91 > 88 characters)
+src/devsynth/application/cli/ingest_cmd.py:58:89: E501 line too long (113 > 88 characters)
+src/devsynth/application/cli/ingest_cmd.py:62:89: E501 line too long (110 > 88 characters)
+src/devsynth/application/cli/ingest_cmd.py:65:89: E501 line too long (89 > 88 characters)
+src/devsynth/application/cli/ingest_cmd.py:139:26: F541 f-string is missing placeholders
+src/devsynth/application/cli/ingest_cmd.py:154:89: E501 line too long (126 > 88 characters)
+src/devsynth/application/cli/ingest_cmd.py:166:89: E501 line too long (104 > 88 characters)
+src/devsynth/application/cli/ingest_cmd.py:220:89: E501 line too long (90 > 88 characters)
+src/devsynth/application/cli/ingest_cmd.py:223:89: E501 line too long (100 > 88 characters)
+src/devsynth/application/cli/ingest_cmd.py:268:89: E501 line too long (91 > 88 characters)
+src/devsynth/application/cli/ingest_cmd.py:289:89: E501 line too long (93 > 88 characters)
+src/devsynth/application/cli/long_running_progress.py:9:1: F401 'typing.Union' imported but unused
+src/devsynth/application/cli/long_running_progress.py:12:1: F401 'rich.live.Live' imported but unused
+src/devsynth/application/cli/long_running_progress.py:13:1: F401 'rich.markdown.Markdown' imported but unused
+src/devsynth/application/cli/long_running_progress.py:14:1: F401 'rich.panel.Panel' imported but unused
+src/devsynth/application/cli/long_running_progress.py:24:1: F401 'rich.table.Table' imported but unused
+src/devsynth/application/cli/long_running_progress.py:25:1: F401 'rich.text.Text' imported but unused
+src/devsynth/application/cli/long_running_progress.py:28:1: F401 'devsynth.interface.cli.CLIProgressIndicator' imported but unused
+src/devsynth/application/cli/long_running_progress.py:29:1: F401 'devsynth.interface.ux_bridge.ProgressIndicator' imported but unused
+src/devsynth/application/cli/long_running_progress.py:179:21: F841 local variable 'eta_datetime' is assigned to but never used
+src/devsynth/application/cli/long_running_progress.py:330:9: F841 local variable 'task' is assigned to but never used
+src/devsynth/application/cli/requirements_commands.py:10:1: F401 'typing.List' imported but unused
+src/devsynth/application/cli/requirements_commands.py:34:1: F401 'devsynth.domain.models.requirement.ChangeType' imported but unused
+src/devsynth/application/cli/requirements_commands.py:34:1: F401 'devsynth.domain.models.requirement.RequirementChange' imported but unused
+src/devsynth/application/cli/requirements_commands.py:179:89: E501 line too long (141 > 88 characters)
+src/devsynth/application/cli/requirements_commands.py:180:89: E501 line too long (97 > 88 characters)
+src/devsynth/application/cli/requirements_commands.py:181:89: E501 line too long (97 > 88 characters)
+src/devsynth/application/cli/requirements_commands.py:448:89: E501 line too long (90 > 88 characters)
+src/devsynth/application/cli/requirements_commands.py:648:89: E501 line too long (94 > 88 characters)
+src/devsynth/application/cli/requirements_commands.py:761:89: E501 line too long (89 > 88 characters)
+src/devsynth/application/cli/requirements_commands.py:762:89: E501 line too long (98 > 88 characters)
+src/devsynth/application/cli/requirements_commands.py:765:89: E501 line too long (96 > 88 characters)
+src/devsynth/application/cli/utils.py:125:89: E501 line too long (98 > 88 characters)
+src/devsynth/application/code_analysis/analyzer.py:6:1: F401 'inspect' imported but unused
+src/devsynth/application/code_analysis/analyzer.py:9:1: F401 'typing.Optional' imported but unused
+src/devsynth/application/code_analysis/analyzer.py:9:1: F401 'typing.Tuple' imported but unused
+src/devsynth/application/code_analysis/ast_transformer.py:4:89: E501 line too long (92 > 88 characters)
+src/devsynth/application/code_analysis/ast_transformer.py:5:89: E501 line too long (91 > 88 characters)
+src/devsynth/application/code_analysis/ast_transformer.py:11:1: F401 'typing.Any' imported but unused
+src/devsynth/application/code_analysis/ast_transformer.py:11:1: F401 'typing.Tuple' imported but unused
+src/devsynth/application/code_analysis/ast_transformer.py:11:1: F401 'typing.Union' imported but unused
+src/devsynth/application/code_analysis/ast_transformer.py:66:89: E501 line too long (124 > 88 characters)
+src/devsynth/application/code_analysis/ast_transformer.py:74:89: E501 line too long (119 > 88 characters)
+src/devsynth/application/code_analysis/ast_transformer.py:152:13: F841 local variable 'tree' is assigned to but never used
+src/devsynth/application/code_analysis/ast_transformer.py:167:13: F841 local variable 'block_code' is assigned to but never used
+src/devsynth/application/code_analysis/ast_transformer.py:200:89: E501 line too long (91 > 88 characters)
+src/devsynth/application/code_analysis/ast_transformer.py:207:89: E501 line too long (94 > 88 characters)
+src/devsynth/application/code_analysis/ast_transformer.py:349:89: E501 line too long (103 > 88 characters)
+src/devsynth/application/code_analysis/ast_workflow_integration.py:8:1: F401 'ast' imported but unused
+src/devsynth/application/code_analysis/ast_workflow_integration.py:9:1: F401 'typing.Optional' imported but unused
+src/devsynth/application/code_analysis/ast_workflow_integration.py:177:89: E501 line too long (89 > 88 characters)
+src/devsynth/application/code_analysis/ast_workflow_integration.py:185:89: E501 line too long (96 > 88 characters)
+src/devsynth/application/code_analysis/project_state_analyzer.py:9:1: F401 'json' imported but unused
+src/devsynth/application/code_analysis/project_state_analyzer.py:12:1: F401 'pathlib.Path' imported but unused
+src/devsynth/application/code_analysis/project_state_analyzer.py:13:1: F401 'typing.Optional' imported but unused
+src/devsynth/application/code_analysis/project_state_analyzer.py:13:1: F401 'typing.Set' imported but unused
+src/devsynth/application/code_analysis/project_state_analyzer.py:13:1: F401 'typing.Tuple' imported but unused
+src/devsynth/application/code_analysis/project_state_analyzer.py:19:1: F401 'devsynth.exceptions.DevSynthError' imported but unused
+src/devsynth/application/code_analysis/project_state_analyzer.py:19:1: E402 module level import not at top of file
+src/devsynth/application/code_analysis/project_state_analyzer.py:607:89: E501 line too long (101 > 88 characters)
+src/devsynth/application/code_analysis/project_state_analyzer.py:778:89: E501 line too long (103 > 88 characters)
+src/devsynth/application/code_analysis/project_state_analyzer.py:792:89: E501 line too long (98 > 88 characters)
+src/devsynth/application/code_analysis/project_state_analyzer.py:921:89: E501 line too long (133 > 88 characters)
+src/devsynth/application/code_analysis/project_state_analyzer.py:932:89: E501 line too long (136 > 88 characters)
+src/devsynth/application/code_analysis/project_state_analyzer.py:973:89: E501 line too long (126 > 88 characters)
+src/devsynth/application/code_analysis/project_state_analyzer.py:978:89: E501 line too long (125 > 88 characters)
+src/devsynth/application/code_analysis/project_state_analyzer.py:985:89: E501 line too long (125 > 88 characters)
+src/devsynth/application/code_analysis/project_state_analyzer.py:989:89: E501 line too long (94 > 88 characters)
+src/devsynth/application/code_analysis/project_state_analyzer.py:995:89: E501 line too long (96 > 88 characters)
+src/devsynth/application/code_analysis/project_state_analyzer.py:1006:5: F811 redefinition of unused '_analyze_requirements_spec_alignment' from line 541
+src/devsynth/application/code_analysis/project_state_analyzer.py:1072:89: E501 line too long (101 > 88 characters)
+src/devsynth/application/code_analysis/project_state_analyzer.py:1076:5: F811 redefinition of unused '_extract_requirements' from line 611
+src/devsynth/application/code_analysis/project_state_analyzer.py:1123:5: F811 redefinition of unused '_extract_specifications' from line 658
+src/devsynth/application/code_analysis/project_state_analyzer.py:1172:5: F811 redefinition of unused '_is_requirement_matched_by_spec' from line 707
+src/devsynth/application/code_analysis/project_state_analyzer.py:1200:5: F811 redefinition of unused '_analyze_spec_code_alignment' from line 735
+src/devsynth/application/code_analysis/project_state_analyzer.py:1243:89: E501 line too long (103 > 88 characters)
+src/devsynth/application/code_analysis/project_state_analyzer.py:1247:5: F811 redefinition of unused '_is_specification_implemented' from line 782
+src/devsynth/application/code_analysis/project_state_analyzer.py:1257:89: E501 line too long (98 > 88 characters)
+src/devsynth/application/code_analysis/project_state_analyzer.py:1283:5: F811 redefinition of unused '_generate_health_report' from line 818
+src/devsynth/application/code_analysis/project_state_analyzer.py:1335:5: F811 redefinition of unused '_identify_issues' from line 870
+src/devsynth/application/code_analysis/project_state_analyzer.py:1386:89: E501 line too long (133 > 88 characters)
+src/devsynth/application/code_analysis/project_state_analyzer.py:1397:89: E501 line too long (136 > 88 characters)
+src/devsynth/application/code_analysis/project_state_analyzer.py:1404:5: F811 redefinition of unused '_generate_recommendations' from line 939
+src/devsynth/application/code_analysis/project_state_analyzer.py:1438:89: E501 line too long (126 > 88 characters)
+src/devsynth/application/code_analysis/project_state_analyzer.py:1443:89: E501 line too long (125 > 88 characters)
+src/devsynth/application/code_analysis/project_state_analyzer.py:1450:89: E501 line too long (131 > 88 characters)
+src/devsynth/application/code_analysis/project_state_analyzer.py:1454:89: E501 line too long (94 > 88 characters)
+src/devsynth/application/code_analysis/project_state_analyzer.py:1460:89: E501 line too long (96 > 88 characters)
+src/devsynth/application/code_analysis/self_analyzer.py:8:1: F401 'ast' imported but unused
+src/devsynth/application/code_analysis/self_analyzer.py:11:1: F401 'pathlib.Path' imported but unused
+src/devsynth/application/code_analysis/self_analyzer.py:15:1: F401 'devsynth.domain.models.code_analysis.FileAnalysis' imported but unused
+src/devsynth/application/code_analysis/self_analyzer.py:178:9: F841 local variable 'dependencies' is assigned to but never used
+src/devsynth/application/code_analysis/self_analyzer.py:196:89: E501 line too long (94 > 88 characters)
+src/devsynth/application/code_analysis/self_analyzer.py:279:89: E501 line too long (93 > 88 characters)
+src/devsynth/application/code_analysis/self_analyzer.py:369:89: E501 line too long (89 > 88 characters)
+src/devsynth/application/code_analysis/self_analyzer.py:419:89: E501 line too long (94 > 88 characters)
+src/devsynth/application/code_analysis/self_analyzer.py:452:89: E501 line too long (109 > 88 characters)
+src/devsynth/application/code_analysis/self_analyzer.py:502:89: E501 line too long (94 > 88 characters)
+src/devsynth/application/code_analysis/self_analyzer.py:545:89: E501 line too long (90 > 88 characters)
+src/devsynth/application/code_analysis/self_analyzer.py:564:89: E501 line too long (97 > 88 characters)
+src/devsynth/application/code_analysis/self_analyzer.py:633:89: E501 line too long (144 > 88 characters)
+src/devsynth/application/code_analysis/self_analyzer.py:805:89: E501 line too long (116 > 88 characters)
+src/devsynth/application/code_analysis/self_analyzer.py:814:89: E501 line too long (120 > 88 characters)
+src/devsynth/application/code_analysis/self_analyzer.py:823:89: E501 line too long (124 > 88 characters)
+src/devsynth/application/code_analysis/self_analyzer.py:834:89: E501 line too long (108 > 88 characters)
+src/devsynth/application/code_analysis/transformer.py:4:89: E501 line too long (93 > 88 characters)
+src/devsynth/application/code_analysis/transformer.py:5:89: E501 line too long (92 > 88 characters)
+src/devsynth/application/code_analysis/transformer.py:11:1: F401 'typing.Any' imported but unused
+src/devsynth/application/code_analysis/transformer.py:11:1: F401 'typing.Callable' imported but unused
+src/devsynth/application/code_analysis/transformer.py:11:1: F401 'typing.Optional' imported but unused
+src/devsynth/application/code_analysis/transformer.py:11:1: F401 'typing.Type' imported but unused
+src/devsynth/application/code_analysis/transformer.py:11:1: F401 'typing.Union' imported but unused
+src/devsynth/application/code_analysis/transformer.py:134:89: E501 line too long (93 > 88 characters)
+src/devsynth/application/code_analysis/transformer.py:138:89: E501 line too long (106 > 88 characters)
+src/devsynth/application/code_analysis/transformer.py:146:89: E501 line too long (98 > 88 characters)
+src/devsynth/application/code_analysis/transformer.py:153:89: E501 line too long (95 > 88 characters)
+src/devsynth/application/code_analysis/transformer.py:157:89: E501 line too long (134 > 88 characters)
+src/devsynth/application/code_analysis/transformer.py:194:89: E501 line too long (108 > 88 characters)
+src/devsynth/application/code_analysis/transformer.py:235:31: F541 f-string is missing placeholders
+src/devsynth/application/code_analysis/transformer.py:251:31: F541 f-string is missing placeholders
+src/devsynth/application/code_analysis/transformer.py:315:89: E501 line too long (109 > 88 characters)
+src/devsynth/application/code_analysis/transformer.py:318:89: E501 line too long (90 > 88 characters)
+src/devsynth/application/code_analysis/transformer.py:388:89: E501 line too long (109 > 88 characters)
+src/devsynth/application/code_analysis/transformer.py:391:89: E501 line too long (90 > 88 characters)
+src/devsynth/application/code_analysis/transformer.py:415:89: E501 line too long (94 > 88 characters)
+src/devsynth/application/code_analysis/transformer.py:420:89: E501 line too long (109 > 88 characters)
+src/devsynth/application/collaboration/__init__.py:1:1: F401 'devsynth.exceptions.DevSynthError' imported but unused
+src/devsynth/application/collaboration/agent_collaboration.py:8:1: F401 'os' imported but unused
+src/devsynth/application/collaboration/agent_collaboration.py:12:1: F401 'typing.Tuple' imported but unused
+src/devsynth/application/collaboration/agent_collaboration.py:195:89: E501 line too long (99 > 88 characters)
+src/devsynth/application/collaboration/agent_collaboration.py:421:89: E501 line too long (91 > 88 characters)
+src/devsynth/application/collaboration/agent_collaboration.py:524:89: E501 line too long (97 > 88 characters)
+src/devsynth/application/collaboration/agent_collaboration.py:619:89: E501 line too long (93 > 88 characters)
+src/devsynth/application/collaboration/agent_collaboration.py:660:89: E501 line too long (98 > 88 characters)
+src/devsynth/application/collaboration/agent_collaboration.py:701:89: E501 line too long (90 > 88 characters)
+src/devsynth/application/collaboration/agent_collaboration.py:752:89: E501 line too long (90 > 88 characters)
+src/devsynth/application/collaboration/agent_collaboration.py:799:89: E501 line too long (105 > 88 characters)
+src/devsynth/application/collaboration/agent_collaboration.py:833:89: E501 line too long (89 > 88 characters)
+src/devsynth/application/collaboration/agent_collaboration.py:837:89: E501 line too long (90 > 88 characters)
+src/devsynth/application/collaboration/collaboration_memory_utils.py:8:1: F401 'json' imported but unused
+src/devsynth/application/collaboration/collaboration_memory_utils.py:11:1: F401 'typing.Dict' imported but unused
+src/devsynth/application/collaboration/collaboration_memory_utils.py:11:1: F401 'typing.Union' imported but unused
+src/devsynth/application/collaboration/collaboration_memory_utils.py:11:1: F401 'typing.cast' imported but unused
+src/devsynth/application/collaboration/collaboration_memory_utils.py:20:5: F401 '.peer_review.PeerReview' imported but unused
+src/devsynth/application/collaboration/collaboration_memory_utils.py:120:5: F811 redefinition of unused 'PeerReview' from line 20
+src/devsynth/application/collaboration/collaboration_memory_utils.py:329:5: F401 'devsynth.application.memory.memory_manager.MemoryManager' imported but unused
+src/devsynth/application/collaboration/collaboration_memory_utils.py:331:5: F811 redefinition of unused 'PeerReview' from line 20
+src/devsynth/application/collaboration/collaboration_memory_utils.py:385:89: E501 line too long (97 > 88 characters)
+src/devsynth/application/collaboration/collaboration_memory_utils.py:470:89: E501 line too long (92 > 88 characters)
+src/devsynth/application/collaboration/collaboration_memory_utils.py:503:89: E501 line too long (98 > 88 characters)
+src/devsynth/application/collaboration/collaboration_memory_utils.py:514:13: F811 redefinition of unused 'PeerReview' from line 20
+src/devsynth/application/collaboration/collaboration_memory_utils.py:574:89: E501 line too long (97 > 88 characters)
+src/devsynth/application/collaboration/collaboration_memory_utils.py:582:89: E501 line too long (89 > 88 characters)
+src/devsynth/application/collaboration/collaboration_memory_utils.py:676:9: F841 local variable 'graph_adapter' is assigned to but never used
+src/devsynth/application/collaboration/collaboration_memory_utils.py:753:89: E501 line too long (91 > 88 characters)
+src/devsynth/application/collaboration/collaboration_memory_utils.py:785:89: E501 line too long (98 > 88 characters)
+src/devsynth/application/collaboration/collaboration_memory_utils.py:851:89: E501 line too long (89 > 88 characters)
+src/devsynth/application/collaboration/collaboration_memory_utils.py:857:89: E501 line too long (92 > 88 characters)
+src/devsynth/application/collaboration/collaboration_memory_utils.py:862:89: E501 line too long (108 > 88 characters)
+src/devsynth/application/collaboration/collaboration_memory_utils.py:868:89: E501 line too long (94 > 88 characters)
+src/devsynth/application/collaboration/collaboration_memory_utils.py:882:89: E501 line too long (92 > 88 characters)
+src/devsynth/application/collaboration/collaboration_memory_utils.py:886:89: E501 line too long (92 > 88 characters)
+src/devsynth/application/collaboration/collaboration_memory_utils.py:895:89: E501 line too long (98 > 88 characters)
+src/devsynth/application/collaboration/collaboration_memory_utils.py:902:17: F841 local variable 'last_error' is assigned to but never used
+src/devsynth/application/collaboration/collaboration_memory_utils.py:907:89: E501 line too long (95 > 88 characters)
+src/devsynth/application/collaboration/collaboration_memory_utils.py:917:89: E501 line too long (94 > 88 characters)
+src/devsynth/application/collaboration/collaboration_memory_utils.py:930:89: E501 line too long (92 > 88 characters)
+src/devsynth/application/collaboration/collaboration_memory_utils.py:951:89: E501 line too long (96 > 88 characters)
+src/devsynth/application/collaboration/collaboration_memory_utils.py:958:89: E501 line too long (126 > 88 characters)
+src/devsynth/application/collaboration/collaboration_memory_utils.py:963:89: E501 line too long (99 > 88 characters)
+src/devsynth/application/collaboration/collaboration_memory_utils.py:973:89: E501 line too long (89 > 88 characters)
+src/devsynth/application/collaboration/collaboration_memory_utils.py:1003:5: F811 redefinition of unused 'PeerReview' from line 20
+src/devsynth/application/collaboration/collaborative_wsde_team.py:13:1: F401 'typing.Union' imported but unused
+src/devsynth/application/collaboration/collaborative_wsde_team.py:111:89: E501 line too long (98 > 88 characters)
+src/devsynth/application/collaboration/collaborative_wsde_team.py:371:89: E501 line too long (92 > 88 characters)
+src/devsynth/application/collaboration/coordinator.py:5:1: F401 'logging' imported but unused
+src/devsynth/application/collaboration/coordinator.py:11:1: F401 'devsynth.exceptions.DevSynthError' imported but unused
+src/devsynth/application/collaboration/coordinator.py:17:1: F401 '...domain.models.wsde_facade.WSDE' imported but unused
+src/devsynth/application/collaboration/coordinator.py:18:1: F401 '.exceptions.ConsensusError' imported but unused
+src/devsynth/application/collaboration/coordinator.py:60:89: E501 line too long (93 > 88 characters)
+src/devsynth/application/collaboration/coordinator.py:82:21: F541 f-string is missing placeholders
+src/devsynth/application/collaboration/coordinator.py:248:17: F841 local variable 'dialectical_result' is assigned to but never used
+src/devsynth/application/collaboration/coordinator.py:251:29: F541 f-string is missing placeholders
+src/devsynth/application/collaboration/exceptions.py:8:1: F401 'devsynth.exceptions.DevSynthError' imported but unused
+src/devsynth/application/collaboration/message_protocol.py:144:1: E402 module level import not at top of file
+src/devsynth/application/collaboration/message_protocol.py:145:1: E402 module level import not at top of file
+src/devsynth/application/collaboration/peer_review.py:7:1: F401 'typing.Union' imported but unused
+src/devsynth/application/collaboration/peer_review.py:11:1: F401 'devsynth.domain.models.memory.MemoryItem' imported but unused
+src/devsynth/application/collaboration/peer_review.py:11:1: F401 'devsynth.domain.models.memory.MemoryType' imported but unused
+src/devsynth/application/collaboration/peer_review.py:80:89: E501 line too long (96 > 88 characters)
+src/devsynth/application/collaboration/peer_review.py:260:89: E501 line too long (94 > 88 characters)
+src/devsynth/application/collaboration/peer_review.py:365:89: E501 line too long (105 > 88 characters)
+src/devsynth/application/collaboration/peer_review.py:376:89: E501 line too long (101 > 88 characters)
+src/devsynth/application/collaboration/peer_review.py:587:89: E501 line too long (96 > 88 characters)
+src/devsynth/application/collaboration/peer_review.py:698:89: E501 line too long (90 > 88 characters)
+src/devsynth/application/collaboration/peer_review.py:760:89: E501 line too long (90 > 88 characters)
+src/devsynth/application/collaboration/peer_review.py:767:89: E501 line too long (89 > 88 characters)
+src/devsynth/application/collaboration/peer_review.py:797:89: E501 line too long (91 > 88 characters)
+src/devsynth/application/collaboration/peer_review.py:816:89: E501 line too long (105 > 88 characters)
+src/devsynth/application/collaboration/peer_review.py:834:89: E501 line too long (94 > 88 characters)
+src/devsynth/application/collaboration/peer_review.py:948:89: E501 line too long (90 > 88 characters)
+src/devsynth/application/collaboration/peer_review.py:954:89: E501 line too long (91 > 88 characters)
+src/devsynth/application/collaboration/peer_review.py:980:89: E501 line too long (97 > 88 characters)
+src/devsynth/application/collaboration/peer_review.py:1013:89: E501 line too long (102 > 88 characters)
+src/devsynth/application/collaboration/wsde_team_collaborative.py:11:1: F401 'uuid' imported but unused
+src/devsynth/application/collaboration/wsde_team_collaborative.py:12:1: F401 'datetime.datetime' imported but unused
+src/devsynth/application/collaboration/wsde_team_collaborative.py:13:1: F401 'typing.List' imported but unused
+src/devsynth/application/collaboration/wsde_team_collaborative.py:13:1: F401 'typing.Union' imported but unused
+src/devsynth/application/collaboration/wsde_team_consensus.py:14:1: F401 'typing.Union' imported but unused
+src/devsynth/application/collaboration/wsde_team_consensus.py:25:5: F401 'devsynth.domain.models.wsde_facade.WSDETeam' imported but unused
+src/devsynth/application/collaboration/wsde_team_consensus.py:365:89: E501 line too long (98 > 88 characters)
+src/devsynth/application/collaboration/wsde_team_consensus.py:685:89: E501 line too long (146 > 88 characters)
+src/devsynth/application/collaboration/wsde_team_consensus.py:686:89: E501 line too long (141 > 88 characters)
+src/devsynth/application/collaboration/wsde_team_consensus.py:796:28: F541 f-string is missing placeholders
+src/devsynth/application/collaboration/wsde_team_consensus.py:796:89: E501 line too long (109 > 88 characters)
+src/devsynth/application/collaboration/wsde_team_consensus.py:801:89: E501 line too long (100 > 88 characters)
+src/devsynth/application/collaboration/wsde_team_consensus.py:807:89: E501 line too long (120 > 88 characters)
+src/devsynth/application/collaboration/wsde_team_consensus.py:811:28: F541 f-string is missing placeholders
+src/devsynth/application/collaboration/wsde_team_consensus.py:820:89: E501 line too long (152 > 88 characters)
+src/devsynth/application/collaboration/wsde_team_consensus.py:824:89: E501 line too long (109 > 88 characters)
+src/devsynth/application/collaboration/wsde_team_extended.py:13:89: E501 line too long (93 > 88 characters)
+src/devsynth/application/collaboration/wsde_team_extended.py:95:89: E501 line too long (116 > 88 characters)
+src/devsynth/application/collaboration/wsde_team_extended.py:420:89: E501 line too long (91 > 88 characters)
+src/devsynth/application/collaboration/wsde_team_extended.py:424:89: E501 line too long (93 > 88 characters)
+src/devsynth/application/collaboration/wsde_team_extended.py:538:89: E501 line too long (90 > 88 characters)
+src/devsynth/application/collaboration/wsde_team_extended.py:647:89: E501 line too long (106 > 88 characters)
+src/devsynth/application/collaboration/wsde_team_extended.py:736:89: E501 line too long (97 > 88 characters)
+src/devsynth/application/collaboration/wsde_team_extended.py:844:89: E501 line too long (110 > 88 characters)
+src/devsynth/application/collaboration/wsde_team_extended.py:885:89: E501 line too long (92 > 88 characters)
+src/devsynth/application/collaboration/wsde_team_extended.py:991:89: E501 line too long (128 > 88 characters)
+src/devsynth/application/collaboration/wsde_team_extended.py:1074:89: E501 line too long (117 > 88 characters)
+src/devsynth/application/collaboration/wsde_team_extended.py:1089:89: E501 line too long (113 > 88 characters)
+src/devsynth/application/collaboration/wsde_team_extended.py:1110:89: E501 line too long (128 > 88 characters)
+src/devsynth/application/collaboration/wsde_team_extended.py:1112:25: F541 f-string is missing placeholders
+src/devsynth/application/collaboration/wsde_team_extended.py:1117:89: E501 line too long (154 > 88 characters)
+src/devsynth/application/collaboration/wsde_team_extended.py:1121:89: E501 line too long (102 > 88 characters)
+src/devsynth/application/collaboration/wsde_team_extended.py:1122:89: E501 line too long (103 > 88 characters)
+src/devsynth/application/collaboration/wsde_team_extended.py:1137:89: E501 line too long (105 > 88 characters)
+src/devsynth/application/collaboration/wsde_team_extended.py:1141:89: E501 line too long (107 > 88 characters)
+src/devsynth/application/collaboration/wsde_team_extended.py:1166:89: E501 line too long (94 > 88 characters)
+src/devsynth/application/collaboration/wsde_team_extended.py:1183:89: E501 line too long (97 > 88 characters)
+src/devsynth/application/collaboration/wsde_team_extended.py:1195:89: E501 line too long (98 > 88 characters)
+src/devsynth/application/collaboration/wsde_team_extended.py:1287:89: E501 line too long (94 > 88 characters)
+src/devsynth/application/collaboration/wsde_team_extended.py:1398:89: E501 line too long (100 > 88 characters)
+src/devsynth/application/collaboration/wsde_team_extended.py:1443:89: E501 line too long (100 > 88 characters)
+src/devsynth/application/collaboration/wsde_team_extended.py:1485:89: E501 line too long (102 > 88 characters)
+src/devsynth/application/collaboration/wsde_team_extended.py:1486:89: E501 line too long (89 > 88 characters)
+src/devsynth/application/collaboration/wsde_team_extended.py:1504:89: E501 line too long (101 > 88 characters)
+src/devsynth/application/collaboration/wsde_team_extended.py:1505:89: E501 line too long (100 > 88 characters)
+src/devsynth/application/collaboration/wsde_team_extended.py:1512:40: F541 f-string is missing placeholders
+src/devsynth/application/collaboration/wsde_team_extended.py:1513:89: E501 line too long (91 > 88 characters)
+src/devsynth/application/collaboration/wsde_team_extended.py:1532:89: E501 line too long (114 > 88 characters)
+src/devsynth/application/collaboration/wsde_team_extended.py:1541:89: E501 line too long (101 > 88 characters)
+src/devsynth/application/collaboration/wsde_team_extended.py:1542:89: E501 line too long (94 > 88 characters)
+src/devsynth/application/collaboration/wsde_team_extended.py:1577:89: E501 line too long (100 > 88 characters)
+src/devsynth/application/collaboration/wsde_team_extended.py:1578:89: E501 line too long (101 > 88 characters)
+src/devsynth/application/collaboration/wsde_team_extended.py:1630:89: E501 line too long (99 > 88 characters)
+src/devsynth/application/collaboration/wsde_team_extended.py:1631:89: E501 line too long (124 > 88 characters)
+src/devsynth/application/collaboration/wsde_team_extended.py:1638:89: E501 line too long (89 > 88 characters)
+src/devsynth/application/collaboration/wsde_team_extended.py:1639:89: E501 line too long (109 > 88 characters)
+src/devsynth/application/collaboration/wsde_team_extended.py:1653:89: E501 line too long (101 > 88 characters)
+src/devsynth/application/collaboration/wsde_team_extended.py:1654:89: E501 line too long (122 > 88 characters)
+src/devsynth/application/collaboration/wsde_team_extended.py:1676:89: E501 line too long (181 > 88 characters)
+src/devsynth/application/collaboration/wsde_team_extended.py:1685:89: E501 line too long (99 > 88 characters)
+src/devsynth/application/collaboration/wsde_team_extended.py:1686:89: E501 line too long (125 > 88 characters)
+src/devsynth/application/collaboration/wsde_team_extended.py:1693:89: E501 line too long (100 > 88 characters)
+src/devsynth/application/collaboration/wsde_team_extended.py:1705:89: E501 line too long (95 > 88 characters)
+src/devsynth/application/collaboration/wsde_team_extended.py:1706:89: E501 line too long (100 > 88 characters)
+src/devsynth/application/collaboration/wsde_team_extended.py:1713:89: E501 line too long (96 > 88 characters)
+src/devsynth/application/collaboration/wsde_team_extended.py:1725:89: E501 line too long (102 > 88 characters)
+src/devsynth/application/collaboration/wsde_team_extended.py:1765:89: E501 line too long (103 > 88 characters)
+src/devsynth/application/collaboration/wsde_team_extended.py:1766:89: E501 line too long (125 > 88 characters)
+src/devsynth/application/collaboration/wsde_team_extended.py:1773:89: E501 line too long (89 > 88 characters)
+src/devsynth/application/collaboration/wsde_team_extended.py:1774:89: E501 line too long (114 > 88 characters)
+src/devsynth/application/collaboration/wsde_team_extended.py:1796:89: E501 line too long (185 > 88 characters)
+src/devsynth/application/collaboration/wsde_team_extended.py:1805:89: E501 line too long (103 > 88 characters)
+src/devsynth/application/collaboration/wsde_team_extended.py:1806:89: E501 line too long (129 > 88 characters)
+src/devsynth/application/collaboration/wsde_team_extended.py:1813:89: E501 line too long (100 > 88 characters)
+src/devsynth/application/collaboration/wsde_team_extended.py:1814:89: E501 line too long (90 > 88 characters)
+src/devsynth/application/collaboration/wsde_team_extended.py:1825:89: E501 line too long (99 > 88 characters)
+src/devsynth/application/collaboration/wsde_team_extended.py:1826:89: E501 line too long (106 > 88 characters)
+src/devsynth/application/collaboration/wsde_team_extended.py:1833:89: E501 line too long (96 > 88 characters)
+src/devsynth/application/collaboration/wsde_team_extended.py:1842:89: E501 line too long (95 > 88 characters)
+src/devsynth/application/collaboration/wsde_team_extended.py:1843:89: E501 line too long (91 > 88 characters)
+src/devsynth/application/collaboration/wsde_team_extended.py:1850:89: E501 line too long (92 > 88 characters)
+src/devsynth/application/collaboration/wsde_team_extended.py:1859:89: E501 line too long (91 > 88 characters)
+src/devsynth/application/collaboration/wsde_team_extended.py:1880:89: E501 line too long (90 > 88 characters)
+src/devsynth/application/collaboration/wsde_team_extended.py:1881:89: E501 line too long (91 > 88 characters)
+src/devsynth/application/collaboration/wsde_team_extended.py:1915:89: E501 line too long (142 > 88 characters)
+src/devsynth/application/collaboration/wsde_team_extended.py:1945:89: E501 line too long (105 > 88 characters)
+src/devsynth/application/collaboration/wsde_team_extended.py:1949:89: E501 line too long (102 > 88 characters)
+src/devsynth/application/collaboration/wsde_team_extended.py:1951:89: E501 line too long (101 > 88 characters)
+src/devsynth/application/collaboration/wsde_team_extended.py:1956:89: E501 line too long (135 > 88 characters)
+src/devsynth/application/collaboration/wsde_team_extended.py:1960:89: E501 line too long (159 > 88 characters)
+src/devsynth/application/collaboration/wsde_team_extended.py:1964:89: E501 line too long (135 > 88 characters)
+src/devsynth/application/collaboration/wsde_team_extended.py:1965:89: E501 line too long (111 > 88 characters)
+src/devsynth/application/collaboration/wsde_team_extended.py:1983:89: E501 line too long (192 > 88 characters)
+src/devsynth/application/collaboration/wsde_team_extended.py:1987:89: E501 line too long (192 > 88 characters)
+src/devsynth/application/collaboration/wsde_team_extended.py:1990:89: E501 line too long (104 > 88 characters)
+src/devsynth/application/collaboration/wsde_team_task_management.py:13:1: F401 'typing.Optional' imported but unused
+src/devsynth/application/collaboration/wsde_team_task_management.py:13:1: F401 'typing.Union' imported but unused
+src/devsynth/application/collaboration/wsde_team_task_management.py:15:1: F401 'devsynth.domain.models.wsde_facade.WSDETeam' imported but unused
+src/devsynth/application/collaboration/wsde_team_task_management.py:182:89: E501 line too long (103 > 88 characters)
+src/devsynth/application/collaboration/wsde_team_task_management.py:332:89: E501 line too long (99 > 88 characters)
+src/devsynth/application/collaboration/wsde_team_task_management.py:333:89: E501 line too long (113 > 88 characters)
+src/devsynth/application/documentation/documentation_fetcher.py:15:1: F401 'pathlib.Path' imported but unused
+src/devsynth/application/documentation/documentation_fetcher.py:16:1: F401 'typing.Optional' imported but unused
+src/devsynth/application/documentation/documentation_fetcher.py:16:1: F401 'typing.Protocol' imported but unused
+src/devsynth/application/documentation/documentation_fetcher.py:17:1: F401 'urllib.parse.urljoin' imported but unused
+src/devsynth/application/documentation/documentation_fetcher.py:257:89: E501 line too long (90 > 88 characters)
+src/devsynth/application/documentation/documentation_fetcher.py:342:89: E501 line too long (99 > 88 characters)
+src/devsynth/application/documentation/documentation_fetcher.py:386:89: E501 line too long (91 > 88 characters)
+src/devsynth/application/documentation/documentation_fetcher.py:404:89: E501 line too long (91 > 88 characters)
+src/devsynth/application/documentation/documentation_fetcher.py:422:89: E501 line too long (95 > 88 characters)
+src/devsynth/application/documentation/documentation_fetcher.py:441:89: E501 line too long (91 > 88 characters)
+src/devsynth/application/documentation/documentation_fetcher.py:478:89: E501 line too long (94 > 88 characters)
+src/devsynth/application/documentation/documentation_fetcher.py:492:89: E501 line too long (95 > 88 characters)
+src/devsynth/application/documentation/documentation_fetcher.py:508:50: F821 undefined name 'name'
+src/devsynth/application/documentation/documentation_fetcher.py:508:58: F821 undefined name 'e'
+src/devsynth/application/documentation/documentation_fetcher.py:510:43: F821 undefined name 'library_name'
+src/devsynth/application/documentation/documentation_fetcher.py:510:59: F821 undefined name 'e'
+src/devsynth/application/documentation/documentation_fetcher.py:584:89: E501 line too long (93 > 88 characters)
+src/devsynth/application/documentation/documentation_manager.py:8:1: F401 'json' imported but unused
+src/devsynth/application/documentation/documentation_manager.py:10:1: F401 're' imported but unused
+src/devsynth/application/documentation/documentation_manager.py:11:1: F401 'datetime.datetime' imported but unused
+src/devsynth/application/documentation/documentation_manager.py:46:89: E501 line too long (101 > 88 characters)
+src/devsynth/application/documentation/documentation_manager.py:48:89: E501 line too long (91 > 88 characters)
+src/devsynth/application/documentation/documentation_manager.py:84:89: E501 line too long (90 > 88 characters)
+src/devsynth/application/documentation/documentation_manager.py:136:89: E501 line too long (92 > 88 characters)
+src/devsynth/application/documentation/documentation_manager.py:226:89: E501 line too long (90 > 88 characters)
+src/devsynth/application/documentation/documentation_manager.py:305:89: E501 line too long (102 > 88 characters)
+src/devsynth/application/documentation/documentation_manager.py:317:89: E501 line too long (100 > 88 characters)
+src/devsynth/application/documentation/documentation_manager.py:327:89: E501 line too long (89 > 88 characters)
+src/devsynth/application/documentation/documentation_manager.py:336:89: E501 line too long (111 > 88 characters)
+src/devsynth/application/documentation/documentation_manager.py:348:89: E501 line too long (97 > 88 characters)
+src/devsynth/application/documentation/documentation_manager.py:429:89: E501 line too long (102 > 88 characters)
+src/devsynth/application/documentation/documentation_manager.py:468:89: E501 line too long (96 > 88 characters)
+src/devsynth/application/documentation/documentation_repository.py:12:1: F401 'pathlib.Path' imported but unused
+src/devsynth/application/documentation/documentation_repository.py:13:1: F401 'typing.Tuple' imported but unused
+src/devsynth/application/documentation/documentation_repository.py:40:89: E501 line too long (100 > 88 characters)
+src/devsynth/application/documentation/documentation_repository.py:55:89: E501 line too long (90 > 88 characters)
+src/devsynth/application/documentation/documentation_repository.py:67:89: E501 line too long (94 > 88 characters)
+src/devsynth/application/documentation/documentation_repository.py:99:89: E501 line too long (121 > 88 characters)
+src/devsynth/application/documentation/documentation_repository.py:161:89: E501 line too long (92 > 88 characters)
+src/devsynth/application/documentation/documentation_repository.py:175:89: E501 line too long (113 > 88 characters)
+src/devsynth/application/documentation/documentation_repository.py:296:9: F841 local variable 'title' is assigned to but never used
+src/devsynth/application/documentation/ingestion.py:4:89: E501 line too long (96 > 88 characters)
+src/devsynth/application/documentation/ingestion.py:137:89: E501 line too long (90 > 88 characters)
+src/devsynth/application/documentation/ingestion.py:189:89: E501 line too long (89 > 88 characters)
+src/devsynth/application/documentation/ingestion.py:277:89: E501 line too long (94 > 88 characters)
+src/devsynth/application/documentation/ingestion.py:371:89: E501 line too long (91 > 88 characters)
+src/devsynth/application/documentation/ingestion.py:390:89: E501 line too long (90 > 88 characters)
+src/devsynth/application/documentation/version_monitor.py:34:89: E501 line too long (90 > 88 characters)
+src/devsynth/application/edrr/__init__.py:14:1: F401 '.templates' imported but unused
+src/devsynth/application/edrr/coordinator.py:372:89: E501 line too long (89 > 88 characters)
+src/devsynth/application/edrr/coordinator.py:413:89: E501 line too long (92 > 88 characters)
+src/devsynth/application/edrr/coordinator.py:423:89: E501 line too long (91 > 88 characters)
+src/devsynth/application/edrr/coordinator.py:489:89: E501 line too long (90 > 88 characters)
+src/devsynth/application/edrr/coordinator.py:639:89: E501 line too long (94 > 88 characters)
+src/devsynth/application/edrr/coordinator.py:640:89: E501 line too long (94 > 88 characters)
+src/devsynth/application/edrr/coordinator.py:740:89: E501 line too long (105 > 88 characters)
+src/devsynth/application/edrr/coordinator.py:778:89: E501 line too long (92 > 88 characters)
+src/devsynth/application/edrr/coordinator.py:859:89: E501 line too long (106 > 88 characters)
+src/devsynth/application/edrr/coordinator.py:962:89: E501 line too long (93 > 88 characters)
+src/devsynth/application/edrr/coordinator.py:963:89: E501 line too long (91 > 88 characters)
+src/devsynth/application/edrr/coordinator.py:974:89: E501 line too long (95 > 88 characters)
+src/devsynth/application/edrr/coordinator.py:1082:89: E501 line too long (119 > 88 characters)
+src/devsynth/application/edrr/coordinator.py:1098:89: E501 line too long (89 > 88 characters)
+src/devsynth/application/edrr/coordinator.py:1099:89: E501 line too long (90 > 88 characters)
+src/devsynth/application/edrr/coordinator.py:1100:89: E501 line too long (93 > 88 characters)
+src/devsynth/application/edrr/coordinator.py:1101:89: E501 line too long (95 > 88 characters)
+src/devsynth/application/edrr/coordinator.py:1113:89: E501 line too long (106 > 88 characters)
+src/devsynth/application/edrr/coordinator.py:1150:89: E501 line too long (94 > 88 characters)
+src/devsynth/application/edrr/coordinator.py:1495:89: E501 line too long (128 > 88 characters)
+src/devsynth/application/edrr/coordinator.py:1617:89: E501 line too long (118 > 88 characters)
+src/devsynth/application/edrr/coordinator.py:1758:89: E501 line too long (134 > 88 characters)
+src/devsynth/application/edrr/coordinator.py:1919:89: E501 line too long (112 > 88 characters)
+src/devsynth/application/edrr/coordinator.py:2098:89: E501 line too long (135 > 88 characters)
+src/devsynth/application/edrr/coordinator.py:2113:89: E501 line too long (95 > 88 characters)
+src/devsynth/application/edrr/coordinator.py:2219:89: E501 line too long (105 > 88 characters)
+src/devsynth/application/edrr/coordinator.py:2383:89: E501 line too long (91 > 88 characters)
+src/devsynth/application/edrr/coordinator.py:2458:89: E501 line too long (90 > 88 characters)
+src/devsynth/application/edrr/coordinator.py:2462:89: E501 line too long (113 > 88 characters)
+src/devsynth/application/edrr/coordinator.py:2523:89: E501 line too long (99 > 88 characters)
+src/devsynth/application/edrr/coordinator.py:2524:89: E501 line too long (101 > 88 characters)
+src/devsynth/application/edrr/coordinator.py:2943:89: E501 line too long (100 > 88 characters)
+src/devsynth/application/edrr/coordinator.py:3239:89: E501 line too long (91 > 88 characters)
+src/devsynth/application/edrr/coordinator.py:3280:89: E501 line too long (96 > 88 characters)
+src/devsynth/application/edrr/coordinator.py:3336:89: E501 line too long (95 > 88 characters)
+src/devsynth/application/edrr/coordinator.py:3359:89: E501 line too long (113 > 88 characters)
+src/devsynth/application/edrr/coordinator.py:3360:89: E501 line too long (137 > 88 characters)
+src/devsynth/application/edrr/coordinator.py:3361:89: E501 line too long (145 > 88 characters)
+src/devsynth/application/edrr/coordinator.py:3368:89: E501 line too long (93 > 88 characters)
+src/devsynth/application/edrr/coordinator.py:3392:89: E501 line too long (110 > 88 characters)
+src/devsynth/application/edrr/coordinator.py:3393:89: E501 line too long (114 > 88 characters)
+src/devsynth/application/edrr/coordinator.py:3400:89: E501 line too long (130 > 88 characters)
+src/devsynth/application/edrr/coordinator.py:3406:89: E501 line too long (140 > 88 characters)
+src/devsynth/application/edrr/coordinator_core.py:12:1: F401 'json' imported but unused
+src/devsynth/application/edrr/coordinator_core.py:16:1: F401 'typing.Set' imported but unused
+src/devsynth/application/edrr/coordinator_core.py:19:1: F401 'yaml' imported but unused
+src/devsynth/application/edrr/coordinator_core.py:30:1: F401 'devsynth.core.CoreValues' imported but unused
+src/devsynth/application/edrr/coordinator_core.py:30:1: F401 'devsynth.core.check_report_for_value_conflicts' imported but unused
+src/devsynth/application/edrr/coordinator_core.py:46:89: E501 line too long (92 > 88 characters)
+src/devsynth/application/edrr/edrr_coordinator_enhanced.py:10:1: F401 'pathlib.Path' imported but unused
+src/devsynth/application/edrr/edrr_coordinator_enhanced.py:11:1: F401 'typing.Tuple' imported but unused
+src/devsynth/application/edrr/edrr_coordinator_enhanced.py:196:89: E501 line too long (108 > 88 characters)
+src/devsynth/application/edrr/edrr_coordinator_enhanced.py:201:89: E501 line too long (112 > 88 characters)
+src/devsynth/application/edrr/edrr_coordinator_enhanced.py:212:89: E501 line too long (106 > 88 characters)
+src/devsynth/application/edrr/edrr_coordinator_enhanced.py:257:89: E501 line too long (121 > 88 characters)
+src/devsynth/application/edrr/edrr_coordinator_enhanced.py:260:89: E501 line too long (106 > 88 characters)
+src/devsynth/application/edrr/edrr_coordinator_enhanced.py:263:89: E501 line too long (89 > 88 characters)
+src/devsynth/application/edrr/edrr_coordinator_enhanced.py:270:89: E501 line too long (127 > 88 characters)
+src/devsynth/application/edrr/edrr_coordinator_enhanced.py:330:89: E501 line too long (92 > 88 characters)
+src/devsynth/application/edrr/edrr_coordinator_enhanced.py:341:89: E501 line too long (95 > 88 characters)
+src/devsynth/application/edrr/edrr_coordinator_enhanced.py:417:89: E501 line too long (103 > 88 characters)
+src/devsynth/application/edrr/edrr_coordinator_enhanced.py:509:89: E501 line too long (122 > 88 characters)
+src/devsynth/application/edrr/edrr_coordinator_enhanced.py:543:89: E501 line too long (92 > 88 characters)
+src/devsynth/application/edrr/edrr_coordinator_enhanced.py:556:89: E501 line too long (122 > 88 characters)
+src/devsynth/application/edrr/edrr_coordinator_enhanced.py:581:89: E501 line too long (103 > 88 characters)
+src/devsynth/application/edrr/edrr_coordinator_enhanced.py:584:89: E501 line too long (92 > 88 characters)
+src/devsynth/application/edrr/edrr_coordinator_enhanced.py:595:89: E501 line too long (107 > 88 characters)
+src/devsynth/application/edrr/edrr_phase_transitions.py:12:1: F401 'typing.Set' imported but unused
+src/devsynth/application/edrr/edrr_phase_transitions.py:12:1: F401 'typing.Union' imported but unused
+src/devsynth/application/edrr/edrr_phase_transitions.py:319:9: F841 local variable 'score' is assigned to but never used
+src/devsynth/application/edrr/edrr_phase_transitions.py:560:13: F841 local variable 'e' is assigned to but never used
+src/devsynth/application/edrr/manifest_parser.py:4:89: E501 line too long (91 > 88 characters)
+src/devsynth/application/edrr/manifest_parser.py:5:89: E501 line too long (96 > 88 characters)
+src/devsynth/application/edrr/manifest_parser.py:13:1: F401 'typing.Optional' imported but unused
+src/devsynth/application/edrr/manifest_parser.py:13:1: F401 'typing.Set' imported but unused
+src/devsynth/application/edrr/manifest_parser.py:13:1: F401 'typing.Tuple' imported but unused
+src/devsynth/application/edrr/manifest_parser.py:219:89: E501 line too long (89 > 88 characters)
+src/devsynth/application/edrr/manifest_parser.py:241:89: E501 line too long (89 > 88 characters)
+src/devsynth/application/edrr/manifest_parser.py:322:13: F841 local variable 'phase_key' is assigned to but never used
+src/devsynth/application/edrr/manifest_parser.py:359:89: E501 line too long (90 > 88 characters)
+src/devsynth/application/edrr/manifest_parser.py:495:89: E501 line too long (105 > 88 characters)
+src/devsynth/application/edrr/templates.py:8:1: F401 'typing.Any' imported but unused
+src/devsynth/application/edrr/templates.py:8:1: F401 'typing.Dict' imported but unused
+src/devsynth/application/edrr/templates.py:8:1: F401 'typing.Optional' imported but unused
+src/devsynth/application/edrr/templates.py:12:1: F401 'devsynth.methodology.base.Phase' imported but unused
+src/devsynth/application/edrr/templates.py:46:89: E501 line too long (103 > 88 characters)
+src/devsynth/application/edrr/templates.py:70:89: E501 line too long (102 > 88 characters)
+src/devsynth/application/edrr/templates.py:94:89: E501 line too long (96 > 88 characters)
+src/devsynth/application/ingestion/__init__.py:4:89: E501 line too long (105 > 88 characters)
+src/devsynth/application/ingestion/__init__.py:5:89: E501 line too long (101 > 88 characters)
+src/devsynth/application/ingestion/__init__.py:175:89: E501 line too long (98 > 88 characters)
+src/devsynth/application/ingestion/__init__.py:221:89: E501 line too long (89 > 88 characters)
+src/devsynth/application/ingestion/__init__.py:266:89: E501 line too long (99 > 88 characters)
+src/devsynth/application/ingestion/__init__.py:271:89: E501 line too long (93 > 88 characters)
+src/devsynth/application/ingestion/__init__.py:505:89: E501 line too long (101 > 88 characters)
+src/devsynth/application/ingestion/__init__.py:523:89: E501 line too long (100 > 88 characters)
+src/devsynth/application/ingestion/__init__.py:571:89: E501 line too long (106 > 88 characters)
+src/devsynth/application/ingestion/__init__.py:620:89: E501 line too long (94 > 88 characters)
+src/devsynth/application/ingestion/__init__.py:828:89: E501 line too long (98 > 88 characters)
+src/devsynth/application/ingestion/__init__.py:925:89: E501 line too long (149 > 88 characters)
+src/devsynth/application/ingestion/__init__.py:950:89: E501 line too long (90 > 88 characters)
+src/devsynth/application/ingestion/__init__.py:970:89: E501 line too long (89 > 88 characters)
+src/devsynth/application/ingestion/__init__.py:1021:89: E501 line too long (100 > 88 characters)
+src/devsynth/application/ingestion/__init__.py:1022:89: E501 line too long (91 > 88 characters)
+src/devsynth/application/ingestion/__init__.py:1048:89: E501 line too long (105 > 88 characters)
+src/devsynth/application/ingestion/__init__.py:1057:89: E501 line too long (99 > 88 characters)
+src/devsynth/application/ingestion/__init__.py:1067:89: E501 line too long (104 > 88 characters)
+src/devsynth/application/ingestion/__init__.py:1077:89: E501 line too long (93 > 88 characters)
+src/devsynth/application/ingestion/__init__.py:1086:89: E501 line too long (95 > 88 characters)
+src/devsynth/application/ingestion/__init__.py:1095:89: E501 line too long (93 > 88 characters)
+src/devsynth/application/ingestion/__init__.py:1106:89: E501 line too long (122 > 88 characters)
+src/devsynth/application/ingestion/__init__.py:1147:25: F541 f-string is missing placeholders
+src/devsynth/application/ingestion/__init__.py:1153:89: E501 line too long (125 > 88 characters)
+src/devsynth/application/ingestion/__init__.py:1157:25: F541 f-string is missing placeholders
+src/devsynth/application/ingestion/__init__.py:1160:89: E501 line too long (89 > 88 characters)
+src/devsynth/application/ingestion/__init__.py:1173:29: F541 f-string is missing placeholders
+src/devsynth/application/ingestion/__init__.py:1181:29: F541 f-string is missing placeholders
+src/devsynth/application/ingestion/__init__.py:1186:89: E501 line too long (101 > 88 characters)
+src/devsynth/application/ingestion/__init__.py:1192:29: F541 f-string is missing placeholders
+src/devsynth/application/ingestion/__init__.py:1195:89: E501 line too long (138 > 88 characters)
+src/devsynth/application/ingestion/__init__.py:1202:25: F541 f-string is missing placeholders
+src/devsynth/application/ingestion/__init__.py:1204:21: F541 f-string is missing placeholders
+src/devsynth/application/ingestion/__init__.py:1204:89: E501 line too long (89 > 88 characters)
+src/devsynth/application/ingestion/phases.py:4:1: F401 'pathlib.Path' imported but unused
+src/devsynth/application/ingestion/phases.py:5:1: F401 'typing.Any' imported but unused
+src/devsynth/application/ingestion/phases.py:5:1: F401 'typing.Dict' imported but unused
+src/devsynth/application/ingestion/phases.py:12:33: F821 undefined name 'Ingestion'
+src/devsynth/application/ingestion/phases.py:53:89: E501 line too long (100 > 88 characters)
+src/devsynth/application/ingestion/phases.py:65:16: F821 undefined name 'Ingestion'
+src/devsynth/application/ingestion/phases.py:71:89: E501 line too long (95 > 88 characters)
+src/devsynth/application/ingestion/phases.py:106:89: E501 line too long (101 > 88 characters)
+src/devsynth/application/ingestion/phases.py:114:33: F821 undefined name 'Ingestion'
+src/devsynth/application/ingestion/phases.py:150:37: F821 undefined name 'Ingestion'
+src/devsynth/application/llm/lmstudio_provider.py:18:1: F401 '..utils.token_tracker.TokenLimitExceededError' imported but unused
+src/devsynth/application/llm/lmstudio_provider.py:22:1: E402 module level import not at top of file
+src/devsynth/application/llm/lmstudio_provider.py:36:89: E501 line too long (144 > 88 characters)
+src/devsynth/application/llm/lmstudio_provider.py:133:89: E501 line too long (100 > 88 characters)
+src/devsynth/application/llm/lmstudio_provider.py:145:89: E501 line too long (99 > 88 characters)
+src/devsynth/application/llm/lmstudio_provider.py:191:89: E501 line too long (104 > 88 characters)
+src/devsynth/application/llm/lmstudio_provider.py:224:89: E501 line too long (91 > 88 characters)
+src/devsynth/application/llm/lmstudio_provider.py:233:89: E501 line too long (99 > 88 characters)
+src/devsynth/application/llm/lmstudio_provider.py:234:89: E501 line too long (92 > 88 characters)
+src/devsynth/application/llm/lmstudio_provider.py:247:89: E501 line too long (114 > 88 characters)
+src/devsynth/application/llm/lmstudio_provider.py:255:89: E501 line too long (90 > 88 characters)
+src/devsynth/application/llm/lmstudio_provider.py:259:89: E501 line too long (96 > 88 characters)
+src/devsynth/application/llm/lmstudio_provider.py:261:89: E501 line too long (95 > 88 characters)
+src/devsynth/application/llm/lmstudio_provider.py:415:89: E501 line too long (100 > 88 characters)
+src/devsynth/application/llm/local_provider.py:13:1: E402 module level import not at top of file
+src/devsynth/application/llm/openai_provider.py:6:1: F401 'asyncio' imported but unused
+src/devsynth/application/llm/openai_provider.py:7:1: F401 'json' imported but unused
+src/devsynth/application/llm/openai_provider.py:10:1: F401 'typing.Optional' imported but unused
+src/devsynth/application/llm/openai_provider.py:10:1: F401 'typing.Tuple' imported but unused
+src/devsynth/application/llm/openai_provider.py:28:1: F401 '...domain.interfaces.llm.LLMProvider' imported but unused
+src/devsynth/application/llm/openai_provider.py:29:1: F401 '..utils.token_tracker.TokenLimitExceededError' imported but unused
+src/devsynth/application/llm/openai_provider.py:32:1: E402 module level import not at top of file
+src/devsynth/application/llm/openai_provider.py:103:89: E501 line too long (103 > 88 characters)
+src/devsynth/application/llm/openai_provider.py:128:89: E501 line too long (105 > 88 characters)
+src/devsynth/application/llm/openai_provider.py:155:89: E501 line too long (97 > 88 characters)
+src/devsynth/application/llm/openai_provider.py:163:89: E501 line too long (92 > 88 characters)
+src/devsynth/application/llm/openai_provider.py:168:89: E501 line too long (101 > 88 characters)
+src/devsynth/application/llm/openai_provider.py:276:89: E501 line too long (100 > 88 characters)
+src/devsynth/application/llm/openai_provider.py:348:89: E501 line too long (90 > 88 characters)
+src/devsynth/application/llm/openai_provider.py:383:89: E501 line too long (93 > 88 characters)
+src/devsynth/application/llm/openai_provider.py:387:89: E501 line too long (100 > 88 characters)
+src/devsynth/application/llm/openai_provider.py:415:89: E501 line too long (90 > 88 characters)
+src/devsynth/application/llm/providers.py:3:1: F401 'typing.Optional' imported but unused
+src/devsynth/application/llm/providers.py:16:1: E402 module level import not at top of file
+src/devsynth/application/llm/providers.py:195:89: E501 line too long (111 > 88 characters)
+src/devsynth/application/llm/providers.py:204:89: E501 line too long (113 > 88 characters)
+src/devsynth/application/llm/providers.py:227:89: E501 line too long (123 > 88 characters)
+src/devsynth/application/llm/providers.py:299:1: E402 module level import not at top of file
+src/devsynth/application/memory/__init__.py:20:1: F401 'devsynth.exceptions.DevSynthError' imported but unused
+src/devsynth/application/memory/__init__.py:20:1: E402 module level import not at top of file
+src/devsynth/application/memory/adapters/chromadb_vector_adapter.py:19:1: F401 'numpy as np' imported but unused
+src/devsynth/application/memory/adapters/chromadb_vector_adapter.py:26:89: E501 line too long (126 > 88 characters)
+src/devsynth/application/memory/adapters/chromadb_vector_adapter.py:38:89: E501 line too long (97 > 88 characters)
+src/devsynth/application/memory/adapters/chromadb_vector_adapter.py:52:89: E501 line too long (91 > 88 characters)
+src/devsynth/application/memory/adapters/enhanced_graph_memory_adapter.py:13:1: F401 'json' imported but unused
+src/devsynth/application/memory/adapters/enhanced_graph_memory_adapter.py:14:1: F401 'os' imported but unused
+src/devsynth/application/memory/adapters/enhanced_graph_memory_adapter.py:15:1: F401 'uuid' imported but unused
+src/devsynth/application/memory/adapters/enhanced_graph_memory_adapter.py:16:1: F401 'typing.Optional' imported but unused
+src/devsynth/application/memory/adapters/enhanced_graph_memory_adapter.py:16:1: F401 'typing.Set' imported but unused
+src/devsynth/application/memory/adapters/enhanced_graph_memory_adapter.py:16:1: F401 'typing.Tuple' imported but unused
+src/devsynth/application/memory/adapters/enhanced_graph_memory_adapter.py:37:1: F401 'devsynth.exceptions.MemoryError' imported but unused
+src/devsynth/application/memory/adapters/enhanced_graph_memory_adapter.py:39:1: F401 '....domain.interfaces.memory.MemoryStore' imported but unused
+src/devsynth/application/memory/adapters/enhanced_graph_memory_adapter.py:39:1: F401 '....domain.interfaces.memory.VectorStore' imported but unused
+src/devsynth/application/memory/adapters/enhanced_graph_memory_adapter.py:40:1: F401 '....domain.models.memory.MemoryVector' imported but unused
+src/devsynth/application/memory/adapters/enhanced_graph_memory_adapter.py:42:1: F401 '..rdflib_store.RDFLibStore' imported but unused
+src/devsynth/application/memory/adapters/enhanced_graph_memory_adapter.py:101:89: E501 line too long (98 > 88 characters)
+src/devsynth/application/memory/adapters/enhanced_graph_memory_adapter.py:195:89: E501 line too long (89 > 88 characters)
+src/devsynth/application/memory/adapters/enhanced_graph_memory_adapter.py:252:89: E501 line too long (110 > 88 characters)
+src/devsynth/application/memory/adapters/enhanced_graph_memory_adapter.py:255:89: E501 line too long (91 > 88 characters)
+src/devsynth/application/memory/adapters/enhanced_graph_memory_adapter.py:311:89: E501 line too long (105 > 88 characters)
+src/devsynth/application/memory/adapters/enhanced_graph_memory_adapter.py:524:89: E501 line too long (110 > 88 characters)
+src/devsynth/application/memory/adapters/enhanced_graph_memory_adapter.py:748:13: F841 local variable 'current_id' is assigned to but never used
+src/devsynth/application/memory/adapters/graph_memory_adapter.py:13:1: F401 'copy.deepcopy' imported but unused
+src/devsynth/application/memory/adapters/graph_memory_adapter.py:37:1: F401 'devsynth.exceptions.MemoryError' imported but unused
+src/devsynth/application/memory/adapters/graph_memory_adapter.py:37:1: F401 'devsynth.exceptions.MemoryItemNotFoundError' imported but unused
+src/devsynth/application/memory/adapters/graph_memory_adapter.py:53:89: E501 line too long (97 > 88 characters)
+src/devsynth/application/memory/adapters/graph_memory_adapter.py:60:89: E501 line too long (98 > 88 characters)
+src/devsynth/application/memory/adapters/graph_memory_adapter.py:268:5: F811 redefinition of unused 'is_transaction_active' from line 118
+src/devsynth/application/memory/adapters/graph_memory_adapter.py:431:89: E501 line too long (101 > 88 characters)
+src/devsynth/application/memory/adapters/graph_memory_adapter.py:436:89: E501 line too long (107 > 88 characters)
+src/devsynth/application/memory/adapters/graph_memory_adapter.py:521:89: E501 line too long (99 > 88 characters)
+src/devsynth/application/memory/adapters/graph_memory_adapter.py:639:89: E501 line too long (116 > 88 characters)
+src/devsynth/application/memory/adapters/graph_memory_adapter.py:653:89: E501 line too long (115 > 88 characters)
+src/devsynth/application/memory/adapters/graph_memory_adapter.py:657:89: E501 line too long (108 > 88 characters)
+src/devsynth/application/memory/adapters/graph_memory_adapter.py:664:89: E501 line too long (111 > 88 characters)
+src/devsynth/application/memory/adapters/graph_memory_adapter.py:759:89: E501 line too long (96 > 88 characters)
+src/devsynth/application/memory/adapters/graph_memory_adapter.py:789:25: F541 f-string is missing placeholders
+src/devsynth/application/memory/adapters/graph_memory_adapter.py:831:89: E501 line too long (102 > 88 characters)
+src/devsynth/application/memory/adapters/graph_memory_adapter.py:857:89: E501 line too long (89 > 88 characters)
+src/devsynth/application/memory/adapters/graph_memory_adapter.py:858:89: E501 line too long (97 > 88 characters)
+src/devsynth/application/memory/adapters/graph_memory_adapter.py:869:89: E501 line too long (99 > 88 characters)
+src/devsynth/application/memory/adapters/graph_memory_adapter.py:870:89: E501 line too long (97 > 88 characters)
+src/devsynth/application/memory/adapters/graph_memory_adapter.py:871:89: E501 line too long (107 > 88 characters)
+src/devsynth/application/memory/adapters/graph_memory_adapter.py:873:89: E501 line too long (100 > 88 characters)
+src/devsynth/application/memory/adapters/graph_memory_adapter.py:874:89: E501 line too long (109 > 88 characters)
+src/devsynth/application/memory/adapters/graph_memory_adapter.py:888:89: E501 line too long (119 > 88 characters)
+src/devsynth/application/memory/adapters/graph_memory_adapter.py:910:89: E501 line too long (106 > 88 characters)
+src/devsynth/application/memory/adapters/graph_memory_adapter.py:921:89: E501 line too long (96 > 88 characters)
+src/devsynth/application/memory/adapters/graph_memory_adapter.py:923:89: E501 line too long (94 > 88 characters)
+src/devsynth/application/memory/adapters/graph_memory_adapter.py:927:89: E501 line too long (93 > 88 characters)
+src/devsynth/application/memory/adapters/graph_memory_adapter.py:930:89: E501 line too long (91 > 88 characters)
+src/devsynth/application/memory/adapters/graph_memory_adapter.py:933:89: E501 line too long (89 > 88 characters)
+src/devsynth/application/memory/adapters/graph_memory_adapter.py:946:89: E501 line too long (95 > 88 characters)
+src/devsynth/application/memory/adapters/graph_memory_adapter.py:957:89: E501 line too long (97 > 88 characters)
+src/devsynth/application/memory/adapters/graph_memory_adapter.py:983:89: E501 line too long (91 > 88 characters)
+src/devsynth/application/memory/adapters/graph_memory_adapter.py:1012:89: E501 line too long (119 > 88 characters)
+src/devsynth/application/memory/adapters/graph_memory_adapter.py:1015:89: E501 line too long (123 > 88 characters)
+src/devsynth/application/memory/adapters/graph_memory_adapter.py:1026:89: E501 line too long (98 > 88 characters)
+src/devsynth/application/memory/adapters/graph_memory_adapter.py:1080:89: E501 line too long (98 > 88 characters)
+src/devsynth/application/memory/adapters/graph_memory_adapter.py:1172:89: E501 line too long (110 > 88 characters)
+src/devsynth/application/memory/adapters/graph_memory_adapter.py:1178:89: E501 line too long (109 > 88 characters)
+src/devsynth/application/memory/adapters/graph_memory_adapter.py:1234:89: E501 line too long (98 > 88 characters)
+src/devsynth/application/memory/adapters/graph_memory_adapter.py:1245:89: E501 line too long (92 > 88 characters)
+src/devsynth/application/memory/adapters/graph_memory_adapter.py:1261:89: E501 line too long (90 > 88 characters)
+src/devsynth/application/memory/adapters/graph_memory_adapter.py:1291:89: E501 line too long (93 > 88 characters)
+src/devsynth/application/memory/adapters/graph_memory_adapter.py:1306:89: E501 line too long (91 > 88 characters)
+src/devsynth/application/memory/adapters/tinydb_memory_adapter.py:40:89: E501 line too long (94 > 88 characters)
+src/devsynth/application/memory/adapters/tinydb_memory_adapter.py:181:89: E501 line too long (112 > 88 characters)
+src/devsynth/application/memory/adapters/tinydb_memory_adapter.py:291:89: E501 line too long (119 > 88 characters)
+src/devsynth/application/memory/adapters/tinydb_memory_adapter.py:309:89: E501 line too long (97 > 88 characters)
+src/devsynth/application/memory/adapters/vector_memory_adapter.py:8:1: F401 'uuid' imported but unused
+src/devsynth/application/memory/chromadb_store.py:12:1: F401 'uuid' imported but unused
+src/devsynth/application/memory/chromadb_store.py:13:1: F401 'contextlib.contextmanager' imported but unused
+src/devsynth/application/memory/chromadb_store.py:15:1: F401 'functools.lru_cache' imported but unused
+src/devsynth/application/memory/chromadb_store.py:16:1: F401 'typing.Tuple' imported but unused
+src/devsynth/application/memory/chromadb_store.py:40:1: F401 'devsynth.exceptions.MemoryError' imported but unused
+src/devsynth/application/memory/chromadb_store.py:40:1: F401 'devsynth.exceptions.DevSynthError' imported but unused
+src/devsynth/application/memory/chromadb_store.py:40:1: F401 'devsynth.exceptions.MemoryCorruptionError' imported but unused
+src/devsynth/application/memory/chromadb_store.py:40:1: F401 'devsynth.exceptions.MemoryItemNotFoundError' imported but unused
+src/devsynth/application/memory/chromadb_store.py:47:1: F401 'devsynth.fallback.with_fallback' imported but unused
+src/devsynth/application/memory/chromadb_store.py:123:89: E501 line too long (96 > 88 characters)
+src/devsynth/application/memory/chromadb_store.py:128:89: E501 line too long (95 > 88 characters)
+src/devsynth/application/memory/chromadb_store.py:168:89: E501 line too long (102 > 88 characters)
+src/devsynth/application/memory/chromadb_store.py:184:89: E501 line too long (93 > 88 characters)
+src/devsynth/application/memory/chromadb_store.py:193:89: E501 line too long (99 > 88 characters)
+src/devsynth/application/memory/chromadb_store.py:195:13: F841 local variable 'e' is assigned to but never used
+src/devsynth/application/memory/chromadb_store.py:201:89: E501 line too long (100 > 88 characters)
+src/devsynth/application/memory/chromadb_store.py:205:89: E501 line too long (106 > 88 characters)
+src/devsynth/application/memory/chromadb_store.py:214:89: E501 line too long (91 > 88 characters)
+src/devsynth/application/memory/chromadb_store.py:362:89: E501 line too long (92 > 88 characters)
+src/devsynth/application/memory/chromadb_store.py:392:89: E501 line too long (91 > 88 characters)
+src/devsynth/application/memory/chromadb_store.py:809:89: E501 line too long (95 > 88 characters)
+src/devsynth/application/memory/circuit_breaker.py:111:89: E501 line too long (89 > 88 characters)
+src/devsynth/application/memory/context_manager.py:2:1: F401 'datetime.datetime' imported but unused
+src/devsynth/application/memory/context_manager.py:9:1: F401 '...domain.models.memory.MemoryType' imported but unused
+src/devsynth/application/memory/context_manager.py:12:1: F401 'devsynth.exceptions.DevSynthError' imported but unused
+src/devsynth/application/memory/context_manager.py:12:1: E402 module level import not at top of file
+src/devsynth/application/memory/context_manager.py:98:89: E501 line too long (91 > 88 characters)
+src/devsynth/application/memory/duckdb_store.py:21:1: F401 'typing.Tuple' imported but unused
+src/devsynth/application/memory/duckdb_store.py:21:1: F401 'typing.Union' imported but unused
+src/devsynth/application/memory/duckdb_store.py:24:1: F401 'devsynth.exceptions.MemoryError' imported but unused
+src/devsynth/application/memory/duckdb_store.py:24:1: F401 'devsynth.exceptions.DevSynthError' imported but unused
+src/devsynth/application/memory/duckdb_store.py:24:1: F401 'devsynth.exceptions.MemoryItemNotFoundError' imported but unused
+src/devsynth/application/memory/duckdb_store.py:62:89: E501 line too long (121 > 88 characters)
+src/devsynth/application/memory/duckdb_store.py:63:89: E501 line too long (102 > 88 characters)
+src/devsynth/application/memory/duckdb_store.py:67:89: E501 line too long (120 > 88 characters)
+src/devsynth/application/memory/duckdb_store.py:93:89: E501 line too long (91 > 88 characters)
+src/devsynth/application/memory/duckdb_store.py:109:89: E501 line too long (102 > 88 characters)
+src/devsynth/application/memory/duckdb_store.py:165:89: E501 line too long (90 > 88 characters)
+src/devsynth/application/memory/duckdb_store.py:176:89: E501 line too long (100 > 88 characters)
+src/devsynth/application/memory/duckdb_store.py:266:89: E501 line too long (100 > 88 characters)
+src/devsynth/application/memory/duckdb_store.py:374:89: E501 line too long (101 > 88 characters)
+src/devsynth/application/memory/duckdb_store.py:388:89: E501 line too long (106 > 88 characters)
+src/devsynth/application/memory/duckdb_store.py:532:89: E501 line too long (104 > 88 characters)
+src/devsynth/application/memory/duckdb_store.py:547:89: E501 line too long (104 > 88 characters)
+src/devsynth/application/memory/duckdb_store.py:559:89: E501 line too long (104 > 88 characters)
+src/devsynth/application/memory/duckdb_store.py:714:89: E501 line too long (89 > 88 characters)
+src/devsynth/application/memory/duckdb_store.py:762:89: E501 line too long (124 > 88 characters)
+src/devsynth/application/memory/error_logger.py:10:1: F401 'time' imported but unused
+src/devsynth/application/memory/error_logger.py:12:1: F401 'pathlib.Path' imported but unused
+src/devsynth/application/memory/error_logger.py:40:89: E501 line too long (92 > 88 characters)
+src/devsynth/application/memory/faiss_store.py:20:89: E501 line too long (113 > 88 characters)
+src/devsynth/application/memory/faiss_store.py:23:1: F401 'pathlib.Path' imported but unused
+src/devsynth/application/memory/faiss_store.py:24:1: F401 'typing.Tuple' imported but unused
+src/devsynth/application/memory/faiss_store.py:24:1: F401 'typing.Union' imported but unused
+src/devsynth/application/memory/faiss_store.py:26:1: F401 'devsynth.exceptions.DevSynthError' imported but unused
+src/devsynth/application/memory/faiss_store.py:26:1: F401 'devsynth.exceptions.MemoryItemNotFoundError' imported but unused
+src/devsynth/application/memory/faiss_store.py:70:89: E501 line too long (91 > 88 characters)
+src/devsynth/application/memory/faiss_store.py:283:89: E501 line too long (111 > 88 characters)
+src/devsynth/application/memory/faiss_store.py:401:89: E501 line too long (103 > 88 characters)
+src/devsynth/application/memory/faiss_store.py:404:89: E501 line too long (103 > 88 characters)
+src/devsynth/application/memory/faiss_store.py:479:89: E501 line too long (95 > 88 characters)
+src/devsynth/application/memory/fallback.py:11:1: F401 'typing.Callable' imported but unused
+src/devsynth/application/memory/fallback.py:11:1: F401 'typing.Union' imported but unused
+src/devsynth/application/memory/fallback.py:11:1: F401 'typing.cast' imported but unused
+src/devsynth/application/memory/fallback.py:103:89: E501 line too long (90 > 88 characters)
+src/devsynth/application/memory/fallback.py:145:25: F541 f-string is missing placeholders
+src/devsynth/application/memory/fallback.py:316:17: F541 f-string is missing placeholders
+src/devsynth/application/memory/fallback.py:425:25: F541 f-string is missing placeholders
+src/devsynth/application/memory/fallback.py:495:17: F541 f-string is missing placeholders
+src/devsynth/application/memory/fallback.py:558:17: F541 f-string is missing placeholders
+src/devsynth/application/memory/fallback.py:658:89: E501 line too long (91 > 88 characters)
+src/devsynth/application/memory/json_file_store.py:14:1: F401 'devsynth.exceptions.MemoryError' imported but unused
+src/devsynth/application/memory/json_file_store.py:14:1: F401 'devsynth.exceptions.DevSynthError' imported but unused
+src/devsynth/application/memory/json_file_store.py:14:1: F401 'devsynth.exceptions.FileSystemError' imported but unused
+src/devsynth/application/memory/json_file_store.py:25:1: F401 'devsynth.fallback.with_fallback' imported but unused
+src/devsynth/application/memory/json_file_store.py:87:89: E501 line too long (92 > 88 characters)
+src/devsynth/application/memory/json_file_store.py:172:17: F541 f-string is missing placeholders
+src/devsynth/application/memory/json_file_store.py:178:17: F541 f-string is missing placeholders
+src/devsynth/application/memory/json_file_store.py:262:17: F541 f-string is missing placeholders
+src/devsynth/application/memory/json_file_store.py:276:25: F541 f-string is missing placeholders
+src/devsynth/application/memory/json_file_store.py:381:17: F541 f-string is missing placeholders
+src/devsynth/application/memory/json_file_store.py:392:25: F541 f-string is missing placeholders
+src/devsynth/application/memory/json_file_store.py:460:89: E501 line too long (92 > 88 characters)
+src/devsynth/application/memory/json_file_store.py:466:30: F541 f-string is missing placeholders
+src/devsynth/application/memory/json_file_store.py:477:30: F541 f-string is missing placeholders
+src/devsynth/application/memory/json_file_store.py:510:26: F541 f-string is missing placeholders
+src/devsynth/application/memory/json_file_store.py:578:21: F541 f-string is missing placeholders
+src/devsynth/application/memory/json_file_store.py:592:17: F541 f-string is missing placeholders
+src/devsynth/application/memory/json_file_store.py:600:25: F541 f-string is missing placeholders
+src/devsynth/application/memory/json_file_store.py:698:26: F541 f-string is missing placeholders
+src/devsynth/application/memory/json_file_store.py:732:32: F541 f-string is missing placeholders
+src/devsynth/application/memory/json_file_store.py:740:13: F841 local variable 'transaction' is assigned to but never used
+src/devsynth/application/memory/json_file_store.py:748:26: F541 f-string is missing placeholders
+src/devsynth/application/memory/json_file_store.py:789:32: F541 f-string is missing placeholders
+src/devsynth/application/memory/json_file_store.py:805:26: F541 f-string is missing placeholders
+src/devsynth/application/memory/knowledge_graph_utils.py:8:1: F401 'typing.Optional' imported but unused
+src/devsynth/application/memory/knowledge_graph_utils.py:8:1: F401 'typing.Tuple' imported but unused
+src/devsynth/application/memory/knowledge_graph_utils.py:8:1: F401 'typing.Union' imported but unused
+src/devsynth/application/memory/knowledge_graph_utils.py:10:1: F401 'rdflib' imported but unused
+src/devsynth/application/memory/knowledge_graph_utils.py:11:1: F401 'rdflib.RDFS' imported but unused
+src/devsynth/application/memory/knowledge_graph_utils.py:11:1: F401 'rdflib.XSD' imported but unused
+src/devsynth/application/memory/knowledge_graph_utils.py:11:1: F401 'rdflib.Graph' imported but unused
+src/devsynth/application/memory/knowledge_graph_utils.py:11:1: F401 'rdflib.Literal' imported but unused
+src/devsynth/application/memory/knowledge_graph_utils.py:12:1: F401 'rdflib.namespace.DC' imported but unused
+src/devsynth/application/memory/knowledge_graph_utils.py:12:1: F401 'rdflib.namespace.FOAF' imported but unused
+src/devsynth/application/memory/knowledge_graph_utils.py:17:1: F401 '...domain.interfaces.memory.MemoryStore' imported but unused
+src/devsynth/application/memory/knowledge_graph_utils.py:17:1: F401 '...domain.interfaces.memory.VectorStore' imported but unused
+src/devsynth/application/memory/knowledge_graph_utils.py:18:1: F401 '...domain.models.memory.MemoryType' imported but unused
+src/devsynth/application/memory/knowledge_graph_utils.py:18:1: F401 '...domain.models.memory.MemoryVector' imported but unused
+src/devsynth/application/memory/knowledge_graph_utils.py:101:89: E501 line too long (100 > 88 characters)
+src/devsynth/application/memory/knowledge_graph_utils.py:268:89: E501 line too long (94 > 88 characters)
+src/devsynth/application/memory/knowledge_graph_utils.py:309:89: E501 line too long (94 > 88 characters)
+src/devsynth/application/memory/knowledge_graph_utils.py:490:89: E501 line too long (122 > 88 characters)
+src/devsynth/application/memory/kuzu_store.py:45:1: E402 module level import not at top of file
+src/devsynth/application/memory/kuzu_store.py:46:1: E402 module level import not at top of file
+src/devsynth/application/memory/kuzu_store.py:47:1: E402 module level import not at top of file
+src/devsynth/application/memory/kuzu_store.py:48:1: F401 'devsynth.exceptions.MemoryStoreError' imported but unused
+src/devsynth/application/memory/kuzu_store.py:48:1: E402 module level import not at top of file
+src/devsynth/application/memory/kuzu_store.py:49:1: E402 module level import not at top of file
+src/devsynth/application/memory/kuzu_store.py:50:1: E402 module level import not at top of file
+src/devsynth/application/memory/kuzu_store.py:84:89: E501 line too long (90 > 88 characters)
+src/devsynth/application/memory/kuzu_store.py:132:89: E501 line too long (92 > 88 characters)
+src/devsynth/application/memory/kuzu_store.py:135:89: E501 line too long (95 > 88 characters)
+src/devsynth/application/memory/lmdb_store.py:22:1: F401 'devsynth.exceptions.MemoryError' imported but unused
+src/devsynth/application/memory/lmdb_store.py:22:1: F401 'devsynth.exceptions.DevSynthError' imported but unused
+src/devsynth/application/memory/lmdb_store.py:22:1: F401 'devsynth.exceptions.MemoryItemNotFoundError' imported but unused
+src/devsynth/application/memory/lmdb_store.py:36:1: E402 module level import not at top of file
+src/devsynth/application/memory/lmdb_store.py:64:89: E501 line too long (114 > 88 characters)
+src/devsynth/application/memory/lmdb_store.py:95:89: E501 line too long (91 > 88 characters)
+src/devsynth/application/memory/memory_integration.py:8:1: F401 'uuid' imported but unused
+src/devsynth/application/memory/memory_integration.py:10:1: F401 'typing.Optional' imported but unused
+src/devsynth/application/memory/memory_integration.py:10:1: F401 'typing.Set' imported but unused
+src/devsynth/application/memory/memory_integration.py:10:1: F401 'typing.Union' imported but unused
+src/devsynth/application/memory/memory_integration.py:12:1: F401 'devsynth.exceptions.MemoryError' imported but unused
+src/devsynth/application/memory/memory_integration.py:15:1: F401 '...domain.models.memory.MemoryType' imported but unused
+src/devsynth/application/memory/memory_integration.py:15:1: F401 '...domain.models.memory.MemoryVector' imported but unused
+src/devsynth/application/memory/memory_integration.py:96:89: E501 line too long (123 > 88 characters)
+src/devsynth/application/memory/memory_integration.py:181:89: E501 line too long (90 > 88 characters)
+src/devsynth/application/memory/memory_integration.py:219:89: E501 line too long (89 > 88 characters)
+src/devsynth/application/memory/memory_integration.py:240:89: E501 line too long (108 > 88 characters)
+src/devsynth/application/memory/memory_manager.py:14:1: F401 '...domain.interfaces.memory.MemoryStore' imported but unused
+src/devsynth/application/memory/memory_manager.py:15:1: F401 '...domain.models.memory.MemoryItemType' imported but unused
+src/devsynth/application/memory/memory_manager.py:24:1: F401 '.circuit_breaker.CircuitBreaker' imported but unused
+src/devsynth/application/memory/memory_manager.py:24:1: F401 '.circuit_breaker.with_circuit_breaker' imported but unused
+src/devsynth/application/memory/memory_manager.py:31:1: F401 '.retry.retry_with_backoff' imported but unused
+src/devsynth/application/memory/memory_manager.py:87:89: E501 line too long (90 > 88 characters)
+src/devsynth/application/memory/memory_manager.py:127:89: E501 line too long (93 > 88 characters)
+src/devsynth/application/memory/memory_manager.py:611:89: E501 line too long (119 > 88 characters)
+src/devsynth/application/memory/memory_manager.py:633:89: E501 line too long (92 > 88 characters)
+src/devsynth/application/memory/memory_manager.py:643:89: E501 line too long (89 > 88 characters)
+src/devsynth/application/memory/memory_manager.py:653:89: E501 line too long (92 > 88 characters)
+src/devsynth/application/memory/memory_manager.py:790:89: E501 line too long (89 > 88 characters)
+src/devsynth/application/memory/multi_layered_memory.py:10:1: F401 'collections.defaultdict' imported but unused
+src/devsynth/application/memory/multi_layered_memory.py:11:1: F401 'typing.Union' imported but unused
+src/devsynth/application/memory/multi_layered_memory.py:13:1: F401 '...domain.interfaces.memory.MemoryStore' imported but unused
+src/devsynth/application/memory/multi_layered_memory.py:14:1: F401 '...domain.models.memory.MemoryVector' imported but unused
+src/devsynth/application/memory/persistent_context_manager.py:7:1: F401 'datetime.timedelta' imported but unused
+src/devsynth/application/memory/persistent_context_manager.py:8:1: F401 'typing.List' imported but unused
+src/devsynth/application/memory/persistent_context_manager.py:16:1: F401 'devsynth.exceptions.DevSynthError' imported but unused
+src/devsynth/application/memory/persistent_context_manager.py:16:1: E402 module level import not at top of file
+src/devsynth/application/memory/rdflib_store.py:13:1: F401 'typing.Tuple' imported but unused
+src/devsynth/application/memory/rdflib_store.py:13:1: F401 'typing.Union' imported but unused
+src/devsynth/application/memory/rdflib_store.py:37:1: F401 'devsynth.exceptions.MemoryError' imported but unused
+src/devsynth/application/memory/rdflib_store.py:37:1: F401 'devsynth.exceptions.DevSynthError' imported but unused
+src/devsynth/application/memory/rdflib_store.py:37:1: F401 'devsynth.exceptions.MemoryItemNotFoundError' imported but unused
+src/devsynth/application/memory/rdflib_store.py:93:89: E501 line too long (91 > 88 characters)
+src/devsynth/application/memory/rdflib_store.py:453:89: E501 line too long (95 > 88 characters)
+src/devsynth/application/memory/rdflib_store.py:460:89: E501 line too long (99 > 88 characters)
+src/devsynth/application/memory/rdflib_store.py:464:89: E501 line too long (113 > 88 characters)
+src/devsynth/application/memory/rdflib_store.py:471:89: E501 line too long (105 > 88 characters)
+src/devsynth/application/memory/rdflib_store.py:479:89: E501 line too long (105 > 88 characters)
+src/devsynth/application/memory/rdflib_store.py:484:89: E501 line too long (103 > 88 characters)
+src/devsynth/application/memory/rdflib_store.py:491:89: E501 line too long (108 > 88 characters)
+src/devsynth/application/memory/rdflib_store.py:492:89: E501 line too long (114 > 88 characters)
+src/devsynth/application/memory/rdflib_store.py:678:89: E501 line too long (99 > 88 characters)
+src/devsynth/application/memory/rdflib_store.py:777:89: E501 line too long (99 > 88 characters)
+src/devsynth/application/memory/rdflib_store.py:789:89: E501 line too long (103 > 88 characters)
+src/devsynth/application/memory/rdflib_store.py:790:89: E501 line too long (109 > 88 characters)
+src/devsynth/application/memory/rdflib_store.py:828:89: E501 line too long (99 > 88 characters)
+src/devsynth/application/memory/recovery.py:14:1: F401 'typing.Union' imported but unused
+src/devsynth/application/memory/retry.py:159:89: E501 line too long (93 > 88 characters)
+src/devsynth/application/memory/retry.py:244:89: E501 line too long (93 > 88 characters)
+src/devsynth/application/memory/retry.py:258:89: E501 line too long (90 > 88 characters)
+src/devsynth/application/memory/retry.py:279:89: E501 line too long (91 > 88 characters)
+src/devsynth/application/memory/retry.py:304:89: E501 line too long (91 > 88 characters)
+src/devsynth/application/memory/retry.py:325:89: E501 line too long (129 > 88 characters)
+src/devsynth/application/memory/retry.py:333:89: E501 line too long (108 > 88 characters)
+src/devsynth/application/memory/retry.py:478:89: E501 line too long (97 > 88 characters)
+src/devsynth/application/memory/retry.py:479:89: E501 line too long (97 > 88 characters)
+src/devsynth/application/memory/retry.py:480:89: E501 line too long (95 > 88 characters)
+src/devsynth/application/memory/retry.py:483:89: E501 line too long (94 > 88 characters)
+src/devsynth/application/memory/sync_manager.py:6:1: F401 'time' imported but unused
+src/devsynth/application/memory/sync_manager.py:225:89: E501 line too long (143 > 88 characters)
+src/devsynth/application/memory/sync_manager.py:706:89: E501 line too long (91 > 88 characters)
+src/devsynth/application/memory/tiered_cache.py:10:1: F401 'typing.Any' imported but unused
+src/devsynth/application/memory/tiered_cache.py:10:1: F401 'typing.Dict' imported but unused
+src/devsynth/application/memory/tiered_cache.py:50:89: E501 line too long (90 > 88 characters)
+src/devsynth/application/memory/tiered_cache.py:71:89: E501 line too long (95 > 88 characters)
+src/devsynth/application/memory/tinydb_store.py:16:1: F401 'devsynth.exceptions.MemoryError' imported but unused
+src/devsynth/application/memory/tinydb_store.py:16:1: F401 'devsynth.exceptions.DevSynthError' imported but unused
+src/devsynth/application/memory/tinydb_store.py:16:1: F401 'devsynth.exceptions.MemoryItemNotFoundError' imported but unused
+src/devsynth/application/memory/tinydb_store.py:105:89: E501 line too long (91 > 88 characters)
+src/devsynth/application/memory/transaction_context.py:4:89: E501 line too long (90 > 88 characters)
+src/devsynth/application/memory/transaction_context.py:9:1: F401 'contextlib.contextmanager' imported but unused
+src/devsynth/application/memory/transaction_context.py:10:1: F401 'typing.Dict' imported but unused
+src/devsynth/application/memory/transaction_context.py:10:1: F401 'typing.Optional' imported but unused
+src/devsynth/application/memory/transaction_context.py:10:1: F401 'typing.Set' imported but unused
+src/devsynth/application/memory/transaction_context.py:45:89: E501 line too long (94 > 88 characters)
+src/devsynth/application/memory/transaction_context.py:54:89: E501 line too long (91 > 88 characters)
+src/devsynth/application/memory/transaction_context.py:71:89: E501 line too long (94 > 88 characters)
+src/devsynth/application/memory/transaction_context.py:81:89: E501 line too long (89 > 88 characters)
+src/devsynth/application/memory/transaction_context.py:163:89: E501 line too long (101 > 88 characters)
+src/devsynth/application/memory/transaction_context.py:183:89: E501 line too long (99 > 88 characters)
+src/devsynth/application/memory/transaction_context.py:205:89: E501 line too long (120 > 88 characters)
+src/devsynth/application/memory/transaction_context.py:226:89: E501 line too long (103 > 88 characters)
+src/devsynth/application/memory/transaction_context.py:232:89: E501 line too long (102 > 88 characters)
+src/devsynth/application/memory/vector_providers.py:30:1: E402 module level import not at top of file
+src/devsynth/application/orchestration/__init__.py:1:1: F401 'devsynth.exceptions.DevSynthError' imported but unused
+src/devsynth/application/orchestration/refactor_workflow.py:10:1: F401 'typing.Optional' imported but unused
+src/devsynth/application/orchestration/refactor_workflow.py:11:1: F401 'uuid.uuid4' imported but unused
+src/devsynth/application/orchestration/refactor_workflow.py:17:1: F401 'devsynth.exceptions.DevSynthError' imported but unused
+src/devsynth/application/orchestration/refactor_workflow.py:17:1: E402 module level import not at top of file
+src/devsynth/application/orchestration/refactor_workflow.py:19:1: E402 module level import not at top of file
+src/devsynth/application/orchestration/refactor_workflow.py:20:1: F401 '...domain.models.workflow.Workflow' imported but unused
+src/devsynth/application/orchestration/refactor_workflow.py:20:1: F401 '...domain.models.workflow.WorkflowStatus' imported but unused
+src/devsynth/application/orchestration/refactor_workflow.py:20:1: F401 '...domain.models.workflow.WorkflowStep' imported but unused
+src/devsynth/application/orchestration/refactor_workflow.py:20:1: E402 module level import not at top of file
+src/devsynth/application/orchestration/refactor_workflow.py:21:1: E402 module level import not at top of file
+src/devsynth/application/orchestration/refactor_workflow.py:144:9: F841 local variable 'entry_point' is assigned to but never used
+src/devsynth/application/orchestration/refactor_workflow.py:154:89: E501 line too long (95 > 88 characters)
+src/devsynth/application/orchestration/refactor_workflow.py:200:89: E501 line too long (172 > 88 characters)
+src/devsynth/application/orchestration/refactor_workflow.py:210:89: E501 line too long (162 > 88 characters)
+src/devsynth/application/orchestration/refactor_workflow.py:261:89: E501 line too long (89 > 88 characters)
+src/devsynth/application/orchestration/refactor_workflow.py:275:89: E501 line too long (90 > 88 characters)
+src/devsynth/application/orchestration/refactor_workflow.py:276:89: E501 line too long (93 > 88 characters)
+src/devsynth/application/orchestration/workflow.py:8:1: F401 'typing.Callable' imported but unused
+src/devsynth/application/orchestration/workflow.py:8:1: F401 'typing.List' imported but unused
+src/devsynth/application/orchestration/workflow.py:8:1: F401 'typing.Optional' imported but unused
+src/devsynth/application/orchestration/workflow.py:12:1: F401 'rich.prompt.Prompt' imported but unused
+src/devsynth/application/orchestration/workflow.py:21:1: F401 'devsynth.exceptions.DevSynthError' imported but unused
+src/devsynth/application/orchestration/workflow.py:21:1: E402 module level import not at top of file
+src/devsynth/application/orchestration/workflow.py:23:1: E402 module level import not at top of file
+src/devsynth/application/orchestration/workflow.py:28:1: E402 module level import not at top of file
+src/devsynth/application/orchestration/workflow.py:29:1: E402 module level import not at top of file
+src/devsynth/application/orchestration/workflow.py:95:89: E501 line too long (89 > 88 characters)
+src/devsynth/application/orchestration/workflow.py:154:89: E501 line too long (100 > 88 characters)
+src/devsynth/application/orchestration/workflow.py:465:89: E501 line too long (97 > 88 characters)
+src/devsynth/application/promises/agent.py:14:1: F401 'typing.Type' imported but unused
+src/devsynth/application/promises/agent.py:14:1: F401 'typing.Union' imported but unused
+src/devsynth/application/promises/agent.py:18:1: F401 '.broker.CapabilityMetadata' imported but unused
+src/devsynth/application/promises/agent.py:18:1: F401 '.broker.CapabilityNotFoundError' imported but unused
+src/devsynth/application/promises/agent.py:18:1: F401 '.broker.UnauthorizedAccessError' imported but unused
+src/devsynth/application/promises/agent.py:65:89: E501 line too long (94 > 88 characters)
+src/devsynth/application/promises/agent.py:96:89: E501 line too long (96 > 88 characters)
+src/devsynth/application/promises/agent.py:126:89: E501 line too long (101 > 88 characters)
+src/devsynth/application/promises/agent.py:136:89: E501 line too long (101 > 88 characters)
+src/devsynth/application/promises/agent.py:194:89: E501 line too long (94 > 88 characters)
+src/devsynth/application/promises/agent.py:200:89: E501 line too long (95 > 88 characters)
+src/devsynth/application/promises/agent.py:228:89: E501 line too long (91 > 88 characters)
+src/devsynth/application/promises/agent.py:275:89: E501 line too long (89 > 88 characters)
+src/devsynth/application/promises/agent.py:283:89: E501 line too long (90 > 88 characters)
+src/devsynth/application/promises/agent.py:339:89: E501 line too long (97 > 88 characters)
+src/devsynth/application/promises/agent.py:382:89: E501 line too long (89 > 88 characters)
+src/devsynth/application/promises/agent.py:413:89: E501 line too long (103 > 88 characters)
+src/devsynth/application/promises/agent.py:512:15: F821 undefined name 'PromiseType'
+src/devsynth/application/promises/agent.py:615:15: F821 undefined name 'PromiseType'
+src/devsynth/application/promises/broker.py:11:1: F401 'typing.Tuple' imported but unused
+src/devsynth/application/promises/broker.py:11:1: F401 'typing.Type' imported but unused
+src/devsynth/application/promises/broker.py:11:1: F401 'typing.Union' imported but unused
+src/devsynth/application/promises/broker.py:13:1: F401 'devsynth.exceptions.DevSynthError' imported but unused
+src/devsynth/application/promises/broker.py:36:89: E501 line too long (93 > 88 characters)
+src/devsynth/application/promises/broker.py:43:89: E501 line too long (90 > 88 characters)
+src/devsynth/application/promises/broker.py:70:89: E501 line too long (95 > 88 characters)
+src/devsynth/application/promises/broker.py:175:89: E501 line too long (95 > 88 characters)
+src/devsynth/application/promises/broker.py:182:89: E501 line too long (100 > 88 characters)
+src/devsynth/application/promises/broker.py:199:89: E501 line too long (96 > 88 characters)
+src/devsynth/application/promises/broker.py:223:89: E501 line too long (97 > 88 characters)
+src/devsynth/application/promises/broker.py:291:89: E501 line too long (98 > 88 characters)
+src/devsynth/application/promises/broker.py:351:89: E501 line too long (93 > 88 characters)
+src/devsynth/application/promises/broker.py:371:89: E501 line too long (98 > 88 characters)
+src/devsynth/application/promises/examples.py:11:1: F401 'devsynth.application.promises.Promise' imported but unused
+src/devsynth/application/promises/examples.py:11:1: F401 'devsynth.application.promises.UnauthorizedAccessError' imported but unused
+src/devsynth/application/promises/examples.py:65:89: E501 line too long (90 > 88 characters)
+src/devsynth/application/promises/examples.py:130:89: E501 line too long (90 > 88 characters)
+src/devsynth/application/promises/examples.py:181:89: E501 line too long (93 > 88 characters)
+src/devsynth/application/promises/examples.py:241:89: E501 line too long (97 > 88 characters)
+src/devsynth/application/promises/examples.py:307:5: F821 undefined name 'logging'
+src/devsynth/application/promises/examples.py:308:15: F821 undefined name 'logging'
+src/devsynth/application/promises/implementation.py:9:1: F401 'typing.Union' imported but unused
+src/devsynth/application/promises/implementation.py:47:89: E501 line too long (89 > 88 characters)
+src/devsynth/application/promises/implementation.py:54:89: E501 line too long (90 > 88 characters)
+src/devsynth/application/promises/implementation.py:57:89: E501 line too long (90 > 88 characters)
+src/devsynth/application/promises/implementation.py:227:89: E501 line too long (103 > 88 characters)
+src/devsynth/application/promises/implementation.py:250:89: E501 line too long (100 > 88 characters)
+src/devsynth/application/promises/implementation.py:256:89: E501 line too long (100 > 88 characters)
+src/devsynth/application/promises/implementation.py:283:89: E501 line too long (92 > 88 characters)
+src/devsynth/application/promises/implementation.py:316:89: E501 line too long (94 > 88 characters)
+src/devsynth/application/promises/implementation.py:377:89: E501 line too long (89 > 88 characters)
+src/devsynth/application/promises/implementation.py:378:89: E501 line too long (91 > 88 characters)
+src/devsynth/application/promises/implementation.py:422:89: E501 line too long (97 > 88 characters)
+src/devsynth/application/promises/interface.py:13:1: F401 'typing.Set' imported but unused
+src/devsynth/application/promises/interface.py:13:1: F401 'typing.Union' imported but unused
+src/devsynth/application/prompts/auto_tuning.py:10:1: F401 're' imported but unused
+src/devsynth/application/prompts/auto_tuning.py:12:1: F401 'typing.List' imported but unused
+src/devsynth/application/prompts/auto_tuning.py:12:1: F401 'typing.Optional' imported but unused
+src/devsynth/application/prompts/auto_tuning.py:242:89: E501 line too long (91 > 88 characters)
+src/devsynth/application/prompts/auto_tuning.py:287:89: E501 line too long (109 > 88 characters)
+src/devsynth/application/prompts/auto_tuning.py:319:89: E501 line too long (103 > 88 characters)
+src/devsynth/application/prompts/auto_tuning.py:340:89: E501 line too long (129 > 88 characters)
+src/devsynth/application/prompts/auto_tuning.py:420:89: E501 line too long (125 > 88 characters)
+src/devsynth/application/prompts/auto_tuning.py:604:89: E501 line too long (121 > 88 characters)
+src/devsynth/application/prompts/auto_tuning.py:620:89: E501 line too long (118 > 88 characters)
+src/devsynth/application/prompts/prompt_efficacy.py:13:1: F401 'pathlib.Path' imported but unused
+src/devsynth/application/prompts/prompt_efficacy.py:14:1: F401 'typing.Tuple' imported but unused
+src/devsynth/application/prompts/prompt_efficacy.py:35:89: E501 line too long (94 > 88 characters)
+src/devsynth/application/prompts/prompt_efficacy.py:49:89: E501 line too long (89 > 88 characters)
+src/devsynth/application/prompts/prompt_efficacy.py:84:89: E501 line too long (103 > 88 characters)
+src/devsynth/application/prompts/prompt_efficacy.py:122:89: E501 line too long (96 > 88 characters)
+src/devsynth/application/prompts/prompt_efficacy.py:137:89: E501 line too long (101 > 88 characters)
+src/devsynth/application/prompts/prompt_efficacy.py:151:89: E501 line too long (96 > 88 characters)
+src/devsynth/application/prompts/prompt_efficacy.py:196:89: E501 line too long (90 > 88 characters)
+src/devsynth/application/prompts/prompt_efficacy.py:197:89: E501 line too long (90 > 88 characters)
+src/devsynth/application/prompts/prompt_efficacy.py:211:89: E501 line too long (103 > 88 characters)
+src/devsynth/application/prompts/prompt_efficacy.py:212:89: E501 line too long (89 > 88 characters)
+src/devsynth/application/prompts/prompt_manager.py:390:32: F821 undefined name 'datetime'
+src/devsynth/application/requirements/dialectical_reasoner.py:7:1: F401 'datetime.datetime' imported but unused
+src/devsynth/application/requirements/dialectical_reasoner.py:9:1: F401 'uuid.uuid4' imported but unused
+src/devsynth/application/requirements/dialectical_reasoner.py:206:89: E501 line too long (92 > 88 characters)
+src/devsynth/application/requirements/dialectical_reasoner.py:349:89: E501 line too long (92 > 88 characters)
+src/devsynth/application/requirements/dialectical_reasoner.py:401:9: F841 local variable 'exc' is assigned to but never used
+src/devsynth/application/requirements/dialectical_reasoner.py:403:89: E501 line too long (99 > 88 characters)
+src/devsynth/application/requirements/dialectical_reasoner.py:425:9: F841 local variable 'exc' is assigned to but never used
+src/devsynth/application/requirements/dialectical_reasoner.py:427:89: E501 line too long (95 > 88 characters)
+src/devsynth/application/requirements/dialectical_reasoner.py:790:89: E501 line too long (90 > 88 characters)
+src/devsynth/application/requirements/dialectical_reasoner.py:882:89: E501 line too long (92 > 88 characters)
+src/devsynth/application/requirements/dialectical_reasoner.py:883:89: E501 line too long (94 > 88 characters)
+src/devsynth/application/requirements/dialectical_reasoner.py:884:89: E501 line too long (94 > 88 characters)
+src/devsynth/application/requirements/dialectical_reasoner.py:895:23: F541 f-string is missing placeholders
+src/devsynth/application/requirements/dialectical_reasoner.py:898:23: F541 f-string is missing placeholders
+src/devsynth/application/requirements/dialectical_reasoner.py:918:89: E501 line too long (92 > 88 characters)
+src/devsynth/application/requirements/dialectical_reasoner.py:919:89: E501 line too long (95 > 88 characters)
+src/devsynth/application/requirements/dialectical_reasoner.py:920:89: E501 line too long (118 > 88 characters)
+src/devsynth/application/requirements/dialectical_reasoner.py:931:23: F541 f-string is missing placeholders
+src/devsynth/application/requirements/dialectical_reasoner.py:934:23: F541 f-string is missing placeholders
+src/devsynth/application/requirements/dialectical_reasoner.py:958:89: E501 line too long (92 > 88 characters)
+src/devsynth/application/requirements/dialectical_reasoner.py:960:89: E501 line too long (116 > 88 characters)
+src/devsynth/application/requirements/dialectical_reasoner.py:972:23: F541 f-string is missing placeholders
+src/devsynth/application/requirements/dialectical_reasoner.py:975:23: F541 f-string is missing placeholders
+src/devsynth/application/requirements/dialectical_reasoner.py:983:89: E501 line too long (102 > 88 characters)
+src/devsynth/application/requirements/dialectical_reasoner.py:1012:89: E501 line too long (92 > 88 characters)
+src/devsynth/application/requirements/dialectical_reasoner.py:1013:89: E501 line too long (109 > 88 characters)
+src/devsynth/application/requirements/dialectical_reasoner.py:1014:89: E501 line too long (124 > 88 characters)
+src/devsynth/application/requirements/dialectical_reasoner.py:1025:23: F541 f-string is missing placeholders
+src/devsynth/application/requirements/dialectical_reasoner.py:1028:23: F541 f-string is missing placeholders
+src/devsynth/application/requirements/dialectical_reasoner.py:1058:89: E501 line too long (92 > 88 characters)
+src/devsynth/application/requirements/dialectical_reasoner.py:1059:89: E501 line too long (100 > 88 characters)
+src/devsynth/application/requirements/dialectical_reasoner.py:1060:89: E501 line too long (176 > 88 characters)
+src/devsynth/application/requirements/dialectical_reasoner.py:1071:23: F541 f-string is missing placeholders
+src/devsynth/application/requirements/dialectical_reasoner.py:1074:23: F541 f-string is missing placeholders
+src/devsynth/application/requirements/dialectical_reasoner.py:1081:89: E501 line too long (92 > 88 characters)
+src/devsynth/application/requirements/dialectical_reasoner.py:1108:89: E501 line too long (105 > 88 characters)
+src/devsynth/application/requirements/dialectical_reasoner.py:1110:89: E501 line too long (104 > 88 characters)
+src/devsynth/application/requirements/dialectical_reasoner.py:1133:27: F541 f-string is missing placeholders
+src/devsynth/application/requirements/dialectical_reasoner.py:1136:27: F541 f-string is missing placeholders
+src/devsynth/application/requirements/dialectical_reasoner.py:1171:89: E501 line too long (105 > 88 characters)
+src/devsynth/application/requirements/dialectical_reasoner.py:1172:89: E501 line too long (111 > 88 characters)
+src/devsynth/application/requirements/dialectical_reasoner.py:1173:89: E501 line too long (131 > 88 characters)
+src/devsynth/application/requirements/dialectical_reasoner.py:1193:27: F541 f-string is missing placeholders
+src/devsynth/application/requirements/dialectical_reasoner.py:1196:27: F541 f-string is missing placeholders
+src/devsynth/application/requirements/dialectical_reasoner.py:1224:89: E501 line too long (105 > 88 characters)
+src/devsynth/application/requirements/dialectical_reasoner.py:1225:89: E501 line too long (139 > 88 characters)
+src/devsynth/application/requirements/dialectical_reasoner.py:1236:23: F541 f-string is missing placeholders
+src/devsynth/application/requirements/dialectical_reasoner.py:1239:23: F541 f-string is missing placeholders
+src/devsynth/application/requirements/dialectical_reasoner.py:1281:89: E501 line too long (121 > 88 characters)
+src/devsynth/application/requirements/dialectical_reasoner.py:1282:89: E501 line too long (118 > 88 characters)
+src/devsynth/application/requirements/dialectical_reasoner.py:1293:23: F541 f-string is missing placeholders
+src/devsynth/application/requirements/dialectical_reasoner.py:1296:23: F541 f-string is missing placeholders
+src/devsynth/application/requirements/dialectical_reasoner.py:1305:89: E501 line too long (131 > 88 characters)
+src/devsynth/application/requirements/dialectical_reasoner.py:1306:89: E501 line too long (116 > 88 characters)
+src/devsynth/application/requirements/requirement_service.py:9:1: F401 'devsynth.domain.models.requirement.RequirementStatus' imported but unused
+src/devsynth/application/requirements/requirement_service.py:153:9: F841 local variable 'reasoning' is assigned to but never used
+src/devsynth/application/requirements/requirement_service.py:156:9: F841 local variable 'impact' is assigned to but never used
+src/devsynth/application/requirements/requirement_service.py:194:9: F841 local variable 'reasoning' is assigned to but never used
+src/devsynth/application/requirements/requirement_service.py:197:9: F841 local variable 'impact' is assigned to but never used
+src/devsynth/application/utils/__init__.py:6:1: F401 'devsynth.exceptions.DevSynthError' imported but unused
+src/devsynth/application/utils/extras.py:12:1: F401 'typing.Iterable' imported but unused
+src/devsynth/application/utils/extras.py:39:89: E501 line too long (89 > 88 characters)
+src/devsynth/application/utils/extras.py:40:89: E501 line too long (92 > 88 characters)
+src/devsynth/application/utils/extras.py:46:89: E501 line too long (89 > 88 characters)
+src/devsynth/application/utils/extras.py:65:89: E501 line too long (122 > 88 characters)
+src/devsynth/application/utils/token_tracker.py:5:1: F401 're' imported but unused
+src/devsynth/application/utils/token_tracker.py:6:1: F401 'typing.Optional' imported but unused
+src/devsynth/application/utils/token_tracker.py:6:1: F401 'typing.Union' imported but unused
+src/devsynth/application/utils/token_tracker.py:12:1: F401 'devsynth.exceptions.DevSynthError' imported but unused
+src/devsynth/application/utils/token_tracker.py:12:1: F401 'devsynth.exceptions.LLMError' imported but unused
+src/devsynth/application/utils/token_tracker.py:12:1: E402 module level import not at top of file
+src/devsynth/application/utils/token_tracker.py:67:9: F824 `global _TEST_MODE` is unused: name is never assigned in scope
+src/devsynth/application/utils/token_tracker.py:67:9: F824 `global _TEST_TOKEN_COUNTS` is unused: name is never assigned in scope
+src/devsynth/application/utils/token_tracker.py:96:89: E501 line too long (101 > 88 characters)
+src/devsynth/application/utils/token_tracker.py:105:89: E501 line too long (90 > 88 characters)
+src/devsynth/application/utils/token_tracker.py:123:89: E501 line too long (95 > 88 characters)
+src/devsynth/application/utils/token_tracker.py:132:89: E501 line too long (93 > 88 characters)
+src/devsynth/application/utils/token_tracker.py:150:89: E501 line too long (97 > 88 characters)
+src/devsynth/application/utils/token_tracker.py:191:89: E501 line too long (121 > 88 characters)
+src/devsynth/config/__init__.py:76:1: E402 module level import not at top of file
+src/devsynth/config/__init__.py:79:1: E402 module level import not at top of file
+src/devsynth/config/__init__.py:118:89: E501 line too long (90 > 88 characters)
+src/devsynth/config/loader.py:15:1: F401 'devsynth.__version__ as project_version' imported but unused
+src/devsynth/config/loader.py:223:89: E501 line too long (107 > 88 characters)
+src/devsynth/config/loader.py:236:89: E501 line too long (107 > 88 characters)
+src/devsynth/config/loader.py:286:89: E501 line too long (116 > 88 characters)
+src/devsynth/config/provider_env.py:18:1: F401 'typing.Dict' imported but unused
+src/devsynth/config/provider_env.py:77:89: E501 line too long (92 > 88 characters)
+src/devsynth/config/settings.py:19:1: F401 'devsynth.exceptions.DevSynthError' imported but unused
+src/devsynth/config/settings.py:19:1: E402 module level import not at top of file
+src/devsynth/config/settings.py:21:1: E402 module level import not at top of file
+src/devsynth/config/settings.py:59:89: E501 line too long (117 > 88 characters)
+src/devsynth/config/settings.py:63:89: E501 line too long (96 > 88 characters)
+src/devsynth/config/settings.py:93:89: E501 line too long (108 > 88 characters)
+src/devsynth/config/settings.py:188:89: E501 line too long (89 > 88 characters)
+src/devsynth/config/settings.py:420:89: E501 line too long (98 > 88 characters)
+src/devsynth/config/settings.py:434:89: E501 line too long (93 > 88 characters)
+src/devsynth/config/settings.py:443:89: E501 line too long (92 > 88 characters)
+src/devsynth/config/settings.py:456:89: E501 line too long (113 > 88 characters)
+src/devsynth/config/settings.py:508:89: E501 line too long (95 > 88 characters)
+src/devsynth/config/settings.py:517:89: E501 line too long (92 > 88 characters)
+src/devsynth/config/settings.py:598:89: E501 line too long (95 > 88 characters)
+src/devsynth/config/settings.py:604:89: E501 line too long (89 > 88 characters)
+src/devsynth/config/settings.py:607:89: E501 line too long (92 > 88 characters)
+src/devsynth/config/settings.py:651:9: F841 local variable 'values' is assigned to but never used
+src/devsynth/config/settings.py:749:89: E501 line too long (110 > 88 characters)
+src/devsynth/config/settings.py:783:89: E501 line too long (113 > 88 characters)
+src/devsynth/core/mvu/report.py:73:89: E501 line too long (132 > 88 characters)
+src/devsynth/core/mvu/report.py:80:89: E501 line too long (129 > 88 characters)
+src/devsynth/domain/__init__.py:1:1: F401 'devsynth.exceptions.DevSynthError' imported but unused
+src/devsynth/domain/interfaces/__init__.py:1:1: F401 'devsynth.exceptions.DevSynthError' imported but unused
+src/devsynth/domain/interfaces/__init__.py:4:1: F401 '.onnx.OnnxRuntime' imported but unused
+src/devsynth/domain/interfaces/agent.py:1:1: F401 'abc.ABC' imported but unused
+src/devsynth/domain/interfaces/agent.py:2:1: F401 'typing.Optional' imported but unused
+src/devsynth/domain/interfaces/agent.py:8:1: F401 '...domain.models.wsde.WSDE' imported but unused
+src/devsynth/domain/interfaces/agent.py:11:1: F401 'devsynth.exceptions.DevSynthError' imported but unused
+src/devsynth/domain/interfaces/agent.py:11:1: E402 module level import not at top of file
+src/devsynth/domain/interfaces/cli.py:8:1: F401 'devsynth.exceptions.DevSynthError' imported but unused
+src/devsynth/domain/interfaces/cli.py:8:1: E402 module level import not at top of file
+src/devsynth/domain/interfaces/code_analysis.py:6:1: F401 'typing.Union' imported but unused
+src/devsynth/domain/interfaces/code_analysis.py:28:89: E501 line too long (90 > 88 characters)
+src/devsynth/domain/interfaces/code_analysis.py:38:89: E501 line too long (90 > 88 characters)
+src/devsynth/domain/interfaces/code_analysis.py:164:89: E501 line too long (109 > 88 characters)
+src/devsynth/domain/interfaces/code_analysis.py:179:89: E501 line too long (109 > 88 characters)
+src/devsynth/domain/interfaces/code_analysis.py:190:89: E501 line too long (97 > 88 characters)
+src/devsynth/domain/interfaces/code_analysis.py:195:89: E501 line too long (109 > 88 characters)
+src/devsynth/domain/interfaces/llm.py:1:1: F401 'abc.ABC' imported but unused
+src/devsynth/domain/interfaces/llm.py:2:1: F401 'typing.Optional' imported but unused
+src/devsynth/domain/interfaces/llm.py:8:1: F401 'devsynth.exceptions.DevSynthError' imported but unused
+src/devsynth/domain/interfaces/llm.py:8:1: E402 module level import not at top of file
+src/devsynth/domain/interfaces/memory.py:1:1: F401 'abc.ABC' imported but unused
+src/devsynth/domain/interfaces/memory.py:7:1: F401 '...domain.models.memory.MemoryType' imported but unused
+src/devsynth/domain/interfaces/memory.py:8:1: F401 '...domain.models.wsde.WSDE' imported but unused
+src/devsynth/domain/interfaces/memory.py:11:1: F401 'devsynth.exceptions.DevSynthError' imported but unused
+src/devsynth/domain/interfaces/memory.py:11:1: E402 module level import not at top of file
+src/devsynth/domain/interfaces/orchestration.py:1:1: F401 'abc.ABC' imported but unused
+src/devsynth/domain/interfaces/orchestration.py:10:1: F401 'devsynth.exceptions.DevSynthError' imported but unused
+src/devsynth/domain/interfaces/orchestration.py:10:1: E402 module level import not at top of file
+src/devsynth/domain/interfaces/requirement.py:12:1: E402 module level import not at top of file
+src/devsynth/domain/models/__init__.py:2:1: F401 'devsynth.exceptions.DevSynthError' imported but unused
+src/devsynth/domain/models/agent.py:9:1: F401 'devsynth.exceptions.DevSynthError' imported but unused
+src/devsynth/domain/models/agent.py:9:1: E402 module level import not at top of file
+src/devsynth/domain/models/agent.py:22:89: E501 line too long (94 > 88 characters)
+src/devsynth/domain/models/code_analysis.py:83:89: E501 line too long (93 > 88 characters)
+src/devsynth/domain/models/memory.py:4:1: F401 'typing.Optional' imported but unused
+src/devsynth/domain/models/memory.py:6:1: F401 'devsynth.exceptions.DevSynthError' imported but unused
+src/devsynth/domain/models/project.py:10:1: F401 'typing.Set' imported but unused
+src/devsynth/domain/models/project.py:66:89: E501 line too long (104 > 88 characters)
+src/devsynth/domain/models/project.py:306:89: E501 line too long (90 > 88 characters)
+src/devsynth/domain/models/requirement.py:8:1: F401 'typing.Union' imported but unused
+src/devsynth/domain/models/task.py:7:1: F401 'uuid.UUID' imported but unused
+src/devsynth/domain/models/workflow.py:4:1: F401 'typing.Optional' imported but unused
+src/devsynth/domain/models/workflow.py:11:1: F401 'devsynth.exceptions.DevSynthError' imported but unused
+src/devsynth/domain/models/workflow.py:11:1: E402 module level import not at top of file
+src/devsynth/domain/models/wsde_base.py:8:1: F401 're' imported but unused
+src/devsynth/domain/models/wsde_base.py:14:1: F401 'devsynth.exceptions.DevSynthError' imported but unused
+src/devsynth/domain/models/wsde_base.py:16:1: F401 'devsynth.methodology.base.Phase' imported but unused
+src/devsynth/domain/models/wsde_base.py:371:89: E501 line too long (90 > 88 characters)
+src/devsynth/domain/models/wsde_base.py:377:89: E501 line too long (90 > 88 characters)
+src/devsynth/domain/models/wsde_code_improvements.py:21:89: E501 line too long (98 > 88 characters)
+src/devsynth/domain/models/wsde_code_improvements.py:41:89: E501 line too long (136 > 88 characters)
+src/devsynth/domain/models/wsde_code_improvements.py:88:89: E501 line too long (92 > 88 characters)
+src/devsynth/domain/models/wsde_code_improvements.py:89:89: E501 line too long (99 > 88 characters)
+src/devsynth/domain/models/wsde_code_improvements.py:92:89: E501 line too long (116 > 88 characters)
+src/devsynth/domain/models/wsde_code_improvements.py:99:89: E501 line too long (109 > 88 characters)
+src/devsynth/domain/models/wsde_code_improvements.py:131:89: E501 line too long (97 > 88 characters)
+src/devsynth/domain/models/wsde_context_driven_leadership.py:10:1: F401 'datetime.datetime' imported but unused
+src/devsynth/domain/models/wsde_context_driven_leadership.py:11:1: F401 'typing.Tuple' imported but unused
+src/devsynth/domain/models/wsde_context_driven_leadership.py:12:1: F401 'uuid.uuid4' imported but unused
+src/devsynth/domain/models/wsde_context_driven_leadership.py:17:1: F401 'devsynth.methodology.base.Phase' imported but unused
+src/devsynth/domain/models/wsde_context_driven_leadership.py:182:89: E501 line too long (90 > 88 characters)
+src/devsynth/domain/models/wsde_context_driven_leadership.py:240:89: E501 line too long (93 > 88 characters)
+src/devsynth/domain/models/wsde_context_driven_leadership.py:246:89: E501 line too long (95 > 88 characters)
+src/devsynth/domain/models/wsde_context_driven_leadership.py:328:89: E501 line too long (99 > 88 characters)
+src/devsynth/domain/models/wsde_context_driven_leadership.py:464:89: E501 line too long (90 > 88 characters)
+src/devsynth/domain/models/wsde_context_driven_leadership.py:478:89: E501 line too long (92 > 88 characters)
+src/devsynth/domain/models/wsde_decision_making.py:9:1: F401 'typing.Optional' imported but unused
+src/devsynth/domain/models/wsde_decision_making.py:65:89: E501 line too long (95 > 88 characters)
+src/devsynth/domain/models/wsde_decision_making.py:166:89: E501 line too long (108 > 88 characters)
+src/devsynth/domain/models/wsde_decision_making.py:269:89: E501 line too long (90 > 88 characters)
+src/devsynth/domain/models/wsde_decision_making.py:363:89: E501 line too long (90 > 88 characters)
+src/devsynth/domain/models/wsde_decision_making.py:427:89: E501 line too long (93 > 88 characters)
+src/devsynth/domain/models/wsde_decision_making.py:508:89: E501 line too long (97 > 88 characters)
+src/devsynth/domain/models/wsde_decision_making.py:738:89: E501 line too long (90 > 88 characters)
+src/devsynth/domain/models/wsde_decision_making.py:863:89: E501 line too long (89 > 88 characters)
+src/devsynth/domain/models/wsde_decision_making.py:925:89: E501 line too long (99 > 88 characters)
+src/devsynth/domain/models/wsde_decision_making.py:937:89: E501 line too long (115 > 88 characters)
+src/devsynth/domain/models/wsde_decision_making.py:962:89: E501 line too long (128 > 88 characters)
+src/devsynth/domain/models/wsde_decision_making.py:1016:89: E501 line too long (110 > 88 characters)
+src/devsynth/domain/models/wsde_decision_making.py:1050:89: E501 line too long (116 > 88 characters)
+src/devsynth/domain/models/wsde_decision_making.py:1070:89: E501 line too long (112 > 88 characters)
+src/devsynth/domain/models/wsde_decision_making.py:1093:89: E501 line too long (91 > 88 characters)
+src/devsynth/domain/models/wsde_decision_making.py:1111:89: E501 line too long (92 > 88 characters)
+src/devsynth/domain/models/wsde_decision_making.py:1118:89: E501 line too long (105 > 88 characters)
+src/devsynth/domain/models/wsde_decision_making.py:1137:89: E501 line too long (144 > 88 characters)
+src/devsynth/domain/models/wsde_decision_making.py:1172:89: E501 line too long (107 > 88 characters)
+src/devsynth/domain/models/wsde_decision_making.py:1179:89: E501 line too long (108 > 88 characters)
+src/devsynth/domain/models/wsde_decision_making.py:1202:89: E501 line too long (107 > 88 characters)
+src/devsynth/domain/models/wsde_decision_making.py:1220:89: E501 line too long (93 > 88 characters)
+src/devsynth/domain/models/wsde_decision_making.py:1227:89: E501 line too long (132 > 88 characters)
+src/devsynth/domain/models/wsde_decision_making.py:1258:89: E501 line too long (133 > 88 characters)
+src/devsynth/domain/models/wsde_decision_making.py:1265:89: E501 line too long (91 > 88 characters)
+src/devsynth/domain/models/wsde_decision_making.py:1288:89: E501 line too long (91 > 88 characters)
+src/devsynth/domain/models/wsde_decision_making.py:1295:89: E501 line too long (119 > 88 characters)
+src/devsynth/domain/models/wsde_dialectical.py:11:1: F401 'typing.Dict' imported but unused
+src/devsynth/domain/models/wsde_dialectical.py:11:1: F401 'typing.List' imported but unused
+src/devsynth/domain/models/wsde_dialectical.py:11:1: F401 'typing.Optional' imported but unused
+src/devsynth/domain/models/wsde_dialectical.py:404:89: E501 line too long (101 > 88 characters)
+src/devsynth/domain/models/wsde_dialectical.py:405:89: E501 line too long (112 > 88 characters)
+src/devsynth/domain/models/wsde_dialectical.py:542:89: E501 line too long (125 > 88 characters)
+src/devsynth/domain/models/wsde_dialectical.py:563:89: E501 line too long (122 > 88 characters)
+src/devsynth/domain/models/wsde_dialectical.py:584:89: E501 line too long (133 > 88 characters)
+src/devsynth/domain/models/wsde_dialectical.py:598:25: F541 f-string is missing placeholders
+src/devsynth/domain/models/wsde_dialectical.py:736:89: E501 line too long (137 > 88 characters)
+src/devsynth/domain/models/wsde_dialectical.py:743:89: E501 line too long (128 > 88 characters)
+src/devsynth/domain/models/wsde_dialectical.py:781:89: E501 line too long (101 > 88 characters)
+src/devsynth/domain/models/wsde_dialectical.py:888:89: E501 line too long (117 > 88 characters)
+src/devsynth/domain/models/wsde_dialectical.py:991:89: E501 line too long (108 > 88 characters)
+src/devsynth/domain/models/wsde_dialectical.py:1083:89: E501 line too long (113 > 88 characters)
+src/devsynth/domain/models/wsde_dialectical.py:1096:40: F541 f-string is missing placeholders
+src/devsynth/domain/models/wsde_dialectical.py:1100:89: E501 line too long (94 > 88 characters)
+src/devsynth/domain/models/wsde_dialectical.py:1112:89: E501 line too long (103 > 88 characters)
+src/devsynth/domain/models/wsde_dialectical.py:1116:44: F541 f-string is missing placeholders
+src/devsynth/domain/models/wsde_dialectical.py:1121:44: F541 f-string is missing placeholders
+src/devsynth/domain/models/wsde_dialectical.py:1211:89: E501 line too long (101 > 88 characters)
+src/devsynth/domain/models/wsde_dialectical.py:1308:89: E501 line too long (104 > 88 characters)
+src/devsynth/domain/models/wsde_dialectical.py:1310:26: F541 f-string is missing placeholders
+src/devsynth/domain/models/wsde_dialectical.py:1362:89: E501 line too long (156 > 88 characters)
+src/devsynth/domain/models/wsde_enhanced_dialectical.py:8:1: F401 're' imported but unused
+src/devsynth/domain/models/wsde_enhanced_dialectical.py:10:1: F401 'typing.Optional' imported but unused
+src/devsynth/domain/models/wsde_enhanced_dialectical.py:307:89: E501 line too long (102 > 88 characters)
+src/devsynth/domain/models/wsde_enhanced_dialectical.py:317:89: E501 line too long (90 > 88 characters)
+src/devsynth/domain/models/wsde_enhanced_dialectical.py:351:89: E501 line too long (89 > 88 characters)
+src/devsynth/domain/models/wsde_enhanced_dialectical.py:516:37: F541 f-string is missing placeholders
+src/devsynth/domain/models/wsde_enhanced_dialectical.py:520:37: F541 f-string is missing placeholders
+src/devsynth/domain/models/wsde_enhanced_dialectical.py:524:37: F541 f-string is missing placeholders
+src/devsynth/domain/models/wsde_enhanced_dialectical.py:528:37: F541 f-string is missing placeholders
+src/devsynth/domain/models/wsde_enhanced_dialectical.py:532:37: F541 f-string is missing placeholders
+src/devsynth/domain/models/wsde_enhanced_dialectical.py:536:37: F541 f-string is missing placeholders
+src/devsynth/domain/models/wsde_enhanced_dialectical.py:540:37: F541 f-string is missing placeholders
+src/devsynth/domain/models/wsde_enhanced_dialectical.py:544:37: F541 f-string is missing placeholders
+src/devsynth/domain/models/wsde_enhanced_dialectical.py:647:89: E501 line too long (135 > 88 characters)
+src/devsynth/domain/models/wsde_enhanced_dialectical.py:667:89: E501 line too long (132 > 88 characters)
+src/devsynth/domain/models/wsde_enhanced_dialectical.py:673:89: E501 line too long (89 > 88 characters)
+src/devsynth/domain/models/wsde_enhanced_dialectical.py:682:89: E501 line too long (128 > 88 characters)
+src/devsynth/domain/models/wsde_enhanced_dialectical.py:690:89: E501 line too long (100 > 88 characters)
+src/devsynth/domain/models/wsde_enhanced_dialectical.py:692:23: F541 f-string is missing placeholders
+src/devsynth/domain/models/wsde_enhanced_dialectical.py:734:89: E501 line too long (240 > 88 characters)
+src/devsynth/domain/models/wsde_facade.py:11:1: F401 'typing.Any' imported but unused
+src/devsynth/domain/models/wsde_knowledge.py:15:1: F401 'typing.List' imported but unused
+src/devsynth/domain/models/wsde_knowledge.py:15:1: F401 'typing.Optional' imported but unused
+src/devsynth/domain/models/wsde_knowledge.py:51:89: E501 line too long (101 > 88 characters)
+src/devsynth/domain/models/wsde_knowledge.py:145:89: E501 line too long (101 > 88 characters)
+src/devsynth/domain/models/wsde_knowledge.py:233:89: E501 line too long (93 > 88 characters)
+src/devsynth/domain/models/wsde_knowledge.py:256:89: E501 line too long (107 > 88 characters)
+src/devsynth/domain/models/wsde_knowledge.py:262:89: E501 line too long (106 > 88 characters)
+src/devsynth/domain/models/wsde_knowledge.py:506:89: E501 line too long (102 > 88 characters)
+src/devsynth/domain/models/wsde_knowledge.py:597:89: E501 line too long (119 > 88 characters)
+src/devsynth/domain/models/wsde_knowledge.py:599:89: E501 line too long (141 > 88 characters)
+src/devsynth/domain/models/wsde_knowledge.py:601:89: E501 line too long (142 > 88 characters)
+src/devsynth/domain/models/wsde_knowledge.py:603:89: E501 line too long (121 > 88 characters)
+src/devsynth/domain/models/wsde_knowledge.py:898:89: E501 line too long (95 > 88 characters)
+src/devsynth/domain/models/wsde_knowledge.py:1135:89: E501 line too long (94 > 88 characters)
+src/devsynth/domain/models/wsde_knowledge.py:1140:89: E501 line too long (94 > 88 characters)
+src/devsynth/domain/models/wsde_knowledge.py:1338:89: E501 line too long (119 > 88 characters)
+src/devsynth/domain/models/wsde_knowledge.py:1341:89: E501 line too long (110 > 88 characters)
+src/devsynth/domain/models/wsde_knowledge.py:1436:89: E501 line too long (90 > 88 characters)
+src/devsynth/domain/models/wsde_knowledge.py:1465:89: E501 line too long (99 > 88 characters)
+src/devsynth/domain/models/wsde_knowledge.py:1469:89: E501 line too long (94 > 88 characters)
+src/devsynth/domain/models/wsde_knowledge.py:1473:89: E501 line too long (97 > 88 characters)
+src/devsynth/domain/models/wsde_knowledge.py:1534:89: E501 line too long (131 > 88 characters)
+src/devsynth/domain/models/wsde_knowledge.py:1536:89: E501 line too long (143 > 88 characters)
+src/devsynth/domain/models/wsde_knowledge.py:1538:89: E501 line too long (132 > 88 characters)
+src/devsynth/domain/models/wsde_knowledge.py:1540:89: E501 line too long (135 > 88 characters)
+src/devsynth/domain/models/wsde_multidisciplinary.py:12:1: F401 're' imported but unused
+src/devsynth/domain/models/wsde_multidisciplinary.py:14:1: F401 'typing.Optional' imported but unused
+src/devsynth/domain/models/wsde_multidisciplinary.py:50:89: E501 line too long (89 > 88 characters)
+src/devsynth/domain/models/wsde_multidisciplinary.py:210:89: E501 line too long (96 > 88 characters)
+src/devsynth/domain/models/wsde_multidisciplinary.py:216:89: E501 line too long (89 > 88 characters)
+src/devsynth/domain/models/wsde_multidisciplinary.py:228:89: E501 line too long (119 > 88 characters)
+src/devsynth/domain/models/wsde_multidisciplinary.py:229:89: E501 line too long (108 > 88 characters)
+src/devsynth/domain/models/wsde_multidisciplinary.py:433:89: E501 line too long (125 > 88 characters)
+src/devsynth/domain/models/wsde_multidisciplinary.py:462:89: E501 line too long (114 > 88 characters)
+src/devsynth/domain/models/wsde_multidisciplinary.py:491:89: E501 line too long (118 > 88 characters)
+src/devsynth/domain/models/wsde_multidisciplinary.py:520:89: E501 line too long (125 > 88 characters)
+src/devsynth/domain/models/wsde_multidisciplinary.py:549:89: E501 line too long (127 > 88 characters)
+src/devsynth/domain/models/wsde_multidisciplinary.py:632:89: E501 line too long (90 > 88 characters)
+src/devsynth/domain/models/wsde_multidisciplinary.py:752:89: E501 line too long (94 > 88 characters)
+src/devsynth/domain/models/wsde_multidisciplinary.py:762:89: E501 line too long (98 > 88 characters)
+src/devsynth/domain/models/wsde_multidisciplinary.py:776:89: E501 line too long (93 > 88 characters)
+src/devsynth/domain/models/wsde_multidisciplinary.py:848:17: F541 f-string is missing placeholders
+src/devsynth/domain/models/wsde_multidisciplinary.py:848:89: E501 line too long (133 > 88 characters)
+src/devsynth/domain/models/wsde_multidisciplinary.py:852:17: F541 f-string is missing placeholders
+src/devsynth/domain/models/wsde_multidisciplinary.py:852:89: E501 line too long (125 > 88 characters)
+src/devsynth/domain/models/wsde_multidisciplinary.py:856:17: F541 f-string is missing placeholders
+src/devsynth/domain/models/wsde_multidisciplinary.py:856:89: E501 line too long (133 > 88 characters)
+src/devsynth/domain/models/wsde_multidisciplinary.py:860:17: F541 f-string is missing placeholders
+src/devsynth/domain/models/wsde_multidisciplinary.py:860:89: E501 line too long (132 > 88 characters)
+src/devsynth/domain/models/wsde_multidisciplinary.py:864:17: F541 f-string is missing placeholders
+src/devsynth/domain/models/wsde_multidisciplinary.py:864:89: E501 line too long (118 > 88 characters)
+src/devsynth/domain/models/wsde_multidisciplinary.py:868:17: F541 f-string is missing placeholders
+src/devsynth/domain/models/wsde_multidisciplinary.py:868:89: E501 line too long (122 > 88 characters)
+src/devsynth/domain/models/wsde_multidisciplinary.py:872:17: F541 f-string is missing placeholders
+src/devsynth/domain/models/wsde_multidisciplinary.py:872:89: E501 line too long (114 > 88 characters)
+src/devsynth/domain/models/wsde_multidisciplinary.py:876:89: E501 line too long (134 > 88 characters)
+src/devsynth/domain/models/wsde_multidisciplinary.py:1033:89: E501 line too long (133 > 88 characters)
+src/devsynth/domain/models/wsde_multidisciplinary.py:1035:89: E501 line too long (156 > 88 characters)
+src/devsynth/domain/models/wsde_multidisciplinary.py:1037:89: E501 line too long (153 > 88 characters)
+src/devsynth/domain/models/wsde_multidisciplinary.py:1039:89: E501 line too long (134 > 88 characters)
+src/devsynth/domain/models/wsde_multidisciplinary.py:1050:89: E501 line too long (136 > 88 characters)
+src/devsynth/domain/models/wsde_multidisciplinary.py:1056:89: E501 line too long (101 > 88 characters)
+src/devsynth/domain/models/wsde_solution_analysis.py:10:1: F401 'typing.Optional' imported but unused
+src/devsynth/domain/models/wsde_solution_analysis.py:62:89: E501 line too long (126 > 88 characters)
+src/devsynth/domain/models/wsde_solution_analysis.py:78:89: E501 line too long (125 > 88 characters)
+src/devsynth/domain/models/wsde_solution_analysis.py:99:89: E501 line too long (89 > 88 characters)
+src/devsynth/domain/models/wsde_solution_analysis.py:117:89: E501 line too long (98 > 88 characters)
+src/devsynth/domain/models/wsde_solution_analysis.py:205:89: E501 line too long (104 > 88 characters)
+src/devsynth/domain/models/wsde_solution_analysis.py:255:89: E501 line too long (103 > 88 characters)
+src/devsynth/domain/models/wsde_solution_analysis.py:320:89: E501 line too long (92 > 88 characters)
+src/devsynth/domain/models/wsde_solution_analysis.py:360:89: E501 line too long (91 > 88 characters)
+src/devsynth/domain/models/wsde_solution_analysis.py:361:89: E501 line too long (89 > 88 characters)
+src/devsynth/domain/models/wsde_solution_analysis.py:413:89: E501 line too long (214 > 88 characters)
+src/devsynth/domain/models/wsde_solution_analysis.py:441:89: E501 line too long (92 > 88 characters)
+src/devsynth/domain/models/wsde_solution_analysis.py:454:89: E501 line too long (89 > 88 characters)
+src/devsynth/domain/models/wsde_solution_analysis.py:478:89: E501 line too long (219 > 88 characters)
+src/devsynth/domain/models/wsde_solution_analysis.py:509:89: E501 line too long (389 > 88 characters)
+src/devsynth/domain/models/wsde_summarization.py:79:89: E501 line too long (90 > 88 characters)
+src/devsynth/domain/models/wsde_utils.py:9:1: F401 'datetime.datetime' imported but unused
+src/devsynth/domain/models/wsde_voting.py:169:5: F841 local variable 'options' is assigned to but never used
+src/devsynth/domain/models/wsde_voting.py:186:89: E501 line too long (90 > 88 characters)
+src/devsynth/domain/models/wsde_voting.py:242:89: E501 line too long (89 > 88 characters)
+src/devsynth/domain/models/wsde_voting.py:296:89: E501 line too long (93 > 88 characters)
+src/devsynth/domain/models/wsde_voting.py:300:89: E501 line too long (105 > 88 characters)
+src/devsynth/domain/models/wsde_voting.py:340:89: E501 line too long (110 > 88 characters)
+src/devsynth/domain/models/wsde_voting.py:344:89: E501 line too long (98 > 88 characters)
+src/devsynth/domain/models/wsde_voting.py:438:5: F841 local variable 'domain' is assigned to but never used
+src/devsynth/domain/models/wsde_voting.py:522:89: E501 line too long (104 > 88 characters)
+src/devsynth/domain/models/wsde_voting.py:527:89: E501 line too long (101 > 88 characters)
+src/devsynth/domain/models/wsde_voting.py:534:89: E501 line too long (99 > 88 characters)
+src/devsynth/domain/models/wsde_voting.py:574:89: E501 line too long (89 > 88 characters)
+src/devsynth/domain/models/wsde_voting.py:592:89: E501 line too long (100 > 88 characters)
+src/devsynth/domain/models/wsde_voting.py:597:89: E501 line too long (99 > 88 characters)
+src/devsynth/exceptions.py:687:9: F841 local variable 'details' is assigned to but never used
+src/devsynth/exceptions.py:722:9: F841 local variable 'details' is assigned to but never used
+src/devsynth/exceptions.py:891:5: F811 redefinition of unused 'logging' from line 8
+src/devsynth/fallback.py:10:1: F401 'queue' imported but unused
+src/devsynth/fallback.py:131:89: E501 line too long (90 > 88 characters)
+src/devsynth/fallback.py:132:89: E501 line too long (95 > 88 characters)
+src/devsynth/fallback.py:210:89: E501 line too long (104 > 88 characters)
+src/devsynth/fallback.py:226:89: E501 line too long (97 > 88 characters)
+src/devsynth/fallback.py:357:89: E501 line too long (116 > 88 characters)
+src/devsynth/fallback.py:388:89: E501 line too long (119 > 88 characters)
+src/devsynth/fallback.py:434:89: E501 line too long (95 > 88 characters)
+src/devsynth/fallback.py:452:89: E501 line too long (95 > 88 characters)
+src/devsynth/fallback.py:484:89: E501 line too long (89 > 88 characters)
+src/devsynth/fallback.py:496:89: E501 line too long (97 > 88 characters)
+src/devsynth/fallback.py:531:89: E501 line too long (101 > 88 characters)
+src/devsynth/fallback.py:588:89: E501 line too long (140 > 88 characters)
+src/devsynth/fallback.py:625:89: E501 line too long (93 > 88 characters)
+src/devsynth/fallback.py:644:89: E501 line too long (97 > 88 characters)
+src/devsynth/fallback.py:656:89: E501 line too long (103 > 88 characters)
+src/devsynth/fallback.py:927:89: E501 line too long (95 > 88 characters)
+src/devsynth/fallback.py:963:89: E501 line too long (105 > 88 characters)
+src/devsynth/fallback.py:981:89: E501 line too long (99 > 88 characters)
+src/devsynth/feature_markers.py:179:1: F811 redefinition of unused 'feature_doctor_command' from line 173
+src/devsynth/feature_markers.py:1012:1: E402 module level import not at top of file
+src/devsynth/feature_markers.py:1013:1: E402 module level import not at top of file
+src/devsynth/feature_markers.py:1016:1: E402 module level import not at top of file
+src/devsynth/feature_markers.py:1017:1: E402 module level import not at top of file
+src/devsynth/interface/agentapi.py:13:1: F401 'datetime' imported but unused
+src/devsynth/interface/agentapi.py:14:1: F401 'os' imported but unused
+src/devsynth/interface/agentapi.py:16:1: F401 'typing.Any' imported but unused
+src/devsynth/interface/agentapi.py:20:1: F401 'pydantic.Field' imported but unused
+src/devsynth/interface/agentapi.py:217:89: E501 line too long (175 > 88 characters)
+src/devsynth/interface/agentapi.py:273:89: E501 line too long (94 > 88 characters)
+src/devsynth/interface/agentapi.py:337:89: E501 line too long (249 > 88 characters)
+src/devsynth/interface/agentapi.py:358:89: E501 line too long (92 > 88 characters)
+src/devsynth/interface/agentapi.py:923:89: E501 line too long (97 > 88 characters)
+src/devsynth/interface/agentapi.py:931:89: E501 line too long (93 > 88 characters)
+src/devsynth/interface/agentapi.py:934:89: E501 line too long (94 > 88 characters)
+src/devsynth/interface/agentapi.py:937:89: E501 line too long (94 > 88 characters)
+src/devsynth/interface/agentapi_enhanced.py:13:1: F401 'datetime' imported but unused
+src/devsynth/interface/agentapi_enhanced.py:18:1: F401 'fastapi.Header' imported but unused
+src/devsynth/interface/agentapi_enhanced.py:151:89: E501 line too long (103 > 88 characters)
+src/devsynth/interface/agentapi_enhanced.py:728:89: E501 line too long (94 > 88 characters)
+src/devsynth/interface/agentapi_enhanced.py:1203:89: E501 line too long (92 > 88 characters)
+src/devsynth/interface/agentapi_enhanced.py:1364:89: E501 line too long (97 > 88 characters)
+src/devsynth/interface/agentapi_enhanced.py:1372:89: E501 line too long (93 > 88 characters)
+src/devsynth/interface/agentapi_enhanced.py:1375:89: E501 line too long (94 > 88 characters)
+src/devsynth/interface/agentapi_enhanced.py:1378:89: E501 line too long (94 > 88 characters)
+src/devsynth/interface/cli.py:7:1: F401 'rich.markdown.Markdown' imported but unused
+src/devsynth/interface/cli.py:8:1: F401 'rich.panel.Panel' imported but unused
+src/devsynth/interface/cli.py:19:1: F401 'rich.style.Style' imported but unused
+src/devsynth/interface/cli.py:24:1: F401 'devsynth.interface.output_formatter.OutputFormatter' imported but unused
+src/devsynth/interface/cli.py:101:89: E501 line too long (111 > 88 characters)
+src/devsynth/interface/cli.py:621:89: E501 line too long (90 > 88 characters)
+src/devsynth/interface/command_output.py:124:89: E501 line too long (102 > 88 characters)
+src/devsynth/interface/command_output.py:128:89: E501 line too long (103 > 88 characters)
+src/devsynth/interface/command_output.py:130:89: E501 line too long (105 > 88 characters)
+src/devsynth/interface/dpg_bridge.py:20:1: E402 module level import not at top of file
+src/devsynth/interface/dpg_bridge.py:21:1: E402 module level import not at top of file
+src/devsynth/interface/dpg_ui.py:102:89: E501 line too long (90 > 88 characters)
+src/devsynth/interface/enhanced_error_handler.py:89:89: E501 line too long (96 > 88 characters)
+src/devsynth/interface/enhanced_error_handler.py:119:89: E501 line too long (94 > 88 characters)
+src/devsynth/interface/enhanced_error_handler.py:150:89: E501 line too long (90 > 88 characters)
+src/devsynth/interface/enhanced_error_handler.py:182:89: E501 line too long (100 > 88 characters)
+src/devsynth/interface/enhanced_error_handler.py:229:89: E501 line too long (94 > 88 characters)
+src/devsynth/interface/enhanced_error_handler.py:233:89: E501 line too long (100 > 88 characters)
+src/devsynth/interface/enhanced_error_handler.py:258:89: E501 line too long (92 > 88 characters)
+src/devsynth/interface/enhanced_error_handler.py:316:89: E501 line too long (98 > 88 characters)
+src/devsynth/interface/enhanced_error_handler.py:331:89: E501 line too long (99 > 88 characters)
+src/devsynth/interface/enhanced_error_handler.py:346:89: E501 line too long (91 > 88 characters)
+src/devsynth/interface/enhanced_error_handler.py:356:89: E501 line too long (99 > 88 characters)
+src/devsynth/interface/enhanced_error_handler.py:427:48: F541 f-string is missing placeholders
+src/devsynth/interface/enhanced_error_handler.py:431:48: F541 f-string is missing placeholders
+src/devsynth/interface/enhanced_error_handler.py:435:48: F541 f-string is missing placeholders
+src/devsynth/interface/enhanced_error_handler.py:439:48: F541 f-string is missing placeholders
+src/devsynth/interface/enhanced_error_handler.py:508:89: E501 line too long (93 > 88 characters)
+src/devsynth/interface/error_handler.py:9:1: F401 'inspect' imported but unused
+src/devsynth/interface/error_handler.py:15:1: F401 'rich.markdown.Markdown' imported but unused
+src/devsynth/interface/error_handler.py:64:89: E501 line too long (91 > 88 characters)
+src/devsynth/interface/error_handler.py:73:89: E501 line too long (111 > 88 characters)
+src/devsynth/interface/error_handler.py:82:89: E501 line too long (108 > 88 characters)
+src/devsynth/interface/error_handler.py:100:89: E501 line too long (91 > 88 characters)
+src/devsynth/interface/error_handler.py:109:89: E501 line too long (108 > 88 characters)
+src/devsynth/interface/error_handler.py:209:89: E501 line too long (97 > 88 characters)
+src/devsynth/interface/nicegui_webui.py:67:89: E501 line too long (105 > 88 characters)
+src/devsynth/interface/output_formatter.py:7:1: F401 'html' imported but unused
+src/devsynth/interface/output_formatter.py:10:1: F401 'textwrap' imported but unused
+src/devsynth/interface/output_formatter.py:12:1: F401 'typing.Tuple' imported but unused
+src/devsynth/interface/output_formatter.py:15:1: F401 'rich.box.Box' imported but unused
+src/devsynth/interface/output_formatter.py:19:1: F401 'rich.style.Style' imported but unused
+src/devsynth/interface/output_formatter.py:129:89: E501 line too long (91 > 88 characters)
+src/devsynth/interface/output_formatter.py:209:89: E501 line too long (93 > 88 characters)
+src/devsynth/interface/progress_utils.py:10:1: F401 'typing.Union' imported but unused
+src/devsynth/interface/shared_bridge.py:28:89: E501 line too long (92 > 88 characters)
+src/devsynth/interface/simple_run.py:22:89: E501 line too long (94 > 88 characters)
+src/devsynth/interface/state_access.py:8:1: F401 'typing.Optional' imported but unused
+src/devsynth/interface/ux_bridge.py:116:89: E501 line too long (90 > 88 characters)
+src/devsynth/interface/uxbridge_config.py:9:1: F401 'typing.Dict' imported but unused
+src/devsynth/interface/webui.py:56:89: E501 line too long (96 > 88 characters)
+src/devsynth/interface/webui.py:70:1: E402 module level import not at top of file
+src/devsynth/interface/webui.py:71:1: E402 module level import not at top of file
+src/devsynth/interface/webui.py:72:1: E402 module level import not at top of file
+src/devsynth/interface/webui.py:73:1: E402 module level import not at top of file
+src/devsynth/interface/webui.py:74:1: E402 module level import not at top of file
+src/devsynth/interface/webui.py:75:1: E402 module level import not at top of file
+src/devsynth/interface/webui.py:86:5: F811 redefinition of unused 'importlib' from line 31
+src/devsynth/interface/webui.py:379:89: E501 line too long (93 > 88 characters)
+src/devsynth/interface/webui.py:581:89: E501 line too long (97 > 88 characters)
+src/devsynth/interface/webui.py:584:89: E501 line too long (102 > 88 characters)
+src/devsynth/interface/webui.py:585:89: E501 line too long (89 > 88 characters)
+src/devsynth/interface/webui.py:596:89: E501 line too long (98 > 88 characters)
+src/devsynth/interface/webui.py:603:89: E501 line too long (117 > 88 characters)
+src/devsynth/interface/webui.py:607:89: E501 line too long (111 > 88 characters)
+src/devsynth/interface/webui.py:611:89: E501 line too long (97 > 88 characters)
+src/devsynth/interface/webui.py:619:89: E501 line too long (101 > 88 characters)
+src/devsynth/interface/webui.py:623:89: E501 line too long (103 > 88 characters)
+src/devsynth/interface/webui.py:681:89: E501 line too long (120 > 88 characters)
+src/devsynth/interface/webui.py:790:89: E501 line too long (110 > 88 characters)
+src/devsynth/interface/webui.py:1096:89: E501 line too long (91 > 88 characters)
+src/devsynth/interface/webui.py:1124:89: E501 line too long (98 > 88 characters)
+src/devsynth/interface/webui.py:1152:89: E501 line too long (106 > 88 characters)
+src/devsynth/interface/webui.py:1312:89: E501 line too long (94 > 88 characters)
+src/devsynth/interface/webui.py:1371:89: E501 line too long (93 > 88 characters)
+src/devsynth/interface/webui.py:1588:89: E501 line too long (92 > 88 characters)
+src/devsynth/interface/webui.py:1703:89: E501 line too long (92 > 88 characters)
+src/devsynth/interface/webui.py:1741:89: E501 line too long (96 > 88 characters)
+src/devsynth/interface/webui.py:1778:89: E501 line too long (94 > 88 characters)
+src/devsynth/interface/webui.py:1779:89: E501 line too long (102 > 88 characters)
+src/devsynth/interface/webui.py:1801:89: E501 line too long (89 > 88 characters)
+src/devsynth/interface/webui.py:1855:89: E501 line too long (92 > 88 characters)
+src/devsynth/interface/webui.py:1884:89: E501 line too long (89 > 88 characters)
+src/devsynth/interface/webui.py:1912:89: E501 line too long (92 > 88 characters)
+src/devsynth/interface/webui.py:1940:89: E501 line too long (92 > 88 characters)
+src/devsynth/interface/webui.py:2313:89: E501 line too long (137 > 88 characters)
+src/devsynth/interface/webui_bridge.py:9:1: E402 module level import not at top of file
+src/devsynth/interface/webui_bridge.py:10:1: E402 module level import not at top of file
+src/devsynth/interface/webui_bridge.py:11:1: E402 module level import not at top of file
+src/devsynth/interface/webui_bridge.py:12:1: E402 module level import not at top of file
+src/devsynth/interface/webui_bridge.py:14:1: F401 '.output_formatter.OutputFormatter' imported but unused
+src/devsynth/interface/webui_bridge.py:14:1: E402 module level import not at top of file
+src/devsynth/interface/webui_bridge.py:15:1: E402 module level import not at top of file
+src/devsynth/interface/webui_bridge.py:16:1: E402 module level import not at top of file
+src/devsynth/interface/webui_bridge.py:36:89: E501 line too long (89 > 88 characters)
+src/devsynth/interface/webui_bridge.py:413:89: E501 line too long (97 > 88 characters)
+src/devsynth/interface/webui_setup.py:26:89: E501 line too long (93 > 88 characters)
+src/devsynth/interface/webui_state.py:9:1: F401 'logging' imported but unused
+src/devsynth/interface/wizard_state_manager.py:8:1: F401 'logging' imported but unused
+src/devsynth/interface/wizard_state_manager.py:13:1: F401 'devsynth.interface.state_access.set_session_value' imported but unused
+src/devsynth/interface/wizard_state_manager.py:111:89: E501 line too long (90 > 88 characters)
+src/devsynth/logger.py:42:89: E501 line too long (92 > 88 characters)
+src/devsynth/logging_setup.py:17:1: F401 'typing.List' imported but unused
+src/devsynth/logging_setup.py:17:1: F401 'typing.Union' imported but unused
+src/devsynth/logging_setup.py:58:89: E501 line too long (89 > 88 characters)
+src/devsynth/logging_setup.py:241:89: E501 line too long (91 > 88 characters)
+src/devsynth/logging_setup.py:249:89: E501 line too long (102 > 88 characters)
+src/devsynth/logging_setup.py:269:89: E501 line too long (110 > 88 characters)
+src/devsynth/logging_setup.py:325:89: E501 line too long (97 > 88 characters)
+src/devsynth/logging_setup.py:400:89: E501 line too long (90 > 88 characters)
+src/devsynth/logging_setup.py:440:89: E501 line too long (109 > 88 characters)
+src/devsynth/logging_setup.py:464:89: E501 line too long (96 > 88 characters)
+src/devsynth/memory/layered_cache.py:28:89: E501 line too long (94 > 88 characters)
+src/devsynth/memory/layered_cache.py:51:89: E501 line too long (108 > 88 characters)
+src/devsynth/methodology/adhoc.py:8:1: F401 'typing.Optional' imported but unused
+src/devsynth/methodology/adhoc.py:264:89: E501 line too long (116 > 88 characters)
+src/devsynth/methodology/adhoc.py:268:89: E501 line too long (113 > 88 characters)
+src/devsynth/methodology/base.py:9:1: F401 'typing.Optional' imported but unused
+src/devsynth/methodology/base.py:9:1: F401 'typing.Union' imported but unused
+src/devsynth/methodology/edrr/reasoning_loop.py:6:89: E501 line too long (113 > 88 characters)
+src/devsynth/methodology/milestone.py:3:89: E501 line too long (89 > 88 characters)
+src/devsynth/methodology/sprint.py:8:1: F401 'time' imported but unused
+src/devsynth/methodology/sprint.py:223:9: F841 local variable 'retrospect_results' is assigned to but never used
+src/devsynth/methodology/sprint.py:319:89: E501 line too long (92 > 88 characters)
+src/devsynth/methodology/sprint.py:440:89: E501 line too long (108 > 88 characters)
+src/devsynth/orchestration/step_executor.py:12:1: F401 'typing.Dict' imported but unused
+src/devsynth/orchestration/step_executor.py:44:89: E501 line too long (90 > 88 characters)
+src/devsynth/ports/__init__.py:19:1: F401 'devsynth.exceptions.DevSynthError' imported but unused
+src/devsynth/ports/__init__.py:19:1: E402 module level import not at top of file
+src/devsynth/ports/agent_port.py:1:1: F401 'typing.List' imported but unused
+src/devsynth/ports/agent_port.py:1:1: F401 'typing.Optional' imported but unused
+src/devsynth/ports/agent_port.py:7:1: F401 '..domain.models.agent.AgentConfig' imported but unused
+src/devsynth/ports/agent_port.py:10:1: F401 'devsynth.exceptions.DevSynthError' imported but unused
+src/devsynth/ports/agent_port.py:10:1: E402 module level import not at top of file
+src/devsynth/ports/cli_port.py:9:1: F401 'devsynth.exceptions.DevSynthError' imported but unused
+src/devsynth/ports/cli_port.py:9:1: E402 module level import not at top of file
+src/devsynth/ports/llm_port.py:1:1: F401 'typing.Optional' imported but unused
+src/devsynth/ports/llm_port.py:13:1: E402 module level import not at top of file
+src/devsynth/ports/llm_port.py:97:35: F541 f-string is missing placeholders
+src/devsynth/ports/memory_port.py:11:1: F401 'devsynth.exceptions.DevSynthError' imported but unused
+src/devsynth/ports/memory_port.py:11:1: E402 module level import not at top of file
+src/devsynth/ports/memory_store.py:8:89: E501 line too long (97 > 88 characters)
+src/devsynth/ports/orchestration_port.py:1:1: F401 'typing.List' imported but unused
+src/devsynth/ports/orchestration_port.py:1:1: F401 'typing.Optional' imported but unused
+src/devsynth/ports/orchestration_port.py:10:1: F401 'devsynth.exceptions.DevSynthError' imported but unused
+src/devsynth/ports/orchestration_port.py:10:1: E402 module level import not at top of file
+src/devsynth/ports/requirement_port.py:6:1: F401 'typing.Dict' imported but unused
+src/devsynth/ports/requirement_port.py:6:1: F401 'typing.Union' imported but unused
+src/devsynth/ports/vector_store_port.py:5:1: F401 'typing.Union' imported but unused
+src/devsynth/ports/vector_store_port.py:11:1: F401 '..domain.models.memory.MemoryItem' imported but unused
+src/devsynth/ports/vector_store_port.py:14:1: F401 'devsynth.exceptions.DevSynthError' imported but unused
+src/devsynth/ports/vector_store_port.py:14:1: E402 module level import not at top of file
+src/devsynth/security/encryption.py:6:89: E501 line too long (97 > 88 characters)
+src/devsynth/testing/prompts.py:9:89: E501 line too long (96 > 88 characters)
+src/devsynth/testing/prompts.py:10:89: E501 line too long (109 > 88 characters)
+src/devsynth/testing/prompts.py:11:89: E501 line too long (103 > 88 characters)
+src/devsynth/testing/prompts.py:14:89: E501 line too long (101 > 88 characters)
+src/devsynth/testing/prompts.py:15:89: E501 line too long (94 > 88 characters)
+src/devsynth/utils/logging.py:12:89: E501 line too long (92 > 88 characters)
+tests/__init__.py:41:89: E501 line too long (91 > 88 characters)
+tests/behavior/steps/test_ast_code_analysis_steps.py:420:5: F841 local variable 'item_id' is assigned to but never used
+tests/behavior/steps/test_code_transformer_steps.py:182:24: F821 undefined name 'name'
+tests/behavior/steps/test_config_enable_feature_steps.py:11:1: F403 'from .cli_commands_steps import *' used; unable to detect undefined names
+tests/behavior/steps/test_config_enable_feature_steps.py:42:12: F405 'run_command' may be undefined, or defined from star imports: .cli_commands_steps
+tests/behavior/steps/test_cross_interface_consistency_extended_steps.py:288:9: F841 local variable 'st' is assigned to but never used
+tests/behavior/steps/test_documentation_ingestion_steps.py:611:5: F841 local variable 'keyword_results' is assigned to but never used
+tests/behavior/steps/test_documentation_ingestion_steps.py:622:5: F841 local variable 'structured_results' is assigned to but never used
+tests/behavior/steps/test_edrr_coordinator_steps.py:148:52: F821 undefined name 'test_store_method_succeeds'
+tests/behavior/steps/test_edrr_coordinator_steps.py:244:52: F821 undefined name 'test_store_method_succeeds'
+tests/behavior/steps/test_edrr_coordinator_steps.py:277:52: F821 undefined name 'test_store_method_succeeds'
+tests/behavior/steps/test_edrr_coordinator_steps.py:619:52: F821 undefined name 'test_store_method_succeeds'
+tests/behavior/steps/test_edrr_enhanced_memory_integration_steps.py:153:52: F821 undefined name 'test_store_method_succeeds'
+tests/behavior/steps/test_edrr_enhanced_memory_integration_steps.py:249:52: F821 undefined name 'test_store_method_succeeds'
+tests/behavior/steps/test_edrr_enhanced_memory_integration_steps.py:282:52: F821 undefined name 'test_store_method_succeeds'
+tests/behavior/steps/test_edrr_enhanced_memory_integration_steps.py:624:52: F821 undefined name 'test_store_method_succeeds'
+tests/behavior/steps/test_edrr_enhanced_phase_transitions_steps.py:155:52: F821 undefined name 'test_store_method_succeeds'
+tests/behavior/steps/test_edrr_enhanced_phase_transitions_steps.py:251:52: F821 undefined name 'test_store_method_succeeds'
+tests/behavior/steps/test_edrr_enhanced_phase_transitions_steps.py:284:52: F821 undefined name 'test_store_method_succeeds'
+tests/behavior/steps/test_edrr_enhanced_phase_transitions_steps.py:626:52: F821 undefined name 'test_store_method_succeeds'
+tests/behavior/steps/test_edrr_enhanced_phase_transitions_steps.py:1315:52: F821 undefined name 'test_store_method'
+tests/behavior/steps/test_edrr_enhanced_phase_transitions_steps.py:1466:52: F821 undefined name 'test_store_method'
+tests/behavior/steps/test_edrr_enhanced_phase_transitions_steps.py:1653:52: F821 undefined name 'test_store_method'
+tests/behavior/steps/test_edrr_enhanced_recursion_steps.py:155:52: F821 undefined name 'test_store_method_succeeds'
+tests/behavior/steps/test_edrr_enhanced_recursion_steps.py:251:52: F821 undefined name 'test_store_method_succeeds'
+tests/behavior/steps/test_edrr_enhanced_recursion_steps.py:284:52: F821 undefined name 'test_store_method_succeeds'
+tests/behavior/steps/test_edrr_enhanced_recursion_steps.py:626:52: F821 undefined name 'test_store_method_succeeds'
+tests/behavior/steps/test_edrr_enhanced_recursion_steps.py:1610:5: F841 local variable 'aggregated_results' is assigned to but never used
+tests/behavior/steps/test_enhanced_chromadb_steps.py:71:5: F841 local variable 'result' is assigned to but never used
+tests/behavior/steps/test_enhanced_chromadb_steps.py:94:5: F841 local variable 'item2' is assigned to but never used
+tests/behavior/steps/test_enhanced_chromadb_steps.py:95:5: F841 local variable 'item3' is assigned to but never used
+tests/behavior/steps/test_enhanced_dialectical_reasoning_steps.py:380:71: E712 comparison to True should be 'if cond is True:' or 'if cond:'
+tests/behavior/steps/test_enhanced_dialectical_reasoning_steps.py:1043:5: F821 undefined name 'solution_proposed_for_complex_task'
+tests/behavior/steps/test_mddr_evaluation_steps.py:334:5: F841 local variable 'disciplines' is assigned to but never used
+tests/behavior/steps/test_memory_backend_integration_steps.py:666:9: F841 local variable 'items' is assigned to but never used
+tests/behavior/steps/test_memory_backend_integration_steps.py:687:9: F841 local variable 'items' is assigned to but never used
+tests/behavior/steps/test_micro_edrr_cycle_steps.py:77:5: F841 local variable 'temp_dir' is assigned to but never used
+tests/behavior/steps/test_non_hierarchical_collaboration_steps.py:536:58: E712 comparison to True should be 'if cond is True:' or 'if cond:'
+tests/behavior/steps/test_non_hierarchical_collaboration_steps.py:551:8: F541 f-string is missing placeholders
+tests/behavior/steps/test_promise_system_steps.py:56:5: F841 local variable 'agent' is assigned to but never used
+tests/behavior/steps/test_prompt_management_steps.py:354:9: F841 local variable 'rendered' is assigned to but never used
+tests/behavior/steps/test_prompt_management_steps.py:655:59: F821 undefined name 'code'
+tests/behavior/steps/test_prompt_management_steps.py:655:69: F821 undefined name 'instructions'
+tests/behavior/steps/test_prompt_management_steps.py:827:12: F541 f-string is missing placeholders
+tests/behavior/steps/test_prompt_management_steps.py:839:16: F541 f-string is missing placeholders
+tests/behavior/steps/test_prompt_management_steps.py:976:12: F541 f-string is missing placeholders
+tests/behavior/steps/test_prompt_management_steps.py:987:12: F541 f-string is missing placeholders
+tests/behavior/steps/test_prompt_management_steps.py:992:12: F541 f-string is missing placeholders
+tests/behavior/steps/test_simple_coordinator_steps.py:154:52: F821 undefined name 'test_store_method_succeeds'
+tests/behavior/steps/test_simple_coordinator_steps.py:250:52: F821 undefined name 'test_store_method_succeeds'
+tests/behavior/steps/test_simple_coordinator_steps.py:283:52: F821 undefined name 'test_store_method_succeeds'
+tests/behavior/steps/test_simple_coordinator_steps.py:625:52: F821 undefined name 'test_store_method_succeeds'
+tests/behavior/steps/test_simple_steps.py:87:21: F841 local variable 'manifest_content' is assigned to but never used
+tests/behavior/steps/test_version_aware_documentation_steps.py:47:5: F841 local variable 'original_query' is assigned to but never used
+tests/behavior/steps/test_webui_config_steps.py:253:5: F841 local variable 'tabs' is assigned to but never used
+tests/behavior/steps/test_webui_config_steps.py:268:5: F841 local variable 'tabs' is assigned to but never used
+tests/behavior/steps/test_webui_config_steps.py:283:5: F841 local variable 'tabs' is assigned to but never used
+tests/behavior/steps/test_webui_integration_steps.py:256:5: F841 local variable 'st_mock' is assigned to but never used
+tests/behavior/steps/test_webui_integration_steps.py:397:5: F841 local variable 'cli_modules' is assigned to but never used
+tests/behavior/steps/test_webui_requirements_wizard_with_state_steps.py:132:9: F824 `nonlocal state` is unused: name is never assigned in scope
+tests/behavior/steps/test_wsde_agent_model_steps.py:276:5: F841 local variable 'python_task' is assigned to but never used
+tests/behavior/steps/test_wsde_agent_model_steps.py:489:5: F841 local variable 'task' is assigned to but never used
+tests/behavior/steps/test_wsde_memory_integration_fixed_steps.py:473:5: F841 local variable 'knowledge_graph' is assigned to but never used
+tests/behavior/steps/test_wsde_memory_integration_steps.py:476:5: F841 local variable 'knowledge_graph' is assigned to but never used
+tests/behavior/steps/test_wsde_message_passing_peer_review_steps.py:499:37: E712 comparison to True should be 'if cond is True:' or 'if cond:'
+tests/behavior/test_chromadb_integration.py:21:1: F403 'from .steps.cli_commands_steps import *' used; unable to detect undefined names
+tests/behavior/test_chromadb_integration.py:22:1: F403 'from .steps.test_chromadb_steps import *' used; unable to detect undefined names
+tests/behavior/test_cli_commands.py:10:1: F403 'from .steps.cli_commands_steps import *' used; unable to detect undefined names
+tests/behavior/test_cli_commands.py:11:1: F403 'from .steps.test_delegate_task_steps import *' used; unable to detect undefined names
+tests/behavior/test_cli_commands.py:12:1: F403 'from .steps.test_doctor_command_steps import *' used; unable to detect undefined names
+tests/behavior/test_cli_commands.py:13:1: F403 'from .steps.test_edrr_cycle_steps import *' used; unable to detect undefined names
+tests/behavior/test_cli_ux_enhancements.py:7:1: E402 module level import not at top of file
+tests/behavior/test_cli_webui_parity.py:266:5: F841 local variable 'cli' is assigned to but never used
+tests/behavior/test_config_loader.py:6:1: F403 'from .steps.test_config_loader_steps import *' used; unable to detect undefined names
+tests/behavior/test_cross_interface_consistency.py:270:5: F841 local variable 'api_bridge' is assigned to but never used
+tests/behavior/test_cross_interface_consistency.py:353:5: F841 local variable 'api_bridge' is assigned to but never used
+tests/behavior/test_cross_interface_consistency_extended.py:26:25: F811 redefinition of unused 'cross_interface_context' from line 9
+tests/behavior/test_cross_interface_consistency_extended.py:33:35: F811 redefinition of unused 'cross_interface_context' from line 9
+tests/behavior/test_cross_interface_consistency_extended.py:43:20: F811 redefinition of unused 'cross_interface_context' from line 9
+tests/behavior/test_cross_interface_consistency_extended.py:53:25: F811 redefinition of unused 'cross_interface_context' from line 9
+tests/behavior/test_cross_interface_consistency_extended.py:63:32: F811 redefinition of unused 'cross_interface_context' from line 9
+tests/behavior/test_cross_interface_consistency_extended.py:73:32: F811 redefinition of unused 'cross_interface_context' from line 9
+tests/behavior/test_cross_interface_consistency_extended.py:83:38: F811 redefinition of unused 'cross_interface_context' from line 9
+tests/behavior/test_cross_interface_consistency_extended.py:93:27: F811 redefinition of unused 'cross_interface_context' from line 9
+tests/behavior/test_cross_interface_consistency_extended.py:103:39: F811 redefinition of unused 'cross_interface_context' from line 9
+tests/behavior/test_cross_interface_consistency_extended.py:113:29: F811 redefinition of unused 'cross_interface_context' from line 9
+tests/behavior/test_devsynth_doctor.py:5:1: F403 'from .steps.cli_commands_steps import *' used; unable to detect undefined names
+tests/behavior/test_devsynth_doctor.py:6:1: F403 'from .steps.test_devsynth_doctor_steps import *' used; unable to detect undefined names
+tests/behavior/test_enhanced_chromadb_integration.py:21:1: F403 'from .steps.cli_commands_steps import *' used; unable to detect undefined names
+tests/behavior/test_enhanced_chromadb_integration.py:22:1: F403 'from .steps.test_chromadb_steps import *' used; unable to detect undefined names
+tests/behavior/test_enhanced_chromadb_integration.py:23:1: F403 'from .steps.test_enhanced_chromadb_steps import *' used; unable to detect undefined names
+tests/behavior/test_project_initialization.py:11:1: F403 'from .steps.cli_commands_steps import *' used; unable to detect undefined names
+tests/behavior/test_project_initialization.py:12:1: F403 'from .steps.test_project_init_steps import *' used; unable to detect undefined names
+tests/behavior/test_requirement_analysis.py:10:1: F403 'from .steps.cli_commands_steps import *' used; unable to detect undefined names
+tests/behavior/test_requirement_analysis.py:13:1: F403 'from .steps.test_requirement_analysis_steps import *' used; unable to detect undefined names
+tests/behavior/test_webui_integration.py:50:30: F811 redefinition of unused 'webui_context' from line 8
+tests/conftest.py:4:89: E501 line too long (94 > 88 characters)
+tests/conftest.py:5:89: E501 line too long (91 > 88 characters)
+tests/conftest.py:10:1: E402 module level import not at top of file
+tests/conftest.py:11:1: E402 module level import not at top of file
+tests/conftest.py:12:1: F401 'random' imported but unused
+tests/conftest.py:12:1: E402 module level import not at top of file
+tests/conftest.py:13:1: E402 module level import not at top of file
+tests/conftest.py:14:1: F401 'socket' imported but unused
+tests/conftest.py:14:1: E402 module level import not at top of file
+tests/conftest.py:15:1: F401 'sys' imported but unused
+tests/conftest.py:15:1: E402 module level import not at top of file
+tests/conftest.py:16:1: E402 module level import not at top of file
+tests/conftest.py:17:1: E402 module level import not at top of file
+tests/conftest.py:18:1: E402 module level import not at top of file
+tests/conftest.py:19:1: E402 module level import not at top of file
+tests/conftest.py:20:1: E402 module level import not at top of file
+tests/conftest.py:22:1: E402 module level import not at top of file
+tests/conftest.py:58:89: E501 line too long (100 > 88 characters)
+tests/conftest.py:98:89: E501 line too long (97 > 88 characters)
+tests/conftest.py:131:1: F401 'tests.fixtures.determinism.deterministic_seed' imported but unused
+tests/conftest.py:131:1: E402 module level import not at top of file
+tests/conftest.py:136:89: E501 line too long (126 > 88 characters)
+tests/conftest.py:137:89: E501 line too long (93 > 88 characters)
+tests/conftest.py:263:89: E501 line too long (94 > 88 characters)
+tests/conftest.py:266:89: E501 line too long (103 > 88 characters)
+tests/conftest.py:322:89: E501 line too long (119 > 88 characters)
+tests/conftest.py:324:89: E501 line too long (96 > 88 characters)
+tests/conftest.py:411:89: E501 line too long (107 > 88 characters)
+tests/conftest.py:424:63: F841 local variable 'mock_configure_logging' is assigned to but never used
+tests/conftest.py:474:1: F401 'tests.fixtures.networking.disable_network' imported but unused
+tests/conftest.py:474:1: E402 module level import not at top of file
+tests/conftest.py:491:1: F401 'tests.fixtures.determinism.enforce_test_timeout' imported but unused
+tests/conftest.py:491:1: E402 module level import not at top of file
+tests/conftest.py:568:89: E501 line too long (97 > 88 characters)
+tests/conftest.py:711:89: E501 line too long (119 > 88 characters)
+tests/conftest.py:717:89: E501 line too long (98 > 88 characters)
+tests/conftest.py:720:89: E501 line too long (98 > 88 characters)
+tests/conftest.py:906:89: E501 line too long (98 > 88 characters)
+tests/conftest.py:909:89: E501 line too long (120 > 88 characters)
+tests/conftest.py:910:89: E501 line too long (123 > 88 characters)
+tests/conftest.py:912:89: E501 line too long (132 > 88 characters)
+tests/conftest.py:925:89: E501 line too long (103 > 88 characters)
+tests/conftest.py:953:89: E501 line too long (94 > 88 characters)
+tests/conftest.py:962:89: E501 line too long (91 > 88 characters)
+tests/conftest.py:980:89: E501 line too long (105 > 88 characters)
+tests/conftest.py:993:89: E501 line too long (89 > 88 characters)
+tests/conftest.py:1005:89: E501 line too long (95 > 88 characters)
+tests/conftest.py:1034:89: E501 line too long (89 > 88 characters)
+tests/conftest.py:1035:89: E501 line too long (90 > 88 characters)
+tests/conftest.py:1037:89: E501 line too long (93 > 88 characters)
+tests/conftest.py:1047:89: E501 line too long (93 > 88 characters)
+tests/conftest.py:1061:1: E402 module level import not at top of file
+tests/conftest.py:1066:89: E501 line too long (90 > 88 characters)
+tests/conftest.py:1068:89: E501 line too long (92 > 88 characters)
+tests/conftest.py:1080:89: E501 line too long (97 > 88 characters)
+tests/conftest.py:1085:89: E501 line too long (104 > 88 characters)
+tests/conftest.py:1104:89: E501 line too long (97 > 88 characters)
+tests/conftest.py:1108:1: F811 redefinition of unused 'pytest_configure' from line 84
+tests/conftest.py:1140:89: E501 line too long (99 > 88 characters)
+tests/conftest_extensions.py:6:1: F401 'collections.abc.Callable' imported but unused
+tests/conftest_extensions.py:7:1: F401 'pathlib.Path' imported but unused
+tests/conftest_extensions.py:8:1: F401 'typing.Any' imported but unused
+tests/conftest_extensions.py:8:1: F401 'typing.Dict' imported but unused
+tests/conftest_extensions.py:8:1: F401 'typing.List' imported but unused
+tests/conftest_extensions.py:8:1: F401 'typing.Optional' imported but unused
+tests/conftest_extensions.py:131:89: E501 line too long (138 > 88 characters)
+tests/conftest_extensions.py:164:89: E501 line too long (92 > 88 characters)
+tests/examples/test_cli_smoke.py:14:1: F401 'os' imported but unused
+tests/examples/test_cli_smoke.py:37:89: E501 line too long (92 > 88 characters)
+tests/examples/test_cli_smoke.py:45:89: E501 line too long (120 > 88 characters)
+tests/examples/test_cli_smoke.py:54:89: E501 line too long (95 > 88 characters)
+tests/examples/test_cli_smoke.py:56:89: E501 line too long (97 > 88 characters)
+tests/examples/test_cli_smoke.py:87:89: E501 line too long (127 > 88 characters)
+tests/examples/test_init_example.py:40:89: E501 line too long (89 > 88 characters)
+tests/fixtures/backends.py:2:89: E501 line too long (101 > 88 characters)
+tests/fixtures/backends.py:14:1: F401 'os' imported but unused
+tests/fixtures/backends.py:16:1: F401 'typing.Iterator' imported but unused
+tests/fixtures/backends.py:16:1: F401 'typing.Optional' imported but unused
+tests/fixtures/data_generators.py:16:1: F401 'typing.Callable' imported but unused
+tests/fixtures/data_generators.py:16:1: F401 'typing.Tuple' imported but unused
+tests/fixtures/data_generators.py:110:22: F541 f-string is missing placeholders
+tests/fixtures/determinism.py:62:89: E501 line too long (100 > 88 characters)
+tests/fixtures/mock_subsystems.py:92:89: E501 line too long (93 > 88 characters)
+tests/fixtures/mock_subsystems.py:96:89: E501 line too long (98 > 88 characters)
+tests/fixtures/mock_subsystems.py:97:89: E501 line too long (103 > 88 characters)
+tests/fixtures/mock_subsystems.py:104:89: E501 line too long (89 > 88 characters)
+tests/fixtures/mock_subsystems.py:160:89: E501 line too long (93 > 88 characters)
+tests/fixtures/networking.py:64:89: E501 line too long (91 > 88 characters)
+tests/fixtures/networking.py:68:89: E501 line too long (108 > 88 characters)
+tests/fixtures/networking.py:72:89: E501 line too long (111 > 88 characters)
+tests/fixtures/networking.py:86:89: E501 line too long (109 > 88 characters)
+tests/fixtures/networking.py:103:89: E501 line too long (121 > 88 characters)
+tests/fixtures/networking.py:120:89: E501 line too long (104 > 88 characters)
+tests/fixtures/networking.py:121:89: E501 line too long (115 > 88 characters)
+tests/fixtures/ports.py:7:1: F401 'devsynth.domain.models.memory.MemoryType' imported but unused
+tests/fixtures/state_access_fixture.py:9:1: F401 'unittest.mock.MagicMock' imported but unused
+tests/fixtures/state_access_fixture.py:9:1: F401 'unittest.mock.patch' imported but unused
+tests/fixtures/state_access_fixture.py:15:89: E501 line too long (97 > 88 characters)
+tests/fixtures/state_access_fixture.py:64:89: E501 line too long (89 > 88 characters)
+tests/fixtures/state_access_fixture.py:90:89: E501 line too long (89 > 88 characters)
+tests/fixtures/state_access_fixture.py:108:89: E501 line too long (89 > 88 characters)
+tests/fixtures/webui_test_utils.py:22:1: F401 'json' imported but unused
+tests/fixtures/webui_test_utils.py:23:1: F401 'os' imported but unused
+tests/fixtures/webui_test_utils.py:24:1: F401 'sys' imported but unused
+tests/fixtures/webui_test_utils.py:26:1: F401 'typing.Callable' imported but unused
+tests/fixtures/webui_test_utils.py:26:1: F401 'typing.Optional' imported but unused
+tests/fixtures/webui_test_utils.py:26:1: F401 'typing.Tuple' imported but unused
+tests/fixtures/webui_test_utils.py:26:1: F401 'typing.Union' imported but unused
+tests/fixtures/webui_test_utils.py:354:89: E501 line too long (89 > 88 characters)
+tests/fixtures/webui_test_utils.py:479:89: E501 line too long (107 > 88 characters)
+tests/fixtures/webui_test_utils.py:495:89: E501 line too long (109 > 88 characters)
+tests/integration/collaboration/test_cross_store_memory_sync.py:4:1: F401 'pytest' imported but unused
+tests/integration/deployment/test_compose_workflow.py:19:89: E501 line too long (102 > 88 characters)
+tests/integration/deployment/test_compose_workflow.py:40:89: E501 line too long (106 > 88 characters)
+tests/integration/deployment/test_deployment_scripts.py:1:1: F401 'os' imported but unused
+tests/integration/deployment/test_deployment_scripts.py:42:89: E501 line too long (125 > 88 characters)
+tests/integration/edrr/test_recursion_security.py:3:1: F401 'pytest' imported but unused
+tests/integration/edrr/test_wsde_edrr_integration.py:6:1: F401 'unittest.mock.patch' imported but unused
+tests/integration/edrr/test_wsde_edrr_integration.py:78:89: E501 line too long (98 > 88 characters)
+tests/integration/edrr/test_wsde_edrr_integration.py:96:89: E501 line too long (103 > 88 characters)
+tests/integration/edrr/test_wsde_edrr_integration.py:114:89: E501 line too long (89 > 88 characters)
+tests/integration/edrr/test_wsde_edrr_integration.py:131:89: E501 line too long (105 > 88 characters)
+tests/integration/general/test_agent_api.py:7:1: E402 module level import not at top of file
+tests/integration/general/test_agent_api.py:8:1: E402 module level import not at top of file
+tests/integration/general/test_agent_api.py:9:1: E402 module level import not at top of file
+tests/integration/general/test_agent_api.py:10:1: E402 module level import not at top of file
+tests/integration/general/test_agent_api.py:12:1: E402 module level import not at top of file
+tests/integration/general/test_agent_api_security.py:6:1: F401 'unittest.mock.patch' imported but unused
+tests/integration/general/test_agent_api_security.py:13:1: E402 module level import not at top of file
+tests/integration/general/test_agent_api_security.py:64:89: E501 line too long (92 > 88 characters)
+tests/integration/general/test_agent_collaboration_integration.py:8:1: F401 'os' imported but unused
+tests/integration/general/test_agent_collaboration_integration.py:14:1: F401 'devsynth.application.collaboration.agent_collaboration.AgentMessage' imported but unused
+tests/integration/general/test_agent_collaboration_integration.py:14:1: F401 'devsynth.application.collaboration.agent_collaboration.CollaborationTask' imported but unused
+tests/integration/general/test_agent_system_integration.py:5:1: F401 'unittest.mock.MagicMock' imported but unused
+tests/integration/general/test_agentapi_routes.py:7:1: E402 module level import not at top of file
+tests/integration/general/test_agentapi_routes.py:8:1: E402 module level import not at top of file
+tests/integration/general/test_agentapi_routes.py:9:1: E402 module level import not at top of file
+tests/integration/general/test_agentapi_routes.py:10:1: E402 module level import not at top of file
+tests/integration/general/test_agentapi_routes.py:12:1: E402 module level import not at top of file
+tests/integration/general/test_anthropic_provider.py:5:1: F401 'devsynth.application.llm.providers.AnthropicConnectionError' imported but unused
+tests/integration/general/test_anthropic_provider.py:5:1: F401 'devsynth.application.llm.providers.AnthropicModelError' imported but unused
+tests/integration/general/test_chromadb_client_connection.py:16:1: E402 module level import not at top of file
+tests/integration/general/test_chromadb_memory_store_integration.py:9:1: E402 module level import not at top of file
+tests/integration/general/test_chromadb_memory_store_integration.py:10:1: E402 module level import not at top of file
+tests/integration/general/test_chromadb_vector_transactions.py:5:1: E402 module level import not at top of file
+tests/integration/general/test_chromadb_vector_transactions.py:8:1: E402 module level import not at top of file
+tests/integration/general/test_cli_webui_agentapi_pipeline.py:11:1: F401 'pathlib.Path' imported but unused
+tests/integration/general/test_cli_webui_agentapi_pipeline.py:18:1: E402 module level import not at top of file
+tests/integration/general/test_cli_webui_agentapi_pipeline.py:20:1: F401 'devsynth.interface.agentapi.WorkflowResponse' imported but unused
+tests/integration/general/test_cli_webui_agentapi_pipeline.py:20:1: E402 module level import not at top of file
+tests/integration/general/test_cli_webui_agentapi_pipeline.py:21:1: E402 module level import not at top of file
+tests/integration/general/test_cli_webui_agentapi_pipeline.py:22:1: E402 module level import not at top of file
+tests/integration/general/test_cli_webui_agentapi_pipeline.py:23:1: E402 module level import not at top of file
+tests/integration/general/test_cli_webui_agentapi_pipeline.py:275:89: E501 line too long (91 > 88 characters)
+tests/integration/general/test_cli_webui_parity.py:3:1: F401 'time' imported but unused
+tests/integration/general/test_cli_webui_parity.py:5:1: F401 'unittest.mock.patch' imported but unused
+tests/integration/general/test_cli_webui_parity.py:161:89: E501 line too long (91 > 88 characters)
+tests/integration/general/test_code_analysis_edrr_integration.py:9:1: F401 'os' imported but unused
+tests/integration/general/test_code_analysis_edrr_integration.py:32:1: F401 'devsynth.domain.models.memory.MemoryType' imported but unused
+tests/integration/general/test_code_analysis_edrr_integration.py:96:13: F841 local variable 'project_path' is assigned to but never used
+tests/integration/general/test_code_analysis_edrr_integration.py:165:89: E501 line too long (103 > 88 characters)
+tests/integration/general/test_code_analysis_edrr_integration.py:204:89: E501 line too long (103 > 88 characters)
+tests/integration/general/test_code_analysis_edrr_integration.py:230:89: E501 line too long (103 > 88 characters)
+tests/integration/general/test_code_analysis_wsde_integration.py:9:1: F401 'os' imported but unused
+tests/integration/general/test_code_analysis_wsde_integration.py:10:1: F401 'unittest.mock.MagicMock' imported but unused
+tests/integration/general/test_code_analysis_wsde_integration.py:10:1: F401 'unittest.mock.patch' imported but unused
+tests/integration/general/test_code_analysis_wsde_integration.py:27:1: F401 'devsynth.domain.models.memory.MemoryType' imported but unused
+tests/integration/general/test_code_analysis_wsde_integration.py:93:17: F841 local variable 'project_path' is assigned to but never used
+tests/integration/general/test_collaborative_voting.py:3:1: F401 'unittest.mock.MagicMock' imported but unused
+tests/integration/general/test_collaborative_voting.py:39:1: E402 module level import not at top of file
+tests/integration/general/test_collaborative_voting.py:42:1: E402 module level import not at top of file
+tests/integration/general/test_collaborative_voting.py:45:1: E402 module level import not at top of file
+tests/integration/general/test_complex_workflow.py:12:1: F401 'pathlib.Path' imported but unused
+tests/integration/general/test_complex_workflow.py:16:1: F401 'devsynth.application.cli.cli_commands.code_cmd' imported but unused
+tests/integration/general/test_complex_workflow.py:16:1: F401 'devsynth.application.cli.cli_commands.inspect_cmd' imported but unused
+tests/integration/general/test_complex_workflow.py:16:1: F401 'devsynth.application.cli.cli_commands.spec_cmd' imported but unused
+tests/integration/general/test_complex_workflow.py:16:1: F401 'devsynth.application.cli.cli_commands.test_cmd' imported but unused
+tests/integration/general/test_complex_workflow.py:158:89: E501 line too long (94 > 88 characters)
+tests/integration/general/test_complex_workflow.py:163:89: E501 line too long (93 > 88 characters)
+tests/integration/general/test_complex_workflow.py:178:89: E501 line too long (95 > 88 characters)
+tests/integration/general/test_complex_workflow.py:183:89: E501 line too long (94 > 88 characters)
+tests/integration/general/test_complex_workflow.py:283:89: E501 line too long (102 > 88 characters)
+tests/integration/general/test_complex_workflow.py:287:89: E501 line too long (103 > 88 characters)
+tests/integration/general/test_complex_workflow.py:298:89: E501 line too long (104 > 88 characters)
+tests/integration/general/test_complex_workflow.py:302:89: E501 line too long (105 > 88 characters)
+tests/integration/general/test_complex_workflow.py:324:89: E501 line too long (122 > 88 characters)
+tests/integration/general/test_complex_workflow.py:327:89: E501 line too long (118 > 88 characters)
+tests/integration/general/test_complex_workflow.py:330:89: E501 line too long (111 > 88 characters)
+tests/integration/general/test_complex_workflow.py:333:89: E501 line too long (107 > 88 characters)
+tests/integration/general/test_comprehensive_workflow.py:4:1: F401 'pathlib.Path' imported but unused
+tests/integration/general/test_comprehensive_workflow.py:13:1: F401 'devsynth.application.orchestration.workflow.WorkflowManager' imported but unused
+tests/integration/general/test_comprehensive_workflow.py:17:89: E501 line too long (89 > 88 characters)
+tests/integration/general/test_comprehensive_workflow.py:151:15: F541 f-string is missing placeholders
+tests/integration/general/test_comprehensive_workflow.py:153:89: E501 line too long (98 > 88 characters)
+tests/integration/general/test_comprehensive_workflow.py:181:15: F541 f-string is missing placeholders
+tests/integration/general/test_comprehensive_workflow.py:185:89: E501 line too long (118 > 88 characters)
+tests/integration/general/test_comprehensive_workflow.py:198:15: F541 f-string is missing placeholders
+tests/integration/general/test_comprehensive_workflow.py:201:89: E501 line too long (110 > 88 characters)
+tests/integration/general/test_comprehensive_workflow.py:206:15: F541 f-string is missing placeholders
+tests/integration/general/test_comprehensive_workflow.py:224:15: F541 f-string is missing placeholders
+tests/integration/general/test_delegate_task.py:2:1: F401 'unittest.mock.patch' imported but unused
+tests/integration/general/test_delegate_task_primus_selection.py:22:89: E501 line too long (92 > 88 characters)
+tests/integration/general/test_edrr_auto_phase_transition.py:52:1: E402 module level import not at top of file
+tests/integration/general/test_edrr_auto_phase_transition.py:53:1: E402 module level import not at top of file
+tests/integration/general/test_edrr_auto_phase_transition.py:54:1: E402 module level import not at top of file
+tests/integration/general/test_edrr_auto_phase_transition.py:57:1: E402 module level import not at top of file
+tests/integration/general/test_edrr_auto_phase_transition.py:58:1: E402 module level import not at top of file
+tests/integration/general/test_edrr_auto_phase_transition.py:59:1: E402 module level import not at top of file
+tests/integration/general/test_edrr_auto_phase_transition.py:60:1: E402 module level import not at top of file
+tests/integration/general/test_edrr_auto_phase_transition.py:61:1: E402 module level import not at top of file
+tests/integration/general/test_edrr_dynamic_roles.py:14:1: F401 'devsynth.methodology.base.Phase' imported but unused
+tests/integration/general/test_edrr_manifest_dependencies.py:37:1: E402 module level import not at top of file
+tests/integration/general/test_edrr_manifest_dependencies.py:38:1: E402 module level import not at top of file
+tests/integration/general/test_edrr_manifest_dependencies.py:39:1: E402 module level import not at top of file
+tests/integration/general/test_edrr_manifest_dependencies.py:42:1: E402 module level import not at top of file
+tests/integration/general/test_edrr_manifest_dependencies.py:43:1: E402 module level import not at top of file
+tests/integration/general/test_edrr_manifest_dependencies.py:44:1: E402 module level import not at top of file
+tests/integration/general/test_edrr_manifest_dependencies.py:45:1: E402 module level import not at top of file
+tests/integration/general/test_edrr_manifest_dependencies.py:46:1: E402 module level import not at top of file
+tests/integration/general/test_edrr_micro_cycle_auto_transition.py:39:1: E402 module level import not at top of file
+tests/integration/general/test_edrr_micro_cycle_auto_transition.py:40:1: E402 module level import not at top of file
+tests/integration/general/test_edrr_micro_cycle_auto_transition.py:41:1: E402 module level import not at top of file
+tests/integration/general/test_edrr_micro_cycle_auto_transition.py:44:1: E402 module level import not at top of file
+tests/integration/general/test_edrr_micro_cycle_auto_transition.py:45:1: E402 module level import not at top of file
+tests/integration/general/test_edrr_micro_cycle_auto_transition.py:46:1: E402 module level import not at top of file
+tests/integration/general/test_edrr_micro_cycle_auto_transition.py:47:1: E402 module level import not at top of file
+tests/integration/general/test_edrr_micro_cycle_auto_transition.py:48:1: E402 module level import not at top of file
+tests/integration/general/test_edrr_micro_cycle_context.py:36:1: E402 module level import not at top of file
+tests/integration/general/test_edrr_micro_cycle_context.py:37:1: E402 module level import not at top of file
+tests/integration/general/test_edrr_micro_cycle_context.py:38:1: E402 module level import not at top of file
+tests/integration/general/test_edrr_micro_cycle_context.py:41:1: E402 module level import not at top of file
+tests/integration/general/test_edrr_micro_cycle_context.py:42:1: E402 module level import not at top of file
+tests/integration/general/test_edrr_micro_cycle_context.py:43:1: E402 module level import not at top of file
+tests/integration/general/test_edrr_micro_cycle_context.py:44:1: E402 module level import not at top of file
+tests/integration/general/test_edrr_mock_llm_integration.py:8:1: E402 module level import not at top of file
+tests/integration/general/test_edrr_mock_llm_integration.py:9:1: E402 module level import not at top of file
+tests/integration/general/test_edrr_mock_llm_integration.py:10:1: E402 module level import not at top of file
+tests/integration/general/test_edrr_mock_llm_integration.py:13:1: E402 module level import not at top of file
+tests/integration/general/test_edrr_mock_llm_integration.py:14:1: E402 module level import not at top of file
+tests/integration/general/test_edrr_mock_llm_integration.py:17:1: E402 module level import not at top of file
+tests/integration/general/test_edrr_mock_llm_integration.py:18:1: E402 module level import not at top of file
+tests/integration/general/test_edrr_mock_llm_integration.py:19:1: E402 module level import not at top of file
+tests/integration/general/test_edrr_mock_llm_integration.py:28:1: E402 module level import not at top of file
+tests/integration/general/test_edrr_mock_llm_integration.py:44:89: E501 line too long (139 > 88 characters)
+tests/integration/general/test_edrr_peer_review_voting.py:36:1: E402 module level import not at top of file
+tests/integration/general/test_edrr_peer_review_voting.py:37:1: E402 module level import not at top of file
+tests/integration/general/test_edrr_peer_review_voting.py:38:1: E402 module level import not at top of file
+tests/integration/general/test_edrr_peer_review_voting.py:41:1: E402 module level import not at top of file
+tests/integration/general/test_edrr_peer_review_voting.py:42:1: E402 module level import not at top of file
+tests/integration/general/test_edrr_peer_review_voting.py:43:1: E402 module level import not at top of file
+tests/integration/general/test_edrr_peer_review_voting.py:44:1: E402 module level import not at top of file
+tests/integration/general/test_edrr_peer_review_voting.py:45:1: E402 module level import not at top of file
+tests/integration/general/test_edrr_phase_quality_assessment.py:40:1: E402 module level import not at top of file
+tests/integration/general/test_edrr_phase_quality_assessment.py:41:1: E402 module level import not at top of file
+tests/integration/general/test_edrr_phase_quality_assessment.py:42:1: E402 module level import not at top of file
+tests/integration/general/test_edrr_phase_quality_assessment.py:45:1: E402 module level import not at top of file
+tests/integration/general/test_edrr_phase_quality_assessment.py:46:1: E402 module level import not at top of file
+tests/integration/general/test_edrr_phase_quality_assessment.py:47:1: E402 module level import not at top of file
+tests/integration/general/test_edrr_phase_quality_assessment.py:48:1: E402 module level import not at top of file
+tests/integration/general/test_edrr_phase_quality_assessment.py:49:1: E402 module level import not at top of file
+tests/integration/general/test_edrr_primus_rotation.py:5:1: F401 'devsynth.application.code_analysis.analyzer.CodeAnalyzer' imported but unused
+tests/integration/general/test_edrr_primus_rotation.py:6:1: F401 'devsynth.application.code_analysis.ast_transformer.AstTransformer' imported but unused
+tests/integration/general/test_edrr_primus_rotation.py:7:1: F401 'devsynth.application.documentation.documentation_manager.DocumentationManager' imported but unused
+tests/integration/general/test_edrr_primus_rotation.py:11:1: F401 'devsynth.application.memory.memory_manager.MemoryManager' imported but unused
+tests/integration/general/test_edrr_primus_rotation.py:12:1: F401 'devsynth.application.prompts.prompt_manager.PromptManager' imported but unused
+tests/integration/general/test_edrr_real_llm_integration.py:8:1: F401 'tempfile' imported but unused
+tests/integration/general/test_edrr_real_llm_integration.py:9:1: F401 'pathlib.Path' imported but unused
+tests/integration/general/test_edrr_real_llm_integration.py:10:1: F401 'typing.Any' imported but unused
+tests/integration/general/test_edrr_real_llm_integration.py:10:1: F401 'typing.Dict' imported but unused
+tests/integration/general/test_edrr_real_llm_integration.py:10:1: F401 'typing.Optional' imported but unused
+tests/integration/general/test_edrr_real_llm_integration.py:14:1: F401 'devsynth.adapters.provider_system.ProviderType' imported but unused
+tests/integration/general/test_edrr_real_llm_integration.py:27:1: F401 'devsynth.domain.models.memory.MemoryType' imported but unused
+tests/integration/general/test_edrr_real_llm_integration.py:109:11: F541 f-string is missing placeholders
+tests/integration/general/test_edrr_real_llm_integration.py:163:89: E501 line too long (173 > 88 characters)
+tests/integration/general/test_edrr_real_llm_integration.py:202:11: F541 f-string is missing placeholders
+tests/integration/general/test_end_to_end_workflow.py:9:1: F401 'shutil' imported but unused
+tests/integration/general/test_end_to_end_workflow.py:10:1: F401 'tempfile' imported but unused
+tests/integration/general/test_end_to_end_workflow.py:11:1: F401 'pathlib.Path' imported but unused
+tests/integration/general/test_end_to_end_workflow.py:15:1: F401 'devsynth.application.cli.cli_commands.inspect_cmd' imported but unused
+tests/integration/general/test_end_to_end_workflow.py:34:89: E501 line too long (93 > 88 characters)
+tests/integration/general/test_end_to_end_workflow.py:79:89: E501 line too long (92 > 88 characters)
+tests/integration/general/test_error_handling_at_integration_points.py:3:89: E501 line too long (96 > 88 characters)
+tests/integration/general/test_error_handling_at_integration_points.py:10:1: F401 'pathlib.Path' imported but unused
+tests/integration/general/test_error_handling_at_integration_points.py:11:1: F401 'unittest.mock.call' imported but unused
+tests/integration/general/test_error_handling_at_integration_points.py:11:1: F401 'unittest.mock.patch' imported but unused
+tests/integration/general/test_error_handling_at_integration_points.py:19:1: E402 module level import not at top of file
+tests/integration/general/test_error_handling_at_integration_points.py:20:1: E402 module level import not at top of file
+tests/integration/general/test_error_handling_at_integration_points.py:21:1: E402 module level import not at top of file
+tests/integration/general/test_error_handling_at_integration_points.py:22:1: F401 'devsynth.application.llm.providers.LMStudioProvider' imported but unused
+tests/integration/general/test_error_handling_at_integration_points.py:22:1: E402 module level import not at top of file
+tests/integration/general/test_error_handling_at_integration_points.py:25:1: E402 module level import not at top of file
+tests/integration/general/test_error_handling_at_integration_points.py:26:1: E402 module level import not at top of file
+tests/integration/general/test_error_handling_at_integration_points.py:27:1: E402 module level import not at top of file
+tests/integration/general/test_error_handling_at_integration_points.py:28:1: E402 module level import not at top of file
+tests/integration/general/test_error_handling_at_integration_points.py:31:1: E402 module level import not at top of file
+tests/integration/general/test_error_handling_at_integration_points.py:32:1: E402 module level import not at top of file
+tests/integration/general/test_error_handling_at_integration_points.py:33:1: E402 module level import not at top of file
+tests/integration/general/test_error_handling_at_integration_points.py:36:1: E402 module level import not at top of file
+tests/integration/general/test_error_handling_at_integration_points.py:37:1: E402 module level import not at top of file
+tests/integration/general/test_error_handling_at_integration_points.py:38:1: E402 module level import not at top of file
+tests/integration/general/test_error_handling_at_integration_points.py:39:1: E402 module level import not at top of file
+tests/integration/general/test_error_handling_at_integration_points.py:40:1: E402 module level import not at top of file
+tests/integration/general/test_error_handling_at_integration_points.py:41:1: E402 module level import not at top of file
+tests/integration/general/test_error_handling_at_integration_points.py:148:9: F841 local variable 'expand_results' is assigned to but never used
+tests/integration/general/test_error_handling_at_integration_points.py:154:13: F841 local variable 'differentiate_results' is assigned to but never used
+tests/integration/general/test_feature_flag_integration.py:130:89: E501 line too long (101 > 88 characters)
+tests/integration/general/test_graph_memory_edrr_integration.py:5:1: F401 'os' imported but unused
+tests/integration/general/test_graph_memory_error_handling.py:5:1: F401 'os' imported but unused
+tests/integration/general/test_graph_memory_error_handling.py:7:1: F401 'unittest.mock.MagicMock' imported but unused
+tests/integration/general/test_graph_memory_error_handling.py:13:1: F401 'devsynth.exceptions.MemoryItemNotFoundError' imported but unused
+tests/integration/general/test_graph_memory_error_handling.py:118:89: E501 line too long (91 > 88 characters)
+tests/integration/general/test_graph_memory_error_handling.py:134:89: E501 line too long (98 > 88 characters)
+tests/integration/general/test_kuzu_adapter_transactions.py:5:1: E402 module level import not at top of file
+tests/integration/general/test_kuzu_adapter_transactions.py:6:1: E402 module level import not at top of file
+tests/integration/general/test_kuzu_memory_fallback.py:1:1: F401 'importlib' imported but unused
+tests/integration/general/test_kuzu_memory_fallback.py:5:1: F401 'types' imported but unused
+tests/integration/general/test_kuzu_memory_fallback.py:19:5: F811 redefinition of unused 'importlib' from line 1
+tests/integration/general/test_lmstudio_provider.py:2:1: F401 'tempfile' imported but unused
+tests/integration/general/test_lmstudio_provider.py:7:1: F401 'devsynth.application.llm.providers.LMStudioProvider' imported but unused
+tests/integration/general/test_lmstudio_provider.py:12:5: F811 redefinition of unused 'LMStudioProvider' from line 7
+tests/integration/general/test_lmstudio_provider.py:34:9: F811 redefinition of unused 'LMStudioProvider' from line 7
+tests/integration/general/test_lmstudio_provider.py:40:89: E501 line too long (99 > 88 characters)
+tests/integration/general/test_lmstudio_provider.py:61:9: F811 redefinition of unused 'LMStudioProvider' from line 7
+tests/integration/general/test_lmstudio_provider.py:70:9: F811 redefinition of unused 'LMStudioProvider' from line 7
+tests/integration/general/test_lmstudio_provider.py:76:89: E501 line too long (99 > 88 characters)
+tests/integration/general/test_lmstudio_provider.py:95:9: F811 redefinition of unused 'LMStudioProvider' from line 7
+tests/integration/general/test_lmstudio_provider.py:97:89: E501 line too long (97 > 88 characters)
+tests/integration/general/test_lmstudio_provider.py:109:9: F811 redefinition of unused 'LMStudioProvider' from line 7
+tests/integration/general/test_lmstudio_provider.py:134:9: F811 redefinition of unused 'LMStudioProvider' from line 7
+tests/integration/general/test_lmstudio_provider.py:158:9: F811 redefinition of unused 'LMStudioProvider' from line 7
+tests/integration/general/test_lmstudio_provider.py:168:89: E501 line too long (90 > 88 characters)
+tests/integration/general/test_lmstudio_provider.py:174:89: E501 line too long (102 > 88 characters)
+tests/integration/general/test_lmstudio_provider.py:200:9: F811 redefinition of unused 'LMStudioProvider' from line 7
+tests/integration/general/test_lmstudio_provider.py:212:89: E501 line too long (90 > 88 characters)
+tests/integration/general/test_lmstudio_provider.py:218:89: E501 line too long (102 > 88 characters)
+tests/integration/general/test_lmstudio_provider.py:242:9: F811 redefinition of unused 'LMStudioProvider' from line 7
+tests/integration/general/test_memory_agent_integration.py:3:89: E501 line too long (89 > 88 characters)
+tests/integration/general/test_memory_agent_integration.py:10:1: F401 'unittest.mock.MagicMock' imported but unused
+tests/integration/general/test_memory_agent_integration.py:10:1: F401 'unittest.mock.patch' imported but unused
+tests/integration/general/test_memory_agent_integration.py:165:50: E712 comparison to True should be 'if cond is True:' or 'if cond:'
+tests/integration/general/test_memory_agent_integration.py:191:81: E712 comparison to True should be 'if cond is not True:' or 'if not cond:'
+tests/integration/general/test_multi_agent_roles_and_voting.py:5:1: F401 'pytest' imported but unused
+tests/integration/general/test_multi_agent_roles_and_voting.py:56:1: E402 module level import not at top of file
+tests/integration/general/test_multi_agent_roles_and_voting.py:57:1: E402 module level import not at top of file
+tests/integration/general/test_multi_store_sync_manager.py:6:1: E402 module level import not at top of file
+tests/integration/general/test_multi_store_sync_manager.py:7:1: E402 module level import not at top of file
+tests/integration/general/test_non_hierarchical_decision.py:1:1: F401 'types' imported but unused
+tests/integration/general/test_openai_provider.py:2:1: F401 'tempfile' imported but unused
+tests/integration/general/test_openai_provider.py:6:1: F401 'requests' imported but unused
+tests/integration/general/test_openai_provider.py:8:1: F401 'devsynth.application.llm.openai_provider.OpenAIModelError' imported but unused
+tests/integration/general/test_openai_provider.py:27:73: F841 local variable 'mock_openai' is assigned to but never used
+tests/integration/general/test_openai_provider.py:30:18: F841 local variable 'mock_async_openai' is assigned to but never used
+tests/integration/general/test_openai_provider.py:44:73: F841 local variable 'mock_openai' is assigned to but never used
+tests/integration/general/test_openai_provider.py:47:18: F841 local variable 'mock_async_openai' is assigned to but never used
+tests/integration/general/test_openai_provider.py:91:18: F841 local variable 'mock_async_openai' is assigned to but never used
+tests/integration/general/test_openai_provider.py:111:18: F841 local variable 'mock_async_openai' is assigned to but never used
+tests/integration/general/test_openai_provider.py:145:18: F841 local variable 'mock_async_openai' is assigned to but never used
+tests/integration/general/test_openai_provider.py:166:18: F841 local variable 'mock_async_openai' is assigned to but never used
+tests/integration/general/test_openai_provider.py:208:18: F841 local variable 'mock_async_openai' is assigned to but never used
+tests/integration/general/test_openai_provider.py:263:18: F841 local variable 'mock_async_openai' is assigned to but never used
+tests/integration/general/test_project_state_analyzer.py:10:1: F401 'pathlib.Path' imported but unused
+tests/integration/general/test_project_state_analyzer.py:58:89: E501 line too long (118 > 88 characters)
+tests/integration/general/test_provider_system.py:8:1: F401 'json' imported but unused
+tests/integration/general/test_provider_system.py:19:1: E402 module level import not at top of file
+tests/integration/general/test_provider_system.py:22:1: E402 module level import not at top of file
+tests/integration/general/test_provider_system.py:23:1: E402 module level import not at top of file
+tests/integration/general/test_provider_system.py:33:1: F401 'devsynth.application.llm.providers.LMStudioProvider' imported but unused
+tests/integration/general/test_provider_system.py:33:1: E402 module level import not at top of file
+tests/integration/general/test_provider_system_configurations.py:3:89: E501 line too long (94 > 88 characters)
+tests/integration/general/test_provider_system_configurations.py:7:1: F401 'json' imported but unused
+tests/integration/general/test_provider_system_configurations.py:9:1: F401 'unittest.mock.MagicMock' imported but unused
+tests/integration/general/test_provider_system_configurations.py:18:1: E402 module level import not at top of file
+tests/integration/general/test_provider_system_configurations.py:21:1: E402 module level import not at top of file
+tests/integration/general/test_provider_system_configurations.py:22:1: F401 'devsynth.adapters.provider_system.ProviderError' imported but unused
+tests/integration/general/test_provider_system_configurations.py:22:1: F401 'devsynth.adapters.provider_system.embed' imported but unused
+tests/integration/general/test_provider_system_configurations.py:22:1: F401 'devsynth.adapters.provider_system.get_provider_config' imported but unused
+tests/integration/general/test_provider_system_configurations.py:22:1: E402 module level import not at top of file
+tests/integration/general/test_provider_system_configurations.py:32:1: F401 'devsynth.application.llm.providers.LMStudioProvider' imported but unused
+tests/integration/general/test_provider_system_configurations.py:32:1: E402 module level import not at top of file
+tests/integration/general/test_refactor_workflow.py:12:1: F401 'pathlib.Path' imported but unused
+tests/integration/general/test_refactor_workflow.py:13:1: F401 'unittest.mock.patch' imported but unused
+tests/integration/general/test_requirements_gathering.py:16:1: E402 module level import not at top of file
+tests/integration/general/test_requirements_gathering.py:17:1: E402 module level import not at top of file
+tests/integration/general/test_requirements_gathering.py:18:1: E402 module level import not at top of file
+tests/integration/general/test_requirements_gathering.py:19:1: E402 module level import not at top of file
+tests/integration/general/test_requirements_gathering.py:20:1: E402 module level import not at top of file
+tests/integration/general/test_requirements_gathering.py:21:1: E402 module level import not at top of file
+tests/integration/general/test_self_analyzer.py:9:1: F401 'pathlib.Path' imported but unused
+tests/integration/general/test_self_analyzer.py:58:15: F541 f-string is missing placeholders
+tests/integration/general/test_self_analyzer.py:63:89: E501 line too long (99 > 88 characters)
+tests/integration/general/test_self_analyzer.py:66:89: E501 line too long (103 > 88 characters)
+tests/integration/general/test_self_analyzer.py:69:89: E501 line too long (107 > 88 characters)
+tests/integration/general/test_self_analyzer.py:72:15: F541 f-string is missing placeholders
+tests/integration/general/test_self_analyzer.py:89:15: F541 f-string is missing placeholders
+tests/integration/general/test_sprint_edrr_integration.py:1:1: F401 'pytest' imported but unused
+tests/integration/general/test_webui_e2e_workflows.py:4:1: F401 'unittest.mock.patch' imported but unused
+tests/integration/general/test_webui_e2e_workflows.py:172:89: E501 line too long (89 > 88 characters)
+tests/integration/general/test_webui_setup.py:3:1: F401 'pathlib.Path' imported but unused
+tests/integration/general/test_webui_setup.py:127:5: F841 local variable 'st' is assigned to but never used
+tests/integration/general/test_webui_setup.py:144:5: F841 local variable 'st' is assigned to but never used
+tests/integration/general/test_wsde_edrr_component_interactions.py:10:1: F401 'pathlib.Path' imported but unused
+tests/integration/general/test_wsde_edrr_component_interactions.py:11:1: F401 'unittest.mock.call' imported but unused
+tests/integration/general/test_wsde_edrr_component_interactions.py:257:9: F841 local variable 'expand_results' is assigned to but never used
+tests/integration/general/test_wsde_edrr_component_interactions.py:261:9: F841 local variable 'differentiate_results' is assigned to but never used
+tests/integration/general/test_wsde_edrr_component_interactions.py:265:9: F841 local variable 'refine_results' is assigned to but never used
+tests/integration/general/test_wsde_edrr_component_interactions.py:269:9: F841 local variable 'retrospect_results' is assigned to but never used
+tests/integration/general/test_wsde_edrr_integration_advanced.py:4:89: E501 line too long (90 > 88 characters)
+tests/integration/general/test_wsde_edrr_integration_advanced.py:5:89: E501 line too long (98 > 88 characters)
+tests/integration/general/test_wsde_edrr_integration_advanced.py:9:1: F401 'unittest.mock.call' imported but unused
+tests/integration/general/test_wsde_edrr_integration_advanced.py:59:89: E501 line too long (91 > 88 characters)
+tests/integration/general/test_wsde_edrr_integration_end_to_end.py:4:89: E501 line too long (96 > 88 characters)
+tests/integration/general/test_wsde_edrr_integration_end_to_end.py:57:89: E501 line too long (91 > 88 characters)
+tests/integration/general/test_wsde_memory_edrr_integration.py:39:5: F841 local variable 'manager' is assigned to but never used
+tests/integration/general/test_wsde_peer_review_memory_integration.py:13:1: F401 'devsynth.adapters.agents.agent_adapter.WSDETeamCoordinator' imported but unused
+tests/integration/general/test_wsde_peer_review_memory_integration.py:15:1: F401 'devsynth.application.collaboration.peer_review.PeerReview' imported but unused
+tests/integration/general/test_wsde_peer_review_memory_integration.py:18:1: F401 'devsynth.domain.models.memory.MemoryItem' imported but unused
+tests/integration/general/test_wsde_peer_review_memory_integration.py:171:5: F841 local variable 'feedback' is assigned to but never used
+tests/integration/interface/__init__.py:2:89: E501 line too long (104 > 88 characters)
+tests/integration/interface/test_bridge_consistency.py:10:1: F401 'devsynth.interface.ux_bridge.sanitize_output' imported but unused
+tests/integration/interface/test_mvuu_dashboard_report.py:8:1: E402 module level import not at top of file
+tests/integration/live/test_lmstudio_live_smoke.py:35:89: E501 line too long (94 > 88 characters)
+tests/integration/llm/test_lmstudio_streaming.py:3:1: F401 'os' imported but unused
+tests/integration/llm/test_lmstudio_streaming.py:8:1: F401 'devsynth.application.llm.providers.LMStudioProvider' imported but unused
+tests/integration/llm/test_lmstudio_streaming.py:12:5: F811 redefinition of unused 'LMStudioProvider' from line 8
+tests/integration/llm/test_lmstudio_streaming.py:25:9: F811 redefinition of unused 'LMStudioProvider' from line 8
+tests/integration/llm/test_lmstudio_streaming.py:45:9: F811 redefinition of unused 'LMStudioProvider' from line 8
+tests/integration/llm/test_provider_selection_integration.py:18:1: F401 'os' imported but unused
+tests/integration/llm/test_provider_selection_integration.py:54:89: E501 line too long (93 > 88 characters)
+tests/integration/llm/test_provider_selection_integration.py:74:89: E501 line too long (92 > 88 characters)
+tests/integration/llm/test_provider_selection_integration.py:91:89: E501 line too long (104 > 88 characters)
+tests/integration/memory/test_backend_persistence.py:8:1: E402 module level import not at top of file
+tests/integration/memory/test_backend_persistence.py:19:89: E501 line too long (91 > 88 characters)
+tests/integration/memory/test_chromadb_adapter_transactions.py:8:1: E402 module level import not at top of file
+tests/integration/memory/test_chromadb_fallback.py:8:1: E402 module level import not at top of file
+tests/integration/memory/test_chromadb_fallback.py:15:89: E501 line too long (92 > 88 characters)
+tests/integration/memory/test_circuit_breaker_integration.py:20:89: E501 line too long (91 > 88 characters)
+tests/integration/memory/test_cross_store_query.py:8:1: E402 module level import not at top of file
+tests/integration/memory/test_cross_store_sync.py:15:1: F401 'typing.Dict' imported but unused
+tests/integration/memory/test_cross_store_sync.py:15:1: F401 'typing.List' imported but unused
+tests/integration/memory/test_cross_store_sync.py:15:1: F401 'typing.Optional' imported but unused
+tests/integration/memory/test_cross_store_sync.py:15:1: F401 'typing.Tuple' imported but unused
+tests/integration/memory/test_cross_store_sync.py:253:5: F841 local variable 'chroma' is assigned to but never used
+tests/integration/memory/test_cross_store_transactions.py:7:1: E402 module level import not at top of file
+tests/integration/memory/test_cross_store_transactions.py:8:1: E402 module level import not at top of file
+tests/integration/memory/test_cross_store_transactions.py:9:1: E402 module level import not at top of file
+tests/integration/memory/test_cross_store_transactions.py:10:1: E402 module level import not at top of file
+tests/integration/memory/test_cross_store_transactions.py:11:1: E402 module level import not at top of file
+tests/integration/memory/test_faiss_transactions.py:4:1: E402 module level import not at top of file
+tests/integration/memory/test_multistore_transaction_wrapper.py:8:1: E402 module level import not at top of file
+tests/integration/memory/test_s3_backend_selection.py:8:1: E402 module level import not at top of file
+tests/integration/memory/test_s3_backend_selection.py:13:89: E501 line too long (104 > 88 characters)
+tests/performance/test_memory_benchmark.py:60:89: E501 line too long (105 > 88 characters)
+tests/performance/test_memory_benchmark.py:61:89: E501 line too long (96 > 88 characters)
+tests/performance/test_multi_agent_benchmarks.py:9:1: E402 module level import not at top of file
+tests/performance/test_multi_agent_benchmarks.py:10:1: E402 module level import not at top of file
+tests/performance/test_smoke_benchmarks.py:10:1: F401 'typing.Any' imported but unused
+tests/performance/test_smoke_benchmarks.py:10:1: F401 'typing.Dict' imported but unused
+tests/property/strategies.py:13:1: F401 'typing.Dict' imported but unused
+tests/property/strategies.py:13:1: F401 'typing.List' imported but unused
+tests/property/strategies.py:14:1: F401 'uuid.UUID' imported but unused
+tests/property/strategies.py:99:89: E501 line too long (94 > 88 characters)
+tests/unit/adapters/cli/test_typer_adapter.py:40:9: F841 local variable 'test_app' is assigned to but never used
+tests/unit/adapters/cli/test_typer_adapter.py:52:89: E501 line too long (91 > 88 characters)
+tests/unit/adapters/cli/test_typer_adapter.py:67:89: E501 line too long (98 > 88 characters)
+tests/unit/adapters/llm/test_llm_adapter.py:6:1: F401 'devsynth.application.llm.providers as providers_module' imported but unused
+tests/unit/adapters/llm/test_llm_adapter.py:8:1: F401 'devsynth.application.llm.providers.AnthropicProvider' imported but unused
+tests/unit/adapters/llm/test_llm_adapter.py:8:1: F401 'devsynth.application.llm.providers.OpenAIProvider' imported but unused
+tests/unit/adapters/llm/test_llm_adapter.py:13:1: F401 'devsynth.domain.interfaces.llm.LLMProviderFactory' imported but unused
+tests/unit/adapters/llm/test_llm_adapter.py:68:89: E501 line too long (90 > 88 characters)
+tests/unit/adapters/memory/test_memory_adapter.py:1:1: F401 'os' imported but unused
+tests/unit/adapters/memory/test_memory_adapter.py:3:1: F401 'typing.Any' imported but unused
+tests/unit/adapters/memory/test_memory_adapter.py:3:1: F401 'typing.Dict' imported but unused
+tests/unit/adapters/memory/test_memory_adapter.py:3:1: F401 'typing.List' imported but unused
+tests/unit/adapters/memory/test_memory_adapter.py:3:1: F401 'typing.Optional' imported but unused
+tests/unit/adapters/memory/test_memory_adapter.py:22:1: E402 module level import not at top of file
+tests/unit/adapters/memory/test_memory_adapter.py:23:1: E402 module level import not at top of file
+tests/unit/adapters/memory/test_memory_adapter.py:24:1: E402 module level import not at top of file
+tests/unit/adapters/memory/test_memory_adapter.py:25:1: E402 module level import not at top of file
+tests/unit/adapters/memory/test_memory_adapter.py:29:1: E402 module level import not at top of file
+tests/unit/adapters/memory/test_memory_adapter.py:30:1: E402 module level import not at top of file
+tests/unit/adapters/memory/test_memory_adapter.py:31:1: E402 module level import not at top of file
+tests/unit/adapters/memory/test_memory_adapter.py:34:1: E402 module level import not at top of file
+tests/unit/adapters/memory/test_memory_adapter.py:35:1: E402 module level import not at top of file
+tests/unit/adapters/memory/test_memory_adapter.py:36:1: F401 'devsynth.domain.interfaces.memory.MemoryStore' imported but unused
+tests/unit/adapters/memory/test_memory_adapter.py:36:1: F401 'devsynth.domain.interfaces.memory.VectorStore' imported but unused
+tests/unit/adapters/memory/test_memory_adapter.py:36:1: E402 module level import not at top of file
+tests/unit/adapters/memory/test_memory_adapter.py:37:1: E402 module level import not at top of file
+tests/unit/adapters/memory/test_memory_adapter.py:38:1: F401 'devsynth.exceptions.MemoryStoreError' imported but unused
+tests/unit/adapters/memory/test_memory_adapter.py:38:1: E402 module level import not at top of file
+tests/unit/adapters/memory/test_memory_adapter.py:131:89: E501 line too long (103 > 88 characters)
+tests/unit/adapters/memory/test_memory_adapter.py:244:9: F401 'devsynth.application.memory.faiss_store.FAISSStore' imported but unused
+tests/unit/adapters/memory/test_memory_adapter.py:285:9: F401 'devsynth.application.memory.faiss_store.FAISSStore' imported but unused
+tests/unit/adapters/providers/test_fallback.py:1:1: F401 'time' imported but unused
+tests/unit/adapters/providers/test_fallback.py:2:1: F401 'unittest.mock.call' imported but unused
+tests/unit/adapters/providers/test_provider_factory.py:14:1: E402 module level import not at top of file
+tests/unit/adapters/test_backend_resource_gates.py:1:1: F401 'os' imported but unused
+tests/unit/adapters/test_chromadb_memory_store.py:20:1: E402 module level import not at top of file
+tests/unit/adapters/test_chromadb_memory_store.py:24:1: E402 module level import not at top of file
+tests/unit/adapters/test_chromadb_memory_store.py:25:1: E402 module level import not at top of file
+tests/unit/adapters/test_chromadb_memory_store.py:87:89: E501 line too long (92 > 88 characters)
+tests/unit/adapters/test_chromadb_memory_store.py:103:89: E501 line too long (103 > 88 characters)
+tests/unit/adapters/test_chromadb_memory_store.py:121:89: E501 line too long (108 > 88 characters)
+tests/unit/adapters/test_chromadb_memory_store.py:163:89: E501 line too long (99 > 88 characters)
+tests/unit/adapters/test_chromadb_memory_store.py:182:89: E501 line too long (103 > 88 characters)
+tests/unit/adapters/test_chromadb_memory_store.py:262:9: F841 local variable 'items' is assigned to but never used
+tests/unit/adapters/test_chromadb_vector_adapter.py:1:1: F401 'os' imported but unused
+tests/unit/adapters/test_chromadb_vector_adapter.py:2:1: F401 'tempfile' imported but unused
+tests/unit/adapters/test_chromadb_vector_adapter.py:3:1: F401 'uuid' imported but unused
+tests/unit/adapters/test_chromadb_vector_adapter.py:12:1: E402 module level import not at top of file
+tests/unit/adapters/test_chromadb_vector_adapter.py:15:1: E402 module level import not at top of file
+tests/unit/adapters/test_chromadb_vector_adapter.py:40:89: E501 line too long (97 > 88 characters)
+tests/unit/adapters/test_provider_safe_defaults.py:2:1: F401 'importlib' imported but unused
+tests/unit/adapters/test_provider_safe_defaults.py:77:89: E501 line too long (98 > 88 characters)
+tests/unit/adapters/test_provider_stub.py:2:1: F401 'os' imported but unused
+tests/unit/adapters/test_provider_system.py:2:1: F401 'json' imported but unused
+tests/unit/adapters/test_provider_system.py:4:1: F401 'unittest.mock.call' imported but unused
+tests/unit/adapters/test_provider_system.py:6:1: F401 'httpx' imported but unused
+tests/unit/adapters/test_provider_system.py:21:1: F401 'devsynth.fallback.retry_with_exponential_backoff' imported but unused
+tests/unit/adapters/test_provider_system.py:436:17: F811 redefinition of unused 'call' from line 4
+tests/unit/adapters/test_resource_gating_seams.py:11:89: E501 line too long (90 > 88 characters)
+tests/unit/adapters/test_resource_gating_seams.py:12:89: E501 line too long (97 > 88 characters)
+tests/unit/adapters/test_resource_gating_seams.py:25:89: E501 line too long (91 > 88 characters)
+tests/unit/adapters/test_resource_gating_seams.py:26:89: E501 line too long (96 > 88 characters)
+tests/unit/adapters/test_storage_adapter_protocol.py:8:89: E501 line too long (104 > 88 characters)
+tests/unit/adapters/test_storage_adapter_protocol.py:12:1: F401 'typing.Dict' imported but unused
+tests/unit/adapters/test_storage_adapter_protocol.py:12:1: F401 'typing.List' imported but unused
+tests/unit/adapters/test_storage_adapter_protocol.py:12:1: F401 'typing.Optional' imported but unused
+tests/unit/adapters/test_storage_adapter_protocol.py:12:1: E402 module level import not at top of file
+tests/unit/adapters/test_storage_adapter_protocol.py:14:1: E402 module level import not at top of file
+tests/unit/adapters/test_storage_adapter_protocol.py:15:1: E402 module level import not at top of file
+tests/unit/adapters/test_storage_adapter_protocol.py:33:89: E501 line too long (90 > 88 characters)
+tests/unit/adapters/test_storage_adapter_protocol.py:49:89: E501 line too long (90 > 88 characters)
+tests/unit/adapters/test_storage_adapter_protocol.py:52:89: E501 line too long (91 > 88 characters)
+tests/unit/adapters/test_sync_manager.py:30:1: E402 module level import not at top of file
+tests/unit/adapters/test_sync_manager.py:31:1: E402 module level import not at top of file
+tests/unit/agents/test_doctor_tool.py:3:1: F401 'sys' imported but unused
+tests/unit/application/agents/test_agent_memory_integration.py:2:1: F401 'typing.Any' imported but unused
+tests/unit/application/agents/test_agent_memory_integration.py:2:1: F401 'typing.Dict' imported but unused
+tests/unit/application/agents/test_agent_memory_integration.py:2:1: F401 'typing.List' imported but unused
+tests/unit/application/agents/test_agent_memory_integration.py:3:1: F401 'unittest.mock.patch' imported but unused
+tests/unit/application/agents/test_base_agent.py:1:1: F401 'typing.List' imported but unused
+tests/unit/application/agents/test_code_agent.py:1:1: F401 'typing.Any' imported but unused
+tests/unit/application/agents/test_code_agent.py:1:1: F401 'typing.Dict' imported but unused
+tests/unit/application/agents/test_code_agent.py:1:1: F401 'typing.List' imported but unused
+tests/unit/application/agents/test_critic_agent.py:1:1: F401 'typing.Any' imported but unused
+tests/unit/application/agents/test_critic_agent.py:1:1: F401 'typing.Dict' imported but unused
+tests/unit/application/agents/test_critic_agent.py:1:1: F401 'typing.List' imported but unused
+tests/unit/application/agents/test_diagram_agent.py:1:1: F401 'typing.Any' imported but unused
+tests/unit/application/agents/test_diagram_agent.py:1:1: F401 'typing.Dict' imported but unused
+tests/unit/application/agents/test_diagram_agent.py:1:1: F401 'typing.List' imported but unused
+tests/unit/application/agents/test_documentation_agent.py:1:1: F401 'typing.Any' imported but unused
+tests/unit/application/agents/test_documentation_agent.py:1:1: F401 'typing.Dict' imported but unused
+tests/unit/application/agents/test_documentation_agent.py:1:1: F401 'typing.List' imported but unused
+tests/unit/application/agents/test_planner_agent.py:1:1: F401 'typing.Any' imported but unused
+tests/unit/application/agents/test_planner_agent.py:1:1: F401 'typing.Dict' imported but unused
+tests/unit/application/agents/test_planner_agent.py:1:1: F401 'typing.List' imported but unused
+tests/unit/application/agents/test_refactor_agent.py:1:1: F401 'typing.Any' imported but unused
+tests/unit/application/agents/test_refactor_agent.py:1:1: F401 'typing.Dict' imported but unused
+tests/unit/application/agents/test_refactor_agent.py:1:1: F401 'typing.List' imported but unused
+tests/unit/application/agents/test_refactor_agent.py:169:89: E501 line too long (90 > 88 characters)
+tests/unit/application/agents/test_specification_agent.py:1:1: F401 'unittest.mock.patch' imported but unused
+tests/unit/application/agents/test_validation_agent_decision.py:1:1: F401 'typing.Dict' imported but unused
+tests/unit/application/agents/test_validation_agent_decision.py:15:89: E501 line too long (129 > 88 characters)
+tests/unit/application/agents/test_wsde_memory_integration.py:2:1: F401 'typing.Any' imported but unused
+tests/unit/application/agents/test_wsde_memory_integration.py:2:1: F401 'typing.Dict' imported but unused
+tests/unit/application/agents/test_wsde_memory_integration.py:2:1: F401 'typing.List' imported but unused
+tests/unit/application/agents/test_wsde_memory_integration.py:3:1: F401 'unittest.mock.patch' imported but unused
+tests/unit/application/agents/test_wsde_memory_integration.py:10:1: F401 'devsynth.domain.models.memory.MemoryType' imported but unused
+tests/unit/application/agents/test_wsde_memory_integration.py:75:89: E501 line too long (131 > 88 characters)
+tests/unit/application/cli/commands/test_config_cmd.py:2:1: F401 'typing.Dict' imported but unused
+tests/unit/application/cli/commands/test_config_cmd.py:2:1: F401 'typing.List' imported but unused
+tests/unit/application/cli/commands/test_config_cmd.py:2:1: F401 'typing.Optional' imported but unused
+tests/unit/application/cli/commands/test_config_cmd.py:89:89: E501 line too long (105 > 88 characters)
+tests/unit/application/cli/commands/test_config_cmd.py:164:89: E501 line too long (105 > 88 characters)
+tests/unit/application/cli/commands/test_doctor_no_ui_imports.py:36:89: E501 line too long (95 > 88 characters)
+tests/unit/application/cli/commands/test_inspect_code_cmd_sanitization.py:1:1: F401 'builtins' imported but unused
+tests/unit/application/cli/commands/test_inspect_code_cmd_sanitization.py:2:1: F401 'types.SimpleNamespace' imported but unused
+tests/unit/application/cli/commands/test_inspect_code_cmd_sanitization.py:28:1: E402 module level import not at top of file
+tests/unit/application/cli/commands/test_parse_feature_options_unit.py:28:89: E501 line too long (91 > 88 characters)
+tests/unit/application/cli/commands/test_run_tests_cmd_env_paths.py:2:1: F401 'typing.Tuple' imported but unused
+tests/unit/application/cli/commands/test_run_tests_cmd_env_paths.py:113:89: E501 line too long (112 > 88 characters)
+tests/unit/application/cli/commands/test_run_tests_cmd_env_paths.py:118:89: E501 line too long (112 > 88 characters)
+tests/unit/application/cli/commands/test_run_tests_cmd_inventory_and_validation.py:14:1: F401 'os' imported but unused
+tests/unit/application/cli/commands/test_run_tests_cmd_inventory_and_validation.py:22:1: F401 'devsynth.application.cli.commands.run_tests_cmd as module' imported but unused
+tests/unit/application/cli/commands/test_run_tests_cmd_more.py:1:1: F401 'os' imported but unused
+tests/unit/application/cli/commands/test_run_tests_cmd_more.py:106:89: E501 line too long (98 > 88 characters)
+tests/unit/application/cli/commands/test_run_tests_cmd_more.py:136:89: E501 line too long (101 > 88 characters)
+tests/unit/application/cli/commands/test_run_tests_cmd_more.py:137:89: E501 line too long (103 > 88 characters)
+tests/unit/application/cli/commands/test_run_tests_cmd_provider_defaults.py:50:89: E501 line too long (98 > 88 characters)
+tests/unit/application/cli/commands/test_run_tests_cmd_provider_defaults.py:77:89: E501 line too long (98 > 88 characters)
+tests/unit/application/cli/commands/test_security_audit_cmd.py:1:1: F401 'builtins' imported but unused
+tests/unit/application/cli/commands/test_security_audit_cmd.py:2:1: F401 'os' imported but unused
+tests/unit/application/cli/test_autocomplete.py:1:1: F401 'pathlib.Path' imported but unused
+tests/unit/application/cli/test_autocomplete.py:32:89: E501 line too long (90 > 88 characters)
+tests/unit/application/cli/test_autocomplete.py:47:89: E501 line too long (93 > 88 characters)
+tests/unit/application/cli/test_autocomplete.py:61:89: E501 line too long (92 > 88 characters)
+tests/unit/application/cli/test_command_output_formatter.py:1:1: F401 'json' imported but unused
+tests/unit/application/cli/test_completion_cmd.py:1:1: F401 'pathlib.Path' imported but unused
+tests/unit/application/cli/test_doctor_cmd.py:155:89: E501 line too long (628 > 88 characters)
+tests/unit/application/cli/test_help.py:1:1: F401 'unittest.mock.call' imported but unused
+tests/unit/application/cli/test_help.py:6:1: F401 'rich.panel.Panel' imported but unused
+tests/unit/application/cli/test_progress.py:18:5: F841 local variable 'indicator' is assigned to but never used
+tests/unit/application/cli/test_requirements_commands.py:2:1: F401 'types.ModuleType' imported but unused
+tests/unit/application/cli/test_requirements_commands.py:3:1: F401 'unittest.mock.MagicMock' imported but unused
+tests/unit/application/cli/test_run_tests_cmd_options.py:48:89: E501 line too long (115 > 88 characters)
+tests/unit/application/cli/test_setup_wizard.py:1:1: F401 'pytest' imported but unused
+tests/unit/application/code_analysis/test_ast_transformer.py:3:89: E501 line too long (180 > 88 characters)
+tests/unit/application/code_analysis/test_ast_transformer.py:17:89: E501 line too long (288 > 88 characters)
+tests/unit/application/code_analysis/test_ast_transformer.py:49:89: E501 line too long (89 > 88 characters)
+tests/unit/application/code_analysis/test_ast_transformer.py:126:89: E501 line too long (111 > 88 characters)
+tests/unit/application/code_analysis/test_ast_transformer.py:137:89: E501 line too long (97 > 88 characters)
+tests/unit/application/code_analysis/test_ast_workflow_integration.py:1:1: F401 'ast' imported but unused
+tests/unit/application/code_analysis/test_ast_workflow_integration.py:3:1: F401 'unittest.mock.MagicMock' imported but unused
+tests/unit/application/code_analysis/test_ast_workflow_integration.py:5:1: F401 'pytest' imported but unused
+tests/unit/application/code_analysis/test_ast_workflow_integration.py:46:89: E501 line too long (260 > 88 characters)
+tests/unit/application/code_analysis/test_ast_workflow_integration.py:64:89: E501 line too long (135 > 88 characters)
+tests/unit/application/code_analysis/test_ast_workflow_integration.py:104:89: E501 line too long (116 > 88 characters)
+tests/unit/application/code_analysis/test_project_state_analyzer.py:9:1: F401 'os' imported but unused
+tests/unit/application/code_analysis/test_project_state_analyzer.py:12:1: F401 'unittest.mock.MagicMock' imported but unused
+tests/unit/application/code_analysis/test_project_state_analyzer.py:40:89: E501 line too long (134 > 88 characters)
+tests/unit/application/code_analysis/test_project_state_analyzer.py:43:89: E501 line too long (100 > 88 characters)
+tests/unit/application/code_analysis/test_project_state_analyzer.py:46:89: E501 line too long (127 > 88 characters)
+tests/unit/application/code_analysis/test_project_state_analyzer.py:49:89: E501 line too long (193 > 88 characters)
+tests/unit/application/code_analysis/test_project_state_analyzer.py:52:89: E501 line too long (134 > 88 characters)
+tests/unit/application/code_analysis/test_project_state_analyzer.py:241:89: E501 line too long (108 > 88 characters)
+tests/unit/application/code_analysis/test_self_analyzer.py:8:1: F401 'os' imported but unused
+tests/unit/application/code_analysis/test_self_analyzer.py:11:1: F401 'unittest.mock.patch' imported but unused
+tests/unit/application/code_analysis/test_self_analyzer.py:84:89: E501 line too long (308 > 88 characters)
+tests/unit/application/code_analysis/test_self_analyzer.py:89:89: E501 line too long (244 > 88 characters)
+tests/unit/application/code_analysis/test_self_analyzer.py:94:89: E501 line too long (143 > 88 characters)
+tests/unit/application/code_analysis/test_self_analyzer.py:97:89: E501 line too long (199 > 88 characters)
+tests/unit/application/code_analysis/test_self_analyzer.py:100:89: E501 line too long (141 > 88 characters)
+tests/unit/application/code_analysis/test_self_analyzer.py:103:89: E501 line too long (169 > 88 characters)
+tests/unit/application/code_analysis/test_self_analyzer.py:274:89: E501 line too long (116 > 88 characters)
+tests/unit/application/code_analysis/test_transformer.py:17:1: F401 'devsynth.application.code_analysis.transformer.CodeStyleTransformer' imported but unused
+tests/unit/application/code_analysis/test_transformer.py:17:1: F401 'devsynth.application.code_analysis.transformer.RedundantAssignmentRemover' imported but unused
+tests/unit/application/code_analysis/test_transformer.py:32:89: E501 line too long (406 > 88 characters)
+tests/unit/application/code_analysis/test_transformer.py:42:89: E501 line too long (415 > 88 characters)
+tests/unit/application/code_analysis/test_transformer.py:60:89: E501 line too long (125 > 88 characters)
+tests/unit/application/code_analysis/test_transformer.py:63:89: E501 line too long (179 > 88 characters)
+tests/unit/application/code_analysis/test_transformer.py:68:89: E501 line too long (105 > 88 characters)
+tests/unit/application/code_analysis/test_transformer.py:185:89: E501 line too long (169 > 88 characters)
+tests/unit/application/code_analysis/test_transformer.py:189:9: F841 local variable 'transformed_code' is assigned to but never used
+tests/unit/application/code_analysis/test_transformer.py:211:89: E501 line too long (163 > 88 characters)
+tests/unit/application/code_analysis/test_transformer.py:345:89: E501 line too long (145 > 88 characters)
+tests/unit/application/code_analysis/test_transformer.py:346:89: E501 line too long (137 > 88 characters)
+tests/unit/application/code_analysis/test_transformer.py:351:89: E501 line too long (197 > 88 characters)
+tests/unit/application/code_analysis/test_transformer.py:352:89: E501 line too long (185 > 88 characters)
+tests/unit/application/code_analysis/test_transformer.py:440:89: E501 line too long (109 > 88 characters)
+tests/unit/application/collaboration/test_collaborative_wsde_team.py:47:89: E501 line too long (93 > 88 characters)
+tests/unit/application/collaboration/test_collaborative_wsde_team.py:225:89: E501 line too long (129 > 88 characters)
+tests/unit/application/collaboration/test_collaborative_wsde_team.py:362:89: E501 line too long (103 > 88 characters)
+tests/unit/application/collaboration/test_collaborative_wsde_team.py:447:17: F841 local variable 'consensus_result' is assigned to but never used
+tests/unit/application/collaboration/test_collaborative_wsde_team.py:465:89: E501 line too long (113 > 88 characters)
+tests/unit/application/collaboration/test_collaborative_wsde_team_task_management.py:1:1: F401 'unittest.mock.patch' imported but unused
+tests/unit/application/collaboration/test_collaborative_wsde_team_task_management.py:39:89: E501 line too long (93 > 88 characters)
+tests/unit/application/collaboration/test_collaborative_wsde_team_task_management.py:299:9: F841 local variable 'subtask' is assigned to but never used
+tests/unit/application/collaboration/test_coordinator.py:99:9: F841 local variable 'original_assign_roles' is assigned to but never used
+tests/unit/application/collaboration/test_wsde_team_consensus_summary.py:1:1: F401 'pytest' imported but unused
+tests/unit/application/documentation/test_documentation_ingestion_manager.py:15:1: F401 'devsynth.exceptions.DocumentationError' imported but unused
+tests/unit/application/documentation/test_documentation_ingestion_manager.py:73:89: E501 line too long (169 > 88 characters)
+tests/unit/application/documentation/test_documentation_ingestion_manager.py:77:89: E501 line too long (137 > 88 characters)
+tests/unit/application/documentation/test_documentation_ingestion_manager.py:297:89: E501 line too long (171 > 88 characters)
+tests/unit/application/documentation/test_documentation_ingestion_manager.py:308:89: E501 line too long (139 > 88 characters)
+tests/unit/application/documentation/test_documentation_manager_utils.py:2:1: F401 'unittest.mock.patch' imported but unused
+tests/unit/application/documentation/test_documentation_manager_utils.py:57:89: E501 line too long (93 > 88 characters)
+tests/unit/application/documentation/test_documentation_manager_utils.py:168:89: E501 line too long (107 > 88 characters)
+tests/unit/application/documentation/test_documentation_manager_utils.py:171:89: E501 line too long (105 > 88 characters)
+tests/unit/application/documentation/test_documentation_manager_utils.py:174:89: E501 line too long (94 > 88 characters)
+tests/unit/application/documentation/test_documentation_manager_utils.py:202:89: E501 line too long (97 > 88 characters)
+tests/unit/application/documentation/test_documentation_manager_utils.py:210:89: E501 line too long (107 > 88 characters)
+tests/unit/application/documentation/test_documentation_manager_utils.py:214:89: E501 line too long (119 > 88 characters)
+tests/unit/application/edrr/test_coordinator.py:10:1: F401 'devsynth.application.edrr.coordinator.EDRRCoordinatorError' imported but unused
+tests/unit/application/edrr/test_coordinator.py:13:1: F401 'devsynth.domain.models.wsde_facade.WSDETeam' imported but unused
+tests/unit/application/edrr/test_coordinator_core.py:1:1: F401 'datetime.datetime' imported but unused
+tests/unit/application/edrr/test_coordinator_core.py:2:1: F401 'pathlib.Path' imported but unused
+tests/unit/application/edrr/test_coordinator_core.py:256:89: E501 line too long (165 > 88 characters)
+tests/unit/application/edrr/test_coordinator_core.py:278:89: E501 line too long (164 > 88 characters)
+tests/unit/application/edrr/test_coordinator_phases_simple.py:27:1: E402 module level import not at top of file
+tests/unit/application/edrr/test_coordinator_phases_simple.py:28:1: E402 module level import not at top of file
+tests/unit/application/edrr/test_edrr_coordinator.py:3:1: F401 'datetime.datetime' imported but unused
+tests/unit/application/edrr/test_edrr_coordinator.py:555:89: E501 line too long (93 > 88 characters)
+tests/unit/application/edrr/test_edrr_coordinator.py:583:89: E501 line too long (93 > 88 characters)
+tests/unit/application/edrr/test_edrr_coordinator_enhanced.py:2:1: F401 'pathlib.Path' imported but unused
+tests/unit/application/edrr/test_edrr_coordinator_enhanced.py:12:1: F401 'devsynth.application.edrr.coordinator.EDRRCoordinatorError' imported but unused
+tests/unit/application/edrr/test_edrr_coordinator_enhanced.py:18:1: F401 'devsynth.domain.models.wsde_facade.WSDETeam' imported but unused
+tests/unit/application/edrr/test_edrr_coordinator_enhanced.py:208:89: E501 line too long (91 > 88 characters)
+tests/unit/application/edrr/test_edrr_coordinator_enhanced.py:502:89: E501 line too long (93 > 88 characters)
+tests/unit/application/edrr/test_edrr_coordinator_enhanced.py:517:89: E501 line too long (90 > 88 characters)
+tests/unit/application/edrr/test_edrr_phase_transitions.py:331:89: E501 line too long (281 > 88 characters)
+tests/unit/application/edrr/test_edrr_phase_transitions.py:480:89: E501 line too long (94 > 88 characters)
+tests/unit/application/edrr/test_edrr_phase_transitions.py:502:89: E501 line too long (141 > 88 characters)
+tests/unit/application/edrr/test_edrr_phase_transitions.py:518:89: E501 line too long (99 > 88 characters)
+tests/unit/application/edrr/test_edrr_phase_transitions.py:529:89: E501 line too long (94 > 88 characters)
+tests/unit/application/edrr/test_edrr_phase_transitions.py:560:89: E501 line too long (99 > 88 characters)
+tests/unit/application/edrr/test_edrr_phase_transitions.py:584:89: E501 line too long (98 > 88 characters)
+tests/unit/application/edrr/test_enhanced_recursion_termination.py:4:89: E501 line too long (94 > 88 characters)
+tests/unit/application/edrr/test_enhanced_recursion_termination.py:12:1: F401 'unittest.mock.patch' imported but unused
+tests/unit/application/edrr/test_enhanced_recursion_termination.py:25:1: F401 'devsynth.methodology.base.Phase' imported but unused
+tests/unit/application/edrr/test_execute_single_agent_task.py:13:1: F401 'devsynth.domain.models.memory.MemoryType' imported but unused
+tests/unit/application/edrr/test_manifest_parser.py:10:1: F401 'datetime.datetime' imported but unused
+tests/unit/application/edrr/test_micro_cycle.py:5:1: F401 'typing.Any' imported but unused
+tests/unit/application/edrr/test_micro_cycle.py:5:1: F401 'typing.Dict' imported but unused
+tests/unit/application/edrr/test_micro_cycle_execution.py:13:1: F401 'devsynth.domain.models.wsde_facade.WSDETeam' imported but unused
+tests/unit/application/edrr/test_reasoning_loop_retries.py:1:1: F401 'types' imported but unused
+tests/unit/application/edrr/test_recursion_features.py:8:1: F401 'copy' imported but unused
+tests/unit/application/edrr/test_recursion_features.py:9:1: F401 'json' imported but unused
+tests/unit/application/edrr/test_recursion_features.py:10:1: F401 'unittest.mock.patch' imported but unused
+tests/unit/application/edrr/test_recursive_edrr_coordinator.py:339:33: E712 comparison to True should be 'if cond is True:' or 'if cond:'
+tests/unit/application/edrr/test_recursive_edrr_coordinator.py:343:33: E712 comparison to False should be 'if cond is False:' or 'if not cond:'
+tests/unit/application/edrr/test_recursive_edrr_coordinator.py:358:33: E712 comparison to True should be 'if cond is True:' or 'if cond:'
+tests/unit/application/edrr/test_recursive_edrr_coordinator.py:366:33: E712 comparison to False should be 'if cond is False:' or 'if not cond:'
+tests/unit/application/edrr/test_recursive_edrr_coordinator.py:397:33: E712 comparison to True should be 'if cond is True:' or 'if cond:'
+tests/unit/application/edrr/test_recursive_edrr_coordinator.py:401:33: E712 comparison to False should be 'if cond is False:' or 'if not cond:'
+tests/unit/application/edrr/test_recursive_edrr_coordinator.py:412:33: E712 comparison to True should be 'if cond is True:' or 'if cond:'
+tests/unit/application/edrr/test_recursive_edrr_coordinator.py:416:33: E712 comparison to False should be 'if cond is False:' or 'if not cond:'
+tests/unit/application/edrr/test_recursive_edrr_coordinator.py:430:33: E712 comparison to True should be 'if cond is True:' or 'if cond:'
+tests/unit/application/edrr/test_recursive_edrr_coordinator.py:434:33: E712 comparison to False should be 'if cond is False:' or 'if not cond:'
+tests/unit/application/llm/test_lmstudio_health_check.py:1:1: F401 'os' imported but unused
+tests/unit/application/llm/test_lmstudio_health_check.py:22:89: E501 line too long (94 > 88 characters)
+tests/unit/application/llm/test_lmstudio_health_check.py:31:89: E501 line too long (99 > 88 characters)
+tests/unit/application/llm/test_lmstudio_health_check.py:50:89: E501 line too long (98 > 88 characters)
+tests/unit/application/llm/test_lmstudio_health_check.py:54:89: E501 line too long (100 > 88 characters)
+tests/unit/application/llm/test_lmstudio_offline_resilience.py:8:89: E501 line too long (93 > 88 characters)
+tests/unit/application/llm/test_openai_env_key_mock.py:1:1: F401 'os' imported but unused
+tests/unit/application/llm/test_openai_env_key_mock.py:36:89: E501 line too long (89 > 88 characters)
+tests/unit/application/llm/test_openai_offline_resilience.py:1:1: F401 'asyncio' imported but unused
+tests/unit/application/llm/test_openai_offline_resilience.py:3:1: F401 'unittest.mock.AsyncMock' imported but unused
+tests/unit/application/llm/test_openai_offline_resilience.py:90:89: E501 line too long (100 > 88 characters)
+tests/unit/application/llm/test_provider_factory_lmstudio_gating.py:1:1: F401 'importlib' imported but unused
+tests/unit/application/llm/test_provider_factory_lmstudio_gating.py:2:1: F401 'os' imported but unused
+tests/unit/application/llm/test_provider_factory_lmstudio_gating.py:3:1: F401 'types' imported but unused
+tests/unit/application/llm/test_provider_factory_lmstudio_gating.py:54:89: E501 line too long (97 > 88 characters)
+tests/unit/application/llm/test_provider_factory_lmstudio_gating.py:55:89: E501 line too long (124 > 88 characters)
+tests/unit/application/memory/test_basic_crud_adapters.py:1:1: F401 'os' imported but unused
+tests/unit/application/memory/test_basic_crud_adapters.py:8:1: E402 module level import not at top of file
+tests/unit/application/memory/test_basic_crud_adapters.py:9:1: E402 module level import not at top of file
+tests/unit/application/memory/test_basic_crud_adapters.py:10:1: E402 module level import not at top of file
+tests/unit/application/memory/test_basic_crud_adapters.py:11:1: E402 module level import not at top of file
+tests/unit/application/memory/test_basic_crud_adapters.py:12:1: E402 module level import not at top of file
+tests/unit/application/memory/test_chromadb_store.py:14:1: E402 module level import not at top of file
+tests/unit/application/memory/test_chromadb_store.py:15:1: E402 module level import not at top of file
+tests/unit/application/memory/test_chromadb_store.py:102:5: F841 local variable 'store' is assigned to but never used
+tests/unit/application/memory/test_chromadb_store_delete_versions.py:16:1: E402 module level import not at top of file
+tests/unit/application/memory/test_chromadb_store_delete_versions.py:17:1: E402 module level import not at top of file
+tests/unit/application/memory/test_chromadb_store_delete_versions.py:42:89: E501 line too long (94 > 88 characters)
+tests/unit/application/memory/test_chromadb_store_delete_versions.py:45:89: E501 line too long (92 > 88 characters)
+tests/unit/application/memory/test_circuit_breaker.py:1:1: F401 'time' imported but unused
+tests/unit/application/memory/test_duckdb_store.py:1:1: F401 'json' imported but unused
+tests/unit/application/memory/test_duckdb_store.py:3:1: F401 'uuid' imported but unused
+tests/unit/application/memory/test_duckdb_store.py:4:1: F401 'datetime.timedelta' imported but unused
+tests/unit/application/memory/test_duckdb_store.py:5:1: F401 'typing.Any' imported but unused
+tests/unit/application/memory/test_duckdb_store.py:5:1: F401 'typing.Dict' imported but unused
+tests/unit/application/memory/test_duckdb_store.py:5:1: F401 'typing.List' imported but unused
+tests/unit/application/memory/test_duckdb_store.py:5:1: F401 'typing.Optional' imported but unused
+tests/unit/application/memory/test_duckdb_store.py:13:1: E402 module level import not at top of file
+tests/unit/application/memory/test_duckdb_store.py:14:1: E402 module level import not at top of file
+tests/unit/application/memory/test_duckdb_store.py:15:1: F401 'devsynth.exceptions.MemoryStoreError' imported but unused
+tests/unit/application/memory/test_duckdb_store.py:15:1: E402 module level import not at top of file
+tests/unit/application/memory/test_duckdb_store_hnsw.py:4:1: F401 'uuid' imported but unused
+tests/unit/application/memory/test_duckdb_store_hnsw.py:5:1: F401 'datetime.timedelta' imported but unused
+tests/unit/application/memory/test_duckdb_store_hnsw.py:6:1: F401 'typing.Any' imported but unused
+tests/unit/application/memory/test_duckdb_store_hnsw.py:6:1: F401 'typing.Dict' imported but unused
+tests/unit/application/memory/test_duckdb_store_hnsw.py:6:1: F401 'typing.List' imported but unused
+tests/unit/application/memory/test_duckdb_store_hnsw.py:6:1: F401 'typing.Optional' imported but unused
+tests/unit/application/memory/test_duckdb_store_hnsw.py:15:1: E402 module level import not at top of file
+tests/unit/application/memory/test_duckdb_store_hnsw.py:16:1: F401 'devsynth.domain.models.memory.MemoryItem' imported but unused
+tests/unit/application/memory/test_duckdb_store_hnsw.py:16:1: F401 'devsynth.domain.models.memory.MemoryType' imported but unused
+tests/unit/application/memory/test_duckdb_store_hnsw.py:16:1: E402 module level import not at top of file
+tests/unit/application/memory/test_duckdb_store_hnsw.py:17:1: F401 'devsynth.exceptions.MemoryStoreError' imported but unused
+tests/unit/application/memory/test_duckdb_store_hnsw.py:17:1: E402 module level import not at top of file
+tests/unit/application/memory/test_duckdb_store_hnsw.py:108:89: E501 line too long (107 > 88 characters)
+tests/unit/application/memory/test_faiss_store.py:1:1: F401 'json' imported but unused
+tests/unit/application/memory/test_faiss_store.py:3:1: F401 'uuid' imported but unused
+tests/unit/application/memory/test_faiss_store.py:4:1: F401 'datetime.timedelta' imported but unused
+tests/unit/application/memory/test_faiss_store.py:5:1: F401 'typing.Any' imported but unused
+tests/unit/application/memory/test_faiss_store.py:5:1: F401 'typing.Dict' imported but unused
+tests/unit/application/memory/test_faiss_store.py:5:1: F401 'typing.List' imported but unused
+tests/unit/application/memory/test_faiss_store.py:5:1: F401 'typing.Optional' imported but unused
+tests/unit/application/memory/test_faiss_store.py:13:1: E402 module level import not at top of file
+tests/unit/application/memory/test_faiss_store.py:14:1: F401 'devsynth.domain.models.memory.MemoryItem' imported but unused
+tests/unit/application/memory/test_faiss_store.py:14:1: F401 'devsynth.domain.models.memory.MemoryType' imported but unused
+tests/unit/application/memory/test_faiss_store.py:14:1: E402 module level import not at top of file
+tests/unit/application/memory/test_faiss_store.py:15:1: F401 'devsynth.exceptions.MemoryStoreError' imported but unused
+tests/unit/application/memory/test_faiss_store.py:15:1: E402 module level import not at top of file
+tests/unit/application/memory/test_fallback.py:6:1: F401 'unittest.mock.call' imported but unused
+tests/unit/application/memory/test_fallback.py:6:1: F401 'unittest.mock.patch' imported but unused
+tests/unit/application/memory/test_fallback.py:443:89: E501 line too long (91 > 88 characters)
+tests/unit/application/memory/test_graph_memory_adapter.py:7:1: F401 'typing.Any' imported but unused
+tests/unit/application/memory/test_graph_memory_adapter.py:7:1: F401 'typing.Dict' imported but unused
+tests/unit/application/memory/test_graph_memory_adapter.py:7:1: F401 'typing.List' imported but unused
+tests/unit/application/memory/test_graph_memory_adapter.py:8:1: F401 'unittest.mock.patch' imported but unused
+tests/unit/application/memory/test_graph_memory_adapter.py:11:1: F401 'rdflib.Namespace' imported but unused
+tests/unit/application/memory/test_graph_memory_adapter.py:26:1: F401 'devsynth.exceptions.MemoryItemNotFoundError' imported but unused
+tests/unit/application/memory/test_graph_memory_adapter.py:26:1: F401 'devsynth.exceptions.MemoryStoreError' imported but unused
+tests/unit/application/memory/test_graph_memory_adapter.py:300:9: F841 local variable 'original_query' is assigned to but never used
+tests/unit/application/memory/test_graph_memory_adapter.py:342:9: F841 local variable 'original_update' is assigned to but never used
+tests/unit/application/memory/test_graph_memory_adapter.py:413:9: F841 local variable 'volatile_items' is assigned to but never used
+tests/unit/application/memory/test_graph_memory_adapter.py:558:89: E501 line too long (105 > 88 characters)
+tests/unit/application/memory/test_knowledge_graph_utils.py:1:1: F401 'json' imported but unused
+tests/unit/application/memory/test_knowledge_graph_utils.py:3:1: F401 'uuid' imported but unused
+tests/unit/application/memory/test_knowledge_graph_utils.py:4:1: F401 'datetime.timedelta' imported but unused
+tests/unit/application/memory/test_knowledge_graph_utils.py:5:1: F401 'typing.Any' imported but unused
+tests/unit/application/memory/test_knowledge_graph_utils.py:5:1: F401 'typing.Dict' imported but unused
+tests/unit/application/memory/test_knowledge_graph_utils.py:5:1: F401 'typing.List' imported but unused
+tests/unit/application/memory/test_knowledge_graph_utils.py:5:1: F401 'typing.Optional' imported but unused
+tests/unit/application/memory/test_knowledge_graph_utils.py:7:1: F401 'numpy as np' imported but unused
+tests/unit/application/memory/test_knowledge_graph_utils.py:9:1: F401 'rdflib.Literal' imported but unused
+tests/unit/application/memory/test_knowledge_graph_utils.py:9:1: F401 'rdflib.Namespace' imported but unused
+tests/unit/application/memory/test_knowledge_graph_utils.py:9:1: F401 'rdflib.URIRef' imported but unused
+tests/unit/application/memory/test_knowledge_graph_utils.py:11:1: F401 'devsynth.domain.models.memory.MemoryVector' imported but unused
+tests/unit/application/memory/test_knowledge_graph_utils.py:15:5: F401 'devsynth.application.memory.knowledge_graph_utils.MEMORY' imported but unused
+tests/unit/application/memory/test_knowledge_graph_utils.py:29:1: F401 'devsynth.exceptions.MemoryStoreError' imported but unused
+tests/unit/application/memory/test_knowledge_graph_utils.py:182:89: E501 line too long (114 > 88 characters)
+tests/unit/application/memory/test_knowledge_graph_utils.py:187:89: E501 line too long (252 > 88 characters)
+tests/unit/application/memory/test_knowledge_graph_utils.py:195:89: E501 line too long (129 > 88 characters)
+tests/unit/application/memory/test_kuzu_store.py:3:1: F401 'tempfile' imported but unused
+tests/unit/application/memory/test_kuzu_store.py:11:1: E402 module level import not at top of file
+tests/unit/application/memory/test_kuzu_store.py:12:1: E402 module level import not at top of file
+tests/unit/application/memory/test_lmdb_store.py:1:1: F401 'json' imported but unused
+tests/unit/application/memory/test_lmdb_store.py:4:1: F401 'uuid' imported but unused
+tests/unit/application/memory/test_lmdb_store.py:5:1: F401 'datetime.timedelta' imported but unused
+tests/unit/application/memory/test_lmdb_store.py:6:1: F401 'typing.Any' imported but unused
+tests/unit/application/memory/test_lmdb_store.py:6:1: F401 'typing.Dict' imported but unused
+tests/unit/application/memory/test_lmdb_store.py:6:1: F401 'typing.List' imported but unused
+tests/unit/application/memory/test_lmdb_store.py:6:1: F401 'typing.Optional' imported but unused
+tests/unit/application/memory/test_lmdb_store.py:15:1: E402 module level import not at top of file
+tests/unit/application/memory/test_lmdb_store.py:16:1: F401 'devsynth.exceptions.MemoryStoreError' imported but unused
+tests/unit/application/memory/test_lmdb_store.py:16:1: E402 module level import not at top of file
+tests/unit/application/memory/test_memory_adapters_regression.py:1:1: F401 'tempfile' imported but unused
+tests/unit/application/memory/test_memory_manager.py:5:1: F401 'unittest.mock.patch' imported but unused
+tests/unit/application/memory/test_memory_manager.py:24:1: F401 'devsynth.domain.models.memory.MemoryItem' imported but unused
+tests/unit/application/memory/test_memory_manager.py:24:1: E402 module level import not at top of file
+tests/unit/application/memory/test_memory_manager_search.py:28:1: E402 module level import not at top of file
+tests/unit/application/memory/test_memory_manager_search.py:30:1: E402 module level import not at top of file
+tests/unit/application/memory/test_multi_layered_memory.py:5:1: F401 'unittest.mock.MagicMock' imported but unused
+tests/unit/application/memory/test_multi_layered_memory.py:5:1: F401 'unittest.mock.patch' imported but unused
+tests/unit/application/memory/test_multi_layered_memory.py:10:1: F401 'devsynth.domain.models.memory.MemoryVector' imported but unused
+tests/unit/application/memory/test_rdflib_store.py:1:1: F401 'json' imported but unused
+tests/unit/application/memory/test_rdflib_store.py:3:1: F401 'uuid' imported but unused
+tests/unit/application/memory/test_rdflib_store.py:5:1: F401 'typing.Any' imported but unused
+tests/unit/application/memory/test_rdflib_store.py:5:1: F401 'typing.Dict' imported but unused
+tests/unit/application/memory/test_rdflib_store.py:5:1: F401 'typing.List' imported but unused
+tests/unit/application/memory/test_rdflib_store.py:5:1: F401 'typing.Optional' imported but unused
+tests/unit/application/memory/test_rdflib_store.py:13:1: E402 module level import not at top of file
+tests/unit/application/memory/test_rdflib_store.py:14:1: E402 module level import not at top of file
+tests/unit/application/memory/test_rdflib_store.py:15:1: F401 'devsynth.exceptions.MemoryStoreError' imported but unused
+tests/unit/application/memory/test_rdflib_store.py:15:1: E402 module level import not at top of file
+tests/unit/application/memory/test_recovery.py:5:1: F401 'json' imported but unused
+tests/unit/application/memory/test_recovery.py:9:1: F401 'unittest.mock.call' imported but unused
+tests/unit/application/memory/test_recovery.py:9:1: F401 'unittest.mock.patch' imported but unused
+tests/unit/application/memory/test_retry.py:5:1: F401 'time' imported but unused
+tests/unit/application/memory/test_retry.py:6:1: F401 'unittest.mock.call' imported but unused
+tests/unit/application/memory/test_retry.py:250:89: E501 line too long (105 > 88 characters)
+tests/unit/application/memory/test_retry.py:251:89: E501 line too long (97 > 88 characters)
+tests/unit/application/memory/test_retry.py:283:89: E501 line too long (98 > 88 characters)
+tests/unit/application/memory/test_retry.py:284:89: E501 line too long (90 > 88 characters)
+tests/unit/application/memory/test_sync_across_backends.py:1:1: F401 'asyncio' imported but unused
+tests/unit/application/memory/test_sync_across_backends.py:9:1: E402 module level import not at top of file
+tests/unit/application/memory/test_sync_across_backends.py:10:1: E402 module level import not at top of file
+tests/unit/application/memory/test_sync_across_backends.py:11:1: E402 module level import not at top of file
+tests/unit/application/memory/test_sync_across_backends.py:12:1: E402 module level import not at top of file
+tests/unit/application/memory/test_sync_across_backends.py:13:1: E402 module level import not at top of file
+tests/unit/application/memory/test_sync_across_backends.py:14:1: E402 module level import not at top of file
+tests/unit/application/memory/test_sync_across_backends.py:15:1: E402 module level import not at top of file
+tests/unit/application/memory/test_tiered_cache_validation.py:8:1: E402 module level import not at top of file
+tests/unit/application/memory/test_tiered_cache_validation.py:9:1: E402 module level import not at top of file
+tests/unit/application/memory/test_tiered_cache_validation.py:11:1: E402 module level import not at top of file
+tests/unit/application/memory/test_tiered_cache_validation.py:12:1: E402 module level import not at top of file
+tests/unit/application/memory/test_tiered_cache_validation.py:13:1: E402 module level import not at top of file
+tests/unit/application/memory/test_tinydb_adapter_bytes_tuple.py:1:1: F401 'os' imported but unused
+tests/unit/application/memory/test_tinydb_adapter_bytes_tuple.py:53:89: E501 line too long (109 > 88 characters)
+tests/unit/application/memory/test_tinydb_store.py:1:1: F401 'json' imported but unused
+tests/unit/application/memory/test_tinydb_store.py:3:1: F401 'uuid' imported but unused
+tests/unit/application/memory/test_tinydb_store.py:4:1: F401 'datetime.timedelta' imported but unused
+tests/unit/application/memory/test_tinydb_store.py:5:1: F401 'typing.Any' imported but unused
+tests/unit/application/memory/test_tinydb_store.py:5:1: F401 'typing.Dict' imported but unused
+tests/unit/application/memory/test_tinydb_store.py:5:1: F401 'typing.List' imported but unused
+tests/unit/application/memory/test_tinydb_store.py:5:1: F401 'typing.Optional' imported but unused
+tests/unit/application/memory/test_tinydb_store.py:12:1: E402 module level import not at top of file
+tests/unit/application/memory/test_tinydb_store.py:13:1: E402 module level import not at top of file
+tests/unit/application/memory/test_tinydb_store.py:14:1: F401 'devsynth.exceptions.MemoryStoreError' imported but unused
+tests/unit/application/memory/test_tinydb_store.py:14:1: E402 module level import not at top of file
+tests/unit/application/orchestration/test_dialectical_reasoner.py:3:1: F401 'pytest' imported but unused
+tests/unit/application/test_prompt_auto_tuning.py:8:1: F401 'unittest.mock.MagicMock' imported but unused
+tests/unit/application/test_prompt_auto_tuning.py:239:89: E501 line too long (102 > 88 characters)
+tests/unit/application/utils/test_extras_helper.py:1:1: F401 're' imported but unused
+tests/unit/application/wsde/__init__.py:1:1: W391 blank line at end of file
+tests/unit/behavior/test_alignment_metrics_steps_unit.py:9:1: E402 module level import not at top of file
+tests/unit/behavior/test_alignment_metrics_steps_unit.py:12:1: E402 module level import not at top of file
+tests/unit/cli/__init__.py:1:1: W391 blank line at end of file
+tests/unit/cli/test_cli_help.py:11:89: E501 line too long (104 > 88 characters)
+tests/unit/cli/test_completion_progress.py:1:1: F401 'io' imported but unused
+tests/unit/cli/test_entry_points_help.py:1:1: F401 'os' imported but unused
+tests/unit/cli/test_exit_codes.py:17:89: E501 line too long (91 > 88 characters)
+tests/unit/cli/test_mvu_commands.py:14:89: E501 line too long (95 > 88 characters)
+tests/unit/cli/test_mvu_commands.py:44:5: F841 local variable 'schema' is assigned to but never used
+tests/unit/cli/test_mvuu_dashboard_smoke.py:11:89: E501 line too long (91 > 88 characters)
+tests/unit/cli/test_mvuu_dashboard_smoke.py:27:89: E501 line too long (101 > 88 characters)
+tests/unit/config/test_config_validation_extended.py:8:1: F401 'unittest.mock.patch' imported but unused
+tests/unit/config/test_config_validation_extended.py:13:1: F401 'devsynth.exceptions.DevSynthError' imported but unused
+tests/unit/config/test_config_validation_extended.py:81:55: F821 undefined name 'yaml'
+tests/unit/config/test_config_validation_extended.py:139:61: E712 comparison to True should be 'if cond is True:' or 'if cond:'
+tests/unit/config/test_config_validation_extended.py:195:65: E712 comparison to True should be 'if cond is True:' or 'if cond:'
+tests/unit/conftest.py:6:89: E501 line too long (91 > 88 characters)
+tests/unit/conftest.py:10:89: E501 line too long (98 > 88 characters)
+tests/unit/conftest.py:11:89: E501 line too long (94 > 88 characters)
+tests/unit/conftest.py:31:89: E501 line too long (91 > 88 characters)
+tests/unit/core/test_config_loader_mvu.py:1:1: F401 'pathlib.Path' imported but unused
+tests/unit/core/test_core_values.py:12:1: E402 module level import not at top of file
+tests/unit/deployment/test_bootstrap_script.py:67:89: E501 line too long (95 > 88 characters)
+tests/unit/deployment/test_bootstrap_script.py:82:89: E501 line too long (94 > 88 characters)
+tests/unit/deployment/test_bootstrap_script.py:87:89: E501 line too long (90 > 88 characters)
+tests/unit/devsynth/test_fallback_reliability.py:1:1: F401 'time' imported but unused
+tests/unit/docs/test_dialectical_audit.py:2:1: F401 'pathlib.Path' imported but unused
+tests/unit/docs/test_feature_matrix.py:2:1: F401 're' imported but unused
+tests/unit/domain/models/test_project_model.py:58:89: E501 line too long (90 > 88 characters)
+tests/unit/domain/models/test_wsde.py:10:1: F401 'unittest.mock.patch' imported but unused
+tests/unit/domain/models/test_wsde_code_improvements.py:1:1: F401 'pytest' imported but unused
+tests/unit/domain/models/test_wsde_code_improvements.py:14:89: E501 line too long (105 > 88 characters)
+tests/unit/domain/models/test_wsde_context_driven_leadership.py:9:1: F401 'unittest.mock.MagicMock' imported but unused
+tests/unit/domain/models/test_wsde_context_driven_leadership.py:9:1: F401 'unittest.mock.patch' imported but unused
+tests/unit/domain/models/test_wsde_context_driven_leadership.py:14:1: F401 'devsynth.methodology.base.Phase' imported but unused
+tests/unit/domain/models/test_wsde_dialectical_reasoning.py:9:1: F401 'typing.Any' imported but unused
+tests/unit/domain/models/test_wsde_dialectical_reasoning.py:9:1: F401 'typing.Dict' imported but unused
+tests/unit/domain/models/test_wsde_dialectical_reasoning.py:9:1: F401 'typing.List' imported but unused
+tests/unit/domain/models/test_wsde_dialectical_reasoning.py:10:1: F401 'unittest.mock.patch' imported but unused
+tests/unit/domain/models/test_wsde_dialectical_reasoning.py:241:61: E712 comparison to True should be 'if cond is True:' or 'if cond:'
+tests/unit/domain/models/test_wsde_dialectical_reasoning.py:242:62: E712 comparison to True should be 'if cond is True:' or 'if cond:'
+tests/unit/domain/models/test_wsde_dialectical_reasoning.py:243:75: E712 comparison to False should be 'if cond is False:' or 'if not cond:'
+tests/unit/domain/models/test_wsde_dialectical_reasoning.py:286:56: E712 comparison to True should be 'if cond is True:' or 'if cond:'
+tests/unit/domain/models/test_wsde_dialectical_reasoning.py:287:57: E712 comparison to True should be 'if cond is True:' or 'if cond:'
+tests/unit/domain/models/test_wsde_dialectical_reasoning.py:324:33: E712 comparison to True should be 'if cond is True:' or 'if cond:'
+tests/unit/domain/models/test_wsde_dialectical_reasoning.py:325:37: E712 comparison to False should be 'if cond is False:' or 'if not cond:'
+tests/unit/domain/models/test_wsde_dialectical_reasoning.py:370:30: E712 comparison to True should be 'if cond is True:' or 'if cond:'
+tests/unit/domain/models/test_wsde_dialectical_reasoning.py:371:32: E712 comparison to False should be 'if cond is False:' or 'if not cond:'
+tests/unit/domain/models/test_wsde_dynamic_workflows.py:3:1: F401 'pytest' imported but unused
+tests/unit/domain/models/test_wsde_team.py:8:1: F401 'unittest.mock.patch' imported but unused
+tests/unit/domain/models/test_wsde_team.py:12:1: F401 'devsynth.domain.models.wsde_facade.WSDE' imported but unused
+tests/unit/domain/models/test_wsde_utils.py:6:1: F401 'pytest' imported but unused
+tests/unit/domain/test_code_analysis_interfaces.py:5:1: F401 'devsynth.domain.interfaces.code_analysis.CodeAnalysisResult' imported but unused
+tests/unit/domain/test_code_analysis_interfaces.py:5:1: F401 'devsynth.domain.interfaces.code_analysis.SimpleCodeAnalysis' imported but unused
+tests/unit/domain/test_code_analysis_interfaces.py:5:1: F401 'devsynth.domain.interfaces.code_analysis.SimpleTransformation' imported but unused
+tests/unit/domain/test_requirement_interfaces.py:6:1: F401 'devsynth.domain.interfaces.requirement.InMemoryDialecticalReasoningRepository' imported but unused
+tests/unit/domain/test_requirement_interfaces.py:6:1: F401 'devsynth.domain.interfaces.requirement.PrintNotificationService' imported but unused
+tests/unit/domain/test_wsde_core_methods.py:1:1: F401 'types' imported but unused
+tests/unit/domain/test_wsde_expertise_score.py:1:1: F401 'unittest.mock.MagicMock' imported but unused
+tests/unit/domain/test_wsde_primus_selection.py:122:5: F401 'os' imported but unused
+tests/unit/domain/test_wsde_voting_logic.py:6:1: F401 'devsynth.application.edrr.edrr_phase_transitions as _ph' imported but unused
+tests/unit/general/test_agent_adapter.py:13:16: E701 multiple statements on one line (colon)
+tests/unit/general/test_agent_adapter_delegate.py:10:1: F401 'devsynth.domain.models.wsde_facade.WSDETeam' imported but unused
+tests/unit/general/test_agent_collaboration.py:16:1: F401 'devsynth.domain.models.wsde_facade.WSDE' imported but unused
+tests/unit/general/test_agent_collaboration.py:16:1: F401 'devsynth.domain.models.wsde_facade.WSDETeam' imported but unused
+tests/unit/general/test_agent_coordinator.py:8:1: F401 'unittest.mock.patch' imported but unused
+tests/unit/general/test_agent_coordinator.py:13:1: F401 'devsynth.application.collaboration.exceptions.CollaborationError' imported but unused
+tests/unit/general/test_agent_coordinator.py:13:1: F401 'devsynth.application.collaboration.exceptions.ConsensusError' imported but unused
+tests/unit/general/test_agent_coordinator.py:13:1: F401 'devsynth.application.collaboration.exceptions.RoleAssignmentError' imported but unused
+tests/unit/general/test_agent_system.py:5:1: F401 'unittest.mock.MagicMock' imported but unused
+tests/unit/general/test_api.py:6:1: E402 module level import not at top of file
+tests/unit/general/test_api.py:7:1: E402 module level import not at top of file
+tests/unit/general/test_api.py:9:1: E402 module level import not at top of file
+tests/unit/general/test_api_health.py:6:1: E402 module level import not at top of file
+tests/unit/general/test_atomic_rewrite_cli.py:40:89: E501 line too long (100 > 88 characters)
+tests/unit/general/test_backend_resource_flags.py:33:89: E501 line too long (89 > 88 characters)
+tests/unit/general/test_backend_resource_flags.py:34:89: E501 line too long (95 > 88 characters)
+tests/unit/general/test_backend_resource_flags.py:38:89: E501 line too long (91 > 88 characters)
+tests/unit/general/test_backend_resource_flags.py:39:89: E501 line too long (90 > 88 characters)
+tests/unit/general/test_chroma_db_adapter.py:5:1: F401 'json' imported but unused
+tests/unit/general/test_chroma_db_adapter.py:6:1: F401 'os' imported but unused
+tests/unit/general/test_chroma_db_adapter.py:9:1: F401 'unittest' imported but unused
+tests/unit/general/test_chroma_db_adapter.py:10:1: F401 'datetime.datetime' imported but unused
+tests/unit/general/test_chroma_db_adapter.py:11:1: F401 'typing.Any' imported but unused
+tests/unit/general/test_chroma_db_adapter.py:11:1: F401 'typing.Dict' imported but unused
+tests/unit/general/test_chroma_db_adapter.py:11:1: F401 'typing.List' imported but unused
+tests/unit/general/test_chroma_db_adapter.py:12:1: F401 'unittest.mock.MagicMock' imported but unused
+tests/unit/general/test_chroma_db_adapter.py:12:1: F401 'unittest.mock.patch' imported but unused
+tests/unit/general/test_chroma_db_adapter.py:14:1: F401 'numpy as np' imported but unused
+tests/unit/general/test_chroma_db_adapter.py:19:1: F401 'devsynth.exceptions.MemoryStoreError' imported but unused
+tests/unit/general/test_chromadb_store.py:5:1: F401 'json' imported but unused
+tests/unit/general/test_chromadb_store.py:10:1: F401 'datetime.datetime' imported but unused
+tests/unit/general/test_chromadb_store.py:11:1: F401 'typing.Any' imported but unused
+tests/unit/general/test_chromadb_store.py:11:1: F401 'typing.Dict' imported but unused
+tests/unit/general/test_chromadb_store.py:12:1: F401 'unittest.mock.MagicMock' imported but unused
+tests/unit/general/test_chromadb_store.py:12:1: F401 'unittest.mock.patch' imported but unused
+tests/unit/general/test_chromadb_store.py:94:89: E501 line too long (102 > 88 characters)
+tests/unit/general/test_chromadb_store.py:130:89: E501 line too long (90 > 88 characters)
+tests/unit/general/test_code_analysis_models.py:6:1: F401 'typing.Any' imported but unused
+tests/unit/general/test_code_analysis_models.py:6:1: F401 'typing.Dict' imported but unused
+tests/unit/general/test_code_analysis_models.py:6:1: F401 'typing.List' imported but unused
+tests/unit/general/test_code_analysis_models.py:6:1: F401 'typing.Optional' imported but unused
+tests/unit/general/test_code_analysis_models.py:10:1: F401 'devsynth.domain.interfaces.code_analysis.CodeAnalysisProvider' imported but unused
+tests/unit/general/test_code_analyzer.py:8:1: F401 'typing.Any' imported but unused
+tests/unit/general/test_code_analyzer.py:8:1: F401 'typing.Dict' imported but unused
+tests/unit/general/test_code_analyzer.py:8:1: F401 'typing.List' imported but unused
+tests/unit/general/test_code_analyzer.py:8:1: F401 'typing.Optional' imported but unused
+tests/unit/general/test_code_analyzer.py:9:1: F401 'unittest.mock.MagicMock' imported but unused
+tests/unit/general/test_code_analyzer.py:14:1: F401 'devsynth.domain.interfaces.code_analysis.CodeAnalysisProvider' imported but unused
+tests/unit/general/test_code_analyzer.py:19:1: F401 'devsynth.domain.models.code_analysis.CodeAnalysis' imported but unused
+tests/unit/general/test_code_analyzer.py:19:1: F401 'devsynth.domain.models.code_analysis.FileAnalysis' imported but unused
+tests/unit/general/test_config_loader.py:2:1: F401 'pathlib.Path' imported but unused
+tests/unit/general/test_config_settings.py:6:1: F401 'tempfile' imported but unused
+tests/unit/general/test_config_settings.py:7:1: F401 'pathlib.Path' imported but unused
+tests/unit/general/test_config_settings.py:23:89: E501 line too long (96 > 88 characters)
+tests/unit/general/test_config_settings.py:34:89: E501 line too long (91 > 88 characters)
+tests/unit/general/test_core_config_loader.py:2:1: F401 'pathlib.Path' imported but unused
+tests/unit/general/test_dialectical_reasoner.py:6:1: F401 'datetime.datetime' imported but unused
+tests/unit/general/test_dialectical_reasoner.py:8:1: F401 'uuid.UUID' imported but unused
+tests/unit/general/test_dialectical_reasoner.py:24:1: F401 'devsynth.domain.models.requirement.ChatMessage' imported but unused
+tests/unit/general/test_dialectical_reasoner.py:24:1: F401 'devsynth.domain.models.requirement.ChatSession' imported but unused
+tests/unit/general/test_dialectical_reasoner.py:24:1: F401 'devsynth.domain.models.requirement.ImpactAssessment' imported but unused
+tests/unit/general/test_dialectical_reasoner.py:213:89: E501 line too long (93 > 88 characters)
+tests/unit/general/test_dialectical_reasoner.py:244:89: E501 line too long (139 > 88 characters)
+tests/unit/general/test_dpg_flag.py:4:1: F401 'pytest' imported but unused
+tests/unit/general/test_dpg_flag.py:55:1: E402 module level import not at top of file
+tests/unit/general/test_edrr_cycle_cmd.py:3:1: F401 'unittest.mock.ANY' imported but unused
+tests/unit/general/test_enhanced_chromadb_store.py:17:1: F401 'json' imported but unused
+tests/unit/general/test_enhanced_chromadb_store.py:17:1: E402 module level import not at top of file
+tests/unit/general/test_enhanced_chromadb_store.py:18:1: E402 module level import not at top of file
+tests/unit/general/test_enhanced_chromadb_store.py:19:1: E402 module level import not at top of file
+tests/unit/general/test_enhanced_chromadb_store.py:20:1: E402 module level import not at top of file
+tests/unit/general/test_enhanced_chromadb_store.py:21:1: E402 module level import not at top of file
+tests/unit/general/test_enhanced_chromadb_store.py:22:1: F401 'datetime.datetime' imported but unused
+tests/unit/general/test_enhanced_chromadb_store.py:22:1: E402 module level import not at top of file
+tests/unit/general/test_enhanced_chromadb_store.py:23:1: F401 'typing.Any' imported but unused
+tests/unit/general/test_enhanced_chromadb_store.py:23:1: F401 'typing.Dict' imported but unused
+tests/unit/general/test_enhanced_chromadb_store.py:23:1: E402 module level import not at top of file
+tests/unit/general/test_enhanced_chromadb_store.py:24:1: F401 'unittest.mock.MagicMock' imported but unused
+tests/unit/general/test_enhanced_chromadb_store.py:24:1: F401 'unittest.mock.call' imported but unused
+tests/unit/general/test_enhanced_chromadb_store.py:24:1: E402 module level import not at top of file
+tests/unit/general/test_enhanced_chromadb_store.py:26:1: E402 module level import not at top of file
+tests/unit/general/test_enhanced_chromadb_store.py:27:1: E402 module level import not at top of file
+tests/unit/general/test_exceptions.py:4:89: E501 line too long (98 > 88 characters)
+tests/unit/general/test_exceptions.py:7:1: F401 'typing.Any' imported but unused
+tests/unit/general/test_exceptions.py:7:1: F401 'typing.Dict' imported but unused
+tests/unit/general/test_exceptions.py:11:1: F401 'devsynth.exceptions.CodeGenerationError' imported but unused
+tests/unit/general/test_exceptions.py:11:1: F401 'devsynth.exceptions.ContextError' imported but unused
+tests/unit/general/test_exceptions.py:11:1: F401 'devsynth.exceptions.ManifestError' imported but unused
+tests/unit/general/test_exceptions.py:11:1: F401 'devsynth.exceptions.MemoryNotFoundError' imported but unused
+tests/unit/general/test_exceptions.py:11:1: F401 'devsynth.exceptions.MemoryStoreError' imported but unused
+tests/unit/general/test_exceptions.py:11:1: F401 'devsynth.exceptions.ProviderAuthenticationError' imported but unused
+tests/unit/general/test_exceptions.py:11:1: F401 'devsynth.exceptions.TestGenerationException' imported but unused
+tests/unit/general/test_fallback_utils.py:14:89: E501 line too long (99 > 88 characters)
+tests/unit/general/test_fallback_utils.py:57:89: E501 line too long (104 > 88 characters)
+tests/unit/general/test_ingest_cmd.py:39:1: E402 module level import not at top of file
+tests/unit/general/test_ingest_cmd.py:48:1: E402 module level import not at top of file
+tests/unit/general/test_ingest_cmd.py:272:89: E501 line too long (94 > 88 characters)
+tests/unit/general/test_ingest_cmd.py:321:89: E501 line too long (94 > 88 characters)
+tests/unit/general/test_ingest_cmd.py:349:89: E501 line too long (94 > 88 characters)
+tests/unit/general/test_ingestion_type_hints.py:1:1: F401 'os' imported but unused
+tests/unit/general/test_ingestion_type_hints.py:4:1: F401 'tempfile' imported but unused
+tests/unit/general/test_inspect_config_cmd.py:4:1: F401 'unittest.mock.MagicMock' imported but unused
+tests/unit/general/test_inspect_config_cmd.py:80:89: E501 line too long (98 > 88 characters)
+tests/unit/general/test_isolation.py:13:1: F401 'unittest.mock.MagicMock' imported but unused
+tests/unit/general/test_isolation.py:71:89: E501 line too long (93 > 88 characters)
+tests/unit/general/test_isolation.py:82:25: F541 f-string is missing placeholders
+tests/unit/general/test_isolation.py:125:89: E501 line too long (90 > 88 characters)
+tests/unit/general/test_isolation.py:129:89: E501 line too long (115 > 88 characters)
+tests/unit/general/test_isolation.py:182:89: E501 line too long (94 > 88 characters)
+tests/unit/general/test_isolation.py:232:13: F841 local variable 'settings' is assigned to but never used
+tests/unit/general/test_isolation.py:236:13: F841 local variable 'memory_path' is assigned to but never used
+tests/unit/general/test_isolation.py:239:13: F841 local variable 'log_path' is assigned to but never used
+tests/unit/general/test_isolation.py:252:89: E501 line too long (99 > 88 characters)
+tests/unit/general/test_isolation_auto_marking.py:23:89: E501 line too long (91 > 88 characters)
+tests/unit/general/test_knowledge_graph_utils.py:1:1: F403 'from tests.unit.application.memory.test_knowledge_graph_utils import *' used; unable to detect undefined names
+tests/unit/general/test_knowledge_graph_utils.py:1:1: F401 'tests.unit.application.memory.test_knowledge_graph_utils.*' imported but unused
+tests/unit/general/test_kuzu_project_startup.py:1:1: F401 'os' imported but unused
+tests/unit/general/test_kuzu_project_startup.py:2:1: F401 'shutil' imported but unused
+tests/unit/general/test_kuzu_project_startup.py:3:1: F401 'pathlib.Path' imported but unused
+tests/unit/general/test_kuzu_store_fallback.py:3:1: F401 'pathlib.Path' imported but unused
+tests/unit/general/test_langgraph_adapter.py:1:1: F401 'os' imported but unused
+tests/unit/general/test_langgraph_adapter.py:2:1: F401 'pickle' imported but unused
+tests/unit/general/test_langgraph_adapter.py:7:1: F401 'devsynth.adapters.orchestration.langgraph_adapter.NeedsHumanInterventionError' imported but unused
+tests/unit/general/test_langgraph_adapter.py:273:9: F841 local variable 'mock_files' is assigned to but never used
+tests/unit/general/test_lmstudio_provider_unit.py:43:89: E501 line too long (94 > 88 characters)
+tests/unit/general/test_logging_setup_idempotent.py:71:89: E501 line too long (95 > 88 characters)
+tests/unit/general/test_memory_system.py:5:1: F401 'json' imported but unused
+tests/unit/general/test_memory_system.py:10:1: F401 'datetime.datetime' imported but unused
+tests/unit/general/test_memory_system.py:11:1: F401 'typing.Any' imported but unused
+tests/unit/general/test_memory_system.py:11:1: F401 'typing.Dict' imported but unused
+tests/unit/general/test_memory_system.py:27:1: F401 'devsynth.config.get_settings' imported but unused
+tests/unit/general/test_memory_system.py:149:89: E501 line too long (96 > 88 characters)
+tests/unit/general/test_memory_system_with_chromadb.py:5:1: F401 'json' imported but unused
+tests/unit/general/test_memory_system_with_chromadb.py:6:1: F401 'os' imported but unused
+tests/unit/general/test_memory_system_with_chromadb.py:9:1: F401 'unittest' imported but unused
+tests/unit/general/test_memory_system_with_chromadb.py:10:1: F401 'datetime.datetime' imported but unused
+tests/unit/general/test_memory_system_with_chromadb.py:11:1: F401 'typing.Any' imported but unused
+tests/unit/general/test_memory_system_with_chromadb.py:11:1: F401 'typing.Dict' imported but unused
+tests/unit/general/test_memory_system_with_chromadb.py:11:1: F401 'typing.List' imported but unused
+tests/unit/general/test_memory_system_with_chromadb.py:12:1: F401 'unittest.mock.MagicMock' imported but unused
+tests/unit/general/test_memory_system_with_chromadb.py:12:1: F401 'unittest.mock.patch' imported but unused
+tests/unit/general/test_memory_system_with_chromadb.py:14:1: F401 'numpy as np' imported but unused
+tests/unit/general/test_memory_system_with_chromadb.py:20:1: F401 'devsynth.exceptions.MemoryStoreError' imported but unused
+tests/unit/general/test_memory_system_with_kuzu.py:1:1: F401 'os' imported but unused
+tests/unit/general/test_mypy_config.py:18:89: E501 line too long (150 > 88 characters)
+tests/unit/general/test_mypy_config.py:44:89: E501 line too long (172 > 88 characters)
+tests/unit/general/test_mypy_config.py:50:89: E501 line too long (388 > 88 characters)
+tests/unit/general/test_mypy_config.py:67:89: E501 line too long (155 > 88 characters)
+tests/unit/general/test_no_devsynth_dir_creation.py:10:1: F401 'unittest.mock.patch' imported but unused
+tests/unit/general/test_no_devsynth_dir_creation.py:18:89: E501 line too long (98 > 88 characters)
+tests/unit/general/test_no_devsynth_dir_creation.py:24:89: E501 line too long (99 > 88 characters)
+tests/unit/general/test_no_devsynth_dir_creation.py:48:89: E501 line too long (89 > 88 characters)
+tests/unit/general/test_no_devsynth_dir_creation.py:75:89: E501 line too long (93 > 88 characters)
+tests/unit/general/test_ports_with_fixtures.py:2:1: E402 module level import not at top of file
+tests/unit/general/test_ports_with_fixtures.py:4:1: E402 module level import not at top of file
+tests/unit/general/test_project_yaml.py:5:89: E501 line too long (94 > 88 characters)
+tests/unit/general/test_project_yaml.py:8:1: F401 'os' imported but unused
+tests/unit/general/test_project_yaml.py:13:1: F401 'yaml' imported but unused
+tests/unit/general/test_project_yaml.py:16:1: F401 'devsynth.exceptions.ManifestError' imported but unused
+tests/unit/general/test_project_yaml.py:44:89: E501 line too long (89 > 88 characters)
+tests/unit/general/test_project_yaml.py:59:89: E501 line too long (92 > 88 characters)
+tests/unit/general/test_project_yaml.py:66:18: F841 local variable 'mock_yaml_load' is assigned to but never used
+tests/unit/general/test_project_yaml.py:67:17: F841 local variable 'result' is assigned to but never used
+tests/unit/general/test_promise_agent.py:6:1: F401 'typing.Any' imported but unused
+tests/unit/general/test_promise_agent.py:6:1: F401 'typing.Dict' imported but unused
+tests/unit/general/test_promise_agent.py:6:1: F401 'typing.List' imported but unused
+tests/unit/general/test_promise_agent.py:188:89: E501 line too long (127 > 88 characters)
+tests/unit/general/test_promise_agent.py:219:89: E501 line too long (119 > 88 characters)
+tests/unit/general/test_promise_system.py:5:1: F401 'typing.Optional' imported but unused
+tests/unit/general/test_promise_system.py:9:1: F401 'devsynth.application.promises.PromiseError' imported but unused
+tests/unit/general/test_provider_logging.py:11:1: E402 module level import not at top of file
+tests/unit/general/test_provider_logging.py:12:1: F401 'devsynth.exceptions.DevSynthError' imported but unused
+tests/unit/general/test_provider_logging.py:12:1: E402 module level import not at top of file
+tests/unit/general/test_provider_logging.py:13:1: E402 module level import not at top of file
+tests/unit/general/test_rdflib_store.py:1:1: F403 'from tests.unit.application.memory.test_rdflib_store import *' used; unable to detect undefined names
+tests/unit/general/test_rdflib_store.py:1:1: F401 'tests.unit.application.memory.test_rdflib_store.*' imported but unused
+tests/unit/general/test_requirement_models.py:6:1: F401 'datetime.datetime' imported but unused
+tests/unit/general/test_requirement_models.py:11:1: F401 'devsynth.domain.models.requirement.ChatMessage' imported but unused
+tests/unit/general/test_requirement_service.py:6:1: F401 'datetime.datetime' imported but unused
+tests/unit/general/test_requirement_service.py:7:1: F401 'unittest.mock.patch' imported but unused
+tests/unit/general/test_requirement_service.py:8:1: F401 'uuid.UUID' imported but unused
+tests/unit/general/test_requirement_service.py:8:1: F401 'uuid.uuid4' imported but unused
+tests/unit/general/test_test_first_metrics.py:6:1: F401 'pathlib.Path' imported but unused
+tests/unit/general/test_test_first_metrics.py:12:1: E402 module level import not at top of file
+tests/unit/general/test_token_tracker.py:2:1: F401 'unittest.mock.MagicMock' imported but unused
+tests/unit/general/test_token_tracker.py:6:1: F401 'devsynth.application.utils.token_tracker._TEST_MODE' imported but unused
+tests/unit/general/test_token_tracker.py:6:1: F401 'devsynth.application.utils.token_tracker._TEST_TOKEN_COUNTS' imported but unused
+tests/unit/general/test_unified_agent.py:60:89: E501 line too long (92 > 88 characters)
+tests/unit/general/test_unit_cli_commands.py:344:89: E501 line too long (91 > 88 characters)
+tests/unit/general/test_unit_cli_commands.py:360:89: E501 line too long (90 > 88 characters)
+tests/unit/general/test_unit_cli_commands.py:805:89: E501 line too long (123 > 88 characters)
+tests/unit/general/test_unit_cli_commands.py:846:89: E501 line too long (110 > 88 characters)
+tests/unit/general/test_unit_cli_commands.py:924:52: F841 local variable 'mock_file' is assigned to but never used
+tests/unit/general/test_unit_cli_commands.py:948:89: E501 line too long (121 > 88 characters)
+tests/unit/general/test_unit_cli_commands.py:971:52: F841 local variable 'mock_file' is assigned to but never used
+tests/unit/general/test_unit_cli_commands.py:1002:89: E501 line too long (122 > 88 characters)
+tests/unit/general/test_unit_cli_commands.py:1105:89: E501 line too long (89 > 88 characters)
+tests/unit/general/test_unit_cli_commands.py:1132:89: E501 line too long (127 > 88 characters)
+tests/unit/general/test_unit_cli_commands.py:1155:52: F841 local variable 'mock_file' is assigned to but never used
+tests/unit/general/test_wsde_dynamic_roles.py:1:1: F401 'unittest.mock.MagicMock' imported but unused
+tests/unit/general/test_wsde_dynamic_roles.py:3:1: F401 'pytest' imported but unused
+tests/unit/general/test_wsde_dynamic_roles.py:18:89: E501 line too long (101 > 88 characters)
+tests/unit/general/test_wsde_role_mapping.py:3:1: F401 'pytest' imported but unused
+tests/unit/general/test_wsde_team_coordinator.py:8:1: F401 'unittest.mock.patch' imported but unused
+tests/unit/general/test_wsde_team_coordinator.py:93:89: E501 line too long (93 > 88 characters)
+tests/unit/general/test_wsde_team_extended.py:1:1: F401 'unittest.mock.patch' imported but unused
+tests/unit/general/test_wsde_team_extended.py:236:9: F841 local variable 'critique1' is assigned to but never used
+tests/unit/general/test_wsde_team_extended.py:237:9: F841 local variable 'critique2' is assigned to but never used
+tests/unit/general/test_wsde_team_extended.py:238:9: F841 local variable 'critique3' is assigned to but never used
+tests/unit/general/test_wsde_team_extended.py:286:89: E501 line too long (89 > 88 characters)
+tests/unit/general/test_wsde_team_extended.py:351:13: E712 comparison to False should be 'if cond is False:' or 'if not cond:'
+tests/unit/general/test_wsde_team_extended.py:353:76: E712 comparison to False should be 'if cond is False:' or 'if not cond:'
+tests/unit/general/test_wsde_team_extended.py:354:72: E712 comparison to True should be 'if cond is True:' or 'if cond:'
+tests/unit/general/test_wsde_team_extended.py:355:48: E712 comparison to False should be 'if cond is False:' or 'if not cond:'
+tests/unit/general/test_wsde_team_extended.py:408:89: E501 line too long (120 > 88 characters)
+tests/unit/general/test_wsde_team_extended.py:410:89: E501 line too long (96 > 88 characters)
+tests/unit/general/test_wsde_team_extended.py:475:89: E501 line too long (90 > 88 characters)
+tests/unit/general/test_wsde_team_extended.py:490:89: E501 line too long (95 > 88 characters)
+tests/unit/general/test_wsde_team_extended.py:493:89: E501 line too long (111 > 88 characters)
+tests/unit/general/test_wsde_team_extended.py:560:9: F841 local variable 'code_agent' is assigned to but never used
+tests/unit/general/test_wsde_team_extended.py:561:9: F841 local variable 'security_agent' is assigned to but never used
+tests/unit/general/test_wsde_team_extended.py:569:89: E501 line too long (108 > 88 characters)
+tests/unit/general/test_wsde_team_extended.py:573:89: E501 line too long (90 > 88 characters)
+tests/unit/general/test_wsde_team_extended.py:591:89: E501 line too long (103 > 88 characters)
+tests/unit/general/test_wsde_team_extended.py:612:89: E501 line too long (89 > 88 characters)
+tests/unit/general/test_wsde_team_extended.py:622:89: E501 line too long (92 > 88 characters)
+tests/unit/general/test_wsde_team_extended.py:662:89: E501 line too long (90 > 88 characters)
+tests/unit/general/test_wsde_team_extended.py:690:89: E501 line too long (136 > 88 characters)
+tests/unit/general/test_wsde_team_extended.py:694:89: E501 line too long (90 > 88 characters)
+tests/unit/general/test_wsde_team_extended.py:712:89: E501 line too long (103 > 88 characters)
+tests/unit/general/test_wsde_team_extended.py:741:89: E501 line too long (91 > 88 characters)
+tests/unit/general/test_wsde_team_extended.py:742:89: E501 line too long (91 > 88 characters)
+tests/unit/general/test_wsde_team_extended.py:890:89: E501 line too long (96 > 88 characters)
+tests/unit/general/test_wsde_team_voting_invalid.py:15:89: E501 line too long (89 > 88 characters)
+tests/unit/general/test_wsde_voting.py:32:89: E501 line too long (89 > 88 characters)
+tests/unit/general/test_wsde_voting_mechanisms.py:8:1: F401 'unittest.mock.patch' imported but unused
+tests/unit/general/test_wsde_voting_mechanisms.py:10:1: F401 'pytest' imported but unused
+tests/unit/general/test_wsde_voting_mechanisms.py:12:1: F401 'devsynth.application.agents.unified_agent.UnifiedAgent' imported but unused
+tests/unit/general/test_wsde_voting_mechanisms.py:13:1: F401 'devsynth.domain.models.agent.AgentConfig' imported but unused
+tests/unit/general/test_wsde_voting_mechanisms.py:13:1: F401 'devsynth.domain.models.agent.AgentType' imported but unused
+tests/unit/general/test_wsde_voting_mechanisms.py:147:89: E501 line too long (94 > 88 characters)
+tests/unit/general/test_wsde_voting_mechanisms.py:175:89: E501 line too long (98 > 88 characters)
+tests/unit/infrastructure/test_test_infrastructure_sanity.py:25:89: E501 line too long (94 > 88 characters)
+tests/unit/interface/test_api_advanced.py:5:1: F401 'unittest.mock.MagicMock' imported but unused
+tests/unit/interface/test_api_advanced.py:5:1: E402 module level import not at top of file
+tests/unit/interface/test_api_advanced.py:7:1: E402 module level import not at top of file
+tests/unit/interface/test_api_advanced.py:8:1: E402 module level import not at top of file
+tests/unit/interface/test_api_advanced.py:10:1: E402 module level import not at top of file
+tests/unit/interface/test_api_advanced.py:11:1: E402 module level import not at top of file
+tests/unit/interface/test_api_advanced.py:21:1: E402 module level import not at top of file
+tests/unit/interface/test_api_advanced.py:24:1: F401 'devsynth.interface.agentapi.status_endpoint' imported but unused
+tests/unit/interface/test_api_advanced.py:24:1: E402 module level import not at top of file
+tests/unit/interface/test_api_endpoints.py:5:1: F401 'unittest.mock.MagicMock' imported but unused
+tests/unit/interface/test_api_endpoints.py:5:1: E402 module level import not at top of file
+tests/unit/interface/test_api_endpoints.py:7:1: E402 module level import not at top of file
+tests/unit/interface/test_api_endpoints.py:8:1: E402 module level import not at top of file
+tests/unit/interface/test_api_endpoints.py:10:1: E402 module level import not at top of file
+tests/unit/interface/test_api_endpoints.py:11:1: E402 module level import not at top of file
+tests/unit/interface/test_api_endpoints.py:21:1: E402 module level import not at top of file
+tests/unit/interface/test_api_endpoints.py:22:1: E402 module level import not at top of file
+tests/unit/interface/test_api_endpoints.py:32:1: E402 module level import not at top of file
+tests/unit/interface/test_api_endpoints.py:325:89: E501 line too long (95 > 88 characters)
+tests/unit/interface/test_cli_components.py:4:1: F401 'rich.console.Console' imported but unused
+tests/unit/interface/test_cli_components.py:5:1: F401 'rich.panel.Panel' imported but unused
+tests/unit/interface/test_cli_components.py:6:1: F401 'rich.progress.Progress' imported but unused
+tests/unit/interface/test_cli_components.py:26:9: F841 local variable 'progress' is assigned to but never used
+tests/unit/interface/test_cli_components.py:31:1: F811 redefinition of unused 'clean_state' from line 12
+tests/unit/interface/test_cli_components.py:66:1: F811 redefinition of unused 'clean_state' from line 31
+tests/unit/interface/test_cli_components.py:118:1: F811 redefinition of unused 'clean_state' from line 66
+tests/unit/interface/test_cli_components.py:167:1: F811 redefinition of unused 'clean_state' from line 118
+tests/unit/interface/test_cli_components.py:196:1: F811 redefinition of unused 'clean_state' from line 167
+tests/unit/interface/test_cli_components.py:226:1: F811 redefinition of unused 'clean_state' from line 196
+tests/unit/interface/test_cli_components.py:252:1: F811 redefinition of unused 'clean_state' from line 226
+tests/unit/interface/test_cli_uxbridge_noninteractive.py:17:89: E501 line too long (99 > 88 characters)
+tests/unit/interface/test_cli_uxbridge_noninteractive.py:47:89: E501 line too long (98 > 88 characters)
+tests/unit/interface/test_cliuxbridge.py:1:1: F401 'unittest.mock.MagicMock' imported but unused
+tests/unit/interface/test_cliuxbridge.py:1:1: F401 'unittest.mock.call' imported but unused
+tests/unit/interface/test_cliuxbridge.py:173:5: F841 local variable 'temp_file' is assigned to but never used
+tests/unit/interface/test_cliuxbridge.py:181:5: F841 local variable 'original_add_task' is assigned to but never used
+tests/unit/interface/test_cliuxbridge.py:182:5: F841 local variable 'original_update' is assigned to but never used
+tests/unit/interface/test_output_formatter.py:3:1: F401 'unittest.mock.patch' imported but unused
+tests/unit/interface/test_state_access.py:5:89: E501 line too long (89 > 88 characters)
+tests/unit/interface/test_state_access.py:227:89: E501 line too long (101 > 88 characters)
+tests/unit/interface/test_state_access.py:268:89: E501 line too long (93 > 88 characters)
+tests/unit/interface/test_state_access.py:270:89: E501 line too long (90 > 88 characters)
+tests/unit/interface/test_uxbridge.py:22:5: F841 local variable 'original_sanitize' is assigned to but never used
+tests/unit/interface/test_uxbridge.py:68:5: F841 local variable 'original_sanitize_func' is assigned to but never used
+tests/unit/interface/test_uxbridge_consistency.py:9:1: F401 'devsynth.interface.ux_bridge.sanitize_output' imported but unused
+tests/unit/interface/test_uxbridge_consistency.py:209:89: E501 line too long (89 > 88 characters)
+tests/unit/interface/test_uxbridge_question_result.py:10:1: F401 'unittest.mock.call' imported but unused
+tests/unit/interface/test_uxbridge_sanitization.py:62:22: F821 undefined name 'module'
+tests/unit/interface/test_webui.py:18:5: F821 undefined name 'monkeypatch'
+tests/unit/interface/test_webui.py:20:5: F821 undefined name 'monkeypatch'
+tests/unit/interface/test_webui.py:34:5: F821 undefined name 'monkeypatch'
+tests/unit/interface/test_webui.py:38:5: F821 undefined name 'monkeypatch'
+tests/unit/interface/test_webui.py:41:5: F821 undefined name 'monkeypatch'
+tests/unit/interface/test_webui.py:59:9: F821 undefined name 'monkeypatch'
+tests/unit/interface/test_webui.py:65:5: F821 undefined name 'monkeypatch'
+tests/unit/interface/test_webui.py:68:5: F821 undefined name 'monkeypatch'
+tests/unit/interface/test_webui.py:71:11: F821 undefined name 'st'
+tests/unit/interface/test_webui_enhanced.py:3:1: F401 'unittest.mock.call' imported but unused
+tests/unit/interface/test_webui_enhanced.py:3:1: F401 'unittest.mock.patch' imported but unused
+tests/unit/interface/test_webui_error_handling.py:3:1: F401 'unittest.mock.patch' imported but unused
+tests/unit/interface/test_webui_gather_wizard_with_state.py:7:1: F401 'tests.fixtures.webui_wizard_state_fixture.set_wizard_data' imported but unused
+tests/unit/interface/test_webui_gather_wizard_with_state.py:7:1: F401 'tests.fixtures.webui_wizard_state_fixture.simulate_wizard_navigation' imported but unused
+tests/unit/interface/test_webui_navigation_and_validation.py:1:1: F401 'importlib' imported but unused
+tests/unit/interface/test_webui_navigation_and_validation.py:4:1: F401 'types.ModuleType' imported but unused
+tests/unit/interface/test_webui_navigation_and_validation.py:21:5: F811 redefinition of unused 'importlib' from line 1
+tests/unit/interface/test_webui_navigation_and_validation.py:26:22: F821 undefined name 'module_2'
+tests/unit/interface/test_webui_onboarding.py:3:1: F401 'unittest.mock.call' imported but unused
+tests/unit/interface/test_webui_onboarding.py:3:1: F401 'unittest.mock.patch' imported but unused
+tests/unit/interface/test_webui_run_edge_cases.py:3:1: F401 'unittest.mock.patch' imported but unused
+tests/unit/interface/test_webui_run_edge_cases.py:198:5: F401 'importlib' imported but unused
+tests/unit/interface/test_webui_wizard_state.py:327:25: F541 f-string is missing placeholders
+tests/unit/interface/test_webui_wizard_state.py:344:25: F541 f-string is missing placeholders
+tests/unit/interface/test_webui_wizard_state.py:369:25: F541 f-string is missing placeholders
+tests/unit/interface/test_wizard_state_manager.py:124:13: F541 f-string is missing placeholders
+tests/unit/interface/test_wizard_state_manager.py:160:13: F541 f-string is missing placeholders
+tests/unit/interface/test_wizard_state_manager.py:216:13: F541 f-string is missing placeholders
+tests/unit/interface/test_wizard_state_manager.py:238:13: F541 f-string is missing placeholders
+tests/unit/interface/test_wizard_state_manager.py:260:13: F541 f-string is missing placeholders
+tests/unit/interface/test_wizard_state_manager.py:284:51: F541 f-string is missing placeholders
+tests/unit/interface/test_wizard_state_manager.py:317:17: F541 f-string is missing placeholders
+tests/unit/interface/test_wizard_state_manager.py:348:89: E501 line too long (93 > 88 characters)
+tests/unit/interface/test_wizard_state_manager.py:402:89: E501 line too long (96 > 88 characters)
+tests/unit/methodology/test_adhoc_adapter.py:1:1: F401 'datetime' imported but unused
+tests/unit/methodology/test_dialectical_reasoning_loop.py:8:1: E402 module level import not at top of file
+tests/unit/methodology/test_dialectical_reasoning_loop.py:9:1: E402 module level import not at top of file
+tests/unit/policies/test_verify_security_policy.py:12:1: E402 module level import not at top of file
+tests/unit/providers/test_provider_stub_offline.py:1:1: F401 'os' imported but unused
+tests/unit/providers/test_provider_stub_offline.py:13:89: E501 line too long (96 > 88 characters)
+tests/unit/providers/test_provider_stub_offline.py:17:89: E501 line too long (90 > 88 characters)
+tests/unit/providers/test_resource_gating_meta.py:1:1: F401 'os' imported but unused
+tests/unit/providers/test_resource_gating_meta.py:22:5: F841 local variable 'p' is assigned to but never used
+tests/unit/providers/test_resource_gating_meta.py:43:5: F841 local variable 'p' is assigned to but never used
+tests/unit/requirements/test_dialectical_reasoner_determinism.py:1:1: F401 'os' imported but unused
+tests/unit/requirements/test_dialectical_reasoner_determinism.py:9:1: F401 'devsynth.domain.models.requirement.RequirementPriority' imported but unused
+tests/unit/scripts/test_auto_issue_comment.py:1:1: F401 'os' imported but unused
+tests/unit/scripts/test_auto_issue_comment.py:2:1: F401 'types.SimpleNamespace' imported but unused
+tests/unit/scripts/test_check_internal_links.py:6:1: E402 module level import not at top of file
+tests/unit/scripts/test_examples_smoke_script.py:7:1: F401 'types.SimpleNamespace' imported but unused
+tests/unit/scripts/test_examples_smoke_script.py:65:89: E501 line too long (89 > 88 characters)
+tests/unit/scripts/test_security_ops.py:2:1: F401 'pathlib.Path' imported but unused
+tests/unit/scripts/test_security_ops.py:9:1: E402 module level import not at top of file
+tests/unit/scripts/test_security_ops.py:10:1: E402 module level import not at top of file
+tests/unit/scripts/test_verify_mvuu_references.py:5:1: E402 module level import not at top of file
+tests/unit/scripts/test_verify_test_markers.py:1:1: F401 'os' imported but unused
+tests/unit/scripts/test_verify_test_markers.py:35:89: E501 line too long (102 > 88 characters)
+tests/unit/scripts/test_verify_test_markers_cli.py:1:1: F401 'builtins' imported but unused
+tests/unit/scripts/test_verify_test_markers_cli.py:4:1: F401 'types' imported but unused
+tests/unit/scripts/test_verify_test_markers_cli.py:38:89: E501 line too long (92 > 88 characters)
+tests/unit/security/__init__.py:2:89: E501 line too long (103 > 88 characters)
+tests/unit/security/test_api_authentication.py:4:1: F401 'unittest.mock.MagicMock' imported but unused
+tests/unit/security/test_api_authentication.py:4:1: E402 module level import not at top of file
+tests/unit/security/test_api_authentication.py:6:1: E402 module level import not at top of file
+tests/unit/security/test_api_authentication.py:8:1: E402 module level import not at top of file
+tests/unit/security/test_authorization.py:21:89: E501 line too long (90 > 88 characters)
+tests/unit/security/test_authorization.py:105:89: E501 line too long (113 > 88 characters)
+tests/unit/security/test_authorization.py:117:89: E501 line too long (94 > 88 characters)
+tests/unit/security/test_authorization.py:127:89: E501 line too long (95 > 88 characters)
+tests/unit/security/test_authorization.py:139:89: E501 line too long (90 > 88 characters)
+tests/unit/security/test_encryption.py:1:1: F401 'os' imported but unused
+tests/unit/security/test_encryption.py:101:89: E501 line too long (95 > 88 characters)
+tests/unit/security/test_encryption.py:126:89: E501 line too long (94 > 88 characters)
+tests/unit/security/test_logging_redaction.py:2:1: F401 'os' imported but unused
+tests/unit/security/test_logging_redaction.py:69:89: E501 line too long (89 > 88 characters)
+tests/unit/security/test_memory_encryption.py:1:1: F401 'json' imported but unused
+tests/unit/security/test_memory_encryption.py:3:1: F401 'tempfile' imported but unused
+tests/unit/security/test_policy_audit.py:10:1: E402 module level import not at top of file
+tests/unit/security/test_review.py:3:1: F401 'pytest' imported but unused
+tests/unit/security/test_sanitization.py:53:89: E501 line too long (95 > 88 characters)
+tests/unit/security/test_sanitization.py:62:89: E501 line too long (91 > 88 characters)
+tests/unit/security/test_sanitization.py:101:89: E501 line too long (93 > 88 characters)
+tests/unit/security/test_security_audit.py:13:1: E402 module level import not at top of file
+tests/unit/security/test_security_flags_env.py:1:1: F401 'os' imported but unused
+tests/unit/security/test_tls_config.py:1:1: F401 'os' imported but unused
+tests/unit/security/test_tls_config.py:32:89: E501 line too long (94 > 88 characters)
+tests/unit/testing/test_collect_cache_sanitize.py:7:1: F401 'devsynth.testing.run_tests.COLLECTION_CACHE_DIR' imported but unused
+tests/unit/testing/test_collect_cache_sanitize.py:42:89: E501 line too long (89 > 88 characters)
+tests/unit/testing/test_collect_cache_sanitize.py:58:89: E501 line too long (93 > 88 characters)
+tests/unit/testing/test_collect_cache_sanitize.py:92:5: F841 local variable 'cache_file' is assigned to but never used
+tests/unit/testing/test_collect_tests_cache_invalidation.py:1:1: F401 'os' imported but unused
+tests/unit/testing/test_collect_tests_cache_invalidation.py:94:89: E501 line too long (89 > 88 characters)
+tests/unit/testing/test_collect_tests_cache_invalidation.py:105:89: E501 line too long (94 > 88 characters)
+tests/unit/testing/test_collect_tests_cache_ttl.py:2:1: F401 'os' imported but unused
+tests/unit/testing/test_collect_tests_cache_ttl.py:4:1: F401 'pathlib.Path' imported but unused
+tests/unit/testing/test_collect_tests_cache_ttl.py:85:89: E501 line too long (104 > 88 characters)
+tests/unit/testing/test_collect_tests_cache_ttl.py:86:89: E501 line too long (100 > 88 characters)
+tests/unit/testing/test_deterministic_seed_fixture.py:18:89: E501 line too long (94 > 88 characters)
+tests/unit/testing/test_deterministic_seed_fixture.py:24:89: E501 line too long (94 > 88 characters)
+tests/unit/testing/test_failure_tips.py:1:1: F401 're' imported but unused
+tests/unit/testing/test_failure_tips.py:10:89: E501 line too long (92 > 88 characters)
+tests/unit/testing/test_run_tests_cache_pruning.py:41:89: E501 line too long (93 > 88 characters)
+tests/unit/testing/test_run_tests_collection_cache.py:1:1: F401 'os' imported but unused
+tests/unit/testing/test_run_tests_extra_paths.py:1:1: F401 'json' imported but unused
+tests/unit/testing/test_run_tests_extra_paths.py:2:1: F401 'os' imported but unused
+tests/unit/testing/test_run_tests_extra_paths.py:3:1: F401 'types.SimpleNamespace' imported but unused
+tests/unit/testing/test_run_tests_keyword_filter_empty.py:2:1: F401 'types.SimpleNamespace' imported but unused
+tests/unit/testing/test_run_tests_keyword_filter_empty.py:3:1: F401 'typing.List' imported but unused
+tests/unit/testing/test_run_tests_keyword_filter_empty.py:26:89: E501 line too long (128 > 88 characters)
+tests/unit/testing/test_run_tests_module.py:1:1: F401 'os' imported but unused
+tests/unit/testing/test_run_tests_module.py:2:1: F401 're' imported but unused
+tests/unit/testing/test_run_tests_module.py:27:89: E501 line too long (110 > 88 characters)
+tests/unit/testing/test_run_tests_module.py:48:89: E501 line too long (108 > 88 characters)
+tests/unit/testing/test_run_tests_module.py:64:89: E501 line too long (106 > 88 characters)
+tests/unit/testing/test_run_tests_module.py:75:89: E501 line too long (91 > 88 characters)
+tests/unit/testing/test_run_tests_module.py:91:89: E501 line too long (114 > 88 characters)
+tests/unit/testing/test_run_tests_module.py:116:89: E501 line too long (110 > 88 characters)
+tests/unit/testing/test_run_tests_module.py:129:89: E501 line too long (141 > 88 characters)
+tests/unit/testing/test_run_tests_module.py:151:89: E501 line too long (125 > 88 characters)
+tests/unit/testing/test_run_tests_module.py:152:89: E501 line too long (90 > 88 characters)
+tests/unit/testing/test_run_tests_module.py:164:89: E501 line too long (95 > 88 characters)
+tests/unit/testing/test_run_tests_no_xdist_assertions.py:9:5: F841 local variable 'test_file' is assigned to but never used
+tests/unit/testing/test_run_tests_parallel_flags.py:1:1: F401 'types.SimpleNamespace' imported but unused
+tests/unit/testing/test_run_tests_segmented.py:1:1: F401 'itertools' imported but unused
+tests/unit/testing/test_sanitize_node_ids.py:10:89: E501 line too long (89 > 88 characters)
+tests/unit/utils/test_serialization.py:1:1: F401 'json' imported but unused
+tests/unit/utils/test_serialization.py:22:89: E501 line too long (89 > 88 characters)
+tests/unit/utils/test_serialization_extra.py:2:1: F401 'os' imported but unused

--- a/docs/plan.md
+++ b/docs/plan.md
@@ -2,7 +2,7 @@
 
 Version: 2025-09-07
 Owner: DevSynth Team (maintainers)
-Status: Execution in progress; install loop closed (2025-09-09); property marker advisories remain
+Status: Execution in progress; install loop closed (2025-09-09); property marker advisories resolved; flake8 and bandit scans failing (2025-09-10)
 
 Executive summary
 - Goal: Reach and sustain >90% coverage with a well‑functioning, reliable test suite across unit, integration, behavior, and property tests for the 0.1.0a1 release, with strict marker discipline and resource gating.
@@ -21,7 +21,7 @@ Commands executed (audit trail)
 - poetry run devsynth run-tests --target unit-tests --speed=fast --no-parallel --maxfail=1 → Success.
 - poetry run devsynth run-tests --target behavior-tests --speed=fast --smoke --no-parallel --maxfail=1 → Success.
 - poetry run devsynth run-tests --target integration-tests --speed=fast --smoke --no-parallel --maxfail=1 → Success.
- - poetry run python scripts/verify_test_markers.py --report --report-file test_markers_report.json → property marker advisories (2 property_violations) in tests/property/test_reasoning_loop_properties.py due to nested Hypothesis helpers.
+ - poetry run python scripts/verify_test_markers.py --report --report-file test_markers_report.json → verify_test_markers now reports 0 property_violations after helper logic refinement.
  - DEVSYNTH_PROPERTY_TESTING=true poetry run pytest tests/property/ -q → 2 failing tests; coverage fail-under triggered (8% on this narrow subset).
 - Environment: Python 3.12.x (pyproject constraint), Poetry 2.1.4; coverage artifacts present under htmlcov/ and coverage.json.
 
@@ -259,6 +259,7 @@ Maintainer quickstart (authoritative commands)
 Notes and next actions
 - Immediate: Fix the two property test failures; add targeted tests for run_tests_cmd branches; re-generate coverage report and iterate on hotspots below 80% coverage.
 - Short-term: Align docs with current CLI behaviors and ensure issues/ action items are traced to tests.
+- Guardrails: diagnostics/flake8_2025-09-10_run2.txt shows E501/F401 in tests/unit/testing/test_run_tests_module.py; bandit scan (diagnostics/bandit_2025-09-10_run2.txt) reports 158 low and 12 medium issues.
 - Post-release: Introduce low-throughput GH Actions pipeline as specified and expand nightly coverage runs.
 - verify_test_markers reports missing @pytest.mark.property in tests/property/test_reasoning_loop_properties.py; track under issues/property-marker-advisories-in-reasoning-loop-tests.md and resolve before release.
 - scripts/codex_setup.sh exits early due to version mismatch (project version 0.1.0a1 vs expected 0.1.0-alpha.1); reconcile versioning or adjust the setup script.

--- a/docs/task_notes.md
+++ b/docs/task_notes.md
@@ -21,3 +21,20 @@ Historical log archived at docs/archived/task_notes_pre2025-09-16.md to keep thi
 - Reviewed open issues; closed duplicates (methodology-sprint, domain-models-requirement, adapters-requirements) and resolved run-tests missing test_first_metrics file.
 - Test evidence: `poetry run pytest tests/unit/general/test_test_first_metrics.py -q` (see test_reports/test_first_metrics.log).
 - Remaining blockers: flake8-violations.md and bandit-findings.md keep guardrails suite red.
+
+## Iteration 2025-09-18
+- Environment: Python 3.12.10; `poetry env info --path` -> /root/.cache/pypoetry/virtualenvs/devsynth-MeXVnKii-py3.12.
+- Installation: `poetry run pip install pypika==0.48.9` then `poetry install --with dev --extras tests --extras retrieval --extras chromadb --extras api`.
+- Commands:
+  - `poetry run devsynth run-tests --smoke --speed=fast --no-parallel --maxfail=1` – pass.
+  - `poetry run python tests/verify_test_organization.py` – 914 test files detected.
+  - `poetry run python scripts/verify_test_markers.py` – 0 issues.
+  - `poetry run python scripts/verify_requirements_traceability.py` – silent success.
+  - `poetry run python scripts/verify_version_sync.py` – OK 0.1.0a1.
+  - `poetry run flake8 src/ tests/` – lint failures (E501, F401); see diagnostics/flake8_2025-09-10_run2.txt.
+  - `poetry run bandit -r src/devsynth -x tests` – 158 low, 12 medium findings; see diagnostics/bandit_2025-09-10_run2.txt.
+- Observations: go-task installed via scripts/install_dev.sh; initial poetry install required manual pypika wheel build.
+- Next:
+  - Resolve flake8 errors in tests/unit/testing/test_run_tests_module.py and related files.
+  - Review bandit medium findings and apply fixes or justifications.
+  - Generate coverage report to address coverage-below-threshold issue.

--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -107,6 +107,8 @@ Instructions: Check off each task when completed. Subtasks are enumerated for cl
 11.7 [x] Closed redundant typing tickets: methodology-sprint, domain-models-requirement, adapters-requirements.
 11.8 [x] Resolved run-tests missing test_first_metrics file; see test_reports/test_first_metrics.log.
 11.9 [ ] Guardrails suite failures persist; flake8-violations.md and bandit-findings.md remain open.
+11.9.1 [ ] Regenerate flake8 report and resolve E501/F401 in tests/unit/testing/test_run_tests_module.py and related files.
+11.9.2 [ ] Review bandit scan (158 low, 12 medium) and address or justify findings.
 
 12. Risk Management and Mitigations
 12.1 [x] Document minimal smoke coverage expectations for optional backends (macOS/Windows) and how to enable:

--- a/issues/bandit-findings.md
+++ b/issues/bandit-findings.md
@@ -9,9 +9,11 @@ Exit Code: 1
 
 Artifacts:
   - diagnostics/bandit_2025-09-10.txt
+  - diagnostics/bandit_2025-09-10_run2.txt
 
 Suspected Cause:
   - Multiple potential security issues flagged across modules.
+- Latest scan reports 158 low and 12 medium issues (0 high).
 
 Next Actions:
   - [ ] Review high-severity findings and apply fixes or justifications

--- a/issues/flake8-violations.md
+++ b/issues/flake8-violations.md
@@ -9,9 +9,11 @@ Exit Code: 1
 
 Artifacts:
   - diagnostics/flake8_2025-09-10.txt
+  - diagnostics/flake8_2025-09-10_run2.txt
 
 Suspected Cause:
   - Widespread lint errors and unused imports across codebase.
+- Latest run shows E501 and F401 in tests/unit/testing/test_run_tests_module.py.
 
 Next Actions:
   - [ ] Audit and fix flake8 warnings in src


### PR DESCRIPTION
## Summary
- record latest flake8 and bandit scan results
- expand guardrail remediation tasks
- note environment setup and outstanding issues in planning docs

## Testing
- `poetry run pre-commit run --files docs/tasks.md docs/plan.md docs/task_notes.md issues/flake8-violations.md issues/bandit-findings.md diagnostics/flake8_2025-09-10_run2.txt diagnostics/bandit_2025-09-10_run2.txt`
- `poetry run devsynth run-tests --smoke --speed=fast --no-parallel --maxfail=1`
- `poetry run python tests/verify_test_organization.py`
- `poetry run python scripts/verify_test_markers.py`
- `poetry run python scripts/verify_requirements_traceability.py`
- `poetry run python scripts/verify_version_sync.py`


------
https://chatgpt.com/codex/tasks/task_e_68c1be9ab29c83339042aaee1d0cb738