### PR TITLE
Add EDRR reasoning loop retry and phase tests

### DIFF
--- a/tests/unit/methodology/edrr/test_reasoning_loop.py
+++ b/tests/unit/methodology/edrr/test_reasoning_loop.py
@@ -1,15 +1,24 @@
+from __future__ import annotations
+
+import sys
+import types
+
 import pytest
 
-from devsynth.methodology.edrr.reasoning_loop import Phase, reasoning_loop
+import devsynth.methodology.edrr.reasoning_loop as rl
+from devsynth.methodology.edrr.reasoning_loop import Phase
 
 
 @pytest.mark.fast
 def test_reasoning_loop_completes_with_deterministic_seed(monkeypatch):
+    """Basic completion still works when the apply function is patched.
+
+    ReqID: N/A"""
+
     calls = {"count": 0}
 
     def fake_apply(wsde_team, task, critic_agent, memory_integration):
         calls["count"] += 1
-        # Simulate progress then completion with phase info
         if calls["count"] == 1:
             return {
                 "status": "in_progress",
@@ -23,16 +32,12 @@ def test_reasoning_loop_completes_with_deterministic_seed(monkeypatch):
             "phase": "refine",
         }
 
-    # Patch the internal function used by reasoning_loop
-    import devsynth.methodology.edrr.reasoning_loop as rl
+    monkeypatch.setattr(rl, "_import_apply_dialectical_reasoning", lambda: fake_apply)
 
-    monkeypatch.setattr(rl, "_apply_dialectical_reasoning", fake_apply)
-
-    out = reasoning_loop(
+    out = rl.reasoning_loop(
         wsde_team=None,
         task={"problem": "X"},
         critic_agent=None,
-        memory_integration=None,
         phase=Phase.REFINE,
         max_iterations=5,
         deterministic_seed=123,
@@ -41,6 +46,130 @@ def test_reasoning_loop_completes_with_deterministic_seed(monkeypatch):
 
     assert len(out) == 2
     assert out[-1]["status"] == "completed"
-    # Ensure synthesis propagated
     assert out[0]["synthesis"] == "partial"
     assert out[1]["synthesis"] == "final"
+
+
+@pytest.mark.fast
+def test_reasoning_loop_phase_transitions_and_memory_integration(monkeypatch):
+    """Next-phase overrides, synthesis propagation, and seeding are honored.
+
+    ReqID: N/A"""
+
+    results_sequence = [
+        {
+            "status": "in_progress",
+            "synthesis": {"content": "step-1"},
+            "phase": "invalid-phase",
+            "next_phase": "differentiate",
+        },
+        {
+            "status": "in_progress",
+            "synthesis": {"content": "step-2"},
+            "phase": "still-invalid",
+            "next_phase": "not-a-phase",
+        },
+        {
+            "status": "completed",
+            "synthesis": {"content": "step-3"},
+            "phase": "refine",
+            "next_phase": "differentiate",
+        },
+    ]
+
+    class MemoryStub:
+        def __init__(self) -> None:
+            self.calls: list[tuple[dict[str, object], dict[str, object]]] = []
+
+        def store_dialectical_result(
+            self, task: dict[str, object], result: dict[str, object]
+        ) -> None:
+            self.calls.append((task.copy(), result))
+
+    class CoordinatorStub:
+        def __init__(self) -> None:
+            self.records: list[tuple[str, dict[str, object]]] = []
+            self.failures: list[object] = []
+
+        def record_consensus_failure(self, exc) -> None:  # pragma: no cover - guard
+            self.failures.append(exc)
+
+        def record_expand_results(self, result):
+            self.records.append(("expand", result))
+
+        def record_differentiate_results(self, result):
+            self.records.append(("differentiate", result))
+
+        def record_refine_results(self, result):
+            self.records.append(("refine", result))
+
+    call_log: list[dict[str, object]] = []
+    memory = MemoryStub()
+    coordinator = CoordinatorStub()
+
+    def scripted_apply(wsde_team, task, critic_agent, memory_integration):
+        index = len(call_log)
+        call_log.append({"task": task, "memory": memory_integration})
+        assert memory_integration is memory
+        result = results_sequence[index]
+        memory_integration.store_dialectical_result(task, result)
+        return result
+
+    monkeypatch.setattr(
+        rl, "_import_apply_dialectical_reasoning", lambda: scripted_apply
+    )
+
+    import random
+
+    random_seeds: list[int] = []
+
+    def fake_random_seed(value: int) -> None:
+        random_seeds.append(value)
+
+    monkeypatch.setattr(random, "seed", fake_random_seed)
+
+    numpy_seeds: list[int] = []
+    fake_numpy_random = types.ModuleType("numpy.random")
+
+    def fake_numpy_seed(value: int) -> None:
+        numpy_seeds.append(value)
+
+    fake_numpy_random.seed = fake_numpy_seed
+    fake_numpy = types.ModuleType("numpy")
+    fake_numpy.random = fake_numpy_random
+    monkeypatch.setitem(sys.modules, "numpy", fake_numpy)
+    monkeypatch.setitem(sys.modules, "numpy.random", fake_numpy_random)
+
+    initial_task = {"problem": "X", "solution": {"content": "initial"}}
+
+    results = rl.reasoning_loop(
+        wsde_team=None,
+        task=initial_task,
+        critic_agent=None,
+        memory_integration=memory,
+        phase=Phase.EXPAND,
+        coordinator=coordinator,
+        deterministic_seed=99,
+        max_iterations=5,
+    )
+
+    assert results == results_sequence
+    assert [entry[0] for entry in coordinator.records] == [
+        "expand",
+        "differentiate",
+        "refine",
+    ]
+    assert coordinator.failures == []
+
+    assert [call["memory"] for call in call_log] == [memory, memory, memory]
+    assert call_log[1]["task"]["solution"] == results_sequence[0]["synthesis"]
+    assert call_log[2]["task"]["solution"] == results_sequence[1]["synthesis"]
+
+    assert [task["solution"] for task, _ in memory.calls] == [
+        {"content": "initial"},
+        {"content": "step-1"},
+        {"content": "step-2"},
+    ]
+
+    assert random_seeds == [99]
+    assert numpy_seeds == [99]

--- a/tests/unit/methodology/edrr/test_reasoning_loop_retry.py
+++ b/tests/unit/methodology/edrr/test_reasoning_loop_retry.py
@@ -1,8 +1,9 @@
-import importlib
+from __future__ import annotations
 
 import pytest
 
-rl = importlib.import_module("devsynth.methodology.edrr.reasoning_loop")
+import devsynth.methodology.edrr.reasoning_loop as rl
+from devsynth.exceptions import ConsensusError
 
 
 @pytest.mark.fast
@@ -10,6 +11,7 @@ def test_reasoning_loop_retries_on_transient(monkeypatch):
     """Transient errors retry once before succeeding.
 
     ReqID: N/A"""
+
     calls = {"count": 0}
 
     def flaky(wsde, task, critic, memory):
@@ -18,8 +20,114 @@ def test_reasoning_loop_retries_on_transient(monkeypatch):
             raise RuntimeError("temp")
         return {"status": "completed", "phase": "refine"}
 
-    monkeypatch.setattr(rl, "_apply_dialectical_reasoning", flaky)
+    monkeypatch.setattr(rl, "_import_apply_dialectical_reasoning", lambda: flaky)
     monkeypatch.setattr(rl.time, "sleep", lambda s: None)
+
     out = rl.reasoning_loop(None, {}, None, retry_attempts=1)
+
     assert len(out) == 1
     assert calls["count"] == 2
+
+
+@pytest.mark.fast
+def test_reasoning_loop_retry_clamps_backoff_and_respects_budget(monkeypatch):
+    """Exponential backoff honors the total budget by clamping sleep.
+
+    ReqID: N/A"""
+
+    call_count = {"value": 0}
+
+    def transient_then_progress(wsde, task, critic, memory):
+        call_count["value"] += 1
+        if call_count["value"] < 3:
+            raise RuntimeError("flaky")
+        return {"status": "in_progress", "phase": "refine"}
+
+    monkeypatch.setattr(
+        rl, "_import_apply_dialectical_reasoning", lambda: transient_then_progress
+    )
+
+    clock = {"value": 0.0}
+    sleep_calls: list[float] = []
+
+    def fake_monotonic() -> float:
+        return clock["value"]
+
+    def fake_sleep(duration: float) -> None:
+        sleep_calls.append(duration)
+        clock["value"] += duration
+
+    monkeypatch.setattr(rl.time, "monotonic", fake_monotonic)
+    monkeypatch.setattr(rl.time, "sleep", fake_sleep)
+
+    results = rl.reasoning_loop(
+        wsde_team=None,
+        task={"problem": "x"},
+        critic_agent=None,
+        max_iterations=5,
+        retry_attempts=2,
+        retry_backoff=0.1,
+        max_total_seconds=0.15,
+    )
+
+    assert call_count["value"] == 3  # two transient failures + success
+    assert sleep_calls == pytest.approx([0.1, 0.05])
+    assert results == [{"status": "in_progress", "phase": "refine"}]
+
+
+@pytest.mark.fast
+def test_reasoning_loop_records_consensus_failure_via_coordinator(monkeypatch):
+    """ConsensusError stops the loop and notifies the coordinator.
+
+    ReqID: N/A"""
+
+    error = ConsensusError("no consensus")
+
+    def always_fail(*_args, **_kwargs):
+        raise error
+
+    monkeypatch.setattr(rl, "_import_apply_dialectical_reasoning", lambda: always_fail)
+
+    class StubCoordinator:
+        def __init__(self) -> None:
+            self.failures: list[ConsensusError] = []
+            self.records: list[tuple[str, dict[str, str]]] = []
+
+        def record_consensus_failure(self, exc: ConsensusError) -> None:
+            self.failures.append(exc)
+
+        def record_expand_results(self, result):  # pragma: no cover - should not run
+            self.records.append(("expand", result))
+
+        def record_differentiate_results(self, result):  # pragma: no cover
+            self.records.append(("differentiate", result))
+
+        def record_refine_results(self, result):  # pragma: no cover
+            self.records.append(("refine", result))
+
+    coordinator = StubCoordinator()
+
+    results = rl.reasoning_loop(None, {}, None, coordinator=coordinator)
+
+    assert results == []
+    assert coordinator.failures == [error]
+    assert coordinator.records == []
+
+
+@pytest.mark.fast
+def test_reasoning_loop_logs_consensus_failure_without_coordinator(monkeypatch, caplog):
+    """ConsensusError without a coordinator is logged and stops the loop.
+
+    ReqID: N/A"""
+
+    def always_fail(*_args, **_kwargs):
+        raise ConsensusError("disagreement")
+
+    monkeypatch.setattr(rl, "_import_apply_dialectical_reasoning", lambda: always_fail)
+
+    caplog.set_level("ERROR", rl.logger.logger.name)
+
+    results = rl.reasoning_loop(None, {}, None)
+
+    assert results == []
+    assert any("Consensus failure" in record.message for record in caplog.records)


### PR DESCRIPTION
## Summary
- add deterministic retry and budget coverage for the EDRR reasoning loop, including consensus failure handling
- cover phase progression, synthesis propagation, memory integration, and deterministic seeding behaviors in the reasoning loop

## Testing
- poetry run pytest --no-cov tests/unit/methodology/edrr/test_reasoning_loop_retry.py tests/unit/methodology/edrr/test_reasoning_loop.py
- poetry run python scripts/verify_test_markers.py
- poetry run pre-commit run --files tests/unit/methodology/edrr/test_reasoning_loop_retry.py tests/unit/methodology/edrr/test_reasoning_loop.py

------
https://chatgpt.com/codex/tasks/task_e_68cb2324cb7c83339c8880f0f65aaf19