### PR TITLE
feat: verify task binary in dev setup

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -519,7 +519,7 @@ tasks:
   env:verify:
     desc: Fail if required tooling is missing
     cmds:
-      - bash -lc 'missing=0; if ! command -v task >/dev/null 2>&1; then echo "[error] task command unavailable; run bash scripts/install_dev.sh" >&2; missing=1; fi; if ! poetry run devsynth --version >/dev/null 2>&1; then echo "[error] devsynth CLI unavailable; run '\''poetry install --with dev --all-extras'\''" >&2; missing=1; fi; exit $missing'
+      - bash -lc 'missing=0; if ! task --version >/dev/null 2>&1; then echo "[error] task command unavailable; run bash scripts/install_dev.sh" >&2; missing=1; fi; if ! poetry run devsynth --version >/dev/null 2>&1; then echo "[error] devsynth CLI unavailable; run '\''poetry install --with dev --all-extras'\''" >&2; missing=1; fi; exit $missing'
 
   env:baseline:
     desc: Capture maintainer environment baseline snapshot and record artifacts

--- a/docs/getting_started/installation.md
+++ b/docs/getting_started/installation.md
@@ -33,7 +33,7 @@ This guide provides step-by-step instructions for installing DevSynth in various
 - Python 3.12.x (CI and docs assume Python 3.12)
 - Poetry 1.8.x (CI uses 1.8.3; install via https://install.python-poetry.org)
 - go-task ≥3.44.1 (Taskfile runner). Fresh environments may not include the `task` CLI;
-  run `bash scripts/install_dev.sh` and ensure `$HOME/.local/bin` is on your `PATH`.
+  run `bash scripts/install_dev.sh`, which installs go-task and adds `$HOME/.local/bin` to your `PATH` if needed.
 
 > Platform support: Linux and macOS are first-class development platforms. On Windows,
 > we recommend Windows Subsystem for Linux (WSL2) with Ubuntu and running commands inside the WSL shell.

--- a/docs/plan.md
+++ b/docs/plan.md
@@ -249,8 +249,8 @@ Acceptance checklist
 
 Maintainer quickstart (authoritative commands)
   - Setup:
-    bash scripts/install_dev.sh  # installs dev dependencies and go-task to $HOME/.local/bin
-    task --version  # verify go-task is on PATH; add $HOME/.local/bin if missing
+    bash scripts/install_dev.sh  # installs dev dependencies and go-task, adds $HOME/.local/bin to PATH
+    task --version  # verify go-task is available
     poetry run devsynth --help   # verify devsynth entry point
     task env:verify  # fail early if task or the devsynth CLI is unavailable
     poetry run devsynth doctor
@@ -265,8 +265,8 @@ Maintainer quickstart (authoritative commands)
 - Static analysis and typing:
   poetry run black --check . && poetry run isort --check-only . && poetry run flake8 src/ tests/ && poetry run mypy src/devsynth && poetry run bandit -r src/devsynth -x tests && poetry run safety check --full-report
 - Persistence strategy:
-  - `scripts/install_dev.sh` installs go-task into `$HOME/.local/bin`.
-  - Ensure `$HOME/.local/bin` is on your PATH or rerun the install script if `task` is missing.
+  - `scripts/install_dev.sh` installs go-task into `$HOME/.local/bin` and adds it to PATH automatically.
+  - Running `task --version` verifies the installation.
 
 Notes and next actions
 - Immediate: Fix the two property test failures; add targeted tests for run_tests_cmd branches; re-generate coverage report and iterate on hotspots below 80% coverage.


### PR DESCRIPTION
## Summary
- verify `task` installation and ensure `$HOME/.local/bin` is on PATH
- add `task --version` self-check to `task env:verify`
- document automatic `go-task` installation for maintainers

## Testing
- `poetry run pre-commit run --files Taskfile.yml docs/getting_started/installation.md docs/plan.md scripts/install_dev.sh`
- `poetry run devsynth run-tests --speed=fast`
- `poetry run python tests/verify_test_organization.py`
- `poetry run python scripts/verify_test_markers.py`
- `poetry run python scripts/verify_requirements_traceability.py`
- `poetry run python scripts/verify_version_sync.py`


------
https://chatgpt.com/codex/tasks/task_e_68c783ded1b48333a6effe0b107755d2