### PR TITLE
test: gate provider-system unit tests on resource flags

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -191,6 +191,18 @@ To run optional backends locally, install extras and set resource flags explicit
   poetry run devsynth run-tests --speed=fast -m "requires_resource('openai') and not slow"
   ```
 
+- Provider-system adapters (unit coverage for HTTP clients):
+
+  ```bash
+  export DEVSYNTH_RESOURCE_OPENAI_AVAILABLE=true   # enable OpenAI adapter paths
+  export DEVSYNTH_RESOURCE_LMSTUDIO_AVAILABLE=true # enable LM Studio adapter paths
+  poetry run pytest -m "requires_resource('openai') or requires_resource('lmstudio')"
+  ```
+
+  Tests that exercise the real `requests`/`httpx` branches in
+  `devsynth.adapters.provider_system` carry these markers and remain skipped until
+  the corresponding flag(s) are set.
+
 Notes:
 - Resource markers: @pytest.mark.requires_resource("<name>") map to DEVSYNTH_RESOURCE_<NAME>_AVAILABLE flags.
 - Extras ↔ flags mapping: see docs/developer_guides/testing.md (Quick Reference: Extras ↔ Resource flags). For example, 'retrieval' → FAISS/KUZU flags; 'chromadb' → CHROMADB flag; 'memory' → TINYDB/DUCKDB/LMDB/KUZU/FAISS/CHROMADB flags; 'lmstudio' → LMSTUDIO flag; 'webui' → WEBUI flag.

--- a/tests/unit/adapters/providers/test_embeddings.py
+++ b/tests/unit/adapters/providers/test_embeddings.py
@@ -14,6 +14,7 @@ from devsynth.adapters.provider_system import (
 
 
 @pytest.mark.medium
+@pytest.mark.requires_resource("openai")
 def test_openai_provider_embed_calls_api_succeeds():
     """Test that openai provider embed calls api succeeds.
 
@@ -32,6 +33,7 @@ def test_openai_provider_embed_calls_api_succeeds():
 
 @pytest.mark.anyio
 @pytest.mark.medium
+@pytest.mark.requires_resource("openai")
 async def test_openai_provider_aembed_calls_api():
     mock_response = MagicMock()
     mock_response.json.return_value = {"data": [{"embedding": [0.3, 0.4]}]}
@@ -50,6 +52,7 @@ async def test_openai_provider_aembed_calls_api():
 
 
 @pytest.mark.medium
+@pytest.mark.requires_resource("lmstudio")
 def test_lmstudio_provider_embed_calls_api_succeeds():
     """Test that lmstudio provider embed calls api succeeds.
 
@@ -67,6 +70,7 @@ def test_lmstudio_provider_embed_calls_api_succeeds():
 
 
 @pytest.mark.medium
+@pytest.mark.requires_resource("lmstudio")
 def test_embed_function_success_with_lmstudio_succeeds():
     """Test that embed function success with lmstudio succeeds.
 
@@ -87,6 +91,7 @@ def test_embed_function_success_with_lmstudio_succeeds():
 
 @pytest.mark.anyio
 @pytest.mark.medium
+@pytest.mark.requires_resource("lmstudio")
 async def test_aembed_function_success_with_lmstudio():
     provider = LMStudioProvider(endpoint="http://localhost:1234")
     async_client = AsyncMock()
@@ -109,6 +114,7 @@ async def test_aembed_function_success_with_lmstudio():
 
 
 @pytest.mark.slow
+@pytest.mark.requires_resource("lmstudio")
 def test_lmstudio_provider_embed_error_succeeds():
     """Test that lmstudio provider embed error succeeds.
 
@@ -124,6 +130,7 @@ def test_lmstudio_provider_embed_error_succeeds():
 
 @pytest.mark.anyio
 @pytest.mark.medium
+@pytest.mark.requires_resource("lmstudio")
 async def test_aembed_function_error_propagation():
     provider = LMStudioProvider(endpoint="http://localhost:1234")
     async_client = AsyncMock()

--- a/tests/unit/adapters/providers/test_provider_factory.py
+++ b/tests/unit/adapters/providers/test_provider_factory.py
@@ -36,6 +36,7 @@ def _config_with_openai_key():
 
 
 @pytest.mark.medium
+@pytest.mark.requires_resource("openai")
 def test_explicit_openai_missing_key_raises(monkeypatch):
     """Explicit OpenAI selection without API key raises an error.
 
@@ -49,6 +50,7 @@ def test_explicit_openai_missing_key_raises(monkeypatch):
 
 
 @pytest.mark.medium
+@pytest.mark.requires_resource("lmstudio")
 def test_create_provider_default_with_missing_key_succeeds(monkeypatch):
     """Test that create provider default with missing key succeeds.
 
@@ -62,6 +64,7 @@ def test_create_provider_default_with_missing_key_succeeds(monkeypatch):
 
 
 @pytest.mark.medium
+@pytest.mark.requires_resource("openai")
 def test_create_provider_openai_succeeds(monkeypatch):
     """Test that create provider openai succeeds.
 

--- a/tests/unit/adapters/test_provider_factory.py
+++ b/tests/unit/adapters/test_provider_factory.py
@@ -12,6 +12,7 @@ from devsynth.adapters.provider_system import (
 
 
 @pytest.mark.medium
+@pytest.mark.requires_resource("lmstudio")
 def test_create_provider_env_fallback_has_expected(monkeypatch, caplog):
     """ProviderFactory should fall back to LMStudio when OPENAI_API_KEY is missing.
 
@@ -26,6 +27,7 @@ def test_create_provider_env_fallback_has_expected(monkeypatch, caplog):
 
 
 @pytest.mark.medium
+@pytest.mark.requires_resource("openai")
 def test_explicit_openai_missing_key_raises_error(monkeypatch):
     """Explicitly requesting OpenAI without an API key should raise an error.
 

--- a/tests/unit/adapters/test_provider_factory_env_vars.py
+++ b/tests/unit/adapters/test_provider_factory_env_vars.py
@@ -9,6 +9,7 @@ from devsynth.adapters.provider_system import (
 
 
 @pytest.mark.medium
+@pytest.mark.requires_resource("openai")
 def test_env_provider_openai_succeeds(monkeypatch):
     """Test that env provider openai succeeds.
 
@@ -21,6 +22,7 @@ def test_env_provider_openai_succeeds(monkeypatch):
 
 
 @pytest.mark.medium
+@pytest.mark.requires_resource("lmstudio")
 def test_env_provider_lmstudio_succeeds(monkeypatch):
     """Test that env provider lmstudio succeeds.
 

--- a/tests/unit/adapters/test_provider_system.py
+++ b/tests/unit/adapters/test_provider_system.py
@@ -268,8 +268,16 @@ def test_base_provider_methods_succeeds():
 @pytest.mark.parametrize(
     "provider_class,config",
     [
-        (OpenAIProvider, {"api_key": "test_key", "model": "gpt-4"}),
-        (LMStudioProvider, {"endpoint": "http://test-endpoint"}),
+        pytest.param(
+            OpenAIProvider,
+            {"api_key": "test_key", "model": "gpt-4"},
+            marks=pytest.mark.requires_resource("openai"),
+        ),
+        pytest.param(
+            LMStudioProvider,
+            {"endpoint": "http://test-endpoint"},
+            marks=pytest.mark.requires_resource("lmstudio"),
+        ),
     ],
 )
 @pytest.mark.medium
@@ -389,6 +397,7 @@ def test_get_provider_config_has_expected():
 
 @patch("requests.post")
 @pytest.mark.medium
+@pytest.mark.requires_resource("openai")
 def test_openai_provider_complete_has_expected(mock_post):
     """Test the complete method of OpenAIProvider.
 
@@ -413,6 +422,7 @@ def test_openai_provider_complete_has_expected(mock_post):
 
 @patch("requests.post")
 @pytest.mark.medium
+@pytest.mark.requires_resource("openai")
 def test_openai_provider_complete_error_raises_error(mock_post):
     """Test error handling in the complete method of OpenAIProvider.
 
@@ -429,6 +439,7 @@ def test_openai_provider_complete_error_raises_error(mock_post):
 
 @patch("requests.post")
 @pytest.mark.medium
+@pytest.mark.requires_resource("openai")
 def test_openai_provider_complete_retry_has_expected(mock_post):
     """Test retry mechanism in the complete method of OpenAIProvider.
 
@@ -475,6 +486,7 @@ def test_openai_provider_complete_retry_has_expected(mock_post):
 
 @patch("httpx.AsyncClient.post")
 @pytest.mark.medium
+@pytest.mark.requires_resource("openai")
 def test_openai_provider_acomplete_has_expected(mock_post):
     """Test the acomplete method of OpenAIProvider.
 
@@ -503,6 +515,7 @@ def test_openai_provider_acomplete_has_expected(mock_post):
 
 @patch("requests.post")
 @pytest.mark.medium
+@pytest.mark.requires_resource("openai")
 def test_openai_provider_embed_has_expected(mock_post):
     """Test the embed method of OpenAIProvider.
 
@@ -532,6 +545,7 @@ def test_openai_provider_embed_has_expected(mock_post):
 @patch("requests.get")
 @patch("requests.post")
 @pytest.mark.medium
+@pytest.mark.requires_resource("lmstudio")
 def test_lmstudio_provider_complete_has_expected(mock_post, mock_get, mock_tls):
     """Test the complete method of LMStudioProvider.
 
@@ -583,6 +597,8 @@ def test_fallback_provider_async_methods_has_expected():
 
 
 @pytest.mark.medium
+@pytest.mark.requires_resource("openai")
+@pytest.mark.requires_resource("lmstudio")
 def test_provider_with_empty_inputs_has_expected():
     """Test providers with empty inputs.
 
@@ -620,6 +636,8 @@ def test_provider_with_empty_inputs_has_expected():
 
 
 @pytest.mark.medium
+@pytest.mark.requires_resource("openai")
+@pytest.mark.requires_resource("lmstudio")
 def test_provider_factory_injected_config_selects_provider():
     """ProviderFactory should respect injected configuration.
 
@@ -685,6 +703,7 @@ def test_fallback_provider_respects_order(monkeypatch):
 @patch("devsynth.adapters.provider_system.requests.post")
 @patch("time.sleep", return_value=None)
 @pytest.mark.medium
+@pytest.mark.requires_resource("openai")
 def test_openai_provider_retries_after_transient_failure(mock_sleep, mock_post):
     """OpenAIProvider retries once on transient failure.
 


### PR DESCRIPTION
## Summary
- mark provider-system HTTP unit tests with the appropriate `requires_resource("openai")` or `requires_resource("lmstudio")` markers so they skip when HTTP clients/resources are unavailable
- update the resource marker documentation to explain how to enable provider-system adapter coverage via `DEVSYNTH_RESOURCE_OPENAI_AVAILABLE` and `DEVSYNTH_RESOURCE_LMSTUDIO_AVAILABLE`

## Testing
- poetry run python scripts/verify_test_markers.py

------
https://chatgpt.com/codex/tasks/task_e_68cf3f2f2b688333b20eb1876e062c7b