### PR TITLE
chore: restore strict typing for feature markers

### DIFF
--- a/issues/restore-strict-typing-feature-markers.md
+++ b/issues/restore-strict-typing-feature-markers.md
@@ -1,11 +1,13 @@
 # Restore strict typing for devsynth.feature_markers
 Milestone: 0.1.0-alpha.1
-Status: open
+Status: closed
 
 ## Problem Statement
 `devsynth.feature_markers` disables `disallow_untyped_defs` and `check_untyped_defs` in `pyproject.toml`, reducing type safety.
 
 ## Action Plan
-- [ ] Add explicit type annotations and enable strict mypy checks.
-- [ ] Remove the override from `pyproject.toml`.
-- [ ] Update `issues/typing_relaxations_tracking.md` and close this issue.
+- [x] Add explicit type annotations and enable strict mypy checks.
+- [x] Remove the override from `pyproject.toml`.
+- [x] Update `issues/typing_relaxations_tracking.md` and close this issue.
+
+Closed: 2025-09-14

--- a/issues/typing_relaxations_tracking.md
+++ b/issues/typing_relaxations_tracking.md
@@ -11,7 +11,7 @@ How to use this document:
 | Module pattern | Current relaxations | Owner | Issue link | Target date | Status |
 |---|---|---|---|---|---|
 | devsynth.application.cli.commands.inspect_code_cmd | disallow_untyped_defs=false, check_untyped_defs=false | TBD | [restore-strict-typing-inspect-code-cmd.md](restore-strict-typing-inspect-code-cmd.md) | 2025-10-01 | open |
-| devsynth.feature_markers | disallow_untyped_defs=false, check_untyped_defs=false | TBD | [restore-strict-typing-feature-markers.md](restore-strict-typing-feature-markers.md) | 2025-10-01 | open |
+| devsynth.feature_markers | removed | TBD | [restore-strict-typing-feature-markers.md](restore-strict-typing-feature-markers.md) | 2025-10-01 | closed |
 | devsynth.core.mvu.* | disallow_untyped_defs=false, check_untyped_defs=false, ignore_missing_imports=true | TBD | [restore-strict-typing-core-mvu.md](restore-strict-typing-core-mvu.md) | 2025-10-01 | open |
 | devsynth.application.documentation.* | removed | TBD | [restore-strict-typing-application-documentation.md](restore-strict-typing-application-documentation.md) | 2025-10-01 | closed |
 | devsynth.domain.models.requirement | ignore_errors=true | TBD | [restore-strict-typing-domain-models-requirement.md](restore-strict-typing-domain-models-requirement.md) | 2025-10-01 | open |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -239,10 +239,6 @@ disallow_incomplete_defs = false
 # while avoiding blocking changes. Add TODOs in modules to restore strictness.
 # Target to restore strictness: 2025-10-01
 [[tool.mypy.overrides]]
-module = "devsynth.feature_markers"
-ignore_errors = true
-
-[[tool.mypy.overrides]]
 module = "devsynth.core.mvu.*"
 disallow_untyped_defs = false
 check_untyped_defs = false

--- a/src/devsynth/feature_markers.py
+++ b/src/devsynth/feature_markers.py
@@ -1,1027 +1,1022 @@
 """Feature markers for dialectical audit."""
 
+import inspect
+import sys
+from collections.abc import Callable
+from enum import Enum
+from typing import TYPE_CHECKING
+
 
 # Feature: API Reference Documentation Generation
-def feature_api_reference_documentation_generation():
+def feature_api_reference_documentation_generation() -> None:
     """Marker function for audit."""
     pass
 
 
 # Feature: API Specification Generation
-def feature_api_specification_generation():
+def feature_api_specification_generation() -> None:
     """Marker function for audit."""
     pass
 
 
 # Feature: AST-Based Code Analysis and Transformation
-def feature_ast_based_code_analysis_and_transformation():
+def feature_ast_based_code_analysis_and_transformation() -> None:
     """Marker function for audit."""
     pass
 
 
 # Feature: Additional Storage Backends
-def feature_additional_storage_backends():
+def feature_additional_storage_backends() -> None:
     """Marker function for audit."""
     pass
 
 
 # Feature: Advanced Graph Memory Features
-def feature_advanced_graph_memory_features():
+def feature_advanced_graph_memory_features() -> None:
     """Marker function for audit."""
     pass
 
 
 # Feature: Agent API Health and Metrics
-def feature_agent_api_health_and_metrics():
+def feature_agent_api_health_and_metrics() -> None:
     """Marker function for audit."""
     pass
 
 
 # Feature: Agent API Interactions
-def feature_agent_api_interactions():
+def feature_agent_api_interactions() -> None:
     """Marker function for audit."""
     pass
 
 
 # Feature: Agent API Stub Usage
-def feature_agent_api_stub_usage():
+def feature_agent_api_stub_usage() -> None:
     """Marker function for audit."""
     pass
 
 
 # Feature: Alignment Metrics Command
-def feature_alignment_metrics_command():
+def feature_alignment_metrics_command() -> None:
     """Marker function for audit."""
     pass
 
 
 # Feature: CLI Command Execution
-def feature_cli_command_execution():
+def feature_cli_command_execution() -> None:
     """Marker function for audit."""
     pass
 
 
 # Feature: CLI UI Parity
-def feature_cli_ui_parity():
+def feature_cli_ui_parity() -> None:
     """Marker function for audit."""
     pass
 
 
 # Feature: CLI UX Enhancements
-def feature_cli_ux_enhancements():
+def feature_cli_ux_enhancements() -> None:
     """Marker function for audit."""
     pass
 
 
 # Feature: ChromaDB Integration
-def feature_chromadb_integration():
+def feature_chromadb_integration() -> None:
     """Marker function for audit."""
     pass
 
 
 # Feature: Code Command
-def feature_code_command():
+def feature_code_command() -> None:
     """Marker function for audit."""
     pass
 
 
 # Feature: Code Generation
-def feature_code_generation():
+def feature_code_generation() -> None:
     """Marker function for audit."""
     pass
 
 
 # Feature: Code Transformation
-def feature_code_transformation():
+def feature_code_transformation() -> None:
     """Marker function for audit."""
     pass
 
 
 # Feature: Comprehensive Documentation Ingestion
-def feature_comprehensive_documentation_ingestion():
+def feature_comprehensive_documentation_ingestion() -> None:
     """Marker function for audit."""
     pass
 
 
 # Feature: Configuration Loader
-def feature_configuration_loader():
+def feature_configuration_loader() -> None:
     """Marker function for audit."""
     pass
 
 
 # Feature: Consensus Building
-def feature_consensus_building():
+def feature_consensus_building() -> None:
     """Marker function for audit."""
     pass
 
 
 # Feature: Consensus failure logging
-def feature_consensus_failure_logging():
+def feature_consensus_failure_logging() -> None:
     """Marker function for audit."""
     pass
 
 
 # Feature: Cross-Interface Consistency
-def feature_cross_interface_consistency():
+def feature_cross_interface_consistency() -> None:
     """Marker function for audit."""
     pass
 
 
 # Feature: Database Schema Generation
-def feature_database_schema_generation():
+def feature_database_schema_generation() -> None:
     """Marker function for audit."""
     pass
 
 
 # Feature: Delegating tasks with consensus voting
-def feature_delegating_tasks_with_consensus_voting():
+def feature_delegating_tasks_with_consensus_voting() -> None:
     """Marker function for audit."""
     pass
 
 
 # Feature: Deployment environment validation
-def feature_deployment_environment_validation():
+def feature_deployment_environment_validation() -> None:
     """Marker function for audit."""
     pass
 
 
 # Feature: DevSynth Doctor
-def feature_devsynth_doctor():
+def feature_devsynth_doctor() -> None:
     """Marker function for audit."""
     pass
 
 
 # Feature: Diagnostics displays audit logs
-def feature_diagnostics_displays_audit_logs():
+def feature_diagnostics_displays_audit_logs() -> None:
     """Marker function for audit."""
     pass
 
 
 # Feature: Dialectical reasoning impact memory integration
-def feature_dialectical_reasoning_impact_memory_integration():
+def feature_dialectical_reasoning_impact_memory_integration() -> None:
     """Marker function for audit."""
     pass
 
 
 # Feature: Dialectical reasoning persists results to memory
-def feature_dialectical_reasoning_persists_results_to_memory():
+def feature_dialectical_reasoning_persists_results_to_memory() -> None:
     """Marker function for audit."""
     pass
 
 
 # Feature: Doctor Command
-def feature_doctor_command():
-    """Marker function for audit."""
-    pass
-
-
-# Feature: Doctor command
-def feature_doctor_command():
+def feature_doctor_command() -> None:
     """Marker function for audit."""
     pass
 
 
 # Feature: Doctor command with missing environment variables
-def feature_doctor_command_with_missing_environment_variables():
+def feature_doctor_command_with_missing_environment_variables() -> None:
     """Marker function for audit."""
     pass
 
 
 # Feature: Documentation Fetch and Cache
-def feature_documentation_fetch_and_cache():
+def feature_documentation_fetch_and_cache() -> None:
     """Marker function for audit."""
     pass
 
 
 # Feature: Documentation Utility Functions
-def feature_documentation_utility_functions():
+def feature_documentation_utility_functions() -> None:
     """Marker function for audit."""
     pass
 
 
 # Feature: EDRR Coordinator
-def feature_edrr_coordinator():
+def feature_edrr_coordinator() -> None:
     """Marker function for audit."""
     pass
 
 
 # Feature: EDRR Integration with Real LLM Providers
-def feature_edrr_integration_with_real_llm_providers():
+def feature_edrr_integration_with_real_llm_providers() -> None:
     """Marker function for audit."""
     pass
 
 
 # Feature: EDRR cycle command
-def feature_edrr_cycle_command():
+def feature_edrr_cycle_command() -> None:
     """Marker function for audit."""
     pass
 
 
 # Feature: Enable optional features
-def feature_enable_optional_features():
+def feature_enable_optional_features() -> None:
     """Marker function for audit."""
     pass
 
 
 # Feature: Enhanced ChromaDB Integration
-def feature_enhanced_chromadb_integration():
+def feature_enhanced_chromadb_integration() -> None:
     """Marker function for audit."""
     pass
 
 
 # Feature: Enhanced Dialectical Reasoning
-def feature_enhanced_dialectical_reasoning():
+def feature_enhanced_dialectical_reasoning() -> None:
     """Marker function for audit."""
     pass
 
 
 # Feature: Enhanced EDRR Memory Integration
-def feature_enhanced_edrr_memory_integration():
+def feature_enhanced_edrr_memory_integration() -> None:
     """Marker function for audit."""
     pass
 
 
 # Feature: Enhanced EDRR Phase Transitions
-def feature_enhanced_edrr_phase_transitions():
+def feature_enhanced_edrr_phase_transitions() -> None:
     """Marker function for audit."""
     pass
 
 
 # Feature: Enhanced EDRR Recursion Handling
-def feature_enhanced_edrr_recursion_handling():
+def feature_enhanced_edrr_recursion_handling() -> None:
     """Marker function for audit."""
     pass
 
 
 # Feature: Environment Variables Integration
-def feature_environment_variables_integration():
+def feature_environment_variables_integration() -> None:
     """Marker function for audit."""
     pass
 
 
 # Feature: Error Handling
-def feature_error_handling():
+def feature_error_handling() -> None:
     """Marker function for audit."""
     pass
 
 
 # Feature: Extended Cross-Interface Consistency
-def feature_extended_cross_interface_consistency():
+def feature_extended_cross_interface_consistency() -> None:
     """Marker function for audit."""
     pass
 
 
 # Feature: Generated tests fail when requirements are unmet
-def feature_generated_tests_fail_when_requirements_are_unmet():
+def feature_generated_tests_fail_when_requirements_are_unmet() -> None:
     """Marker function for audit."""
     pass
 
 
 # Feature: Hybrid Memory Query Patterns and Synchronization
-def feature_hybrid_memory_query_patterns_and_synchronization():
+def feature_hybrid_memory_query_patterns_and_synchronization() -> None:
     """Marker function for audit."""
     pass
 
 
 # Feature: Ingest Command
-def feature_ingest_command():
+def feature_ingest_command() -> None:
     """Marker function for audit."""
     pass
 
 
 # Feature: Inspect Code Command
-def feature_inspect_code_command():
+def feature_inspect_code_command() -> None:
     """Marker function for audit."""
     pass
 
 
 # Feature: Inspect Commands
-def feature_inspect_commands():
+def feature_inspect_commands() -> None:
     """Marker function for audit."""
     pass
 
 
 # Feature: Integration test scaffolding
-def feature_integration_test_scaffolding():
+def feature_integration_test_scaffolding() -> None:
     """Marker function for audit."""
     pass
 
 
 # Feature: Interactive Init Wizard
-def feature_interactive_init_wizard():
+def feature_interactive_init_wizard() -> None:
     """Marker function for audit."""
     pass
 
 
 # Feature: Interactive Requirements Flow CLI
-def feature_interactive_requirements_flow_cli():
+def feature_interactive_requirements_flow_cli() -> None:
     """Marker function for audit."""
     pass
 
 
 # Feature: Interactive Requirements Flow WebUI
-def feature_interactive_requirements_flow_webui():
+def feature_interactive_requirements_flow_webui() -> None:
     """Marker function for audit."""
     pass
 
 
 # Feature: Interactive Requirements Wizard
-def feature_interactive_requirements_wizard():
+def feature_interactive_requirements_wizard() -> None:
     """Marker function for audit."""
     pass
 
 
 # Feature: Invalid configuration handling
-def feature_invalid_configuration_handling():
+def feature_invalid_configuration_handling() -> None:
     """Marker function for audit."""
     pass
 
 
 # Feature: Kuzu memory integration
-def feature_kuzu_memory_integration():
+def feature_kuzu_memory_integration() -> None:
     """Marker function for audit."""
     pass
 
 
 # Feature: MVU Command Execution
-def feature_mvu_command_execution():
+def feature_mvu_command_execution() -> None:
     """Marker function for audit."""
     pass
 
 
 # Feature: Memory Adapter Integration
-def feature_memory_adapter_integration():
+def feature_memory_adapter_integration() -> None:
     """Marker function for audit."""
     pass
 
 
 # Feature: Memory Backend Integration
-def feature_memory_backend_integration():
+def feature_memory_backend_integration() -> None:
     """Marker function for audit."""
     pass
 
 
 # Feature: Memory Manager and Adapters
-def feature_memory_manager_and_adapters():
+def feature_memory_manager_and_adapters() -> None:
     """Marker function for audit."""
     pass
 
 
 # Feature: Memory adapter read and write operations
-def feature_memory_adapter_read_and_write_operations():
+def feature_memory_adapter_read_and_write_operations() -> None:
     """Marker function for audit."""
     pass
 
 
 # Feature: Memory and Context System
-def feature_memory_and_context_system():
+def feature_memory_and_context_system() -> None:
     """Marker function for audit."""
     pass
 
 
 # Feature: Memory module handles missing TinyDB dependency
-def feature_memory_module_handles_missing_tinydb_dependency():
+def feature_memory_module_handles_missing_tinydb_dependency() -> None:
     """Marker function for audit."""
     pass
 
 
 # Feature: Methodology Adapters Integration
-def feature_methodology_adapters_integration():
+def feature_methodology_adapters_integration() -> None:
     """Marker function for audit."""
     pass
 
 
 # Feature: Micro EDRR Cycle
-def feature_micro_edrr_cycle():
+def feature_micro_edrr_cycle() -> None:
     """Marker function for audit."""
     pass
 
 
 # Feature: Multi-Layered Memory System and Tiered Cache Strategy
-def feature_multi_layered_memory_system_and_tiered_cache_strategy():
+def feature_multi_layered_memory_system_and_tiered_cache_strategy() -> None:
     """Marker function for audit."""
     pass
 
 
 # Feature: Multi-agent task delegation
-def feature_multi_agent_task_delegation():
+def feature_multi_agent_task_delegation() -> None:
     """Marker function for audit."""
     pass
 
 
 # Feature: Multi-disciplinary Dialectical Reasoning
-def feature_multi_disciplinary_dialectical_reasoning():
+def feature_multi_disciplinary_dialectical_reasoning() -> None:
     """Marker function for audit."""
     pass
 
 
 # Feature: Multi-module test generation
-def feature_multi_module_test_generation():
+def feature_multi_module_test_generation() -> None:
     """Marker function for audit."""
     pass
 
 
 # Feature: NiceGUI WebUI
-def feature_nicegui_webui():
+def feature_nicegui_webui() -> None:
     """Marker function for audit."""
     pass
 
 
 # Feature: Non-Hierarchical Collaboration
-def feature_non_hierarchical_collaboration():
+def feature_non_hierarchical_collaboration() -> None:
     """Marker function for audit."""
     pass
 
 
 # Feature: Per-error retry policies
-def feature_per_error_retry_policies():
+def feature_per_error_retry_policies() -> None:
     """Marker function for audit."""
     pass
 
 
 # Feature: Performance and Scalability Testing
-def feature_performance_and_scalability_testing():
+def feature_performance_and_scalability_testing() -> None:
     """Marker function for audit."""
     pass
 
 
 # Feature: Policy audit
-def feature_policy_audit():
+def feature_policy_audit() -> None:
     """Marker function for audit."""
     pass
 
 
 # Feature: Project Documentation Ingestion
-def feature_project_documentation_ingestion():
+def feature_project_documentation_ingestion() -> None:
     """Marker function for audit."""
     pass
 
 
 # Feature: Project Ingestion
-def feature_project_ingestion():
+def feature_project_ingestion() -> None:
     """Marker function for audit."""
     pass
 
 
 # Feature: Project Initialization
-def feature_project_initialization():
+def feature_project_initialization() -> None:
     """Marker function for audit."""
     pass
 
 
 # Feature: Project State Analysis
-def feature_project_state_analysis():
+def feature_project_state_analysis() -> None:
     """Marker function for audit."""
     pass
 
 
 # Feature: Promise System Capability Management
-def feature_promise_system_capability_management():
+def feature_promise_system_capability_management() -> None:
     """Marker function for audit."""
     pass
 
 
 # Feature: Prompt Management with DPSy-AI
-def feature_prompt_management_with_dpsy_ai():
+def feature_prompt_management_with_dpsy_ai() -> None:
     """Marker function for audit."""
     pass
 
 
 # Feature: Reasoning loop integrates with EDRR phases
-def feature_reasoning_loop_integrates_with_edrr_phases():
+def feature_reasoning_loop_integrates_with_edrr_phases() -> None:
     """Marker function for audit."""
     pass
 
 
 # Feature: Recursive EDRR Coordinator
-def feature_recursive_edrr_coordinator():
+def feature_recursive_edrr_coordinator() -> None:
     """Marker function for audit."""
     pass
 
 
 # Feature: Recursive EDRR phase recovery
-def feature_recursive_edrr_phase_recovery():
+def feature_recursive_edrr_phase_recovery() -> None:
     """Marker function for audit."""
     pass
 
 
 # Feature: Refactor Command
-def feature_refactor_command():
+def feature_refactor_command() -> None:
     """Marker function for audit."""
     pass
 
 
 # Feature: Requirement Analysis
-def feature_requirement_analysis():
+def feature_requirement_analysis() -> None:
     """Marker function for audit."""
     pass
 
 
 # Feature: Requirements Gathering Wizard
-def feature_requirements_gathering_wizard():
+def feature_requirements_gathering_wizard() -> None:
     """Marker function for audit."""
     pass
 
 
 # Feature: Requirements Management
-def feature_requirements_management():
+def feature_requirements_management() -> None:
     """Marker function for audit."""
     pass
 
 
 # Feature: Requirements Wizard
-def feature_requirements_wizard():
+def feature_requirements_wizard() -> None:
     """Marker function for audit."""
     pass
 
 
 # Feature: Requirements Wizard Logging
-def feature_requirements_wizard_logging():
+def feature_requirements_wizard_logging() -> None:
     """Marker function for audit."""
     pass
 
 
 # Feature: Requirements Wizard Navigation
-def feature_requirements_wizard_navigation():
+def feature_requirements_wizard_navigation() -> None:
     """Marker function for audit."""
     pass
 
 
 # Feature: Requirements wizard logging and priority persistence
-def feature_requirements_wizard_logging_and_priority_persistence():
+def feature_requirements_wizard_logging_and_priority_persistence() -> None:
     """Marker function for audit."""
     pass
 
 
 # Feature: Retry Mechanism with Exponential Backoff
-def feature_retry_mechanism_with_exponential_backoff():
+def feature_retry_mechanism_with_exponential_backoff() -> None:
     """Marker function for audit."""
     pass
 
 
 # Feature: Retry Predicates for HTTP status codes
-def feature_retry_predicates_for_http_status_codes():
+def feature_retry_predicates_for_http_status_codes() -> None:
     """Marker function for audit."""
     pass
 
 
 # Feature: Role reassignment uses shared memory
-def feature_role_reassignment_uses_shared_memory():
+def feature_role_reassignment_uses_shared_memory() -> None:
     """Marker function for audit."""
     pass
 
 
 # Feature: Run Pipeline Command
-def feature_run_pipeline_command():
+def feature_run_pipeline_command() -> None:
     """Marker function for audit."""
     pass
 
 
 # Feature: Run tests from the CLI
-def feature_run_tests_from_the_cli():
+def feature_run_tests_from_the_cli() -> None:
     """Marker function for audit."""
     pass
 
 
 # Feature: Security audit reporting
-def feature_security_audit_reporting():
+def feature_security_audit_reporting() -> None:
     """Marker function for audit."""
     pass
 
 
 # Feature: Self Analysis
-def feature_self_analysis():
+def feature_self_analysis() -> None:
     """Marker function for audit."""
     pass
 
 
 # Feature: Serve Command
-def feature_serve_command():
+def feature_serve_command() -> None:
     """Marker function for audit."""
     pass
 
 
 # Feature: Setup Wizard
-def feature_setup_wizard():
+def feature_setup_wizard() -> None:
     """Marker function for audit."""
     pass
 
 
 # Feature: Shared UXBridge across CLI and WebUI
-def feature_shared_uxbridge_across_cli_and_webui():
+def feature_shared_uxbridge_across_cli_and_webui() -> None:
     """Marker function for audit."""
     pass
 
 
 # Feature: Simple Addition
-def feature_simple_addition():
+def feature_simple_addition() -> None:
     """Marker function for audit."""
     pass
 
 
 # Feature: Spec Command
-def feature_spec_command():
+def feature_spec_command() -> None:
     """Marker function for audit."""
     pass
 
 
 # Feature: Sprint ceremonies align with EDRR phases
-def feature_sprint_ceremonies_align_with_edrr_phases():
+def feature_sprint_ceremonies_align_with_edrr_phases() -> None:
     """Marker function for audit."""
     pass
 
 
 # Feature: Streamlit WebUI Navigation
-def feature_streamlit_webui_navigation():
+def feature_streamlit_webui_navigation() -> None:
     """Marker function for audit."""
     pass
 
 
 # Feature: Test Generation
-def feature_test_generation():
+def feature_test_generation() -> None:
     """Marker function for audit."""
     pass
 
 
 # Feature: Test Metrics
-def feature_test_metrics():
+def feature_test_metrics() -> None:
     """Marker function for audit."""
     pass
 
 
 # Feature: Training Materials for TDD/BDD-EDRR Integration
-def feature_training_materials_for_tdd_bdd_edrr_integration():
+def feature_training_materials_for_tdd_bdd_edrr_integration() -> None:
     """Marker function for audit."""
     pass
 
 
 # Feature: UXBridge Interface
-def feature_uxbridge_interface():
+def feature_uxbridge_interface() -> None:
     """Marker function for audit."""
     pass
 
 
 # Feature: User Guide Enhancement
-def feature_user_guide_enhancement():
+def feature_user_guide_enhancement() -> None:
     """Marker function for audit."""
     pass
 
 
 # Feature: Validate Manifest
-def feature_validate_manifest():
+def feature_validate_manifest() -> None:
     """Marker function for audit."""
     pass
 
 
 # Feature: Validate Manifest Command
-def feature_validate_manifest_command():
+def feature_validate_manifest_command() -> None:
     """Marker function for audit."""
     pass
 
 
 # Feature: Validate Metadata
-def feature_validate_metadata():
+def feature_validate_metadata() -> None:
     """Marker function for audit."""
     pass
 
 
 # Feature: Validate Metadata Command
-def feature_validate_metadata_command():
+def feature_validate_metadata_command() -> None:
     """Marker function for audit."""
     pass
 
 
 # Feature: Version-Aware Documentation Management
-def feature_version_aware_documentation_management():
+def feature_version_aware_documentation_management() -> None:
     """Marker function for audit."""
     pass
 
 
 # Feature: WSDE Agent Model Refinement
-def feature_wsde_agent_model_refinement():
+def feature_wsde_agent_model_refinement() -> None:
     """Marker function for audit."""
     pass
 
 
 # Feature: WSDE Message Passing and Peer Review
-def feature_wsde_message_passing_and_peer_review():
+def feature_wsde_message_passing_and_peer_review() -> None:
     """Marker function for audit."""
     pass
 
 
 # Feature: WSDE Model and Memory System Integration
-def feature_wsde_model_and_memory_system_integration():
+def feature_wsde_model_and_memory_system_integration() -> None:
     """Marker function for audit."""
     pass
 
 
 # Feature: WSDE Peer Review Workflow
-def feature_wsde_peer_review_workflow():
+def feature_wsde_peer_review_workflow() -> None:
     """Marker function for audit."""
     pass
 
 
 # Feature: WSDE Voting Mechanisms for Critical Decisions
-def feature_wsde_voting_mechanisms_for_critical_decisions():
+def feature_wsde_voting_mechanisms_for_critical_decisions() -> None:
     """Marker function for audit."""
     pass
 
 
 # Feature: WSDE and EDRR collaboration
-def feature_wsde_and_edrr_collaboration():
+def feature_wsde_and_edrr_collaboration() -> None:
     """Marker function for audit."""
     pass
 
 
 # Feature: WSDE collaboration flow
-def feature_wsde_collaboration_flow():
+def feature_wsde_collaboration_flow() -> None:
     """Marker function for audit."""
     pass
 
 
 # Feature: WSDE-EDRR Integration
-def feature_wsde_edrr_integration():
+def feature_wsde_edrr_integration() -> None:
     """Marker function for audit."""
     pass
 
 
 # Feature: Web Application Generation
-def feature_web_application_generation():
+def feature_web_application_generation() -> None:
     """Marker function for audit."""
     pass
 
 
 # Feature: WebUI APISpec Page
-def feature_webui_apispec_page():
+def feature_webui_apispec_page() -> None:
     """Marker function for audit."""
     pass
 
 
 # Feature: WebUI Alignment Metrics Page
-def feature_webui_alignment_metrics_page():
+def feature_webui_alignment_metrics_page() -> None:
     """Marker function for audit."""
     pass
 
 
 # Feature: WebUI Analysis Page
-def feature_webui_analysis_page():
+def feature_webui_analysis_page() -> None:
     """Marker function for audit."""
     pass
 
 
 # Feature: WebUI Command Execution
-def feature_webui_command_execution():
+def feature_webui_command_execution() -> None:
     """Marker function for audit."""
     pass
 
 
 # Feature: WebUI Configuration Page
-def feature_webui_configuration_page():
+def feature_webui_configuration_page() -> None:
     """Marker function for audit."""
     pass
 
 
 # Feature: WebUI DBSchema Page
-def feature_webui_dbschema_page():
+def feature_webui_dbschema_page() -> None:
     """Marker function for audit."""
     pass
 
 
 # Feature: WebUI Diagnostics Page
-def feature_webui_diagnostics_page():
+def feature_webui_diagnostics_page() -> None:
     """Marker function for audit."""
     pass
 
 
 # Feature: WebUI Docs Generation Page
-def feature_webui_docs_generation_page():
+def feature_webui_docs_generation_page() -> None:
     """Marker function for audit."""
     pass
 
 
 # Feature: WebUI Doctor
-def feature_webui_doctor():
+def feature_webui_doctor() -> None:
     """Marker function for audit."""
     pass
 
 
 # Feature: WebUI Gather Wizard
-def feature_webui_gather_wizard():
+def feature_webui_gather_wizard() -> None:
     """Marker function for audit."""
     pass
 
 
 # Feature: WebUI Ingestion Page
-def feature_webui_ingestion_page():
+def feature_webui_ingestion_page() -> None:
     """Marker function for audit."""
     pass
 
 
 # Feature: WebUI Inspect Config Page
-def feature_webui_inspect_config_page():
+def feature_webui_inspect_config_page() -> None:
     """Marker function for audit."""
     pass
 
 
 # Feature: WebUI Integration
-def feature_webui_integration():
+def feature_webui_integration() -> None:
     """Marker function for audit."""
     pass
 
 
 # Feature: WebUI Navigation and Prompts
-def feature_webui_navigation_and_prompts():
+def feature_webui_navigation_and_prompts() -> None:
     """Marker function for audit."""
     pass
 
 
 # Feature: WebUI Onboarding Flow
-def feature_webui_onboarding_flow():
+def feature_webui_onboarding_flow() -> None:
     """Marker function for audit."""
     pass
 
 
 # Feature: WebUI Refactor Page
-def feature_webui_refactor_page():
+def feature_webui_refactor_page() -> None:
     """Marker function for audit."""
     pass
 
 
 # Feature: WebUI Requirements Wizard with WizardState
-def feature_webui_requirements_wizard_with_wizardstate():
+def feature_webui_requirements_wizard_with_wizardstate() -> None:
     """Marker function for audit."""
     pass
 
 
 # Feature: WebUI Serve Page
-def feature_webui_serve_page():
+def feature_webui_serve_page() -> None:
     """Marker function for audit."""
     pass
 
 
 # Feature: WebUI Specification Editor
-def feature_webui_specification_editor():
+def feature_webui_specification_editor() -> None:
     """Marker function for audit."""
     pass
 
 
 # Feature: WebUI Specification Editor Extended
-def feature_webui_specification_editor_extended():
+def feature_webui_specification_editor_extended() -> None:
     """Marker function for audit."""
     pass
 
 
 # Feature: WebUI Synthesis Page
-def feature_webui_synthesis_page():
+def feature_webui_synthesis_page() -> None:
     """Marker function for audit."""
     pass
 
 
 # Feature: WebUI Test Metrics Page
-def feature_webui_test_metrics_page():
+def feature_webui_test_metrics_page() -> None:
     """Marker function for audit."""
     pass
 
 
 # Feature: WebUI Validate Manifest Page
-def feature_webui_validate_manifest_page():
+def feature_webui_validate_manifest_page() -> None:
     """Marker function for audit."""
     pass
 
 
 # Feature: WebUI Validate Metadata Page
-def feature_webui_validate_metadata_page():
+def feature_webui_validate_metadata_page() -> None:
     """Marker function for audit."""
     pass
 
 
 # Feature: WebUI WebApp Page
-def feature_webui_webapp_page():
+def feature_webui_webapp_page() -> None:
     """Marker function for audit."""
     pass
 
 
 # Feature: Workflow Execution
-def feature_workflow_execution():
+def feature_workflow_execution() -> None:
     """Marker function for audit."""
     pass
 
 
 # Feature: devsynth run-tests command
-def feature_devsynth_run_tests_command():
+def feature_devsynth_run_tests_command() -> None:
     """Marker function for audit."""
     pass
 
 
 # Feature: Code Analysis
-def feature_code_analysis():
+def feature_code_analysis() -> None:
     """Marker function for audit."""
     pass
 
 
 # Feature: Complete Sprint-EDRR integration
-def feature_complete_sprint_edrr_integration():
+def feature_complete_sprint_edrr_integration() -> None:
     """Marker function for audit."""
     pass
 
 
 # Feature: Critical recommendations follow-up
-def feature_critical_recommendations_follow_up():
+def feature_critical_recommendations_follow_up() -> None:
     """Marker function for audit."""
     pass
 
 
 # Feature: Dialectical audit gating
-def feature_dialectical_audit_gating():
+def feature_dialectical_audit_gating() -> None:
     """Marker function for audit."""
     pass
 
 
 # Feature: Enhance retry mechanism
-def feature_enhance_retry_mechanism():
+def feature_enhance_retry_mechanism() -> None:
     """Marker function for audit."""
     pass
 
 
 # Feature: Expand test generation capabilities
-def feature_expand_test_generation_capabilities():
+def feature_expand_test_generation_capabilities() -> None:
     """Marker function for audit."""
     pass
 
 
 # Feature: Finalize WSDE/EDRR workflow logic
-def feature_finalize_wsde_edrr_workflow_logic():
+def feature_finalize_wsde_edrr_workflow_logic() -> None:
     """Marker function for audit."""
     pass
 
 
 # Feature: Improve deployment automation
-def feature_improve_deployment_automation():
+def feature_improve_deployment_automation() -> None:
     """Marker function for audit."""
     pass
 
 
 # Feature: Integrate dialectical audit into CI
-def feature_integrate_dialectical_audit_into_ci():
+def feature_integrate_dialectical_audit_into_ci() -> None:
     """Marker function for audit."""
     pass
 
 
 # Feature: Multi-Agent Collaboration
-def feature_multi_agent_collaboration():
+def feature_multi_agent_collaboration() -> None:
     """Marker function for audit."""
     pass
 
 
 # Feature: Multi-Layered Memory System
-def feature_multi_layered_memory_system():
+def feature_multi_layered_memory_system() -> None:
     """Marker function for audit."""
     pass
 
 
 # Feature: Release state check
-def feature_release_state_check():
+def feature_release_state_check() -> None:
     """Marker function for audit."""
     pass
 
 
 # Feature: Resolve pytest-xdist assertion errors
-def feature_resolve_pytest_xdist_assertion_errors():
+def feature_resolve_pytest_xdist_assertion_errors() -> None:
     """Marker function for audit."""
     pass
 
 
 # Feature: Review and Reprioritize Open Issues
-def feature_review_and_reprioritize_open_issues():
+def feature_review_and_reprioritize_open_issues() -> None:
     """Marker function for audit."""
     pass
 
 
 # Feature: User Authentication
-def feature_user_authentication():
+def feature_user_authentication() -> None:
     """Marker function for audit."""
     pass
 
 
 # Feature: Version bump script
-def feature_version_bump_script():
+def feature_version_bump_script() -> None:
     """Marker function for audit."""
     pass
 
 
-import inspect
-import sys
-
 # Automatically generated feature marker enumeration and lookup utilities
-from enum import Enum
-from typing import Callable, Dict
 
 
-def _discover_markers() -> Dict[str, Callable[[], None]]:
+def _discover_markers() -> dict[str, Callable[[], None]]:
     """Return mapping of feature names to marker callables."""
     current_module = sys.modules[__name__]
     prefix = "feature_"
-    markers: Dict[str, Callable[[], None]] = {}
+    markers: dict[str, Callable[[], None]] = {}
     for name, obj in inspect.getmembers(current_module, inspect.isfunction):
         if name.startswith(prefix):
             key = name[len(prefix) :].upper()
@@ -1031,9 +1026,17 @@ def _discover_markers() -> Dict[str, Callable[[], None]]:
 
 _MARKER_FUNCTIONS = _discover_markers()
 
-FeatureMarker = Enum(
-    "FeatureMarker", {name: name for name in _MARKER_FUNCTIONS}, type=str
-)
+if TYPE_CHECKING:
+
+    class FeatureMarker(str, Enum):
+        """Enumeration of discovered feature markers."""
+
+        ...
+
+else:
+    FeatureMarker = Enum(
+        "FeatureMarker", {name: name for name in _MARKER_FUNCTIONS}, type=str
+    )
 
 
 def get_marker(marker: "FeatureMarker") -> Callable[[], None]:


### PR DESCRIPTION
## Summary
- annotate all feature marker functions with explicit `None` return type
- dynamically generate `FeatureMarker` enum with type-checking stub
- drop mypy override and close tracking issue

## Testing
- `poetry run pre-commit run --files src/devsynth/feature_markers.py pyproject.toml issues/typing_relaxations_tracking.md issues/restore-strict-typing-feature-markers.md`
- `poetry run mypy src/devsynth/feature_markers.py`
- `PYTHONPATH=src poetry run pytest -m fast` *(fails: ModuleNotFoundError: No module named 'faiss'; No module named 'chromadb.api')*
- `PYTHONPATH=src poetry run python tests/verify_test_organization.py`
- `PYTHONPATH=src poetry run python scripts/verify_test_markers.py`
- `PYTHONPATH=src poetry run python scripts/verify_requirements_traceability.py`
- `PYTHONPATH=src poetry run python scripts/verify_version_sync.py`

------
https://chatgpt.com/codex/tasks/task_e_68c64d378a108333967e4a2e6e1284ea