### PR TITLE
refactor: restore strict typing for performance module

### DIFF
--- a/issues/restore-strict-typing-application-performance.md
+++ b/issues/restore-strict-typing-application-performance.md
@@ -2,6 +2,8 @@
 Milestone: 0.1.0-alpha.1
 Status: closed
 
+Closed: 2025-09-14
+
 ## Problem Statement
 `devsynth.application.performance` used `ignore_errors=true` in `pyproject.toml`, bypassing type checks.
 

--- a/issues/typing_relaxations_tracking.md
+++ b/issues/typing_relaxations_tracking.md
@@ -37,7 +37,7 @@ Notes:
 - 2025-09-14: Removed the mypy override for `devsynth.feature_markers` after annotating marker functions.
 - 2025-09-15: Removed broad mypy override for `devsynth.domain.*`; current run reports 549 errors across 22 files.
 - 2025-09-14: Removed the mypy override for `devsynth.domain.models.requirement`; domain typing now reports 617 errors across 26 files.
-- 2025-09-16: Removed the mypy override for `devsynth.application.performance` after adding structured metrics types.
+- 2025-09-14: Removed the mypy override for `devsynth.application.performance` after adding structured metrics types.
 - 2025-09-14: Removed the mypy override for `devsynth.core.mvu.*` after restoring strict typing.
 - 2025-09-14: Removed the mypy overrides for `devsynth.methodology.*` and `devsynth.methodology.sprint` after enforcing strict typing.
 - 2025-09-14: Removed the mypy override for `devsynth.testing.*` after clarifying helper contracts.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -313,7 +313,24 @@ ignore_errors = true
 # Broad temporary relaxation for application layer to unblock typing gate while we add annotations iteratively.
 # TODO: Narrow and remove by 2025-10-15; track in docs/plan.md Phase 4.
 [[tool.mypy.overrides]]
-module = "devsynth.application.*"
+module = [
+  "devsynth.application.agents.*",
+  "devsynth.application.cli.*",
+  "devsynth.application.code_analysis.*",
+  "devsynth.application.collaboration.*",
+  "devsynth.application.config.*",
+  "devsynth.application.documentation.*",
+  "devsynth.application.ingestion.*",
+  "devsynth.application.issues.*",
+  "devsynth.application.llm.*",
+  "devsynth.application.memory.*",
+  "devsynth.application.orchestration.*",
+  "devsynth.application.promises.*",
+  "devsynth.application.prompts.*",
+  "devsynth.application.server.*",
+  "devsynth.application.sprint.*",
+  "devsynth.application.utils.*",
+]
 ignore_errors = true
 
 # Added by Task 54 (2025-09-03): targeted temporary relaxations based on strict mypy run

--- a/src/devsynth/application/performance/__init__.py
+++ b/src/devsynth/application/performance/__init__.py
@@ -32,7 +32,7 @@ def _run_workload(workload: int) -> int:
     Returns:
         Accumulated value from the synthetic workload.
     """
-    total = 0
+    total: int = 0
     for i in range(workload):
         total += i * i
     return total
@@ -50,10 +50,10 @@ def capture_baseline_metrics(
     Returns:
         Metrics dictionary with workload, duration, and throughput.
     """
-    start = time.perf_counter()
+    start: float = time.perf_counter()
     _run_workload(workload)
-    duration = time.perf_counter() - start
-    throughput = workload / duration if duration else 0.0
+    duration: float = time.perf_counter() - start
+    throughput: float = workload / duration if duration else 0.0
     metrics: PerformanceMetrics = {
         "workload": workload,
         "duration_seconds": duration,
@@ -79,10 +79,10 @@ def capture_scalability_metrics(
     """
     results: list[PerformanceMetrics] = []
     for workload in workloads:
-        start = time.perf_counter()
+        start: float = time.perf_counter()
         _run_workload(workload)
-        duration = time.perf_counter() - start
-        throughput = workload / duration if duration else 0.0
+        duration: float = time.perf_counter() - start
+        throughput: float = workload / duration if duration else 0.0
         results.append(
             {
                 "workload": workload,


### PR DESCRIPTION
## Summary
- enforce explicit variable annotations in performance utilities
- remove mypy ignore for `devsynth.application.performance`
- update typing-relaxation tracking and close issue

## Testing
- `poetry run pre-commit run --files pyproject.toml src/devsynth/application/performance/__init__.py issues/restore-strict-typing-application-performance.md issues/typing_relaxations_tracking.md`
- `poetry run mypy src/devsynth/application/performance`
- `PYTHONPATH=src poetry run python -m devsynth run-tests --speed=fast`


------
https://chatgpt.com/codex/tasks/task_e_68c6e7bb967883338a7fe5ecb820e896