### PR TITLE
fix: read version from pyproject in Codex setup

### DIFF
--- a/docs/plan.md
+++ b/docs/plan.md
@@ -285,7 +285,6 @@ Notes and next actions
 - Guardrails: diagnostics/flake8_2025-09-10_run2.txt shows E501/F401 in tests/unit/testing/test_run_tests_module.py; bandit scan (diagnostics/bandit_2025-09-10_run2.txt) reports 158 low and 12 medium issues.
 - Post-release: Introduce low-throughput GH Actions pipeline as specified and expand nightly coverage runs.
 - verify_test_markers reports missing @pytest.mark.property in tests/property/test_reasoning_loop_properties.py; track under issues/property-marker-advisories-in-reasoning-loop-tests.md and resolve before release.
-- scripts/codex_setup.sh exits early due to version mismatch (project version 0.1.0a1 vs expected 0.1.0-alpha.1); reconcile versioning or adjust the setup script.
 - 2025-09-12: Deduplicated docs/task_notes.md to remove redundant entries and keep the iteration log concise.
 - 2025-09-19: `devsynth` package initially missing; reran `poetry install --with dev --all-extras` to restore CLI. Smoke and property tests pass; flake8 and bandit still failing; coverage aggregation (tasks 6.3, 13.3) pending.
 - 2025-09-30: `task --version` not found; smoke run produced no coverage data (`coverage report --fail-under=90` → "No data to report"); flake8 and bandit scans still failing.

--- a/scripts/codex_setup.sh
+++ b/scripts/codex_setup.sh
@@ -85,7 +85,12 @@ echo "DIALECTICAL CHECKPOINT: How do we verify the cache reproduces identical en
 # 0.1.0a1 form. Normalize the current version to the latter for comparison so
 # future releases can switch schemes without breaking setup.
 EXPECTED_VERSION="0.1.0a1"
-CURRENT_VERSION="$(poetry version -s)"
+CURRENT_VERSION="$(python - <<'PY'
+import tomllib
+with open('pyproject.toml', 'rb') as f:
+    print(tomllib.load(f)['tool']['poetry']['version'])
+PY
+)"
 NORMALIZED_VERSION="${CURRENT_VERSION/-alpha./a}"
 if [[ "$NORMALIZED_VERSION" != "$EXPECTED_VERSION" ]]; then
   echo "Project version $CURRENT_VERSION does not match $EXPECTED_VERSION" >&2


### PR DESCRIPTION
## Summary
- read project version from `pyproject.toml` in `codex_setup.sh`
- drop outdated version-mismatch note from `docs/plan.md`

## Testing
- `poetry run pre-commit run --files scripts/codex_setup.sh docs/plan.md`
- `python --version`
- `poetry env info --path`
- `poetry run devsynth run-tests --speed=fast`
- `poetry run python tests/verify_test_organization.py`
- `poetry run python scripts/verify_test_markers.py`
- `poetry run python scripts/verify_requirements_traceability.py`
- `poetry run python scripts/verify_version_sync.py`


------
https://chatgpt.com/codex/tasks/task_e_68c5e4e8c3b48333b7cc49b28d61777d