### PR TITLE
test: add coverage checks for run tests helpers

### DIFF
--- a/issues/coverage-below-threshold.md
+++ b/issues/coverage-below-threshold.md
@@ -72,6 +72,7 @@ Coverage command exits with a failure after tests pass because `.coverage` is mi
 - 2025-09-12: Coverage rerun via `poetry run devsynth run-tests --speed=fast --speed=medium --no-parallel --report` achieved 95% aggregate coverage; badge and documentation updated. Issue remains closed.
 - 2025-09-17: Output formatter invariants promoted to review with explicit spec, behavior, and unit evidence to anchor new regression cases for sanitization, styling, structured fallbacks, and command overrides.【F:docs/implementation/output_formatter_invariants.md†L1-L74】【F:docs/specifications/cross-interface-consistency.md†L1-L40】【F:tests/behavior/features/general/cross_interface_consistency.feature†L1-L40】【F:tests/unit/interface/test_output_formatter_core_behaviors.py†L14-L149】【F:tests/unit/interface/test_output_formatter_fallbacks.py†L28-L146】
 - 2025-10-07: Added targeted unit tests for provider system, WebUI, output formatter, WebUI bridge, logging, reasoning loop, and test runner; coverage remains below 90%.
+- 2025-09-17: Added fast regression tests for `devsynth.testing.run_tests` option parsing and coverage-artifact status helpers to prevent regressions in the CLI shim. Full `devsynth run-tests --target all-tests --speed=fast --speed=medium --no-parallel --report` still fails because pytest receives node IDs such as `integration/collaboration/test_role_reassignment_shared_memory.py` (missing the `tests/` prefix) during aggregated runs, so coverage artifacts were not regenerated this pass.
 
 ## Coverage Gap Analysis
 

--- a/tests/unit/testing/test_run_tests_coverage_status.py
+++ b/tests/unit/testing/test_run_tests_coverage_status.py
@@ -1,0 +1,109 @@
+"""Unit tests for :func:`devsynth.testing.run_tests.coverage_artifacts_status`."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+import devsynth.testing.run_tests as rt
+
+
+@pytest.mark.fast
+def test_coverage_status_reports_missing_json(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """Missing JSON should return ``False`` with a helpful reason."""
+
+    monkeypatch.setattr(rt, "COVERAGE_JSON_PATH", tmp_path / "cov.json")
+    monkeypatch.setattr(rt, "COVERAGE_HTML_DIR", tmp_path / "htmlcov")
+
+    ok, reason = rt.coverage_artifacts_status()
+    assert ok is False
+    assert str(tmp_path / "cov.json") in (reason or "")
+
+
+@pytest.mark.fast
+def test_coverage_status_flags_invalid_json(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """Malformed JSON surfaces a descriptive message."""
+
+    json_path = tmp_path / "coverage.json"
+    json_path.write_text("{not-json}")
+    html_dir = tmp_path / "htmlcov"
+    html_dir.mkdir()
+    (html_dir / "index.html").write_text("<!doctype html><title>coverage</title>")
+
+    monkeypatch.setattr(rt, "COVERAGE_JSON_PATH", json_path)
+    monkeypatch.setattr(rt, "COVERAGE_HTML_DIR", html_dir)
+
+    ok, reason = rt.coverage_artifacts_status()
+    assert ok is False
+    assert "invalid" in (reason or "").lower()
+
+
+@pytest.mark.fast
+def test_coverage_status_requires_totals(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """JSON without ``totals.percent_covered`` is rejected."""
+
+    json_path = tmp_path / "coverage.json"
+    json_path.write_text(json.dumps({"meta": {}}))
+    html_dir = tmp_path / "htmlcov"
+    html_dir.mkdir()
+    (html_dir / "index.html").write_text("<!doctype html><title>coverage</title>")
+
+    monkeypatch.setattr(rt, "COVERAGE_JSON_PATH", json_path)
+    monkeypatch.setattr(rt, "COVERAGE_HTML_DIR", html_dir)
+
+    ok, reason = rt.coverage_artifacts_status()
+    assert ok is False
+    assert "totals" in (reason or "")
+
+
+@pytest.mark.fast
+def test_coverage_status_requires_html_index(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """Missing HTML index is surfaced."""
+
+    json_path = tmp_path / "coverage.json"
+    json_path.write_text(json.dumps({"totals": {"percent_covered": 91.0}}))
+
+    monkeypatch.setattr(rt, "COVERAGE_JSON_PATH", json_path)
+    monkeypatch.setattr(rt, "COVERAGE_HTML_DIR", tmp_path / "htmlcov")
+
+    ok, reason = rt.coverage_artifacts_status()
+    assert ok is False
+    assert "html" in (reason or "").lower()
+
+
+@pytest.mark.fast
+def test_coverage_status_rejects_empty_html(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """HTML indicating no coverage data should fail the status check."""
+
+    json_path = tmp_path / "coverage.json"
+    json_path.write_text(json.dumps({"totals": {"percent_covered": 93.0}}))
+    html_dir = tmp_path / "htmlcov"
+    html_dir.mkdir()
+    (html_dir / "index.html").write_text("No coverage data available")
+
+    monkeypatch.setattr(rt, "COVERAGE_JSON_PATH", json_path)
+    monkeypatch.setattr(rt, "COVERAGE_HTML_DIR", html_dir)
+
+    ok, reason = rt.coverage_artifacts_status()
+    assert ok is False
+    assert "no recorded data" in (reason or "").lower()
+
+
+@pytest.mark.fast
+def test_coverage_status_success_path(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """Valid JSON and HTML return ``True`` and ``None``."""
+
+    json_path = tmp_path / "coverage.json"
+    json_path.write_text(json.dumps({"totals": {"percent_covered": 97.5}}))
+    html_dir = tmp_path / "htmlcov"
+    html_dir.mkdir()
+    (html_dir / "index.html").write_text("<!doctype html><p>Coverage OK</p>")
+
+    monkeypatch.setattr(rt, "COVERAGE_JSON_PATH", json_path)
+    monkeypatch.setattr(rt, "COVERAGE_HTML_DIR", html_dir)
+
+    ok, reason = rt.coverage_artifacts_status()
+    assert ok is True
+    assert reason is None

--- a/tests/unit/testing/test_run_tests_option_parsing.py
+++ b/tests/unit/testing/test_run_tests_option_parsing.py
@@ -1,0 +1,41 @@
+"""Option parsing helpers for :mod:`devsynth.testing.run_tests`."""
+
+from __future__ import annotations
+
+import pytest
+
+import devsynth.testing.run_tests as rt
+
+
+@pytest.mark.fast
+def test_parse_pytest_addopts_handles_balanced_and_unbalanced_quotes() -> None:
+    """Balanced strings use :mod:`shlex` while malformed ones fallback to split."""
+
+    tokens = rt._parse_pytest_addopts("-k 'alpha beta' --maxfail=1")
+    assert tokens == ["-k", "alpha beta", "--maxfail=1"]
+
+    fallback = rt._parse_pytest_addopts('--flag "unterminated')
+    assert fallback == ["--flag", '"unterminated']
+
+    assert rt._parse_pytest_addopts(None) == []
+    assert rt._parse_pytest_addopts("   ") == []
+
+
+@pytest.mark.fast
+def test_addopts_has_plugin_detects_split_and_concatenated_forms() -> None:
+    """Both ``-p plugin`` and ``-pplugin`` should be recognized."""
+
+    tokens = ["-p", "pytest_cov", "-pno:cov", "--maxfail=1"]
+    assert rt._addopts_has_plugin(tokens, "pytest_cov") is True
+    assert rt._addopts_has_plugin(tokens, "no:cov") is True
+    assert rt._addopts_has_plugin(tokens, "missing") is False
+
+
+@pytest.mark.fast
+def test_coverage_plugin_disabled_detects_common_overrides() -> None:
+    """Explicit disables should prevent pytest-cov from being injected."""
+
+    assert rt._coverage_plugin_disabled(["--no-cov"]) is True
+    assert rt._coverage_plugin_disabled(["-p", "no:cov"]) is True
+    assert rt._coverage_plugin_disabled(["-pno:pytest_cov"]) is True
+    assert rt._coverage_plugin_disabled(["-k", "test_something"]) is False


### PR DESCRIPTION
## Summary
- add focused unit tests for run_tests option parsing helpers
- exercise coverage_artifacts_status for the common failure and success paths
- note progress and remaining CLI failure in issues/coverage-below-threshold.md

## Testing
- PYTEST_ADDOPTS="--cov-fail-under=0" poetry run pytest tests/unit/testing/test_run_tests_option_parsing.py tests/unit/testing/test_run_tests_coverage_status.py -q
- PYTEST_ADDOPTS="--maxfail=1" poetry run devsynth run-tests --target all-tests --speed=fast --speed=medium --no-parallel --report > run_tests.log 2>&1
- poetry run python scripts/verify_coverage_threshold.py

------
https://chatgpt.com/codex/tasks/task_e_68caf6da2d148333887f675fc85d9ad3