### PR TITLE
feat: add typed wsde dialectical workflow facade

### DIFF
--- a/src/devsynth/domain/models/wsde_dialectical_types.py
+++ b/src/devsynth/domain/models/wsde_dialectical_types.py
@@ -1,0 +1,163 @@
+"""Typed helpers wrapping the legacy dialectical reasoning workflow."""
+
+from __future__ import annotations
+
+from collections.abc import Iterator, Mapping
+from datetime import datetime
+from typing import Any
+from uuid import uuid4
+
+from devsynth.logging_setup import DevSynthLogger
+
+from . import wsde_dialectical as _legacy
+
+logger = DevSynthLogger(__name__)
+
+
+class DialecticalTask(Mapping[str, Any]):
+    """Structured representation of a task entering the dialectical loop."""
+
+    __slots__ = ("identifier", "solution", "metadata", "_payload")
+
+    def __init__(
+        self,
+        *,
+        identifier: str,
+        solution: Any,
+        payload: Mapping[str, Any] | None = None,
+        metadata: Mapping[str, Any] | None = None,
+    ) -> None:
+        self.identifier = identifier
+        self.solution = solution
+        self.metadata = dict(metadata or {})
+        base_payload = dict(payload or {})
+        base_payload.setdefault("id", identifier)
+        base_payload["solution"] = solution
+        self._payload: dict[str, Any] = base_payload
+
+    def __getitem__(self, key: str) -> Any:
+        return self._payload[key]
+
+    def __iter__(self) -> Iterator[str]:  # pragma: no cover - trivial
+        return iter(self._payload)
+
+    def __len__(self) -> int:  # pragma: no cover - trivial
+        return len(self._payload)
+
+    def copy(self) -> dict[str, Any]:
+        return dict(self._payload)
+
+    def get(self, key: str, default: Any = None) -> Any:  # pragma: no cover - trivial
+        return self._payload.get(key, default)
+
+    def to_dict(self) -> dict[str, Any]:
+        return self.copy()
+
+    def with_solution(self, solution: Any) -> DialecticalTask:
+        payload = dict(self._payload)
+        payload["solution"] = solution
+        return DialecticalTask(
+            identifier=self.identifier,
+            solution=solution,
+            payload=payload,
+            metadata=self.metadata,
+        )
+
+    @classmethod
+    def from_mapping(cls, payload: Mapping[str, Any]) -> DialecticalTask:
+        identifier = str(payload.get("id", uuid4()))
+        solution = payload.get("solution")
+        metadata = payload.get("metadata", {})
+        return cls(
+            identifier=identifier,
+            solution=solution,
+            payload=payload,
+            metadata=metadata,
+        )
+
+
+def ensure_dialectical_task(
+    task: DialecticalTask | Mapping[str, Any]
+) -> DialecticalTask:
+    if isinstance(task, DialecticalTask):
+        return task
+    if isinstance(task, Mapping):
+        return DialecticalTask.from_mapping(task)
+    msg = f"Unsupported task payload type: {type(task)!r}"
+    raise TypeError(msg)
+
+
+def apply_dialectical_reasoning(
+    self: _legacy.WSDETeam,
+    task: DialecticalTask | Mapping[str, Any],
+    critic_agent: Any,
+    memory_integration: Any = None,
+) -> _legacy.DialecticalSequence:
+    """Typed façade around the legacy dialectical reasoning implementation."""
+
+    task_obj = ensure_dialectical_task(task)
+    if task_obj.solution is None:
+        logger.warning("Cannot apply dialectical reasoning: no solution provided")
+        return _legacy.DialecticalSequence.failed(reason="no_solution")
+
+    if isinstance(task_obj.solution, Mapping):
+        thesis_payload = dict(task_obj.solution)
+    else:
+        thesis_payload = {"content": task_obj.solution}
+
+    antithesis = self._generate_antithesis(thesis_payload, critic_agent)
+
+    critic_id = antithesis.critic_id
+    critique_messages = list(antithesis.critiques)
+    domain_mapping = self._categorize_critiques_by_domain(critique_messages)
+    message_domains = _legacy._invert_domain_mapping(domain_mapping)
+
+    critiques: list[_legacy.Critique] = []
+    for ordinal, message in enumerate(critique_messages):
+        critiques.append(
+            _legacy.Critique.from_message(
+                reviewer_id=critic_id,
+                ordinal=ordinal,
+                message=message,
+                domains=message_domains.get(message, ()),
+                metadata={"antithesis_id": antithesis.identifier},
+            )
+        )
+
+    resolution = self._generate_synthesis(
+        thesis_payload,
+        antithesis,
+        tuple(critiques),
+        domain_mapping,
+    )
+
+    step = _legacy.DialecticalStep(
+        step_id=str(uuid4()),
+        timestamp=datetime.now(),
+        task_id=task_obj.identifier,
+        thesis=thesis_payload,
+        critiques=tuple(critiques),
+        resolution=resolution,
+        critic_id=critic_id,
+        antithesis_id=antithesis.identifier,
+        antithesis_generated_at=antithesis.timestamp,
+        improvement_suggestions=antithesis.improvement_suggestions,
+        alternative_approaches=antithesis.alternative_approaches,
+    )
+
+    sequence = _legacy.DialecticalSequence(
+        sequence_id=str(uuid4()),
+        steps=(step,),
+    )
+
+    for hook in self.dialectical_hooks:
+        hook(task_obj, (sequence,))
+
+    if memory_integration:
+        memory_integration.store_dialectical_result(task_obj, sequence)
+
+    return sequence
+
+
+_legacy.WSDETeam.apply_dialectical_reasoning = apply_dialectical_reasoning
+

--- a/tests/helpers/__init__.py
+++ b/tests/helpers/__init__.py
@@ -1,1 +1,13 @@
 """Test helper utilities."""
+
+from .factories import (
+    DialecticalTaskFactory,
+    build_dialectical_sequence,
+    build_resolution_plan,
+)
+
+__all__ = [
+    "DialecticalTaskFactory",
+    "build_dialectical_sequence",
+    "build_resolution_plan",
+]

--- a/tests/helpers/factories.py
+++ b/tests/helpers/factories.py
@@ -1,0 +1,93 @@
+"""Factories for constructing domain model instances in tests."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Any, Mapping, Sequence
+from uuid import uuid4
+
+from devsynth.domain.models.wsde_dialectical import (
+    Critique,
+    DialecticalSequence,
+    DialecticalStep,
+    ResolutionPlan,
+)
+from devsynth.domain.models.wsde_dialectical_types import DialecticalTask
+
+
+@dataclass(slots=True)
+class DialecticalTaskFactory:
+    """Factory helpers for creating :class:`DialecticalTask` instances."""
+
+    default_solution: Mapping[str, Any] | None = None
+
+    def build(self, **overrides: Any) -> DialecticalTask:
+        payload: dict[str, Any] = {
+            "id": overrides.pop("task_id", str(uuid4())),
+            "solution": overrides.pop(
+                "solution",
+                self.default_solution or {"content": "Example", "code": "print('hi')"},
+            ),
+        }
+        payload.update(overrides)
+        return DialecticalTask.from_mapping(payload)
+
+
+def build_resolution_plan(
+    *,
+    integrated_critiques: Sequence[Critique] | None = None,
+    rejected_critiques: Sequence[Critique] | None = None,
+    improvements: Sequence[str] | None = None,
+    reasoning: str = "",
+    content: str | None = None,
+    code: str | None = None,
+) -> ResolutionPlan:
+    """Create a :class:`ResolutionPlan` with deterministic defaults."""
+
+    now = datetime.now()
+    return ResolutionPlan(
+        plan_id=str(uuid4()),
+        timestamp=now,
+        integrated_critiques=tuple(integrated_critiques or ()),
+        rejected_critiques=tuple(rejected_critiques or ()),
+        improvements=tuple(improvements or ()),
+        reasoning=reasoning,
+        content=content,
+        code=code,
+    )
+
+
+def build_dialectical_sequence(
+    *,
+    status: str = "completed",
+    thesis: Mapping[str, Any] | None = None,
+    resolution: ResolutionPlan | None = None,
+    critiques: Sequence[Critique] | None = None,
+    method: str = "dialectical_reasoning",
+    critic_id: str = "critic",
+    task_id: str | None = None,
+) -> DialecticalSequence:
+    """Assemble a :class:`DialecticalSequence` for testing flows."""
+
+    now = datetime.now()
+    thesis_payload = dict(thesis or {"content": "Initial thesis"})
+    plan = resolution or build_resolution_plan(reasoning="Auto-generated plan")
+    step = DialecticalStep(
+        step_id=str(uuid4()),
+        timestamp=now,
+        task_id=task_id or str(uuid4()),
+        thesis=thesis_payload,
+        critiques=tuple(critiques or ()),
+        resolution=plan,
+        method=method,
+        critic_id=critic_id,
+        antithesis_id=str(uuid4()),
+        antithesis_generated_at=now,
+    )
+    return DialecticalSequence(
+        sequence_id=str(uuid4()),
+        steps=(step,),
+        status=status,
+    )
+

--- a/tests/integration/general/test_chromadb_memory_store_integration.py
+++ b/tests/integration/general/test_chromadb_memory_store_integration.py
@@ -4,7 +4,10 @@ from unittest.mock import patch
 
 import pytest
 
-pytest.importorskip("chromadb")
+pytest.importorskip(
+    "chromadb.api",
+    reason="ChromaDB integration tests require the chromadb API client",
+)
 
 from devsynth.adapters.chromadb_memory_store import ChromaDBMemoryStore
 from devsynth.domain.models.memory import MemoryItem, MemoryType

--- a/tests/property/test_reasoning_loop_properties.py
+++ b/tests/property/test_reasoning_loop_properties.py
@@ -15,6 +15,7 @@ try:
 except ImportError:  # pragma: no cover
     pytest.skip("hypothesis not available", allow_module_level=True)
 
+from devsynth.domain.models.wsde_dialectical import DialecticalSequence
 from devsynth.domain.models.wsde_facade import WSDETeam
 from devsynth.methodology.base import Phase
 
@@ -193,7 +194,9 @@ def test_reasoning_loop_propagates_synthesis(monkeypatch, syntheses):
         idx = call["i"]
         status = "completed" if idx == len(syntheses) - 1 else "in_progress"
         call["i"] += 1
-        return {"status": status, "synthesis": syntheses[idx]}
+        return DialecticalSequence.from_dict(
+            {"status": status, "synthesis": syntheses[idx]}
+        )
 
     monkeypatch.setattr(
         reasoning_loop_module,
@@ -238,7 +241,9 @@ def test_reasoning_loop_invokes_dialectical_hooks(
 
     def fake_apply(wsde_team, task, critic, memory):
         idx = call["i"]
-        result = {"status": statuses[idx], "synthesis": syntheses[idx]}
+        result = DialecticalSequence.from_dict(
+            {"status": statuses[idx], "synthesis": syntheses[idx]}
+        )
         call["i"] += 1
         for hook_fn in getattr(wsde_team, "dialectical_hooks", []):
             hook_fn(task, [result])

--- a/tests/unit/domain/models/test_wsde_dialectical_workflow.py
+++ b/tests/unit/domain/models/test_wsde_dialectical_workflow.py
@@ -1,0 +1,87 @@
+"""Regression coverage for the typed dialectical reasoning workflow."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from devsynth.domain.models.wsde_dialectical import DialecticalSequence
+from devsynth.domain.models.wsde_dialectical_types import DialecticalTask
+from devsynth.domain.models.wsde_facade import WSDETeam
+
+from tests.helpers import DialecticalTaskFactory
+
+
+class MemoryRecorder:
+    """Memory stub capturing typed dialectical interactions."""
+
+    def __init__(self) -> None:
+        self.calls: list[tuple[DialecticalTask, DialecticalSequence]] = []
+
+    def store_dialectical_result(
+        self, task: DialecticalTask, result: DialecticalSequence
+    ) -> None:
+        self.calls.append((task, result))
+
+
+@pytest.mark.fast
+def test_apply_dialectical_reasoning_invokes_hooks_and_memory() -> None:
+    """End-to-end reasoning returns typed artefacts and integrates hooks."""
+
+    team = WSDETeam(name="workflow-regression")
+    task_factory = DialecticalTaskFactory()
+    task = task_factory.build(
+        solution={
+            "content": "Short solution lacking examples.",
+            "code": "print('hello world')",
+        }
+    )
+
+    critic = SimpleNamespace(name="critic-agent")
+    memory = MemoryRecorder()
+    hook_calls: list[tuple[DialecticalTask, tuple[DialecticalSequence, ...]]] = []
+
+    def hook(task_payload: DialecticalTask, sequences: tuple[DialecticalSequence, ...]):
+        hook_calls.append((task_payload, sequences))
+
+    team.register_dialectical_hook(hook)
+
+    result = team.apply_dialectical_reasoning(task, critic, memory_integration=memory)
+
+    assert isinstance(result, DialecticalSequence)
+    serialized = result.to_dict()
+    assert serialized["status"] == "completed"
+    assert serialized["synthesis"]
+
+    assert hook_calls, "Hook should be invoked with the generated sequence"
+    hook_task, hook_sequences = hook_calls[0]
+    assert isinstance(hook_task, DialecticalTask)
+    assert hook_task.identifier == task.identifier
+    assert hook_sequences[0] is result
+
+    assert memory.calls
+    recorded_task, recorded_sequence = memory.calls[0]
+    assert recorded_task.identifier == task.identifier
+    assert recorded_sequence is result
+
+
+@pytest.mark.fast
+def test_dialectical_task_serialization_round_trip() -> None:
+    """Tasks convert cleanly between mappings and typed wrappers."""
+
+    payload = {
+        "id": "task-123",
+        "solution": {"content": "Original"},
+        "metadata": {"priority": "high"},
+    }
+
+    task = DialecticalTask.from_mapping(payload)
+    assert task.identifier == "task-123"
+    assert task.metadata["priority"] == "high"
+
+    updated = task.with_solution({"content": "Updated"})
+    assert updated["solution"] == {"content": "Updated"}
+    assert updated.identifier == task.identifier
+
+    assert updated.to_dict()["solution"] == {"content": "Updated"}

--- a/tests/unit/methodology/edrr/test_reasoning_loop_invariants.py
+++ b/tests/unit/methodology/edrr/test_reasoning_loop_invariants.py
@@ -6,6 +6,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
+from devsynth.domain.models.wsde_dialectical import DialecticalSequence
 from devsynth.methodology.base import Phase
 
 reasoning_loop_module = importlib.import_module(
@@ -23,7 +24,9 @@ def test_reasoning_loop_enforces_total_time_budget(
 
     def fake_apply(_team, task, _critic, _memory):
         call_count["value"] += 1
-        return {"status": "in_progress", "task_snapshot": task.copy()}
+        return DialecticalSequence.from_dict(
+            {"status": "in_progress", "task_snapshot": task.copy()}
+        )
 
     monkeypatch.setattr(
         reasoning_loop_module,
@@ -67,7 +70,9 @@ def test_reasoning_loop_retries_until_success(monkeypatch: pytest.MonkeyPatch) -
         outcome = next(outcomes)
         if isinstance(outcome, Exception):
             raise outcome
-        return {"status": "completed", "synthesis": task.get("solution")}
+        return DialecticalSequence.from_dict(
+            {"status": "completed", "synthesis": task.get("solution")}
+        )
 
     monkeypatch.setattr(
         reasoning_loop_module,
@@ -112,7 +117,7 @@ def test_reasoning_loop_fallback_transitions_and_propagation(
         observed_tasks.append(task.copy())
         payload = payloads[call_index["value"]]
         call_index["value"] += 1
-        return payload
+        return DialecticalSequence.from_dict(payload)
 
     monkeypatch.setattr(
         reasoning_loop_module,
@@ -182,7 +187,7 @@ def test_reasoning_loop_respects_max_iterations_limit(
     def fake_apply(_team, task, _critic, _memory):
         payload = payloads[call_count["value"]]
         call_count["value"] += 1
-        return payload
+        return DialecticalSequence.from_dict(payload)
 
     monkeypatch.setattr(
         reasoning_loop_module,
@@ -217,7 +222,9 @@ def test_reasoning_loop_retry_backoff_respects_remaining_budget(
         if attempts["value"] == 0:
             attempts["value"] += 1
             raise RuntimeError("transient")
-        return {"status": "completed", "synthesis": task.get("solution", {})}
+        return DialecticalSequence.from_dict(
+            {"status": "completed", "synthesis": task.get("solution", {})}
+        )
 
     monkeypatch.setattr(
         reasoning_loop_module,

--- a/tests/unit/methodology/edrr/test_reasoning_loop_regressions.py
+++ b/tests/unit/methodology/edrr/test_reasoning_loop_regressions.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import pytest
 
 import devsynth.methodology.edrr.reasoning_loop as reasoning_loop_module
+from devsynth.domain.models.wsde_dialectical import DialecticalSequence
 from devsynth.exceptions import ConsensusError
 from devsynth.methodology.base import Phase
 
@@ -17,7 +18,7 @@ def test_reasoning_loop_exits_when_budget_elapsed_before_iteration(
 
     def fake_apply(*_args, **_kwargs):  # pragma: no cover - should not be hit
         calls["count"] += 1
-        return {"status": "completed"}
+        return DialecticalSequence.from_dict({"status": "completed"})
 
     monkeypatch.setattr(
         reasoning_loop_module,
@@ -79,7 +80,7 @@ def test_reasoning_loop_retry_sequence_updates_phase_and_coordinator(
         if isinstance(outcome, Exception):
             raise outcome
         observed_tasks.append(task.copy())
-        return outcome
+        return DialecticalSequence.from_dict(outcome)
 
     monkeypatch.setattr(
         reasoning_loop_module,

--- a/tests/unit/methodology/test_dialectical_reasoning.py
+++ b/tests/unit/methodology/test_dialectical_reasoning.py
@@ -6,6 +6,7 @@ from devsynth.domain.models.memory import MemoryType
 from devsynth.exceptions import ConsensusError
 from devsynth.methodology.base import Phase
 from devsynth.methodology.edrr import EDRRCoordinator, reasoning_loop
+from tests.helpers import build_dialectical_sequence
 
 
 @pytest.mark.fast
@@ -16,7 +17,7 @@ def test_reasoning_loop_records_results(mocker) -> None:
     """
 
     coordinator = mocker.create_autospec(EDRRCoordinator, instance=True)
-    result = {"status": "completed"}
+    result = build_dialectical_sequence(status="completed")
     mocker.patch(
         "devsynth.methodology.edrr.reasoning_loop._apply_dialectical_reasoning",
         return_value=result,
@@ -25,7 +26,7 @@ def test_reasoning_loop_records_results(mocker) -> None:
     output = reasoning_loop(None, {}, None, coordinator=coordinator)
 
     assert output == [result]
-    coordinator.record_refine_results.assert_called_once_with(result)
+    coordinator.record_refine_results.assert_called_once_with(dict(result))
     coordinator.record_consensus_failure.assert_not_called()
 
 
@@ -62,7 +63,7 @@ def test_reasoning_loop_persists_phase_results(mocker) -> None:
 
     memory_manager = mocker.Mock()
     coordinator = EDRRCoordinator(memory_manager)
-    result = {"status": "completed"}
+    result = build_dialectical_sequence(status="completed")
     mocker.patch(
         "devsynth.methodology.edrr.reasoning_loop._apply_dialectical_reasoning",
         return_value=result,
@@ -71,5 +72,5 @@ def test_reasoning_loop_persists_phase_results(mocker) -> None:
     reasoning_loop(None, {}, None, coordinator=coordinator, phase=Phase.DIFFERENTIATE)
 
     memory_manager.store_with_edrr_phase.assert_called_once_with(
-        result, MemoryType.KNOWLEDGE, "DIFFERENTIATE"
+        dict(result), MemoryType.KNOWLEDGE, "DIFFERENTIATE"
     )


### PR DESCRIPTION
## Summary
- introduce typed dialectical workflow façade that reuses the legacy helpers while returning `DialecticalSequence`
- retrofit the EDRR reasoning loop and supporting tests to pass typed domain objects through the workflow
- expand factories and regression coverage for the new typed flow and guard optional ChromaDB integration tests when the API is unavailable

## Testing
- poetry run pytest -m fast --cov-fail-under=0

------
https://chatgpt.com/codex/tasks/task_e_68d5770f5184833386b8f2ea4590dc3a