### PR TITLE
docs: log environment check and release progress

### DIFF
--- a/docs/plan.md
+++ b/docs/plan.md
@@ -315,3 +315,4 @@ Notes and next actions
 - 2025-09-13: Attempted final fast+medium coverage run; htmlcov/ and coverage.json omitted from commit due to Codex diff size limits and run reported `ERROR tests/unit/general/test_test_first_metrics.py`.
 - 2025-09-13: Restored `devsynth` via `poetry install`; smoke tests and verification scripts passed in fresh session; UAT and maintainer tagging remain outstanding.
 - 2025-09-14: Smoke tests and verification scripts pass; full coverage run still references `tests/unit/general/test_test_first_metrics.py` and produces no artifact. Reopened [run-tests-missing-test-first-metrics-file.md](../issues/run-tests-missing-test-first-metrics-file.md) to track fix before UAT and tagging.
+- 2025-09-15: Environment lacked go-task; `bash scripts/install_dev.sh` restored it. Smoke tests and verification scripts pass; awaiting UAT and maintainer tagging.

--- a/docs/task_notes.md
+++ b/docs/task_notes.md
@@ -206,3 +206,15 @@ Historical log archived at docs/archived/task_notes_pre2025-09-16.md to keep thi
 - `poetry run python scripts/verify_version_sync.py` – OK.
 - Observations: Fixed test path; `devsynth run-tests` hung in this environment, but targeted pytest generated coverage artifacts htmlcov/ and coverage.json.
 - Next: Proceed with User Acceptance Testing and maintainer tagging.
+
+## Iteration 2025-09-15
+- Environment: Python 3.12.10; `poetry env info --path` -> /root/.cache/pypoetry/virtualenvs/devsynth-MeXVnKii-py3.12; `task --version` 3.44.1 after reinstall.
+- Commands:
+  - `bash scripts/install_dev.sh` – restored go-task.
+  - `poetry run devsynth run-tests --smoke --speed=fast --no-parallel --maxfail=1` – pass.
+  - `poetry run python tests/verify_test_organization.py` – 928 test files detected.
+  - `poetry run python scripts/verify_test_markers.py --report --report-file test_markers_report.json` – 0 issues.
+  - `poetry run python scripts/verify_requirements_traceability.py` – success.
+  - `poetry run python scripts/verify_version_sync.py` – OK.
+- Observations: Initial session lacked go-task; install script fixed it. Smoke tests and verification scripts pass; awaiting User Acceptance Testing and maintainer tagging.
+- Next: Conduct UAT and hand off tagging.

--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -159,6 +159,7 @@ Notes:
 - Ensure tests use resource gating and avoid accidental network calls. The run-tests command should set provider defaults when unset.
 - Maintain exactly one speed marker per test function.
 - Prefer adding tests for pure logic first, then expand to gated integrations.
+- 2025-09-15: Environment needed go-task reinstallation; smoke tests and verification scripts pass; UAT and tagging remain.
 
 17. Documentation Maintenance
 17.1 [x] Deduplicate historical entries in docs/task_notes.md to keep the iteration log concise.

--- a/issues/release-finalization-uat.md
+++ b/issues/release-finalization-uat.md
@@ -23,5 +23,6 @@ Progress:
 - 2025-09-13: Final fast+medium coverage run attempted; run reported `ERROR tests/unit/general/test_test_first_metrics.py`. Coverage artifacts omitted from commit due to Codex diff size limits.
 - 2025-09-13: Verified fresh environment with `poetry install`; smoke tests and verification scripts passed; awaiting UAT and maintainer tagging.
 - 2025-09-13: Fixed path handling for `test_first_metrics` and reran coverage; committed updated reports.
+- 2025-09-15: Reinstalled go-task, executed smoke tests and verification scripts; awaiting UAT and maintainer tagging.
 Resolution Evidence:
   - docs/tasks.md item 19


### PR DESCRIPTION
## Summary
- record that go-task was missing and restored before running tests
- document environment check progress in release planning issue
- note pending UAT and tagging in tasks and plan

## Testing
- `poetry run devsynth run-tests --smoke --speed=fast --no-parallel --maxfail=1`
- `poetry run python tests/verify_test_organization.py`
- `poetry run python scripts/verify_test_markers.py --report --report-file test_markers_report.json`
- `poetry run python scripts/verify_requirements_traceability.py`
- `poetry run python scripts/verify_version_sync.py`


------
https://chatgpt.com/codex/tasks/task_e_68c7782d10b48333a0c7a84daf7f1f59