### PR TITLE
feat(interface): type ux bridge error contract

### DIFF
--- a/src/devsynth/interface/cli.py
+++ b/src/devsynth/interface/cli.py
@@ -637,7 +637,7 @@ class CLIUXBridge(SharedBridgeMixin, UXBridge):
         message: str,
         *,
         highlight: bool = False,
-        message_type: Union[str, None] = None,
+        message_type: str | None = None,
     ) -> None:
         """Format and display a message to the user.
 
@@ -680,6 +680,24 @@ class CLIUXBridge(SharedBridgeMixin, UXBridge):
 
         # Print the styled message
         self.console.print(styled, style=style)
+
+    def display_error(
+        self,
+        error: Union[Exception, Dict[str, Any], str],
+        *,
+        include_suggestions: bool = True,
+    ) -> None:
+        """Render errors with Rich panels and actionable suggestions."""
+
+        logger.error("Displaying CLI error", extra={"error": str(error)})
+
+        if include_suggestions:
+            self.handle_error(error)
+        else:
+            # Fall back to plain formatting when suggestions are explicitly
+            # disabled. ``sanitize_output`` is intentionally skipped so stack
+            # traces retain their formatting.
+            self.console.print(str(error), style="error")
 
     def create_progress(
         self, description: str, *, total: int = 100

--- a/src/devsynth/interface/ux_bridge.py
+++ b/src/devsynth/interface/ux_bridge.py
@@ -100,7 +100,11 @@ class UXBridge(ABC):
 
     @abstractmethod
     def display_result(
-        self, message: str, *, highlight: bool = False, message_type: str = None
+        self,
+        message: str,
+        *,
+        highlight: bool = False,
+        message_type: str | None = None,
     ) -> None:
         """Display a message to the user.
 
@@ -120,7 +124,33 @@ class UXBridge(ABC):
             error: The error to handle
         """
         # Default implementation just displays the error message
-        self.display_result(str(error), highlight=True)
+        self.display_result(str(error), highlight=True, message_type="error")
+
+    def display_error(
+        self,
+        error: Union[Exception, Dict[str, Any], str],
+        *,
+        include_suggestions: bool = True,
+    ) -> None:
+        """Display an error message using the bridge's error handling pipeline.
+
+        Implementations can override this method to surface richer diagnostics
+        (for example, actionable suggestions). The default implementation
+        delegates to :meth:`handle_error` so existing subclasses automatically
+        benefit from the enhanced error display logic.
+
+        Args:
+            error: The error object or message to display.
+            include_suggestions: Whether to include actionable suggestions when
+                available. The base implementation ignores this flag but accepts
+                it for API compatibility with CLI helpers.
+        """
+
+        # ``include_suggestions`` is accepted for compatibility with CLI
+        # helpers. Implementations that support suggestion toggles can honour
+        # the flag. The default behaviour simply routes through ``handle_error``.
+        _ = include_suggestions
+        self.handle_error(error)
 
     def create_progress(
         self, description: str, *, total: int = 100


### PR DESCRIPTION
## Summary
- extend the UXBridge contract with a typed display_error helper that routes through the shared error handler
- update the CLI implementation to honour the new contract and keep message_type annotations precise

## Testing
- poetry run mypy src/devsynth/application/cli

------
https://chatgpt.com/codex/tasks/task_e_68d597d927948333ab5bb5b35afbf1ff