### PR TITLE
feat(testing): enforce coverage instrumentation

### DIFF
--- a/tests/unit/application/cli/commands/test_run_tests_cmd_env_paths.py
+++ b/tests/unit/application/cli/commands/test_run_tests_cmd_env_paths.py
@@ -28,6 +28,7 @@ def _clean_env(monkeypatch: pytest.MonkeyPatch):
     ]
     for k in keys:
         monkeypatch.delenv(k, raising=False)
+    monkeypatch.setattr(rtc, "enforce_coverage_threshold", lambda *a, **k: 100.0)
     yield
     for k in keys:
         monkeypatch.delenv(k, raising=False)
@@ -89,7 +90,7 @@ def test_inner_test_env_tightening_forces_no_parallel(monkeypatch: pytest.Monkey
     # Assert environment effects of inner test mode
     assert os.environ.get("PYTEST_DISABLE_PLUGIN_AUTOLOAD") == "1"
     addopts = os.environ.get("PYTEST_ADDOPTS", "")
-    assert "-p no:xdist" in addopts and "-p no:cov" in addopts
+    assert "-p no:xdist" in addopts and "-p no:cov" not in addopts
 
     # And parallel should be False due to forced no_parallel=True in inner mode
     assert captured["parallel"] is False

--- a/tests/unit/application/cli/commands/test_run_tests_cmd_features.py
+++ b/tests/unit/application/cli/commands/test_run_tests_cmd_features.py
@@ -6,6 +6,14 @@ import pytest
 from devsynth.application.cli.commands.run_tests_cmd import run_tests_cmd
 
 
+@pytest.fixture(autouse=True)
+def _patch_coverage_helper(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        "devsynth.application.cli.commands.run_tests_cmd.enforce_coverage_threshold",
+        lambda *a, **k: 100.0,
+    )
+
+
 class DummyBridge:
     def __init__(self) -> None:
         self.messages: list[str] = []

--- a/tests/unit/application/cli/commands/test_run_tests_cmd_inventory_and_validation.py
+++ b/tests/unit/application/cli/commands/test_run_tests_cmd_inventory_and_validation.py
@@ -22,6 +22,11 @@ from devsynth.adapters.cli.typer_adapter import build_app
 from devsynth.application.cli.commands import run_tests_cmd as module
 
 
+@pytest.fixture(autouse=True)
+def _patch_coverage_helper(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(module, "enforce_coverage_threshold", lambda *a, **k: 100.0)
+
+
 @pytest.mark.fast
 def test_inventory_mode_exports_json_and_skips_run(monkeypatch, tmp_path):
     """--inventory should write a JSON file and not call run_tests.

--- a/tests/unit/application/cli/commands/test_run_tests_cmd_markers.py
+++ b/tests/unit/application/cli/commands/test_run_tests_cmd_markers.py
@@ -8,6 +8,14 @@ from devsynth.application.cli.commands.run_tests_cmd import run_tests_cmd
 from devsynth.interface.ux_bridge import UXBridge
 
 
+@pytest.fixture(autouse=True)
+def _patch_coverage_helper(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        "devsynth.application.cli.commands.run_tests_cmd.enforce_coverage_threshold",
+        lambda *a, **k: 100.0,
+    )
+
+
 class DummyBridge(UXBridge):
     def __init__(self) -> None:
         self.messages: list[str] = []

--- a/tests/unit/application/cli/commands/test_run_tests_cmd_more.py
+++ b/tests/unit/application/cli/commands/test_run_tests_cmd_more.py
@@ -28,6 +28,7 @@ def _clean_env(monkeypatch: pytest.MonkeyPatch):
     ]
     for k in keys:
         monkeypatch.delenv(k, raising=False)
+    monkeypatch.setattr(rtc, "enforce_coverage_threshold", lambda *a, **k: 100.0)
     yield
     for k in keys:
         monkeypatch.delenv(k, raising=False)

--- a/tests/unit/application/cli/commands/test_run_tests_cmd_provider_defaults.py
+++ b/tests/unit/application/cli/commands/test_run_tests_cmd_provider_defaults.py
@@ -23,6 +23,7 @@ def _clean_env(monkeypatch: pytest.MonkeyPatch):
     ]
     for k in keys:
         monkeypatch.delenv(k, raising=False)
+    monkeypatch.setattr(rtc, "enforce_coverage_threshold", lambda *a, **k: 100.0)
     yield
     for k in keys:
         monkeypatch.delenv(k, raising=False)

--- a/tests/unit/application/cli/commands/test_run_tests_cmd_report_path.py
+++ b/tests/unit/application/cli/commands/test_run_tests_cmd_report_path.py
@@ -7,6 +7,14 @@ from devsynth.application.cli.commands.run_tests_cmd import run_tests_cmd
 from devsynth.interface.ux_bridge import UXBridge
 
 
+@pytest.fixture(autouse=True)
+def _patch_coverage_helper(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        "devsynth.application.cli.commands.run_tests_cmd.enforce_coverage_threshold",
+        lambda *a, **k: 100.0,
+    )
+
+
 class DummyBridge(UXBridge):
     def __init__(self) -> None:
         self.messages: list[str] = []

--- a/tests/unit/application/cli/commands/test_run_tests_reporting_and_env.py
+++ b/tests/unit/application/cli/commands/test_run_tests_reporting_and_env.py
@@ -16,6 +16,11 @@ from devsynth.adapters.cli.typer_adapter import build_app
 from devsynth.application.cli.commands import run_tests_cmd as module
 
 
+@pytest.fixture(autouse=True)
+def _patch_coverage_helper(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(module, "enforce_coverage_threshold", lambda *a, **k: 100.0)
+
+
 class _DummyBridge:
     def print(self, *args: Any, **kwargs: Any) -> None:  # pragma: no cover - trivial
         pass

--- a/tests/unit/application/cli/test_run_tests_cmd_smoke.py
+++ b/tests/unit/application/cli/test_run_tests_cmd_smoke.py
@@ -10,6 +10,11 @@ from devsynth.adapters.cli.typer_adapter import build_app
 from devsynth.application.cli.commands import run_tests_cmd as module
 
 
+@pytest.fixture(autouse=True)
+def _patch_coverage_helper(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(module, "enforce_coverage_threshold", lambda *a, **k: 100.0)
+
+
 @pytest.mark.fast
 def test_smoke_mode_sets_pytest_disable_plugin_autoload_env(monkeypatch) -> None:
     """--smoke should set PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 and disable xdist.
@@ -29,5 +34,5 @@ def test_smoke_mode_sets_pytest_disable_plugin_autoload_env(monkeypatch) -> None
         assert os.environ.get("PYTEST_DISABLE_PLUGIN_AUTOLOAD") == "1"
         addopts = os.environ.get("PYTEST_ADDOPTS", "")
         assert "-p no:xdist" in addopts
-        assert "-p no:cov" in addopts
+        assert "-p no:cov" not in addopts
         mock_run.assert_called_once()

--- a/tests/unit/testing/test_run_tests_coverage_artifacts.py
+++ b/tests/unit/testing/test_run_tests_coverage_artifacts.py
@@ -12,6 +12,24 @@ def test_coverage_artifacts_created_when_no_tests(tmp_path, monkeypatch):
     empty_dir = tmp_path / "empty"
     empty_dir.mkdir()
     monkeypatch.setitem(rt.TARGET_PATHS, "dummy-tests", str(empty_dir))
+    monkeypatch.setattr(
+        rt.subprocess,
+        "run",
+        lambda *args, **kwargs: type(
+            "R",
+            (),
+            {"stdout": "", "stderr": "", "returncode": 5},
+        )(),
+    )
+
+    class DummyPopen:
+        def __init__(self, *args, **kwargs):  # noqa: ANN001
+            self.returncode = 5
+
+        def communicate(self):  # noqa: ANN001
+            return "", ""
+
+    monkeypatch.setattr(rt.subprocess, "Popen", DummyPopen)
     cwd = os.getcwd()
     os.chdir(tmp_path)
     try:
@@ -19,5 +37,5 @@ def test_coverage_artifacts_created_when_no_tests(tmp_path, monkeypatch):
     finally:
         os.chdir(cwd)
     assert success
-    assert (tmp_path / "htmlcov" / "index.html").exists()
-    assert (tmp_path / "coverage.json").exists()
+    assert (tmp_path / "test_reports" / "htmlcov" / "index.html").exists()
+    assert (tmp_path / "test_reports" / "coverage.json").exists()

--- a/tests/unit/testing/test_run_tests_parallel_flags.py
+++ b/tests/unit/testing/test_run_tests_parallel_flags.py
@@ -4,11 +4,12 @@ from devsynth.testing.run_tests import run_tests
 
 
 @pytest.mark.fast
-def test_run_tests_parallel_adds_no_cov_and_n_auto(monkeypatch):
+def test_run_tests_parallel_includes_cov_and_n_auto(monkeypatch):
     """ReqID: RUN-TESTS-PARALLEL-1
 
     When parallel=True and no explicit node ids are collected (single-pass branch),
-    run_tests should include '-n auto' and '--no-cov' in the pytest command.
+    run_tests should include '-n auto' and explicit coverage instrumentation in the
+    pytest command.
     """
 
     import devsynth.testing.run_tests as rt
@@ -22,7 +23,13 @@ def test_run_tests_parallel_adds_no_cov_and_n_auto(monkeypatch):
         ):  # noqa: ANN001
             # Assert parallel-related flags are present
             assert "-n" in cmd and "auto" in cmd, f"parallel flags missing in: {cmd}"
-            assert "--no-cov" in cmd, f"--no-cov missing in: {cmd}"
+            cov_flag = f"--cov={rt.COVERAGE_TARGET}"
+            json_flag = f"--cov-report=json:{rt.COVERAGE_JSON_PATH}"
+            html_flag = f"--cov-report=html:{rt.COVERAGE_HTML_DIR}"
+            assert cov_flag in cmd, f"{cov_flag} missing in: {cmd}"
+            assert json_flag in cmd, f"{json_flag} missing in: {cmd}"
+            assert html_flag in cmd, f"{html_flag} missing in: {cmd}"
+            assert "--cov-append" in cmd, f"--cov-append missing in: {cmd}"
             self.returncode = 0
 
         def communicate(self):

--- a/tests/unit/testing/test_run_tests_parallel_no_cov.py
+++ b/tests/unit/testing/test_run_tests_parallel_no_cov.py
@@ -1,15 +1,15 @@
 import pytest
 
+import devsynth.testing.run_tests as rt
 from devsynth.testing.run_tests import run_tests
 
 
 @pytest.mark.fast
-def test_parallel_injects_no_cov_and_xdist_auto(monkeypatch):
-    """ReqID: TR-RT-11 — Parallel path injects -n auto and --no-cov.
+def test_parallel_injects_cov_reports_and_xdist_auto(monkeypatch):
+    """ReqID: TR-RT-11 — Parallel path injects -n auto with coverage reports.
 
-    Verify that when parallel=True, run_tests injects xdist flags and disables
-    coverage collection via --no-cov to avoid known pytest-xdist/pytest-cov
-    teardown issues.
+    Verify that when parallel=True, run_tests injects xdist flags and preserves
+    coverage instrumentation so JSON/HTML artifacts are generated.
     """
 
     called = {}
@@ -62,7 +62,13 @@ def test_parallel_injects_no_cov_and_xdist_auto(monkeypatch):
 
     # Assert xdist auto and coverage disabled flags are present
     assert "-n" in cmd and "auto" in cmd, f"xdist flags not present in cmd: {cmd}"
-    assert "--no-cov" in cmd, f"--no-cov not present in cmd: {cmd}"
+    cov_flag = f"--cov={rt.COVERAGE_TARGET}"
+    json_flag = f"--cov-report=json:{rt.COVERAGE_JSON_PATH}"
+    html_flag = f"--cov-report=html:{rt.COVERAGE_HTML_DIR}"
+    assert cov_flag in cmd, f"{cov_flag} not present in cmd: {cmd}"
+    assert json_flag in cmd, f"{json_flag} not present in cmd: {cmd}"
+    assert html_flag in cmd, f"{html_flag} not present in cmd: {cmd}"
+    assert "--cov-append" in cmd, f"--cov-append not present in cmd: {cmd}"
 
     # Node ids from collection should be passed through to the run command
     assert any(isinstance(x, str) and x.endswith("foo_test.py::test_one") for x in cmd)


### PR DESCRIPTION
## Summary
- ensure the core test runner resets coverage artifacts, injects coverage reports on every execution path, and exposes an `enforce_coverage_threshold` helper
- update the `devsynth run-tests` CLI command to keep coverage enabled, report results, and exit when the aggregated coverage is below the configured threshold
- expand unit coverage across the runner and CLI wrappers to validate the new instrumentation and adjust fixtures for deterministic execution

## Testing
- `PYTEST_ADDOPTS="--cov-fail-under=0" poetry run pytest tests/unit/testing/test_run_tests_module.py tests/unit/testing/test_run_tests_parallel_flags.py tests/unit/testing/test_run_tests_parallel_no_cov.py tests/unit/testing/test_run_tests_coverage_artifacts.py`
- `PYTEST_ADDOPTS="--cov-fail-under=0" poetry run pytest tests/unit/application/cli/commands/test_run_tests_cmd.py`


------
https://chatgpt.com/codex/tasks/task_e_68c88d8d0e408333a4bb6d0cdc7c5041