### PR TITLE
test: cover webui layout display and run

### DIFF
--- a/tests/fixtures/fake_streamlit.py
+++ b/tests/fixtures/fake_streamlit.py
@@ -1,0 +1,104 @@
+"""Test doubles for Streamlit interactions."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+
+
+class FakeSessionState(dict):
+    """Dictionary-like session state supporting attribute access."""
+
+    def __getattr__(self, item: str) -> Any:
+        try:
+            return self[item]
+        except KeyError as exc:  # pragma: no cover - defensive fallback
+            raise AttributeError(item) from exc
+
+    def __setattr__(self, key: str, value: Any) -> None:
+        self[key] = value
+
+
+class FakeStreamlit:
+    """Lightweight Streamlit replacement capturing WebUI interactions."""
+
+    def __init__(self) -> None:
+        self.session_state = FakeSessionState()
+        self.markdown_calls: list[tuple[str, dict[str, Any]]] = []
+        self.write_calls: list[str] = []
+        self.error_calls: list[str] = []
+        self.info_calls: list[str] = []
+        self.success_calls: list[str] = []
+        self.warning_calls: list[str] = []
+        self.header_calls: list[str] = []
+        self.subheader_calls: list[str] = []
+        self.components_html_calls: list[tuple[str, dict[str, Any]]] = []
+        self.sidebar_title_calls: list[str] = []
+        self.sidebar_markdown_calls: list[tuple[str, dict[str, Any]]] = []
+        self.sidebar_radio_calls: list[tuple[str, tuple[str, ...], int]] = []
+        self.set_page_config_calls: list[dict[str, Any]] = []
+        self.set_page_config_exception: Exception | None = None
+        self.sidebar_radio_selection: str | None = None
+
+        self.components = SimpleNamespace(v1=SimpleNamespace(html=self._components_html))
+        self.sidebar = SimpleNamespace(
+            title=self._sidebar_title,
+            markdown=self._sidebar_markdown,
+            radio=self._sidebar_radio,
+        )
+
+    # ------------------------------------------------------------------
+    # Streamlit primitives
+    # ------------------------------------------------------------------
+    def set_page_config(self, **kwargs: Any) -> None:
+        self.set_page_config_calls.append(kwargs)
+        if self.set_page_config_exception is not None:
+            raise self.set_page_config_exception
+
+    def markdown(self, content: str, **kwargs: Any) -> None:
+        self.markdown_calls.append((content, kwargs))
+
+    def write(self, content: str) -> None:
+        self.write_calls.append(content)
+
+    def error(self, content: str) -> None:
+        self.error_calls.append(content)
+
+    def info(self, content: str) -> None:
+        self.info_calls.append(content)
+
+    def success(self, content: str) -> None:
+        self.success_calls.append(content)
+
+    def warning(self, content: str) -> None:
+        self.warning_calls.append(content)
+
+    def header(self, content: str) -> None:
+        self.header_calls.append(content)
+
+    def subheader(self, content: str) -> None:
+        self.subheader_calls.append(content)
+
+    # ------------------------------------------------------------------
+    # Sidebar helpers
+    # ------------------------------------------------------------------
+    def _sidebar_title(self, text: str) -> None:
+        self.sidebar_title_calls.append(text)
+
+    def _sidebar_markdown(self, text: str, **kwargs: Any) -> None:
+        self.sidebar_markdown_calls.append((text, kwargs))
+
+    def _sidebar_radio(self, label: str, options: list[str], index: int = 0) -> str:
+        self.sidebar_radio_calls.append((label, tuple(options), index))
+        if self.sidebar_radio_selection is not None:
+            return self.sidebar_radio_selection
+        return options[index]
+
+    # ------------------------------------------------------------------
+    # Components
+    # ------------------------------------------------------------------
+    def _components_html(self, content: str, **kwargs: Any) -> None:
+        self.components_html_calls.append((content, kwargs))
+
+
+__all__ = ["FakeSessionState", "FakeStreamlit"]

--- a/tests/integration/interface/test_webui_run_navigation.py
+++ b/tests/integration/interface/test_webui_run_navigation.py
@@ -1,0 +1,111 @@
+"""Medium-scope tests covering the WebUI ``run`` bootstrap and navigation hooks."""
+
+from __future__ import annotations
+
+import importlib
+import sys
+from typing import Any
+
+import pytest
+
+from tests.fixtures.fake_streamlit import FakeStreamlit
+
+pytestmark = [pytest.mark.medium]
+
+
+@pytest.fixture
+def webui_module(monkeypatch):
+    """Reload the WebUI module with a controlled Streamlit substitute."""
+
+    fake_streamlit = FakeStreamlit()
+    monkeypatch.setitem(sys.modules, "streamlit", fake_streamlit)
+
+    import devsynth.interface.webui as webui
+
+    importlib.reload(webui)
+    return webui, fake_streamlit
+
+
+def test_run_injects_assets_and_resets_navigation(monkeypatch, webui_module):
+    """``run`` injects resize hooks, CSS, and stabilises navigation defaults."""
+
+    webui, fake_streamlit = webui_module
+    created: dict[str, Any] = {}
+
+    class StubRouter:
+        def __init__(self, ui, pages, *_, **__):
+            self.ui = ui
+            self.pages = dict(pages)
+            self.default = next(iter(self.pages))
+            self.run_called = False
+            self.selected: str | None = None
+            created["instance"] = self
+
+        def run(self) -> None:
+            self.run_called = True
+            st = self.ui.streamlit
+            session_state = getattr(st, "session_state", None)
+            stored = None
+            if session_state is not None:
+                stored = getattr(session_state, "nav", None)
+                if hasattr(session_state, "get"):
+                    stored = session_state.get("nav", stored)
+                if stored not in self.pages:
+                    session_state.nav = self.default
+                    if hasattr(session_state, "__setitem__"):
+                        session_state["nav"] = self.default
+                self.selected = getattr(session_state, "nav", self.default)
+            else:
+                self.selected = self.default
+
+    monkeypatch.setattr(webui, "Router", StubRouter)
+
+    fake_streamlit.session_state.nav = "Missing"
+    fake_streamlit.session_state["nav"] = "Missing"
+
+    ui = webui.WebUI()
+    ui.run()
+
+    router = created["instance"]
+    assert router.run_called
+    assert router.selected == "Onboarding"
+
+    assert fake_streamlit.session_state.screen_width == 1200
+    assert fake_streamlit.session_state.screen_height == 800
+    assert fake_streamlit.session_state["nav"] == "Onboarding"
+
+    assert fake_streamlit.components_html_calls
+    script, kwargs = fake_streamlit.components_html_calls[0]
+    assert "updateScreenWidth" in script
+    assert kwargs.get("height") == 0
+
+    css_calls = [entry for entry in fake_streamlit.markdown_calls if "<style>" in entry[0]]
+    assert css_calls
+    assert css_calls[0][1].get("unsafe_allow_html") is True
+
+    assert fake_streamlit.sidebar_title_calls == ["DevSynth"]
+    assert any("devsynth-secondary" in text for text, _ in fake_streamlit.sidebar_markdown_calls)
+
+
+def test_run_handles_page_config_errors(monkeypatch, webui_module):
+    """Configuration failures surface through ``display_result`` without bootstrapping UI assets."""
+
+    webui, fake_streamlit = webui_module
+    fake_streamlit.set_page_config_exception = RuntimeError("blocked")
+
+    ui = webui.WebUI()
+    recorded: list[tuple[str, dict[str, Any]]] = []
+
+    def capture(message: str, **kwargs: Any) -> None:
+        recorded.append((message, kwargs))
+
+    monkeypatch.setattr(ui, "display_result", capture)
+
+    ui.run()
+
+    assert recorded == [("ERROR: blocked", {})]
+    assert fake_streamlit.set_page_config_calls == [
+        {"page_title": "DevSynth WebUI", "layout": "wide"}
+    ]
+    assert not fake_streamlit.components_html_calls
+    assert not fake_streamlit.markdown_calls

--- a/tests/unit/interface/test_webui_display_and_layout.py
+++ b/tests/unit/interface/test_webui_display_and_layout.py
@@ -1,0 +1,180 @@
+"""Unit tests covering WebUI layout selection and result rendering."""
+
+from __future__ import annotations
+
+import importlib
+import sys
+from typing import Any
+
+import pytest
+
+from tests.fixtures.fake_streamlit import FakeStreamlit
+
+pytestmark = [pytest.mark.fast]
+
+
+@pytest.fixture
+def webui_module(monkeypatch):
+    """Reload the WebUI module with a lightweight Streamlit substitute."""
+
+    fake_streamlit = FakeStreamlit()
+    monkeypatch.setitem(sys.modules, "streamlit", fake_streamlit)
+
+    import devsynth.interface.webui as webui
+
+    importlib.reload(webui)
+    return webui, fake_streamlit
+
+
+@pytest.mark.parametrize(
+    "width, expected",
+    [
+        (
+            500,
+            {
+                "columns": 1,
+                "sidebar_width": "100%",
+                "content_width": "100%",
+                "font_size": "small",
+                "padding": "0.5rem",
+                "is_mobile": True,
+            },
+        ),
+        (
+            800,
+            {
+                "columns": 2,
+                "sidebar_width": "30%",
+                "content_width": "70%",
+                "font_size": "medium",
+                "padding": "1rem",
+                "is_mobile": False,
+            },
+        ),
+        (
+            1200,
+            {
+                "columns": 3,
+                "sidebar_width": "20%",
+                "content_width": "80%",
+                "font_size": "medium",
+                "padding": "1.5rem",
+                "is_mobile": False,
+            },
+        ),
+        (
+            None,
+            {
+                "columns": 3,
+                "sidebar_width": "20%",
+                "content_width": "80%",
+                "font_size": "medium",
+                "padding": "1.5rem",
+                "is_mobile": False,
+            },
+        ),
+    ],
+)
+def test_get_layout_config_breakpoints(webui_module: tuple[Any, FakeStreamlit], width: int | None, expected: dict[str, Any]) -> None:
+    """``get_layout_config`` adapts layout metadata to screen width."""
+
+    webui, fake_streamlit = webui_module
+    if width is not None:
+        fake_streamlit.session_state.screen_width = width
+    else:
+        fake_streamlit.session_state.pop("screen_width", None)
+
+    layout = webui.WebUI().get_layout_config()
+    assert layout == expected
+
+
+def test_display_result_renders_markup_and_sanitizes(monkeypatch, webui_module):
+    """Markup content is converted to Markdown with sanitized payloads."""
+
+    webui, fake_streamlit = webui_module
+    sanitized_inputs: list[str] = []
+
+    def record_and_escape(text: str) -> str:
+        sanitized_inputs.append(text)
+        return text.replace("<danger>", "&lt;danger&gt;")
+
+    monkeypatch.setattr(webui, "sanitize_output", record_and_escape)
+
+    ui = webui.WebUI()
+    ui.display_result("[bold]Alert[/bold] with [red]danger[/red] <danger>")
+
+    assert sanitized_inputs == ["[bold]Alert[/bold] with [red]danger[/red] <danger>"]
+    assert fake_streamlit.markdown_calls, "Expected markdown rendering for markup content"
+
+    content, kwargs = fake_streamlit.markdown_calls[0]
+    assert "**Alert**" in content
+    assert '<span style="color:red">danger</span>' in content
+    assert "&lt;danger&gt;" in content
+    assert kwargs.get("unsafe_allow_html") is True
+    assert not fake_streamlit.write_calls
+
+
+def test_display_result_highlight_uses_info(monkeypatch, webui_module):
+    """Highlighted messages prefer ``st.info`` and still sanitize text."""
+
+    webui, fake_streamlit = webui_module
+    sanitized_inputs: list[str] = []
+
+    def sanitizer(text: str) -> str:
+        sanitized_inputs.append(text)
+        return f"sanitized::{text}"
+
+    monkeypatch.setattr(webui, "sanitize_output", sanitizer)
+
+    ui = webui.WebUI()
+    ui.display_result("Important <notice>", highlight=True)
+
+    assert sanitized_inputs == ["Important <notice>"]
+    assert fake_streamlit.info_calls == ["sanitized::Important <notice>"]
+    assert not fake_streamlit.write_calls
+
+
+def test_display_result_error_suggestions_and_docs(monkeypatch, webui_module):
+    """Error messages surface contextual suggestions and documentation links."""
+
+    webui, fake_streamlit = webui_module
+    sanitized_inputs: list[str] = []
+
+    def sanitizer(text: str) -> str:
+        sanitized_inputs.append(text)
+        return text
+
+    monkeypatch.setattr(webui, "sanitize_output", sanitizer)
+
+    ui = webui.WebUI()
+    message = "ERROR: File not found: config.yaml"
+    ui.display_result(message, message_type="error")
+
+    assert sanitized_inputs == [message]
+    assert fake_streamlit.error_calls == [message]
+
+    markdown_texts = [content for content, _kwargs in fake_streamlit.markdown_calls]
+    assert "**Suggestions:**" in markdown_texts
+    assert any("Check that the file path is correct" in text for text in markdown_texts)
+    assert "**Documentation:**" in markdown_texts
+    assert any("File Handling Guide" in text for text in markdown_texts)
+
+
+def test_display_result_heading_routes_to_header(monkeypatch, webui_module):
+    """Markdown headings are routed to the appropriate Streamlit heading APIs."""
+
+    webui, fake_streamlit = webui_module
+    sanitized_inputs: list[str] = []
+
+    def sanitizer(text: str) -> str:
+        sanitized_inputs.append(text)
+        return text
+
+    monkeypatch.setattr(webui, "sanitize_output", sanitizer)
+
+    ui = webui.WebUI()
+    ui.display_result("# Welcome to DevSynth")
+
+    assert sanitized_inputs == ["# Welcome to DevSynth"]
+    assert fake_streamlit.header_calls == ["Welcome to DevSynth"]
+    assert not fake_streamlit.markdown_calls


### PR DESCRIPTION
## Summary
- add a reusable FakeStreamlit test double for WebUI-focused suites
- cover WebUI.get_layout_config and display_result branches with fast unit tests
- exercise WebUI.run bootstrap, navigation defaults, and error handling in a medium integration test

## Testing
- poetry run pytest --no-cov tests/unit/interface/test_webui_display_and_layout.py
- poetry run pytest --no-cov tests/integration/interface/test_webui_run_navigation.py
- poetry run pytest --no-cov tests/unit/interface/test_webui_display_and_layout.py tests/integration/interface/test_webui_run_navigation.py

------
https://chatgpt.com/codex/tasks/task_e_68c9e7b35d6c8333b121929c06b845d2