### PR TITLE
Document coverage regression and reopen remediation tasks

### DIFF
--- a/docs/task_notes.md
+++ b/docs/task_notes.md
@@ -1,208 +1,74 @@
 # Task Notes (DevSynth 0.1.0a1) — Iteration Log
 
 Historical log archived at docs/archived/task_notes_pre2025-09-16.md to keep this file under 200 lines.
+Current file condensed on 2025-09-15 to remove redundant 2025-09-13 entries while retaining key decisions and evidence.
 
-## Iteration 2025-09-12 (Environment verification)
-- Environment: Python 3.12.10; `poetry env info --path` -> /root/.cache/pypoetry/virtualenvs/devsynth-MeXVnKii-py3.12.
+## Iteration 2025-09-12A – Environment verification
+- Environment: Python 3.12.10; `poetry env info --path` → /root/.cache/pypoetry/virtualenvs/devsynth-MeXVnKii-py3.12.
 - Commands:
   - `bash scripts/install_dev.sh` – restored `task --version` 3.44.1.
-  - `poetry install --with dev --all-extras` – installed `devsynth` entry point.
+  - `poetry install --with dev --all-extras` – installed DevSynth entry point.
   - `poetry run devsynth run-tests --smoke --speed=fast --no-parallel --maxfail=1` – pass.
   - `poetry run python tests/verify_test_organization.py` – 920 files.
   - `poetry run python scripts/verify_test_markers.py` – 0 issues.
   - `poetry run python scripts/verify_requirements_traceability.py` – all references present.
   - `poetry run python scripts/verify_version_sync.py` – OK.
-- Observations: `task` and `devsynth` CLI missing on boot; manual reinstall required. Coverage aggregation and release-state check still pending.
+- Observations: `task` and `devsynth` CLI missing on boot; manual reinstall required. Coverage aggregation and release-state check pending.
 - Next: automate CLI/tool provisioning; implement release state check; add BDD coverage for agent_api_stub, chromadb_store, dialectical_reasoning; resolve coverage failure in tests/unit/general/test_test_first_metrics.py.
 
-## Iteration 2025-09-12 (Release state and BDD features)
-- Environment: Python 3.12.10; `poetry env info --path` -> /root/.cache/pypoetry/virtualenvs/devsynth-MeXVnKii-py3.12.
+## Iteration 2025-09-12B – Release state and BDD features
+- Environment: Python 3.12.10; virtualenv `/root/.cache/pypoetry/virtualenvs/devsynth-MeXVnKii-py3.12`.
 - Commands:
   - `poetry run pre-commit run --files tests/behavior/features/agent_api_stub.feature tests/behavior/steps/test_api_stub_steps.py tests/behavior/features/release_state_check.feature tests/behavior/steps/release_state_steps.py tests/behavior/features/dialectical_reasoning.feature tests/behavior/steps/test_dialectical_reasoning_hooks_steps.py docs/tasks.md docs/task_notes.md docs/plan.md issues/release-state-check.md issues/agent-api-stub-usage.md` – pass.
   - `poetry run devsynth run-tests --speed=fast --no-parallel --maxfail=1` – pass.
   - `poetry run python scripts/verify_test_markers.py` – 0 issues.
   - `poetry run python scripts/verify_requirements_traceability.py` – success.
 - Observations: Added release-state verification and new BDD features for agent API stub and dialectical reasoning; GitHub Actions confirmed dispatch-only; coverage aggregation still needs artifact generation.
-- Next: Review proofs for gaps and automate CLI/tool provisioning; restore coverage artifact generation.
+- Next: Review proofs for gaps, automate CLI/tool provisioning, restore coverage artifact generation.
 
-## Iteration 2025-09-13
-- Environment: Python 3.12.10; `poetry env info --path` -> /root/.cache/pypoetry/virtualenvs/devsynth-MeXVnKii-py3.12.
+## Iteration 2025-09-13 – Consolidated actions
+- Environment: Python 3.12.10; `/root/.cache/pypoetry/virtualenvs/devsynth-MeXVnKii-py3.12`; go-task restored to 3.44.1 via `bash scripts/install_dev.sh` when missing.
+- Commands (representative across sub-iterations):
+  - `task --version`; repeated smoke runs via `poetry run devsynth run-tests --smoke --speed=fast --no-parallel --maxfail=1`.
+  - Verification scripts (`verify_test_organization`, `verify_test_markers --report`, `verify_requirements_traceability`, `verify_version_sync`).
+  - `poetry install --only-root` followed by `poetry install --with dev --extras tests` when CLI missing.
+  - `poetry run pre-commit run` on scripts/install_dev.sh, docs/plan.md, docs/tasks.md, docs/task_notes.md, CHANGELOG.md, release docs, strict-typing issues.
+  - Attempted `poetry run devsynth run-tests --speed=fast --speed=medium --no-parallel --report` (timed out or errored on `tests/unit/general/test_test_first_metrics.py`).
+- Observations:
+  - Closed release-blockers-0-1-0a1 after verifying workflows remain dispatch-only; release-finalization-uat.md opened for UAT tracking.
+  - Clarified that maintainers tag `v0.1.0a1` post-UAT and ensured docs/tasks reflect manual tagging.
+  - Enhanced scripts/install_dev.sh to detect Python 3.12 via PATH/pyenv, preventing false negatives.
+  - Drafted release notes and updated CHANGELOG; strict typing roadmap consolidated and follow-up issues created with pyproject overrides removed for logger/exceptions/CLI.
+  - Coverage attempts produced either timeouts or missing artifacts; htmlcov/ omitted due to diff limits; `tests/unit/general/test_test_first_metrics.py` path errors persisted until follow-up work.
+- Next: regenerate full coverage artifacts, complete UAT, hand off tagging to maintainers, continue strict typing restorations.
+
+## Iteration 2025-09-14 – Coverage follow-up
+- Environment: Python 3.12.10; same virtualenv; `task --version` 3.44.1.
 - Commands:
-  - `task --version` – 3.44.1 after `bash scripts/install_dev.sh`.
+  - `bash scripts/install_dev.sh` (restores go-task).
   - `poetry run devsynth run-tests --smoke --speed=fast --no-parallel --maxfail=1` – pass.
-  - `poetry run python tests/verify_test_organization.py` – 923 test files detected.
-  - `poetry run python scripts/verify_test_markers.py --report --report-file test_markers_report.json` – 0 issues.
-  - `poetry run python scripts/verify_requirements_traceability.py` – success.
-  - `poetry run python scripts/verify_version_sync.py` – OK.
-- Observations: Environment booted without go-task; reinstall succeeded. Closed release-blockers-0-1-0a1.md after confirming dispatch-only workflows.
-- Next: Draft release notes, perform final coverage run, complete User Acceptance Testing, and hand off tagging to maintainers on GitHub.
+  - Verification scripts as above plus `poetry run pytest tests/unit/general/test_test_first_metrics.py` (initially errored due to missing file).
+  - `poetry run pre-commit run --files docs/tasks.md docs/task_notes.md docs/plan.md issues/release-blockers-0-1-0a1.md issues/run-tests-missing-test-first-metrics-file.md issues/release-finalization-uat.md` – pass.
+  - `poetry run pytest tests/unit/general/test_test_first_metrics.py --cov --cov-report=html --cov-report=json` – pass after path fix.
+- Observations: Resolved test path reference but full `devsynth run-tests --speed=fast --speed=medium --report --no-parallel` hung; targeted pytest generated coverage artifacts yet aggregate coverage remained unverified; run-tests coverage issue reopened.
+- Next: Restore aggregated coverage, perform UAT, coordinate tagging once coverage meets threshold.
 
-## Iteration 2025-09-13 (Tagging clarified)
-- Environment: Python 3.12.10; `poetry env info --path` -> /root/.cache/pypoetry/virtualenvs/devsynth-MeXVnKii-py3.12.
+## Iteration 2025-09-15 – Environment verification summary
+- Environment: Python 3.12.10; `/root/.cache/pypoetry/virtualenvs/devsynth-MeXVnKii-py3.12`; `task --version` 3.44.1 after reinstall.
 - Commands:
+  - `bash scripts/install_dev.sh` and `poetry install --with dev --all-extras` to restore CLI/tools.
   - `poetry run devsynth run-tests --smoke --speed=fast --no-parallel --maxfail=1` – pass.
-  - `poetry run python tests/verify_test_organization.py` – 923 test files detected.
-  - `poetry run python scripts/verify_test_markers.py --report --report-file test_markers_report.json` – 0 issues.
-  - `poetry run python scripts/verify_requirements_traceability.py` – success.
-  - `poetry run python scripts/verify_version_sync.py` – OK.
-- Observations: Plan and tasks updated to clarify manual GitHub tagging after UAT; opened release-finalization-uat issue.
-- Next: Draft release notes, run final coverage, complete User Acceptance Testing, and hand off tagging to maintainers on GitHub.
+  - Verification scripts (`verify_test_organization`, `verify_test_markers --report`, `verify_requirements_traceability`, `verify_version_sync`).
+- Observations: Fresh sessions lacked go-task/CLI until reinstall; smoke tests and verification scripts pass but coverage and UAT remain blockers.
+- Next: Execute full coverage run with instrumentation fixes, complete User Acceptance Testing, and prepare maintainer tagging.
 
-## Iteration 2025-09-13 (Environment bootstrap check)
-- Environment: Python 3.12.10; `poetry env info --path` -> /root/.cache/pypoetry/virtualenvs/devsynth-MeXVnKii-py3.12; `task --version` 3.44.1.
-- Commands:
-  - `poetry install --only-root`
-  - `poetry install --with dev --extras tests`
+## Iteration 2025-09-15 – Coverage regression analysis (current)
+- Environment: Python 3.12.10; `/root/.cache/pypoetry/virtualenvs/devsynth-MeXVnKii-py3.12`; `task --version` 3.45.3 after rerunning install script.
+- Commands (today):
+  - `bash scripts/install_dev.sh` – reinstalls go-task and runs Poetry install.
   - `poetry run devsynth run-tests --smoke --speed=fast --no-parallel --maxfail=1` – pass.
-  - `poetry run python tests/verify_test_organization.py` – 923 test files detected.
-  - `poetry run python scripts/verify_test_markers.py --report --report-file test_markers_report.json` – 0 issues.
-  - `poetry run python scripts/verify_requirements_traceability.py` – success.
-  - `poetry run python scripts/verify_version_sync.py` – OK.
-- Observations: `scripts/install_dev.sh` initially reported "Python 3.12 not available for Poetry"; added task 15.4. DevSynth CLI required explicit installation steps.
-- Next: Draft release notes, perform final coverage run, complete User Acceptance Testing, and hand off tagging to maintainers on GitHub.
-
-## Iteration 2025-09-13 (install_dev.sh Python detection fix)
-- Environment: Python 3.12.10; `poetry env info --path` -> /root/.cache/pypoetry/virtualenvs/devsynth-MeXVnKii-py3.12; `task --version` 3.44.1.
-- Commands:
-  - `poetry run pre-commit run --files scripts/install_dev.sh docs/tasks.md docs/plan.md docs/task_notes.md issues/install-dev-python-version-error.md` – pass.
-  - `poetry run devsynth run-tests --smoke --speed=fast --no-parallel --maxfail=1` – pass.
-  - `poetry run python tests/verify_test_organization.py` – 923 test files detected.
-  - `poetry run python scripts/verify_test_markers.py` – 0 issues.
-  - `poetry run python scripts/verify_requirements_traceability.py` – success.
-  - `poetry run python scripts/verify_version_sync.py` – OK.
-- Observations: `scripts/install_dev.sh` now locates Python 3.12 via pyenv or PATH, preventing false setup failures; task 15.4 completed and issue closed.
-- Next: Draft release notes, perform final coverage run, complete User Acceptance Testing, and hand off tagging to maintainers on GitHub.
-
-## Iteration 2025-09-13 (release notes drafted)
-- Environment: Python 3.12.10; `poetry env info --path` -> /root/.cache/pypoetry/virtualenvs/devsynth-MeXVnKii-py3.12; `task --version` 3.44.1.
-- Commands:
-  - `poetry run pre-commit run --files docs/release/0.1.0-alpha.1.md CHANGELOG.md docs/tasks.md docs/plan.md docs/task_notes.md issues/release-finalization-uat.md` – pass.
-  - `poetry run devsynth run-tests --smoke --speed=fast --no-parallel --maxfail=1` – pass.
-  - `poetry run python tests/verify_test_organization.py` – 923 test files detected.
-  - `poetry run python scripts/verify_test_markers.py` – 0 issues.
-  - `poetry run python scripts/verify_requirements_traceability.py` – success.
-  - `poetry run python scripts/verify_version_sync.py` – OK.
-- Observations: Release notes drafted and CHANGELOG updated; release-finalization issue ticked. Tools available after reinstall.
-- Next: Perform final coverage run, complete User Acceptance Testing, and hand off tagging to maintainers on GitHub.
-
-## Iteration 2025-09-13 (smoke validation and typing roadmap)
-- Environment: Python 3.12.10; `poetry env info --path` -> /root/.cache/pypoetry/virtualenvs/devsynth-MeXVnKii-py3.12; `task --version` 3.44.1.
-- Commands:
-  - `poetry run devsynth run-tests --smoke --speed=fast --no-parallel --maxfail=1` – pass.
-  - `poetry run python tests/verify_test_organization.py` – 926 test files detected.
-  - `poetry run python scripts/verify_test_markers.py` – 0 issues.
-  - `poetry run python scripts/verify_requirements_traceability.py` – success.
-  - `poetry run python scripts/verify_version_sync.py` – OK.
-  - Attempted `poetry run devsynth run-tests --speed=fast --speed=medium --no-parallel --report` – timed out before completion.
-- Observations: Smoke validation succeeded; full coverage run requires further investigation. Created issues/strict-typing-roadmap.md to consolidate typing tickets.
-- Next: Complete full coverage run, perform UAT, and hand off tagging to maintainers.
-
-## Iteration 2025-09-13 (strict typing inventory)
-- Environment: Python 3.12.10; `poetry env info --path` -> /root/.cache/pypoetry/virtualenvs/devsynth-MeXVnKii-py3.12; `task --version` 3.44.1 after `bash scripts/install_dev.sh`.
-- Commands:
-  - `poetry run pre-commit run --files docs/plan.md docs/tasks.md docs/task_notes.md issues/strict-typing-roadmap.md` – pass.
-  - `poetry run devsynth run-tests --smoke --speed=fast --no-parallel --maxfail=1` – pass.
-  - `poetry run python tests/verify_test_organization.py` – 926 test files detected.
-  - `poetry run python scripts/verify_test_markers.py --report --report-file test_markers_report.json` – 0 issues.
-  - `poetry run python scripts/verify_requirements_traceability.py` – success.
-  - `poetry run python scripts/verify_version_sync.py` – OK.
-- Observations: Cataloged all 'restore-strict-typing-*' issues in strict-typing-roadmap.md and marked task 20.1 complete; smoke tests and verification scripts pass.
-- Next: Run full fast+medium coverage, conduct UAT, and prioritize strict typing restorations.
-
-## Iteration 2025-09-13 (strict typing follow-ups)
-- Environment: Python 3.12.3; `poetry env info --path` unavailable.
-- Commands:
-  - `poetry run pre-commit run --files pyproject.toml docs/tasks.md docs/plan.md docs/task_notes.md issues/strict-typing-roadmap.md issues/strict-typing-*-follow-up.md`
-  - `poetry run devsynth run-tests --speed=fast --no-parallel --maxfail=1`
-  - `poetry run python tests/verify_test_organization.py`
-  - `poetry run python scripts/verify_test_markers.py`
-  - `poetry run python scripts/verify_requirements_traceability.py`
-  - `poetry run python scripts/verify_version_sync.py`
-- Observations: Created follow-up strict typing issues with owners/timelines, removed mypy overrides for logger, exceptions, and CLI modules, and updated roadmap and tasks.
-- Next: Continue typing restorations for remaining modules.
-
-## Iteration 2025-09-13 (final coverage run attempt)
-- Environment: Python 3.12.10; `poetry env info --path` -> /root/.cache/pypoetry/virtualenvs/devsynth-MeXVnKii-py3.12; `task --version` 3.44.1.
-- Commands:
-  - `poetry run devsynth run-tests --speed=fast --speed=medium --report --no-parallel` – errored (`ERROR tests/unit/general/test_test_first_metrics.py`).
-  - `poetry run python tests/verify_test_organization.py` – 926 test files detected.
-  - `poetry run python scripts/verify_test_markers.py --report --report-file test_markers_report.json` – 0 issues.
-  - `poetry run python scripts/verify_requirements_traceability.py` – success.
-  - `poetry run python scripts/verify_version_sync.py` – OK.
-- Observations: Coverage artifacts (htmlcov/ and coverage.json) were generated locally but omitted from commit due to Codex diff size limits; docs updated to reflect run.
-- Next: Proceed with User Acceptance Testing and maintainer tagging.
-
-## Iteration 2025-09-13 (release audit)
-- Environment: Python 3.12.10; `poetry env info --path` -> /root/.cache/pypoetry/virtualenvs/devsynth-MeXVnKii-py3.12; `task --version` 3.44.1.
-- Commands:
-  - `bash scripts/install_dev.sh`
-  - `poetry install --with dev --all-extras`
-  - `poetry run devsynth run-tests --smoke --speed=fast --no-parallel --maxfail=1`
-  - `poetry run python tests/verify_test_organization.py`
-  - `poetry run python scripts/verify_test_markers.py --report --report-file test_markers_report.json`
-  - `poetry run python scripts/verify_requirements_traceability.py`
-  - `poetry run python scripts/verify_version_sync.py`
-- Observations: Environment restored, smoke tests and verification scripts passed; UAT and maintainer tagging remain.
-- Next: Obtain User Acceptance Testing sign-off and hand off tagging.
-## Iteration 2025-09-14
-- Environment: Python 3.12.10; `poetry env info --path` -> /root/.cache/pypoetry/virtualenvs/devsynth-MeXVnKii-py3.12; `task --version` 3.44.1.
-- Commands:
-  - `bash scripts/install_dev.sh` – installed task.
-  - `poetry run devsynth run-tests --smoke --speed=fast --no-parallel --maxfail=1` – pass.
-  - `poetry run python tests/verify_test_organization.py` – 926 test files detected.
-  - `poetry run python scripts/verify_test_markers.py` – 0 issues.
-  - `poetry run python scripts/verify_requirements_traceability.py` – success.
-  - `poetry run python scripts/verify_version_sync.py` – OK.
-  - `poetry run pytest tests/unit/general/test_test_first_metrics.py` – ERROR file or directory not found.
-- Observations: Coverage run still references nonexistent `tests/unit/general/test_test_first_metrics.py`; reopened issue run-tests-missing-test-first-metrics-file.md.
-- Next: Fix test path reference, rerun full coverage, then proceed with UAT and maintainer tagging.
-
-## Iteration 2025-09-14 (test_first_metrics fix)
-- Environment: Python 3.12.10; `poetry env info --path` -> /root/.cache/pypoetry/virtualenvs/devsynth-MeXVnKii-py3.12; `task --version` 3.44.1.
-- Commands:
-- `poetry run pre-commit run --files docs/tasks.md docs/task_notes.md docs/plan.md issues/release-blockers-0-1-0a1.md issues/run-tests-missing-test-first-metrics-file.md issues/release-finalization-uat.md` – pass.
-- `poetry run devsynth run-tests --speed=fast --speed=medium --report --no-parallel` – hung (no output).
-- `poetry run pytest tests/unit/general/test_test_first_metrics.py --cov --cov-report=html --cov-report=json` – pass.
-- `poetry run python tests/verify_test_organization.py` – 926 test files detected.
-- `poetry run python scripts/verify_test_markers.py --report --report-file test_markers_report.json` – 0 issues.
-- `poetry run python scripts/verify_requirements_traceability.py` – success.
-- `poetry run python scripts/verify_version_sync.py` – OK.
-- Observations: Fixed test path; `devsynth run-tests` hung in this environment, but targeted pytest generated coverage artifacts htmlcov/ and coverage.json.
-- Next: Proceed with User Acceptance Testing and maintainer tagging.
-
-## Iteration 2025-09-15
-- Environment: Python 3.12.10; `poetry env info --path` -> /root/.cache/pypoetry/virtualenvs/devsynth-MeXVnKii-py3.12; `task --version` 3.44.1 after reinstall.
-- Commands:
-  - `bash scripts/install_dev.sh` – restored go-task.
-  - `poetry run devsynth run-tests --smoke --speed=fast --no-parallel --maxfail=1` – pass.
-  - `poetry run python tests/verify_test_organization.py` – 928 test files detected.
-  - `poetry run python scripts/verify_test_markers.py --report --report-file test_markers_report.json` – 0 issues.
-  - `poetry run python scripts/verify_requirements_traceability.py` – success.
-  - `poetry run python scripts/verify_version_sync.py` – OK.
-- Observations: Initial session lacked go-task; install script fixed it. Smoke tests and verification scripts pass; awaiting User Acceptance Testing and maintainer tagging.
-- Next: Conduct UAT and hand off tagging.
-
-## Iteration 2025-09-15 (environment verification)
-- Environment: Python 3.12.10; `poetry env info --path` -> /root/.cache/pypoetry/virtualenvs/devsynth-MeXVnKii-py3.12; `task --version` 3.44.1.
-- Commands:
-  - `poetry install --with dev --all-extras` – restored `devsynth` CLI.
-  - `poetry run devsynth run-tests --smoke --speed=fast --no-parallel --maxfail=1` – pass.
-  - `poetry run python tests/verify_test_organization.py` – 928 test files detected.
-  - `poetry run python scripts/verify_test_markers.py --report --report-file test_markers_report.json` – 0 issues.
-  - `poetry run python scripts/verify_requirements_traceability.py` – success.
-  - `poetry run python scripts/verify_version_sync.py` – OK.
-- Observations: Fresh session reported `ModuleNotFoundError: devsynth`; running `poetry install --with dev --all-extras` restored the entry point and all verification commands passed. Remaining tasks: UAT and maintainer tagging.
-- Next: Complete UAT and coordinate tagging; re-enable CI workflows post-release.
-## Iteration 2025-09-15 (smoke+verify)
-- Env: Python 3.12.10; venv /root/.cache/pypoetry/virtualenvs/devsynth-MeXVnKii-py3.12; task 3.44.1.
-- Commands: poetry install --with dev --all-extras; devsynth run-tests --smoke --speed=fast --no-parallel --maxfail=1; verify_test_organization; verify_test_markers; verify_requirements_traceability; verify_version_sync.
-- Observations: all pass; awaiting UAT/tagging.
-- Next: UAT then maintainer tagging.
-
-## Iteration 2025-09-16 (coverage artifact regression)
-- Environment: Python 3.12.10; `poetry env info --path` -> /root/.cache/pypoetry/virtualenvs/devsynth-MeXVnKii-py3.12; `task --version` 3.44.1.
-- Commands:
-  - `poetry run devsynth run-tests --speed=fast --marker test_metrics --no-parallel --maxfail=1 --report` – pass.
-  - `poetry run python scripts/verify_test_markers.py` – 0 issues.
-- Observations: Added regression test to ensure htmlcov/ and coverage.json are produced even when no tests are collected.
-- Next: Monitor coverage runs for stability.
+  - `poetry run devsynth run-tests --speed=fast --speed=medium --no-parallel --report --maxfail=1` – pass but coverage low.
+  - `poetry run python tests/verify_test_organization.py`, `poetry run python scripts/verify_test_markers.py --report --report-file test_markers_report.json`, `poetry run python scripts/verify_requirements_traceability.py`, `poetry run python scripts/verify_version_sync.py` – all pass.
+  - Parsed `test_reports/coverage.json` → 13.68 % coverage; observed empty `htmlcov/index.html`.
+- Observations: Aggregated coverage regressed to 13.68 % despite successful run; htmlcov output zero bytes; reopened issues/coverage-below-threshold.md; added docs/tasks.md section 21 for coverage remediation; plan/tasks updated to reflect unmet coverage gate.
+- Next: Repair coverage instrumentation, raise coverage for highlighted modules (output_formatter, webui, webui_bridge, logging_setup, reasoning_loop, testing/run_tests), implement automated coverage gate, regenerate artifacts before UAT.

--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -66,8 +66,8 @@ Instructions: Check off each task when completed. Subtasks are enumerated for cl
 6.2.1 [x] `poetry run devsynth run-tests --speed=fast --segment --segment-size 100 --no-parallel 2>&1 | tee test_reports/seg_fast_1.log`
 6.2.2 [x] `poetry run devsynth run-tests --speed=medium --segment --segment-size 100 --no-parallel 2>&1 | tee test_reports/seg_medium_1.log`
 6.2.3 [x] `poetry run coverage combine && poetry run coverage html -d htmlcov && poetry run coverage json -o coverage.json`
-6.3 [x] Verify global threshold: ensure combined coverage >=90% with pytest.ini fail-under.
-6.3.1 [x] Investigate missing coverage data after smoke run; ensure coverage is captured before threshold validation.
+6.3 [ ] Verify global threshold: ensure combined coverage >=90% with pytest.ini fail-under (current aggregated result: 13.68 %).
+6.3.1 [ ] Investigate missing coverage data after smoke run; ensure coverage is captured before threshold validation (htmlcov/index.html is empty in latest run).
 6.4 [x] Save logs to test_reports/ and artifacts to htmlcov/ and coverage.json.
 
 7. Behavior and Integration Completeness (Phase 3)
@@ -128,7 +128,7 @@ Instructions: Check off each task when completed. Subtasks are enumerated for cl
 13. Acceptance Criteria Validation
 13.1 [x] All unit, integration, and behavior tests pass locally using documented commands.
 13.2 [x] Property tests pass under `DEVSYNTH_PROPERTY_TESTING=true` with exactly one speed marker per function.
-13.3 [x] Combined coverage >= 90% with HTML report generated and saved.
+13.3 [ ] Combined coverage >= 90% with HTML report generated and saved (latest artifacts show 13.68 % and empty htmlcov output).
 13.4 [x] Lint, type, and security gates pass with documented exceptions (if any).
 13.5 [x] Docs updated: maintainer setup, CLI reference, provider defaults, resource flags, coverage guidance.
 13.6 [x] Known environment warnings in doctor.txt triaged and documented as non-blocking by default.
@@ -181,7 +181,7 @@ Notes:
 19. Release Finalization (Phase 8)
 19.1 [x] Draft v0.1.0a1 release notes and update CHANGELOG.md.
 19.2 [ ] Conduct User Acceptance Testing and confirm approval.
-19.3 [x] Perform final full fast+medium coverage run and archive artifacts. Coverage artifacts (htmlcov/ and coverage.json) omitted from commit due to Codex diff size limits.
+19.3 [ ] Perform final full fast+medium coverage run and archive artifacts with ≥90 % coverage. Latest attempt (2025-09-15) produced only 13.68 % coverage and empty htmlcov output; artifacts require regeneration after fixes.
 19.4 [ ] Hand off to maintainers to tag v0.1.0a1 on GitHub and prepare post-release tasks (re-enable GitHub Actions triggers).
 19.5 [ ] Close issues/release-finalization-uat.md after tagging is complete.
 
@@ -189,6 +189,17 @@ Notes:
 20.1 [x] Consolidate open strict typing tickets into issues/strict-typing-roadmap.md for unified tracking.
 20.2 [x] Sequence post-release PRs to reintroduce strict typing to logger, exceptions, and CLI modules.
 20.3 [x] Document typing restoration decisions in docs/plan.md and update related issue files upon completion.
+
+21. Coverage Remediation Iteration (Phase 2B)
+21.1 [ ] Update `devsynth run-tests` instrumentation to guarantee `--cov=src/devsynth` (and supporting HTML/JSON outputs) is applied in all aggregated runs; add regression coverage tests (Issue: [coverage-below-threshold.md](../issues/coverage-below-threshold.md)).
+21.2 [ ] Add focused unit tests for `src/devsynth/interface/output_formatter.py` covering formatting and error branches highlighted as uncovered (Issue: [coverage-below-threshold.md](../issues/coverage-below-threshold.md)).
+21.3 [ ] Add fast unit tests for `src/devsynth/interface/webui_bridge.py` to exercise routing/handshake paths (Issue: [coverage-below-threshold.md](../issues/coverage-below-threshold.md)).
+21.4 [ ] Introduce integration tests (resource-gated if needed) for `src/devsynth/interface/webui.py` to cover navigation, prompt rendering, and command execution flows without external services (Issue: [coverage-below-threshold.md](../issues/coverage-below-threshold.md)).
+21.5 [ ] Extend tests for `src/devsynth/logging_setup.py` to validate log level overrides, JSON formatting, and handler wiring (Issue: [coverage-below-threshold.md](../issues/coverage-below-threshold.md)).
+21.6 [ ] Add deterministic unit tests for `src/devsynth/methodology/edrr/reasoning_loop.py` demonstrating recursion safeguards and invariants (Issue: [coverage-below-threshold.md](../issues/coverage-below-threshold.md)).
+21.7 [ ] Increase coverage for `src/devsynth/testing/run_tests.py` by validating CLI invocation paths and error handling distinct from `run_tests_cmd` (Issue: [coverage-below-threshold.md](../issues/coverage-below-threshold.md)).
+21.8 [ ] Implement a coverage gate that parses `test_reports/coverage.json` and fails when coverage <90 % to prevent silent regressions (Issue: [coverage-below-threshold.md](../issues/coverage-below-threshold.md)).
+21.9 [ ] Document the remediated coverage workflow in docs/plan.md and docs/tasks.md after instrumentation and new tests land (Issue: [coverage-below-threshold.md](../issues/coverage-below-threshold.md)).
 
 Notes:
 - 2025-09-15: Verified environment after running `poetry install --with dev --all-extras`; smoke tests and verification scripts pass. Remaining open tasks: 19.2, 19.4, 19.5.

--- a/issues/coverage-below-threshold.md
+++ b/issues/coverage-below-threshold.md
@@ -1,18 +1,24 @@
 # Coverage below threshold
-Status: closed
+Status: open
 
 ## Summary
-Coverage run using `DEVSYNTH_PROPERTY_TESTING=true poetry run pytest --cov=src/devsynth --cov-report=term --cov-report=html -q` fails with numerous test failures, preventing generation of a complete coverage report and verifying the ≥90% requirement.
+Aggregated coverage runs complete but only produce 13.68 % line coverage (`test_reports/coverage.json`) and an empty `htmlcov/index.html`, so the ≥90 % gate remains unsatisfied even though the test command exits successfully.
 
 ## Steps to Reproduce
 1. Ensure dependencies installed via `poetry install --with dev --all-extras`.
 2. Execute the coverage command above.
+3. Alternatively run `poetry run devsynth run-tests --speed=fast --speed=medium --no-parallel --report --maxfail=1` and inspect `test_reports/coverage.json`.
 
 ## Expected Behavior
 Coverage report completes with ≥90% coverage.
 
 ## Actual Behavior
-Test execution halts early due to failing tests, and coverage percentage cannot be determined.
+Coverage command exits successfully but reports only 13.68 % line coverage and produces empty HTML output, so the fail-under=90 guard is not satisfied.
+
+## Next Actions
+- [ ] Update `devsynth run-tests` to enforce coverage instrumentation for `src/devsynth` and regenerate htmlcov/coverage.json with ≥90 % results.
+- [ ] Add targeted unit/integration tests for modules highlighted in docs/tasks.md §21 (output_formatter, webui, webui_bridge, logging_setup, reasoning_loop, testing/run_tests).
+- [ ] Automate a coverage gate that inspects `test_reports/coverage.json` and fails when coverage <90 %.
 
 ## Notes
 - Tasks `docs/tasks.md` items 13.3 and 13.4 remain unchecked pending resolution.
@@ -23,7 +29,7 @@ Test execution halts early due to failing tests, and coverage percentage cannot 
 - 2025-09-28: Combined report `coverage report --fail-under=90` returned 5% total coverage, confirming the ≥90% requirement is unmet.
 - 2025-09-30: `poetry run coverage report --fail-under=90` after smoke run reported "No data to report"; coverage instrumentation missing.
 - 2025-10-01: After reinstalling dependencies, `poetry run devsynth run-tests --smoke --speed=fast --no-parallel --maxfail=1` completed but produced only "Tests completed successfully" without coverage data.
-- 2025-10-07: Added targeted unit tests for provider system, WebUI, output formatter, WebUI bridge, logging, reasoning loop, and test runner; coverage remains below 90%.
+- 2025-09-15: `poetry run devsynth run-tests --speed=fast --speed=medium --no-parallel --report --maxfail=1` completed yet `test_reports/coverage.json` reported 13.68 % and `htmlcov/index.html` remained empty; issue reopened and coverage remediation tasks added to docs/tasks.md section 21.
 - 2025-09-12: Coverage rerun via `poetry run devsynth run-tests --speed=fast --speed=medium --no-parallel --report` achieved 95% aggregate coverage; badge and documentation updated. Issue remains closed.
 - 2025-10-07: Added targeted unit tests for provider system, WebUI, output formatter, WebUI bridge, logging, reasoning loop, and test runner; coverage remains below 90%.
 

--- a/issues/release-finalization-uat.md
+++ b/issues/release-finalization-uat.md
@@ -25,5 +25,6 @@ Progress:
 - 2025-09-13: Fixed path handling for `test_first_metrics` and reran coverage; committed updated reports.
 - 2025-09-15: Reinstalled go-task, executed smoke tests and verification scripts; awaiting UAT and maintainer tagging.
 - 2025-09-15: Reinstalled dependencies and reran smoke/verification scripts; UAT and tagging pending.
+- 2025-09-15: `poetry run devsynth run-tests --speed=fast --speed=medium --no-parallel --report --maxfail=1` succeeded but coverage stayed at 13.68 % with empty HTML output; coverage remediation reopened (see docs/tasks.md §21 and issues/coverage-below-threshold.md).
 Resolution Evidence:
   - docs/tasks.md item 19

--- a/test_markers_report.json
+++ b/test_markers_report.json
@@ -1,12 +1,12 @@
 {
   "markers": {
-    "fast": 1055,
-    "medium": 1552,
+    "fast": 1110,
+    "medium": 1525,
     "gui": 1,
-    "requires_resource": 55,
+    "requires_resource": 61,
     "isolation": 8,
     "no_network": 12,
-    "parametrize": 38,
+    "parametrize": 39,
     "docker": 2,
     "slow": 52,
     "memory_intensive": 1,
@@ -18,8 +18,9 @@
     "anyio": 3,
     "unit": 6,
     "smoke": 4,
-    "skip": 2
+    "skip": 2,
+    "test_metrics": 1
   },
-  "files_scanned": 1047,
+  "files_scanned": 1076,
   "files_with_issues": 0
 }


### PR DESCRIPTION
## Summary
- note the coverage regression in docs/plan.md, reopen the acceptance checklist item, and capture the new 13.68 % result
- reopen coverage-related tasks, add a focused remediation backlog, and refresh iteration notes for the current analysis pass
- update issues/coverage-below-threshold.md, issues/release-finalization-uat.md, and the marker report to reflect the latest verification run

## Testing
- poetry run devsynth run-tests --smoke --speed=fast --no-parallel --maxfail=1
- poetry run devsynth run-tests --speed=fast --speed=medium --no-parallel --report --maxfail=1
- poetry run python tests/verify_test_organization.py
- poetry run python scripts/verify_test_markers.py --report --report-file test_markers_report.json
- poetry run python scripts/verify_requirements_traceability.py
- poetry run python scripts/verify_version_sync.py

------
https://chatgpt.com/codex/tasks/task_e_68c881efb5b08333997f794d6fb8ce10