### PR TITLE
chore(cli): drop uxbridge type ignore

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,7 +27,7 @@ repos:
     rev: v1.17.1
     hooks:
       - id: mypy
-        additional_dependencies: [types-requests, types-PyYAML, types-jsonschema]
+        additional_dependencies: [types-requests, types-PyYAML, types-jsonschema, typer]
         files: ^src/
         args: ["--config-file", "pyproject.toml"]
   - repo: https://github.com/asottile/pyupgrade

--- a/issues/restore-strict-typing-cli.md
+++ b/issues/restore-strict-typing-cli.md
@@ -13,3 +13,5 @@ Status: closed
 
 Closed on 2025-09-14 after confirming `devsynth.cli` has fully annotated
 parameters and return types with no remaining `type: ignore` comments.
+2025-09-14: Removed residual `type: ignore` in `application.cli.commands.mvu_report_cmd`
+and re-verified with `poetry run mypy src/devsynth/application/cli/commands/mvu_report_cmd.py`.

--- a/issues/strict-typing-roadmap.md
+++ b/issues/strict-typing-roadmap.md
@@ -14,7 +14,7 @@ Inventory (2025-09-13):
   - restore-strict-typing-application-edrr.md
   - restore-strict-typing-application-memory-adapters.md
   - restore-strict-typing-application-performance.md
-  - restore-strict-typing-cli.md
+  - ~~restore-strict-typing-cli.md~~
   - restore-strict-typing-core-mvu.md
   - restore-strict-typing-domain-models-requirement.md
   - restore-strict-typing-domain.md
@@ -32,3 +32,4 @@ Next Actions:
   - [x] Prioritize modules and schedule PRs by creating follow-up issues with owners and timelines.
 Resolution Evidence:
   - Inventory recorded 2025-09-13.
+  - 2025-09-14: `restore-strict-typing-cli.md` completed; removed remaining type ignore in `mvu_report_cmd` and verified `poetry run mypy src/devsynth/application/cli/commands/mvu_report_cmd.py`.

--- a/src/devsynth/application/cli/commands/mvu_report_cmd.py
+++ b/src/devsynth/application/cli/commands/mvu_report_cmd.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING
 
 import typer
 
@@ -12,11 +12,15 @@ from devsynth.core.mvu.report import generate_report
 if TYPE_CHECKING:  # pragma: no cover - type checking import
     from devsynth.interface.ux_bridge import UXBridge
 else:  # pragma: no cover - fallback for optional dependency
-    UXBridge = object  # type: ignore[misc,assignment]
+
+    class UXBridge:  # pragma: no cover
+        """Runtime stub used when :class:`UXBridge` isn't installed."""
+
+        pass
 
 
 def mvu_report_cmd(
-    since: Optional[str] = typer.Option(
+    since: str | None = typer.Option(
         None,
         "--since",
         help="Git revision to start scanning from (e.g. origin/main).",
@@ -26,13 +30,13 @@ def mvu_report_cmd(
         "--format",
         help="Output format: markdown or html.",
     ),
-    output: Optional[Path] = typer.Option(
+    output: Path | None = typer.Option(
         None,
         "--output",
         help="Destination file. Prints to stdout when omitted.",
     ),
     *,
-    bridge: Optional[UXBridge] = None,
+    bridge: UXBridge | None = None,
 ) -> None:
     """Generate a traceability matrix from MVU metadata in git history."""
 


### PR DESCRIPTION
## Summary
- remove leftover `type: ignore` in MVU report command by stubbing `UXBridge`
- document CLI strict-typing completion and update roadmap
- ensure mypy hook includes `typer` for pre-commit

## Testing
- `poetry run mypy src/devsynth/application/cli/commands/mvu_report_cmd.py`
- `poetry run pre-commit run --files src/devsynth/application/cli/commands/mvu_report_cmd.py issues/restore-strict-typing-cli.md issues/strict-typing-roadmap.md .pre-commit-config.yaml`
- `poetry run devsynth run-tests --speed=fast` *(prints "astor library not found"; no further output)*
- `poetry run python tests/verify_test_organization.py`
- `poetry run python scripts/verify_test_markers.py`
- `poetry run python scripts/verify_requirements_traceability.py`
- `poetry run python scripts/verify_version_sync.py`


------
https://chatgpt.com/codex/tasks/task_e_68c72735eeb48333a07e63aa1810a338