### PR TITLE
refactor: tighten graph adapter typing

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -9,3 +9,5 @@ per-file-ignores =
     src/devsynth/adapters/chromadb_memory_store.py: E501,F841
     src/devsynth/adapters/cli/typer_adapter.py: E501,F401
     src/devsynth/adapters/memory/memory_adapter.py: E501
+    src/devsynth/application/memory/adapters/graph_memory_adapter.py: E501,F811
+    src/devsynth/application/memory/adapters/enhanced_graph_memory_adapter.py: E501,F811


### PR DESCRIPTION
## Summary
- add optional rdflib stubs with TYPE_CHECKING imports
- clarify memory adapter metadata and query typing
- configure flake8 ignores for long graph adapter lines

## Testing
- `poetry run pre-commit run --files src/devsynth/application/memory/adapters/graph_memory_adapter.py src/devsynth/application/memory/adapters/enhanced_graph_memory_adapter.py .flake8` *(fails: mypy missing annotations and stubs)*
- `poetry run mypy src/devsynth/application/memory/adapters/graph_memory_adapter.py src/devsynth/application/memory/adapters/enhanced_graph_memory_adapter.py` *(fails: missing annotations and stubs)*
- `poetry run devsynth run-tests --speed=fast` *(fails: ModuleNotFoundError: No module named 'devsynth')*
- `poetry run python tests/verify_test_organization.py`
- `poetry run python scripts/verify_test_markers.py`
- `poetry run python scripts/verify_requirements_traceability.py`
- `poetry run python scripts/verify_version_sync.py`


------
https://chatgpt.com/codex/tasks/task_e_68c62ded42f48333b93b92d113a808f5