### PR TITLE
fix(cli): ensure smoke runs handle coverage instrumentation

### DIFF
--- a/tests/unit/application/cli/test_run_tests_cmd_smoke.py
+++ b/tests/unit/application/cli/test_run_tests_cmd_smoke.py
@@ -17,16 +17,19 @@ def _patch_coverage_helper(monkeypatch: pytest.MonkeyPatch) -> None:
 
 @pytest.mark.fast
 def test_smoke_mode_sets_pytest_disable_plugin_autoload_env(monkeypatch) -> None:
-    """--smoke should set PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 and disable xdist.
-
-    Also verifies that no_parallel is forced and that run_tests is invoked.
-    """
+    """ReqID: CLI-RT-19 — Smoke mode disables plugin autoload while keeping
+    coverage instrumentation."""
     # Ensure env is clean
     monkeypatch.delenv("PYTEST_DISABLE_PLUGIN_AUTOLOAD", raising=False)
     monkeypatch.delenv("PYTEST_ADDOPTS", raising=False)
 
     runner = CliRunner()
-    with patch.object(module, "run_tests", return_value=(True, "")) as mock_run:
+    with (
+        patch.object(module, "run_tests", return_value=(True, "")) as mock_run,
+        patch.object(
+            module, "enforce_coverage_threshold", return_value=100.0
+        ) as mock_enforce,
+    ):
         app = build_app()
         result = runner.invoke(app, ["run-tests", "--smoke"])  # defaults to fast
         assert result.exit_code == 0
@@ -34,5 +37,31 @@ def test_smoke_mode_sets_pytest_disable_plugin_autoload_env(monkeypatch) -> None
         assert os.environ.get("PYTEST_DISABLE_PLUGIN_AUTOLOAD") == "1"
         addopts = os.environ.get("PYTEST_ADDOPTS", "")
         assert "-p no:xdist" in addopts
+        assert "-p pytest_cov" in addopts
         assert "-p no:cov" not in addopts
         mock_run.assert_called_once()
+        mock_enforce.assert_called_once()
+
+
+@pytest.mark.fast
+def test_smoke_mode_skips_coverage_gate_when_cov_disabled(monkeypatch) -> None:
+    """ReqID: CLI-RT-19b — Smoke mode skips coverage enforcement when
+    instrumentation is disabled."""
+
+    monkeypatch.delenv("PYTEST_DISABLE_PLUGIN_AUTOLOAD", raising=False)
+    monkeypatch.setenv("PYTEST_ADDOPTS", "-p no:cov")
+
+    runner = CliRunner()
+    with (
+        patch.object(module, "run_tests", return_value=(True, "")) as mock_run,
+        patch.object(module, "enforce_coverage_threshold") as mock_enforce,
+    ):
+        app = build_app()
+        result = runner.invoke(app, ["run-tests", "--smoke"])  # defaults to fast
+
+    assert result.exit_code == 0
+    mock_run.assert_called_once()
+    mock_enforce.assert_not_called()
+    output = result.stdout
+    assert "Coverage enforcement skipped" in output
+    assert "-p pytest_cov" not in os.environ.get("PYTEST_ADDOPTS", "")


### PR DESCRIPTION
## Summary
- explicitly parse `PYTEST_ADDOPTS` so smoke mode loads `pytest-cov` when instrumentation is enabled and records a reason when it is disabled
- skip coverage threshold enforcement gracefully when coverage instrumentation is not active
- add smoke-mode CLI unit tests to cover the plugin injection path and the disabled-instrumentation path

## Testing
- PYTEST_ADDOPTS="--no-cov" poetry run pytest tests/unit/application/cli/test_run_tests_cmd_smoke.py
- poetry run pre-commit run --files src/devsynth/application/cli/commands/run_tests_cmd.py tests/unit/application/cli/test_run_tests_cmd_smoke.py

------
https://chatgpt.com/codex/tasks/task_e_68c8b97452088333bd56e9caf0dc7b94