### PR TITLE
docs: log edrr typing attempt

### DIFF
--- a/dialectical_audit.log
+++ b/dialectical_audit.log
@@ -27,6 +27,7 @@
     "Feature 'Feature Markers' reference discrepancy resolved (2025-09-09).",
     "Feature 'Finalize dialectical reasoning' reference discrepancy resolved (2025-09-09).",
     "Feature 'Logging Setup Utilities' reference discrepancy resolved (2025-09-09).",
-    "Feature 'Performance and scalability testing' reference discrepancy resolved (2025-09-09)."
+    "Feature 'Performance and scalability testing' reference discrepancy resolved (2025-09-09).",
+    "Restoring strict typing for devsynth.application.edrr.* deferred after mypy reported 430 errors (2025-09-13)."
   ]
 }

--- a/issues/restore-strict-typing-application-edrr.md
+++ b/issues/restore-strict-typing-application-edrr.md
@@ -9,3 +9,7 @@ Modules under `devsynth.application.edrr.*` use `ignore_errors=true` in `pyproje
 - [ ] Annotate EDRR application modules and resolve typing problems.
 - [ ] Remove the `ignore_errors` override from `pyproject.toml`.
 - [ ] Update `issues/typing_relaxations_tracking.md` and close this issue.
+
+## Progress
+- 2025-09-13: Running `poetry run mypy src/devsynth/application/edrr` reported 430 errors across multiple modules, so the
+  `ignore_errors` override remains and further annotation work is required.

--- a/issues/typing_relaxations_tracking.md
+++ b/issues/typing_relaxations_tracking.md
@@ -31,4 +31,6 @@ Notes:
 - 2025-09-10: Removed the mypy override for `devsynth.cli` after upgrading Typer to a typed release.
 - 2025-09-11: Removed the mypy override for `devsynth.methodology.edrr.reasoning_loop` after adding type annotations.
 - 2025-09-13: Removed the mypy override for `devsynth.adapters.*` after restoring type coverage.
+- 2025-09-13: Attempted to remove the `devsynth.application.edrr.*` override, but `poetry run mypy src/devsynth/application/edrr`
+  reported 430 errors; the ignore remains in place.
 - 2025-09-15: Removed broad mypy override for `devsynth.domain.*`; current run reports 549 errors across 22 files.


### PR DESCRIPTION
## Summary
- record failed attempt to restore strict typing for application.edrr modules
- note 430 mypy errors keep ignore_errors override in place
- log analysis in dialectical audit history

## Testing
- `poetry run pre-commit run --files dialectical_audit.log issues/restore-strict-typing-application-edrr.md issues/typing_relaxations_tracking.md`
- `poetry run mypy src/devsynth/application/edrr` *(fails: Found 430 errors in 21 files)*
- `poetry run devsynth run-tests --speed=fast`
- `poetry run python tests/verify_test_organization.py`
- `poetry run python scripts/verify_test_markers.py`
- `poetry run python scripts/verify_requirements_traceability.py`
- `poetry run python scripts/verify_version_sync.py`


------
https://chatgpt.com/codex/tasks/task_e_68c602dbfc148333b08ec70511e35e75