### PR TITLE
feat: harden CLI typing and add regression tests

### DIFF
--- a/src/devsynth/application/cli/ingest_cmd.py
+++ b/src/devsynth/application/cli/ingest_cmd.py
@@ -38,7 +38,7 @@ console = Console()
 
 
 def ingest_cmd(
-    manifest_path: Optional[str] = None,
+    manifest_path: Optional[Path | str] = None,
     dry_run: bool = False,
     verbose: bool = False,
     validate_only: bool = False,
@@ -76,13 +76,18 @@ def ingest_cmd(
     try:
         # Allow environment variables to provide default values when arguments
         # are not supplied. CLI flags still override these settings.
+        path_argument: Optional[Path]
         if manifest_path is None:
-            manifest_path = os.environ.get("DEVSYNTH_MANIFEST_PATH")
-        if manifest_path is None:
-            # Use manifest.yaml as the default path for tests
-            manifest_path = Path(os.path.join(os.getcwd(), "manifest.yaml"))
+            env_path = os.environ.get("DEVSYNTH_MANIFEST_PATH")
+            if env_path is None:
+                # Use manifest.yaml as the default path for tests
+                path_argument = Path(os.path.join(os.getcwd(), "manifest.yaml"))
+            else:
+                path_argument = Path(env_path)
         else:
-            manifest_path = Path(manifest_path)
+            path_argument = Path(manifest_path)
+
+        manifest_path = path_argument
 
         project_root = (
             manifest_path.parent.parent

--- a/src/devsynth/application/cli/setup_wizard.py
+++ b/src/devsynth/application/cli/setup_wizard.py
@@ -4,8 +4,9 @@ from __future__ import annotations
 
 import json
 import os
+from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Dict, Literal, Mapping, Optional, Protocol, Sequence, TypedDict, Union
 
 from rich.console import Console
 from rich.markdown import Markdown
@@ -15,7 +16,7 @@ from rich.progress import Progress, SpinnerColumn, TextColumn
 from devsynth.config import ProjectUnifiedConfig, load_project_config
 from devsynth.config.unified_loader import UnifiedConfigLoader
 from devsynth.interface.cli import CLIUXBridge
-from devsynth.interface.ux_bridge import UXBridge
+from devsynth.interface.ux_bridge import ProgressIndicator, UXBridge
 
 from .progress import ProgressManager
 
@@ -28,37 +29,144 @@ def _env_flag(name: str) -> Optional[bool]:
     return val.lower() in {"1", "true", "yes"}
 
 
-def _parse_features(value: Optional[Union[List[str], str]]) -> Dict[str, bool]:
-    """Parse feature flags from list or JSON string."""
+FeatureFlags = TypedDict(
+    "FeatureFlags",
+    {
+        "wsde_collaboration": bool,
+        "dialectical_reasoning": bool,
+        "code_generation": bool,
+        "test_generation": bool,
+        "documentation_generation": bool,
+        "experimental_features": bool,
+    },
+    total=False,
+)
+
+
+FeatureName = Literal[
+    "wsde_collaboration",
+    "dialectical_reasoning",
+    "code_generation",
+    "test_generation",
+    "documentation_generation",
+    "experimental_features",
+]
+
+
+FEATURE_NAMES: tuple[FeatureName, ...] = (
+    "wsde_collaboration",
+    "dialectical_reasoning",
+    "code_generation",
+    "test_generation",
+    "documentation_generation",
+    "experimental_features",
+)
+
+
+def _normalize_feature_flags(mapping: Mapping[str, object]) -> FeatureFlags:
+    normalized: FeatureFlags = {}
+    for name in FEATURE_NAMES:
+        if name in mapping:
+            normalized[name] = bool(mapping[name])
+    return normalized
+
+
+FeatureInput = Union[Mapping[str, object], Sequence[str], str, None]
+
+
+def _parse_features(value: FeatureInput) -> FeatureFlags:
+    """Parse feature flags from various representations into a mapping."""
+
     if value is None or hasattr(value, "param_decls"):
         return {}
-    if isinstance(value, list):
+
+    raw_flags: Dict[str, bool]
+
+    if isinstance(value, Mapping):
+        raw_flags = {k: bool(v) for k, v in value.items() if isinstance(k, str)}
+    elif isinstance(value, Sequence) and not isinstance(value, str):
         if len(value) == 1:
             item = value[0]
             try:
                 parsed = json.loads(item)
-            except json.JSONDecodeError:
-                return {item: True}
+            except (TypeError, json.JSONDecodeError):
+                raw_flags = {str(item): True}
+            else:
+                return _parse_features(parsed)
         else:
-            return {f: True for f in value}
+            raw_flags = {str(f): True for f in value}
     else:
         try:
             parsed = json.loads(value)
-        except json.JSONDecodeError:
-            return {f.strip(): True for f in value.split(";") if f.strip()}
+        except (TypeError, json.JSONDecodeError):
+            raw_flags = {
+                f.strip(): True for f in str(value).split(";") if f and f.strip()
+            }
+        else:
+            return _parse_features(parsed)
 
-    if isinstance(parsed, dict):
-        return {k: bool(v) for k, v in parsed.items()}
-    if isinstance(parsed, list):
-        return {f: True for f in parsed}
-    return {}
+    return _normalize_feature_flags(raw_flags)
+
+
+@dataclass(frozen=True)
+class QuickSetupPreset:
+    """Immutable representation of quick setup defaults."""
+
+    structure: str
+    memory_backend: str
+    offline_mode: bool
+    features: Mapping[str, bool]
+
+    def as_feature_flags(self) -> FeatureFlags:
+        """Return a mutable mapping suitable for configuration updates."""
+
+        return _normalize_feature_flags(self.features)
+
+
+@dataclass(slots=True)
+class WizardSelections:
+    """Collects choices made during the setup wizard."""
+
+    root: Path
+    language: str
+    structure: str
+    constraints: Optional[Path]
+    goals: Optional[str]
+    memory_backend: str
+    offline_mode: bool
+    features: FeatureFlags
+
+
+class WizardBridge(Protocol):
+    """Protocol documenting the UX hooks used by :class:`SetupWizard`."""
+
+    def ask_question(
+        self,
+        message: str,
+        *,
+        choices: Optional[Sequence[str]] = None,
+        default: Optional[str] = None,
+        show_default: bool = True,
+    ) -> str:
+        ...
+
+    def confirm_choice(self, message: str, *, default: bool = False) -> bool:
+        ...
+
+    def display_result(
+        self, message: str, *, highlight: bool = False, message_type: str | None = None
+    ) -> None:
+        ...
+
+    def create_progress(self, description: str, *, total: int = 100) -> ProgressIndicator:
+        ...
 
 
 class SetupWizard:
     """Guide the user through project initialization."""
 
     # Help text for each option
-    HELP_TEXT = {
+    HELP_TEXT: Dict[str, str | Dict[str, str]] = {
         "root": (
             "The root directory of your project. "
             "This is where DevSynth will store configuration files."
@@ -108,13 +216,12 @@ class SetupWizard:
         },
     }
 
-    # Quick setup presets
-    QUICK_SETUP_PRESETS = {
-        "minimal": {
-            "structure": "single_package",
-            "memory_backend": "memory",
-            "offline_mode": False,
-            "features": {
+    QUICK_SETUP_PRESETS: Dict[str, QuickSetupPreset] = {
+        "minimal": QuickSetupPreset(
+            structure="single_package",
+            memory_backend="memory",
+            offline_mode=False,
+            features={
                 "wsde_collaboration": False,
                 "dialectical_reasoning": False,
                 "code_generation": True,
@@ -122,12 +229,12 @@ class SetupWizard:
                 "documentation_generation": True,
                 "experimental_features": False,
             },
-        },
-        "standard": {
-            "structure": "single_package",
-            "memory_backend": "file",
-            "offline_mode": False,
-            "features": {
+        ),
+        "standard": QuickSetupPreset(
+            structure="single_package",
+            memory_backend="file",
+            offline_mode=False,
+            features={
                 "wsde_collaboration": True,
                 "dialectical_reasoning": True,
                 "code_generation": True,
@@ -135,12 +242,12 @@ class SetupWizard:
                 "documentation_generation": True,
                 "experimental_features": False,
             },
-        },
-        "advanced": {
-            "structure": "monorepo",
-            "memory_backend": "chromadb",
-            "offline_mode": False,
-            "features": {
+        ),
+        "advanced": QuickSetupPreset(
+            structure="monorepo",
+            memory_backend="chromadb",
+            offline_mode=False,
+            features={
                 "wsde_collaboration": True,
                 "dialectical_reasoning": True,
                 "code_generation": True,
@@ -148,11 +255,11 @@ class SetupWizard:
                 "documentation_generation": True,
                 "experimental_features": True,
             },
-        },
+        ),
     }
 
-    def __init__(self, bridge: Optional[UXBridge] = None) -> None:
-        self.bridge = bridge or CLIUXBridge()
+    def __init__(self, bridge: Optional[WizardBridge | UXBridge] = None) -> None:
+        self.bridge: WizardBridge = bridge or CLIUXBridge()
         self.console = Console()
         # Basic, Project, Memory, Features, Finalize
         self.total_steps = 5
@@ -163,7 +270,7 @@ class SetupWizard:
     # ------------------------------------------------------------------
     # Private helpers
     # ------------------------------------------------------------------
-    def _show_progress(self, description: str, status: str = None) -> None:
+    def _show_progress(self, description: str, status: Optional[str] = None) -> None:
         """Advance the wizard progress indicator with an optional status."""
         self.current_step += 1
         desc = f"Step {self.current_step}/{self.total_steps}: {description}"
@@ -175,11 +282,14 @@ class SetupWizard:
     def _show_help(self, topic: str, subtopic: Optional[str] = None) -> None:
         """Show help text for a specific option."""
         if subtopic:
-            help_text = self.HELP_TEXT.get("features", {}).get(
-                subtopic, "No help available"
-            )
+            features_help = self.HELP_TEXT.get("features")
+            if isinstance(features_help, dict):
+                help_text = features_help.get(subtopic, "No help available")
+            else:
+                help_text = "No help available"
         else:
-            help_text = self.HELP_TEXT.get(topic, "No help available")
+            entry = self.HELP_TEXT.get(topic)
+            help_text = entry if isinstance(entry, str) else "No help available"
 
         self.console.print(
             Panel(
@@ -189,7 +299,7 @@ class SetupWizard:
             )
         )
 
-    def _prompt_with_help(self, topic: str, question: str, **kwargs) -> Any:
+    def _prompt_with_help(self, topic: str, question: str, **kwargs: Any) -> str:
         """Prompt the user with a question and offer help."""
         self._show_help(topic)
         return self.bridge.ask_question(question, **kwargs)
@@ -197,11 +307,11 @@ class SetupWizard:
     def _prompt_features(
         self,
         cfg: ProjectUnifiedConfig,
-        features: Optional[Dict[str, bool]],
+        features: Optional[FeatureFlags],
         auto_confirm: bool,
-    ) -> Dict[str, bool]:
-        existing = cfg.config.features or {}
-        result: Dict[str, bool] = {}
+    ) -> FeatureFlags:
+        existing: Mapping[str, bool] = cfg.config.features or {}
+        raw_flags: Dict[str, bool] = {}
         features = features or {}
 
         self._show_progress("Configure Features", status="selection")
@@ -210,31 +320,24 @@ class SetupWizard:
             "DevSynth project.[/italic]"
         )
 
-        feature_list = [
-            "wsde_collaboration",
-            "dialectical_reasoning",
-            "code_generation",
-            "test_generation",
-            "documentation_generation",
-            "experimental_features",
-        ]
+        feature_list: tuple[FeatureName, ...] = FEATURE_NAMES
 
         for feat in feature_list:
             if feat in features:
-                result[feat] = bool(features[feat])
+                raw_flags[feat] = bool(features[feat])
             elif auto_confirm:
-                result[feat] = bool(existing.get(feat, False))
+                raw_flags[feat] = bool(existing.get(feat, False))
             else:
                 self._show_help("features", feat)
-                result[feat] = self.bridge.confirm_choice(
+                raw_flags[feat] = self.bridge.confirm_choice(
                     f"Enable {feat.replace('_', ' ')}?",
                     default=existing.get(feat, False),
                 )
-        return result
+        return _normalize_feature_flags(raw_flags)
 
     def _apply_quick_setup(
         self, preset: str, cfg: ProjectUnifiedConfig
-    ) -> Dict[str, Any]:
+    ) -> QuickSetupPreset:
         """Apply a quick setup preset."""
         if preset not in self.QUICK_SETUP_PRESETS:
             self.bridge.display_result(
@@ -243,13 +346,12 @@ class SetupWizard:
             preset = "standard"
 
         preset_config = self.QUICK_SETUP_PRESETS[preset]
-
-        return {
-            "structure": preset_config["structure"],
-            "memory_backend": preset_config["memory_backend"],
-            "offline_mode": preset_config["offline_mode"],
-            "features": preset_config["features"],
-        }
+        return QuickSetupPreset(
+            structure=preset_config.structure,
+            memory_backend=preset_config.memory_backend,
+            offline_mode=preset_config.offline_mode,
+            features=dict(preset_config.features),
+        )
 
     # ------------------------------------------------------------------
     # Public API
@@ -257,22 +359,24 @@ class SetupWizard:
     def run(
         self,
         *,
-        root: Optional[str] = None,
+        root: Path | str | None = None,
         structure: Optional[str] = None,
         language: Optional[str] = None,
-        constraints: Optional[str] = None,
+        constraints: Path | str | None = None,
         goals: Optional[str] = None,
         memory_backend: Optional[str] = None,
         offline_mode: Optional[bool] = None,
-        features: Optional[List[str]] = None,
+        features: FeatureInput = None,
         auto_confirm: Optional[bool] = None,
     ) -> ProjectUnifiedConfig:
         """Execute the wizard steps and persist configuration."""
 
-        auto_confirm = (
-            _env_flag("DEVSYNTH_AUTO_CONFIRM") if auto_confirm is None else auto_confirm
+        auto_confirm_flag = (
+            _env_flag("DEVSYNTH_AUTO_CONFIRM")
+            if auto_confirm is None
+            else auto_confirm
         )
-        features = _parse_features(features)
+        feature_flags = _parse_features(features)
 
         self.progress_manager.create_progress(
             self._progress_id, "Setup Wizard", total=self.total_steps
@@ -296,7 +400,6 @@ class SetupWizard:
             self.progress_manager.complete_progress(self._progress_id)
             return cfg
 
-        # Welcome message
         self.bridge.display_result(
             "[bold green]Welcome to the DevSynth Setup Wizard![/bold green]"
         )
@@ -305,134 +408,160 @@ class SetupWizard:
             "DevSynth project.[/italic]"
         )
 
-        # Offer quick setup option
+        def _ensure_path(value: Path | str | None) -> Optional[Path]:
+            if value is None:
+                return None
+            if isinstance(value, Path):
+                return value
+            text = value.strip()
+            return Path(text) if text else None
+
+        root_path = _ensure_path(root or os.environ.get("DEVSYNTH_INIT_ROOT"))
+        language_value = language or os.environ.get("DEVSYNTH_INIT_LANGUAGE")
+        structure_value = structure or os.environ.get("DEVSYNTH_INIT_STRUCTURE")
+        constraints_value: Path | str | None = (
+            constraints or os.environ.get("DEVSYNTH_INIT_CONSTRAINTS")
+        )
+        goals_value = goals or os.environ.get("DEVSYNTH_INIT_GOALS")
+        memory_backend_value = (
+            memory_backend or os.environ.get("DEVSYNTH_INIT_MEMORY_BACKEND")
+        )
+        offline_mode_value = offline_mode
+
         quick_setup = False
-        if not auto_confirm:
+        preset_config: Optional[QuickSetupPreset] = None
+        if not auto_confirm_flag:
             quick_setup = self.bridge.confirm_choice(
                 "Would you like to use quick setup with predefined configurations?",
                 default=False,
             )
 
-        quick_preset = None
         if quick_setup:
-            quick_preset = self.bridge.ask_question(
+            preset_choice = self.bridge.ask_question(
                 "Choose a configuration preset",
                 choices=["minimal", "standard", "advanced"],
                 default="standard",
             )
-            preset_config = self._apply_quick_setup(quick_preset, cfg)
-            structure = preset_config["structure"]
-            memory_backend = preset_config["memory_backend"]
-            offline_mode = preset_config["offline_mode"]
-            features = preset_config["features"]
-
-            # Still need to ask for these basic settings
+            preset_config = self._apply_quick_setup(preset_choice, cfg)
+            structure_value = preset_config.structure
+            memory_backend_value = preset_config.memory_backend
+            offline_mode_value = preset_config.offline_mode
+            feature_flags = preset_config.as_feature_flags()
             self._show_progress("Basic Settings", status="preset applied")
-            # Mark remaining sections as satisfied by preset
             self._show_progress("Project Configuration", status="preset")
             self._show_progress("Memory Configuration", status="preset")
             self._show_progress("Feature Selection", status="preset")
         else:
             self._show_progress("Basic Settings", status="collecting")
 
-        # Basic settings (always ask for these)
-        root = root or os.environ.get("DEVSYNTH_INIT_ROOT")
-        if root is None:
-            root = self._prompt_with_help("root", "Project root", default=os.getcwd())
+        if root_path is None:
+            root_path = Path(
+                self._prompt_with_help("root", "Project root", default=os.getcwd())
+            )
 
-        language = language or os.environ.get("DEVSYNTH_INIT_LANGUAGE")
-        if language is None:
-            language = self._prompt_with_help(
+        if language_value is None:
+            language_value = self._prompt_with_help(
                 "language", "Primary language", default="python"
             )
 
-        # Project settings
         if not quick_setup:
             self._show_progress("Project Configuration", status="collecting")
 
-            structure = structure or os.environ.get("DEVSYNTH_INIT_STRUCTURE")
-            if structure is None:
-                structure = self._prompt_with_help(
+            if structure_value is None:
+                structure_value = self._prompt_with_help(
                     "structure",
                     "Project structure",
                     choices=["single_package", "monorepo"],
                     default="single_package",
                 )
 
-            if constraints is None:
-                constraints = os.environ.get("DEVSYNTH_INIT_CONSTRAINTS")
-                if constraints is None:
-                    constraints = (
-                        self._prompt_with_help(
-                            "constraints",
-                            "Path to constraint file (optional)",
-                            default="",
-                            show_default=False,
-                        )
-                        or None
-                    )
+            if constraints_value is None:
+                constraints_prompt = self._prompt_with_help(
+                    "constraints",
+                    "Path to constraint file (optional)",
+                    default="",
+                    show_default=False,
+                )
+                constraints_value = constraints_prompt or None
 
-            if goals is None:
-                goals = os.environ.get("DEVSYNTH_INIT_GOALS")
-                if goals is None:
-                    goals = (
-                        self._prompt_with_help(
-                            "goals",
-                            "Project goals (optional)",
-                            default="",
-                            show_default=False,
-                        )
-                        or None
-                    )
+            if goals_value is None:
+                goals_prompt = self._prompt_with_help(
+                    "goals",
+                    "Project goals (optional)",
+                    default="",
+                    show_default=False,
+                )
+                goals_value = goals_prompt or None
 
-            # Memory settings
             self._show_progress("Memory Configuration", status="configuring")
 
-            memory_backend = memory_backend or os.environ.get(
-                "DEVSYNTH_INIT_MEMORY_BACKEND"
-            )
-            if memory_backend is None:
-                memory_backend = self._prompt_with_help(
+            if memory_backend_value is None:
+                memory_backend_value = self._prompt_with_help(
                     "memory_backend",
                     "Select memory backend",
                     choices=["memory", "file", "kuzu", "chromadb"],
                     default=cfg.config.memory_store_type,
                 )
 
-            if offline_mode is None:
+            if offline_mode_value is None:
                 env_offline = _env_flag("DEVSYNTH_INIT_OFFLINE_MODE")
                 if env_offline is not None:
-                    offline_mode = env_offline
+                    offline_mode_value = env_offline
                 else:
-                    offline_mode = self.bridge.confirm_choice(
+                    offline_mode_value = self.bridge.confirm_choice(
                         "Enable offline mode?", default=cfg.config.offline_mode
                     )
 
-            # Feature settings (progress handled within _prompt_features)
-            features = self._prompt_features(cfg, features, auto_confirm)
+            feature_flags = self._prompt_features(
+                cfg, feature_flags, bool(auto_confirm_flag)
+            )
 
-        # Summary and confirmation
+        constraints_path = _ensure_path(constraints_value)
+        goals_text = goals_value or None
+        memory_backend_value = memory_backend_value or cfg.config.memory_store_type
+        offline_mode_value = (
+            offline_mode_value
+            if offline_mode_value is not None
+            else cfg.config.offline_mode
+        )
+        language_value = language_value or "python"
+        structure_value = structure_value or "single_package"
+
+        selections = WizardSelections(
+            root=root_path,
+            language=language_value,
+            structure=structure_value,
+            constraints=constraints_path,
+            goals=goals_text,
+            memory_backend=memory_backend_value,
+            offline_mode=offline_mode_value,
+            features=feature_flags,
+        )
+
         self.bridge.display_result("\n[bold]Configuration Summary:[/bold]")
-        self.bridge.display_result(f"Project Root: {root}")
-        self.bridge.display_result(f"Language: {language}")
-        self.bridge.display_result(f"Structure: {structure}")
-        if constraints:
-            self.bridge.display_result(f"Constraints: {constraints}")
-        if goals:
-            self.bridge.display_result(f"Goals: {goals}")
-        self.bridge.display_result(f"Memory Backend: {memory_backend}")
+        self.bridge.display_result(f"Project Root: {selections.root}")
+        self.bridge.display_result(f"Language: {selections.language}")
+        self.bridge.display_result(f"Structure: {selections.structure}")
+        if selections.constraints:
+            self.bridge.display_result(f"Constraints: {selections.constraints}")
+        if selections.goals:
+            self.bridge.display_result(f"Goals: {selections.goals}")
         self.bridge.display_result(
-            f"Offline Mode: {'Enabled' if offline_mode else 'Disabled'}"
+            f"Memory Backend: {selections.memory_backend}"
+        )
+        self.bridge.display_result(
+            "Offline Mode: "
+            f"{'Enabled' if selections.offline_mode else 'Disabled'}"
         )
 
         self.bridge.display_result("\nFeatures:")
-        for feat, enabled in features.items():
+        for feat, enabled in selections.features.items():
             self.bridge.display_result(
                 f"  {feat.replace('_', ' ').title()}: "
                 f"{'Enabled' if enabled else 'Disabled'}"
             )
 
-        proceed = auto_confirm
+        proceed = bool(auto_confirm_flag)
         if not proceed:
             proceed = self.bridge.confirm_choice(
                 "Proceed with initialization?", default=True
@@ -440,15 +569,14 @@ class SetupWizard:
 
         if not proceed:
             self.bridge.display_result(
-                "[yellow]Initialization aborted.[/yellow]", message_type="warning"
+                "[yellow]Initialization aborted.[/yellow]",
+                message_type="warning",
             )
             self.progress_manager.complete_progress(self._progress_id)
             return cfg
 
-        # Finalization step
         self._show_progress("Finalizing Setup", status="writing config")
 
-        # Show progress during initialization
         with Progress(
             SpinnerColumn(),
             TextColumn("[progress.description]{task.description}"),
@@ -456,14 +584,18 @@ class SetupWizard:
         ) as progress:
             task = progress.add_task("[green]Initializing project...", total=None)
 
-            cfg.set_root(root)
-            cfg.config.structure = structure
-            cfg.set_language(language)
-            cfg.set_goals(goals or "")
-            cfg.config.constraints = constraints
-            cfg.config.memory_store_type = memory_backend
-            cfg.config.offline_mode = offline_mode
-            cfg.config.features = features
+            cfg.set_root(str(selections.root))
+            cfg.config.structure = selections.structure
+            cfg.set_language(selections.language)
+            cfg.set_goals(selections.goals or "")
+            cfg.config.constraints = (
+                str(selections.constraints)
+                if selections.constraints is not None
+                else None
+            )
+            cfg.config.memory_store_type = selections.memory_backend
+            cfg.config.offline_mode = selections.offline_mode
+            cfg.config.features = dict(selections.features)
             cfg.path = UnifiedConfigLoader.save(cfg)
 
             progress.update(
@@ -477,7 +609,6 @@ class SetupWizard:
             message_type="success",
         )
 
-        # Show next steps
         self.bridge.display_result("\n[bold]Next Steps:[/bold]")
         self.bridge.display_result(
             "1. Create or edit your requirements file: requirements.md"

--- a/src/devsynth/application/cli/sprint_cmd.py
+++ b/src/devsynth/application/cli/sprint_cmd.py
@@ -1,10 +1,12 @@
 from __future__ import annotations
 
+from __future__ import annotations
+
 """Sprint planning and retrospective CLI helpers."""
 
 import json
 from pathlib import Path
-from typing import Any, Dict, Optional
+from typing import Optional, Sequence, TypedDict, Union, cast
 
 from devsynth.application.sprint.planning import map_requirements_to_plan
 from devsynth.application.sprint.retrospective import map_retrospective_to_summary
@@ -13,7 +15,54 @@ from devsynth.logging_setup import DevSynthLogger
 logger = DevSynthLogger(__name__)
 
 
-def sprint_planning_cmd(requirements: str) -> Dict[str, Any]:
+JSONPrimitive = Union[str, int, float, bool, None]
+
+
+class JSONMapping(TypedDict, total=False):
+    """Minimal recursive JSON mapping structure used by sprint helpers."""
+
+    # TypedDict cannot express recursive types directly; values fall back to
+    # ``JSONValue`` via ``JSONLike`` alias defined below.
+
+
+JSONValue = Union[JSONPrimitive, Sequence["JSONValue"], JSONMapping]
+
+
+class SprintPlan(TypedDict):
+    """Structured sprint planning output."""
+
+    planned_scope: Sequence[JSONValue]
+    objectives: Sequence[JSONValue]
+    success_criteria: Sequence[JSONValue]
+
+
+class SprintRetrospectiveSummary(TypedDict):
+    """Structured summary returned by :func:`sprint_retrospective_cmd`."""
+
+    positives: Sequence[JSONValue]
+    improvements: Sequence[JSONValue]
+    action_items: Sequence[JSONValue]
+    sprint: int
+
+
+def _empty_plan() -> SprintPlan:
+    return {
+        "planned_scope": [],
+        "objectives": [],
+        "success_criteria": [],
+    }
+
+
+def _empty_summary(sprint: int) -> SprintRetrospectiveSummary:
+    return {
+        "positives": [],
+        "improvements": [],
+        "action_items": [],
+        "sprint": sprint,
+    }
+
+
+def sprint_planning_cmd(requirements: str) -> SprintPlan:
     """Generate a sprint plan from requirement analysis results.
 
     Args:
@@ -26,16 +75,20 @@ def sprint_planning_cmd(requirements: str) -> Dict[str, Any]:
 
     data = _load_json(requirements)
     if data is None:
-        return {}
+        return _empty_plan()
 
     plan = map_requirements_to_plan(data)
     logger.info(
         "Generated sprint plan with %d items", len(plan.get("planned_scope", []))
     )
-    return plan
+    return SprintPlan(
+        planned_scope=plan.get("planned_scope", []),
+        objectives=plan.get("objectives", []),
+        success_criteria=plan.get("success_criteria", []),
+    )
 
 
-def sprint_retrospective_cmd(retrospective: str, sprint: int) -> Dict[str, Any]:
+def sprint_retrospective_cmd(retrospective: str, sprint: int) -> SprintRetrospectiveSummary:
     """Summarize retrospective information for a sprint.
 
     Args:
@@ -49,21 +102,26 @@ def sprint_retrospective_cmd(retrospective: str, sprint: int) -> Dict[str, Any]:
 
     data = _load_json(retrospective)
     if data is None:
-        return {}
+        return _empty_summary(sprint)
 
     summary = map_retrospective_to_summary(data, sprint)
     logger.info("Generated retrospective summary for sprint %d", sprint)
-    return summary
+    return SprintRetrospectiveSummary(
+        positives=summary.get("positives", []),
+        improvements=summary.get("improvements", []),
+        action_items=summary.get("action_items", []),
+        sprint=summary.get("sprint", sprint),
+    )
 
 
-def _load_json(source: str) -> Optional[Dict[str, Any]]:
+def _load_json(source: str) -> Optional[JSONMapping]:
     """Load JSON from a file path or raw string."""
 
     try:
         path = Path(source)
         if path.exists():
-            return json.loads(path.read_text())
-        return json.loads(source)
+            return cast(JSONMapping, json.loads(path.read_text()))
+        return cast(JSONMapping, json.loads(source))
     except Exception as exc:  # pragma: no cover - defensive
         logger.error("Failed to load JSON: %s", exc)
         return None

--- a/tests/unit/application/cli/commands/test_doctor_cmd_typed.py
+++ b/tests/unit/application/cli/commands/test_doctor_cmd_typed.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+import importlib
+import types
+from pathlib import Path
+
+import pytest
+
+doctor_module = importlib.import_module("devsynth.application.cli.commands.doctor_cmd")
+
+
+class StubBridge:
+    def __init__(self) -> None:
+        self.messages: list[str] = []
+
+    def print(
+        self, message: str, *, highlight: bool = False, message_type: str | None = None
+    ) -> None:
+        self.messages.append(message)
+
+
+@pytest.mark.fast
+def test_doctor_cmd_accepts_path_arguments(monkeypatch, tmp_path: Path) -> None:
+    """``doctor_cmd`` normalizes ``config_dir`` to :class:`Path`."""
+
+    bridge = StubBridge()
+    monkeypatch.chdir(tmp_path)
+    for required in ("src", "tests", "docs"):
+        (tmp_path / required).mkdir(exist_ok=True)
+    monkeypatch.setenv("OPENAI_API_KEY", "token")
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "token")
+
+    monkeypatch.setattr(doctor_module, "_check_services", lambda *_: None)
+    monkeypatch.setattr(doctor_module, "load_config", lambda: types.SimpleNamespace(features={}, memory_store_type="memory"))
+    monkeypatch.setattr(doctor_module, "_find_project_config", lambda _: Path("."))
+    monkeypatch.setattr(doctor_module.shutil, "which", lambda _: "poetry")
+    monkeypatch.setattr(doctor_module.importlib.util, "find_spec", lambda _: object())
+    monkeypatch.setattr(doctor_module.sys, "version_info", (3, 12))
+    monkeypatch.setattr(doctor_module.sys, "version", "3.12.0")
+
+    class _Loader:
+        def exec_module(self, module: types.SimpleNamespace) -> None:
+            module.load_config = lambda path: {}
+            module.validate_config = lambda data, schema: []
+            module.validate_environment_variables = lambda data: []
+            module.check_config_consistency = lambda configs: []
+            module.CONFIG_SCHEMA = {}
+
+    monkeypatch.setattr(
+        doctor_module.importlib.util,
+        "spec_from_file_location",
+        lambda *_, **__: types.SimpleNamespace(loader=_Loader()),
+    )
+    monkeypatch.setattr(
+        doctor_module.importlib.util,
+        "module_from_spec",
+        lambda spec: types.SimpleNamespace(),
+    )
+
+    config_dir = tmp_path / "config"
+    config_dir.mkdir(exist_ok=True)
+    for env in ("default", "development", "testing", "staging", "production"):
+        (config_dir / f"{env}.yml").write_text("{}")
+
+    doctor_module.doctor_cmd(config_dir=config_dir, quick=False, bridge=bridge)
+
+    assert any("All configuration files are valid." in msg for msg in bridge.messages)

--- a/tests/unit/application/cli/commands/test_ingest_cli_command.py
+++ b/tests/unit/application/cli/commands/test_ingest_cli_command.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+import importlib
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+ingest_module = importlib.import_module("devsynth.application.cli.commands.ingest_cmd")
+
+
+@pytest.mark.fast
+def test_ingest_cli_command_uses_typed_options(monkeypatch, tmp_path: Path) -> None:
+    """The Typer command forwards typed options to the implementation."""
+
+    captured: dict[str, Any] = {}
+
+    def fake_ingest_cmd(**kwargs: Any) -> None:
+        captured.update(kwargs)
+
+    monkeypatch.setattr(ingest_module, "_ingest_cmd", fake_ingest_cmd)
+
+    manifest_path = tmp_path / "manifest.yaml"
+    manifest_path.write_text("{}")
+
+    ingest_module.ingest_cmd(
+        manifest_path=manifest_path,
+        dry_run=True,
+        verbose=True,
+        validate_only=False,
+        yes=True,
+        priority="high",
+        auto_phase_transitions=False,
+        defaults=True,
+        non_interactive=True,
+        bridge=None,
+    )
+
+    assert captured["manifest_path"] == manifest_path
+    assert isinstance(captured["manifest_path"], Path)
+    assert captured["bridge"] is not None
+    assert captured["non_interactive"] is True
+    assert captured["defaults"] is True

--- a/tests/unit/application/cli/test_sprint_cmd_types.py
+++ b/tests/unit/application/cli/test_sprint_cmd_types.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from devsynth.application.cli import sprint_cmd
+
+
+@pytest.mark.fast
+def test_sprint_planning_cmd_returns_structured_plan(tmp_path: Path) -> None:
+    """The sprint planning helper returns a typed dictionary."""
+
+    payload = {
+        "recommended_scope": ["story-123"],
+        "objectives": ["ship"],
+        "success_criteria": ["tests green"],
+    }
+    source = tmp_path / "requirements.json"
+    source.write_text(json.dumps(payload))
+
+    plan = sprint_cmd.sprint_planning_cmd(str(source))
+
+    assert plan["planned_scope"] == payload["recommended_scope"]
+    assert plan["objectives"] == payload["objectives"]
+    assert plan["success_criteria"] == payload["success_criteria"]
+
+
+@pytest.mark.fast
+def test_sprint_retrospective_cmd_defaults_when_missing(tmp_path: Path) -> None:
+    """The retrospective helper always returns structured fields."""
+
+    summary = sprint_cmd.sprint_retrospective_cmd("{}", sprint=5)
+    assert summary["positives"] == []
+    assert summary["improvements"] == []
+    assert summary["action_items"] == []
+    assert summary["sprint"] == 5
+
+
+@pytest.mark.fast
+def test_sprint_retrospective_cmd_handles_invalid_json() -> None:
+    """Gracefully handle non-JSON input by returning empty structures."""
+
+    summary = sprint_cmd.sprint_retrospective_cmd("not-json", sprint=7)
+    assert summary["positives"] == []
+    assert summary["sprint"] == 7


### PR DESCRIPTION
## Summary
- refactor the setup wizard to use typed dataclasses, stricter feature parsing, and consistent Path handling for CLI input
- introduce typed option containers for the Typer ingest command and doctor CLI, and tighten the lightweight progress manager
- add sprint helper typed dicts plus focused CLI regression tests that exercise the typed interfaces

## Testing
- poetry run mypy src/devsynth/application/cli/setup_wizard.py src/devsynth/application/cli/progress.py src/devsynth/application/cli/sprint_cmd.py src/devsynth/application/cli/commands/ingest_cmd.py src/devsynth/application/cli/commands/doctor_cmd.py
- poetry run pytest --no-cov tests/unit/application/cli/test_setup_wizard.py tests/unit/application/cli/test_sprint_cmd_types.py tests/unit/application/cli/commands/test_ingest_cli_command.py tests/unit/application/cli/commands/test_doctor_cmd_typed.py

------
https://chatgpt.com/codex/tasks/task_e_68d4950f9b6c83338b96244885463ab8