### PR TITLE
Add run-tests Typer CLI coverage invariants

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -202,9 +202,21 @@ tasks:
       - poetry run pytest tests/integration/
       - poetry run pytest tests/behavior/
 
+  tests:coverage:cli-run-tests:
+    desc: Focused coverage sweep for devsynth run-tests CLI invariants
+    cmds:
+      - bash -lc 'poetry run pytest -o addopts="" \
+          tests/unit/application/cli/commands/test_run_tests_cmd_cli_runner_paths.py \
+          tests/unit/application/cli/commands/test_run_tests_cmd.py \
+          --cov=devsynth.application.cli.commands.run_tests_cmd \
+          --cov=devsynth.testing.run_tests \
+          --cov-report=term-missing \
+          --cov-fail-under=0'
+
   test:coverage:
     desc: Run tests with coverage
     cmds:
+      - task: tests:coverage:cli-run-tests
       - poetry run pytest {{.PYTEST_COV_ARGS}} {{.PYTEST_ARGS}}
 
   test:smoke:


### PR DESCRIPTION
## Summary
- add Typer CliRunner tests that simulate coverage success and failure paths for `devsynth run-tests`
- stub pytest coverage helpers to assert segmentation tips, plugin reinjection, and threshold messaging
- extend the coverage task pipeline with a focused run-tests CLI sweep

## Testing
- poetry run pytest tests/unit/application/cli/commands/test_run_tests_cmd_cli_runner_paths.py
- poetry run pytest tests/unit/application/cli/commands/test_run_tests_cmd.py --cov

------
https://chatgpt.com/codex/tasks/task_e_68d778416d8883339937832ab324ae14