### PR TITLE
test: extend coverage for interface and tooling

### DIFF
--- a/tests/unit/logging/test_logging_setup_levels.py
+++ b/tests/unit/logging/test_logging_setup_levels.py
@@ -1,0 +1,137 @@
+"""Additional coverage for logging configuration behaviours."""
+
+from __future__ import annotations
+
+import importlib
+import json
+import logging
+from collections.abc import Iterator
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+
+@pytest.fixture()
+def logging_setup_module() -> Iterator[ModuleType]:
+    """Reload :mod:`devsynth.logging_setup` with a clean root logger."""
+
+    import devsynth.logging_setup as logging_setup
+
+    root_logger = logging.getLogger()
+    original_handlers = list(root_logger.handlers)
+    original_filters = list(root_logger.filters)
+    original_level = root_logger.level
+
+    for handler in root_logger.handlers[:]:
+        root_logger.removeHandler(handler)
+    for filt in root_logger.filters[:]:
+        root_logger.removeFilter(filt)
+
+    reloaded = importlib.reload(logging_setup)
+
+    try:
+        yield reloaded
+    finally:
+        root_logger = logging.getLogger()
+        for handler in root_logger.handlers[:]:
+            root_logger.removeHandler(handler)
+            if handler not in original_handlers:
+                try:
+                    handler.close()
+                except Exception:  # pragma: no cover - defensive cleanup
+                    pass
+        for filt in root_logger.filters[:]:
+            root_logger.removeFilter(filt)
+        root_logger.setLevel(original_level)
+        for handler in original_handlers:
+            root_logger.addHandler(handler)
+        for filt in original_filters:
+            root_logger.addFilter(filt)
+        importlib.reload(logging_setup)
+
+
+@pytest.mark.fast
+def test_configure_logging_honors_env_log_level(
+    logging_setup_module: ModuleType, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Environment log level overrides propagate to the root logger."""
+
+    logging_setup = logging_setup_module
+    monkeypatch.setenv("DEVSYNTH_PROJECT_DIR", str(tmp_path))
+    monkeypatch.setenv("DEVSYNTH_LOG_LEVEL", str(logging.DEBUG))
+    monkeypatch.delenv("DEVSYNTH_NO_FILE_LOGGING", raising=False)
+
+    logging_setup.configure_logging(log_dir=str(tmp_path / "logs"))
+
+    assert logging.getLogger().level == logging.DEBUG
+
+
+@pytest.mark.fast
+def test_json_formatter_captures_request_context(
+    logging_setup_module: ModuleType,
+) -> None:
+    """Structured logs include custom context fields and computed message."""
+
+    formatter = logging_setup_module.JSONFormatter()
+
+    record = logging.LogRecord(
+        name="devsynth.tests.json",
+        level=logging.INFO,
+        pathname=__file__,
+        lineno=42,
+        msg="processing %s",
+        args=("payload",),
+        exc_info=None,
+        func="test_json_formatter_captures_request_context",
+    )
+    record.caller_module = "custom.module"
+    record.caller_function = "custom_function"
+    record.caller_line = 101
+    record.request_id = "req-xyz"
+    record.phase = "refine"
+    record.extra_detail = "value"
+
+    payload = json.loads(formatter.format(record))
+
+    assert payload["message"] == "processing payload"
+    assert payload["module"] == "custom.module"
+    assert payload["function"] == "custom_function"
+    assert payload["line"] == 101
+    assert payload["request_id"] == "req-xyz"
+    assert payload["phase"] == "refine"
+    assert payload["extra_detail"] == "value"
+
+
+@pytest.mark.fast
+def test_dev_logger_attaches_filters_and_handlers(
+    logging_setup_module: ModuleType, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """DevSynth loggers inherit redaction filters and structured handlers."""
+
+    logging_setup = logging_setup_module
+    monkeypatch.setenv("DEVSYNTH_PROJECT_DIR", str(tmp_path))
+    monkeypatch.delenv("DEVSYNTH_NO_FILE_LOGGING", raising=False)
+
+    logging_setup.configure_logging(log_dir=str(tmp_path / "logs"))
+
+    root_logger = logging.getLogger()
+    assert any(
+        isinstance(filt, logging_setup.RedactSecretsFilter)
+        for filt in root_logger.filters
+    )
+
+    file_handlers = [
+        handler for handler in root_logger.handlers if isinstance(handler, logging.FileHandler)
+    ]
+    assert file_handlers, "Expected JSON file handler to be configured"
+    assert isinstance(file_handlers[0].formatter, logging_setup.JSONFormatter)
+
+    dev_logger = logging_setup.DevSynthLogger("devsynth.tests.wiring")
+    attached_filters = dev_logger.logger.filters
+    assert any(
+        isinstance(filt, logging_setup.RequestContextFilter) for filt in attached_filters
+    )
+    assert any(
+        isinstance(filt, logging_setup.RedactSecretsFilter) for filt in attached_filters
+    )

--- a/tests/unit/methodology/edrr/test_reasoning_loop_safeguards.py
+++ b/tests/unit/methodology/edrr/test_reasoning_loop_safeguards.py
@@ -1,0 +1,103 @@
+"""Deterministic recursion safeguard tests for the reasoning loop."""
+
+from __future__ import annotations
+
+import importlib
+from typing import Any
+
+import pytest
+
+from devsynth.methodology.edrr.reasoning_loop import Phase
+
+rl = importlib.import_module("devsynth.methodology.edrr.reasoning_loop")
+
+
+class _RecorderCoordinator:
+    """Coordinator capturing the order of recorded phases."""
+
+    def __init__(self) -> None:
+        self.recorded: list[Phase] = []
+
+    def record_expand_results(self, result: dict[str, Any]) -> dict[str, Any]:
+        self.recorded.append(Phase.EXPAND)
+        return result
+
+    def record_differentiate_results(self, result: dict[str, Any]) -> dict[str, Any]:
+        self.recorded.append(Phase.DIFFERENTIATE)
+        return result
+
+    def record_refine_results(self, result: dict[str, Any]) -> dict[str, Any]:
+        self.recorded.append(Phase.REFINE)
+        return result
+
+    def record_consensus_failure(self, _exc: Exception) -> None:  # pragma: no cover - defensive
+        return None
+
+
+@pytest.fixture()
+def patch_reasoning_loop(monkeypatch: pytest.MonkeyPatch):
+    """Patch reasoning loop internals to use deterministic callables."""
+
+    def _apply(fake_callable):
+        monkeypatch.setattr(rl, "_apply_dialectical_reasoning", fake_callable, raising=False)
+        monkeypatch.setattr(rl, "_import_apply_dialectical_reasoning", lambda: fake_callable)
+
+    return _apply
+
+
+@pytest.mark.fast
+def test_invalid_next_phase_falls_back_to_transition_map(
+    patch_reasoning_loop, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Unknown ``next_phase`` values fall back to deterministic transitions."""
+
+    coordinator = _RecorderCoordinator()
+    calls = {"count": 0}
+
+    def fake_apply(_: Any, __: dict[str, Any], ___: Any, ____: Any) -> dict[str, Any]:
+        calls["count"] += 1
+        if calls["count"] < 3:
+            return {"status": "in_progress", "next_phase": "mystery"}
+        return {"status": "completed", "phase": "refine"}
+
+    patch_reasoning_loop(fake_apply)
+    monkeypatch.setattr(rl.time, "sleep", lambda _seconds: None)
+
+    results = rl.reasoning_loop(
+        wsde_team=None,
+        task={"solution": "seed"},
+        critic_agent=None,
+        coordinator=coordinator,
+        phase=Phase.EXPAND,
+        max_iterations=5,
+    )
+
+    assert len(results) == 3
+    assert [phase.value for phase in coordinator.recorded] == [
+        Phase.EXPAND.value,
+        Phase.DIFFERENTIATE.value,
+        Phase.REFINE.value,
+    ]
+
+
+@pytest.mark.fast
+def test_missing_status_relies_on_max_iterations(patch_reasoning_loop) -> None:
+    """Results without a ``status`` key terminate via the iteration safeguard."""
+
+    calls = {"count": 0}
+
+    def fake_apply(_: Any, task: dict[str, Any], __: Any, ___: Any) -> dict[str, Any]:
+        calls["count"] += 1
+        return {"phase": task.get("phase", "refine")}
+
+    patch_reasoning_loop(fake_apply)
+
+    results = rl.reasoning_loop(
+        wsde_team=None,
+        task={"solution": "seed"},
+        critic_agent=None,
+        max_iterations=2,
+    )
+
+    assert len(results) == 2
+    assert calls["count"] == 2


### PR DESCRIPTION
## Summary
- exercise additional Streamlit routing and sanitization logic in the WebUI bridge tests
- add WebUI integration checks for navigation fallback and command error feedback
- cover logging configuration, reasoning loop safeguards, and CLI keyword/report paths with dedicated unit tests

## Testing
- poetry run pytest --no-cov tests/unit/interface/test_webui_bridge_routing.py
- DEVSYNTH_RESOURCE_WEBUI_AVAILABLE=true poetry run pytest --no-cov tests/integration/interface/test_webui_flow.py
- poetry run pytest --no-cov tests/unit/logging/test_logging_setup_levels.py
- poetry run pytest --no-cov tests/unit/methodology/edrr/test_reasoning_loop_safeguards.py
- poetry run pytest --no-cov tests/unit/testing/test_run_tests_cli_invocation.py


------
https://chatgpt.com/codex/tasks/task_e_68c9818354388333858b7e2cd810aac5