### PR TITLE
fix: type logger and drop mypy ignore

### DIFF
--- a/issues/restore-strict-typing-logger.md
+++ b/issues/restore-strict-typing-logger.md
@@ -1,11 +1,11 @@
 # Restore strict typing for devsynth.logger
 Milestone: 0.1.0-alpha.1
-Status: open
+Status: closed
 
 ## Problem Statement
-`devsynth.logger` uses `ignore_errors=true` in `pyproject.toml`, bypassing mypy validation.
+`devsynth.logger` used `ignore_errors=true` in `pyproject.toml`, bypassing mypy validation.
 
 ## Action Plan
-- [ ] Add type annotations to logger module.
-- [ ] Remove the `ignore_errors` override from `pyproject.toml`.
-- [ ] Update `issues/typing_relaxations_tracking.md` and close this issue.
+- [x] Add type annotations to logger module.
+- [x] Remove the `ignore_errors` override from `pyproject.toml`.
+- [x] Update `issues/typing_relaxations_tracking.md` and close this issue.

--- a/issues/typing_relaxations_tracking.md
+++ b/issues/typing_relaxations_tracking.md
@@ -21,7 +21,7 @@ How to use this document:
 | devsynth.exceptions | ignore_errors=true | TBD | [restore-strict-typing-exceptions.md](restore-strict-typing-exceptions.md) | 2025-10-01 | open |
 | devsynth.testing.* | ignore_errors=true | TBD | [restore-strict-typing-testing.md](restore-strict-typing-testing.md) | 2025-10-01 | open |
 | devsynth.methodology.sprint | ignore_errors=true | TBD | [restore-strict-typing-methodology-sprint.md](restore-strict-typing-methodology-sprint.md) | 2025-10-01 | open |
-| devsynth.logger | ignore_errors=true | TBD | [restore-strict-typing-logger.md](restore-strict-typing-logger.md) | 2025-10-01 | open |
+| devsynth.logger | removed | TBD | [restore-strict-typing-logger.md](restore-strict-typing-logger.md) | 2025-10-01 | closed |
 | devsynth.methodology.* | ignore_errors=true | TBD | [restore-strict-typing-methodology.md](restore-strict-typing-methodology.md) | 2025-10-01 | open |
 | devsynth.application.edrr.* | ignore_errors=true | TBD | [restore-strict-typing-application-edrr.md](restore-strict-typing-application-edrr.md) | 2025-10-01 | open |
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -338,6 +338,10 @@ module = "devsynth"
 ignore_errors = true
 
 [[tool.mypy.overrides]]
+module = "devsynth.logger"
+ignore_errors = false
+
+[[tool.mypy.overrides]]
 module = "devsynth.methodology.*"
 ignore_errors = true
 

--- a/src/devsynth/logger.py
+++ b/src/devsynth/logger.py
@@ -15,9 +15,10 @@ from __future__ import annotations
 import logging
 import os
 import sys
+from collections.abc import Mapping
 from logging.handlers import RotatingFileHandler
 from pathlib import Path
-from typing import Any, Dict
+from typing import Any
 
 from devsynth.logging_setup import DevSynthLogger as _BaseDevSynthLogger
 from devsynth.logging_setup import (
@@ -39,7 +40,7 @@ class DevSynthLogger(_BaseDevSynthLogger):
     base logger.
     """
 
-    def _log(self, level: int, msg: str, *args, **kwargs) -> None:  # type: ignore[override]
+    def _log(self, level: int, msg: str, *args: Any, **kwargs: Any) -> None:
         """Normalize ``exc_info`` and delegate to the base logger.
 
         The standard :mod:`logging` API expects ``exc_info`` to either be a
@@ -153,7 +154,7 @@ def setup_logging(name: str, log_level: int | str | None = None) -> DevSynthLogg
 def log_consensus_failure(
     logger: DevSynthLogger,
     error: Exception,
-    extra: Dict[str, Any] | None = None,
+    extra: Mapping[str, object] | None = None,
 ) -> None:
     """Log a consensus failure using ``logger``.
 
@@ -166,7 +167,7 @@ def log_consensus_failure(
         error: The exception that triggered the failure.
         extra: Optional additional context for the log record.
     """
-    data: Dict[str, Any] = {
+    data: dict[str, object] = {
         "error": str(error),
         "error_type": error.__class__.__name__,
     }


### PR DESCRIPTION
## Summary
- type DevSynthLogger internals and consensus failure helper
- re-enable mypy checks for logger and update tracking docs

## Testing
- `poetry run pre-commit run --files pyproject.toml src/devsynth/logger.py issues/typing_relaxations_tracking.md issues/restore-strict-typing-logger.md`
- `poetry run mypy src/devsynth/logger.py`
- `poetry run devsynth run-tests --speed=fast` *(fails: ModuleNotFoundError: No module named 'devsynth')*
- `poetry run pytest tests/unit/general/test_dev_synth_logger_normalizes_exc_info -q` *(fails: Coverage failure: total of 5 is less than fail-under=90)*
- `poetry run python tests/verify_test_organization.py`
- `poetry run python scripts/verify_test_markers.py`
- `poetry run python scripts/verify_requirements_traceability.py`
- `poetry run python scripts/verify_version_sync.py`


------
https://chatgpt.com/codex/tasks/task_e_68c6416f8bfc8333a628e1740f467cc2