### PR TITLE
refactor: refine memory adapter typing

### DIFF
--- a/src/devsynth/application/memory/adapters/storage_adapter.py
+++ b/src/devsynth/application/memory/adapters/storage_adapter.py
@@ -8,9 +8,13 @@ implements the :class:`~devsynth.domain.interfaces.memory.MemoryStore` contract.
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from typing import ClassVar, Protocol
 
 from ....domain.interfaces.memory import MemoryStore
+from ....domain.models.memory import MemoryItem, MemoryVector
+
+MemorySnapshot = dict[str, MemoryItem] | dict[str, MemoryVector]
 
 
 class StorageAdapter(MemoryStore, Protocol):
@@ -22,3 +26,33 @@ class StorageAdapter(MemoryStore, Protocol):
     """
 
     backend_type: ClassVar[str]
+
+    def begin_transaction(self, transaction_id: str | None = None) -> str:
+        """Begin a transaction and return the active ID."""
+        ...
+
+    def prepare_commit(self, transaction_id: str) -> bool:
+        """Prepare to commit a transaction."""
+        ...
+
+    def commit_transaction(self, transaction_id: str | None = None) -> bool:
+        """Commit a transaction."""
+        ...
+
+    def rollback_transaction(self, transaction_id: str | None = None) -> bool:
+        """Rollback a transaction."""
+        ...
+
+    def is_transaction_active(self, transaction_id: str) -> bool:
+        """Return ``True`` if ``transaction_id`` is active."""
+        ...
+
+    def snapshot(self) -> MemorySnapshot:
+        """Create a snapshot of the current state."""
+        ...
+
+    def restore(
+        self, snapshot: Mapping[str, MemoryItem] | Mapping[str, MemoryVector]
+    ) -> bool:
+        """Restore the adapter from ``snapshot``."""
+        ...


### PR DESCRIPTION
## Summary
- tighten memory adapter type hints to use domain-specific structures
- expand storage adapter protocol with explicit transaction and snapshot typing

## Testing
- `poetry run pre-commit run --files src/devsynth/application/memory/adapters/tinydb_memory_adapter.py src/devsynth/application/memory/adapters/chromadb_vector_adapter.py src/devsynth/application/memory/adapters/vector_memory_adapter.py src/devsynth/application/memory/adapters/storage_adapter.py` (fails: mypy repo-wide errors)
- `poetry run mypy src/devsynth/application/memory/adapters` (fails: typing errors in dependencies)
- `poetry run devsynth run-tests --speed=fast` (fails: module not found / hangs)
- `poetry run python tests/verify_test_organization.py`
- `poetry run python scripts/verify_test_markers.py`
- `poetry run python scripts/verify_requirements_traceability.py`
- `poetry run python scripts/verify_version_sync.py`


------
https://chatgpt.com/codex/tasks/task_e_68c62df205f483338457e9d76088c4bb