### PR TITLE
chore: enforce strict typing on metrics modules

### DIFF
--- a/docs/typing/strictness.md
+++ b/docs/typing/strictness.md
@@ -34,7 +34,7 @@ Focus: interface utilities, metrics, fallback logic, ports, and shared utils.
 - ✅ `config` package loaders/settings pass strict mode after tightening validator signatures and schema parsing. Remaining debt: `Settings` still mixes runtime environment coercion with persistence defaults—plan a follow-up to extract typed DTOs for `resources` and LLM overrides.
 - `interface/progress_utils.py` lacks type parameters and annotations on progress message helpers.【353ac0†L1-L5】
 - `utils/logging.py` relies on `type: ignore` to mask subclassing issues and untyped functions.【9319c3†L1-L5】
-- `metrics.py` and `observability/metrics.py` rely on blanket ignores hiding real redefinition and dynamic attribute issues.【02935e†L1-L4】【dfacd6†L1-L10】
+- ✅ `metrics.py` and `observability/metrics.py` now pass strict mode after introducing typed Prometheus counter protocols and localized fallbacks (2025-09-26). Future refinement: replace ad-hoc casts with dedicated shim stubs if upstream signatures drift.【F:src/devsynth/metrics.py†L15-L77】【F:src/devsynth/observability/metrics.py†L15-L74】
 - `fallback.py` contains 28 errors dominated by implicit Optional defaults, lambda inference gaps, and incorrect exception typing.【a80d39†L1-L29】
 - `ports/agent_port.py` still suffers from dynamic attribute wiring; tightening port DTOs remains on the backlog.【018dc7†L1-L6】
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -303,14 +303,6 @@ module = "devsynth.utils.*"
 ignore_errors = true
 
 [[tool.mypy.overrides]]
-module = "devsynth.metrics"
-ignore_errors = true
-
-[[tool.mypy.overrides]]
-module = "devsynth.observability.metrics"
-ignore_errors = true
-
-[[tool.mypy.overrides]]
 module = "devsynth.fallback"
 ignore_errors = true
 

--- a/src/devsynth/metrics.py
+++ b/src/devsynth/metrics.py
@@ -13,35 +13,49 @@ runtime scraping.
 from __future__ import annotations
 
 from collections import Counter as DictCounter
-from typing import Callable, Dict, Optional
+from typing import Callable, Dict, Optional, Protocol, Self, cast
+
+
+class CounterProtocol(Protocol):
+    """Subset of the Prometheus counter API used within DevSynth."""
+
+    def labels(self, *args: object, **kwargs: object) -> Self:
+        ...
+
+    def inc(self, *args: object, **kwargs: object) -> None:
+        ...
+
+    def clear(self) -> None:
+        ...
 
 # Attempt to import Prometheus metrics, falling back to no-op counters when the
 # optional dependency is unavailable.  This allows the core system and tests to
 # run in minimal environments where ``prometheus_client`` isn't installed.
 try:  # pragma: no cover - import guarded for optional dependency
-    from prometheus_client import Counter
+    from prometheus_client import Counter as _PrometheusCounter
 except Exception:  # pragma: no cover - fallback for minimal environments
+    _PrometheusCounter = None
 
-    class Counter:  # type: ignore[override]
-        """Lightweight stand-in for :class:`prometheus_client.Counter`.
 
-        The dummy implementation exposes the ``labels``, ``inc`` and ``clear``
-        methods used throughout the codebase but performs no operations.  Using
-        this class keeps metric calls lightweight when Prometheus support isn't
-        installed without requiring additional conditionals at call sites.
-        """
-
-        def __init__(self, *args: object, **kwargs: object) -> None:  # noqa: D401
-            pass
-
-        def labels(self, *args: object, **kwargs: object) -> "Counter":
+def _noop_counter(*args: object, **kwargs: object) -> CounterProtocol:
+    class _NoOpCounter:
+        def labels(self, *l_args: object, **l_kwargs: object) -> "_NoOpCounter":
             return self
 
-        def inc(self, *args: object, **kwargs: object) -> None:
-            pass
+        def inc(self, *i_args: object, **i_kwargs: object) -> None:
+            return None
 
         def clear(self) -> None:
-            pass
+            return None
+
+    return cast(CounterProtocol, _NoOpCounter())
+
+
+Counter: Callable[..., CounterProtocol]
+if _PrometheusCounter is not None:
+    Counter = cast(Callable[..., CounterProtocol], _PrometheusCounter)
+else:
+    Counter = _noop_counter
 
 
 # ---------------------------------------------------------------------------
@@ -68,35 +82,37 @@ _dashboard_hook: Optional[Callable[[str], None]] = None
 # ---------------------------------------------------------------------------
 # Prometheus counters
 # ---------------------------------------------------------------------------
-_memory_counter = Counter(
+_memory_counter: CounterProtocol = Counter(
     "devsynth_memory_operations_total", "Memory operations", ["op"]
 )
-_provider_counter = Counter(
+_provider_counter: CounterProtocol = Counter(
     "devsynth_provider_operations_total", "Provider operations", ["op"]
 )
-retry_event_counter = Counter("devsynth_retry_events_total", "Retry events", ["status"])
-retry_function_counter = Counter(
+retry_event_counter: CounterProtocol = Counter(
+    "devsynth_retry_events_total", "Retry events", ["status"]
+)
+retry_function_counter: CounterProtocol = Counter(
     "devsynth_retry_function_total", "Retry attempts per function", ["function"]
 )
-retry_error_counter = Counter(
+retry_error_counter: CounterProtocol = Counter(
     "devsynth_retry_errors_total", "Retry events grouped by exception", ["error_type"]
 )
-retry_condition_counter = Counter(
+retry_condition_counter: CounterProtocol = Counter(
     "devsynth_retry_conditions_total",
     "Retry aborts grouped by failed condition",
     ["condition"],
 )
-retry_stat_counter = Counter(
+retry_stat_counter: CounterProtocol = Counter(
     "devsynth_retry_stat_total",
     "Retry outcomes grouped by function and status",
     ["function", "status"],
 )
 # Dashboard events counter
-dashboard_event_counter = Counter(
+dashboard_event_counter: CounterProtocol = Counter(
     "devsynth_dashboard_events_total", "Dashboard events", ["event"]
 )
 # Circuit breaker state transitions counter
-circuit_breaker_state_counter = Counter(
+circuit_breaker_state_counter: CounterProtocol = Counter(
     "devsynth_circuit_breaker_state_total",
     "Circuit breaker state transitions",
     ["function", "state"],


### PR DESCRIPTION
## Summary
- replace Prometheus counter fallbacks with typed protocols and casts in metrics modules so strict mypy passes
- remove the mypy override entries for the metrics packages and document the restored strictness in the typing progress note

## Testing
- poetry run mypy --strict devsynth/metrics.py devsynth/observability/metrics.py

------
https://chatgpt.com/codex/tasks/task_e_68d4b5ee24348333b52973d06ca14608