### PR TITLE
test: enforce explicit behavior speed markers

### DIFF
--- a/tests/behavior/steps/test_performance_and_scalability_steps.py
+++ b/tests/behavior/steps/test_performance_and_scalability_steps.py
@@ -9,8 +9,6 @@ from devsynth.testing.performance import (
     capture_scalability_metrics,
 )
 
-pytestmark = [pytest.mark.fast]
-
 scenarios("../features/performance_and_scalability_testing.feature")
 
 

--- a/tests/behavior/test_alignment_metrics_command.py
+++ b/tests/behavior/test_alignment_metrics_command.py
@@ -7,7 +7,6 @@ from .steps.cli_commands_steps import *  # noqa: F401,F403
 from .steps.test_alignment_metrics_steps import *  # noqa: F401,F403
 
 pytestmark = [
-    pytest.mark.fast,
     pytest.mark.requires_resource("cli"),
 ]
 

--- a/tests/behavior/test_marker_auto_injection_guardrail.py
+++ b/tests/behavior/test_marker_auto_injection_guardrail.py
@@ -1,19 +1,19 @@
-# This test intentionally defines a behavior-like test without an explicit speed marker.
-# We simulate a pytest-bdd scenario wrapper by placing it under tests/behavior/ and relying
-# on tests/conftest.py's pytest_collection_modifyitems to auto-inject exactly one speed marker.
-#
-# The guardrail: ensure exactly one of {fast, medium, slow} is present at runtime.
+# This test ensures behavior-style tests enforce explicit speed markers instead of
+# relying on auto-injection during collection. The guardrail inspects the collected
+# node to confirm exactly one speed marker is present at runtime.
+
+import pytest
 
 
-def test_behavior_auto_inject_speed_marker(request):
-    """ReqID: A2 — Auto-injection of exactly one speed marker for behavior tests"""
+@pytest.mark.fast
+def test_behavior_requires_explicit_speed_marker(request):
+    """ReqID: A2 — Explicit speed markers are required for behavior tests"""
     # At runtime, pytest item marks are not directly accessible; instead we introspect
     # the request.node which represents this test item.
     item = request.node
     speed_marks = {
         m.name for m in item.iter_markers() if m.name in {"fast", "medium", "slow"}
     }
-    # The collection hook is expected to add a default 'fast' mark for behavior tests lacking it.
     assert (
         len(speed_marks) == 1
     ), "Behavior tests must have exactly one speed marker injected at collection time"


### PR DESCRIPTION
## Summary
- remove module-level fast marker from performance and scalability BDD steps so feature tags supply the sole speed marker
- keep alignment metrics behavior scenarios tagged medium by dropping the redundant fast marker while retaining the CLI resource requirement
- convert the speed-marker guardrail to require an explicit @pytest.mark.fast decorator and document the expectation

## Testing
- poetry run python scripts/verify_test_markers.py
- poetry run pytest tests/behavior -k performance_and_scalability *(fails: existing behavior suites reference missing feature files outside this change)*

------
https://chatgpt.com/codex/tasks/task_e_68d75230b350833393d1c3aa082f4dde