### PR TITLE
chore: begin typing domain modules

### DIFF
--- a/issues/typing_relaxations_tracking.md
+++ b/issues/typing_relaxations_tracking.md
@@ -24,7 +24,6 @@ How to use this document:
 | devsynth.methodology.sprint | ignore_errors=true | TBD | [restore-strict-typing-methodology-sprint.md](restore-strict-typing-methodology-sprint.md) | 2025-10-01 | open |
 | devsynth.logger | ignore_errors=true | TBD | [restore-strict-typing-logger.md](restore-strict-typing-logger.md) | 2025-10-01 | open |
 | devsynth.methodology.* | ignore_errors=true | TBD | [restore-strict-typing-methodology.md](restore-strict-typing-methodology.md) | 2025-10-01 | open |
-| devsynth.domain.* | ignore_errors=true | TBD | [restore-strict-typing-domain.md](restore-strict-typing-domain.md) | 2025-10-01 | open |
 | devsynth.application.edrr.* | ignore_errors=true | TBD | [restore-strict-typing-application-edrr.md](restore-strict-typing-application-edrr.md) | 2025-10-01 | open |
 
 Notes:
@@ -32,3 +31,4 @@ Notes:
 - Add TODO comments in modules when touching code to remind about the strictness restoration deadline.
 - 2025-09-10: Removed the mypy override for `devsynth.cli` after upgrading Typer to a typed release.
 - 2025-09-11: Removed the mypy override for `devsynth.methodology.edrr.reasoning_loop` after adding type annotations.
+ - 2025-09-15: Removed broad mypy override for `devsynth.domain.*`; current run reports 549 errors across 22 files.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -374,10 +374,6 @@ module = "devsynth.methodology.*"
 ignore_errors = true
 
 [[tool.mypy.overrides]]
-module = "devsynth.domain.*"
-ignore_errors = true
-
-[[tool.mypy.overrides]]
 module = "devsynth.application.edrr.*"
 ignore_errors = true
 

--- a/src/devsynth/domain/models/wsde_context_driven_leadership.py
+++ b/src/devsynth/domain/models/wsde_context_driven_leadership.py
@@ -8,7 +8,7 @@ and adaptive leadership selection based on task context.
 
 import re
 from datetime import datetime
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Dict, List, Optional, Tuple, cast
 from uuid import uuid4
 
 # Import the base WSDETeam class for type hints
@@ -17,10 +17,11 @@ from devsynth.logging_setup import DevSynthLogger
 from devsynth.methodology.base import Phase
 
 logger = DevSynthLogger(__name__)
+# TODO: Restore strict typing and remove temporary relaxations by 2025-10-01.
 
 
 def enhanced_calculate_expertise_score(
-    self: WSDETeam, agent: Any, task: Dict[str, Any]
+    self: WSDETeam, agent: Any, task: dict[str, Any]
 ) -> float:
     """
     Calculate an enhanced expertise score for an agent based on a task.
@@ -40,7 +41,7 @@ def enhanced_calculate_expertise_score(
         Expertise score (higher is better)
     """
     # Get agent expertise
-    agent_expertise: List[str] = []
+    agent_expertise: list[str] = []
 
     # Try different ways to get agent expertise
     if hasattr(agent, "expertise"):
@@ -57,10 +58,10 @@ def enhanced_calculate_expertise_score(
         return 0.0
 
     # Extract keywords from the task
-    task_keywords = {}
+    task_keywords: dict[str, str] = {}
 
     # Helper function to flatten nested dictionaries for keyword extraction
-    def _flatten(prefix: str, value: Any, out: Dict[str, Any]):
+    def _flatten(prefix: str, value: Any, out: dict[str, Any]) -> None:
         if isinstance(value, dict):
             for k, v in value.items():
                 _flatten(f"{prefix}.{k}" if prefix else k, v, out)
@@ -71,7 +72,7 @@ def enhanced_calculate_expertise_score(
             out[prefix] = value
 
     # Flatten the task dictionary to extract all text
-    flattened_task = {}
+    flattened_task: dict[str, Any] = {}
     _flatten("", task, flattened_task)
 
     # Extract all string values for keyword analysis
@@ -164,7 +165,7 @@ def enhanced_calculate_expertise_score(
 
 
 def enhanced_calculate_phase_expertise_score(
-    self: WSDETeam, agent: Any, task: Dict[str, Any], phase_keywords: List[str]
+    self: WSDETeam, agent: Any, task: dict[str, Any], phase_keywords: list[str]
 ) -> float:
     """
     Calculate an enhanced expertise score that considers phase-specific requirements.
@@ -182,10 +183,10 @@ def enhanced_calculate_phase_expertise_score(
         A score representing how well the agent's expertise matches the phase requirements
     """
     # Get the base expertise score using the enhanced method
-    base_score = self.enhanced_calculate_expertise_score(agent, task)
+    base_score = cast(float, self.enhanced_calculate_expertise_score(agent, task))
 
     # Get agent expertise
-    agent_expertise: List[str] = []
+    agent_expertise: list[str] = []
 
     # Try different ways to get agent expertise
     if hasattr(agent, "expertise"):
@@ -251,8 +252,8 @@ def enhanced_calculate_phase_expertise_score(
 
 
 def enhanced_select_primus_by_expertise(
-    self: WSDETeam, task: Dict[str, Any]
-) -> Optional[Any]:
+    self: WSDETeam, task: dict[str, Any]
+) -> Any | None:
     """
     Select the Primus based on task context and agent expertise with enhanced logic.
 
@@ -335,8 +336,8 @@ def enhanced_select_primus_by_expertise(
 
 
 def dynamic_role_reassignment_enhanced(
-    self: WSDETeam, task: Dict[str, Any]
-) -> Dict[str, Any]:
+    self: WSDETeam, task: dict[str, Any]
+) -> dict[str, Any]:
     """
     Dynamically reassign roles based on the current task with enhanced logic.
 
@@ -407,7 +408,7 @@ def dynamic_role_reassignment_enhanced(
         return self.roles
 
     # Calculate role-specific expertise scores for each available agent
-    role_scores = {}
+    role_scores: dict[str, dict[str, float]] = {}
     for agent in available_agents:
         role_scores[agent.name] = {}
         for role, keywords in role_expertise.items():

--- a/src/devsynth/domain/models/wsde_decision_making.py
+++ b/src/devsynth/domain/models/wsde_decision_making.py
@@ -14,14 +14,15 @@ from devsynth.domain.models.wsde_base import WSDETeam
 from devsynth.logging_setup import DevSynthLogger
 
 logger = DevSynthLogger(__name__)
+# TODO: Restore strict typing and remove temporary relaxations by 2025-10-01.
 
 
 def generate_diverse_ideas(
     self: WSDETeam,
-    task: Dict[str, Any],
+    task: dict[str, Any],
     max_ideas: int = 10,
     diversity_threshold: float = 0.7,
-) -> List[Dict[str, Any]]:
+) -> list[dict[str, Any]]:
     """
     Generate diverse ideas for a task.
 
@@ -94,7 +95,7 @@ def generate_diverse_ideas(
 
 
 def _calculate_idea_similarity(
-    self: WSDETeam, idea1: Dict[str, Any], idea2: Dict[str, Any]
+    self: WSDETeam, idea1: dict[str, Any], idea2: dict[str, Any]
 ) -> float:
     """
     Calculate the similarity between two ideas.
@@ -128,8 +129,8 @@ def _calculate_idea_similarity(
 
 
 def create_comparison_matrix(
-    self: WSDETeam, ideas: List[Dict[str, Any]], evaluation_criteria: List[str]
-) -> Dict[str, Dict[str, float]]:
+    self: WSDETeam, ideas: list[dict[str, Any]], evaluation_criteria: list[str]
+) -> dict[str, dict[str, float]]:
     """
     Create a comparison matrix for evaluating ideas.
 
@@ -177,10 +178,10 @@ def create_comparison_matrix(
 
 def evaluate_options(
     self: WSDETeam,
-    ideas: List[Dict[str, Any]],
-    comparison_matrix: Dict[str, Dict[str, float]],
-    weighting_scheme: Dict[str, float],
-) -> List[Dict[str, Any]]:
+    ideas: list[dict[str, Any]],
+    comparison_matrix: dict[str, dict[str, float]],
+    weighting_scheme: dict[str, float],
+) -> list[dict[str, Any]]:
     """
     Evaluate options based on a comparison matrix and weighting scheme.
 
@@ -244,10 +245,10 @@ def evaluate_options(
 
 def analyze_trade_offs(
     self: WSDETeam,
-    evaluated_options: List[Dict[str, Any]],
+    evaluated_options: list[dict[str, Any]],
     conflict_detection_threshold: float = 0.7,
     identify_complementary_options: bool = True,
-) -> List[Dict[str, Any]]:
+) -> list[dict[str, Any]]:
     """
     Analyze trade-offs between evaluated options.
 
@@ -332,12 +333,12 @@ def analyze_trade_offs(
 
 def formulate_decision_criteria(
     self: WSDETeam,
-    task: Dict[str, Any],
-    evaluated_options: List[Dict[str, Any]],
-    trade_offs: List[Dict[str, Any]],
+    task: dict[str, Any],
+    evaluated_options: list[dict[str, Any]],
+    trade_offs: list[dict[str, Any]],
     contextualize_with_code: bool = False,
     code_analyzer: Any = None,
-) -> Dict[str, float]:
+) -> dict[str, float]:
     """
     Formulate decision criteria based on evaluated options and trade-offs.
 
@@ -418,9 +419,9 @@ def formulate_decision_criteria(
 
 def select_best_option(
     self: WSDETeam,
-    evaluated_options: List[Dict[str, Any]],
-    decision_criteria: Dict[str, float],
-) -> Dict[str, Any]:
+    evaluated_options: list[dict[str, Any]],
+    decision_criteria: dict[str, float],
+) -> dict[str, Any]:
     """
     Select the best option based on decision criteria.
 
@@ -462,8 +463,8 @@ def select_best_option(
 
 
 def elaborate_details(
-    self: WSDETeam, selected_option: Dict[str, Any]
-) -> List[Dict[str, Any]]:
+    self: WSDETeam, selected_option: dict[str, Any]
+) -> list[dict[str, Any]]:
     """
     Elaborate details for a selected option.
 
@@ -512,8 +513,8 @@ def elaborate_details(
 
 
 def create_implementation_plan(
-    self: WSDETeam, details: List[Dict[str, Any]]
-) -> List[Dict[str, Any]]:
+    self: WSDETeam, details: list[dict[str, Any]]
+) -> list[dict[str, Any]]:
     """
     Create an implementation plan from elaborated details.
 
@@ -558,8 +559,8 @@ def create_implementation_plan(
 
 
 def _topological_sort_steps(
-    self: WSDETeam, steps: List[Dict[str, Any]]
-) -> List[Dict[str, Any]]:
+    self: WSDETeam, steps: list[dict[str, Any]]
+) -> list[dict[str, Any]]:
     """
     Sort steps topologically based on dependencies.
 
@@ -590,7 +591,7 @@ def _topological_sort_steps(
     temp_visited = set()
     order = []
 
-    def visit(node):
+    def visit(node: str) -> None:
         if node in temp_visited:
             # Cycle detected
             return
@@ -622,10 +623,10 @@ def _topological_sort_steps(
 
 def optimize_implementation(
     self: WSDETeam,
-    plan: List[Dict[str, Any]],
-    optimization_targets: List[str],
+    plan: list[dict[str, Any]],
+    optimization_targets: list[str],
     code_analyzer: Any = None,
-) -> List[Dict[str, Any]]:
+) -> list[dict[str, Any]]:
     """
     Optimize an implementation plan.
 
@@ -666,8 +667,8 @@ def optimize_implementation(
 
 
 def _optimize_for_performance(
-    self: WSDETeam, plan: List[Dict[str, Any]], code_analyzer: Any = None
-) -> List[Dict[str, Any]]:
+    self: WSDETeam, plan: list[dict[str, Any]], code_analyzer: Any = None
+) -> list[dict[str, Any]]:
     """
     Optimize an implementation plan for performance.
 
@@ -710,8 +711,8 @@ def _optimize_for_performance(
 
 
 def _optimize_for_maintainability(
-    self: WSDETeam, plan: List[Dict[str, Any]], code_analyzer: Any = None
-) -> List[Dict[str, Any]]:
+    self: WSDETeam, plan: list[dict[str, Any]], code_analyzer: Any = None
+) -> list[dict[str, Any]]:
     """
     Optimize an implementation plan for maintainability.
 
@@ -754,8 +755,8 @@ def _optimize_for_maintainability(
 
 
 def _optimize_for_security(
-    self: WSDETeam, plan: List[Dict[str, Any]], code_analyzer: Any = None
-) -> List[Dict[str, Any]]:
+    self: WSDETeam, plan: list[dict[str, Any]], code_analyzer: Any = None
+) -> list[dict[str, Any]]:
     """
     Optimize an implementation plan for security.
 
@@ -802,10 +803,10 @@ def _optimize_for_security(
 
 def perform_quality_assurance(
     self: WSDETeam,
-    plan: List[Dict[str, Any]],
-    check_categories: List[str],
+    plan: list[dict[str, Any]],
+    check_categories: list[str],
     code_analyzer: Any = None,
-) -> Dict[str, Any]:
+) -> dict[str, Any]:
     """
     Perform quality assurance on an implementation plan.
 
@@ -867,7 +868,7 @@ def perform_quality_assurance(
 
 
 def _check_completeness(
-    self: WSDETeam, plan: List[Dict[str, Any]], qa_results: Dict[str, Any]
+    self: WSDETeam, plan: list[dict[str, Any]], qa_results: dict[str, Any]
 ) -> None:
     """
     Check the completeness of an implementation plan.
@@ -977,7 +978,7 @@ def _check_completeness(
 
 
 def _check_consistency(
-    self: WSDETeam, plan: List[Dict[str, Any]], qa_results: Dict[str, Any]
+    self: WSDETeam, plan: list[dict[str, Any]], qa_results: dict[str, Any]
 ) -> None:
     """
     Check the consistency of an implementation plan.
@@ -1003,7 +1004,7 @@ def _check_consistency(
         return
 
     # Check for duplicate steps
-    descriptions = {}
+    descriptions: dict[str, int] = {}
 
     for i, step in enumerate(plan):
         description = step.get("description", "").lower()
@@ -1052,7 +1053,7 @@ def _check_consistency(
         )
 
     # Suggest standardizing terminology
-    terms = {}
+    terms: dict[str, int] = {}
 
     for i, step in enumerate(plan):
         description = step.get("description", "").lower()
@@ -1073,7 +1074,7 @@ def _check_consistency(
 
 
 def _check_testability(
-    self: WSDETeam, plan: List[Dict[str, Any]], qa_results: Dict[str, Any]
+    self: WSDETeam, plan: list[dict[str, Any]], qa_results: dict[str, Any]
 ) -> None:
     """
     Check the testability of an implementation plan.
@@ -1182,7 +1183,7 @@ def _check_testability(
 
 
 def _check_security(
-    self: WSDETeam, plan: List[Dict[str, Any]], qa_results: Dict[str, Any]
+    self: WSDETeam, plan: list[dict[str, Any]], qa_results: dict[str, Any]
 ) -> None:
     """
     Check the security considerations in an implementation plan.


### PR DESCRIPTION
## Summary
- remove broad mypy ignore for `devsynth.domain.*`
- add explicit types in domain leadership and decision modules
- track override removal in typing-relaxations log

## Testing
- `poetry run pre-commit run --files pyproject.toml issues/typing_relaxations_tracking.md src/devsynth/domain/models/wsde_context_driven_leadership.py src/devsynth/domain/models/wsde_decision_making.py` *(fails: attr-defined errors in mypy)*
- `poetry run devsynth run-tests --speed=fast`
- `poetry run python tests/verify_test_organization.py`
- `poetry run python scripts/verify_test_markers.py`
- `poetry run python scripts/verify_requirements_traceability.py`
- `poetry run python scripts/verify_version_sync.py`
- `poetry run mypy src/devsynth/domain` *(fails: 549 errors in 22 files)*

------
https://chatgpt.com/codex/tasks/task_e_68c4f25a044c833393d6f82e9330fd18