### PR TITLE
Add resource-gated web interface tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,8 @@ Optional resources (opt-in)
 - RDFLib knowledge graph memory backend:
   - rdflib installs with the core package; `poetry install --extras memory` keeps companion adapters aligned
   - export DEVSYNTH_RESOURCE_RDFLIB_AVAILABLE=true  # set to false to skip RDFLib-specific tests
+- Streamlit/Web UI workflows:
+  - export DEVSYNTH_RESOURCE_WEBUI_AVAILABLE=1  # enable WebUI and agent HTTP interface tests
 - Common flags: DEVSYNTH_RESOURCE_CODEBASE_AVAILABLE, DEVSYNTH_RESOURCE_CLI_AVAILABLE, DEVSYNTH_RESOURCE_LMSTUDIO_AVAILABLE
 - Note: The run-tests CLI defaults to a stub provider and offline mode in tests unless overridden.
 - See also: [Resources Matrix](docs/resources_matrix.md) for mapping extras to DEVSYNTH_RESOURCE_* flags and enablement examples.

--- a/pytest.ini
+++ b/pytest.ini
@@ -11,6 +11,7 @@ markers =
     resource_tinydb: derived marker for selecting TinyDB-gated tests (auto-added)
     resource_duckdb: derived marker for selecting DuckDB-gated tests (auto-added)
     resource_rdflib: derived marker for selecting RDFLib-gated tests (auto-added)
+    resource_webui: derived marker for selecting WebUI-gated tests (auto-added)
     resource_faiss: derived marker for selecting FAISS-gated tests (auto-added)
     requires_llm_provider: mark test as requiring an LLM provider
     fast: mark test as fast (execution time < 1s)

--- a/test_reports/webui_interface_coverage.txt
+++ b/test_reports/webui_interface_coverage.txt
@@ -1,0 +1,51 @@
+===================================================== test session starts ======================================================
+platform linux -- Python 3.12.10, pytest-8.4.2, pluggy-1.6.0
+benchmark: 5.1.0 (defaults: timer=time.perf_counter disable_gc=False min_rounds=5 min_time=0.000005 max_time=1.0 calibration_precision=10 warmup=False warmup_iterations=100000)
+rootdir: /workspace/devsynth
+configfile: pytest.ini
+plugins: asyncio-1.1.0, Faker-37.6.0, benchmark-5.1.0, mock-3.15.0, bdd-8.1.0, rerunfailures-16.0.1, html-4.1.1, anyio-4.10.0, langsmith-0.4.26, hypothesis-6.138.14, metadata-3.1.1, xdist-3.8.0, cov-6.3.0
+asyncio: mode=Mode.STRICT, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
+collected 18 items
+
+tests/unit/interface/test_webui_handle_command_errors.py .......                                                         [ 38%]
+tests/unit/interface/test_agentapi_rate_limit_progress.py ...                                                            [ 55%]
+tests/unit/interface/test_agentapi_enhanced_bridge.py ....                                                               [ 77%]
+tests/unit/interface/test_webui_bridge_normalize.py ....                                                                 [100%]
+
+======================================================= warnings summary =======================================================
+tests/unit/interface/test_agentapi_enhanced_bridge.py: 105 warnings
+  /root/.cache/pypoetry/virtualenvs/devsynth-MeXVnKii-py3.12/lib/python3.12/site-packages/pydantic/fields.py:826: PydanticDeprecatedSince20: Using extra keyword arguments on `Field` is deprecated and will be removed. Use `json_schema_extra` instead. (Extra keys: 'example'). Deprecated in Pydantic V2.0 to be removed in V3.0. See Pydantic V2 Migration Guide at https://errors.pydantic.dev/2.9/migration/
+    warn(
+
+-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
+======================================================== tests coverage ========================================================
+_______________________________________ coverage: platform linux, python 3.12.10-final-0 _______________________________________
+
+Name                                     Stmts   Miss  Cover   Missing
+----------------------------------------------------------------------
+src/devsynth/interface/webui.py           1054    942    11%   54-62, 67-68, 122-126, 205-230, 259-321, 334-339, 342, 354-449, 461, 472-497, 569, 580-630, 634-647, 651-704, 714-734, 738-747, 760-780, 784-797, 809-818, 826-837, 843, 850-872, 876-988, 992-1002, 1008-1032, 1055-1093, 1110-1251, 1256-1387, 1394-1395, 1400-1417, 1422-1432, 1437-1508, 1521-1559, 1563-1597, 1606-1662, 1670-1752, 1760-1816, 1820-1838, 1842-1869, 1873-1898, 1902-1925, 1929-1954, 1958-1980, 1984-2007, 2011-2036, 2040-2065, 2069-2082, 2086-2106, 2110-2126, 2130-2150, 2154-2167, 2171-2196, 2203-2378, 2383
+src/devsynth/interface/webui_bridge.py     205    167    19%   29, 45-50, 67-99, 103, 116-130, 142-154, 162-171, 191-216, 235-294, 303-314, 325-326, 350-371, 390-423, 447-450, 465-468, 474-500, 514, 534, 551
+----------------------------------------------------------------------
+TOTAL                                     1259   1109    12%
+================================================= Test Categorization Summary ==================================================
+Test Type Distribution:
+  Unit Tests: 18
+  Integration Tests: 0
+  Behavior Tests: 0
+
+Test Speed Distribution:
+  Fast Tests (< 1s): 17
+  Medium Tests (1-5s): 1
+  Slow Tests (> 5s): 0
+===================================================== Top 10 Slowest Tests =====================================================
+1. tests/unit/interface/test_webui_handle_command_errors.py::test_handle_command_errors_passthrough: 2.75s
+2. tests/unit/interface/test_agentapi_enhanced_bridge.py::test_api_bridge_answers_and_defaults: 0.39s
+3. tests/unit/interface/test_agentapi_rate_limit_progress.py::test_rate_limit_allows_after_window: 0.16s
+4. tests/unit/interface/test_agentapi_enhanced_bridge.py::test_enhanced_progress_tracks_subtasks: 0.15s
+5. tests/unit/interface/test_agentapi_enhanced_bridge.py::test_enhanced_rate_limit_blocks_abusive_clients: 0.14s
+6. tests/unit/interface/test_agentapi_enhanced_bridge.py::test_api_bridge_confirm_choice_coerces_booleans: 0.12s
+7. tests/unit/interface/test_agentapi_rate_limit_progress.py::test_rate_limit_raises_when_exceeded: 0.08s
+8. tests/unit/interface/test_agentapi_rate_limit_progress.py::test_api_bridge_progress_records_subtasks: 0.07s
+9. tests/unit/interface/test_webui_handle_command_errors.py::test_handle_command_errors_known_exceptions[<lambda>-ERROR: File not found: config.yaml-Make sure the file exists]: 0.02s
+10. tests/unit/interface/test_webui_handle_command_errors.py::test_handle_command_errors_known_exceptions[<lambda>-ERROR: Permission denied: secrets.env-necessary permissions]: 0.02s
+=============================================== 18 passed, 105 warnings in 4.54s ===============================================

--- a/tests/unit/interface/test_agentapi_enhanced_bridge.py
+++ b/tests/unit/interface/test_agentapi_enhanced_bridge.py
@@ -1,0 +1,82 @@
+"""Focused tests for the enhanced Agent API bridge helpers."""
+
+from __future__ import annotations
+
+import importlib
+from types import SimpleNamespace
+
+import pytest
+
+pytestmark = [pytest.mark.requires_resource("webui"), pytest.mark.fast]
+
+
+@pytest.fixture
+def enhanced_module():
+    """Reload the enhanced Agent API module for a pristine state."""
+
+    import devsynth.interface.agentapi_enhanced as agentapi_enhanced
+
+    importlib.reload(agentapi_enhanced)
+    agentapi_enhanced.REQUEST_TIMESTAMPS.clear()
+    return agentapi_enhanced
+
+
+def test_api_bridge_answers_and_defaults(enhanced_module):
+    """Scripted answers are consumed before falling back to defaults."""
+
+    bridge = enhanced_module.APIBridge(["YES"])
+    assert bridge.ask_question("Question?", choices=["alpha", "beta"]) == "YES"
+    assert "Question?" in bridge.messages[0]
+
+    # When answers are exhausted the first choice is used.
+    assert bridge.ask_question("Next?", choices=["first", "second"]) == "first"
+    assert "Next?" in bridge.messages[1]
+
+
+def test_api_bridge_confirm_choice_coerces_booleans(enhanced_module):
+    """Boolean prompts accept flexible truthy/falsey responses."""
+
+    bridge = enhanced_module.APIBridge(["TrUe"])
+    assert bridge.confirm_choice("Confirm?", default=False) is True
+    assert "Confirm?" in bridge.messages[0]
+
+    # Without scripted answers the default is returned but still recorded.
+    assert bridge.confirm_choice("Again?", default=True) is True
+    assert bridge.messages[-1].endswith("Again?")
+
+
+def test_enhanced_progress_tracks_subtasks(enhanced_module):
+    """Progress helper captures task state and validates subtask IDs."""
+
+    bridge = enhanced_module.APIBridge()
+    progress = bridge.create_progress("Build", total=4)
+
+    progress.update(advance=1)
+    task_id = progress.add_subtask("Sub", total=2)
+    progress.update_subtask(task_id, advance=1)
+
+    with pytest.raises(ValueError):
+        progress.update_subtask("unknown")
+
+    progress.complete_subtask(task_id)
+    progress.complete()
+
+    assert bridge.messages[0] == "Starting: Build (0/4)"
+    assert any("Progress: Build (1/4) - Processing..." in msg for msg in bridge.messages)
+    assert any("Subtask started: Sub" in msg for msg in bridge.messages)
+    assert any("Subtask progress: Sub" in msg for msg in bridge.messages)
+    assert any("Subtask completed: Sub" in msg for msg in bridge.messages)
+    assert bridge.messages[-1] == "Completed: Build"
+
+
+def test_enhanced_rate_limit_blocks_abusive_clients(enhanced_module, monkeypatch):
+    """Rate limiting mirrors the base implementation for consistency."""
+
+    request = SimpleNamespace(client=SimpleNamespace(host="10.0.0.5"))
+    enhanced_module.REQUEST_TIMESTAMPS["10.0.0.5"] = [1.0, 2.0]
+    monkeypatch.setattr(enhanced_module.time, "time", lambda: 3.0)
+
+    with pytest.raises(enhanced_module.HTTPException) as exc:
+        enhanced_module.rate_limit(request, limit=2, window=60)
+
+    assert exc.value.status_code == enhanced_module.status.HTTP_429_TOO_MANY_REQUESTS

--- a/tests/unit/interface/test_agentapi_rate_limit_progress.py
+++ b/tests/unit/interface/test_agentapi_rate_limit_progress.py
@@ -1,0 +1,77 @@
+"""Unit tests for Agent API rate limiting and progress tracking."""
+
+from __future__ import annotations
+
+import importlib
+from types import SimpleNamespace
+
+import pytest
+
+pytestmark = [pytest.mark.requires_resource("webui"), pytest.mark.fast]
+
+
+@pytest.fixture
+def agentapi_module():
+    """Reload the module to ensure clean global state between tests."""
+
+    import devsynth.interface.agentapi as agentapi
+
+    importlib.reload(agentapi)
+    agentapi.REQUEST_TIMESTAMPS.clear()
+    agentapi.LATEST_MESSAGES.clear()
+    return agentapi
+
+
+def test_rate_limit_allows_after_window(agentapi_module, monkeypatch):
+    """Old requests outside the window are discarded before counting."""
+
+    request = SimpleNamespace(client=SimpleNamespace(host="127.0.0.1"))
+    monkeypatch.setattr(agentapi_module.time, "time", lambda: 100.0)
+
+    agentapi_module.rate_limit(request, limit=2, window=60)
+    assert agentapi_module.REQUEST_TIMESTAMPS["127.0.0.1"] == [100.0]
+
+    monkeypatch.setattr(agentapi_module.time, "time", lambda: 170.0)
+    agentapi_module.rate_limit(request, limit=2, window=60)
+    assert agentapi_module.REQUEST_TIMESTAMPS["127.0.0.1"] == [170.0]
+
+
+def test_rate_limit_raises_when_exceeded(agentapi_module, monkeypatch):
+    """Clients exceeding the limit receive a HTTP 429 error."""
+
+    request = SimpleNamespace(client=SimpleNamespace(host="8.8.8.8"))
+    agentapi_module.REQUEST_TIMESTAMPS["8.8.8.8"] = [10.0, 20.0]
+    monkeypatch.setattr(agentapi_module.time, "time", lambda: 30.0)
+
+    with pytest.raises(agentapi_module.HTTPException) as exc:
+        agentapi_module.rate_limit(request, limit=2, window=60)
+
+    assert exc.value.status_code == agentapi_module.status.HTTP_429_TOO_MANY_REQUESTS
+
+
+def test_api_bridge_progress_records_subtasks(agentapi_module):
+    """The progress helper emits clear messages for tasks and subtasks."""
+
+    bridge = agentapi_module.APIBridge()
+    progress = bridge.create_progress("Task", total=4)
+
+    progress.update(advance=1)
+    progress.update(advance=1, status="Half done")
+
+    task_id = progress.add_subtask("Subtask", total=2)
+    progress.update_subtask(task_id, advance=1)
+
+    snapshot = list(bridge.messages)
+    progress.update_subtask("missing")
+    assert bridge.messages == snapshot
+
+    progress.complete_subtask(task_id)
+    progress.complete()
+
+    assert bridge.messages[0] == "Task"
+    assert bridge.messages[1] == "Task (1/4) - Starting..."
+    assert any(message.endswith("- Half done") for message in bridge.messages)
+    assert any(message.strip().startswith("↳ Subtask") for message in bridge.messages)
+    assert any("(1/2)" in message for message in bridge.messages)
+    assert any(message.strip().endswith("Subtask complete") for message in bridge.messages)
+    assert bridge.messages[-1] == "Task complete"

--- a/tests/unit/interface/test_webui_bridge_normalize.py
+++ b/tests/unit/interface/test_webui_bridge_normalize.py
@@ -1,0 +1,64 @@
+"""Additional coverage for WebUI bridge helpers."""
+
+from __future__ import annotations
+
+import importlib
+import sys
+
+import pytest
+
+from tests.fixtures.streamlit_mocks import make_streamlit_mock
+
+pytestmark = [pytest.mark.requires_resource("webui"), pytest.mark.fast]
+
+
+@pytest.fixture
+def bridge_module(monkeypatch):
+    """Reload the bridge with a mocked Streamlit dependency."""
+
+    st = make_streamlit_mock()
+    monkeypatch.setitem(sys.modules, "streamlit", st)
+
+    import devsynth.interface.webui_bridge as bridge
+
+    importlib.reload(bridge)
+    return bridge
+
+
+def test_normalize_wizard_step_handles_varied_inputs(bridge_module):
+    """Values are coerced to valid step indices and clamped to bounds."""
+
+    normalize = bridge_module.WebUIBridge.normalize_wizard_step
+
+    assert normalize(" 2 ", total=5) == 2
+    assert normalize("4.9", total=4) == 3
+    assert normalize(None, total=3) == 0
+    assert normalize("", total=3) == 0
+    assert normalize("not-a-number", total=3) == 0
+
+
+def test_normalize_wizard_step_invalid_total_defaults_to_zero(bridge_module):
+    """Non-positive totals fall back to a single-step wizard."""
+
+    normalize = bridge_module.WebUIBridge.normalize_wizard_step
+    assert normalize(5, total=0) == 0
+    assert normalize(-1, total=-2) == 0
+
+
+def test_progress_indicator_rejects_missing_parent(bridge_module):
+    """Adding nested subtasks without a parent yields an empty identifier."""
+
+    indicator = bridge_module.WebUIProgressIndicator("Task", 100)
+    assert indicator.add_nested_subtask("missing", "Nested") == ""
+
+
+def test_display_result_routes_messages_to_streamlit(bridge_module):
+    """Successful messages use the Streamlit success channel and are stored."""
+
+    streamlit_stub = sys.modules["streamlit"]
+    bridge = bridge_module.WebUIBridge()
+
+    bridge.display_result("All good", message_type="success")
+
+    streamlit_stub.success.assert_called_once()
+    assert "All good" in bridge.messages[0]

--- a/tests/unit/interface/test_webui_handle_command_errors.py
+++ b/tests/unit/interface/test_webui_handle_command_errors.py
@@ -1,0 +1,109 @@
+"""WebUI error handling tests focusing on `_handle_command_errors`."""
+
+from __future__ import annotations
+
+import importlib
+import sys
+from unittest.mock import MagicMock
+
+import pytest
+
+from tests.fixtures.streamlit_mocks import make_streamlit_mock
+
+pytestmark = [pytest.mark.requires_resource("webui"), pytest.mark.fast]
+
+
+@pytest.fixture
+def webui_module(monkeypatch):
+    """Reload the WebUI module with a mocked Streamlit dependency."""
+
+    st = make_streamlit_mock()
+    monkeypatch.setitem(sys.modules, "streamlit", st)
+
+    import devsynth.interface.webui as webui
+
+    importlib.reload(webui)
+    return webui
+
+
+def test_handle_command_errors_passthrough(webui_module, monkeypatch):
+    """Successful calls return their result without touching the UI."""
+
+    ui = webui_module.WebUI()
+    monkeypatch.setattr(ui, "display_result", MagicMock())
+
+    assert ui._handle_command_errors(lambda value: value + 1, "unused", 2) == 3
+    ui.display_result.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    "factory, expected, hint",
+    [
+        (
+            lambda: FileNotFoundError(2, "missing", "config.yaml"),
+            "ERROR: File not found: config.yaml",
+            "Make sure the file exists",
+        ),
+        (
+            lambda: PermissionError(13, "denied", "secrets.env"),
+            "ERROR: Permission denied: secrets.env",
+            "necessary permissions",
+        ),
+        (
+            lambda: ValueError("bad input"),
+            "ERROR: Invalid value: bad input",
+            "Please check your input",
+        ),
+        (
+            lambda: KeyError("api_key"),
+            "ERROR: Missing key: 'api_key'",
+            "Verify that the referenced key exists",
+        ),
+        (
+            lambda: TypeError("wrong type"),
+            "ERROR: Type error: wrong type",
+            "Check that all inputs",
+        ),
+    ],
+)
+def test_handle_command_errors_known_exceptions(webui_module, factory, expected, hint, monkeypatch):
+    """Each specific exception surfaces user guidance via ``display_result``."""
+
+    ui = webui_module.WebUI()
+    calls: list[tuple[str, dict[str, object]]] = []
+
+    def record(message: str, **kwargs: object) -> None:
+        calls.append((message, kwargs))
+
+    monkeypatch.setattr(ui, "display_result", record)
+
+    def raising() -> None:
+        raise factory()
+
+    assert ui._handle_command_errors(raising, "ignored") is None
+    assert any(expected in message for message, _ in calls)
+    assert any(hint in message for message, _ in calls)
+
+
+def test_handle_command_errors_generic_exception(webui_module, monkeypatch):
+    """Unexpected errors include traceback details via Streamlit widgets."""
+
+    streamlit_stub = sys.modules["streamlit"]
+    ui = webui_module.WebUI()
+    recorded: list[str] = []
+
+    def capture(message: str, **_kwargs: object) -> None:
+        recorded.append(message)
+
+    monkeypatch.setattr(ui, "display_result", capture)
+
+    class Boom(RuntimeError):
+        pass
+
+    def raising() -> None:
+        raise Boom("kaboom")
+
+    assert ui._handle_command_errors(raising, "While performing task") is None
+    assert any("While performing task" in message for message in recorded)
+    assert any("Boom" in message for message in recorded)
+    assert streamlit_stub.code.called


### PR DESCRIPTION
## Summary
- add focused WebUI error-handling tests that exercise `_handle_command_errors` with a mocked Streamlit dependency
- cover Agent API rate limiting and progress messaging (including the enhanced bridge) under the web UI resource gate
- extend WebUI bridge normalization coverage, document `DEVSYNTH_RESOURCE_WEBUI_AVAILABLE`, and capture the coverage run output

## Testing
- DEVSYNTH_RESOURCE_WEBUI_AVAILABLE=1 PYTEST_ADDOPTS="" poetry run pytest -o addopts="" --cov=devsynth.interface.webui --cov=devsynth.interface.agentapi --cov=devsynth.interface.agentapi_enhanced --cov=devsynth.interface.webui_bridge --cov-report=term --cov-report=term-missing --cov-fail-under=0 tests/unit/interface/test_webui_handle_command_errors.py tests/unit/interface/test_agentapi_rate_limit_progress.py tests/unit/interface/test_agentapi_enhanced_bridge.py tests/unit/interface/test_webui_bridge_normalize.py

------
https://chatgpt.com/codex/tasks/task_e_68c85e87b7fc8333b1d616d45e47787a