### PR TITLE
Add logging and reasoning loop invariant coverage

### DIFF
--- a/docs/implementation/logging_invariants.md
+++ b/docs/implementation/logging_invariants.md
@@ -29,6 +29,18 @@ assert logger.name == "demo"
 
 Proof: [tests/integration/utils/test_logging_integration.py](../../tests/integration/utils/test_logging_integration.py) validates the configured project logger.
 
+## Handler Wiring Across Contexts
+
+CLI invocations preserve both console rendering and structured JSON output. `tests/unit/logging/test_logging_setup_contexts.py::test_cli_context_wires_console_and_json_file_handlers` configures the logger with environment overrides and asserts the file handler writes JSON payloads while the console handler retains the default formatter.
+
+## Console-Only Mode and Test Redirection
+
+Test harnesses set `DEVSYNTH_PROJECT_DIR` to sandbox filesystem writes. `tests/unit/logging/test_logging_setup_contexts.py::test_test_context_redirects_and_supports_console_only_toggle` demonstrates that `configure_logging` redirects absolute paths underneath the project directory and that toggling `DEVSYNTH_NO_FILE_LOGGING` removes the JSON file handler while console capture continues.
+
+## Manual JSON Toggle
+
+`tests/unit/logging/test_logging_setup_contexts.py::test_create_dir_toggle_disables_json_file_handler` verifies that explicitly setting `create_dir=False` disables the JSON file handler even without environment flags, satisfying scenarios where CLI utilities want console-only diagnostics.
+
 ## Warning Isolation
 
 Tests capture log output to avoid cross-test interference.

--- a/docs/implementation/reasoning_loop_invariants.md
+++ b/docs/implementation/reasoning_loop_invariants.md
@@ -35,6 +35,8 @@ for _ in range(3):
 assert phase is Phase.REFINE
 ```
 
+Unit coverage: `tests/unit/methodology/edrr/test_reasoning_loop_invariants.py::test_reasoning_loop_fallback_transitions_and_propagation` drives the loop without explicit `phase` hints and confirms the fallback transition map records `expand→differentiate→refine` deterministically.
+
 ## Synthesis Propagation
 
 If iteration *i* produces `synthesis_i`, the next iteration receives
@@ -42,7 +44,12 @@ If iteration *i* produces `synthesis_i`, the next iteration receives
 state.
 
 This behavior is verified by
-`tests/property/test_reasoning_loop_properties.py::test_reasoning_loop_propagates_synthesis`.
+`tests/property/test_reasoning_loop_properties.py::test_reasoning_loop_propagates_synthesis` and the deterministic
+`tests/unit/methodology/edrr/test_reasoning_loop_invariants.py::test_reasoning_loop_fallback_transitions_and_propagation`.
+
+## Recursion Safeguards
+
+`tests/unit/methodology/edrr/test_reasoning_loop_invariants.py::test_reasoning_loop_enforces_total_time_budget` demonstrates that `max_total_seconds` halts additional iterations, while `tests/unit/methodology/edrr/test_reasoning_loop_invariants.py::test_reasoning_loop_retries_until_success` covers the retry/backoff guard for transient failures.
 
 ## References
 

--- a/issues/Finalize-dialectical-reasoning.md
+++ b/issues/Finalize-dialectical-reasoning.md
@@ -28,6 +28,7 @@ This issue tracks tasks needed to finish the dialectical reasoning framework.
 - 2025-08-17: dependencies resolved; finalizing reasoning loop.
 
 - 2025-08-20: specification expanded; WSDE knowledge utilities link to it.
+- 2025-09-17: Added deterministic safeguards via `tests/unit/methodology/edrr/test_reasoning_loop_invariants.py::{test_reasoning_loop_enforces_total_time_budget,test_reasoning_loop_retries_until_success,test_reasoning_loop_fallback_transitions_and_propagation}` (seed: deterministic/no RNG) to cover recursion limits, retries, and synthesis propagation.
 
 ## References
 - Related: [Resolve remaining dialectical audit questions](archived/Resolve-remaining-dialectical-audit-questions.md)

--- a/issues/coverage-below-threshold.md
+++ b/issues/coverage-below-threshold.md
@@ -24,6 +24,7 @@ Coverage command exits successfully but reports only 13.68 % line coverage and
 
 ## Notes
 - Tasks `docs/tasks.md` items 13.3 and 13.4 remain unchecked pending resolution.
+- 2025-09-17: Added fast deterministic coverage via `tests/unit/logging/test_logging_setup_contexts.py::{test_cli_context_wires_console_and_json_file_handlers,test_test_context_redirects_and_supports_console_only_toggle,test_create_dir_toggle_disables_json_file_handler}` and `tests/unit/methodology/edrr/test_reasoning_loop_invariants.py::{test_reasoning_loop_enforces_total_time_budget,test_reasoning_loop_retries_until_success,test_reasoning_loop_fallback_transitions_and_propagation}` (seed: deterministic/no RNG) to exercise logging handler wiring and reasoning-loop safeguards.
 - Address flake8 lint failures, as they may contribute to test instability.
 - 2025-09-11: `poetry run pytest -q --cov-fail-under=90 -k "nonexistent_to_force_no_tests"` fails during test collection due to missing modules `faiss` and `chromadb`; coverage remains unverified.
 - 2025-09-19: `devsynth` installed; smoke and property tests pass. Full coverage run not executed this iteration; threshold remains unverified.

--- a/issues/logging-setup-utilities.md
+++ b/issues/logging-setup-utilities.md
@@ -15,6 +15,7 @@ Logging Setup Utilities are not yet implemented, limiting DevSynth's diagnostic 
 
 ## Progress
 - 2025-09-09: extracted from dialectical audit backlog.
+- 2025-09-17: Validated handler wiring and environment toggles via `tests/unit/logging/test_logging_setup_contexts.py::{test_cli_context_wires_console_and_json_file_handlers,test_test_context_redirects_and_supports_console_only_toggle,test_create_dir_toggle_disables_json_file_handler}` (seed: deterministic/no RNG).
 
 ## References
 - Specification: docs/specifications/logging_setup.md

--- a/tests/unit/logging/test_logging_setup_contexts.py
+++ b/tests/unit/logging/test_logging_setup_contexts.py
@@ -1,0 +1,214 @@
+from __future__ import annotations
+
+import importlib
+import json
+import logging
+from collections.abc import Iterator
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+from _pytest.logging import LogCaptureHandler
+
+
+@pytest.fixture()
+def logging_setup_module() -> Iterator[ModuleType]:
+    """Reload :mod:`devsynth.logging_setup` with a clean root logger."""
+
+    import devsynth.logging_setup as logging_setup
+
+    root_logger = logging.getLogger()
+    original_handlers = list(root_logger.handlers)
+    original_filters = list(root_logger.filters)
+    original_level = root_logger.level
+
+    for handler in root_logger.handlers[:]:
+        root_logger.removeHandler(handler)
+    for filt in root_logger.filters[:]:
+        root_logger.removeFilter(filt)
+
+    reloaded = importlib.reload(logging_setup)
+
+    try:
+        yield reloaded
+    finally:
+        root_logger = logging.getLogger()
+        for handler in root_logger.handlers[:]:
+            root_logger.removeHandler(handler)
+            if handler not in original_handlers:
+                try:
+                    handler.close()
+                except Exception:  # pragma: no cover - defensive cleanup
+                    pass
+        for filt in root_logger.filters[:]:
+            root_logger.removeFilter(filt)
+        root_logger.setLevel(original_level)
+        for handler in original_handlers:
+            root_logger.addHandler(handler)
+        for filt in original_filters:
+            root_logger.addFilter(filt)
+        importlib.reload(logging_setup)
+
+
+@pytest.mark.fast
+def test_cli_context_wires_console_and_json_file_handlers(
+    logging_setup_module: ModuleType,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """ReqID: LOG-CTX-01 — CLI wiring keeps console and JSON handlers aligned."""
+
+    logging_setup = logging_setup_module
+    monkeypatch.delenv("DEVSYNTH_PROJECT_DIR", raising=False)
+    monkeypatch.delenv("DEVSYNTH_NO_FILE_LOGGING", raising=False)
+    monkeypatch.setenv("DEVSYNTH_LOG_DIR", str(tmp_path / "cli-logs"))
+    monkeypatch.setenv("DEVSYNTH_LOG_FILENAME", "cli.jsonl")
+
+    logging_setup.configure_logging()
+
+    root_logger = logging.getLogger()
+
+    file_handlers = [
+        handler
+        for handler in root_logger.handlers
+        if isinstance(handler, logging.FileHandler)
+    ]
+    assert len(file_handlers) == 1, "Expected JSON file handler for CLI output."
+    file_handler = file_handlers[0]
+    assert isinstance(file_handler.formatter, logging_setup.JSONFormatter)
+    assert Path(file_handler.baseFilename).name == "cli.jsonl"
+
+    console_handlers = [
+        handler
+        for handler in root_logger.handlers
+        if isinstance(handler, logging.StreamHandler)
+        and not isinstance(handler, logging.FileHandler)
+    ]
+    assert len(console_handlers) == 1
+    assert (
+        getattr(console_handlers[0].formatter, "_fmt", None)
+        == logging_setup.DEFAULT_LOG_FORMAT
+    )
+
+    logger = logging_setup.DevSynthLogger("devsynth.tests.cli")
+    logger.info("cli run", extra={"mode": "cli"})
+
+    for handler in root_logger.handlers:
+        try:
+            handler.flush()
+        except Exception:  # pragma: no cover - defensive flush guard
+            pass
+
+    log_path = Path(logging_setup.get_log_file())
+    lines = log_path.read_text().splitlines()
+    payloads = [json.loads(line) for line in lines if line]
+    assert payloads, "Expected structured payload in CLI log file."
+    last = payloads[-1]
+    assert last["message"] == "cli run"
+    assert last["logger"] == "devsynth.tests.cli"
+    assert last["mode"] == "cli"
+
+
+@pytest.mark.fast
+def test_test_context_redirects_and_supports_console_only_toggle(
+    logging_setup_module: ModuleType,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """ReqID: LOG-CTX-02 — Test runs redirect logs and respect console-only toggles."""
+
+    logging_setup = logging_setup_module
+    project_dir = tmp_path / "project"
+    project_dir.mkdir(exist_ok=True)
+
+    monkeypatch.setenv("DEVSYNTH_PROJECT_DIR", str(project_dir))
+    monkeypatch.delenv("DEVSYNTH_NO_FILE_LOGGING", raising=False)
+
+    absolute_dir = Path.home() / "devsynth" / "logs"
+    logging_setup.configure_logging(log_dir=str(absolute_dir))
+
+    root_logger = logging.getLogger()
+    file_handlers = [
+        handler
+        for handler in root_logger.handlers
+        if isinstance(handler, logging.FileHandler)
+    ]
+    assert file_handlers, "File handler should be present before toggle."
+    redirected_path = Path(file_handlers[0].baseFilename)
+    assert str(redirected_path).startswith(str(project_dir))
+
+    logger = logging_setup.DevSynthLogger("devsynth.tests.redirect")
+    logger.info("redirected file message", extra={"phase": "refine"})
+    for handler in file_handlers:
+        handler.flush()
+
+    log_file_path = Path(file_handlers[0].baseFilename)
+    entries = [
+        json.loads(line) for line in log_file_path.read_text().splitlines() if line
+    ]
+    assert entries, "Expected redirected file log entries."
+    payload = entries[-1]
+    assert payload["phase"] == "refine"
+
+    monkeypatch.setenv("DEVSYNTH_NO_FILE_LOGGING", "1")
+    logging_setup.configure_logging(log_dir=str(absolute_dir))
+
+    root_logger = logging.getLogger()
+    console_only = all(
+        not isinstance(handler, logging.FileHandler) for handler in root_logger.handlers
+    )
+    assert console_only, "Console-only toggle should remove file handlers."
+
+    capture_handler = LogCaptureHandler()
+    capture_handler.setLevel(logging.INFO)
+    root_logger.addHandler(capture_handler)
+    try:
+        logging_setup.DevSynthLogger("devsynth.tests.console").info(
+            "console only", extra={"workflow": "test"}
+        )
+    finally:
+        root_logger.removeHandler(capture_handler)
+        capture_handler.close()
+
+    assert any(
+        record.name == "devsynth.tests.console"
+        and record.getMessage() == "console only"
+        for record in capture_handler.records
+    )
+
+
+@pytest.mark.fast
+def test_create_dir_toggle_disables_json_file_handler(
+    logging_setup_module: ModuleType,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """ReqID: LOG-CTX-03 — create_dir disables JSON handler; console logs persist."""
+
+    logging_setup = logging_setup_module
+    monkeypatch.delenv("DEVSYNTH_PROJECT_DIR", raising=False)
+    monkeypatch.delenv("DEVSYNTH_NO_FILE_LOGGING", raising=False)
+
+    logging_setup.configure_logging(log_dir=str(tmp_path / "manual"), create_dir=False)
+
+    assert all(
+        not isinstance(handler, logging.FileHandler)
+        for handler in logging.getLogger().handlers
+    )
+
+    root_logger = logging.getLogger()
+    capture_handler = LogCaptureHandler()
+    capture_handler.setLevel(logging.INFO)
+    root_logger.addHandler(capture_handler)
+    try:
+        logging_setup.DevSynthLogger("devsynth.tests.manual").info(
+            "manual toggle", extra={"mode": "manual"}
+        )
+    finally:
+        root_logger.removeHandler(capture_handler)
+        capture_handler.close()
+
+    assert capture_handler.records, "Console handler should capture manual toggle log."
+    last_record = capture_handler.records[-1]
+    assert last_record.name == "devsynth.tests.manual"
+    assert last_record.getMessage() == "manual toggle"


### PR DESCRIPTION
## Summary
- add fast logging setup tests that exercise CLI defaults, sandbox redirection, and console-only toggles
- introduce deterministic reasoning loop unit tests that cover time-bounded recursion, retry backoff, and synthesis propagation
- document the new proofs in invariant notes and link the deterministic test cases in related issues

## Testing
- `poetry run pre-commit run --files docs/implementation/logging_invariants.md docs/implementation/reasoning_loop_invariants.md issues/Finalize-dialectical-reasoning.md issues/coverage-below-threshold.md issues/logging-setup-utilities.md tests/unit/methodology/edrr/test_reasoning_loop_invariants.py tests/unit/logging/test_logging_setup_contexts.py`
- `poetry run devsynth run-tests --speed=fast` *(fails: ModuleNotFoundError: No module named 'devsynth')*
- `poetry run pytest tests/unit/logging/test_logging_setup_contexts.py tests/unit/methodology/edrr/test_reasoning_loop_invariants.py -m fast --no-cov`

------
https://chatgpt.com/codex/tasks/task_e_68ca2cb36970833384da179e6e186708