### PR TITLE
chore: clarify feature marker typing

### DIFF
--- a/issues/restore-strict-typing-feature-markers.md
+++ b/issues/restore-strict-typing-feature-markers.md
@@ -10,4 +10,4 @@ Status: closed
 - [x] Remove the override from `pyproject.toml`.
 - [x] Update `issues/typing_relaxations_tracking.md` and close this issue.
 
-Closed on 2025-09-14 after removing mypy override and adding annotations.
+Closed on 2025-09-14 after removing the mypy override, eliminating ``type: ignore`` comments, and adding explicit annotations.

--- a/src/devsynth/feature_markers.py
+++ b/src/devsynth/feature_markers.py
@@ -1,9 +1,12 @@
 """Feature markers for dialectical audit."""
 
+from __future__ import annotations
+
 import inspect
 import sys
 from collections.abc import Callable
 from enum import Enum
+from types import ModuleType
 from typing import TYPE_CHECKING
 
 
@@ -1021,7 +1024,7 @@ if TYPE_CHECKING:
 
 def _discover_markers() -> dict[str, Callable[[], None]]:
     """Return mapping of feature names to marker callables."""
-    current_module = sys.modules[__name__]
+    current_module: ModuleType = sys.modules[__name__]
     prefix = "feature_"
     markers: dict[str, Callable[[], None]] = {}
     for name, obj in inspect.getmembers(current_module, inspect.isfunction):
@@ -1031,7 +1034,7 @@ def _discover_markers() -> dict[str, Callable[[], None]]:
     return markers
 
 
-_MARKER_FUNCTIONS = _discover_markers()
+_MARKER_FUNCTIONS: dict[str, Callable[[], None]] = _discover_markers()
 
 if not TYPE_CHECKING:
     FeatureMarker = Enum(  # noqa: F811
@@ -1039,6 +1042,6 @@ if not TYPE_CHECKING:
     )
 
 
-def get_marker(marker: "FeatureMarker") -> Callable[[], None]:
+def get_marker(marker: FeatureMarker) -> Callable[[], None]:
     """Return the marker function associated with ``marker``."""
     return _MARKER_FUNCTIONS[marker.name]


### PR DESCRIPTION
## Summary
- add future annotations and explicit module typing to feature markers
- type marker registry and retrieval without `type: ignore`
- document closure of the strict-typing issue

## Testing
- `poetry run pre-commit run --files src/devsynth/feature_markers.py issues/restore-strict-typing-feature-markers.md`
- `poetry run mypy src/devsynth/feature_markers.py`
- `poetry run devsynth run-tests --speed=fast`

------
https://chatgpt.com/codex/tasks/task_e_68c6edb4fe2c833389ceb064461583d3