### PR TITLE
refactor: tighten sandbox typing

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -280,7 +280,6 @@ module = [
   "devsynth.core.config_loader",
   "devsynth.core.workflows",
   "devsynth.agents.base_agent_graph",
-  "devsynth.agents.sandbox",
   "devsynth.agents.wsde_team_coordinator",
   "devsynth.agents.tools",
   "devsynth.memory.sync_manager",

--- a/src/devsynth/agents/sandbox.py
+++ b/src/devsynth/agents/sandbox.py
@@ -4,10 +4,12 @@ from __future__ import annotations
 
 import builtins
 import subprocess
+from collections.abc import Callable
 from contextlib import ContextDecorator
 from functools import wraps
 from pathlib import Path
-from typing import Any, Callable
+from types import TracebackType
+from typing import Any, Literal, ParamSpec, TypeVar, cast
 
 # Determine the project root (three levels up from this file)
 PROJECT_ROOT = Path(__file__).resolve().parents[3]
@@ -23,9 +25,13 @@ class Sandbox(ContextDecorator):
             allow_shell: Whether to permit shell command execution.
         """
         self.allow_shell = allow_shell
-        self._original_open = builtins.open
-        self._original_popen = subprocess.Popen
-        self._original_run = subprocess.run
+        self._original_open: Callable[..., Any] = cast(Callable[..., Any], builtins.open)
+        self._original_popen: Callable[..., subprocess.Popen[Any]] = cast(
+            Callable[..., subprocess.Popen[Any]], subprocess.Popen
+        )
+        self._original_run: Callable[..., subprocess.CompletedProcess[Any]] = cast(
+            Callable[..., subprocess.CompletedProcess[Any]], subprocess.run
+        )
 
     @staticmethod
     def _in_project(path: Path) -> bool:
@@ -33,42 +39,56 @@ class Sandbox(ContextDecorator):
         resolved = path.resolve()
         return PROJECT_ROOT == resolved or PROJECT_ROOT in resolved.parents
 
-    def _safe_open(self, file: str | Path, *args: Any, **kwargs: Any):
+    def _safe_open(self, file: str | Path, *args: Any, **kwargs: Any) -> Any:
         if not self._in_project(Path(file)):
             raise PermissionError("Access outside project directory is not allowed")
         return self._original_open(file, *args, **kwargs)
 
-    def _blocked_popen(self, *args: Any, **kwargs: Any):
+    def _blocked_popen(
+        self, *args: Any, **kwargs: Any
+    ) -> subprocess.Popen[Any]:
         if not self.allow_shell:
             raise PermissionError("Shell commands are not permitted")
         return self._original_popen(*args, **kwargs)
 
-    def _blocked_run(self, *args: Any, **kwargs: Any):
+    def _blocked_run(
+        self, *args: Any, **kwargs: Any
+    ) -> subprocess.CompletedProcess[Any]:
         if not self.allow_shell:
             raise PermissionError("Shell commands are not permitted")
         return self._original_run(*args, **kwargs)
 
-    def __enter__(self):  # pragma: no cover - trivial
-        builtins.open = self._safe_open
-        subprocess.Popen = self._blocked_popen
-        subprocess.run = self._blocked_run
+    def __enter__(self) -> "Sandbox":  # pragma: no cover - trivial
+        builtins.open = cast(Any, self._safe_open)
+        setattr(subprocess, "Popen", cast(Any, self._blocked_popen))
+        setattr(subprocess, "run", cast(Any, self._blocked_run))
         return self
 
-    def __exit__(self, exc_type, exc, tb):  # pragma: no cover - trivial
-        builtins.open = self._original_open
-        subprocess.Popen = self._original_popen
-        subprocess.run = self._original_run
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        tb: TracebackType | None,
+    ) -> Literal[False]:  # pragma: no cover - trivial
+        builtins.open = cast(Any, self._original_open)
+        setattr(subprocess, "Popen", cast(Any, self._original_popen))
+        setattr(subprocess, "run", cast(Any, self._original_run))
         return False
 
 
+P = ParamSpec("P")
+T = TypeVar("T")
+
+
 def sandboxed(
-    func: Callable[..., Any], *, allow_shell: bool = False
-) -> Callable[..., Any]:
+    func: Callable[P, T], *, allow_shell: bool = False
+) -> Callable[P, T]:
     """Return ``func`` wrapped to execute inside a :class:`Sandbox`."""
 
     @wraps(func)
-    def wrapper(*args: Any, **kwargs: Any):
+    def wrapper(*args: P.args, **kwargs: P.kwargs) -> T:
         with Sandbox(allow_shell=allow_shell):
-            return func(*args, **kwargs)
+            result = func(*args, **kwargs)
+        return result
 
     return wrapper


### PR DESCRIPTION
## Summary
- add explicit typing details to the sandbox context manager and decorator, including ParamSpec-based wrapper preservation
- guard subprocess/builtins overrides with casts so mypy accepts the temporary monkeypatching
- remove the sandbox module from mypy ignore overrides to enforce strict checking

## Testing
- poetry run mypy --strict src/devsynth/agents/sandbox.py

------
https://chatgpt.com/codex/tasks/task_e_68d76eeaf8b083339c196a5644d34491