### PR TITLE
Reorganize BDD step import blocks

### DIFF
--- a/tests/behavior/steps/test_edrr_enhanced_phase_transitions_steps.py
+++ b/tests/behavior/steps/test_edrr_enhanced_phase_transitions_steps.py
@@ -2,28 +2,12 @@
 
 from __future__ import annotations
 
-from pytest_bdd import given, parsers, scenarios, then, when
-
-# Import the feature file for this test
-
-pytestmark = [pytest.mark.fast]
-
-scenarios("../features/general/edrr_enhanced_phase_transitions.feature")
-
-# Content from test_edrr_coordinator_steps.py inlined here
-"""Step definitions for the EDRR Coordinator feature."""
-
-import pytest
-
-# Removed duplicate __future__ import
-from pytest_bdd import given, parsers, scenarios, then, when
-
-scenarios("../features/general/edrr_coordinator.feature")
 import json
 import os
 import tempfile
-from pathlib import Path
-from typing import Dict, Tuple
+
+import pytest
+from pytest_bdd import given, parsers, scenarios, then, when
 
 from devsynth.application.code_analysis.analyzer import CodeAnalyzer
 from devsynth.application.code_analysis.ast_transformer import AstTransformer
@@ -37,6 +21,12 @@ from devsynth.application.requirements.prompt_manager import PromptManager
 from devsynth.domain.models.memory import MemoryType
 from devsynth.domain.models.wsde_facade import WSDETeam
 from devsynth.methodology.base import Phase
+
+pytestmark = [pytest.mark.fast]
+
+# Register feature scenarios.
+scenarios("../features/general/edrr_enhanced_phase_transitions.feature")
+scenarios("../features/general/edrr_coordinator.feature")
 
 
 @pytest.fixture

--- a/tests/behavior/steps/test_memory_backend_integration_steps.py
+++ b/tests/behavior/steps/test_memory_backend_integration_steps.py
@@ -10,6 +10,15 @@ import os
 import time
 
 import pytest
+from pytest_bdd import given, parsers, scenarios, then, when
+
+from devsynth.adapters.agents.agent_adapter import WSDETeamCoordinator
+from devsynth.adapters.memory.memory_adapter import MemorySystemAdapter
+from devsynth.application.agents.unified_agent import UnifiedAgent
+from devsynth.application.memory.memory_manager import MemoryManager
+from devsynth.domain.models.agent import AgentConfig, AgentType
+from devsynth.domain.models.memory import MemoryItem, MemoryType
+from devsynth.domain.models.wsde_facade import WSDETeam
 
 chromadb_enabled = os.environ.get("ENABLE_CHROMADB", "false").lower() not in {
     "0",
@@ -18,31 +27,17 @@ chromadb_enabled = os.environ.get("ENABLE_CHROMADB", "false").lower() not in {
 }
 if not chromadb_enabled:
     pytest.skip("ChromaDB feature not enabled", allow_module_level=True)
-from pytest_bdd import given, parsers, scenarios, then, when
-
-# Import the feature file
 
 pytestmark = [
-
-scenarios("../features/general/memory_backend_integration.feature")
-
-from devsynth.adapters.agents.agent_adapter import WSDETeamCoordinator
-
-# Import the modules needed for the steps
-from devsynth.domain.models.wsde_facade import WSDETeam
-
-logger = logging.getLogger(__name__)
-from devsynth.adapters.memory.memory_adapter import MemorySystemAdapter
-from devsynth.application.agents.unified_agent import UnifiedAgent
-from devsynth.domain.models.agent import AgentConfig, AgentType
-
     pytest.mark.fast,
     pytest.mark.requires_resource("chromadb"),
     pytest.mark.requires_resource("lmdb"),
     pytest.mark.requires_resource("faiss"),
 ]
-from devsynth.application.memory.memory_manager import MemoryManager
-from devsynth.domain.models.memory import MemoryItem, MemoryType
+
+logger = logging.getLogger(__name__)
+
+scenarios("../features/general/memory_backend_integration.feature")
 
 
 @pytest.fixture


### PR DESCRIPTION
## Summary
- move the enhanced EDRR phase transition step imports above the scenario registration and consolidate the markers
- normalize the memory backend integration step imports and markers before registering the feature scenarios

## Testing
- `poetry run ruff check` *(fails: existing lint errors throughout the repository)*
- `poetry run pytest tests/behavior/steps/test_edrr_enhanced_phase_transitions_steps.py tests/behavior/steps/test_memory_backend_integration_steps.py` *(fails: existing missing step definitions and assertions in the phase transition steps)*

------
https://chatgpt.com/codex/tasks/task_e_68d750d36b748333b84ed5c8e55d7444