### PR TITLE
refactor: introduce typed DTOs for code analysis workflows

### DIFF
--- a/src/devsynth/application/code_analysis/ast_workflow_integration.py
+++ b/src/devsynth/application/code_analysis/ast_workflow_integration.py
@@ -1,22 +1,147 @@
-"""
-AST Workflow Integration module.
+"""AST Workflow Integration module.
 
 This module provides integration between AST-based code analysis and transformation
 and the EDRR (Expand, Differentiate, Refine, Retrospect) workflow.
 """
 
+from __future__ import annotations
+
 import ast
-from typing import Any, Dict, List, Optional
+from dataclasses import dataclass, field
+from typing import Any, Optional, Sequence
 
 from devsynth.application.code_analysis.analyzer import CodeAnalyzer
 from devsynth.application.code_analysis.ast_transformer import AstTransformer, DocstringSpec
 from devsynth.application.memory.memory_manager import MemoryManager
-from devsynth.domain.models.memory import MemoryType
+from devsynth.domain.models.memory import MemoryItem, MemoryType
 from devsynth.logging_setup import DevSynthLogger
 from devsynth.methodology.base import Phase
 
 # Create a logger for this module
 logger = DevSynthLogger(__name__)
+
+
+@dataclass(slots=True)
+class ImplementationAlternative:
+    """Represents a single implementation choice produced during the Expand phase."""
+
+    name: str
+    description: str
+    code: str
+    analysis_id: str
+
+
+@dataclass(slots=True)
+class ImplementationOptions:
+    """Container bundling the original code and suggested alternatives."""
+
+    original: str
+    alternatives: list[ImplementationAlternative] = field(default_factory=list)
+
+
+@dataclass(slots=True)
+class EvaluationMetrics:
+    """Quantified quality metrics for a code snippet."""
+
+    complexity: float
+    readability: float
+    maintainability: float
+
+    def average(self) -> float:
+        """Return the simple arithmetic mean for ranking implementations."""
+
+        return (self.complexity + self.readability + self.maintainability) / 3
+
+
+@dataclass(slots=True)
+class EvaluatedImplementation:
+    """Implementation alternative augmented with evaluation metadata."""
+
+    name: str
+    description: str
+    code: str
+    analysis_id: str
+    metrics: EvaluationMetrics
+    evaluation_id: str
+
+    @property
+    def average_score(self) -> float:
+        """Expose the computed average score as an attribute for callers."""
+
+        return self.metrics.average()
+
+
+@dataclass(slots=True)
+class RefinementResult:
+    """Outcome of the Refine phase transformation."""
+
+    original_code: str
+    refined_code: str
+    improvements: list[str] = field(default_factory=list)
+
+
+@dataclass(slots=True)
+class ImprovementRecommendation:
+    """Actionable retrospective recommendation."""
+
+    type: str
+    description: str
+    items: list[str] = field(default_factory=list)
+
+
+@dataclass(slots=True)
+class RetrospectiveResult:
+    """Result of the Retrospect phase with stored metadata."""
+
+    code: str
+    quality_metrics: EvaluationMetrics
+    improvement_suggestions: list[ImprovementRecommendation] = field(default_factory=list)
+    retrospective_id: str = ""
+
+
+@dataclass(slots=True)
+class ImplementationAnalysisRecord:
+    """Persisted payload for implementation analysis steps."""
+
+    analysis: Any
+
+
+@dataclass(slots=True)
+class QualityEvaluationRecord:
+    """Persisted payload capturing quality analysis metadata."""
+
+    option: str
+    analysis: Any
+    metrics: EvaluationMetrics
+
+
+@dataclass(slots=True)
+class RefinementRecord:
+    """Persisted payload for refinement operations."""
+
+    original_code: str
+    refined_code: str
+    transformations_applied: list[str]
+
+
+@dataclass(slots=True)
+class RetrospectiveRecord:
+    """Persisted payload summarising retrospective outcomes."""
+
+    metrics: EvaluationMetrics
+    recommendations: list[ImprovementRecommendation]
+
+
+__all__ = [
+    "AstWorkflowIntegration",
+    "EvaluationMetrics",
+    "EvaluatedImplementation",
+    "ImplementationAlternative",
+    "ImplementationOptions",
+    "ImprovementRecommendation",
+    "RefinementResult",
+    "RetrospectiveResult",
+]
 
 
 class AstWorkflowIntegration:
@@ -40,7 +165,7 @@ class AstWorkflowIntegration:
 
         logger.info("AST workflow integration initialized")
 
-    def expand_implementation_options(self, code: str, task_id: str) -> Dict[str, Any]:
+    def expand_implementation_options(self, code: str, task_id: str) -> ImplementationOptions:
         """
         Use AST analysis in the Expand phase to explore implementation options.
 
@@ -55,36 +180,31 @@ class AstWorkflowIntegration:
         analysis = self.code_analyzer.analyze_code(code)
 
         # Store the analysis in memory
-        memory_item = type(
-            "MemoryItem",
-            (),
-            {
-                "content": analysis,
-                "memory_type": MemoryType.CODE_ANALYSIS,
-                "metadata": {
-                    "task_id": task_id,
-                    "code_hash": hash(code),
-                    "analysis_type": "implementation_options",
-                    "edrr_phase": Phase.EXPAND.value,
-                },
-            },
+        metadata = {
+            "task_id": task_id,
+            "code_hash": hash(code),
+            "analysis_type": "implementation_options",
+            "edrr_phase": Phase.EXPAND.value,
+        }
+        memory_item = MemoryItem(
+            id="",
+            content=ImplementationAnalysisRecord(analysis=analysis),
+            memory_type=MemoryType.CODE_ANALYSIS,
+            metadata=metadata,
         )
         memory_item_id = self.memory_manager.store(memory_item)
 
-        # Create a memory item object with the ID for compatibility with tests
-        memory_item = type("MemoryItem", (), {"id": memory_item_id})
-
         # Generate implementation options based on the analysis
-        options = []
+        options: list[ImplementationAlternative] = []
 
         # Option 1: Keep the current implementation
         options.append(
-            {
-                "name": "current_implementation",
-                "description": "Keep the current implementation",
-                "code": code,
-                "analysis_id": memory_item.id,
-            }
+            ImplementationAlternative(
+                name="current_implementation",
+                description="Keep the current implementation",
+                code=code,
+                analysis_id=memory_item_id,
+            )
         )
 
         # Option 2: Refactor to improve readability
@@ -102,12 +222,12 @@ class AstWorkflowIntegration:
                     )
 
             options.append(
-                {
-                    "name": "improved_readability",
-                    "description": "Refactor to improve readability",
-                    "code": improved_code,
-                    "analysis_id": memory_item.id,
-                }
+                ImplementationAlternative(
+                    name="improved_readability",
+                    description="Refactor to improve readability",
+                    code=improved_code,
+                    analysis_id=memory_item_id,
+                )
             )
         except Exception as e:
             logger.warning(f"Error generating readability option: {str(e)}")
@@ -119,12 +239,12 @@ class AstWorkflowIntegration:
             f"Generated {len(options)} implementation options for task {task_id}"
         )
 
-        # Return a dictionary with original code and alternatives
-        return {"original": code, "alternatives": options}
+        # Return a structured representation of available implementations
+        return ImplementationOptions(original=code, alternatives=options)
 
     def differentiate_implementation_quality(
-        self, options: List[Dict[str, Any]], task_id: str
-    ) -> Dict[str, Any]:
+        self, options: Sequence[ImplementationAlternative], task_id: str
+    ) -> Optional[EvaluatedImplementation]:
         """
         Use AST analysis in the Differentiate phase to evaluate code quality.
 
@@ -136,28 +256,26 @@ class AstWorkflowIntegration:
             The selected option with quality metrics
         """
         # Evaluate each option
-        evaluated_options = []
+        evaluated_options: list[EvaluatedImplementation] = []
 
         for option in options:
-            code = option["code"]
+            code = option.code
 
             # Analyze the code
             analysis = self.code_analyzer.analyze_code(code)
 
             # Calculate quality metrics
-            metrics = {
-                "complexity": self._calculate_complexity(analysis),
-                "readability": self._calculate_readability(analysis),
-                "maintainability": self._calculate_maintainability(analysis),
-            }
+            metrics = EvaluationMetrics(
+                complexity=self._calculate_complexity(analysis),
+                readability=self._calculate_readability(analysis),
+                maintainability=self._calculate_maintainability(analysis),
+            )
 
             # Store the analysis in memory with EDRR phase tag
             memory_item_id = self.memory_manager.store_with_edrr_phase(
-                content={
-                    "option": option["name"],
-                    "analysis": analysis,
-                    "metrics": metrics,
-                },
+                content=QualityEvaluationRecord(
+                    option=option.name, analysis=analysis, metrics=metrics
+                ),
                 memory_type=MemoryType.CODE_ANALYSIS,
                 edrr_phase=Phase.DIFFERENTIATE.value,
                 metadata={
@@ -167,31 +285,35 @@ class AstWorkflowIntegration:
                 },
             )
 
-            # Create a memory item object with the ID for compatibility with tests
-            memory_item = type("MemoryItem", (), {"id": memory_item_id})
-
             evaluated_options.append(
-                {**option, "metrics": metrics, "evaluation_id": memory_item.id}
+                EvaluatedImplementation(
+                    name=option.name,
+                    description=option.description,
+                    code=option.code,
+                    analysis_id=option.analysis_id,
+                    metrics=metrics,
+                    evaluation_id=memory_item_id,
+                )
             )
 
         # Select the best option based on metrics
         if evaluated_options:
             # Simple selection strategy: choose the option with the highest average score
-            for option in evaluated_options:
-                metrics = option["metrics"]
-                option["average_score"] = sum(metrics.values()) / len(metrics)
-
-            selected_option = max(evaluated_options, key=lambda x: x["average_score"])
+            selected_option = max(
+                evaluated_options, key=lambda option: option.average_score
+            )
 
             logger.info(
-                f"Selected implementation option '{selected_option['name']}' for task {task_id}"
+                "Selected implementation option '%s' for task %s",
+                selected_option.name,
+                task_id,
             )
             return selected_option
         else:
             logger.warning(f"No implementation options to evaluate for task {task_id}")
-            return {}
+            return None
 
-    def refine_implementation(self, code: str, task_id: str) -> Dict[str, Any]:
+    def refine_implementation(self, code: str, task_id: str) -> RefinementResult:
         """
         Use AST transformations in the Refine phase to improve the code.
 
@@ -247,39 +369,31 @@ class AstWorkflowIntegration:
         # This would require more sophisticated analysis in a real implementation
 
         # Store the refined code in memory
-        memory_item = type(
-            "MemoryItem",
-            (),
-            {
-                "content": {
-                    "original_code": code,
-                    "refined_code": refined_code,
-                    "transformations_applied": ["add_missing_docstrings"],
-                },
-                "memory_type": MemoryType.CODE_TRANSFORMATION,
-                "metadata": {
-                    "task_id": task_id,
-                    "code_hash": hash(code),
-                    "transformation_type": "code_refinement",
-                    "edrr_phase": Phase.REFINE.value,
-                },
+        memory_item = MemoryItem(
+            id="",
+            content=RefinementRecord(
+                original_code=code,
+                refined_code=refined_code,
+                transformations_applied=["add_missing_docstrings"],
+            ),
+            memory_type=MemoryType.CODE_TRANSFORMATION,
+            metadata={
+                "task_id": task_id,
+                "code_hash": hash(code),
+                "transformation_type": "code_refinement",
+                "edrr_phase": Phase.REFINE.value,
             },
         )
-        memory_item_id = self.memory_manager.store(memory_item)
-
-        # Create a memory item object with the ID for compatibility with tests
-        memory_item = type("MemoryItem", (), {"id": memory_item_id})
+        self.memory_manager.store(memory_item)
 
         logger.info(f"Refined code for task {task_id}")
 
         # Return a dictionary with original code, refined code, and improvements
-        return {
-            "original_code": code,
-            "refined_code": refined_code,
-            "improvements": improvements,
-        }
+        return RefinementResult(
+            original_code=code, refined_code=refined_code, improvements=improvements
+        )
 
-    def retrospect_code_quality(self, code: str, task_id: str) -> Dict[str, Any]:
+    def retrospect_code_quality(self, code: str, task_id: str) -> RetrospectiveResult:
         """
         Use AST analysis in the Retrospect phase to verify code quality.
 
@@ -294,14 +408,14 @@ class AstWorkflowIntegration:
         analysis = self.code_analyzer.analyze_code(code)
 
         # Calculate quality metrics
-        metrics = {
-            "complexity": self._calculate_complexity(analysis),
-            "readability": self._calculate_readability(analysis),
-            "maintainability": self._calculate_maintainability(analysis),
-        }
+        metrics = EvaluationMetrics(
+            complexity=self._calculate_complexity(analysis),
+            readability=self._calculate_readability(analysis),
+            maintainability=self._calculate_maintainability(analysis),
+        )
 
         # Generate recommendations
-        recommendations = []
+        recommendations: list[ImprovementRecommendation] = []
 
         # Check for missing docstrings
         missing_docstrings = []
@@ -315,11 +429,11 @@ class AstWorkflowIntegration:
 
         if missing_docstrings:
             recommendations.append(
-                {
-                    "type": "missing_docstrings",
-                    "description": "Add docstrings to improve code documentation",
-                    "items": missing_docstrings,
-                }
+                ImprovementRecommendation(
+                    type="missing_docstrings",
+                    description="Add docstrings to improve code documentation",
+                    items=missing_docstrings,
+                )
             )
 
         # Check for complex functions
@@ -332,11 +446,11 @@ class AstWorkflowIntegration:
 
         if complex_functions:
             recommendations.append(
-                {
-                    "type": "complex_functions",
-                    "description": "Simplify complex functions",
-                    "items": complex_functions,
-                }
+                ImprovementRecommendation(
+                    type="complex_functions",
+                    description="Simplify complex functions",
+                    items=complex_functions,
+                )
             )
 
         # Add a search method to the memory_manager if it doesn't exist
@@ -345,34 +459,28 @@ class AstWorkflowIntegration:
             self.memory_manager.search = lambda query, limit=10: []
 
         # Store the retrospective in memory
-        memory_item = type(
-            "MemoryItem",
-            (),
-            {
-                "content": {"metrics": metrics, "recommendations": recommendations},
-                "memory_type": MemoryType.CODE_ANALYSIS,
-                "metadata": {
-                    "task_id": task_id,
-                    "code_hash": hash(code),
-                    "analysis_type": "quality_verification",
-                    "edrr_phase": Phase.RETROSPECT.value,
-                },
+        memory_item = MemoryItem(
+            id="",
+            content=RetrospectiveRecord(
+                metrics=metrics, recommendations=recommendations
+            ),
+            memory_type=MemoryType.CODE_ANALYSIS,
+            metadata={
+                "task_id": task_id,
+                "code_hash": hash(code),
+                "analysis_type": "quality_verification",
+                "edrr_phase": Phase.RETROSPECT.value,
             },
         )
         memory_item_id = self.memory_manager.store(memory_item)
 
-        # Create a memory item object with the ID for compatibility with tests
-        memory_item = type("MemoryItem", (), {"id": memory_item_id})
-
-        result = {
-            "code": code,  # Add the code to the result
-            "quality_metrics": metrics,
-            "improvement_suggestions": recommendations,
-            "retrospective_id": memory_item.id,
-        }
-
         logger.info(f"Completed code quality retrospective for task {task_id}")
-        return result
+        return RetrospectiveResult(
+            code=code,
+            quality_metrics=metrics,
+            improvement_suggestions=recommendations,
+            retrospective_id=memory_item_id,
+        )
 
     def _calculate_complexity(self, analysis: Any) -> float:
         """Calculate code complexity score (0-1, higher is better/less complex)."""

--- a/src/devsynth/application/code_analysis/repo_analyzer.py
+++ b/src/devsynth/application/code_analysis/repo_analyzer.py
@@ -11,12 +11,21 @@ from __future__ import annotations
 
 import ast
 import os
+from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Dict, List, Set
+from typing import Dict, List, Set
 
 from devsynth.logging_setup import DevSynthLogger
 
 logger = DevSynthLogger(__name__)
+
+
+@dataclass(slots=True)
+class RepositoryAnalysis:
+    """Structured result produced by :class:`RepoAnalyzer`."""
+
+    dependencies: dict[str, list[str]]
+    structure: dict[str, list[str]]
 
 
 class RepoAnalyzer:
@@ -43,14 +52,14 @@ class RepoAnalyzer:
         self.root_path = Path(root_path).resolve()
 
     # ------------------------------------------------------------------
-    def analyze(self) -> Dict[str, Any]:
+    def analyze(self) -> RepositoryAnalysis:
         """Run the analysis and return structure and dependency maps."""
 
         logger.debug("Starting repository analysis at %s", self.root_path)
-        result = {
-            "dependencies": self._map_dependencies(),
-            "structure": self._build_structure(),
-        }
+        result = RepositoryAnalysis(
+            dependencies=self._map_dependencies(),
+            structure=self._build_structure(),
+        )
         logger.debug("Finished repository analysis")
         return result
 
@@ -118,4 +127,4 @@ class RepoAnalyzer:
         return imports
 
 
-__all__ = ["RepoAnalyzer"]
+__all__ = ["RepoAnalyzer", "RepositoryAnalysis"]

--- a/src/devsynth/cli.py
+++ b/src/devsynth/cli.py
@@ -19,7 +19,8 @@ import importlib
 import json
 import sys
 from collections.abc import Callable
-from typing import Any, cast
+from dataclasses import asdict
+from typing import cast
 
 from devsynth.application.code_analysis.repo_analyzer import RepoAnalyzer
 from devsynth.logger import setup_logging
@@ -60,8 +61,8 @@ def main(argv: list[str] | None = None) -> None:
         sys.modules.pop("devsynth.adapters.cli.typer_adapter", None)
         analyze_repo = cast(str, args.analyze_repo)
         analyzer: RepoAnalyzer = RepoAnalyzer(analyze_repo)
-        result: dict[str, Any] = analyzer.analyze()
-        print(json.dumps(result, indent=2))
+        result = analyzer.analyze()
+        print(json.dumps(asdict(result), indent=2))
     else:
         from devsynth.application.cli.errors import handle_error
         from devsynth.interface.cli import CLIUXBridge

--- a/tests/integration/general/test_code_analysis_edrr_integration.py
+++ b/tests/integration/general/test_code_analysis_edrr_integration.py
@@ -16,6 +16,7 @@ from devsynth.application.code_analysis.analyzer import CodeAnalyzer
 from devsynth.application.code_analysis.ast_transformer import AstTransformer
 from devsynth.application.code_analysis.ast_workflow_integration import (
     AstWorkflowIntegration,
+    RefinementResult,
 )
 from devsynth.application.code_analysis.project_state_analyzer import (
     ProjectStateAnalyzer,
@@ -235,6 +236,7 @@ def calculate(a, b):
         )
         assert "refined" in result
         refined = result["refined"]
-        assert "original_code" in refined
-        assert "refined_code" in refined
-        assert "improvements" in refined
+        assert isinstance(refined, RefinementResult)
+        assert refined.original_code.strip().startswith("def calculate")
+        assert refined.refined_code.strip()
+        assert isinstance(refined.improvements, list)

--- a/tests/integration/general/test_code_analysis_wsde_integration.py
+++ b/tests/integration/general/test_code_analysis_wsde_integration.py
@@ -16,6 +16,7 @@ from devsynth.application.code_analysis.analyzer import CodeAnalyzer
 from devsynth.application.code_analysis.ast_transformer import AstTransformer
 from devsynth.application.code_analysis.ast_workflow_integration import (
     AstWorkflowIntegration,
+    RefinementResult,
 )
 from devsynth.application.code_analysis.project_state_analyzer import (
     ProjectStateAnalyzer,
@@ -284,6 +285,7 @@ def calculate(a, b):
     result = code_analyst.process(task_data)
     assert "refined" in result
     refined = result["refined"]
-    assert "original_code" in refined
-    assert "refined_code" in refined
-    assert "improvements" in refined
+    assert isinstance(refined, RefinementResult)
+    assert refined.original_code.strip().startswith("def calculate")
+    assert refined.refined_code.strip()
+    assert isinstance(refined.improvements, list)

--- a/tests/unit/application/code_analysis/test_repo_analyzer.py
+++ b/tests/unit/application/code_analysis/test_repo_analyzer.py
@@ -11,7 +11,10 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from devsynth.application.code_analysis.repo_analyzer import RepoAnalyzer
+from devsynth.application.code_analysis.repo_analyzer import (
+    RepoAnalyzer,
+    RepositoryAnalysis,
+)
 
 
 class TestRepoAnalyzer:
@@ -33,9 +36,10 @@ class TestRepoAnalyzer:
             analyzer = RepoAnalyzer(tmpdir)
             result = analyzer.analyze()
 
-            assert result["dependencies"]["a.py"] == ["b"]
-            assert result["dependencies"]["sub/c.py"] == ["a"]
-            structure = result["structure"]
+            assert isinstance(result, RepositoryAnalysis)
+            assert result.dependencies["a.py"] == ["b"]
+            assert result.dependencies["sub/c.py"] == ["a"]
+            structure = result.structure
             assert set(structure["."]) == {"a.py", "b.py", "sub"}
             assert "c.py" in structure["sub"]
 
@@ -43,7 +47,7 @@ class TestRepoAnalyzer:
     def test_cli_entry_invokes_repo_analyzer(self, monkeypatch) -> None:
         """Verify ``--analyze-repo`` uses the RepoAnalyzer and prints JSON."""
 
-        fake_result = {"dependencies": {}, "structure": {}}
+        fake_result = RepositoryAnalysis(dependencies={}, structure={})
         analyze_mock = MagicMock(return_value=fake_result)
         monkeypatch.setattr(
             "devsynth.application.code_analysis.repo_analyzer.RepoAnalyzer.analyze",
@@ -61,4 +65,4 @@ class TestRepoAnalyzer:
 
         assert "devsynth.adapters.cli.typer_adapter" not in sys.modules
         analyze_mock.assert_called_once()
-        assert json.loads(buf.getvalue()) == fake_result
+        assert json.loads(buf.getvalue()) == {"dependencies": {}, "structure": {}}


### PR DESCRIPTION
## Summary
- replace dynamic MemoryItem shims with dataclass-based DTOs for AST workflow phases and update return types
- add a RepositoryAnalysis dataclass and have the CLI emit structured repository analysis output
- adjust behavioral, integration, and unit tests to consume the new typed objects

## Testing
- `poetry run mypy --strict -m devsynth.application.code_analysis.ast_workflow_integration -m devsynth.application.code_analysis.repo_analyzer`


------
https://chatgpt.com/codex/tasks/task_e_68d61a47557c8333a0f0020c9c764df2