### PR TITLE
Repair strict mypy automation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,6 +71,25 @@ jobs:
           poetry run flake8 src/ tests/
           poetry run mypy src/ tests/
 
+      - name: Run strict mypy slice
+        id: strict_mypy
+        continue-on-error: true
+        run: |
+          set -o pipefail
+          mkdir -p diagnostics
+          poetry run mypy --strict src/devsynth | tee diagnostics/mypy_strict.txt
+
+      - name: Upload strict mypy artifact
+        if: steps.strict_mypy.outcome == 'failure'
+        uses: actions/upload-artifact@v4
+        with:
+          name: mypy-strict-artifacts
+          path: diagnostics/mypy_strict.txt
+
+      - name: Fail on strict mypy errors
+        if: steps.strict_mypy.outcome == 'failure'
+        run: exit 1
+
   smoke:
     name: Smoke Tests
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Setup (choose one)
 
 Sanity checks
 - task env:verify  # ensure go-task and the devsynth CLI are available
-- task mypy:strict  # run strict mypy for the typed application slices
+- task mypy:strict  # run strict mypy for src/devsynth (append CLI args for extras)
 - poetry run devsynth --help
 - poetry run devsynth doctor
 - poetry run devsynth run-tests --target unit-tests --speed=fast --no-parallel --maxfail=1

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -143,15 +143,7 @@ tasks:
   mypy:strict:
     desc: Run strict mypy on typed application slices and newly strict packages
     cmds:
-      - >-
-        poetry run mypy --strict
-        src/devsynth/application/config
-        src/devsynth/application/server
-        src/devsynth/security
-        src/devsynth/core
-        src/devsynth/agents
-        src/devsynth/memory
-        src/devsynth/api.py
+      - poetry run mypy --strict src/devsynth {{.CLI_ARGS}}
 
   tests:property:
     desc: Run opt-in property tests (requires DEVSYNTH_PROPERTY_TESTING=true)

--- a/docs/typing/strictness.md
+++ b/docs/typing/strictness.md
@@ -2,6 +2,7 @@
 
 ## Methodology
 - Ran exploratory `poetry run mypy --strict` commands with a minimal `/tmp/mypy_strict.ini` configuration that mirrors the repo defaults minus the per-module overrides, allowing us to observe true violations in suppressed modules.
+- Use `task mypy:strict` (wrapper around `poetry run mypy --strict src/devsynth`) to exercise the enforced strict slice; append CLI arguments when auditing additional packages or modules.【F:Taskfile.yml†L143-L146】
 - Chose one representative module per override group so future audits can compare outputs with identical commands.
 
 ## Override Inventory
@@ -25,7 +26,7 @@ Focus: security, adapters, memory, core, agents, and API endpoints. These files 
 
 | Module group | Owner | Deadline | Current gaps |
 | --- | --- | --- | --- |
-| Security authentication stack (`devsynth.security.authentication`, `devsynth.security.encryption`, `devsynth.security.tls`) | Security Guild – Priya Ramanathan | 2025-11-15 | ✅ Strict mode enforced via `task mypy:strict`; overrides removed after tightening Argon2 helpers and TLS config typing.【F:Taskfile.yml†L143-L152】【F:src/devsynth/security/authentication.py†L9-L73】【F:src/devsynth/security/encryption.py†L1-L58】【F:src/devsynth/security/tls.py†L1-L58】 |
+| Security authentication stack (`devsynth.security.authentication`, `devsynth.security.encryption`, `devsynth.security.tls`) | Security Guild – Priya Ramanathan | 2025-11-15 | ✅ Strict mode enforced via `task mypy:strict`; overrides removed after tightening Argon2 helpers and TLS config typing.【F:Taskfile.yml†L143-L146】【F:src/devsynth/security/authentication.py†L9-L73】【F:src/devsynth/security/encryption.py†L1-L58】【F:src/devsynth/security/tls.py†L1-L58】 |
 | Core runtime (`devsynth.core.config_loader`, `devsynth.core.workflows`, `devsynth.agents.base_agent_graph`, `devsynth.agents.sandbox`, `devsynth.agents.wsde_team_coordinator`, `devsynth.agents.tools`, `devsynth.memory.sync_manager`, `devsynth.api`) | Core Platform – Miguel Sato | 2025-11-15 | Config loader and workflow orchestration still rely on dynamic dicts; API endpoints lack typed decorators.【F:pyproject.toml†L264-L271】 |
 | Adapter backlog (`devsynth.adapters.agents.agent_adapter`, …, `devsynth.adapters.provider_system`) | Integrations Team – Alex Chen | 2025-11-15 | Provider scaffolding defaults to implicit Optionals and unchecked `Any` payloads.【F:pyproject.toml†L283-L302】 |
 
@@ -87,6 +88,6 @@ The application memory manager and stores are the noisiest area, with dozens of 
 3. **Carve down application overrides** by first enforcing strictness on already-compliant modules (e.g., ingestion phases, server bridge) before deeper refactors, preparing for the February 2026 milestone.
 4. **Plan a dedicated memory typing effort**—introduce typed dataclasses or Pydantic models for metadata and query results to eliminate `Any` in the memory manager before March 2026.
 5. **Align FastAPI interfaces** with shared schema definitions before attempting to lift the enhanced API overrides; this needs coordinated workstreams in Q1 2026.
-6. **Run `task mypy:strict` frequently** now that it covers the newly narrowed packages (security, core, agents, memory, API, and typed app slices) to surface regressions before CI.【F:Taskfile.yml†L143-L154】
+6. **Run `task mypy:strict` frequently** now that it covers the consolidated strict slice under `src/devsynth`; pass extra targets via CLI args to audit adjacent modules as they tighten.【F:Taskfile.yml†L143-L146】
 
 The phased deadlines above replace the earlier blanket dates and are referenced directly from `pyproject.toml` comments for visibility.


### PR DESCRIPTION
## Summary
- collapse the Taskfile strict target to run `poetry run mypy --strict src/devsynth` and allow extra CLI arguments
- document the strict typing command in the roadmap guide and quickstart instructions
- extend the CI typing job with a strict mypy run and upload the log as an artifact on failure

## Testing
- poetry run mypy --strict src/devsynth *(fails: existing strict errors to be triaged separately)*

------
https://chatgpt.com/codex/tasks/task_e_68d5c532e34c83338d41e7760dac59ed