### PR TITLE
Document coverage instrumentation regression

### DIFF
--- a/docs/task_notes.md
+++ b/docs/task_notes.md
@@ -98,3 +98,12 @@ Current file condensed on 2025-09-15 to remove redundant 2025-09-13 entries whil
   - `poetry run pytest tests/unit/testing/test_run_tests_cli_invocation.py::test_run_tests_generates_coverage_totals tests/unit/application/cli/test_run_tests_cmd.py::test_cli_reports_coverage_percent` (new regression coverage suite).
 - Observations: `_ensure_coverage_artifacts()` now refuses to emit placeholders when `.coverage` is missing and the CLI surfaces actionable guidance. The regression tests confirm `test_reports/coverage.json` includes `totals.percent_covered`, meeting the ≥90 % gate precondition.
 - Next: Run the full aggregate profile once remaining coverage hot spots receive tests so the gate can pass without manual intervention.
+
+## Iteration 2025-09-17 – Coverage instrumentation regression resurfaced
+- Environment: Python 3.12.10 (`python --version`) with Poetry env `/root/.cache/pypoetry/virtualenvs/devsynth-MeXVnKii-py3.12`; reran `bash scripts/install_dev.sh` and confirmed `task --version` 3.45.3 afterward.【a5710f†L1-L2】【1c714f†L1-L3】
+- Commands:
+  - `bash scripts/install_dev.sh` (restored go-task and refreshed verification hooks).【c08481†L1-L4】
+  - `poetry run devsynth run-tests --smoke --speed=fast --no-parallel --maxfail=1` → success but printed "Coverage artifact generation skipped" and left `test_reports/coverage.json` absent.【d5fad8†L1-L4】
+  - `poetry run devsynth run-tests --speed=fast --speed=medium --no-parallel --report --maxfail=1` → exited with code 1 because `.coverage` was missing even though tests completed; coverage HTML/JSON not generated.【20dbec†L1-L5】【45de43†L1-L2】
+  - `jq '.totals.percent_covered' test_reports/coverage.json` before the regression cleaned the artifact → 20.78 % (last captured measurement prior to deletion).【cbc560†L1-L3】
+- Observations: Smoke and aggregate runs both drop `.coverage`; coverage gate cannot evaluate, blocking tasks 6.3, 13.3, 19.3, and §21.8/§21.11. Need to add regression tests ensuring `.coverage` persists when the CLI injects `-p pytest_cov` under `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1`.

--- a/issues/release-finalization-uat.md
+++ b/issues/release-finalization-uat.md
@@ -28,5 +28,6 @@ Progress:
 - 2025-09-15: `poetry run devsynth run-tests --speed=fast --speed=medium --no-parallel --report --maxfail=1` succeeded but coverage stayed at 13.68 % with empty HTML output; coverage remediation reopened (see docs/tasks.md §21 and issues/coverage-below-threshold.md).
 - 2025-09-15: Smoke profile run after reinstalling `devsynth` (`poetry install --with dev --all-extras`) emitted coverage warning (`totals.percent_covered` missing) and wrote empty coverage artifacts, confirming instrumentation gaps remain before UAT can proceed.
 - 2025-09-16: Full reinstall plus smoke and fast+medium runs reproduced the coverage warning and left `.coverage` missing; gating cannot proceed until instrumentation writes real totals (`poetry run devsynth run-tests --smoke --speed=fast --no-parallel --maxfail=1`, `poetry run devsynth run-tests --speed=fast --speed=medium --no-parallel --report --maxfail=1`).【63011a†L1-L4】【50195f†L1-L5】
+- 2025-09-17: Repeated smoke and fast+medium commands exit with "Coverage artifact generation skipped" and code 1 because `.coverage` is absent; last captured coverage JSON before cleanup reported only 20.78 %, so coverage remediation remains a release blocker.【d5fad8†L1-L4】【20dbec†L1-L5】【45de43†L1-L2】【cbc560†L1-L3】
 Resolution Evidence:
   - docs/tasks.md item 19


### PR DESCRIPTION
## Summary
- Documented the renewed 2025-09-17 coverage instrumentation failure, including command evidence and environment remediation steps, in the release readiness plan and task notes.【F:docs/plan.md†L5-L33】【F:docs/task_notes.md†L102-L109】
- Updated the actionable backlog with new coverage instrumentation fixes, regression tests, and proof backfill tasks to guide the next PR-sized efforts.【F:docs/tasks.md†L69-L207】【F:docs/tasks.md†L221-L224】
- Refreshed the coverage and release issues with the latest failing runs and concrete next actions to unblock v0.1.0a1.【F:issues/coverage-below-threshold.md†L4-L27】【F:issues/release-finalization-uat.md†L18-L32】

## Testing
- `poetry run devsynth run-tests --smoke --speed=fast --no-parallel --maxfail=1` *(passes with coverage artifacts missing)*【d5fad8†L1-L4】
- `poetry run devsynth run-tests --speed=fast --speed=medium --no-parallel --report --maxfail=1` *(fails: coverage artifacts missing)*【20dbec†L1-L5】

------
https://chatgpt.com/codex/tasks/task_e_68ca37f63768833380084a5408082b97