### PR TITLE
fix: align streaming llm providers with coroutine protocol

### DIFF
--- a/docs/architecture/provider_system.md
+++ b/docs/architecture/provider_system.md
@@ -999,11 +999,13 @@ provider = ProviderFactory.create()
 
 # Stream generation results
 
-async for chunk in provider.generate_stream(
+stream = await provider.generate_stream(
     prompt="Write a step-by-step guide for implementing dependency injection in Python.",
     temperature=0.6,
-    max_tokens=2000
-):
+    max_tokens=2000,
+)
+
+async for chunk in stream:
     print(chunk, end="", flush=True)
 ```
 

--- a/src/devsynth/adapters/llm/mock_llm_adapter.py
+++ b/src/devsynth/adapters/llm/mock_llm_adapter.py
@@ -83,14 +83,15 @@ class MockLLMAdapter(BaseLLMProvider, StreamingLLMProvider):
             prompt[:50],
         )
 
-        # Get the full response
         response = self.generate(prompt, parameters)
 
-        # Split the response into chunks and yield them
-        words = response.split()
-        for i in range(0, len(words), 3):
-            chunk = " ".join(words[i : i + 3])
-            yield chunk + " "
+        async def _stream() -> AsyncGenerator[str, None]:
+            words = response.split()
+            for i in range(0, len(words), 3):
+                chunk = " ".join(words[i : i + 3])
+                yield chunk + " "
+
+        return _stream()
 
     async def generate_with_context_stream(
         self,
@@ -104,11 +105,12 @@ class MockLLMAdapter(BaseLLMProvider, StreamingLLMProvider):
             prompt[:50],
         )
 
-        # For simplicity, we'll just use the same logic as generate_stream
         response = self.generate_with_context(prompt, context, parameters)
 
-        # Split the response into chunks and yield them
-        words = response.split()
-        for i in range(0, len(words), 3):
-            chunk = " ".join(words[i : i + 3])
-            yield chunk + " "
+        async def _stream() -> AsyncGenerator[str, None]:
+            words = response.split()
+            for i in range(0, len(words), 3):
+                chunk = " ".join(words[i : i + 3])
+                yield chunk + " "
+
+        return _stream()

--- a/src/devsynth/application/llm/local_provider.py
+++ b/src/devsynth/application/llm/local_provider.py
@@ -62,7 +62,11 @@ class LocalProvider(StreamingLLMProvider):
         self, prompt: str, parameters: Dict[str, Any] | None = None
     ) -> AsyncGenerator[str, None]:
         """Stream a generated response."""
-        yield self.generate(prompt, parameters)
+
+        async def _stream() -> AsyncGenerator[str, None]:
+            yield self.generate(prompt, parameters)
+
+        return _stream()
 
     async def generate_with_context_stream(
         self,
@@ -71,4 +75,8 @@ class LocalProvider(StreamingLLMProvider):
         parameters: Dict[str, Any] | None = None,
     ) -> AsyncGenerator[str, None]:
         """Stream a generated response using conversation context."""
-        yield self.generate_with_context(prompt, context, parameters)
+
+        async def _stream() -> AsyncGenerator[str, None]:
+            yield self.generate_with_context(prompt, context, parameters)
+
+        return _stream()

--- a/src/devsynth/ports/llm_port.py
+++ b/src/devsynth/ports/llm_port.py
@@ -67,7 +67,8 @@ class LLMPort:
                 f"Provider {provider_type or 'default'} does not support streaming"
             )
 
-        async for chunk in provider.generate_stream(prompt, parameters):
+        stream = await provider.generate_stream(prompt, parameters)
+        async for chunk in stream:
             yield chunk
 
     async def generate_with_context_stream(
@@ -84,9 +85,10 @@ class LLMPort:
                 f"Provider {provider_type or 'default'} does not support streaming"
             )
 
-        async for chunk in provider.generate_with_context_stream(
+        stream = await provider.generate_with_context_stream(
             prompt, context, parameters
-        ):
+        )
+        async for chunk in stream:
             yield chunk
 
     def _get_provider(self, provider_type: str = None) -> LLMProvider:

--- a/tests/unit/adapters/llm/test_mock_llm_adapter_streaming.py
+++ b/tests/unit/adapters/llm/test_mock_llm_adapter_streaming.py
@@ -1,0 +1,44 @@
+"""Streaming behaviour tests for MockLLMAdapter."""
+
+from __future__ import annotations
+
+import pytest
+
+from devsynth.adapters.llm.mock_llm_adapter import MockLLMAdapter
+
+
+@pytest.mark.fast
+@pytest.mark.asyncio
+async def test_generate_stream_returns_chunks():
+    """Mock adapter should stream chunked responses when awaited."""
+    adapter = MockLLMAdapter()
+
+    stream = await adapter.generate_stream("default prompt")
+
+    chunks: list[str] = []
+    async for chunk in stream:
+        chunks.append(chunk.strip())
+
+    assembled = " ".join(chunks).strip()
+    assert len(chunks) > 1
+    assert assembled.startswith("This is a mock response")
+
+
+@pytest.mark.fast
+@pytest.mark.asyncio
+async def test_generate_with_context_stream_returns_chunks():
+    """Mock adapter should stream chunked responses with context."""
+    adapter = MockLLMAdapter()
+
+    context = [{"role": "system", "content": "context"}]
+    expected = adapter.generate_with_context("prompt", context)
+
+    stream = await adapter.generate_with_context_stream("prompt", context)
+
+    chunks = []
+    async for chunk in stream:
+        chunks.append(chunk.strip())
+
+    assembled = " ".join(chunks).strip()
+    assert len(chunks) > 1
+    assert assembled == expected


### PR DESCRIPTION
## Summary
- make LocalProvider, MockLLMAdapter, and OpenAIProvider streaming methods return awaited async generators per protocol
- await provider coroutines in LLMPort and refresh documentation to show the new streaming usage
- tighten OpenAI error handling and add async streaming unit tests for the mock adapter and offline OpenAI path

## Testing
- poetry run pytest --no-cov tests/unit/application/llm/test_openai_offline_resilience.py tests/unit/adapters/llm/test_mock_llm_adapter_streaming.py

------
https://chatgpt.com/codex/tasks/task_e_68d5947ff52483338943489dfc196f31