### PR TITLE
docs: document release-state check invariants

### DIFF
--- a/docs/implementation/release_state_check_invariants.md
+++ b/docs/implementation/release_state_check_invariants.md
@@ -1,0 +1,59 @@
+---
+author: DevSynth Team
+date: '2025-09-15'
+status: draft
+tags:
+- implementation
+- invariants
+title: Release State Check Invariants
+---
+<div class="breadcrumbs">
+<a href="../index.md">Documentation</a> &gt; <a href="index.md">Implementation</a> &gt; Release State Check Invariants
+</div>
+
+# Release State Check Invariants
+
+This note details expected release states, their transitions, and proofs provided
+by behavior-driven and unit tests.
+
+## Expected States
+
+- **draft** – release not yet published; no tag requirement.
+- **published** – release published; requires a corresponding Git tag.
+
+## Transitions and Checks
+
+The `verify_release_state` script enforces audit cleanliness and tag
+requirements before declaring success ([source](../../scripts/verify_release_state.py)).
+
+- `draft` → `published` requires creating tag `v<version>`.
+- Any state is blocked when `dialectical_audit.log` contains unresolved
+  questions.
+
+## Proofs
+
+### Published without tag fails
+
+BDD scenario demonstrates failure when a published release lacks its
+corresponding tag ([feature](../../tests/behavior/features/release_state_check.feature)).
+Unit tests mirror this behavior, asserting a non-zero exit code for a published
+release missing its tag ([unit test](../../tests/unit/scripts/test_verify_release_state.py#L69-L76)).
+
+### Draft release passes without tag
+
+Draft releases succeed even without a tag ([feature](../../tests/behavior/features/release_state_check.feature#L11-L14), [unit test](../../tests/unit/scripts/test_verify_release_state.py#L59-L66)).
+
+### Published release with tag succeeds
+
+When the tag exists, verification succeeds ([unit test](../../tests/unit/scripts/test_verify_release_state.py#L79-L88)).
+
+### Unresolved audit questions block release
+
+Verification stops when the audit log has unanswered questions ([feature](../../tests/behavior/features/dialectical_audit_gating.feature#L6-L9)).
+
+## References
+
+- Specification: [docs/specifications/release-state-check.md](../specifications/release-state-check.md)
+- BDD Features: [tests/behavior/features/release_state_check.feature](../../tests/behavior/features/release_state_check.feature), [tests/behavior/features/dialectical_audit_gating.feature](../../tests/behavior/features/dialectical_audit_gating.feature)
+- Unit Tests: [tests/unit/scripts/test_verify_release_state.py](../../tests/unit/scripts/test_verify_release_state.py)
+- Issue: [issues/release-state-check.md](../../issues/release-state-check.md)

--- a/docs/plan.md
+++ b/docs/plan.md
@@ -281,6 +281,11 @@ Notes and next actions
   docs/implementation/run_tests_cli_invariants.md and
   docs/implementation/edrr_invariants.md (Issues:
   issues/run-tests-cli-invariants.md, issues/edrr-invariants.md).
+- Formal proofs for release-state check invariants recorded in
+  docs/implementation/release_state_check_invariants.md (BDD scenarios in
+  tests/behavior/features/release_state_check.feature and
+  tests/behavior/features/dialectical_audit_gating.feature; unit tests in
+  tests/unit/scripts/test_verify_release_state.py).
 - Short-term: Align docs with current CLI behaviors and ensure issues/ action items are traced to tests.
 - Guardrails: diagnostics/flake8_2025-09-10_run2.txt shows E501/F401 in tests/unit/testing/test_run_tests_module.py; bandit scan (diagnostics/bandit_2025-09-10_run2.txt) reports 158 low and 12 medium issues.
 - Post-release: Introduce low-throughput GH Actions pipeline as specified and expand nightly coverage runs.


### PR DESCRIPTION
## Summary
- add release-state check invariants doc with expected states, transitions, and proofs
- link invariants doc from plan and reference supporting BDD scenarios and unit tests

## Testing
- `poetry run pre-commit run --files docs/implementation/release_state_check_invariants.md docs/plan.md`
- `poetry run devsynth run-tests --smoke --speed=fast --no-parallel --maxfail=1`
- `poetry run python tests/verify_test_organization.py`
- `poetry run python scripts/verify_test_markers.py`
- `poetry run python scripts/verify_requirements_traceability.py`
- `poetry run python scripts/verify_version_sync.py`


------
https://chatgpt.com/codex/tasks/task_e_68c783f168c88333bb5e36bbb959ce91