### PR TITLE
refactor: declare CLI command exports explicitly

### DIFF
--- a/src/devsynth/application/cli/__init__.py
+++ b/src/devsynth/application/cli/__init__.py
@@ -1,5 +1,7 @@
 """Application-level CLI facades that delegate into orchestration layer."""
 
+from typing import Callable
+
 from devsynth.logging_setup import DevSynthLogger
 
 logger = DevSynthLogger(__name__)
@@ -18,9 +20,116 @@ from .commands.inspect_code_cmd import inspect_code_cmd
 from .ingest_cmd import ingest_cmd
 from .registry import COMMAND_REGISTRY
 
-# Re-export commands from registry as module-level functions
-globals().update(
-    {f"{name.replace('-', '_')}_cmd": fn for name, fn in COMMAND_REGISTRY.items()}
+from ._command_exports import COMMAND_ATTRIBUTE_TO_SLUG, COMMAND_ATTRIBUTE_NAMES
+
+
+CommandCallable = Callable[..., object]
+
+
+def _registered_command(slug: str) -> CommandCallable:
+    """Return the callable registered for ``slug``."""
+
+    try:
+        return COMMAND_REGISTRY[slug]
+    except KeyError as exc:  # pragma: no cover - defensive guardrail
+        raise RuntimeError(f"CLI command '{slug}' is not registered") from exc
+
+
+align_cmd: CommandCallable = _registered_command(
+    COMMAND_ATTRIBUTE_TO_SLUG["align_cmd"]
+)
+completion_cmd: CommandCallable = _registered_command(
+    COMMAND_ATTRIBUTE_TO_SLUG["completion_cmd"]
+)
+init_cmd: CommandCallable = _registered_command(
+    COMMAND_ATTRIBUTE_TO_SLUG["init_cmd"]
+)
+run_tests_cmd: CommandCallable = _registered_command(
+    COMMAND_ATTRIBUTE_TO_SLUG["run_tests_cmd"]
+)
+edrr_cycle_cmd: CommandCallable = _registered_command(
+    COMMAND_ATTRIBUTE_TO_SLUG["edrr_cycle_cmd"]
+)
+security_audit_cmd: CommandCallable = _registered_command(
+    COMMAND_ATTRIBUTE_TO_SLUG["security_audit_cmd"]
+)
+reprioritize_issues_cmd: CommandCallable = _registered_command(
+    COMMAND_ATTRIBUTE_TO_SLUG["reprioritize_issues_cmd"]
+)
+atomic_rewrite_cmd: CommandCallable = _registered_command(
+    COMMAND_ATTRIBUTE_TO_SLUG["atomic_rewrite_cmd"]
+)
+mvuu_dashboard_cmd: CommandCallable = _registered_command(
+    COMMAND_ATTRIBUTE_TO_SLUG["mvuu_dashboard_cmd"]
+)
+spec_cmd: CommandCallable = _registered_command(
+    COMMAND_ATTRIBUTE_TO_SLUG["spec_cmd"]
+)
+test_cmd: CommandCallable = _registered_command(
+    COMMAND_ATTRIBUTE_TO_SLUG["test_cmd"]
+)
+code_cmd: CommandCallable = _registered_command(
+    COMMAND_ATTRIBUTE_TO_SLUG["code_cmd"]
+)
+webapp_cmd: CommandCallable = _registered_command(
+    COMMAND_ATTRIBUTE_TO_SLUG["webapp_cmd"]
+)
+serve_cmd: CommandCallable = _registered_command(
+    COMMAND_ATTRIBUTE_TO_SLUG["serve_cmd"]
+)
+dbschema_cmd: CommandCallable = _registered_command(
+    COMMAND_ATTRIBUTE_TO_SLUG["dbschema_cmd"]
+)
+webui_cmd: CommandCallable = _registered_command(
+    COMMAND_ATTRIBUTE_TO_SLUG["webui_cmd"]
+)
+dpg_cmd: CommandCallable = _registered_command(
+    COMMAND_ATTRIBUTE_TO_SLUG["dpg_cmd"]
+)
+alignment_metrics_cmd: CommandCallable = _registered_command(
+    COMMAND_ATTRIBUTE_TO_SLUG["alignment_metrics_cmd"]
+)
+test_metrics_cmd: CommandCallable = _registered_command(
+    COMMAND_ATTRIBUTE_TO_SLUG["test_metrics_cmd"]
+)
+run_pipeline_cmd: CommandCallable = _registered_command(
+    COMMAND_ATTRIBUTE_TO_SLUG["run_pipeline_cmd"]
+)
+run_cmd: CommandCallable = _registered_command(
+    COMMAND_ATTRIBUTE_TO_SLUG["run_cmd"]
+)
+gather_cmd: CommandCallable = _registered_command(
+    COMMAND_ATTRIBUTE_TO_SLUG["gather_cmd"]
+)
+refactor_cmd: CommandCallable = _registered_command(
+    COMMAND_ATTRIBUTE_TO_SLUG["refactor_cmd"]
+)
+inspect_cmd: CommandCallable = _registered_command(
+    COMMAND_ATTRIBUTE_TO_SLUG["inspect_cmd"]
+)
+inspect_config_cmd: CommandCallable = _registered_command(
+    COMMAND_ATTRIBUTE_TO_SLUG["inspect_config_cmd"]
+)
+config_cmd: CommandCallable = _registered_command(
+    COMMAND_ATTRIBUTE_TO_SLUG["config_cmd"]
+)
+enable_feature_cmd: CommandCallable = _registered_command(
+    COMMAND_ATTRIBUTE_TO_SLUG["enable_feature_cmd"]
+)
+doctor_cmd: CommandCallable = _registered_command(
+    COMMAND_ATTRIBUTE_TO_SLUG["doctor_cmd"]
+)
+check_cmd: CommandCallable = _registered_command(
+    COMMAND_ATTRIBUTE_TO_SLUG["check_cmd"]
+)
+generate_docs_cmd: CommandCallable = _registered_command(
+    COMMAND_ATTRIBUTE_TO_SLUG["generate_docs_cmd"]
+)
+validate_manifest_cmd: CommandCallable = _registered_command(
+    COMMAND_ATTRIBUTE_TO_SLUG["validate_manifest_cmd"]
+)
+validate_metadata_cmd: CommandCallable = _registered_command(
+    COMMAND_ATTRIBUTE_TO_SLUG["validate_metadata_cmd"]
 )
 
 __all__ = [
@@ -28,4 +137,4 @@ __all__ = [
     "inspect_code_cmd",
     "ingest_cmd",
     "COMMAND_REGISTRY",
-] + [f"{name.replace('-', '_')}_cmd" for name in COMMAND_REGISTRY]
+] + list(COMMAND_ATTRIBUTE_NAMES)

--- a/src/devsynth/application/cli/_command_exports.py
+++ b/src/devsynth/application/cli/_command_exports.py
@@ -1,0 +1,75 @@
+"""Central definitions for CLI command export names.
+
+This module captures the mapping between attribute names exposed on
+``devsynth.application.cli`` / ``devsynth.application.cli.cli_commands`` and the
+command slugs registered in :data:`~devsynth.application.cli.registry.COMMAND_REGISTRY`.
+
+By centralising this mapping we ensure that runtime exports, typing stubs, and
+tests that stub or introspect CLI commands stay in sync.
+"""
+
+from __future__ import annotations
+
+from typing import Mapping
+
+# NOTE: ``Mapping`` is used instead of ``dict`` to communicate the intent that
+# consumers should treat this structure as read-only.
+COMMAND_ATTRIBUTE_TO_SLUG: Mapping[str, str] = {
+    # Extra commands
+    "align_cmd": "align",
+    "completion_cmd": "completion",
+    "init_cmd": "init",
+    "run_tests_cmd": "run-tests",
+    "edrr_cycle_cmd": "edrr-cycle",
+    "security_audit_cmd": "security-audit",
+    "reprioritize_issues_cmd": "reprioritize-issues",
+    "atomic_rewrite_cmd": "atomic-rewrite",
+    "mvuu_dashboard_cmd": "mvuu-dashboard",
+    # Generation commands
+    "spec_cmd": "spec",
+    "test_cmd": "test",
+    "code_cmd": "code",
+    # Single-command modules
+    "ingest_cmd": "ingest",
+    # Interface commands
+    "webapp_cmd": "webapp",
+    "serve_cmd": "serve",
+    "dbschema_cmd": "dbschema",
+    "webui_cmd": "webui",
+    "dpg_cmd": "dpg",
+    # Metrics commands
+    "alignment_metrics_cmd": "alignment-metrics",
+    "test_metrics_cmd": "test-metrics",
+    # Pipeline commands and aliases
+    "run_pipeline_cmd": "run-pipeline",
+    "run_cmd": "run",
+    "gather_cmd": "gather",
+    "refactor_cmd": "refactor",
+    "inspect_cmd": "inspect",
+    "inspect_config_cmd": "inspect-config",
+    # Configuration commands
+    "config_cmd": "config",
+    "enable_feature_cmd": "enable-feature",
+    # Diagnostics commands
+    "doctor_cmd": "doctor",
+    "check_cmd": "check",
+    # Documentation commands
+    "generate_docs_cmd": "generate-docs",
+    # Validation commands
+    "validate_manifest_cmd": "validate-manifest",
+    "validate_metadata_cmd": "validate-metadata",
+}
+
+# Convenience tuple exposing the attribute names for quick iteration.
+COMMAND_ATTRIBUTE_NAMES = tuple(COMMAND_ATTRIBUTE_TO_SLUG.keys())
+
+# Convenience tuple exposing the registered command slugs.
+COMMAND_SLUGS = tuple(COMMAND_ATTRIBUTE_TO_SLUG.values())
+
+
+__all__ = [
+    "COMMAND_ATTRIBUTE_TO_SLUG",
+    "COMMAND_ATTRIBUTE_NAMES",
+    "COMMAND_SLUGS",
+]
+

--- a/src/devsynth/application/cli/cli_commands.py
+++ b/src/devsynth/application/cli/cli_commands.py
@@ -8,6 +8,8 @@ the Typer application.
 
 from __future__ import annotations
 
+from typing import Callable
+
 from devsynth.core import workflows
 
 init_project = workflows.init_project
@@ -19,6 +21,7 @@ from devsynth.interface.ux_bridge import UXBridge
 # Tests expect `devsynth.application.cli.cli_commands.bridge` to exist.
 bridge: UXBridge = CLIUXBridge()
 
+from ._command_exports import COMMAND_ATTRIBUTE_TO_SLUG, COMMAND_ATTRIBUTE_NAMES
 from .commands import (
     config_cmds,
     diagnostics_cmds,
@@ -40,6 +43,24 @@ from .utils import _check_services
 
 generate_specs = _spec_module.generate_specs
 _spec_module.generate_specs = generate_specs
+
+
+CommandCallable = Callable[..., object]
+
+
+def _registered_command(slug: str) -> CommandCallable:
+    """Return the callable registered for ``slug``.
+
+    Raises:
+        RuntimeError: If the command slug is missing from the registry. This
+            signals a programming error where the command module was not
+            imported prior to exposing the compatibility shim used in tests.
+    """
+
+    try:
+        return COMMAND_REGISTRY[slug]
+    except KeyError as exc:  # pragma: no cover - defensive guardrail
+        raise RuntimeError(f"CLI command '{slug}' is not registered") from exc
 
 
 def create_progress(
@@ -71,8 +92,105 @@ def show_help(command: str | None = None) -> str:
     return get_command_help(command) if command else get_all_commands_help()
 
 
-for _name, _cmd in COMMAND_REGISTRY.items():
-    globals()[f"{_name.replace('-', '_')}_cmd"] = _cmd
+align_cmd: CommandCallable = _registered_command(
+    COMMAND_ATTRIBUTE_TO_SLUG["align_cmd"]
+)
+completion_cmd: CommandCallable = _registered_command(
+    COMMAND_ATTRIBUTE_TO_SLUG["completion_cmd"]
+)
+init_cmd: CommandCallable = _registered_command(
+    COMMAND_ATTRIBUTE_TO_SLUG["init_cmd"]
+)
+run_tests_cmd: CommandCallable = _registered_command(
+    COMMAND_ATTRIBUTE_TO_SLUG["run_tests_cmd"]
+)
+edrr_cycle_cmd: CommandCallable = _registered_command(
+    COMMAND_ATTRIBUTE_TO_SLUG["edrr_cycle_cmd"]
+)
+security_audit_cmd: CommandCallable = _registered_command(
+    COMMAND_ATTRIBUTE_TO_SLUG["security_audit_cmd"]
+)
+reprioritize_issues_cmd: CommandCallable = _registered_command(
+    COMMAND_ATTRIBUTE_TO_SLUG["reprioritize_issues_cmd"]
+)
+atomic_rewrite_cmd: CommandCallable = _registered_command(
+    COMMAND_ATTRIBUTE_TO_SLUG["atomic_rewrite_cmd"]
+)
+mvuu_dashboard_cmd: CommandCallable = _registered_command(
+    COMMAND_ATTRIBUTE_TO_SLUG["mvuu_dashboard_cmd"]
+)
+spec_cmd: CommandCallable = _registered_command(
+    COMMAND_ATTRIBUTE_TO_SLUG["spec_cmd"]
+)
+test_cmd: CommandCallable = _registered_command(
+    COMMAND_ATTRIBUTE_TO_SLUG["test_cmd"]
+)
+code_cmd: CommandCallable = _registered_command(
+    COMMAND_ATTRIBUTE_TO_SLUG["code_cmd"]
+)
+ingest_cmd: CommandCallable = _registered_command(
+    COMMAND_ATTRIBUTE_TO_SLUG["ingest_cmd"]
+)
+webapp_cmd: CommandCallable = _registered_command(
+    COMMAND_ATTRIBUTE_TO_SLUG["webapp_cmd"]
+)
+serve_cmd: CommandCallable = _registered_command(
+    COMMAND_ATTRIBUTE_TO_SLUG["serve_cmd"]
+)
+dbschema_cmd: CommandCallable = _registered_command(
+    COMMAND_ATTRIBUTE_TO_SLUG["dbschema_cmd"]
+)
+webui_cmd: CommandCallable = _registered_command(
+    COMMAND_ATTRIBUTE_TO_SLUG["webui_cmd"]
+)
+dpg_cmd: CommandCallable = _registered_command(
+    COMMAND_ATTRIBUTE_TO_SLUG["dpg_cmd"]
+)
+alignment_metrics_cmd: CommandCallable = _registered_command(
+    COMMAND_ATTRIBUTE_TO_SLUG["alignment_metrics_cmd"]
+)
+test_metrics_cmd: CommandCallable = _registered_command(
+    COMMAND_ATTRIBUTE_TO_SLUG["test_metrics_cmd"]
+)
+run_pipeline_cmd: CommandCallable = _registered_command(
+    COMMAND_ATTRIBUTE_TO_SLUG["run_pipeline_cmd"]
+)
+run_cmd: CommandCallable = _registered_command(
+    COMMAND_ATTRIBUTE_TO_SLUG["run_cmd"]
+)
+gather_cmd: CommandCallable = _registered_command(
+    COMMAND_ATTRIBUTE_TO_SLUG["gather_cmd"]
+)
+refactor_cmd: CommandCallable = _registered_command(
+    COMMAND_ATTRIBUTE_TO_SLUG["refactor_cmd"]
+)
+inspect_cmd: CommandCallable = _registered_command(
+    COMMAND_ATTRIBUTE_TO_SLUG["inspect_cmd"]
+)
+inspect_config_cmd: CommandCallable = _registered_command(
+    COMMAND_ATTRIBUTE_TO_SLUG["inspect_config_cmd"]
+)
+config_cmd: CommandCallable = _registered_command(
+    COMMAND_ATTRIBUTE_TO_SLUG["config_cmd"]
+)
+enable_feature_cmd: CommandCallable = _registered_command(
+    COMMAND_ATTRIBUTE_TO_SLUG["enable_feature_cmd"]
+)
+doctor_cmd: CommandCallable = _registered_command(
+    COMMAND_ATTRIBUTE_TO_SLUG["doctor_cmd"]
+)
+check_cmd: CommandCallable = _registered_command(
+    COMMAND_ATTRIBUTE_TO_SLUG["check_cmd"]
+)
+generate_docs_cmd: CommandCallable = _registered_command(
+    COMMAND_ATTRIBUTE_TO_SLUG["generate_docs_cmd"]
+)
+validate_manifest_cmd: CommandCallable = _registered_command(
+    COMMAND_ATTRIBUTE_TO_SLUG["validate_manifest_cmd"]
+)
+validate_metadata_cmd: CommandCallable = _registered_command(
+    COMMAND_ATTRIBUTE_TO_SLUG["validate_metadata_cmd"]
+)
 
 
 __all__ = [
@@ -83,4 +201,4 @@ __all__ = [
     "show_help",
     "get_command_help",
     "get_all_commands_help",
-] + [f"{name.replace('-', '_')}_cmd" for name in COMMAND_REGISTRY]
+] + list(COMMAND_ATTRIBUTE_NAMES)

--- a/tests/behavior/test_cli_webui_parity.py
+++ b/tests/behavior/test_cli_webui_parity.py
@@ -5,6 +5,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
+from devsynth.application.cli._command_exports import COMMAND_ATTRIBUTE_NAMES
 from devsynth.interface.agentapi import APIBridge
 
 # Resource gating: exercises both CLI and WebUI layers
@@ -50,16 +51,11 @@ def parity_env(monkeypatch):
     cli_commands_stub.init_cmd = MagicMock(side_effect=init_cmd)
     cli_commands_stub.spec_cmd = MagicMock(side_effect=spec_cmd)
     cli_commands_stub.code_cmd = MagicMock(side_effect=code_cmd)
-    for name in ["test_cmd", "run_pipeline_cmd", "config_cmd", "inspect_cmd"]:
-        setattr(cli_commands_stub, name, MagicMock())
     cli_stub.cli_commands = cli_commands_stub
-    cli_stub.init_cmd = cli_commands_stub.init_cmd
-    cli_stub.spec_cmd = cli_commands_stub.spec_cmd
-    cli_stub.code_cmd = cli_commands_stub.code_cmd
-    cli_stub.test_cmd = cli_commands_stub.test_cmd
-    cli_stub.run_pipeline_cmd = cli_commands_stub.run_pipeline_cmd
-    cli_stub.config_cmd = cli_commands_stub.config_cmd
-    cli_stub.inspect_cmd = cli_commands_stub.inspect_cmd
+    for name in COMMAND_ATTRIBUTE_NAMES:
+        if not hasattr(cli_commands_stub, name):
+            setattr(cli_commands_stub, name, MagicMock())
+        setattr(cli_stub, name, getattr(cli_commands_stub, name))
     ingest_mod = ModuleType("devsynth.application.cli.ingest_cmd")
     ingest_mod.ingest_cmd = MagicMock()
     monkeypatch.setitem(sys.modules, "devsynth.application.cli.ingest_cmd", ingest_mod)

--- a/tests/unit/interface/test_api_advanced.py
+++ b/tests/unit/interface/test_api_advanced.py
@@ -8,6 +8,7 @@ from unittest.mock import MagicMock, patch
 from fastapi import HTTPException
 from fastapi.testclient import TestClient
 
+from devsynth.application.cli._command_exports import COMMAND_ATTRIBUTE_NAMES
 from devsynth.api import app
 from devsynth.interface.agentapi import (
     LATEST_MESSAGES,
@@ -52,6 +53,21 @@ def client(mock_settings):
 @pytest.fixture
 def mock_cli_commands():
     """Mock CLI commands for testing."""
+    required = {
+        "init_cmd",
+        "gather_cmd",
+        "run_pipeline_cmd",
+        "spec_cmd",
+        "test_cmd",
+        "code_cmd",
+        "doctor_cmd",
+        "edrr_cycle_cmd",
+    }
+    missing = required.difference(COMMAND_ATTRIBUTE_NAMES)
+    if missing:  # pragma: no cover - defensive
+        raise AssertionError(
+            "CLI command exports missing expected attributes: " + ", ".join(sorted(missing))
+        )
     with (
         patch("devsynth.application.cli.init_cmd") as mock_init_cmd,
         patch("devsynth.application.cli.gather_cmd") as mock_gather_cmd,

--- a/tests/unit/interface/test_api_endpoints.py
+++ b/tests/unit/interface/test_api_endpoints.py
@@ -8,6 +8,7 @@ from unittest.mock import MagicMock, patch
 from fastapi import HTTPException
 from fastapi.testclient import TestClient
 
+from devsynth.application.cli._command_exports import COMMAND_ATTRIBUTE_NAMES
 from devsynth.api import app
 from devsynth.interface.agentapi import (
     LATEST_MESSAGES,
@@ -68,6 +69,21 @@ def client(mock_settings):
 @pytest.fixture
 def mock_cli_commands():
     """Mock the CLI command functions."""
+    required = {
+        "init_cmd",
+        "gather_cmd",
+        "run_pipeline_cmd",
+        "spec_cmd",
+        "test_cmd",
+        "code_cmd",
+        "doctor_cmd",
+        "edrr_cycle_cmd",
+    }
+    missing = required.difference(COMMAND_ATTRIBUTE_NAMES)
+    if missing:  # pragma: no cover - defensive
+        raise AssertionError(
+            "CLI command exports missing expected attributes: " + ", ".join(sorted(missing))
+        )
     with (
         patch("devsynth.application.cli.init_cmd") as mock_init,
         patch("devsynth.application.cli.gather_cmd") as mock_gather,


### PR DESCRIPTION
## Summary
- add a central mapping of CLI command export names to registry slugs and reuse it to define static exports in `cli_commands` and `application.cli`
- update CLI compatibility tests to consume the shared mapping so their stubs stay in sync with the production exports

## Testing
- `PYTHONPATH=src poetry run mypy tests/unit/application/cli` *(fails: environment lacks optional Starlette dependency and the suite has existing typing violations outside the touched modules)*

------
https://chatgpt.com/codex/tasks/task_e_68d5dea8aa44833383876f2143e0d4f7