### PR TITLE
test: add collaboration and memory integration coverage

### DIFF
--- a/tests/unit/application/agents/test_wsde_memory_integration_fast.py
+++ b/tests/unit/application/agents/test_wsde_memory_integration_fast.py
@@ -1,0 +1,38 @@
+import json
+from types import SimpleNamespace
+
+import pytest
+
+from devsynth.application.agents.wsde_memory_integration import WSDEMemoryIntegration
+
+
+class DummyAgentMemory:
+    def __init__(self) -> None:
+        self.store_calls = []
+
+    def store_dialectical_reasoning(self, task_id, thesis, antithesis, synthesis):
+        self.store_calls.append((task_id, thesis, antithesis, synthesis))
+        return "m1"
+
+    def retrieve_dialectical_reasoning(self, task_id):
+        return SimpleNamespace(
+            content=json.dumps({"thesis": 1, "antithesis": 2, "synthesis": 3})
+        )
+
+
+@pytest.mark.fast
+def test_store_and_retrieve_dialectical_process() -> None:
+    """ReqID: N/A"""
+
+    adapter = SimpleNamespace(get_context_manager=lambda: None)
+    team = SimpleNamespace()
+    memory = DummyAgentMemory()
+    integration = WSDEMemoryIntegration(adapter, team, agent_memory=memory)
+    task = {"id": "t1"}
+
+    item_id = integration.store_dialectical_process(task, {}, {}, {})
+    assert item_id == "m1"
+    assert memory.store_calls[0][0] == "t1"
+
+    result = integration.retrieve_dialectical_process("t1")
+    assert result == {"thesis": 1, "antithesis": 2, "synthesis": 3}

--- a/tests/unit/application/collaboration/test_agent_collaboration_system.py
+++ b/tests/unit/application/collaboration/test_agent_collaboration_system.py
@@ -1,0 +1,55 @@
+import pytest
+
+from devsynth.application.collaboration.agent_collaboration import (
+    AgentCollaborationSystem,
+    AgentMessage,
+    MessageType,
+)
+
+
+@pytest.mark.fast
+def test_agent_message_to_dict() -> None:
+    """ReqID: N/A"""
+
+    msg = AgentMessage("a", "b", MessageType.TASK_ASSIGNMENT, {"x": 1})
+    data = msg.to_dict()
+    assert data["sender_id"] == "a"
+    assert data["recipient_id"] == "b"
+    assert data["message_type"] == "TASK_ASSIGNMENT"
+    assert data["content"] == {"x": 1}
+
+
+class DummyMemoryManager:
+    def __init__(self) -> None:
+        self.adapters = {"tinydb": object()}
+        self.updated = None
+        self.flushed = False
+
+    def update_item(self, store, item):
+        self.updated = (store, item)
+
+    def flush_updates(self):
+        self.flushed = True
+
+
+@pytest.mark.fast
+def test_create_team_stores_in_memory() -> None:
+    """ReqID: N/A"""
+
+    mm = DummyMemoryManager()
+    system = AgentCollaborationSystem(memory_manager=mm)
+
+    class Agent:
+        def __init__(self) -> None:
+            self.id = "a1"
+            self.name = "agent1"
+            self.capabilities = ["code"]
+            self.expertise = ["coding"]
+
+    agent = Agent()
+    system.register_agent(agent)
+    team = system.create_team("t1", ["a1"])
+
+    assert mm.updated[0] == "tinydb"
+    assert mm.flushed is True
+    assert team.agents[0] is agent

--- a/tests/unit/application/collaboration/test_memory_utils_conversion.py
+++ b/tests/unit/application/collaboration/test_memory_utils_conversion.py
@@ -1,0 +1,19 @@
+import pytest
+
+from devsynth.application.collaboration.agent_collaboration import CollaborationTask
+from devsynth.application.collaboration.collaboration_memory_utils import (
+    from_memory_item,
+    to_memory_item,
+)
+from devsynth.domain.models.memory import MemoryType
+
+
+@pytest.mark.fast
+def test_task_round_trip_to_memory_item() -> None:
+    """ReqID: N/A"""
+
+    task = CollaborationTask("type", "desc", {"x": 1})
+    item = to_memory_item(task, MemoryType.COLLABORATION_TASK)
+    restored = from_memory_item(item)
+    assert isinstance(restored, CollaborationTask)
+    assert restored.id == task.id

--- a/tests/unit/application/collaboration/test_peer_review_store.py
+++ b/tests/unit/application/collaboration/test_peer_review_store.py
@@ -1,0 +1,41 @@
+from unittest.mock import patch
+
+import pytest
+
+from devsynth.application.collaboration.peer_review import PeerReview
+
+
+class DummyMemoryManager:
+    def __init__(self) -> None:
+        self.adapters = {"tinydb": object()}
+        self.flushed = False
+
+    def flush_updates(self) -> None:
+        self.flushed = True
+
+
+@pytest.mark.fast
+def test_store_in_memory_uses_retry_and_flush() -> None:
+    """ReqID: N/A"""
+
+    mm = DummyMemoryManager()
+    review = PeerReview(
+        work_product="wp", author="a", reviewers=["r"], memory_manager=mm
+    )
+
+    with patch(
+        "devsynth.application.collaboration."
+        "collaboration_memory_utils.store_with_retry",
+        return_value="id123",
+    ) as mock_store:
+        item_id = review.store_in_memory()
+
+    mock_store.assert_called_once_with(
+        mm,
+        review,
+        primary_store="tinydb",
+        immediate_sync=False,
+        max_retries=3,
+    )
+    assert item_id == "id123"
+    assert mm.flushed is True

--- a/tests/unit/application/collaboration/test_wsde_team_consensus_conflict_detection.py
+++ b/tests/unit/application/collaboration/test_wsde_team_consensus_conflict_detection.py
@@ -1,0 +1,36 @@
+from types import SimpleNamespace
+
+import pytest
+
+from devsynth.application.collaboration.wsde_team_consensus import (
+    ConsensusBuildingMixin,
+)
+
+
+class DummyTeam(ConsensusBuildingMixin):
+    def __init__(self) -> None:
+        self.agents = [SimpleNamespace(name="A"), SimpleNamespace(name="B")]
+
+    def get_messages(self, agent: str, filters):  # type: ignore[override]
+        opinion_map = {
+            "A": {"opinion": "yes", "rationale": ""},
+            "B": {"opinion": "no", "rationale": ""},
+        }
+        return [
+            {
+                "content": opinion_map[agent],
+                "timestamp": 1,
+            }
+        ]
+
+
+@pytest.mark.fast
+def test_identify_conflicts_detects_opposing_opinions() -> None:
+    """ReqID: N/A"""
+
+    team = DummyTeam()
+    conflicts = team._identify_conflicts({"id": "t1"})
+    assert len(conflicts) == 1
+    conflict = conflicts[0]
+    assert conflict["agent1"] == "A"
+    assert conflict["agent2"] == "B"

--- a/tests/unit/application/collaboration/test_wsde_team_extended_peer_review.py
+++ b/tests/unit/application/collaboration/test_wsde_team_extended_peer_review.py
@@ -1,0 +1,29 @@
+from types import SimpleNamespace
+
+import pytest
+
+from devsynth.application.collaboration.wsde_team_extended import CollaborativeWSDETeam
+
+
+@pytest.mark.fast
+def test_peer_review_solution_excludes_author() -> None:
+    """ReqID: N/A"""
+
+    team = CollaborativeWSDETeam()
+    author = SimpleNamespace(name="author")
+    reviewer = SimpleNamespace(name="reviewer")
+    team.agents = [author, reviewer]
+
+    called = {}
+
+    def dummy_conduct(work_product, auth, reviewers):
+        called["args"] = (work_product, auth, reviewers)
+        return {"status": "ok"}
+
+    team.conduct_peer_review = dummy_conduct  # type: ignore[assignment]
+    result = team.peer_review_solution("artifact", author)
+
+    assert result == {"status": "ok"}
+    assert called["args"][0] == "artifact"
+    assert called["args"][1] is author
+    assert called["args"][2] == [reviewer]

--- a/tests/unit/application/collaboration/test_wsde_team_task_management_mixin.py
+++ b/tests/unit/application/collaboration/test_wsde_team_task_management_mixin.py
@@ -1,0 +1,39 @@
+from types import SimpleNamespace
+
+import pytest
+
+from devsynth.application.collaboration.wsde_team_task_management import (
+    TaskManagementMixin,
+)
+
+
+class DummyTeam(TaskManagementMixin):
+    def __init__(self) -> None:
+        self.agents = [
+            SimpleNamespace(name="A", expertise=["python"]),
+            SimpleNamespace(name="B", expertise=["rust"]),
+        ]
+        self.logger = SimpleNamespace(
+            info=lambda *a, **k: None, debug=lambda *a, **k: None
+        )
+        self.send_message = lambda **kwargs: None
+
+    def _calculate_expertise_score(self, agent, subtask):  # type: ignore[override]
+        return 3 if subtask.get("primary_expertise") in agent.expertise else 0
+
+
+@pytest.mark.fast
+def test_delegate_subtasks_assigns_best_agent() -> None:
+    """ReqID: N/A"""
+
+    team = DummyTeam()
+    subtask = {
+        "id": "s1",
+        "title": "do thing",
+        "primary_expertise": "python",
+        "status": "pending",
+    }
+    assignments = team.delegate_subtasks([subtask])
+    assert assignments[0]["assigned_to"] == "A"
+    assert subtask["assigned_to"] == "A"
+    assert subtask["status"] == "assigned"


### PR DESCRIPTION
## Summary
- add fast unit tests for collaborative agent coordination, peer review storage, and memory utilities
- exercise consensus conflict detection and task delegation mixins
- cover WSDE memory integration round trips

## Testing
- `poetry run pre-commit run --files tests/unit/application/agents/test_wsde_memory_integration_fast.py tests/unit/application/collaboration/test_agent_collaboration_system.py tests/unit/application/collaboration/test_memory_utils_conversion.py tests/unit/application/collaboration/test_peer_review_store.py tests/unit/application/collaboration/test_wsde_team_consensus_conflict_detection.py tests/unit/application/collaboration/test_wsde_team_extended_peer_review.py tests/unit/application/collaboration/test_wsde_team_task_management_mixin.py`
- `poetry run devsynth run-tests --speed=fast` *(fails: ModuleNotFoundError: No module named 'devsynth')*
- `poetry run pytest -m fast --no-cov tests/unit/application/agents/test_wsde_memory_integration_fast.py tests/unit/application/collaboration/test_agent_collaboration_system.py tests/unit/application/collaboration/test_memory_utils_conversion.py tests/unit/application/collaboration/test_peer_review_store.py tests/unit/application/collaboration/test_wsde_team_consensus_conflict_detection.py tests/unit/application/collaboration/test_wsde_team_extended_peer_review.py tests/unit/application/collaboration/test_wsde_team_task_management_mixin.py`
- `poetry run python scripts/verify_test_markers.py`


------
https://chatgpt.com/codex/tasks/task_e_68c824c8dab4833392708af369f90fa7