### PR TITLE
fix: align requirement reasoner phase handling

### DIFF
--- a/src/devsynth/application/cli/requirements_commands.py
+++ b/src/devsynth/application/cli/requirements_commands.py
@@ -28,7 +28,10 @@ from devsynth.adapters.requirements.memory_repository import (
 from devsynth.application.requirements.dialectical_reasoner import (
     DialecticalReasonerService,
 )
-from devsynth.application.requirements.requirement_service import RequirementService
+from devsynth.application.requirements.requirement_service import (
+    RequirementService,
+    determine_edrr_phase,
+)
 from devsynth.config import get_project_config, save_config
 from devsynth.config.settings import ensure_path_exists
 from devsynth.domain.models.requirement import (
@@ -684,7 +687,9 @@ def evaluate_change(
     bridge.print(f"[bold]Evaluating change with ID: {change_id}[/bold]")
 
     # Evaluate the change
-    reasoning = dialectical_reasoner.evaluate_change(change)
+    reasoning = dialectical_reasoner.evaluate_change(
+        change, edrr_phase=determine_edrr_phase(change)
+    )
 
     bridge.print(
         Panel(
@@ -746,7 +751,9 @@ def assess_impact(
     bridge.print(f"[bold]Assessing impact of change with ID: {change_id}[/bold]")
 
     # Assess the impact
-    impact = dialectical_reasoner.assess_impact(change)
+    impact = dialectical_reasoner.assess_impact(
+        change, edrr_phase=determine_edrr_phase(change)
+    )
 
     # Get the affected requirements
     affected_requirements = []

--- a/src/devsynth/application/requirements/requirement_service.py
+++ b/src/devsynth/application/requirements/requirement_service.py
@@ -20,6 +20,17 @@ from devsynth.ports.requirement_port import (
 )
 
 
+def determine_edrr_phase(change: RequirementChange) -> str:
+    """Return the appropriate EDRR phase for a requirement change."""
+
+    change_type = getattr(change, "change_type", None)
+    if change_type == ChangeType.ADD:
+        return "EXPAND"
+    if change_type == ChangeType.REMOVE:
+        return "RETROSPECT"
+    return "REFINE"
+
+
 class RequirementService:
     """
     Service for managing requirements.
@@ -150,10 +161,14 @@ class RequirementService:
         self.notification_service.notify_change_proposed(change)
 
         # Evaluate the change using dialectical reasoning
-        reasoning = self.dialectical_reasoner.evaluate_change(change)
+        reasoning = self.dialectical_reasoner.evaluate_change(
+            change, edrr_phase=determine_edrr_phase(change)
+        )
 
         # Assess the impact of the change
-        impact = self.dialectical_reasoner.assess_impact(change)
+        impact = self.dialectical_reasoner.assess_impact(
+            change, edrr_phase=determine_edrr_phase(change)
+        )
 
         # Save the updated requirement
         return self.requirement_repository.save_requirement(requirement)
@@ -191,10 +206,14 @@ class RequirementService:
         self.notification_service.notify_change_proposed(change)
 
         # Evaluate the change using dialectical reasoning
-        reasoning = self.dialectical_reasoner.evaluate_change(change)
+        reasoning = self.dialectical_reasoner.evaluate_change(
+            change, edrr_phase=determine_edrr_phase(change)
+        )
 
         # Assess the impact of the change
-        impact = self.dialectical_reasoner.assess_impact(change)
+        impact = self.dialectical_reasoner.assess_impact(
+            change, edrr_phase=determine_edrr_phase(change)
+        )
 
         # Delete the requirement
         return self.requirement_repository.delete_requirement(requirement_id)

--- a/src/devsynth/domain/interfaces/requirement.py
+++ b/src/devsynth/domain/interfaces/requirement.py
@@ -238,7 +238,9 @@ class SimpleDialecticalReasoner(DialecticalReasonerInterface):
     def __init__(self, chat_repo: ChatRepositoryInterface) -> None:
         self.chat_repo = chat_repo
 
-    def evaluate_change(self, change: RequirementChange) -> DialecticalReasoning:
+    def evaluate_change(
+        self, change: RequirementChange, edrr_phase: str = "REFINE"
+    ) -> DialecticalReasoning:
         reasoning = DialecticalReasoning(change_id=change.id)
         reasoning.thesis = f"Proposed change {change.id}"
         reasoning.antithesis = "Opposing view"
@@ -266,7 +268,9 @@ class SimpleDialecticalReasoner(DialecticalReasonerInterface):
         self.chat_repo.save_session(session)
         return session
 
-    def assess_impact(self, change: RequirementChange) -> ImpactAssessment:
+    def assess_impact(
+        self, change: RequirementChange, edrr_phase: str = "REFINE"
+    ) -> ImpactAssessment:
         assessment = ImpactAssessment(change_id=change.id, analysis="None")
         return assessment
 

--- a/tests/unit/domain/test_requirement_interfaces.py
+++ b/tests/unit/domain/test_requirement_interfaces.py
@@ -80,6 +80,26 @@ class TestRequirementInterfaces(unittest.TestCase):
         self.assertEqual(response.content, "hello")
         self.assertEqual(len(chat_repo.get_messages_for_session(session.id)), 2)
 
+    @pytest.mark.medium
+    def test_simple_reasoner_accepts_explicit_edrr_phase(self) -> None:
+        chat_repo = InMemoryChatRepository()
+        reasoner = SimpleDialecticalReasoner(chat_repo)
+        change = RequirementChange(requirement_id=uuid4())
+
+        reasoning = reasoner.evaluate_change(change, edrr_phase="EXPAND")
+
+        self.assertEqual(reasoning.change_id, change.id)
+
+    @pytest.mark.medium
+    def test_simple_reasoner_assess_impact_with_phase(self) -> None:
+        chat_repo = InMemoryChatRepository()
+        reasoner = SimpleDialecticalReasoner(chat_repo)
+        change = RequirementChange(requirement_id=uuid4())
+
+        assessment = reasoner.assess_impact(change, edrr_phase="RETROSPECT")
+
+        self.assertEqual(assessment.change_id, change.id)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- restore optional `edrr_phase` parameters on the in-memory requirement dialectical reasoner and cover the explicit argument path
- centralize requirement change phase selection and pass the derived phase through the service and CLI entry points

## Testing
- poetry run mypy src/devsynth/domain/interfaces/requirement.py
- poetry run pytest --no-cov tests/unit/domain/test_requirement_interfaces.py

------
https://chatgpt.com/codex/tasks/task_e_68d4937cc2188333b4f803c6c1310582