### PR TITLE
chore: add third-party typing stubs

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -3881,7 +3881,7 @@ version = "2.3.2"
 description = "Fundamental package for array computing in Python"
 optional = false
 python-versions = ">=3.11"
-groups = ["main"]
+groups = ["main", "dev"]
 files = [
     {file = "numpy-2.3.2-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:852ae5bed3478b92f093e30f785c98e0cb62fa0a939ed057c31716e18a7a22b9"},
     {file = "numpy-2.3.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:7a0e27186e781a69959d0230dd9909b5e26024f8da10683bd6344baea1885168"},
@@ -7150,6 +7150,21 @@ files = [
 referencing = "*"
 
 [[package]]
+name = "types-networkx"
+version = "3.5.0.20250918"
+description = "Typing stubs for networkx"
+optional = false
+python-versions = ">=3.10"
+groups = ["dev"]
+files = [
+    {file = "types_networkx-3.5.0.20250918-py3-none-any.whl", hash = "sha256:c7d3951e747333a65c0fb3011461e2de990c7ed5b49f4292ffc0d3febc8e2536"},
+    {file = "types_networkx-3.5.0.20250918.tar.gz", hash = "sha256:346cc347fc7670b5db29af9d4ba5fa077507ad7100ed7a02707f74fbf317be3c"},
+]
+
+[package.dependencies]
+numpy = ">=1.20"
+
+[[package]]
 name = "types-pyyaml"
 version = "6.0.12.20250915"
 description = "Typing stubs for PyYAML"
@@ -7160,6 +7175,36 @@ files = [
     {file = "types_pyyaml-6.0.12.20250915-py3-none-any.whl", hash = "sha256:e7d4d9e064e89a3b3cae120b4990cd370874d2bf12fa5f46c97018dd5d3c9ab6"},
     {file = "types_pyyaml-6.0.12.20250915.tar.gz", hash = "sha256:0f8b54a528c303f0e6f7165687dd33fafa81c807fcac23f632b63aa624ced1d3"},
 ]
+
+[[package]]
+name = "types-requests"
+version = "2.32.4.20250913"
+description = "Typing stubs for requests"
+optional = false
+python-versions = ">=3.9"
+groups = ["dev"]
+files = [
+    {file = "types_requests-2.32.4.20250913-py3-none-any.whl", hash = "sha256:78c9c1fffebbe0fa487a418e0fa5252017e9c60d1a2da394077f1780f655d7e1"},
+    {file = "types_requests-2.32.4.20250913.tar.gz", hash = "sha256:abd6d4f9ce3a9383f269775a9835a4c24e5cd6b9f647d64f88aa4613c33def5d"},
+]
+
+[package.dependencies]
+urllib3 = ">=2"
+
+[[package]]
+name = "types-tqdm"
+version = "4.67.0.20250809"
+description = "Typing stubs for tqdm"
+optional = false
+python-versions = ">=3.9"
+groups = ["dev"]
+files = [
+    {file = "types_tqdm-4.67.0.20250809-py3-none-any.whl", hash = "sha256:1a73053b31fcabf3c1f3e2a9d5ecdba0f301bde47a418cd0e0bdf774827c5c57"},
+    {file = "types_tqdm-4.67.0.20250809.tar.gz", hash = "sha256:02bf7ab91256080b9c4c63f9f11b519c27baaf52718e5fdab9e9606da168d500"},
+]
+
+[package.dependencies]
+types-requests = "*"
 
 [[package]]
 name = "typing-extensions"
@@ -8073,4 +8118,4 @@ webui-nicegui = ["nicegui"]
 [metadata]
 lock-version = "2.1"
 python-versions = "<3.13,>=3.12"
-content-hash = "fc46ffd7d05b9ed15322d408b3045eedc9ad9a168cbcce9311f8bc4050c613c1"
+content-hash = "4bb3703d5f1b69ad2f2cb2106dbeae338de718bbfda662fdf4cdd11a0ec9934d"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -113,6 +113,9 @@ prometheus-client = "*"
 freezegun = "*"
 types-pyyaml = "^6.0.12.20250915"
 types-jsonschema = "^4.25.1.20250822"
+types-requests = "*"
+types-networkx = "*"
+types-tqdm = "*"
 
 [tool.poetry.group.docs]
 optional = true
@@ -199,6 +202,8 @@ mvuu-dashboard = "devsynth.application.cli.commands.mvuu_dashboard_cmd:mvuu_dash
 [tool.mypy]
 python_version = "3.12"
 warn_return_any = true
+# Keep third-party imports at `skip` even after stub packages land to limit
+# type-checking churn while we continue tightening module-level overrides.
 follow_imports = "skip"
 exclude = [
   # Exclude nothing at path-level; use per-module overrides below.


### PR DESCRIPTION
## Summary
- add types-requests, types-networkx, and types-tqdm to the dev dependency group
- document why follow_imports remains set to skip to control mypy churn as stubs land
- regenerate poetry.lock so the new stub packages are captured

## Testing
- `poetry run mypy src/devsynth/application/documentation/version_monitor.py src/devsynth/application/documentation/documentation_fetcher.py src/devsynth/application/cli/commands/edrr_cycle_cmd.py src/devsynth/domain/models/project.py` *(fails: existing annotation gaps remain but missing-stub errors are gone)*

------
https://chatgpt.com/codex/tasks/task_e_68d48cdc553083339d4a39ce99b67661