### PR TITLE
Enforce strict typing for security stack

### DIFF
--- a/docs/typing/strictness.md
+++ b/docs/typing/strictness.md
@@ -1,23 +1,22 @@
-# Typing Strictness Progress Note (2025-09-25)
+# Typing Strictness Progress Note (2025-09-26)
 
 ## Methodology
 - Ran exploratory `poetry run mypy --strict` commands with a minimal `/tmp/mypy_strict.ini` configuration that mirrors the repo defaults minus the per-module overrides, allowing us to observe true violations in suppressed modules.
 - Chose one representative module per override group so future audits can compare outputs with identical commands.
 
 ## Override Inventory
-`pyproject.toml` now records the remaining relaxations as module-level commitments with explicit owners and deadlines.【F:pyproject.toml†L251-L467】 The table below mirrors the scoped lists so teams can track progress at a glance.
+`pyproject.toml` now records the remaining relaxations as module-level commitments with explicit owners and deadlines.【F:pyproject.toml†L251-L446】 The table below mirrors the scoped lists so teams can track progress at a glance.
 
 | Override scope | Notes |
 | --- | --- |
 | `tests.*` | QA Guild | n/a | Keeps the test suite flexible for fixtures that intentionally exercise dynamic typing. |
-| `devsynth.security.authentication`, `devsynth.security.encryption`, `devsynth.security.tls` | Security Guild – Priya Ramanathan | 2025-11-15 | Replace `Any` helpers with typed secrets handling before rotating keys.【F:pyproject.toml†L261-L268】 |
-| `devsynth.core.config_loader`, `devsynth.core.workflows`, `devsynth.agents.base_agent_graph`, `devsynth.agents.sandbox`, `devsynth.agents.wsde_team_coordinator`, `devsynth.agents.tools`, `devsynth.memory.sync_manager`, `devsynth.api` | Core Platform – Miguel Sato | 2025-11-15 | Document third-party stub gaps and finish the config loader DTO refactor.【F:pyproject.toml†L270-L281】 |
-| Adapter backlog (`devsynth.adapters.agents.agent_adapter`, …, `devsynth.adapters.provider_system`) | Integrations Team – Alex Chen | 2025-11-15 | Remove implicit Optional defaults and align provider protocols with typed ports.【F:pyproject.toml†L283-L302】 |
-| Interface surfaces (`devsynth.interface.cli`, …, `devsynth.interface.wizard_state_manager`) | Experience Platform – Dana Laurent | 2025-12-20 | Introduce typed UX bridge contracts and retire legacy `type: ignore` scaffolding.【F:pyproject.toml†L304-L327】 |
-| Reliability utilities (`devsynth.utils.logging`, `devsynth.fallback`, port shims) | Reliability Guild – Dana Laurent | 2025-12-20 | Model retry policies and port DTOs to unblock follow-up linting and guard-rail work.【F:pyproject.toml†L329-L341】 |
-| Application workflows (`devsynth.application.agents.*`, CLI suites, orchestration, prompts, etc.) | Applications Group – Lara Singh | 2026-02-15 | Track Any-heavy orchestration layers while DTO designs stabilize.【F:pyproject.toml†L344-L422】 |
-| Application memory stack (`devsynth.application.memory*`) | Memory Systems – Chen Wu | 2026-03-15 | Requires typed storage adapters and query responses before enabling strict mode.【F:pyproject.toml†L424-L452】 |
-| Enhanced API surface (`devsynth.interface.agentapi*`, `devsynth.application.requirements.*`) | API Guild – Morgan Patel | 2026-03-31 | Coordinate with schema convergence workstreams before lifting ignores.【F:pyproject.toml†L455-L463】 |
+| `devsynth.core.config_loader`, `devsynth.core.workflows`, `devsynth.agents.base_agent_graph`, `devsynth.agents.sandbox`, `devsynth.agents.wsde_team_coordinator`, `devsynth.agents.tools`, `devsynth.memory.sync_manager`, `devsynth.api` | Core Platform – Miguel Sato | 2025-11-15 | Document third-party stub gaps and finish the config loader DTO refactor.【F:pyproject.toml†L264-L271】 |
+| Adapter backlog (`devsynth.adapters.agents.agent_adapter`, …, `devsynth.adapters.provider_system`) | Integrations Team – Alex Chen | 2025-11-15 | Remove implicit Optional defaults and align provider protocols with typed ports.【F:pyproject.toml†L276-L293】 |
+| Interface surfaces (`devsynth.interface.cli`, …, `devsynth.interface.wizard_state_manager`) | Experience Platform – Dana Laurent | 2025-12-20 | Introduce typed UX bridge contracts and retire legacy `type: ignore` scaffolding.【F:pyproject.toml†L298-L318】 |
+| Reliability utilities (`devsynth.utils.logging`, `devsynth.fallback`, port shims) | Reliability Guild – Dana Laurent | 2025-12-20 | Model retry policies and port DTOs to unblock follow-up linting and guard-rail work.【F:pyproject.toml†L322-L334】 |
+| Application workflows (`devsynth.application.agents.*`, CLI suites, orchestration, prompts, etc.) | Applications Group – Lara Singh | 2026-02-15 | Track Any-heavy orchestration layers while DTO designs stabilize.【F:pyproject.toml†L337-L413】 |
+| Application memory stack (`devsynth.application.memory*`) | Memory Systems – Chen Wu | 2026-03-15 | Requires typed storage adapters and query responses before enabling strict mode.【F:pyproject.toml†L418-L445】 |
+| Enhanced API surface (`devsynth.interface.agentapi*`, `devsynth.application.requirements.*`) | API Guild – Morgan Patel | 2026-03-31 | Coordinate with schema convergence workstreams before lifting ignores.【F:pyproject.toml†L450-L454】 |
 
 ## Findings by subsystem
 
@@ -26,11 +25,11 @@ Focus: security, adapters, memory, core, agents, and API endpoints. These files 
 
 | Module group | Owner | Deadline | Current gaps |
 | --- | --- | --- | --- |
-| Security authentication stack (`devsynth.security.authentication`, `devsynth.security.encryption`, `devsynth.security.tls`) | Security Guild – Priya Ramanathan | 2025-11-15 | Typed secrets helpers and TLS context plumbing remain `Any`-heavy.【F:pyproject.toml†L261-L268】 |
-| Core runtime (`devsynth.core.config_loader`, `devsynth.core.workflows`, `devsynth.agents.base_agent_graph`, `devsynth.agents.sandbox`, `devsynth.agents.wsde_team_coordinator`, `devsynth.agents.tools`, `devsynth.memory.sync_manager`, `devsynth.api`) | Core Platform – Miguel Sato | 2025-11-15 | Config loader and workflow orchestration still rely on dynamic dicts; API endpoints lack typed decorators.【F:pyproject.toml†L270-L281】 |
+| Security authentication stack (`devsynth.security.authentication`, `devsynth.security.encryption`, `devsynth.security.tls`) | Security Guild – Priya Ramanathan | 2025-11-15 | ✅ Strict mode enforced via `task mypy:strict`; overrides removed after tightening Argon2 helpers and TLS config typing.【F:Taskfile.yml†L143-L152】【F:src/devsynth/security/authentication.py†L9-L73】【F:src/devsynth/security/encryption.py†L1-L58】【F:src/devsynth/security/tls.py†L1-L58】 |
+| Core runtime (`devsynth.core.config_loader`, `devsynth.core.workflows`, `devsynth.agents.base_agent_graph`, `devsynth.agents.sandbox`, `devsynth.agents.wsde_team_coordinator`, `devsynth.agents.tools`, `devsynth.memory.sync_manager`, `devsynth.api`) | Core Platform – Miguel Sato | 2025-11-15 | Config loader and workflow orchestration still rely on dynamic dicts; API endpoints lack typed decorators.【F:pyproject.toml†L264-L271】 |
 | Adapter backlog (`devsynth.adapters.agents.agent_adapter`, …, `devsynth.adapters.provider_system`) | Integrations Team – Alex Chen | 2025-11-15 | Provider scaffolding defaults to implicit Optionals and unchecked `Any` payloads.【F:pyproject.toml†L283-L302】 |
 
-- `security/authentication.py` still returns `Any` from helper functions expected to return concrete `str`/`bool` values.【ac31cd†L1-L3】
+- ✅ Security modules now run cleanly under `poetry run mypy --strict`; the hash/verify helpers and TLS configuration wrapper have explicit typing and no longer rely on overrides.【F:src/devsynth/security/authentication.py†L1-L73】【F:src/devsynth/security/encryption.py†L1-L58】【F:src/devsynth/security/tls.py†L1-L58】
 - `adapters/github_project.py` leaks `Any` when composing the GitHub payload response.【d0d961†L1-L3】
 - `memory/layered_cache.py` already passes strict mypy, so the package-wide ignore can begin shrinking immediately.【084ac1†L1-L2】
 - `core/config_loader.py` mixes missing `toml` stubs with dynamic config munging that needs proper model typing.【063e40†L1-L9】
@@ -42,23 +41,23 @@ Focus: interface utilities, metrics, fallback logic, ports, and shared utils.
 
 | Module group | Owner | Deadline | Current gaps |
 | --- | --- | --- | --- |
-| Interface surfaces (`devsynth.interface.cli`, …, `devsynth.interface.wizard_state_manager`) | Experience Platform – Dana Laurent | 2025-12-20 | Progress helpers and web UI bridges depend on untyped decorators and dynamic module attributes.【F:pyproject.toml†L304-L327】 |
-| Reliability utilities (`devsynth.utils.logging`, `devsynth.fallback`, ports) | Reliability Guild – Dana Laurent | 2025-12-20 | Retry policies and port DTOs expose implicit Optionals and unchecked exception wiring.【F:pyproject.toml†L329-L341】 |
+| Interface surfaces (`devsynth.interface.cli`, …, `devsynth.interface.wizard_state_manager`) | Experience Platform – Dana Laurent | 2025-12-20 | Progress helpers and web UI bridges depend on untyped decorators and dynamic module attributes.【F:pyproject.toml†L298-L318】 |
+| Reliability utilities (`devsynth.utils.logging`, `devsynth.fallback`, ports) | Reliability Guild – Dana Laurent | 2025-12-20 | Retry policies and port DTOs expose implicit Optionals and unchecked exception wiring.【F:pyproject.toml†L322-L334】 |
 
 - ✅ `logging_setup.py` now passes strict mode with explicit Optional handling for configuration state and structured redaction helpers; override removed 2025-09-25.
 - ✅ `config` package loaders/settings pass strict mode after tightening validator signatures and schema parsing. Remaining debt: `Settings` still mixes runtime environment coercion with persistence defaults—plan a follow-up to extract typed DTOs for `resources` and LLM overrides.
 - `interface/progress_utils.py` lacks type parameters and annotations on progress message helpers.【353ac0†L1-L5】
-- `utils/logging.py` relies on `type: ignore` to mask subclassing issues and untyped functions.【9319c3†L1-L5】
+- `utils/logging.py` still fails strict mode due to Any-based subclassing and missing annotations.【663d4c†L67-L74】
+- `fallback.py` continues to emit strict errors from implicit Optionals and untyped lambda callbacks.【663d4c†L75-L122】
+- Port shims still return `Any` values and rely on implicit Optional defaults, so strict mode reports multiple failures across the adapters.【663d4c†L12-L66】
 - ✅ `metrics.py` and `observability/metrics.py` now pass strict mode after introducing typed Prometheus counter protocols and localized fallbacks (2025-09-26). Future refinement: replace ad-hoc casts with dedicated shim stubs if upstream signatures drift.【F:src/devsynth/metrics.py†L15-L77】【F:src/devsynth/observability/metrics.py†L15-L74】
-- `fallback.py` contains 28 errors dominated by implicit Optional defaults, lambda inference gaps, and incorrect exception typing.【a80d39†L1-L29】
-- `ports/agent_port.py` still suffers from dynamic attribute wiring; tightening port DTOs remains on the backlog.【018dc7†L1-L6】
 
 ### Phase 3 – Application workflows (target 2026-02-15)
 Focus: orchestration, prompts, agents, ingestion, and supporting utilities.
 
 | Module group | Owner | Deadline | Current gaps |
 | --- | --- | --- | --- |
-| Workflow suites (`devsynth.application.agents.*`, CLI commands, collaboration, orchestration, prompts, utilities) | Applications Group – Lara Singh | 2026-02-15 | Annotate orchestration DTOs, CLI progress handlers, and prompt builders to eliminate pervasive `Any` flows.【F:pyproject.toml†L344-L422】 |
+| Workflow suites (`devsynth.application.agents.*`, CLI commands, collaboration, orchestration, prompts, utilities) | Applications Group – Lara Singh | 2026-02-15 | Annotate orchestration DTOs, CLI progress handlers, and prompt builders to eliminate pervasive `Any` flows.【F:pyproject.toml†L337-L413】 |
 
 - `application/agents/agent_memory_integration.py` leaks `Any` through almost every integration pathway, driving downstream uncertainty.【46b4b0†L1-L9】
 - `application/orchestration/workflow.py` returns `Any` from key orchestrators, indicating missing typed DTOs.【c8f82e†L1-L3】
@@ -73,21 +72,21 @@ The application memory manager and stores are the noisiest area, with dozens of 
 
 | Module group | Owner | Deadline | Current gaps |
 | --- | --- | --- | --- |
-| Memory stores and adapters (`devsynth.application.memory*`) | Memory Systems – Chen Wu | 2026-03-15 | Typed adapters and deterministic transaction contexts still pending.【F:pyproject.toml†L424-L452】 |
+| Memory stores and adapters (`devsynth.application.memory*`) | Memory Systems – Chen Wu | 2026-03-15 | Typed adapters and deterministic transaction contexts still pending.【F:pyproject.toml†L418-L445】 |
 
 ### Phase 5 – Enhanced API surface (target 2026-03-31)
 `interface/agentapi.py` and `interface/agentapi_enhanced.py` each emit 40–90 errors dominated by untyped FastAPI decorators, Optional defaults, and reliance on dynamically typed Pydantic models.【695d69†L1-L43】【81cae7†L1-L86】 Tackling these should follow upstream schema consolidation work so that BaseModel subclasses and bridge interfaces can be annotated once and reused.
 
 | Module group | Owner | Deadline | Current gaps |
 | --- | --- | --- | --- |
-| Enhanced agent APIs and requirements services (`devsynth.interface.agentapi*`, `devsynth.application.requirements.*`) | API Guild – Morgan Patel | 2026-03-31 | Align FastAPI decorators with shared schemas and introduce typed requirement DTOs.【F:pyproject.toml†L455-L463】 |
+| Enhanced agent APIs and requirements services (`devsynth.interface.agentapi*`, `devsynth.application.requirements.*`) | API Guild – Morgan Patel | 2026-03-31 | Align FastAPI decorators with shared schemas and introduce typed requirement DTOs.【F:pyproject.toml†L450-L454】 |
 
 ## Recommendations & Next Steps
 1. **Create type-safe response models** for the security, adapter, and API layers; these modules show low error counts and can meet the 2025-11-15 deadline once DTOs and helper signatures are fixed.
-2. **Refactor logging and fallback utilities** to remove implicit Optionals and document dynamic attributes, aligning with the 2025-12-20 target.
+2. **Refactor logging and fallback utilities** to eliminate implicit Optionals and document dynamic attributes before lifting the reliability override.【663d4c†L12-L122】
 3. **Carve down application overrides** by first enforcing strictness on already-compliant modules (e.g., ingestion phases, server bridge) before deeper refactors, preparing for the February 2026 milestone.
 4. **Plan a dedicated memory typing effort**—introduce typed dataclasses or Pydantic models for metadata and query results to eliminate `Any` in the memory manager before March 2026.
 5. **Align FastAPI interfaces** with shared schema definitions before attempting to lift the enhanced API overrides; this needs coordinated workstreams in Q1 2026.
-6. **Run `task mypy:strict` frequently** now that it covers the newly narrowed packages (security, core, agents, memory, API, and typed app slices) to surface regressions before CI.【F:Taskfile.yml†L143-L151】
+6. **Run `task mypy:strict` frequently** now that it covers the newly narrowed packages (security, core, agents, memory, API, and typed app slices) to surface regressions before CI.【F:Taskfile.yml†L143-L154】
 
 The phased deadlines above replace the earlier blanket dates and are referenced directly from `pyproject.toml` comments for visibility.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -258,15 +258,6 @@ disallow_incomplete_defs = false
 module = "devsynth.core.mvu.*"
 ignore_errors = false
 
-# Phase 1 – Foundational modules (due 2025-11-15; owner: Security Guild – Priya Ramanathan; see docs/typing/strictness.md §Phase 1 commitments)
-[[tool.mypy.overrides]]
-module = [
-  "devsynth.security.authentication",
-  "devsynth.security.encryption",
-  "devsynth.security.tls",
-]
-ignore_errors = true
-
 # Phase 1 – Core runtime tightening (due 2025-11-15; owner: Core Platform – Miguel Sato; see docs/typing/strictness.md §Phase 1 commitments)
 [[tool.mypy.overrides]]
 module = [

--- a/src/devsynth/security/authentication.py
+++ b/src/devsynth/security/authentication.py
@@ -6,7 +6,7 @@ Security defaults:
 These values follow widely recommended baselines and can be revised centrally.
 """
 
-from typing import Dict
+from typing import Dict, cast
 
 from argon2 import PasswordHasher
 from argon2.exceptions import VerifyMismatchError
@@ -35,13 +35,13 @@ _password_hasher = PasswordHasher(
 
 def hash_password(password: str) -> str:
     """Hash a plain text password using Argon2."""
-    return _password_hasher.hash(password)
+    return cast(str, _password_hasher.hash(password))
 
 
 def verify_password(stored_hash: str, password: str) -> bool:
     """Verify a password against an existing Argon2 hash."""
     try:
-        return _password_hasher.verify(stored_hash, password)
+        return bool(_password_hasher.verify(stored_hash, password))
     except VerifyMismatchError:
         return False
 

--- a/src/devsynth/security/encryption.py
+++ b/src/devsynth/security/encryption.py
@@ -9,7 +9,7 @@ Security defaults:
 
 import base64
 import os
-from typing import Optional
+from typing import Optional, cast
 
 from cryptography.fernet import Fernet
 
@@ -18,7 +18,7 @@ _DEFAULT_ENV_KEY = "DEVSYNTH_ENCRYPTION_KEY"
 
 def generate_key() -> str:
     """Generate a base64 encoded Fernet key."""
-    return Fernet.generate_key().decode()
+    return cast(bytes, Fernet.generate_key()).decode()
 
 
 def _validate_key_format(key_bytes: bytes) -> None:
@@ -35,20 +35,21 @@ def _validate_key_format(key_bytes: bytes) -> None:
 
 
 def _get_fernet(key: Optional[str] = None) -> Fernet:
-    key_bytes = key or os.environ.get(_DEFAULT_ENV_KEY)
-    if not key_bytes:
+    key_source: Optional[str | bytes] = key
+    if key_source is None:
+        key_source = os.environ.get(_DEFAULT_ENV_KEY)
+    if key_source is None:
         raise ValueError("Encryption key not provided")
-    if isinstance(key_bytes, str):
-        key_bytes = key_bytes.encode()
+    key_bytes = key_source.encode() if isinstance(key_source, str) else key_source
     _validate_key_format(key_bytes)
     return Fernet(key_bytes)
 
 
 def encrypt_bytes(data: bytes, key: Optional[str] = None) -> bytes:
     """Encrypt bytes using Fernet."""
-    return _get_fernet(key).encrypt(data)
+    return cast(bytes, _get_fernet(key).encrypt(data))
 
 
 def decrypt_bytes(token: bytes, key: Optional[str] = None) -> bytes:
     """Decrypt bytes using Fernet."""
-    return _get_fernet(key).decrypt(token)
+    return cast(bytes, _get_fernet(key).decrypt(token))

--- a/src/devsynth/security/tls.py
+++ b/src/devsynth/security/tls.py
@@ -48,7 +48,7 @@ class TLSConfig:
             if path and not os.path.exists(path):
                 raise FileNotFoundError(f"{name} not found: {path}")
 
-    def as_requests_kwargs(self) -> dict:
+    def as_requests_kwargs(self) -> dict[str, bool | str | tuple[str, str] | float]:
         """Return kwargs for requests/httpx methods.
 
         Includes:
@@ -56,7 +56,11 @@ class TLSConfig:
         - timeout (float seconds) sourced from `self.timeout` or
           `DEVSYNTH_HTTP_TIMEOUT` env var (default: 10.0 seconds)
         """
-        kwargs = {"verify": self.ca_file or self.verify}
+        kwargs: dict[str, bool | str | tuple[str, str] | float] = {
+            "verify": self.verify
+        }
+        if self.ca_file:
+            kwargs["verify"] = self.ca_file
         if self.cert_file and self.key_file:
             kwargs["cert"] = (self.cert_file, self.key_file)
         elif self.cert_file:


### PR DESCRIPTION
## Summary
- cast Argon2 helpers and TLS/crypto utilities so the security stack satisfies `mypy --strict` without fallback ignores.
- drop the `devsynth.security.*` mypy override so strict checks apply automatically to the hardened modules.
- refresh `docs/typing/strictness.md` to record the security win and keep the override inventory aligned with the remaining debt.

## Testing
- `poetry run mypy --strict src/devsynth/application/config src/devsynth/application/server src/devsynth/security src/devsynth/core src/devsynth/agents src/devsynth/memory src/devsynth/api.py`


------
https://chatgpt.com/codex/tasks/task_e_68d5b2a8af1483339815b0dec1c79c61