### PR TITLE
docs: log coverage blocker and reopen test path issue

### DIFF
--- a/docs/plan.md
+++ b/docs/plan.md
@@ -314,3 +314,4 @@ Notes and next actions
 - 2025-09-13: Follow-up strict typing issues filed with owners and timelines; removed pyproject overrides for logger, exceptions, and CLI modules; tasks 20.2 and 20.3 marked complete.
 - 2025-09-13: Attempted final fast+medium coverage run; htmlcov/ and coverage.json omitted from commit due to Codex diff size limits and run reported `ERROR unit/general/test_test_first_metrics.py`.
 - 2025-09-13: Restored `devsynth` via `poetry install`; smoke tests and verification scripts passed in fresh session; UAT and maintainer tagging remain outstanding.
+- 2025-09-14: Smoke tests and verification scripts pass; full coverage run still references `unit/general/test_test_first_metrics.py` and produces no artifact. Reopened [run-tests-missing-test-first-metrics-file.md](../issues/run-tests-missing-test-first-metrics-file.md) to track fix before UAT and tagging.

--- a/docs/task_notes.md
+++ b/docs/task_notes.md
@@ -2,28 +2,6 @@
 
 Historical log archived at docs/archived/task_notes_pre2025-09-16.md to keep this file under 200 lines.
 
-## Iteration 2025-09-10
-- Environment: Python 3.12.10; `poetry env info --path` -> /root/.cache/pypoetry/virtualenvs/devsynth-MeXVnKii-py3.12.
-- Commands:
-  - `poetry run devsynth run-tests --smoke --speed=fast --no-parallel --maxfail=1` – pass.
-  - `poetry run python tests/verify_test_organization.py` – 914 test files detected.
-  - `poetry run python scripts/verify_test_markers.py` – 0 issues.
-  - `poetry run python scripts/verify_requirements_traceability.py` – success.
-  - `poetry run flake8 src/ tests/` – E501/F401; `poetry run bandit -r src/devsynth -x tests` – 158 low, 12 medium findings.
-- Observations: go-task installed via `scripts/install_dev.sh`; coverage not yet generated.
-- Next: resolve flake8 and bandit issues; generate coverage report.
-
-## Iteration 2025-09-11
-- Environment: Python 3.12.10; `poetry install --with dev --all-extras`; go-task 3.44.1 after `scripts/install_dev.sh`.
-- Commands:
-  - `poetry run devsynth run-tests --smoke --speed=fast --no-parallel --maxfail=1` – pass.
-  - `poetry run python tests/verify_test_organization.py` – 916 test files detected.
-  - `poetry run python scripts/verify_test_markers.py --report --report-file test_markers_report.json` – 0 issues.
-  - `poetry run python scripts/verify_requirements_traceability.py` – success.
-  - Coverage attempts reported "No data to report"; lint and bandit findings persisted.
-- Observations: go-task missing until installed; coverage aggregation and guardrail fixes outstanding.
-- Next: aggregate coverage ≥90%; address flake8 and bandit findings; document go-task persistence.
-
 ## Iteration 2025-09-12
 - Environment: Python 3.12.10; `poetry install --with dev --all-extras`; `task --version` 3.44.1.
 - Commands:
@@ -203,3 +181,15 @@ Historical log archived at docs/archived/task_notes_pre2025-09-16.md to keep thi
   - `poetry run python scripts/verify_version_sync.py`
 - Observations: Environment restored, smoke tests and verification scripts passed; UAT and maintainer tagging remain.
 - Next: Obtain User Acceptance Testing sign-off and hand off tagging.
+## Iteration 2025-09-14
+- Environment: Python 3.12.10; `poetry env info --path` -> /root/.cache/pypoetry/virtualenvs/devsynth-MeXVnKii-py3.12; `task --version` 3.44.1.
+- Commands:
+  - `bash scripts/install_dev.sh` – installed task.
+  - `poetry run devsynth run-tests --smoke --speed=fast --no-parallel --maxfail=1` – pass.
+  - `poetry run python tests/verify_test_organization.py` – 926 test files detected.
+  - `poetry run python scripts/verify_test_markers.py` – 0 issues.
+  - `poetry run python scripts/verify_requirements_traceability.py` – success.
+  - `poetry run python scripts/verify_version_sync.py` – OK.
+  - `poetry run pytest unit/general/test_test_first_metrics.py` – ERROR file or directory not found.
+- Observations: Coverage run still references nonexistent `unit/general/test_test_first_metrics.py`; reopened issue run-tests-missing-test-first-metrics-file.md.
+- Next: Fix test path reference, rerun full coverage, then proceed with UAT and maintainer tagging.

--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -113,6 +113,7 @@ Instructions: Check off each task when completed. Subtasks are enumerated for cl
 11.9 [x] Guardrails suite resolved; see [flake8-violations.md](../issues/flake8-violations.md) and [bandit-findings.md](../issues/bandit-findings.md).
 11.9.1 [x] Regenerate flake8 report and resolve E501/F401 in tests/unit/testing/test_run_tests_module.py and related files (Issue: [flake8-violations.md](../issues/flake8-violations.md)).
 11.9.2 [x] Review bandit scan (158 low, 0 medium) and address or justify findings (Issue: [bandit-findings.md](../issues/bandit-findings.md)).
+11.10 [ ] Reopen run-tests-missing-test-first-metrics-file.md due to recurring path error; fix reference and rerun full coverage.
 
 12. Risk Management and Mitigations
 12.1 [x] Document minimal smoke coverage expectations for optional backends (macOS/Windows) and how to enable:

--- a/issues/run-tests-missing-test-first-metrics-file.md
+++ b/issues/run-tests-missing-test-first-metrics-file.md
@@ -1,18 +1,17 @@
 Title: DevSynth run-tests missing test_first_metrics file
-Date: 2025-09-10 14:16 UTC
-Status: closed
+Date: 2025-09-14 21:35 UTC
+Status: open
 Affected Area: tests
 Reproduction:
-  - `poetry run devsynth run-tests --speed=fast --speed=medium --report --no-parallel`
+  - `poetry run devsynth run-tests --speed=fast --speed=medium --report --no-parallel` (hangs; logs empty)
   - `poetry run pytest unit/general/test_test_first_metrics.py`
 Exit Code: 4
 Artifacts:
-  - test_reports/20250910_141451/all-tests/report.html (not generated)
-  - htmlcov/ (empty)
+  - /tmp/full_run.log (empty)
 Suspected Cause: Test invocation references `unit/general/test_test_first_metrics.py` which does not exist; expected `tests/unit/general/test_test_first_metrics.py`.
 Next Actions:
-  - [x] Correct the test path or update invocation to use `tests/unit/general/test_test_first_metrics.py`.
-  - [x] Rerun `poetry run devsynth run-tests --speed=fast --speed=medium --report --no-parallel`.
+  - [ ] Remove stale `unit/general/test_test_first_metrics.py` reference and ensure test resides under `tests/unit/general/`.
+  - [ ] Rerun `poetry run devsynth run-tests --speed=fast --speed=medium --report --no-parallel` after fix and capture coverage artifacts.
 Resolution Evidence:
-  - [test_reports/test_first_metrics.log](../test_reports/test_first_metrics.log)
+  - [test_reports/test_first_metrics.log](../test_reports/test_first_metrics.log) (previous attempt)
 Related Task: [docs/tasks.md item 11.8](../docs/tasks.md)


### PR DESCRIPTION
## Summary
- note recurring coverage blocker in release plan
- reopen missing test_first_metrics path issue
- track new follow-up task and iteration notes

## Testing
- `poetry run devsynth run-tests --smoke --speed=fast --no-parallel --maxfail=1`
- `poetry run python tests/verify_test_organization.py`
- `poetry run python scripts/verify_test_markers.py`
- `poetry run python scripts/verify_requirements_traceability.py`
- `poetry run python scripts/verify_version_sync.py`
- `poetry run pytest unit/general/test_test_first_metrics.py` (fails: file not found)


------
https://chatgpt.com/codex/tasks/task_e_68c733b949388333b90ef140e4692f50