### PR TITLE
chore: enforce strict mypy for application config slice

### DIFF
--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -39,3 +39,8 @@ jobs:
         env:
           MYPY_CACHE_DIR: .mypy_cache
         run: poetry run mypy src/devsynth
+
+      - name: Run strict mypy on application slices
+        env:
+          MYPY_CACHE_DIR: .mypy_cache
+        run: poetry run mypy --strict src/devsynth/application/config src/devsynth/application/server

--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ Setup (choose one)
 
 Sanity checks
 - task env:verify  # ensure go-task and the devsynth CLI are available
+- task mypy:strict  # run strict mypy for the typed application slices
 - poetry run devsynth --help
 - poetry run devsynth doctor
 - poetry run devsynth run-tests --target unit-tests --speed=fast --no-parallel --maxfail=1

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -140,6 +140,11 @@ tasks:
       - poetry run bandit -r src/devsynth -x tests -q -f txt -o test_reports/bandit_report.txt
       - bash -lc 'mkdir -p test_reports; poetry run safety check --full-report | tee test_reports/safety_report.txt; exit ${PIPESTATUS[0]}'
 
+  mypy:strict:
+    desc: Run strict mypy on typed application slices
+    cmds:
+      - poetry run mypy --strict src/devsynth/application/config src/devsynth/application/server
+
   tests:property:
     desc: Run opt-in property tests (requires DEVSYNTH_PROPERTY_TESTING=true)
     cmds:

--- a/docs/typing/strictness.md
+++ b/docs/typing/strictness.md
@@ -44,7 +44,8 @@ Focus: orchestration, prompts, agents, ingestion, and supporting utilities.
 - `application/agents/agent_memory_integration.py` leaks `Any` through almost every integration pathway, driving downstream uncertainty.【46b4b0†L1-L9】
 - `application/orchestration/workflow.py` returns `Any` from key orchestrators, indicating missing typed DTOs.【c8f82e†L1-L3】
 - `application/prompts/prompt_manager.py` mixes `Any` returns with missing imports like `datetime`, breaking strict mode.【236778†L1-L5】
-- `application/server/bridge.py` and `application/ingestion/phases.py` already pass, providing quick wins for scoping ignores more tightly.【2b599a†L1-L2】【55db3f†L1-L2】
+- ✅ `application/config/unified_config_loader.py` and `application/server/bridge.py` now run under `poetry run mypy --strict` via the `task mypy:strict` guard; the override has been narrowed accordingly to prevent regressions.【F:src/devsynth/application/config/unified_config_loader.py†L1-L37】【F:Taskfile.yml†L143-L146】
+- `application/ingestion/phases.py` already passes, providing a quick win for scoping ignores more tightly.【55db3f†L1-L2】
 - `application/utils/token_tracker.py` needs dict annotations and concrete return types for telemetry counters.【107bfe†L1-L4】
 - `application/requirements/requirement_service.py` still returns `Any` and lacks dict generics, so the requirements override remains necessary until typed data contracts land.【e64816†L1-L5】
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -317,7 +317,6 @@ module = [
   "devsynth.application.agents.*",
   "devsynth.application.code_analysis.*",
   "devsynth.application.collaboration.*",
-  "devsynth.application.config.*",
   "devsynth.application.ingestion.*",
   "devsynth.application.issues.*",
   "devsynth.application.llm.*",
@@ -325,7 +324,6 @@ module = [
   "devsynth.application.orchestration.*",
   "devsynth.application.promises.*",
   "devsynth.application.prompts.*",
-  "devsynth.application.server.*",
   "devsynth.application.sprint.*",
   "devsynth.application.utils.*",
 ]

--- a/src/devsynth/application/config/unified_config_loader.py
+++ b/src/devsynth/application/config/unified_config_loader.py
@@ -8,12 +8,12 @@ with awareness of the ``DEVSYNTH_PROJECT_DIR`` environment variable.
 
 import os
 from pathlib import Path
-from typing import Optional
+from typing import Optional, cast
 
 from devsynth.config.unified_loader import (
     UnifiedConfig,
+    UnifiedConfigLoader as CoreUnifiedConfigLoader,
 )
-from devsynth.config.unified_loader import UnifiedConfigLoader as _CoreLoader
 
 
 class UnifiedConfigLoader:
@@ -23,11 +23,15 @@ class UnifiedConfigLoader:
     def load(path: Optional[str | Path] = None) -> UnifiedConfig:
         project_dir = os.environ.get("DEVSYNTH_PROJECT_DIR")
         base = Path(path or project_dir or Path.cwd())
-        return _CoreLoader.load(base)
+        return CoreUnifiedConfigLoader.load(base)
 
     @staticmethod
     def save(config: UnifiedConfig) -> Path:
-        return _CoreLoader.save(config)
+        core_loader = CoreUnifiedConfigLoader()
+        # NOTE(2026-02-15): mypy loses the staticmethod return type when the
+        # application layer re-exports the loader; cast until the upstream
+        # loader is exposed via a typed facade for reuse.
+        return cast(Path, core_loader.save(config))
 
 
 __all__ = ["UnifiedConfigLoader"]


### PR DESCRIPTION
## Summary
- remove the application-layer mypy override for config and server modules now passing strict checks
- harden UnifiedConfigLoader to keep strict typing, add a strict mypy task, and document the new workflow
- surface the strict slice in CI, README, and the typing progress note so regressions are caught early

## Testing
- `poetry run mypy --strict src/devsynth/application/config src/devsynth/application/server`

------
https://chatgpt.com/codex/tasks/task_e_68d4b7d7fe3c8333b1142db32ce42d1f