### PR TITLE
fix: retire unused runtime type ignores

### DIFF
--- a/src/devsynth/config/settings.py
+++ b/src/devsynth/config/settings.py
@@ -18,7 +18,7 @@ if TYPE_CHECKING:
 
     F = TypeVar("F", bound=Callable[..., Any])
 
-    class BaseSettings(_BaseModel):  # type: ignore[misc]
+    class BaseSettings(_BaseModel):
         model_config: SettingsConfigDict
 
     def field_validator(*args: Any, **kwargs: Any) -> Callable[[F], F]: ...
@@ -26,7 +26,7 @@ else:
     from pydantic_settings import BaseSettings as _BaseSettings
     from pydantic import field_validator as _field_validator
 
-    BaseSettings = _BaseSettings  # type: ignore[assignment]  # TODO(2025-12-20): Drop once upstream ships typed BaseSettings.
+    BaseSettings = _BaseSettings  # TODO(2025-12-20): Drop once upstream ships typed BaseSettings.
     field_validator = _field_validator
 
 # Create a logger for this module

--- a/src/sitecustomize.py
+++ b/src/sitecustomize.py
@@ -7,6 +7,7 @@ import importlib.util
 import sys
 import types
 from pathlib import Path
+from typing import Any, Dict
 
 
 def _patch_starlette_testclient() -> None:
@@ -38,7 +39,7 @@ def _patch_starlette_testclient() -> None:
         return
 
     try:
-        import httpx  # type: ignore
+        import httpx
         from starlette.websockets import WebSocketDisconnect
     except Exception:
         return
@@ -66,7 +67,7 @@ def _patch_starlette_testclient() -> None:
         "starlette.testclient", spec.loader
     )
 
-    exec_globals = module.__dict__
+    exec_globals: Dict[str, Any] = module.__dict__
     exec_globals["httpx"] = httpx
     exec_globals["WebSocketDisconnect"] = WebSocketDisconnect
 


### PR DESCRIPTION
## Summary
- import typing helpers in sitecustomize to replace the unused httpx ignore
- drop the stale type: ignore scaffolding in settings while keeping the TODO context

## Testing
- poetry run mypy src/sitecustomize.py src/devsynth/config/settings.py
- poetry run mypy src

------
https://chatgpt.com/codex/tasks/task_e_68d4c2f4fc80833393189722f5faa3bd