### PR TITLE
fix(testing): prevent placeholder coverage artifacts

### DIFF
--- a/docs/task_notes.md
+++ b/docs/task_notes.md
@@ -90,3 +90,11 @@ Current file condensed on 2025-09-15 to remove redundant 2025-09-13 entries whil
   - `poetry run devsynth run-tests --speed=fast --speed=medium --no-parallel --report --maxfail=1`.
 - Observations: Both commands print "Unable to determine total coverage" and leave `.coverage` missing even though `--cov` arguments are passed; `test_reports/coverage.json` reverts to 13.68 % only after restoring the previous artifact from git. Added docs/tasks.md §22–23 to capture instrumentation fixes and documentation promotions.
 - Next: Diagnose missing `.coverage`, add regression tests for `totals.percent_covered`, and promote draft invariant notes once coverage improvements land.
+
+## Iteration 2025-09-16B – Coverage artifact remediation
+- Environment: Python 3.12.10; Poetry env `/root/.cache/pypoetry/virtualenvs/devsynth-MeXVnKii-py3.12`.
+- Commands:
+  - `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 PYTEST_ADDOPTS="-k test_that_does_not_exist --maxfail=1" poetry run devsynth run-tests --target all-tests --speed=fast --speed=medium --no-parallel --report` – now exits with remediation instead of leaving `{}` coverage artifacts.【7cb697†L1-L3】
+  - `poetry run pytest tests/unit/testing/test_run_tests_cli_invocation.py::test_run_tests_generates_coverage_totals tests/unit/application/cli/test_run_tests_cmd.py::test_cli_reports_coverage_percent` (new regression coverage suite).
+- Observations: `_ensure_coverage_artifacts()` now refuses to emit placeholders when `.coverage` is missing and the CLI surfaces actionable guidance. The regression tests confirm `test_reports/coverage.json` includes `totals.percent_covered`, meeting the ≥90 % gate precondition.
+- Next: Run the full aggregate profile once remaining coverage hot spots receive tests so the gate can pass without manual intervention.

--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -203,10 +203,10 @@ Notes:
 21.10 [x] Document the remediated coverage workflow in docs/plan.md and docs/tasks.md after instrumentation lands (Issue: [coverage-below-threshold.md](../issues/coverage-below-threshold.md)).
 
 22. Coverage Instrumentation Recovery (Phase 2C)
-22.1 [ ] Diagnose why `.coverage` is absent after `devsynth run-tests` when coverage warnings appear; ensure `_ensure_coverage_artifacts()` only runs once real data is available (Issue: [coverage-below-threshold.md](../issues/coverage-below-threshold.md)).
-22.2 [ ] Add an integration test around `run_tests_cmd` that simulates a successful pytest run and asserts `test_reports/coverage.json` contains `totals.percent_covered` (Issue: [coverage-below-threshold.md](../issues/coverage-below-threshold.md)).
-22.3 [ ] Update enforcement logic to detect placeholder coverage artifacts and surface actionable remediation guidance in the CLI output (Issue: [coverage-below-threshold.md](../issues/coverage-below-threshold.md)).
-22.4 [ ] Document the instrumentation recovery steps and minimum reproducible command in docs/plan.md and docs/task_notes.md once fixed.
+22.1 [x] Diagnose why `.coverage` is absent after `devsynth run-tests` when coverage warnings appear; ensure `_ensure_coverage_artifacts()` only runs once real data is available (Issue: [coverage-below-threshold.md](../issues/coverage-below-threshold.md)).
+22.2 [x] Add an integration test around `run_tests_cmd` that simulates a successful pytest run and asserts `test_reports/coverage.json` contains `totals.percent_covered` (Issue: [coverage-below-threshold.md](../issues/coverage-below-threshold.md)).
+22.3 [x] Update enforcement logic to detect placeholder coverage artifacts and surface actionable remediation guidance in the CLI output (Issue: [coverage-below-threshold.md](../issues/coverage-below-threshold.md)).
+22.4 [x] Document the instrumentation recovery steps and minimum reproducible command in docs/plan.md and docs/task_notes.md once fixed.
 
 23. Academic Rigor Alignment (Phase 5B)
 23.1 [ ] Promote `docs/implementation/output_formatter_invariants.md` from draft to reviewed status after new tests cover formatting branches (Issues: [coverage-below-threshold.md](../issues/coverage-below-threshold.md), [documentation-utility-functions.md](../issues/documentation-utility-functions.md)).

--- a/pytest.ini
+++ b/pytest.ini
@@ -37,6 +37,7 @@ markers =
     docker: mark test as requiring Docker
     smoke: mark test as part of smoke profile (minimal plugins, no parallel)
     unit: mark test as a unit test subset
+    allow_real_coverage_artifacts: opt-in to exercising real coverage artifact helpers during tests
 
 # Note on running isolation tests:
 # Tests marked with @pytest.mark.isolation should be run separately from other tests.


### PR DESCRIPTION
## Summary
- require real `.coverage` data before writing coverage reports and expose a helper to inspect artifact health【F:src/devsynth/testing/run_tests.py†L121-L232】
- harden `run_tests` CLI to error when pytest-cov is disabled or artifacts are empty, surfacing actionable remediation【F:src/devsynth/application/cli/commands/run_tests_cmd.py†L396-L439】
- add focused tests covering the new coverage-handling branches and document the workflow updates in the plan and task log【F:tests/unit/testing/test_run_tests_cli_invocation.py†L317-L391】【F:tests/unit/application/cli/test_run_tests_cmd.py†L34-L107】【F:docs/plan.md†L53-L79】【F:docs/task_notes.md†L90-L99】【F:docs/tasks.md†L203-L210】

## Testing
- `PYTEST_ADDOPTS="--no-cov" poetry run pytest tests/unit/testing/test_run_tests_cli_invocation.py`【f36e19†L1-L24】
- `PYTEST_ADDOPTS="--no-cov" poetry run pytest tests/unit/application/cli/test_run_tests_cmd.py`【9da047†L1-L27】

------
https://chatgpt.com/codex/tasks/task_e_68c9a36bc7908333b425d26fff7e75eb