### PR TITLE
test: harden WebUI fast run fixture

### DIFF
--- a/tests/unit/interface/test_webui_run_fast.py
+++ b/tests/unit/interface/test_webui_run_fast.py
@@ -12,7 +12,7 @@ from devsynth.interface.webui import WebUI
 
 
 @pytest.fixture
-def streamlit_router_stub():
+def streamlit_router_stub(monkeypatch: pytest.MonkeyPatch):
     """Provide a stubbed Streamlit module and Router replacement."""
 
     from devsynth.interface import webui as webui_module
@@ -48,7 +48,7 @@ def streamlit_router_stub():
         markdown=MagicMock(),
     )
 
-    sys.modules["streamlit"] = st
+    monkeypatch.setitem(sys.modules, "streamlit", st)
 
     class RouterStub:
         instances: list["RouterStub"] = []
@@ -64,7 +64,7 @@ def streamlit_router_stub():
 
     RouterStub.instances = []
 
-    webui_module.Router = RouterStub
+    monkeypatch.setattr(webui_module, "Router", RouterStub)
     webui_module._STREAMLIT = None
 
     try:


### PR DESCRIPTION
## Summary
- extend the streamlit_router_stub fixture to use pytest's monkeypatch for sys.modules and Router replacement while still restoring prior globals

## Testing
- PYTEST_ADDOPTS=--no-cov poetry run pytest tests/unit/interface/test_webui_run_fast.py --maxfail=1

------
https://chatgpt.com/codex/tasks/task_e_68cd901f0a8c8333a60f3f7f371b4c04