### PR TITLE
test: gate optional backend tests behind resource flags

### DIFF
--- a/tests/fixtures/resources.py
+++ b/tests/fixtures/resources.py
@@ -37,3 +37,11 @@ def is_property_testing_enabled() -> bool:
         return bool(data.get("formalVerification", {}).get("propertyTesting", False))
     except Exception:
         return False
+
+
+def resource_flag_enabled(resource: str) -> bool:
+    """Return ``True`` when a resource flag explicitly enables the resource."""
+
+    env_name = f"DEVSYNTH_RESOURCE_{resource.upper()}_AVAILABLE"
+    value = os.environ.get(env_name, "").strip().lower()
+    return value in {"1", "true", "yes"}

--- a/tests/unit/application/memory/test_sync_across_backends.py
+++ b/tests/unit/application/memory/test_sync_across_backends.py
@@ -1,11 +1,20 @@
-import asyncio
-import os
-
 import pytest
 
+from tests.fixtures.resources import resource_flag_enabled
+
+if not resource_flag_enabled("chromadb"):
+    pytest.skip(
+        "ChromaDB resource not enabled via DEVSYNTH_RESOURCE_CHROMADB_AVAILABLE",
+        allow_module_level=True,
+    )
+
+if not resource_flag_enabled("kuzu"):
+    pytest.skip(
+        "Kuzu resource not enabled via DEVSYNTH_RESOURCE_KUZU_AVAILABLE",
+        allow_module_level=True,
+    )
+
 pytest.importorskip("chromadb")
-os.environ.setdefault("ENABLE_CHROMADB", "1")
-os.environ.setdefault("DEVSYNTH_NO_FILE_LOGGING", "1")
 from devsynth.adapters.kuzu_memory_store import KuzuMemoryStore
 from devsynth.application.memory.chromadb_store import ChromaDBStore
 from devsynth.application.memory.kuzu_store import KuzuStore
@@ -13,6 +22,12 @@ from devsynth.application.memory.memory_manager import MemoryManager
 from devsynth.application.memory.sync_manager import SyncManager
 from devsynth.application.memory.tinydb_store import TinyDBStore
 from devsynth.domain.models.memory import MemoryItem, MemoryType
+
+
+pytestmark = [
+    pytest.mark.requires_resource("chromadb"),
+    pytest.mark.requires_resource("kuzu"),
+]
 
 
 @pytest.fixture


### PR DESCRIPTION
## Summary
- add a reusable helper to detect resource flags via DEVSYNTH_RESOURCE_* env vars
- guard the basic CRUD adapter suite with per-backend resource markers and flag checks
- require chromadb and kuzu flags for the sync-across-backends suite to avoid running offline by default

## Testing
- poetry run python scripts/verify_test_markers.py

------
https://chatgpt.com/codex/tasks/task_e_68cb7697b0e883339f5691f91fa90571