### PR TITLE
refactor: typed prompt auto-tuning persistence

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -373,7 +373,6 @@ module = [
   "devsynth.application.promises.examples",
   "devsynth.application.promises.implementation",
   "devsynth.application.promises.interface",
-  "devsynth.application.prompts.auto_tuning",
   "devsynth.application.prompts.prompt_efficacy",
   "devsynth.application.prompts.prompt_manager",
   "devsynth.application.prompts.prompt_reflection",

--- a/src/devsynth/application/prompts/models.py
+++ b/src/devsynth/application/prompts/models.py
@@ -1,0 +1,166 @@
+"""Typed models for prompt auto-tuning components."""
+
+from __future__ import annotations
+
+import hashlib
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import Iterator, MutableMapping, Optional, Sequence, TypedDict
+from typing_extensions import Literal
+
+
+class StoredPromptVariant(TypedDict):
+    """Serialized representation of :class:`PromptVariant`."""
+
+    variant_id: str
+    template: str
+    usage_count: int
+    success_count: int
+    failure_count: int
+    feedback_scores: list[float]
+    last_used: Optional[str]
+
+
+SelectionStrategyName = Literal["performance", "exploration", "random"]
+
+
+@dataclass
+class SelectionStrategyConfig:
+    """Configuration describing how prompt variants should be selected."""
+
+    name: SelectionStrategyName = "performance"
+    exploration_rate: float = 0.2
+
+    def validate(self) -> None:
+        """Validate the configuration values."""
+
+        if not 0.0 <= self.exploration_rate <= 1.0:
+            msg = "exploration_rate must be between 0.0 and 1.0"
+            raise ValueError(msg)
+
+
+@dataclass
+class PromptVariant:
+    """Represents a variant of a prompt template with performance metrics."""
+
+    template: str
+    variant_id: Optional[str] = None
+    usage_count: int = 0
+    success_count: int = 0
+    failure_count: int = 0
+    feedback_scores: list[float] = field(default_factory=list)
+    last_used: Optional[str] = None
+
+    def __post_init__(self) -> None:
+        if self.variant_id is None:
+            self.variant_id = hashlib.sha256(self.template.encode()).hexdigest()[:8]
+
+    @property
+    def success_rate(self) -> float:
+        """Calculate the success rate of this prompt variant."""
+
+        if self.usage_count == 0:
+            return 0.0
+        return self.success_count / self.usage_count
+
+    @property
+    def average_feedback_score(self) -> float:
+        """Calculate the average feedback score of this prompt variant."""
+
+        if not self.feedback_scores:
+            return 0.0
+        return sum(self.feedback_scores) / len(self.feedback_scores)
+
+    @property
+    def performance_score(self) -> float:
+        """Calculate the overall performance score of this prompt variant."""
+
+        success_weight = 0.7
+        feedback_weight = 0.3
+        return (success_weight * self.success_rate) + (
+            feedback_weight * self.average_feedback_score
+        )
+
+    def record_usage(
+        self, success: Optional[bool] = None, feedback_score: Optional[float] = None
+    ) -> None:
+        """Record usage of this prompt variant."""
+
+        self.usage_count += 1
+        self.last_used = datetime.now().isoformat()
+
+        if success is not None:
+            if success:
+                self.success_count += 1
+            else:
+                self.failure_count += 1
+
+        if feedback_score is not None:
+            self.feedback_scores.append(feedback_score)
+
+    def to_dict(self) -> StoredPromptVariant:
+        """Convert the prompt variant to a :class:`StoredPromptVariant`."""
+
+        return {
+            "variant_id": self.variant_id or "",
+            "template": self.template,
+            "usage_count": self.usage_count,
+            "success_count": self.success_count,
+            "failure_count": self.failure_count,
+            "feedback_scores": list(self.feedback_scores),
+            "last_used": self.last_used,
+        }
+
+    @classmethod
+    def from_dict(cls, data: StoredPromptVariant) -> "PromptVariant":
+        """Create a prompt variant from a :class:`StoredPromptVariant`."""
+
+        return cls(
+            template=data["template"],
+            variant_id=data["variant_id"],
+            usage_count=data["usage_count"],
+            success_count=data["success_count"],
+            failure_count=data["failure_count"],
+            feedback_scores=list(data["feedback_scores"]),
+            last_used=data["last_used"],
+        )
+
+
+@dataclass
+class PromptVariantCollection(MutableMapping[str, list[PromptVariant]]):
+    """Typed collection of prompt variants keyed by template id."""
+
+    variants_by_template: dict[str, list[PromptVariant]] = field(default_factory=dict)
+
+    def __getitem__(self, key: str) -> list[PromptVariant]:
+        return self.variants_by_template[key]
+
+    def __setitem__(
+        self, key: str, value: Sequence[PromptVariant]
+    ) -> None:  # pragma: no cover - trivial
+        self.variants_by_template[key] = list(value)
+
+    def __delitem__(self, key: str) -> None:  # pragma: no cover - unused
+        del self.variants_by_template[key]
+
+    def __iter__(self) -> Iterator[str]:
+        return iter(self.variants_by_template)
+
+    def __len__(self) -> int:
+        return len(self.variants_by_template)
+
+    def add_variant(self, template_id: str, variant: PromptVariant) -> None:
+        """Add a prompt variant for the given template id."""
+
+        self.variants_by_template.setdefault(template_id, []).append(variant)
+
+    def ensure_template(self, template_id: str) -> None:
+        """Ensure a template entry exists for the given id."""
+
+        self.variants_by_template.setdefault(template_id, [])
+
+    def total_variants(self) -> int:
+        """Return the total number of variants stored."""
+
+        return sum(len(variants) for variants in self.variants_by_template.values())
+

--- a/src/devsynth/application/prompts/persistence.py
+++ b/src/devsynth/application/prompts/persistence.py
@@ -1,0 +1,42 @@
+"""Persistence helpers for prompt auto-tuning data."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Dict, List
+
+from .models import StoredPromptVariant
+
+
+PromptVariantsDocument = Dict[str, List[StoredPromptVariant]]
+
+
+class PromptVariantStorageError(Exception):
+    """Raised when prompt variant persistence fails."""
+
+
+def load_prompt_variants(storage_dir: Path) -> PromptVariantsDocument:
+    """Load prompt variants from ``prompt_variants.json`` within ``storage_dir``."""
+
+    path = storage_dir / "prompt_variants.json"
+    try:
+        with path.open("r", encoding="utf-8") as file:
+            data: PromptVariantsDocument = json.load(file)
+    except FileNotFoundError as exc:  # pragma: no cover - handled by caller logging
+        raise PromptVariantStorageError(str(exc)) from exc
+    except json.JSONDecodeError as exc:
+        raise PromptVariantStorageError(str(exc)) from exc
+    return data
+
+
+def save_prompt_variants(storage_dir: Path, data: PromptVariantsDocument) -> None:
+    """Persist prompt variants to ``prompt_variants.json`` within ``storage_dir``."""
+
+    path = storage_dir / "prompt_variants.json"
+    try:
+        with path.open("w", encoding="utf-8") as file:
+            json.dump(data, file, indent=2)
+    except OSError as exc:  # pragma: no cover - handled by caller logging
+        raise PromptVariantStorageError(str(exc)) from exc
+

--- a/stubs/devsynth/exceptions.pyi
+++ b/stubs/devsynth/exceptions.pyi
@@ -1,0 +1,5 @@
+from __future__ import annotations
+
+
+class DevSynthError(Exception):
+    ...

--- a/tests/unit/application/prompts/test_auto_tuning.py
+++ b/tests/unit/application/prompts/test_auto_tuning.py
@@ -10,6 +10,7 @@ from devsynth.application.prompts.auto_tuning import (
     iterative_prompt_adjustment,
     run_tuning_iteration,
 )
+from devsynth.application.prompts.models import PromptVariantCollection
 from devsynth.domain.models.agent import AgentConfig, AgentType
 
 
@@ -64,6 +65,17 @@ def test_unified_agent_uses_tuner_succeeds(llm_port):
 
 
 @pytest.mark.medium
+def test_prompt_auto_tuner_uses_typed_collection():
+    """PromptAutoTuner exposes a typed variant collection."""
+
+    tuner = PromptAutoTuner()
+
+    assert isinstance(tuner.prompt_variants, PromptVariantCollection)
+    assert tuner.selection_strategy == "performance"
+    assert tuner.exploration_rate == pytest.approx(0.2)
+
+
+@pytest.mark.medium
 def test_run_tuning_iteration_records_feedback_succeeds():
     """Test that run tuning iteration records feedback succeeds.
 
@@ -93,7 +105,7 @@ def test_iterative_prompt_adjustment_returns_best_variant_succeeds():
         new_v = PromptVariant("improved")
         for _ in range(2):
             new_v.record_usage(success=True, feedback_score=1.0)
-        tuner.prompt_variants[_id].append(new_v)
+        tuner.prompt_variants.add_variant(_id, new_v)
 
     with patch.object(
         PromptAutoTuner, "_generate_variants_if_needed", side_effect=generate_variant

--- a/tests/unit/application/prompts/test_persistence.py
+++ b/tests/unit/application/prompts/test_persistence.py
@@ -1,0 +1,41 @@
+from pathlib import Path
+
+import pytest
+
+from devsynth.application.prompts.models import PromptVariant
+from devsynth.application.prompts.persistence import (
+    PromptVariantStorageError,
+    load_prompt_variants,
+    save_prompt_variants,
+)
+
+
+@pytest.mark.medium
+def test_save_and_load_round_trip(tmp_path: Path) -> None:
+    """Prompt variant persistence round-trips serialized data."""
+
+    variant = PromptVariant("example template")
+    stored = {"template": [variant.to_dict()]}
+
+    save_prompt_variants(tmp_path, stored)
+    loaded = load_prompt_variants(tmp_path)
+
+    assert loaded == stored
+
+
+@pytest.mark.medium
+def test_load_raises_for_missing_file(tmp_path: Path) -> None:
+    """Loading without a persisted file raises a storage error."""
+
+    with pytest.raises(PromptVariantStorageError):
+        load_prompt_variants(tmp_path)
+
+
+@pytest.mark.medium
+def test_load_raises_for_invalid_json(tmp_path: Path) -> None:
+    """Invalid JSON content is surfaced via the storage error."""
+
+    (tmp_path / "prompt_variants.json").write_text("{" , encoding="utf-8")
+
+    with pytest.raises(PromptVariantStorageError):
+        load_prompt_variants(tmp_path)


### PR DESCRIPTION
## Summary
- replace untyped prompt variant dicts with dataclass-based models and expose typed selection configuration
- factor persistence into a dedicated helper module and cover it with new unit tests
- remove the mypy ignore override for the auto_tuning module and add a stub so the module passes strict type checking

## Testing
- poetry run pytest tests/unit/application/prompts/test_auto_tuning.py tests/unit/application/prompts/test_persistence.py
- poetry run mypy --strict src/devsynth/application/prompts/auto_tuning.py

------
https://chatgpt.com/codex/tasks/task_e_68d7742de7a483339431e4e17152a939