### PR TITLE
docs: close missing BDD tests issue

### DIFF
--- a/issues/missing-bdd-tests.md
+++ b/issues/missing-bdd-tests.md
@@ -1,8 +1,11 @@
 # Missing BDD tests
 Milestone: 0.1.0a1
-Status: open
+Status: closed
 Priority: medium
 Dependencies:
+
+## Summary
+All specifications now include BDD feature coverage, leaving the gap inventory empty. Implementation committed in [a7b84d4](../commit/a7b84d4) with coverage verified by the [full profile coverage run](../diagnostics/full_profile_coverage.txt).
 
 ## Problem Statement
 Many specifications lack corresponding behavior-driven tests, which limits confidence that 90% coverage reflects system-wide behavior.


### PR DESCRIPTION
## Summary
- close missing BDD tests issue and note gap inventory empty
- reference commit a7b84d4 and full profile coverage report confirming BDD coverage

## Testing
- `poetry run pre-commit run --files issues/missing-bdd-tests.md`
- `poetry run devsynth run-tests --speed=fast` *(fails: ModuleNotFoundError: No module named 'devsynth')*
- `poetry run python tests/verify_test_organization.py`
- `poetry run python scripts/verify_test_markers.py`
- `poetry run python scripts/verify_requirements_traceability.py`
- `poetry run python scripts/verify_version_sync.py`


------
https://chatgpt.com/codex/tasks/task_e_68c5ef16a96c833383c4eaef61ecdbfe