### PR TITLE
Add typed facades for UI mocks

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -206,6 +206,7 @@ mvuu-dashboard = "devsynth.application.cli.commands.mvuu_dashboard_cmd:mvuu_dash
 [tool.mypy]
 mypy_path = [
     "src",
+    "stubs/streamlit",
     "stubs/types-pytest",
     "stubs/types-pytest-bdd",
     "stubs/types-responses",

--- a/stubs/streamlit/__init__.pyi
+++ b/stubs/streamlit/__init__.pyi
@@ -1,0 +1,5 @@
+from typing import Any
+
+__all__: list[str]
+
+def __getattr__(name: str) -> Any: ...

--- a/stubs/streamlit/testing/__init__.pyi
+++ b/stubs/streamlit/testing/__init__.pyi
@@ -1,0 +1,3 @@
+from .v1 import AppTest as AppTest
+
+__all__ = ["AppTest"]

--- a/stubs/streamlit/testing/v1.pyi
+++ b/stubs/streamlit/testing/v1.pyi
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+from typing import Any, Sequence, Self
+
+
+class _Widget:
+    value: Any
+    options: Sequence[Any]
+    def __call__(self, *args: Any, **kwargs: Any) -> Any: ...
+
+
+class _Sidebar:
+    selectbox: Sequence[_Widget]
+
+
+class AppTest:
+    title: Sequence[_Widget]
+    sidebar: _Sidebar
+
+    @classmethod
+    def from_file(cls, path: Any, /, **kwargs: Any) -> Self: ...
+
+    def run(self, **kwargs: Any) -> Self: ...

--- a/tests/fixtures/mock_subsystems.py
+++ b/tests/fixtures/mock_subsystems.py
@@ -18,7 +18,22 @@ from __future__ import annotations
 import os
 import sys
 from types import ModuleType
+from typing import Protocol
 from unittest.mock import MagicMock
+
+
+class NiceGUIModule(Protocol):
+    """Protocol capturing the NiceGUI attributes used within tests."""
+
+    ui: MagicMock
+
+
+class NiceGUIStub(ModuleType):
+    """Typed NiceGUI replacement that satisfies :class:`NiceGUIModule`."""
+
+    def __init__(self) -> None:
+        super().__init__("nicegui")
+        self.ui: MagicMock = MagicMock(name="nicegui.ui")
 
 
 def _install_module_stub(module_name: str, attrs: dict | None = None) -> ModuleType:
@@ -41,7 +56,7 @@ def stub_gui_modules() -> None:
     """
     # NiceGUI stubs
     if "nicegui" not in sys.modules:
-        _install_module_stub("nicegui", attrs={"ui": MagicMock(name="nicegui.ui")})
+        sys.modules["nicegui"] = NiceGUIStub()
     # Common nested imports used by apps
     if "nicegui.app" not in sys.modules:
         _install_module_stub("nicegui.app", attrs={})

--- a/tests/fixtures/state_access_fixture.py
+++ b/tests/fixtures/state_access_fixture.py
@@ -5,11 +5,9 @@ This module provides fixtures for testing the state_access module and
 the WizardStateManager class with proper session state mocking.
 """
 
-from types import ModuleType
-from unittest.mock import MagicMock, patch
-
 import pytest
 
+from tests.fixtures.streamlit_mocks import StreamlitModule, StreamlitStub
 
 class MockSessionState(dict):
     """A mock session state that behaves like both a dictionary and an object with attributes."""
@@ -35,14 +33,14 @@ def mock_session_state():
 
 
 @pytest.fixture
-def mock_streamlit_for_state():
+def mock_streamlit_for_state() -> StreamlitModule:
     """
     Create a mock streamlit module with session state for testing.
 
     This is similar to the mock_streamlit fixture in webui_wizard_state_fixture.py,
     but focused specifically on session state for testing state_access functions.
     """
-    st = ModuleType("streamlit")
+    st = StreamlitStub()
     st.session_state = create_mock_session_state()
     return st
 

--- a/tests/fixtures/webui_test_utils.py
+++ b/tests/fixtures/webui_test_utils.py
@@ -22,11 +22,12 @@ Usage:
 import json
 import os
 import sys
-from types import ModuleType
 from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 from unittest.mock import MagicMock, patch
 
 import pytest
+
+from tests.fixtures.streamlit_mocks import StreamlitModule, StreamlitStub
 
 
 class DummyForm:
@@ -48,7 +49,7 @@ class DummyForm:
         return self.submitted
 
 
-def create_mock_streamlit():
+def create_mock_streamlit() -> StreamlitModule:
     """
     Create a standardized mock Streamlit implementation.
 
@@ -59,36 +60,24 @@ def create_mock_streamlit():
     Returns:
         A mock Streamlit module
     """
-    st = ModuleType("streamlit")
-
-    # Create a session state that behaves like a dictionary
-    class SessionState(dict):
-        def __getattr__(self, name):
-            if name in self:
-                return self[name]
-            return None
-
-        def __setattr__(self, name, value):
-            self[name] = value
-
-    st.session_state = SessionState()
+    st = StreamlitStub()
 
     # Mock input functions
-    st.button = MagicMock(return_value=False)
-    st.text_input = MagicMock(return_value="")
-    st.text_area = MagicMock(return_value="")
-    st.selectbox = MagicMock(return_value="")
-    st.multiselect = MagicMock(return_value=[])
-    st.checkbox = MagicMock(return_value=False)
-    st.radio = MagicMock(return_value="")
-    st.number_input = MagicMock(return_value=0)
-    st.slider = MagicMock(return_value=0)
-    st.select_slider = MagicMock(return_value="")
-    st.date_input = MagicMock(return_value=None)
-    st.time_input = MagicMock(return_value=None)
-    st.file_uploader = MagicMock(return_value=None)
-    st.color_picker = MagicMock(return_value="")
-    st.toggle = MagicMock(return_value=True)
+    st.button.return_value = False
+    st.text_input.return_value = ""
+    st.text_area.return_value = ""
+    st.selectbox.return_value = ""
+    st.multiselect.return_value = []
+    st.checkbox.return_value = False
+    st.radio.return_value = ""
+    st.number_input.return_value = 0
+    st.slider.return_value = 0
+    st.select_slider.return_value = ""
+    st.date_input.return_value = None
+    st.time_input.return_value = None
+    st.file_uploader.return_value = None
+    st.color_picker.return_value = ""
+    st.toggle.return_value = True
 
     # Mock display functions
     st.write = MagicMock()
@@ -140,7 +129,7 @@ def create_mock_streamlit():
     form_mock.__enter__ = MagicMock(return_value=form_mock)
     form_mock.__exit__ = MagicMock(return_value=None)
     st.form = MagicMock(return_value=form_mock)
-    st.form_submit_button = MagicMock(return_value=False)
+    st.form_submit_button.return_value = False
 
     # Mock spinner functions
     spinner_mock = MagicMock()
@@ -165,19 +154,10 @@ def create_mock_streamlit():
     st.experimental_rerun = MagicMock()
 
     # Mock components
-    class ComponentsV1:
-        def html(self, html_string, **kwargs):
-            return None
+    st.components.v1.html = MagicMock(return_value=None)
 
-    class Components:
-        v1 = ComponentsV1()
-
-    st.components = Components()
-
-    # Mock set_page_config
+    # Mock set_page_config and divider
     st.set_page_config = MagicMock()
-
-    # Add divider if it exists in the real Streamlit
     st.divider = MagicMock()
 
     return st

--- a/tests/fixtures/webui_wizard_state_fixture.py
+++ b/tests/fixtures/webui_wizard_state_fixture.py
@@ -6,30 +6,18 @@ It uses the WizardState class from webui_state.py to ensure consistent state
 persistence between wizard steps.
 """
 
-from types import ModuleType
 from unittest.mock import MagicMock, patch
 
 import pytest
 
+from tests.fixtures.streamlit_mocks import StreamlitModule, StreamlitStub
 
-def create_mock_streamlit():
+def create_mock_streamlit() -> StreamlitModule:
     """Create a mock streamlit module with session state for testing."""
-    st = ModuleType("streamlit")
-
-    # Create a session state that behaves like a dictionary
-    class SessionState(dict):
-        def __getattr__(self, name):
-            if name in self:
-                return self[name]
-            return None
-
-        def __setattr__(self, name, value):
-            self[name] = value
-
-    st.session_state = SessionState()
+    st = StreamlitStub()
 
     # Mock common streamlit functions
-    st.button = MagicMock(return_value=False)
+    st.button.return_value = False
     st.text_input = MagicMock(
         side_effect=lambda *args, **kwargs: kwargs.get("value", "")
     )
@@ -53,16 +41,16 @@ def create_mock_streamlit():
             return options[0]
 
     st.selectbox = MagicMock(side_effect=_selectbox_side_effect)
-    st.multiselect = MagicMock(return_value=[])
-    st.checkbox = MagicMock(return_value=False)
-    st.radio = MagicMock(return_value="")
-    st.number_input = MagicMock(return_value=0)
-    st.slider = MagicMock(return_value=0)
-    st.select_slider = MagicMock(return_value="")
-    st.date_input = MagicMock(return_value=None)
-    st.time_input = MagicMock(return_value=None)
-    st.file_uploader = MagicMock(return_value=None)
-    st.color_picker = MagicMock(return_value="")
+    st.multiselect.return_value = []
+    st.checkbox.return_value = False
+    st.radio.return_value = ""
+    st.number_input.return_value = 0
+    st.slider.return_value = 0
+    st.select_slider.return_value = ""
+    st.date_input.return_value = None
+    st.time_input.return_value = None
+    st.file_uploader.return_value = None
+    st.color_picker.return_value = ""
 
     # Mock display functions
     st.write = MagicMock()


### PR DESCRIPTION
## Summary
- add protocol-backed Streamlit stub to centralize typed UI mocks for tests
- update WebUI fixtures to reuse the typed Streamlit stub and expose typed NiceGUI stub
- provide Streamlit testing stubs and extend mypy configuration for new types

## Testing
- poetry run mypy tests/**/streamlit_*

------
https://chatgpt.com/codex/tasks/task_e_68d5cf008ae48333ad2a3e7cf4ae4644