### PR TITLE
test: add pure function coverage tests

### DIFF
--- a/tests/unit/application/documentation/test_documentation_fetcher_parsing.py
+++ b/tests/unit/application/documentation/test_documentation_fetcher_parsing.py
@@ -1,0 +1,98 @@
+"""Pure-function tests for :mod:`documentation_fetcher`."""
+
+from __future__ import annotations
+
+import pytest
+
+from devsynth.application.documentation.documentation_fetcher import (
+    DocumentationFetcher,
+    PyPIDocumentationSource,
+)
+
+pytestmark = pytest.mark.fast
+
+
+def test_parse_html_documentation_extracts_sections() -> None:
+    """HTML parsing splits content by headings and strips markup.
+
+    ReqID: N/A
+    """
+
+    source = PyPIDocumentationSource()
+    html = "<h1>Intro</h1><p>Welcome</p><h2>Usage</h2><p>Use it wisely.</p>"
+
+    chunks = source._parse_html_documentation(
+        html, "https://example.com/docs", "sample-lib", "1.0"
+    )
+
+    assert chunks[0]["title"] == "Intro"
+    assert "Welcome" in chunks[0]["content"]
+    assert chunks[-1]["title"] == "Usage"
+    assert chunks[-1]["metadata"]["source_url"] == "https://example.com/docs"
+
+
+def test_parse_markdown_documentation_respects_heading_levels() -> None:
+    """Markdown parsing preserves section order and metadata.
+
+    ReqID: N/A
+    """
+
+    source = PyPIDocumentationSource()
+    markdown = "## Intro\nIntro details\n## Usage\nUsage details"
+
+    chunks = source._parse_markdown_documentation(markdown, "sample", "2.0")
+
+    assert [chunk["title"] for chunk in chunks] == ["Intro", "Usage"]
+    assert chunks[0]["content"] == "Intro details"
+    assert chunks[1]["metadata"]["section"] == "Usage"
+
+
+def test_convert_docstrings_to_chunks_builds_expected_metadata() -> None:
+    """Docstring conversion emits module, class, method, and function chunks.
+
+    ReqID: N/A
+    """
+
+    source = PyPIDocumentationSource()
+    docstrings = {
+        "modules": {"pkg": {"docstring": "Module documentation."}},
+        "classes": {
+            "Widget": {
+                "docstring": "Class documentation.",
+                "methods": {
+                    "configure": {"docstring": "Method details."},
+                },
+            }
+        },
+        "functions": {"helper": {"docstring": "Helper documentation."}},
+    }
+
+    chunks = source._convert_docstrings_to_chunks(docstrings, "sample", "3.1")
+
+    titles = {chunk["title"] for chunk in chunks}
+    assert titles == {
+        "Module: pkg",
+        "Class: Widget",
+        "Method: Widget.configure",
+        "Function: helper",
+    }
+    module_chunk = next(chunk for chunk in chunks if chunk["title"] == "Module: pkg")
+    assert module_chunk["metadata"]["library"] == "sample"
+    assert module_chunk["metadata"]["version"] == "3.1"
+
+
+def test_version_key_supports_numeric_sorting_and_literals() -> None:
+    """Version keys normalise numeric parts while preserving literals.
+
+    ReqID: N/A
+    """
+
+    fetcher = DocumentationFetcher()
+    assert fetcher._version_key("1.2.3") == (1, 2, 3)
+    assert fetcher._version_key("2") == (2,)
+    assert fetcher._version_key("1.2b") == (1, "2b")
+    assert sorted(["1.9", "1.10", "1.2"], key=fetcher._version_key) == [
+        "1.2",
+        "1.9",
+        "1.10",
+    ]

--- a/tests/unit/application/ingestion/test_ingestion_pure.py
+++ b/tests/unit/application/ingestion/test_ingestion_pure.py
@@ -1,0 +1,125 @@
+"""Unit tests for pure helpers in the ingestion module."""
+
+import pytest
+
+from devsynth.application.ingestion import (
+    ArtifactStatus,
+    ArtifactType,
+    Ingestion,
+    IngestionMetrics,
+    IngestionPhase,
+    ProjectStructureType,
+)
+
+pytestmark = pytest.mark.fast
+
+
+def _fresh_metrics() -> IngestionMetrics:
+    """Create metrics with deterministic timestamps for assertions."""
+
+    metrics = IngestionMetrics()
+    # Stabilise timestamps for reproducibility in assertions that inspect metadata.
+    metrics.start_time = 0.0
+    metrics.phase_durations = {phase: 0.0 for phase in IngestionPhase}
+    metrics.artifacts_by_type = {atype: 0 for atype in ArtifactType}
+    metrics.artifacts_by_status = {status: 0 for status in ArtifactStatus}
+    return metrics
+
+
+def test_is_artifact_changed_respects_metadata_differences() -> None:
+    """``_is_artifact_changed`` compares metadata dictionaries only.
+
+    ReqID: N/A
+    """
+
+    ingestion = object.__new__(Ingestion)
+
+    current = {"metadata": {"hash": "abc"}}
+    previous = {"metadata": {"hash": "def"}}
+    unchanged = {"metadata": {"hash": "abc"}}
+
+    assert ingestion._is_artifact_changed(current, previous) is True
+    assert ingestion._is_artifact_changed(current, unchanged) is False
+    assert ingestion._is_artifact_changed({}, {}) is False
+
+
+def test_identify_improvement_areas_flags_missing_manifest_information() -> None:
+    """The helper highlights absent manifest data and weak coverage.
+
+    ReqID: N/A
+    """
+
+    ingestion = object.__new__(Ingestion)
+    ingestion.manifest_data = {
+        "structure": {
+            "directories": {},
+        }
+    }
+    ingestion.metrics = _fresh_metrics()
+    ingestion.metrics.artifacts_by_type[ArtifactType.CODE] = 4
+    ingestion.metrics.artifacts_by_type[ArtifactType.TEST] = 1
+    ingestion.metrics.artifacts_by_type[ArtifactType.DOCUMENTATION] = 0
+    ingestion.metrics.phase_durations[IngestionPhase.REFINE] = 6.2
+
+    improvements = ingestion._identify_improvement_areas(verbose=False)
+
+    def _has(area: str, issue: str) -> bool:
+        return any(
+            entry["area"] == area and entry["issue"] == issue for entry in improvements
+        )
+
+    assert _has("Project Configuration", "Missing project name")
+    assert _has("Project Configuration", "Missing version")
+    assert _has("Project Structure", "No source directories specified")
+    assert _has("Testing", "Low test coverage")
+    assert _has("Documentation", "No documentation artifacts found")
+    assert _has(
+        "Performance",
+        "Slow REFINE phase (6.20 seconds)",
+    )
+
+
+def test_generate_recommendations_reflects_project_context() -> None:
+    """Recommendations combine structure, type counts, and statuses.
+
+    ReqID: N/A
+    """
+
+    ingestion = object.__new__(Ingestion)
+    ingestion.project_structure = ProjectStructureType.MONOREPO
+    ingestion.metrics = _fresh_metrics()
+    ingestion.metrics.artifacts_by_type[ArtifactType.CONFIGURATION] = 11
+    ingestion.metrics.artifacts_by_status[ArtifactStatus.DEPRECATED] = 2
+
+    recommendations = ingestion._generate_recommendations(verbose=False)
+
+    texts = {
+        (entry["category"], entry["recommendation"], entry.get("priority"))
+        for entry in recommendations
+    }
+
+    assert (
+        "Project Structure",
+        "Consider using a monorepo management tool like Lerna or Nx",
+        "Medium",
+    ) in texts
+    assert (
+        "Configuration",
+        "Consider consolidating configuration files to reduce complexity",
+        "Medium",
+    ) in texts
+    assert (
+        "Code Cleanup",
+        "Remove deprecated artifacts to reduce technical debt",
+        "High",
+    ) in texts
+    assert (
+        "Project Configuration",
+        "Keep .devsynth/project.yaml updated as the project evolves",
+        "High",
+    ) in texts
+    assert (
+        "Process",
+        "Run ingestion regularly to keep project model up to date",
+        "Medium",
+    ) in texts

--- a/tests/unit/application/promises/test_agent_create_promise.py
+++ b/tests/unit/application/promises/test_agent_create_promise.py
@@ -1,0 +1,42 @@
+"""Pure behaviour tests for ``PromiseAgent.create_promise``."""
+
+from __future__ import annotations
+
+import pytest
+
+from devsynth.application.promises import PromiseAgent
+from devsynth.application.promises.implementation import Promise
+
+pytestmark = pytest.mark.fast
+
+
+def test_create_promise_sets_metadata_and_parent_relationship() -> None:
+    """Metadata fields and parent-child links are populated deterministically.
+
+    ReqID: N/A
+    """
+
+    agent = PromiseAgent(agent_id="agent")
+    parent = Promise()
+    agent.mixin._pending_requests[parent.id] = parent
+
+    promise = agent.create_promise(
+        type="analysis",
+        parameters={"task": "review"},
+        context_id="ctx-1",
+        tags=["quality"],
+        parent_id=parent.id,
+        priority=3,
+    )
+
+    assert isinstance(promise, Promise)
+    assert promise.parent_id == parent.id
+    assert parent.children_ids == [promise.id]
+
+    assert promise.get_metadata("type") == "analysis"
+    assert promise.get_metadata("parameters") == {"task": "review"}
+    assert promise.get_metadata("owner_id") == "agent"
+    assert promise.get_metadata("context_id") == "ctx-1"
+    assert promise.get_metadata("tags") == ["quality"]
+    assert promise.get_metadata("priority") == 3
+    assert promise.get_metadata("parent_id") == parent.id

--- a/tests/unit/application/promises/test_interface_pure.py
+++ b/tests/unit/application/promises/test_interface_pure.py
@@ -1,0 +1,53 @@
+"""Pure tests for the lightweight :mod:`promises.interface` helpers."""
+
+from __future__ import annotations
+
+import pytest
+
+from devsynth.application.promises import BasicPromise, PromiseState
+from devsynth.exceptions import PromiseStateError
+
+pytestmark = pytest.mark.fast
+
+
+def test_basic_promise_metadata_round_trip() -> None:
+    """Metadata helpers behave as a simple dictionary wrapper.
+
+    ReqID: N/A
+    """
+
+    promise = BasicPromise[int]()
+    assert promise.get_metadata("unknown") is None
+    chained = promise.set_metadata("stage", "draft")
+    assert chained is promise
+    assert promise.get_metadata("stage") == "draft"
+
+
+def test_then_on_fulfilled_promise_invokes_callback_immediately() -> None:
+    """``then`` executed post-resolution returns an already-fulfilled promise.
+
+    ReqID: N/A
+    """
+
+    promise = BasicPromise[int]()
+    promise.resolve(10)
+    chained = promise.then(lambda value: value + 5)
+    assert chained.is_fulfilled
+    assert chained.value == 15
+    assert promise.state is PromiseState.FULFILLED
+
+
+def test_catch_on_rejected_promise_yields_handler_result() -> None:
+    """``catch`` converts the rejection reason using the supplied callback.
+
+    ReqID: N/A
+    """
+
+    promise = BasicPromise[int]()
+    promise.reject(RuntimeError("boom"))
+    handled = promise.catch(lambda exc: str(exc).upper())
+    assert handled.is_fulfilled
+    assert handled.value == "BOOM"
+    with pytest.raises(PromiseStateError):
+        _ = promise.value
+    assert promise.reason.args == ("boom",)

--- a/tests/unit/application/prompts/test_auto_tuning_pure.py
+++ b/tests/unit/application/prompts/test_auto_tuning_pure.py
@@ -1,0 +1,64 @@
+"""Pure PromptVariant helper behaviour."""
+
+from __future__ import annotations
+
+import pytest
+
+from devsynth.application.prompts.auto_tuning import PromptVariant
+
+pytestmark = pytest.mark.fast
+
+
+def test_success_rate_and_average_feedback_are_computed_from_state() -> None:
+    """Derive success metrics purely from stored counters.
+
+    ReqID: N/A
+    """
+
+    variant = PromptVariant("template", variant_id="v1")
+    variant.usage_count = 8
+    variant.success_count = 6
+    variant.feedback_scores = [0.25, 0.75]
+
+    assert variant.success_rate == pytest.approx(0.75)
+    assert variant.average_feedback_score == pytest.approx(0.5)
+
+
+def test_performance_score_combines_success_and_feedback() -> None:
+    """The weighted score blends success rate and feedback average.
+
+    ReqID: N/A
+    """
+
+    variant = PromptVariant("template", variant_id="v2")
+    variant.usage_count = 4
+    variant.success_count = 3
+    variant.feedback_scores = [0.9, 0.6, 0.3]
+
+    expected = 0.7 * (3 / 4) + 0.3 * ((0.9 + 0.6 + 0.3) / 3)
+    assert variant.performance_score == pytest.approx(expected)
+
+
+def test_round_trip_serialisation_preserves_variant_fields() -> None:
+    """``to_dict`` followed by ``from_dict`` yields an equivalent instance.
+
+    ReqID: N/A
+    """
+
+    variant = PromptVariant("template", variant_id="variant-x")
+    variant.usage_count = 5
+    variant.success_count = 4
+    variant.failure_count = 1
+    variant.feedback_scores = [1.0, 0.4]
+    variant.last_used = "2024-01-01T00:00:00"
+
+    data = variant.to_dict()
+    recreated = PromptVariant.from_dict(data)
+
+    assert recreated.variant_id == "variant-x"
+    assert recreated.template == "template"
+    assert recreated.usage_count == 5
+    assert recreated.success_count == 4
+    assert recreated.failure_count == 1
+    assert recreated.feedback_scores == [1.0, 0.4]
+    assert recreated.last_used == "2024-01-01T00:00:00"

--- a/tests/unit/application/requirements/test_dialectical_reasoner_pure.py
+++ b/tests/unit/application/requirements/test_dialectical_reasoner_pure.py
@@ -1,0 +1,135 @@
+"""Pure helper tests for the dialectical reasoner."""
+
+from __future__ import annotations
+
+from uuid import uuid4
+
+import pytest
+
+from devsynth.application.requirements.dialectical_reasoner import (
+    DialecticalReasonerService,
+)
+from devsynth.domain.models.requirement import (
+    Requirement,
+    RequirementChange,
+    RequirementPriority,
+)
+
+pytestmark = pytest.mark.fast
+
+
+class _StubRequirementRepository:
+    def __init__(self) -> None:
+        self.requirements: list[Requirement] = []
+        self.lookup: dict = {}
+
+    def get_all_requirements(self) -> list[Requirement]:
+        return list(self.requirements)
+
+    def get_requirement(self, req_id):  # noqa: ANN001 - interface compatibility
+        return self.lookup.get(req_id)
+
+
+def _service_with_repo(repo: _StubRequirementRepository) -> DialecticalReasonerService:
+    service = object.__new__(DialecticalReasonerService)
+    service.requirement_repository = repo
+    return service
+
+
+def test_identify_affected_requirements_collects_dependencies() -> None:
+    """Dependent requirement identifiers are returned in sorted order.
+
+    ReqID: N/A
+    """
+
+    repo = _StubRequirementRepository()
+    changed_id = uuid4()
+    dependent_a = Requirement(id=uuid4(), dependencies=[changed_id])
+    dependent_b = Requirement(id=uuid4(), dependencies=[uuid4(), changed_id])
+    repo.requirements = [dependent_b, dependent_a]
+
+    change = RequirementChange(requirement_id=changed_id)
+    service = _service_with_repo(repo)
+
+    affected = service._identify_affected_requirements(change)
+
+    assert affected == sorted([changed_id, dependent_a.id, dependent_b.id], key=str)
+
+
+def test_identify_affected_components_merges_sources() -> None:
+    """Components from existing and new requirement states are merged uniquely.
+
+    ReqID: N/A
+    """
+
+    repo = _StubRequirementRepository()
+    changed_id = uuid4()
+    repo.lookup[changed_id] = Requirement(
+        id=changed_id,
+        priority=RequirementPriority.MEDIUM,
+        metadata={"component": "api"},
+    )
+
+    new_state = Requirement(metadata={"component": "database"})
+    change = RequirementChange(requirement_id=changed_id, new_state=new_state)
+    service = _service_with_repo(repo)
+
+    components = service._identify_affected_components(change)
+
+    assert components == ["api", "database"]
+
+
+def test_assess_risk_level_accounts_for_priority() -> None:
+    """Risk assessment responds to both priority and blast radius.
+
+    ReqID: N/A
+    """
+
+    repo = _StubRequirementRepository()
+    changed_id = uuid4()
+    high_req = Requirement(
+        id=changed_id,
+        priority=RequirementPriority.CRITICAL,
+    )
+    repo.lookup[changed_id] = high_req
+    service = _service_with_repo(repo)
+
+    change = RequirementChange(requirement_id=changed_id)
+    affected = [uuid4() for _ in range(4)]
+    assert service._assess_risk_level(change, affected) == "critical"
+
+    repo.lookup[changed_id] = Requirement(
+        id=changed_id,
+        priority=RequirementPriority.MEDIUM,
+    )
+    medium_span = [uuid4() for _ in range(3)]
+    assert service._assess_risk_level(change, medium_span) == "medium"
+    assert service._assess_risk_level(change, []) == "low"
+
+
+def test_estimate_effort_scales_with_affected_entities() -> None:
+    """Effort estimation is additive across requirements and components.
+
+    ReqID: N/A
+    """
+
+    service = _service_with_repo(_StubRequirementRepository())
+    change = RequirementChange(requirement_id=uuid4())
+
+    assert service._estimate_effort(change, [], []) == "low"
+    assert (
+        service._estimate_effort(
+            change,
+            [uuid4(), uuid4(), uuid4()],
+            ["api"],
+        )
+        == "medium"
+    )
+    assert (
+        service._estimate_effort(
+            change,
+            [uuid4() for _ in range(5)],
+            ["api", "db", "ui", "worker"],
+        )
+        == "very high"
+    )


### PR DESCRIPTION
## Summary
- add fast unit tests for ingestion metrics summaries and recommendations
- exercise documentation fetcher parsing, prompt variant scoring, and dialectical helper logic
- cover promise agent creation metadata and BasicPromise metadata/handler behavior

## Testing
- poetry run pre-commit run --files tests/unit/application/documentation/test_documentation_fetcher_parsing.py tests/unit/application/ingestion/test_ingestion_pure.py tests/unit/application/promises/test_agent_create_promise.py tests/unit/application/promises/test_interface_pure.py tests/unit/application/prompts/test_auto_tuning_pure.py tests/unit/application/requirements/test_dialectical_reasoner_pure.py
- PYTHONPATH=src poetry run devsynth run-tests --speed=fast
- poetry run pytest tests/unit/application/ingestion/test_ingestion_pure.py tests/unit/application/documentation/test_documentation_fetcher_parsing.py tests/unit/application/prompts/test_auto_tuning_pure.py tests/unit/application/requirements/test_dialectical_reasoner_pure.py tests/unit/application/promises/test_agent_create_promise.py tests/unit/application/promises/test_interface_pure.py -m fast --cov=src/devsynth --cov-report=json:coverage.json --cov-fail-under=0
- poetry run python scripts/coverage_summary.py

------
https://chatgpt.com/codex/tasks/task_e_68c863544ef88333a09cb27634451336