### PR TITLE
fix: annotate testing helpers

### DIFF
--- a/issues/restore-strict-typing-testing.md
+++ b/issues/restore-strict-typing-testing.md
@@ -9,3 +9,7 @@ Modules under `devsynth.testing.*` use `ignore_errors=true` in `pyproject.toml`,
 - [x] Add type annotations to testing utilities.
 - [x] Remove the `ignore_errors` override from `pyproject.toml`.
 - [x] Update `issues/typing_relaxations_tracking.md` and close this issue.
+
+## Resolution Evidence
+- 2025-09-14: `poetry run mypy src/devsynth/testing` reports no errors.
+- 2025-09-14: `poetry run devsynth run-tests --speed=fast` passes.

--- a/issues/typing_relaxations_tracking.md
+++ b/issues/typing_relaxations_tracking.md
@@ -50,3 +50,5 @@ Notes:
 - 2025-09-14: Verified removal of `devsynth.application.documentation.*` override after adding type annotations.
 - 2025-09-15: Revalidated `devsynth.methodology.*` modules; no `type: ignore`
   comments remain.
+- 2025-09-14: Revalidated `devsynth.testing.*`; `poetry run mypy src/devsynth/testing`
+  reports no issues.

--- a/src/devsynth/testing/__init__.py
+++ b/src/devsynth/testing/__init__.py
@@ -6,4 +6,4 @@ assist with generating and running tests for DevSynth modules.
 
 from .prompts import INTEGRATION_TEST_PROMPT
 
-__all__ = ["INTEGRATION_TEST_PROMPT"]
+__all__: list[str] = ["INTEGRATION_TEST_PROMPT"]

--- a/src/devsynth/testing/generation.py
+++ b/src/devsynth/testing/generation.py
@@ -8,8 +8,8 @@ added.
 
 from __future__ import annotations
 
+from collections.abc import Iterable
 from pathlib import Path
-from typing import Dict, Iterable
 
 PLACEHOLDER_TEMPLATE = (
     '"""Scaffolded integration test for {name}.\n\n'
@@ -19,10 +19,10 @@ PLACEHOLDER_TEMPLATE = (
     "    assert 2 + 2 == 4\n"
 )
 
-__all__ = ["scaffold_integration_tests", "write_scaffolded_tests"]
+__all__: list[str] = ["scaffold_integration_tests", "write_scaffolded_tests"]
 
 
-def scaffold_integration_tests(names: Iterable[str]) -> Dict[str, str]:
+def scaffold_integration_tests(names: Iterable[str]) -> dict[str, str]:
     """Create placeholder integration test modules.
 
     Args:
@@ -31,7 +31,7 @@ def scaffold_integration_tests(names: Iterable[str]) -> Dict[str, str]:
     Returns:
         Mapping of filenames to placeholder test content.
     """
-    placeholders: Dict[str, str] = {}
+    placeholders: dict[str, str] = {}
     sanitized = list(names) or ["placeholder"]
     for raw in sanitized:
         name = raw.strip().lower().replace(" ", "_")
@@ -40,7 +40,7 @@ def scaffold_integration_tests(names: Iterable[str]) -> Dict[str, str]:
     return placeholders
 
 
-def write_scaffolded_tests(directory: Path, names: Iterable[str]) -> Dict[Path, str]:
+def write_scaffolded_tests(directory: Path, names: Iterable[str]) -> dict[Path, str]:
     """Write placeholder integration tests to ``directory``.
 
     This helper builds on :func:`scaffold_integration_tests` by emitting the
@@ -58,7 +58,7 @@ def write_scaffolded_tests(directory: Path, names: Iterable[str]) -> Dict[Path, 
 
     directory.mkdir(parents=True, exist_ok=True)
     generated = scaffold_integration_tests(names)
-    written: Dict[Path, str] = {}
+    written: dict[Path, str] = {}
     for filename, content in generated.items():
         path = directory / filename
         path.write_text(content)

--- a/src/devsynth/testing/performance.py
+++ b/src/devsynth/testing/performance.py
@@ -78,4 +78,4 @@ def capture_scalability_metrics(
     return results
 
 
-__all__ = ["capture_baseline_metrics", "capture_scalability_metrics"]
+__all__: list[str] = ["capture_baseline_metrics", "capture_scalability_metrics"]

--- a/src/devsynth/testing/prompts.py
+++ b/src/devsynth/testing/prompts.py
@@ -4,15 +4,17 @@ This module contains prompt strings used by the testing helpers to
 bootstrap integration test generation.
 """
 
-INTEGRATION_TEST_PROMPT = (
+INTEGRATION_TEST_PROMPT: str = (
     "You are an expert software tester. Given a description of a module, "
-    "write pytest integration tests that exercise realistic workflows and boundary conditions. "
-    "Cover invalid inputs, error-handling paths, and concurrency or asynchronous behavior where applicable. "
-    "Account for edge cases such as empty or malformed payloads, extreme values, missing permissions, "
-    "network or filesystem failures, and cleanup of external resources. "
-    "Use fixtures and parameterization to reduce duplication. "
-    "Ensure each test contains meaningful assertions, applies 'pytest.mark.asyncio' for async code, "
-    "avoids placeholders like 'assert True' or 'pass', and never performs real network calls."
+    "write pytest integration tests that exercise realistic workflows and "
+    "boundary conditions. Cover invalid inputs, error-handling paths, and "
+    "concurrency or asynchronous behavior where applicable. Account for "
+    "edge cases such as empty or malformed payloads, extreme values, missing "
+    "permissions, network or filesystem failures, and cleanup of external "
+    "resources. Use fixtures and parameterization to reduce duplication. "
+    "Ensure each test contains meaningful assertions, applies 'pytest.mark.asyncio' "
+    "for async code, avoids placeholders like 'assert True' or 'pass', and never "
+    "performs real network calls."
 )
 
-__all__ = ["INTEGRATION_TEST_PROMPT"]
+__all__: list[str] = ["INTEGRATION_TEST_PROMPT"]

--- a/src/devsynth/testing/run_tests.py
+++ b/src/devsynth/testing/run_tests.py
@@ -21,7 +21,7 @@ from typing import Any, cast
 from devsynth.logging_setup import DevSynthLogger
 
 # Cache directory for test collection
-COLLECTION_CACHE_DIR = ".test_collection_cache"
+COLLECTION_CACHE_DIR: str = ".test_collection_cache"
 # TTL for collection cache in seconds (default: 3600); configurable via env var
 try:
     COLLECTION_CACHE_TTL_SECONDS: int = int(
@@ -78,7 +78,7 @@ def _failure_tips(returncode: int, cmd: Sequence[str]) -> str:
 
 
 # Mapping of CLI targets to test paths
-TARGET_PATHS = {
+TARGET_PATHS: dict[str, str] = {
     "unit-tests": "tests/unit/",
     "integration-tests": "tests/integration/",
     "behavior-tests": "tests/behavior/",


### PR DESCRIPTION
## Summary
- type annotations for testing helpers and module constants
- document strict typing removal in tracking issue
- close devsynth.testing typing issue

## Testing
- `poetry run pre-commit run --files issues/restore-strict-typing-testing.md issues/typing_relaxations_tracking.md src/devsynth/testing/__init__.py src/devsynth/testing/generation.py src/devsynth/testing/performance.py src/devsynth/testing/prompts.py src/devsynth/testing/run_tests.py`
- `poetry run mypy src/devsynth/testing`
- `poetry run python - <<'PY'
from devsynth.testing.run_tests import run_tests
import sys
success, output = run_tests('unit-tests', ['fast'])
print(output)
if not success:
    sys.exit(1)
PY`


------
https://chatgpt.com/codex/tasks/task_e_68c71a5b1f688333998c3c285ec70241