### PR TITLE
docs: add typing strictness audit baseline

### DIFF
--- a/docs/typing/strictness.md
+++ b/docs/typing/strictness.md
@@ -1,0 +1,63 @@
+# Typing Strictness Progress Note (2025-09-25)
+
+## Methodology
+- Ran exploratory `poetry run mypy --strict` commands with a minimal `/tmp/mypy_strict.ini` configuration that mirrors the repo defaults minus the per-module overrides, allowing us to observe true violations in suppressed modules.
+- Chose one representative module per override group so future audits can compare outputs with identical commands.
+
+## Override Inventory
+The current `pyproject.toml` keeps `ignore_errors = true` across most production subsystems, with relaxed def-checking for the test suite and a broad application-layer carveout.【F:pyproject.toml†L251-L392】
+
+| Override scope | Notes |
+| --- | --- |
+| `tests.*` | Allows untyped defs while the rest of the suite stays strict. |
+| `devsynth.security.*`, `devsynth.adapters.*`, `devsynth.memory.*`, `devsynth.core.*`, `devsynth.agents.*`, `devsynth.api` | Legacy relaxations to unblock refactors; mostly `Any` returns and missing annotations. |
+| `devsynth.logging_setup`, `devsynth.interface.*`, `devsynth.utils.*`, `devsynth.metrics`, `devsynth.observability.metrics`, `devsynth.fallback`, `devsynth.ports.*`, `devsynth.config.*` | High fan-out services with pervasive dynamic patterns. |
+| `devsynth.application.*` bundles | Broad ignore blocks spanning orchestration, prompts, LLMs, memory stores, etc. |
+| `devsynth.application.requirements.*`, `devsynth.interface.agentapi_enhanced` | Added after the last strict sweep to keep delivery velocity.【F:pyproject.toml†L384-L392】 |
+
+## Findings by subsystem
+
+### Phase 1 – Foundational modules (target 2025-11-15)
+Focus: security, adapters, memory, core, agents, and API endpoints. These files mostly fail due to `Any` flows and missing return annotations, which are straightforward to address once interfaces stabilize.
+
+- `security/authentication.py` still returns `Any` from helper functions expected to return concrete `str`/`bool` values.【ac31cd†L1-L3】
+- `adapters/github_project.py` leaks `Any` when composing the GitHub payload response.【d0d961†L1-L3】
+- `memory/layered_cache.py` already passes strict mypy, so the package-wide ignore can begin shrinking immediately.【084ac1†L1-L2】
+- `core/config_loader.py` mixes missing `toml` stubs with dynamic config munging that needs proper model typing.【063e40†L1-L9】
+- `agents/multi_agent_coordinator.py` passes, indicating orchestration logic is ready for strictness once dependencies are typed.【559585†L1-L2】
+- `api.py` shows untyped FastAPI decorators and missing annotations on endpoint functions.【17599c†L1-L4】
+
+### Phase 2 – Platform services (target 2025-12-20)
+Focus: logging, interface utilities, metrics, fallback logic, ports, config loaders, and shared utils.
+
+- `logging_setup.py` produces 18 errors, highlighting missing generics, Optional handling, and extensive logger patching without types.【d88613†L1-L22】
+- `interface/progress_utils.py` lacks type parameters and annotations on progress message helpers.【353ac0†L1-L5】
+- `utils/logging.py` relies on `type: ignore` to mask subclassing issues and untyped functions.【9319c3†L1-L5】
+- `metrics.py` and `observability/metrics.py` rely on blanket ignores hiding real redefinition and dynamic attribute issues.【02935e†L1-L4】【dfacd6†L1-L10】
+- `fallback.py` contains 28 errors dominated by implicit Optional defaults, lambda inference gaps, and incorrect exception typing.【a80d39†L1-L29】
+- `ports/agent_port.py` and `config/settings.py` show pervasive Optional misuse and missing model annotations, suggesting a broader need for typed config schemas.【018dc7†L1-L6】【c7f96d†L1-L36】
+
+### Phase 3 – Application workflows (target 2026-02-15)
+Focus: orchestration, prompts, agents, ingestion, and supporting utilities.
+
+- `application/agents/agent_memory_integration.py` leaks `Any` through almost every integration pathway, driving downstream uncertainty.【46b4b0†L1-L9】
+- `application/orchestration/workflow.py` returns `Any` from key orchestrators, indicating missing typed DTOs.【c8f82e†L1-L3】
+- `application/prompts/prompt_manager.py` mixes `Any` returns with missing imports like `datetime`, breaking strict mode.【236778†L1-L5】
+- `application/server/bridge.py` and `application/ingestion/phases.py` already pass, providing quick wins for scoping ignores more tightly.【2b599a†L1-L2】【55db3f†L1-L2】
+- `application/utils/token_tracker.py` needs dict annotations and concrete return types for telemetry counters.【107bfe†L1-L4】
+- `application/requirements/requirement_service.py` still returns `Any` and lacks dict generics, so the requirements override remains necessary until typed data contracts land.【e64816†L1-L5】
+
+### Phase 4 – Memory stack (target 2026-03-15)
+The application memory manager and stores are the noisiest area, with dozens of `Any`-returning methods and Optional defaults that violate strictness.【322ce9†L1-L24】 Addressing these will likely require stabilized domain models and possibly dedicated stubs for storage adapters.
+
+### Phase 5 – Enhanced API surface (target 2026-03-31)
+`interface/agentapi.py` and `interface/agentapi_enhanced.py` each emit 40–90 errors dominated by untyped FastAPI decorators, Optional defaults, and reliance on dynamically typed Pydantic models.【695d69†L1-L43】【81cae7†L1-L86】 Tackling these should follow upstream schema consolidation work so that BaseModel subclasses and bridge interfaces can be annotated once and reused.
+
+## Recommendations & Next Steps
+1. **Create type-safe response models** for the security, adapter, and API layers; these modules show low error counts and can meet the 2025-11-15 deadline once DTOs and helper signatures are fixed.
+2. **Refactor logging and fallback utilities** to remove implicit Optionals and document dynamic attributes, aligning with the 2025-12-20 target.
+3. **Carve down application overrides** by first enforcing strictness on already-compliant modules (e.g., ingestion phases, server bridge) before deeper refactors, preparing for the February 2026 milestone.
+4. **Plan a dedicated memory typing effort**—introduce typed dataclasses or Pydantic models for metadata and query results to eliminate `Any` in the memory manager before March 2026.
+5. **Align FastAPI interfaces** with shared schema definitions before attempting to lift the enhanced API overrides; this needs coordinated workstreams in Q1 2026.
+
+The phased deadlines above replace the earlier blanket dates and are referenced directly from `pyproject.toml` comments for visibility.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -257,10 +257,10 @@ disallow_incomplete_defs = false
 # Relax strictness for recently changed modules to allow incremental typing.
 # Rationale: these modules are actively evolving; we keep global strictness high
 # while avoiding blocking changes. Add TODOs in modules to restore strictness.
-# Target to restore strictness: 2025-10-01
+# Target to restore strictness: 2025-11-15 (see docs/typing/strictness.md §Phase 1 – Foundational modules)
 
 # Temporary relaxations to achieve green typing while we incrementally add annotations.
-# TODO: Restore strictness by 2025-10-15; prioritize modules cited in docs/plan.md Phase 4.
+# TODO: Restore strictness by 2025-11-15 (see docs/typing/strictness.md §Phase 1 – Foundational modules).
 [[tool.mypy.overrides]]
 module = "devsynth.security.*"
 ignore_errors = true
@@ -289,7 +289,7 @@ module = "devsynth.api"
 ignore_errors = true
 
 # Temporary relaxations for remaining hotspots (Iteration 2025-08-31)
-# TODO: Restore strictness by 2025-10-01.
+# TODO: Restore strictness by 2025-12-20 (see docs/typing/strictness.md §Phase 2 – Platform services).
 [[tool.mypy.overrides]]
 module = "devsynth.logging_setup"
 ignore_errors = true
@@ -327,7 +327,7 @@ module = "devsynth.config.*"
 ignore_errors = true
 
 # Broad temporary relaxation for application layer to unblock typing gate while we add annotations iteratively.
-# TODO: Narrow and remove by 2025-10-15; track in docs/plan.md Phase 4.
+# TODO: Narrow and remove by 2026-02-15 (see docs/typing/strictness.md §Phase 3 – Application workflows).
 [[tool.mypy.overrides]]
 module = [
   "devsynth.application.agents.*",
@@ -382,7 +382,7 @@ module = ["chromadb", "chromadb.*"]
 ignore_missing_imports = true
 
 # Added by Task 54 (2025-09-03): targeted temporary relaxations based on strict mypy run
-# TODO: Restore strictness by 2025-10-15 after incremental typing
+# TODO: Restore strictness by 2026-03-31 (see docs/typing/strictness.md §§Phase 3–5 for sequencing)
 [[tool.mypy.overrides]]
 module = "devsynth.application.requirements.*"
 ignore_errors = true


### PR DESCRIPTION
## Summary
- add a typing progress note that captures strict mypy sampling results and phased removal targets for each override group
- update mypy override comments in `pyproject.toml` to reference the audit note and align TODO dates with the new roadmap

## Testing
- `task docs:build` *(fails: command not found in container PATH)*
- `poetry run mkdocs build --strict` *(fails: mkdocs_autorefs ValueError from existing docs warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68d4b082bcf083339178ed15b44041d6