### PR TITLE
docs: log smoke coverage gaps and extend remediation tasks

### DIFF
--- a/docs/task_notes.md
+++ b/docs/task_notes.md
@@ -72,3 +72,12 @@ Current file condensed on 2025-09-15 to remove redundant 2025-09-13 entries whil
   - Parsed `test_reports/coverage.json` → 13.68 % coverage; observed empty `htmlcov/index.html`.
 - Observations: Aggregated coverage regressed to 13.68 % despite successful run; htmlcov output zero bytes; reopened issues/coverage-below-threshold.md; added docs/tasks.md section 21 for coverage remediation; plan/tasks updated to reflect unmet coverage gate.
 - Next: Repair coverage instrumentation, raise coverage for highlighted modules (output_formatter, webui, webui_bridge, logging_setup, reasoning_loop, testing/run_tests), implement automated coverage gate, regenerate artifacts before UAT.
+
+## Iteration 2025-09-15B – Smoke profile coverage gap
+- Environment: Python 3.12.10; Poetry env `/root/.cache/pypoetry/virtualenvs/devsynth-MeXVnKii-py3.12`; `task --version` 3.45.3.
+- Commands:
+  - `poetry run devsynth run-tests --smoke --speed=fast --no-parallel --maxfail=1` → initial attempt failed with `ModuleNotFoundError: No module named 'devsynth'` until `poetry install --with dev --all-extras` restored the entry point.
+  - Re-ran the smoke command post-install; CLI completed but emitted "Unable to determine total coverage…" twice and `test_reports/coverage.json` contained `{}` with zero-byte HTML coverage.
+  - Confirmed existing aggregated coverage artifact still reports 13.68 % via JSON totals.
+- Observations: Smoke mode sets `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1`, preventing pytest-cov from writing `.coverage`, so enforcement degrades to a warning; added docs/tasks.md §21.8 and plan updates to capture remediation options.
+- Next: Track a fix ensuring smoke runs either load pytest-cov explicitly or bypass coverage enforcement when intentionally skipping instrumentation; coordinate with issues/coverage-below-threshold.md.

--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -198,8 +198,9 @@ Notes:
 21.5 [ ] Extend tests for `src/devsynth/logging_setup.py` to validate log level overrides, JSON formatting, and handler wiring (Issue: [coverage-below-threshold.md](../issues/coverage-below-threshold.md)).
 21.6 [ ] Add deterministic unit tests for `src/devsynth/methodology/edrr/reasoning_loop.py` demonstrating recursion safeguards and invariants (Issue: [coverage-below-threshold.md](../issues/coverage-below-threshold.md)).
 21.7 [ ] Increase coverage for `src/devsynth/testing/run_tests.py` by validating CLI invocation paths and error handling distinct from `run_tests_cmd` (Issue: [coverage-below-threshold.md](../issues/coverage-below-threshold.md)).
-21.8 [ ] Implement a coverage gate that parses `test_reports/coverage.json` and fails when coverage <90 % to prevent silent regressions (Issue: [coverage-below-threshold.md](../issues/coverage-below-threshold.md)).
-21.9 [ ] Document the remediated coverage workflow in docs/plan.md and docs/tasks.md after instrumentation and new tests land (Issue: [coverage-below-threshold.md](../issues/coverage-below-threshold.md)).
+21.8 [ ] Ensure smoke profile coverage enforcement is coherent: either force-load `pytest-cov` when `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1` or skip threshold enforcement when coverage data is intentionally unavailable (Issue: [coverage-below-threshold.md](../issues/coverage-below-threshold.md)).
+21.9 [ ] Implement a coverage gate that parses `test_reports/coverage.json` and fails when coverage <90 % to prevent silent regressions (Issue: [coverage-below-threshold.md](../issues/coverage-below-threshold.md)).
+21.10 [ ] Document the remediated coverage workflow in docs/plan.md and docs/tasks.md after instrumentation and new tests land (Issue: [coverage-below-threshold.md](../issues/coverage-below-threshold.md)).
 
 Notes:
 - 2025-09-15: Verified environment after running `poetry install --with dev --all-extras`; smoke tests and verification scripts pass. Remaining open tasks: 19.2, 19.4, 19.5.

--- a/issues/coverage-below-threshold.md
+++ b/issues/coverage-below-threshold.md
@@ -19,6 +19,7 @@ Coverage command exits successfully but reports only 13.68 % line coverage and
 - [ ] Update `devsynth run-tests` to enforce coverage instrumentation for `src/devsynth` and regenerate htmlcov/coverage.json with ≥90 % results.
 - [ ] Add targeted unit/integration tests for modules highlighted in docs/tasks.md §21 (output_formatter, webui, webui_bridge, logging_setup, reasoning_loop, testing/run_tests).
 - [ ] Automate a coverage gate that inspects `test_reports/coverage.json` and fails when coverage <90 %.
+- [ ] Resolve smoke profile coverage gap: either force-load pytest-cov when `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1` or bypass enforcement when coverage is intentionally omitted (docs/tasks.md §21.8).
 
 ## Notes
 - Tasks `docs/tasks.md` items 13.3 and 13.4 remain unchecked pending resolution.
@@ -30,6 +31,7 @@ Coverage command exits successfully but reports only 13.68 % line coverage and
 - 2025-09-30: `poetry run coverage report --fail-under=90` after smoke run reported "No data to report"; coverage instrumentation missing.
 - 2025-10-01: After reinstalling dependencies, `poetry run devsynth run-tests --smoke --speed=fast --no-parallel --maxfail=1` completed but produced only "Tests completed successfully" without coverage data.
 - 2025-09-15: `poetry run devsynth run-tests --speed=fast --speed=medium --no-parallel --report --maxfail=1` completed yet `test_reports/coverage.json` reported 13.68 % and `htmlcov/index.html` remained empty; issue reopened and coverage remediation tasks added to docs/tasks.md section 21.
+- 2025-09-15: Smoke profile run (`poetry run devsynth run-tests --smoke --speed=fast --no-parallel --maxfail=1`) emitted "Unable to determine total coverage…" and produced `{}` for `test_reports/coverage.json` after reinstalling the CLI via `poetry install --with dev --all-extras`; indicates pytest-cov is skipped when plugin autoload is disabled.
 - 2025-09-12: Coverage rerun via `poetry run devsynth run-tests --speed=fast --speed=medium --no-parallel --report` achieved 95% aggregate coverage; badge and documentation updated. Issue remains closed.
 - 2025-10-07: Added targeted unit tests for provider system, WebUI, output formatter, WebUI bridge, logging, reasoning loop, and test runner; coverage remains below 90%.
 

--- a/issues/release-finalization-uat.md
+++ b/issues/release-finalization-uat.md
@@ -26,5 +26,6 @@ Progress:
 - 2025-09-15: Reinstalled go-task, executed smoke tests and verification scripts; awaiting UAT and maintainer tagging.
 - 2025-09-15: Reinstalled dependencies and reran smoke/verification scripts; UAT and tagging pending.
 - 2025-09-15: `poetry run devsynth run-tests --speed=fast --speed=medium --no-parallel --report --maxfail=1` succeeded but coverage stayed at 13.68 % with empty HTML output; coverage remediation reopened (see docs/tasks.md §21 and issues/coverage-below-threshold.md).
+- 2025-09-15: Smoke profile run after reinstalling `devsynth` (`poetry install --with dev --all-extras`) emitted coverage warning (`totals.percent_covered` missing) and wrote empty coverage artifacts, confirming instrumentation gaps remain before UAT can proceed.
 Resolution Evidence:
   - docs/tasks.md item 19


### PR DESCRIPTION
## Summary
- record the smoke profile coverage warning and reinstall requirement in the 0.1.0a1 readiness plan
- expand the coverage remediation task list with a smoke-mode instrumentation fix and align open issues with the new workstream
- capture the latest observations in task notes and the release-finalization tracker to keep stakeholders informed

## Testing
- poetry run devsynth run-tests --smoke --speed=fast --no-parallel --maxfail=1

------
https://chatgpt.com/codex/tasks/task_e_68c89ee383f88333b8b09c5125896ed0