### PR TITLE
feat: formalize EDRR orchestration protocols

### DIFF
--- a/src/devsynth/methodology/edrr/__init__.py
+++ b/src/devsynth/methodology/edrr/__init__.py
@@ -3,7 +3,17 @@
 # - from devsynth.methodology.edrr import reasoning_loop  -> returns callable
 # - import devsynth.methodology.edrr.reasoning_loop as rl -> returns submodule
 
-__all__: list[str] = ["EDRRCoordinator", "reasoning_loop"]
+__all__: list[str] = [
+    "EDRRCoordinator",
+    "reasoning_loop",
+    "MemoryIntegration",
+    "MemoryManager",
+    "EDRRCoordinatorProtocol",
+    "WSDETeamProtocol",
+    "NullWSDETeam",
+    "CoordinatorRecorder",
+    "MemoryIntegrationLog",
+]
 
 
 def __getattr__(name: str) -> object:  # PEP 562
@@ -15,4 +25,17 @@ def __getattr__(name: str) -> object:  # PEP 562
         from .reasoning_loop import reasoning_loop as _reasoning_loop
 
         return _reasoning_loop
+    contract_names = {
+        "MemoryIntegration",
+        "MemoryManager",
+        "EDRRCoordinatorProtocol",
+        "WSDETeamProtocol",
+        "NullWSDETeam",
+        "CoordinatorRecorder",
+        "MemoryIntegrationLog",
+    }
+    if name in contract_names:
+        from . import contracts as _contracts
+
+        return getattr(_contracts, name)
     raise AttributeError(name)

--- a/src/devsynth/methodology/edrr/contracts.py
+++ b/src/devsynth/methodology/edrr/contracts.py
@@ -1,0 +1,122 @@
+"""Shared protocols and helper dataclasses for EDRR orchestration."""
+
+from __future__ import annotations
+"""Typed contracts shared across EDRR orchestration components."""
+
+from collections.abc import Callable, Mapping
+from dataclasses import dataclass, field
+from typing import Any, Protocol, runtime_checkable
+
+from devsynth.domain.models.wsde_dialectical import DialecticalSequence
+from devsynth.domain.models.wsde_dialectical_types import DialecticalTask
+
+SyncHook = Callable[[Any | None], None]
+
+
+@runtime_checkable
+class MemoryIntegration(Protocol):
+    """Protocol describing the memory interface used by the reasoning loop."""
+
+    def store_dialectical_result(
+        self,
+        task: DialecticalTask,
+        result: DialecticalSequence | Mapping[str, Any],
+    ) -> None:
+        """Persist a dialectical reasoning result for later retrieval."""
+
+
+@runtime_checkable
+class MemoryManager(Protocol):
+    """Protocol describing memory managers that support synchronization hooks."""
+
+    def register_sync_hook(self, hook: SyncHook) -> None:
+        """Register a callback that should run after updates are flushed."""
+
+    def flush_updates(self) -> None:
+        """Flush pending updates to durable storage."""
+
+
+@runtime_checkable
+class EDRRCoordinatorProtocol(Protocol):
+    """Protocol for coordinator implementations consumed by the reasoning loop."""
+
+    def record_consensus_failure(self, error: Exception) -> None:
+        """Record a consensus failure raised by the dialectical reasoning step."""
+
+    def record_expand_results(self, result: dict[str, Any]) -> dict[str, Any]:
+        """Persist results produced during the Expand phase."""
+
+    def record_differentiate_results(
+        self, result: dict[str, Any]
+    ) -> dict[str, Any]:
+        """Persist results produced during the Differentiate phase."""
+
+    def record_refine_results(self, result: dict[str, Any]) -> dict[str, Any]:
+        """Persist results produced during the Refine phase."""
+
+
+@runtime_checkable
+class WSDETeamProtocol(Protocol):
+    """Minimal protocol exposing the hooks used by dialectical reasoning."""
+
+    dialectical_hooks: list[Callable[..., Any]]
+
+
+@dataclass(slots=True)
+class NullWSDETeam:
+    """Simple WSDE team stub satisfying :class:`WSDETeamProtocol`."""
+
+    dialectical_hooks: list[Callable[..., Any]] = field(default_factory=list)
+
+
+@dataclass(slots=True)
+class CoordinatorRecorder:
+    """Dataclass collecting coordinator interactions for assertions in tests."""
+
+    records: list[tuple[str, dict[str, Any]]] = field(default_factory=list)
+    failures: list[Exception] = field(default_factory=list)
+
+    def record_consensus_failure(self, error: Exception) -> None:
+        self.failures.append(error)
+
+    def record_expand_results(self, result: dict[str, Any]) -> dict[str, Any]:
+        self.records.append(("expand", result))
+        return result
+
+    def record_differentiate_results(
+        self, result: dict[str, Any]
+    ) -> dict[str, Any]:
+        self.records.append(("differentiate", result))
+        return result
+
+    def record_refine_results(self, result: dict[str, Any]) -> dict[str, Any]:
+        self.records.append(("refine", result))
+        return result
+
+
+@dataclass(slots=True)
+class MemoryIntegrationLog:
+    """Dataclass capturing calls made to the memory integration."""
+
+    calls: list[tuple[dict[str, Any], dict[str, Any]]] = field(default_factory=list)
+
+    def store_dialectical_result(
+        self,
+        task: DialecticalTask,
+        result: DialecticalSequence | Mapping[str, Any],
+    ) -> None:
+        if isinstance(task, DialecticalTask):
+            task_payload = task.to_dict()
+        elif isinstance(task, Mapping):
+            task_payload = dict(task)
+        else:  # pragma: no cover - defensive guard for unexpected payloads
+            task_payload = {"value": task}
+
+        if isinstance(result, DialecticalSequence):
+            result_payload = result.to_dict()
+        elif isinstance(result, Mapping):
+            result_payload = dict(result)
+        else:  # pragma: no cover - defensive guard for unexpected payloads
+            result_payload = {"value": result}
+
+        self.calls.append((task_payload, result_payload))

--- a/stubs/types-pytest/pytest/__init__.pyi
+++ b/stubs/types-pytest/pytest/__init__.pyi
@@ -10,7 +10,7 @@ T = TypeVar("T")
 ScopeName = Literal["function", "class", "module", "package", "session"]
 
 
-MarkDecorator: TypeAlias = Callable[[Callable[P, R]], Callable[P, R]]
+MarkDecorator: TypeAlias = Callable[[Callable[..., Any]], Callable[..., Any]]
 
 
 class _MarkProxy:

--- a/tests/unit/methodology/edrr/test_reasoning_loop_invariants.py
+++ b/tests/unit/methodology/edrr/test_reasoning_loop_invariants.py
@@ -8,6 +8,7 @@ import pytest
 
 from devsynth.domain.models.wsde_dialectical import DialecticalSequence
 from devsynth.methodology.base import Phase
+from devsynth.methodology.edrr.contracts import NullWSDETeam
 
 reasoning_loop_module = importlib.import_module(
     "devsynth.methodology.edrr.reasoning_loop",
@@ -48,7 +49,7 @@ def test_reasoning_loop_enforces_total_time_budget(
     monkeypatch.setattr(reasoning_loop_module.time, "sleep", sleep_calls.append)
 
     results = reasoning_loop_module.reasoning_loop(
-        MagicMock(),
+        NullWSDETeam(),
         {"id": "task-1"},
         MagicMock(),
         max_iterations=5,
@@ -88,7 +89,7 @@ def test_reasoning_loop_retries_until_success(monkeypatch: pytest.MonkeyPatch) -
     monkeypatch.setattr(reasoning_loop_module.time, "sleep", fake_sleep)
 
     results = reasoning_loop_module.reasoning_loop(
-        MagicMock(),
+        NullWSDETeam(),
         {"solution": {"step": 0}},
         MagicMock(),
         retry_attempts=2,
@@ -117,7 +118,7 @@ def test_reasoning_loop_fallback_transitions_and_propagation(
         observed_tasks.append(task.copy())
         payload = payloads[call_index["value"]]
         call_index["value"] += 1
-        return DialecticalSequence.from_dict(payload)
+        return payload
 
     monkeypatch.setattr(
         reasoning_loop_module,
@@ -146,7 +147,7 @@ def test_reasoning_loop_fallback_transitions_and_propagation(
     recorder = Recorder()
 
     results = reasoning_loop_module.reasoning_loop(
-        MagicMock(),
+        NullWSDETeam(),
         {"id": "task-2"},
         MagicMock(),
         coordinator=recorder,
@@ -187,7 +188,7 @@ def test_reasoning_loop_respects_max_iterations_limit(
     def fake_apply(_team, task, _critic, _memory):
         payload = payloads[call_count["value"]]
         call_count["value"] += 1
-        return DialecticalSequence.from_dict(payload)
+        return payload
 
     monkeypatch.setattr(
         reasoning_loop_module,
@@ -196,7 +197,7 @@ def test_reasoning_loop_respects_max_iterations_limit(
     )
 
     results = reasoning_loop_module.reasoning_loop(
-        MagicMock(),
+        NullWSDETeam(),
         {"id": "task-iterations"},
         MagicMock(),
         max_iterations=2,


### PR DESCRIPTION
## Summary
- introduce an edrr contracts module that defines the orchestration protocols and reusable test fakes
- update the reasoning loop and orchestration coordinator to rely on the new contracts while preserving mapping results for callers
- refresh the edrr unit tests and pytest stub so patched doubles satisfy the stricter typing expectations

## Testing
- poetry run mypy --strict src/devsynth/application/orchestration/edrr_coordinator.py tests/unit/methodology/edrr
- poetry run pytest tests/unit/methodology/edrr


------
https://chatgpt.com/codex/tasks/task_e_68d5f4646c088333adf52ad938f9d928