### PR TITLE
Align WebUI config typing with typed stubs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -206,6 +206,7 @@ mvuu-dashboard = "devsynth.application.cli.commands.mvuu_dashboard_cmd:mvuu_dash
 [tool.mypy]
 mypy_path = [
     "src",
+    "stubs/devsynth",
     "stubs/streamlit",
     "stubs/types-pytest",
     "stubs/types-pytest-bdd",

--- a/stubs/devsynth/__init__.pyi
+++ b/stubs/devsynth/__init__.pyi
@@ -1,0 +1,6 @@
+from typing import Any as _Any
+
+__all__: list[str]
+
+# Allow unresolved attributes to defer to the runtime package.
+def __getattr__(name: str) -> _Any: ...

--- a/stubs/devsynth/config/__init__.pyi
+++ b/stubs/devsynth/config/__init__.pyi
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from .loader import ConfigModel, config_key_autocomplete, load_config, save_config
+from .unified_loader import UnifiedConfig, UnifiedConfigLoader
+
+__all__ = [
+    "ConfigModel",
+    "UnifiedConfig",
+    "UnifiedConfigLoader",
+    "ProjectUnifiedConfig",
+    "load_config",
+    "save_config",
+    "get_project_config",
+    "load_project_config",
+    "config_key_autocomplete",
+    "PROJECT_CONFIG",
+]
+
+PROJECT_CONFIG: ConfigModel
+
+
+def get_project_config(path: Path | None = ...) -> ConfigModel: ...
+
+
+class ProjectUnifiedConfig(UnifiedConfig[ConfigModel]):
+    config: ConfigModel
+    path: Path
+    use_pyproject: bool
+
+    @classmethod
+    def load(cls, path: Path | None = ...) -> ProjectUnifiedConfig: ...
+
+    def save(self) -> Path: ...
+
+
+def load_project_config(path: Path | None = ...) -> ProjectUnifiedConfig: ...

--- a/stubs/devsynth/config/loader.pyi
+++ b/stubs/devsynth/config/loader.pyi
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+class ConfigModel:
+    project_root: Optional[str]
+    version: str
+    structure: str
+    language: str
+    goals: Optional[str]
+    constraints: Optional[str]
+    priority: Optional[str]
+    directories: Dict[str, list[str]]
+    features: Dict[str, bool]
+    memory_store_type: str
+    kuzu_embedded: bool
+    offline_mode: bool
+    resources: Dict[str, Any] | None
+    edrr_settings: Dict[str, Any]
+    wsde_settings: Dict[str, Any]
+    uxbridge_settings: Dict[str, Any]
+
+    def __init__(
+        self,
+        project_root: Optional[str] = ...,
+        *,
+        version: str = ...,
+        structure: str = ...,
+        language: str = ...,
+        goals: Optional[str] = ...,
+        constraints: Optional[str] = ...,
+        priority: Optional[str] = ...,
+        directories: Dict[str, list[str]] | None = ...,
+        features: Dict[str, bool] | None = ...,
+        memory_store_type: str = ...,
+        kuzu_embedded: bool = ...,
+        offline_mode: bool = ...,
+        resources: Dict[str, Any] | None = ...,
+        edrr_settings: Dict[str, Any] | None = ...,
+        wsde_settings: Dict[str, Any] | None = ...,
+        uxbridge_settings: Dict[str, Any] | None = ...,
+    ) -> None: ...
+
+    def as_dict(self) -> Dict[str, Any]: ...
+
+
+def _find_config_path(start: Path) -> Path | None: ...
+
+def load_config(path: str | Path | None = ...) -> ConfigModel: ...
+
+def save_config(
+    config: ConfigModel,
+    use_pyproject: bool = ...,
+    path: Optional[str] = ...,
+) -> Path: ...
+
+def config_key_autocomplete(ctx: object, incomplete: str) -> list[str]: ...

--- a/stubs/devsynth/config/unified_loader.pyi
+++ b/stubs/devsynth/config/unified_loader.pyi
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Generic, TypeVar
+
+from .loader import ConfigModel
+
+ConfigT = TypeVar("ConfigT", bound=ConfigModel)
+
+
+@dataclass
+class UnifiedConfig(Generic[ConfigT]):
+    config: ConfigT
+    path: Path
+    use_pyproject: bool
+
+    def exists(self) -> bool: ...
+    def set_root(self, root: str) -> None: ...
+    def set_language(self, language: str) -> None: ...
+    def set_goals(self, goals: str) -> None: ...
+    def set_kuzu_embedded(self, embedded: bool) -> None: ...
+    def save(self) -> Path: ...
+
+
+class UnifiedConfigLoader:
+    @staticmethod
+    def load(path: str | Path | None = ...) -> UnifiedConfig[ConfigModel]: ...
+
+    @staticmethod
+    def save(config: UnifiedConfig[ConfigModel]) -> Path: ...

--- a/tests/behavior/steps/test_webui_analysis_steps.py
+++ b/tests/behavior/steps/test_webui_analysis_steps.py
@@ -138,7 +138,6 @@ def webui_context(monkeypatch):
     )
     cli_stub.inspect_code_cmd = analyze_stub.inspect_code_cmd
 
-    # Mock the load_project_config function to return a valid ProjectUnifiedConfig object
     from pathlib import Path
 
     from devsynth.config import ProjectUnifiedConfig
@@ -151,38 +150,19 @@ def webui_context(monkeypatch):
         use_pyproject=False,
     )
 
-    config_stub = ModuleType("devsynth.config")
-    config_stub.load_project_config = MagicMock(return_value=mock_project_config)
-    config_stub.save_config = MagicMock()
-    config_stub.get_llm_settings = MagicMock(
-        return_value={
-            "provider_type": "openai",
-            "model": "gpt-3.5-turbo",
-            "temperature": 0.7,
-            "max_tokens": 2000,
-        }
-    )
-    config_stub.ProjectUnifiedConfig = ProjectUnifiedConfig
-    config_stub.ConfigModel = ConfigModel
-    monkeypatch.setitem(sys.modules, "devsynth.config", config_stub)
-
-    # Mock the settings module
-    settings_stub = ModuleType("devsynth.config.settings")
-    settings_stub.get_llm_settings = config_stub.get_llm_settings
-    settings_stub._settings = MagicMock()
-
-    # Add ensure_path_exists function
-    def ensure_path_exists(path):
-        return path
-
-    settings_stub.ensure_path_exists = ensure_path_exists
-    monkeypatch.setitem(sys.modules, "devsynth.config.settings", settings_stub)
-
     import importlib
 
     import devsynth.interface.webui as webui
 
     importlib.reload(webui)
+    import devsynth.interface.webui.rendering as rendering
+
+    load_project_config_mock = MagicMock(return_value=mock_project_config)
+    save_config_mock = MagicMock()
+
+    monkeypatch.setattr(rendering, "load_project_config", load_project_config_mock)
+    monkeypatch.setattr(rendering, "save_config", save_config_mock)
+    webui.save_config = save_config_mock
     monkeypatch.setattr(webui.WebUI, "_requirements_wizard", lambda self: None)
     monkeypatch.setattr(webui.WebUI, "_gather_wizard", lambda self: None)
     monkeypatch.setattr(Path, "exists", lambda _self: True)
@@ -191,6 +171,8 @@ def webui_context(monkeypatch):
         "cli": cli_stub,
         "webui": webui,
         "ui": webui.WebUI(),
+        "save_config_mock": save_config_mock,
+        "load_project_config_mock": load_project_config_mock,
     }
     return ctx
 

--- a/tests/behavior/steps/test_webui_synthesis_steps.py
+++ b/tests/behavior/steps/test_webui_synthesis_steps.py
@@ -133,7 +133,6 @@ def webui_context(monkeypatch):
         setattr(cli_stub, name, MagicMock())
     monkeypatch.setitem(sys.modules, "devsynth.application.cli", cli_stub)
 
-    # Mock the load_project_config function to return a valid ProjectUnifiedConfig object
     from pathlib import Path
 
     from devsynth.config import ProjectUnifiedConfig
@@ -146,38 +145,19 @@ def webui_context(monkeypatch):
         use_pyproject=False,
     )
 
-    config_stub = ModuleType("devsynth.config")
-    config_stub.load_project_config = MagicMock(return_value=mock_project_config)
-    config_stub.save_config = MagicMock()
-    config_stub.get_llm_settings = MagicMock(
-        return_value={
-            "provider_type": "openai",
-            "model": "gpt-3.5-turbo",
-            "temperature": 0.7,
-            "max_tokens": 2000,
-        }
-    )
-    config_stub.ProjectUnifiedConfig = ProjectUnifiedConfig
-    config_stub.ConfigModel = ConfigModel
-    monkeypatch.setitem(sys.modules, "devsynth.config", config_stub)
-
-    # Mock the settings module
-    settings_stub = ModuleType("devsynth.config.settings")
-    settings_stub.get_llm_settings = config_stub.get_llm_settings
-    settings_stub._settings = MagicMock()
-
-    # Add ensure_path_exists function
-    def ensure_path_exists(path):
-        return path
-
-    settings_stub.ensure_path_exists = ensure_path_exists
-    monkeypatch.setitem(sys.modules, "devsynth.config.settings", settings_stub)
-
     import importlib
 
     import devsynth.interface.webui as webui
 
     importlib.reload(webui)
+    import devsynth.interface.webui.rendering as rendering
+
+    load_project_config_mock = MagicMock(return_value=mock_project_config)
+    save_config_mock = MagicMock()
+
+    monkeypatch.setattr(rendering, "load_project_config", load_project_config_mock)
+    monkeypatch.setattr(rendering, "save_config", save_config_mock)
+    webui.save_config = save_config_mock
     monkeypatch.setattr(webui.WebUI, "_requirements_wizard", lambda self: None)
     monkeypatch.setattr(webui.WebUI, "_gather_wizard", lambda self: None)
     monkeypatch.setattr(Path, "exists", lambda _self: True)
@@ -186,6 +166,8 @@ def webui_context(monkeypatch):
         "cli": cli_stub,
         "webui": webui,
         "ui": webui.WebUI(),
+        "save_config_mock": save_config_mock,
+        "load_project_config_mock": load_project_config_mock,
     }
     return ctx
 


### PR DESCRIPTION
## Summary
- add dedicated typing stubs for `devsynth.config` so `ConfigModel`, `UnifiedConfig`, and `ProjectUnifiedConfig` expose precise constructors
- extend mypy search path to consume the new stubs
- update WebUI behavior and integration tests to patch `devsynth.interface.webui.rendering` with typed configuration mocks instead of module-level shims

## Testing
- poetry run mypy tests/behavior/steps/test_webui_config_steps.py tests/behavior/steps/test_webui_analysis_steps.py tests/behavior/steps/test_webui_synthesis_steps.py tests/integration/general/test_webui_e2e_workflows.py *(fails: dynamic `ModuleType` streamlit stub emits attr-defined errors as before)*

------
https://chatgpt.com/codex/tasks/task_e_68d5ffc2331883338766a6232944205a