### PR TITLE
docs: record environment verification and update guardrail issues

### DIFF
--- a/docs/plan.md
+++ b/docs/plan.md
@@ -263,3 +263,4 @@ Notes and next actions
 - Post-release: Introduce low-throughput GH Actions pipeline as specified and expand nightly coverage runs.
 - verify_test_markers reports missing @pytest.mark.property in tests/property/test_reasoning_loop_properties.py; track under issues/property-marker-advisories-in-reasoning-loop-tests.md and resolve before release.
 - scripts/codex_setup.sh exits early due to version mismatch (project version 0.1.0a1 vs expected 0.1.0-alpha.1); reconcile versioning or adjust the setup script.
+- 2025-09-19: `devsynth` package initially missing; reran `poetry install --with dev --all-extras` to restore CLI. Smoke and property tests pass; flake8 and bandit still failing; coverage aggregation (tasks 6.3, 13.3) pending.

--- a/docs/task_notes.md
+++ b/docs/task_notes.md
@@ -38,3 +38,20 @@ Historical log archived at docs/archived/task_notes_pre2025-09-16.md to keep thi
   - Resolve flake8 errors in tests/unit/testing/test_run_tests_module.py and related files.
   - Review bandit medium findings and apply fixes or justifications.
   - Generate coverage report to address coverage-below-threshold issue.
+
+## Iteration 2025-09-19
+- Environment: Python 3.12.10; `poetry env info --path` -> /root/.cache/pypoetry/virtualenvs/devsynth-MeXVnKii-py3.12.
+- Installation: `poetry install --with dev --all-extras` to restore missing `devsynth` CLI.
+- Commands:
+  - `poetry run devsynth run-tests --smoke --speed=fast --no-parallel --maxfail=1` – pass.
+  - `poetry run python tests/verify_test_organization.py` – 914 test files detected.
+  - `poetry run python scripts/verify_test_markers.py --report --report-file test_markers_report.json` – 0 issues.
+  - `poetry run python scripts/verify_requirements_traceability.py` – silent success.
+  - `poetry run python scripts/verify_version_sync.py` – OK 0.1.0a1.
+  - `DEVSYNTH_PROPERTY_TESTING=true poetry run pytest tests/property/ -q` – 12 passed.
+  - `poetry run flake8 src/ tests/` – E501/F401 and F841 violations persist.
+  - `poetry run bandit -r src/devsynth -x tests` – 158 low and 12 medium issues.
+- Observations: Environment lacked installed package; `poetry install` resolved. Guardrail failures (flake8, bandit) remain; coverage not yet recomputed.
+- Next:
+  - Fix flake8 and bandit issues referenced in docs/tasks.md 11.9.*.
+  - Run coverage aggregation to address docs/tasks.md 6.3 and 13.3.

--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -18,6 +18,7 @@ Instructions: Check off each task when completed. Subtasks are enumerated for cl
 1.5.5 [x] `date -u '+%Y-%m-%dT%H:%M:%SZ' | tee diagnostics/run_timestamp_utc.txt`
 1.6 [x] Investigate `poetry install --with dev --all-extras` hanging on `nvidia/__init__.py` (Issue: poetry-install-nvidia-loop.md).
 1.7 [x] Resolve scripts/codex_setup.sh version mismatch (project 0.1.0a1 vs expected 0.1.0-alpha.1).
+1.8 [x] Ensure `devsynth` CLI entry point is installed; run `poetry install --with dev --all-extras` if missing.
 
 2. Property Tests Remediation (Phase 1)
 2.1 [x] Fix Hypothesis misuse in tests/property/test_requirements_consensus_properties.py:

--- a/issues/bandit-findings.md
+++ b/issues/bandit-findings.md
@@ -10,10 +10,11 @@ Exit Code: 1
 Artifacts:
   - diagnostics/bandit_2025-09-10.txt
   - diagnostics/bandit_2025-09-10_run2.txt
+  - tmp/bandit.log (2025-09-19)
 
 Suspected Cause:
   - Multiple potential security issues flagged across modules.
-- Latest scan reports 158 low and 12 medium issues (0 high).
+  - Latest scan reports 158 low and 12 medium issues (0 high).
 
 Next Actions:
   - [ ] Review high-severity findings and apply fixes or justifications

--- a/issues/coverage-below-threshold.md
+++ b/issues/coverage-below-threshold.md
@@ -16,3 +16,4 @@ Test execution halts early due to failing tests, and coverage percentage cannot 
 ## Notes
 - Tasks `docs/tasks.md` items 13.3 and 13.4 remain unchecked pending resolution.
 - Address flake8 lint failures, as they may contribute to test instability.
+- 2025-09-19: `devsynth` installed; smoke and property tests pass. Full coverage run not executed this iteration; threshold remains unverified.

--- a/issues/flake8-violations.md
+++ b/issues/flake8-violations.md
@@ -10,10 +10,11 @@ Exit Code: 1
 Artifacts:
   - diagnostics/flake8_2025-09-10.txt
   - diagnostics/flake8_2025-09-10_run2.txt
+  - tmp/flake8.log (2025-09-19)
 
 Suspected Cause:
   - Widespread lint errors and unused imports across codebase.
-- Latest run shows E501 and F401 in tests/unit/testing/test_run_tests_module.py.
+  - Latest run shows E501/F401/F841 in tests/unit/testing/test_run_tests_module.py and related files.
 
 Next Actions:
   - [ ] Audit and fix flake8 warnings in src

--- a/test_markers_report.json
+++ b/test_markers_report.json
@@ -1,7 +1,7 @@
 {
   "markers": {
-    "fast": 1037,
-    "medium": 1539,
+    "fast": 1038,
+    "medium": 1541,
     "gui": 1,
     "requires_resource": 55,
     "isolation": 8,
@@ -14,12 +14,12 @@
     "asyncio": 11,
     "integration": 1,
     "skipif": 3,
-    "property": 17,
+    "property": 19,
     "anyio": 3,
-    "unit": 5,
+    "unit": 6,
     "smoke": 4,
     "skip": 2
   },
-  "files_scanned": 1030,
+  "files_scanned": 1031,
   "files_with_issues": 0
 }


### PR DESCRIPTION
## Summary
- note that `poetry install --with dev --all-extras` restored the missing `devsynth` CLI and highlight remaining flake8/bandit/coverage gaps
- extend environment checklist with an item to ensure the `devsynth` entry point is installed
- log 2025-09-19 iteration and refresh coverage, flake8, and bandit issue tickets

## Testing
- `poetry run devsynth run-tests --smoke --speed=fast --no-parallel --maxfail=1`
- `poetry run python tests/verify_test_organization.py`
- `poetry run python scripts/verify_test_markers.py --report --report-file test_markers_report.json`
- `poetry run python scripts/verify_requirements_traceability.py`
- `poetry run python scripts/verify_version_sync.py`
- `DEVSYNTH_PROPERTY_TESTING=true poetry run pytest tests/property/ -q`
- `poetry run flake8 src/ tests/` *(fails: E501/F401/F841)*
- `poetry run bandit -r src/devsynth -x tests` *(158 low, 12 medium issues)*

------
https://chatgpt.com/codex/tasks/task_e_68c1c9b7e5fc8333ac1b904382f84fba