### PR TITLE
feat(testing): ensure run-tests emits coverage artifacts

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -21,6 +21,7 @@ markers =
     gui: mark test as requiring GUI or optional UI extras (NiceGUI/DearPyGUI)
     isolation: mark test as requiring isolation (should be run separately from other tests)
     test-metrics: mark test as related to test metrics functionality
+    test_metrics: alias for test metrics functionality
     code-analysis: mark test as related to code analysis functionality
     manifest-analysis: mark test as related to manifest analysis functionality
     apispec-generation: mark test as related to API specification generation

--- a/tests/unit/testing/test_run_tests_coverage_artifacts.py
+++ b/tests/unit/testing/test_run_tests_coverage_artifacts.py
@@ -1,5 +1,3 @@
-import os
-
 import pytest
 
 import devsynth.testing.run_tests as rt
@@ -30,12 +28,76 @@ def test_coverage_artifacts_created_when_no_tests(tmp_path, monkeypatch):
             return "", ""
 
     monkeypatch.setattr(rt.subprocess, "Popen", DummyPopen)
-    cwd = os.getcwd()
-    os.chdir(tmp_path)
-    try:
-        success, _ = rt.run_tests("dummy-tests", ["fast"], report=False, parallel=False)
-    finally:
-        os.chdir(cwd)
+    monkeypatch.chdir(tmp_path)
+    success, _ = rt.run_tests("dummy-tests", ["fast"], report=False, parallel=False)
     assert success
-    assert (tmp_path / "test_reports" / "htmlcov" / "index.html").exists()
+    html_index = tmp_path / "htmlcov" / "index.html"
+    assert html_index.exists()
+    assert html_index.read_text().strip() != ""
     assert (tmp_path / "test_reports" / "coverage.json").exists()
+
+
+@pytest.mark.fast
+@pytest.mark.test_metrics
+def test_coverage_artifacts_created_for_aggregated_speeds(tmp_path, monkeypatch):
+    """Aggregated fast+medium runs should emit coverage artifacts."""
+
+    monkeypatch.chdir(tmp_path)
+    tests_dir = tmp_path / "tests"
+    tests_dir.mkdir()
+    sample_test = tests_dir / "test_sample.py"
+    sample_test.write_text("def test_sample():\n    assert True\n")
+
+    monkeypatch.setattr(
+        rt,
+        "TARGET_PATHS",
+        {"dummy-tests": "tests", "all-tests": "tests"},
+    )
+
+    node_output = "test_sample.py::test_sample\n"
+
+    def fake_collect(
+        cmd, check=False, capture_output=False, text=False
+    ):  # type: ignore[no-untyped-def]
+        assert "--collect-only" in cmd
+        return type(
+            "R",
+            (),
+            {"stdout": node_output, "stderr": "", "returncode": 0},
+        )()
+
+    commands: list[list[str]] = []
+
+    class DummyProcess:
+        def __init__(self, cmd, stdout=None, stderr=None, text=False, env=None):  # type: ignore[no-untyped-def]
+            commands.append(cmd)
+            self.returncode = 0
+
+        def communicate(self):  # type: ignore[no-untyped-def]
+            return ("ok", "")
+
+    monkeypatch.setattr(rt.subprocess, "run", fake_collect)
+    monkeypatch.setattr(rt.subprocess, "Popen", DummyProcess)
+
+    success, _ = rt.run_tests(
+        "dummy-tests",
+        ["fast", "medium"],
+        report=False,
+        parallel=False,
+    )
+
+    assert success is True
+    assert commands, "Expected coverage-enabled pytest invocations"
+    for cmd in commands:
+        assert f"--cov={rt.COVERAGE_TARGET}" in cmd
+        assert f"--cov-report=json:{rt.COVERAGE_JSON_PATH}" in cmd
+        assert f"--cov-report=html:{rt.COVERAGE_HTML_DIR}" in cmd
+        assert "--cov-append" in cmd
+
+    html_index = tmp_path / "htmlcov" / "index.html"
+    assert html_index.exists()
+    assert html_index.read_text().strip() != ""
+
+    cov_json = tmp_path / "test_reports" / "coverage.json"
+    assert cov_json.exists()
+    assert cov_json.read_text().strip() != ""


### PR DESCRIPTION
## Summary
- ensure `run_tests` writes coverage HTML into `htmlcov/`, keeps JSON artifacts, and mirrors legacy locations for downstream tooling
- surface coverage artifact locations from the CLI and cover the helper with unit tests
- add a regression for fast+medium aggregated runs to assert coverage artifacts are produced and register the `test_metrics` marker alias

## Testing
- poetry run pytest tests/unit/testing/test_run_tests_coverage_artifacts.py -o addopts=
- poetry run pytest tests/unit/application/cli/commands/test_run_tests_cmd_report_path.py -o addopts=
- poetry run python scripts/verify_test_markers.py
- poetry run devsynth run-tests --speed=fast --speed=medium --no-parallel --report *(fails: suite has numerous errors; coverage JSON reports ~20.7% with htmlcov/index.html populated)*

------
https://chatgpt.com/codex/tasks/task_e_68c8a4ac41cc8333b0adb502420e162e