### PR TITLE
Add coverage for WebUI bridge progress behaviors

### DIFF
--- a/issues/coverage-below-threshold.md
+++ b/issues/coverage-below-threshold.md
@@ -137,6 +137,8 @@ The uncovered WebUI modules now have explicit behavior checklists so new tests c
 | `display_result` & `create_progress` (L470-L514)【F:src/devsynth/interface/webui_bridge.py†L470-L514】 | Assert message-type routing to Streamlit APIs and the `OutputFormatter` pipeline, then confirm progress handles highlight toggles. | [WebUI Integration spec](../docs/specifications/webui-integration.md)【F:docs/specifications/webui-integration.md†L42-L55】; [Output formatter invariants](../docs/implementation/output_formatter_invariants.md)【F:docs/implementation/output_formatter_invariants.md†L16-L56】 |
 | Session accessors (L519-L551)【F:src/devsynth/interface/webui_bridge.py†L519-L551】 | Verify state wrappers persist defaults and propagate writes for the requirements wizard scaffolding. | [WizardState integration guide](../docs/implementation/requirements_wizard_wizardstate_integration.md)【F:docs/implementation/requirements_wizard_wizardstate_integration.md†L27-L33】 |
 
+- 2025-09-21: `poetry run pytest tests/unit/interface/test_webui_bridge_progress.py -o addopts="--cov=devsynth.interface.webui_bridge --cov-report=term --cov-fail-under=0 -m 'not slow and not gui'"` reports 32 % coverage for `webui_bridge.py`, improving on the 19 % baseline noted above after adding tests for wizard clamps, nested progress status cycles, session accessors, and UXBridge prompts.【77f0f6†L1-L20】
+
 ## Dialectical Examination
 
 - **Thesis:** Raising coverage above 90 % yields higher confidence in system behavior and eases regression detection.


### PR DESCRIPTION
## Summary
- extend WebUI progress indicator tests to cover nested status cycles, wizard clamping, session helpers, and UXBridge prompts
- verify Streamlit routing and sanitized output for `display_result`
- document the targeted coverage run that raises `webui_bridge.py` coverage to 32%

## Testing
- `poetry run pytest --no-cov tests/unit/interface/test_webui_bridge_progress.py`
- `poetry run pytest tests/unit/interface/test_webui_bridge_progress.py -o addopts="--cov=devsynth.interface.webui_bridge --cov-report=term --cov-fail-under=0 -m 'not slow and not gui'"`


------
https://chatgpt.com/codex/tasks/task_e_68cf48792ec883338c17f579668ab00f