### PR TITLE
Add property invariants for coverage reset and synchronization

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -200,6 +200,11 @@ jobs:
       - name: Verify coverage threshold
         run: poetry run python scripts/verify_coverage_threshold.py
 
+      - name: Run property invariant tests
+        env:
+          DEVSYNTH_PROPERTY_TESTING: "true"
+        run: poetry run pytest tests/property/
+
       - name: Collect diagnostics
         if: failure()
         run: |

--- a/docs/analysis/coverage_reset_proof.md
+++ b/docs/analysis/coverage_reset_proof.md
@@ -5,7 +5,7 @@ version: "0.1.0-alpha.1"
 tags:
   - "analysis"
   - "coverage"
-status: "draft"
+status: "published"
 author: "DevSynth Team"
 last_reviewed: "2025-08-23"
 ---
@@ -29,6 +29,10 @@ Let \(C_i\) be the set of lines executed in test \(i\). The algorithm maintains 
 Calling `reset()` restores \(S = \varnothing\) before test \(i+1\).
 Thus, coverage from one test never leaks into another, and the union of per-test sets
 is the total coverage. \(\square\)
+
+## Validation
+
+- Property invariants: `tests/property/test_coverage_reset_invariants.py::{test_reset_clears_coverage_state,test_reset_preserves_union_of_individual_runs}` executed via `task tests:property` (`poetry run pytest tests/property/`).
 
 ## References
 

--- a/docs/analysis/synchronization_algorithm_proof.md
+++ b/docs/analysis/synchronization_algorithm_proof.md
@@ -5,7 +5,7 @@ version: "0.1.0-alpha.1"
 tags:
   - "analysis"
   - "synchronization"
-status: "draft"
+status: "published"
 author: "DevSynth Team"
 last_reviewed: "2025-08-23"
 ---
@@ -25,6 +25,10 @@ Consider two stores \(A\) and \(B\) with pending update set \(P_A\).
 **Proof.** Each write updates \(A\) and adds the change to \(P_A\).
 Whenever `synchronize` runs, \(B\) receives all pending changes and \(P_A\) resets.
 Thus after the final synchronization, \(A = B\) and no updates remain. \(\square\)
+
+## Validation
+
+- Property invariants: `tests/property/test_synchronization_invariants.py::test_synchronize_clears_pending_updates` executed via `task tests:property` (`poetry run pytest tests/property/`).
 
 ## References
 

--- a/tests/property/test_coverage_reset_invariants.py
+++ b/tests/property/test_coverage_reset_invariants.py
@@ -1,0 +1,130 @@
+"""Property tests for the coverage reset invariants.
+
+DocRef: docs/analysis/coverage_reset_proof.md
+"""
+
+from __future__ import annotations
+
+import os
+from types import SimpleNamespace
+from typing import Iterable, List, Set
+
+import pytest
+
+try:  # pragma: no cover - Hypothesis is optional
+    from hypothesis import given, settings
+    from hypothesis import strategies as st
+except Exception:  # pragma: no cover - skip when Hypothesis missing
+    pytest.skip("hypothesis not available", allow_module_level=True)
+
+import tests.conftest as conftest
+
+
+class _FakeCoverageTracker:
+    """Mimic coverage.Coverage for the reset invariant tests."""
+
+    def __init__(self) -> None:
+        self.lines: Set[int] = set()
+
+    def load(self, executed: Iterable[int]) -> None:
+        self.lines = set(executed)
+
+    def erase(self) -> None:
+        self.lines.clear()
+
+
+def _fake_coverage_namespace(tracker: _FakeCoverageTracker) -> SimpleNamespace:
+    """Return an object that looks like the coverage module."""
+
+    class _Coverage:  # pylint: disable=too-few-public-methods
+        @staticmethod
+        def current() -> _FakeCoverageTracker:
+            return tracker
+
+    return SimpleNamespace(Coverage=_Coverage)
+
+
+def _invoke_reset() -> None:
+    """Mirror the reset_coverage fixture logic without using pytest internals."""
+
+    coverage_mod = getattr(conftest, "coverage", None)
+    if not coverage_mod or not os.environ.get("PYTEST_XDIST_WORKER"):
+        return
+    cov = coverage_mod.Coverage.current()
+    if cov:
+        cov.erase()
+
+
+@pytest.mark.property
+@pytest.mark.medium
+@given(
+    test_runs=st.lists(
+        st.sets(st.integers(min_value=0, max_value=10), max_size=8),
+        min_size=1,
+        max_size=12,
+    )
+)
+@settings(max_examples=50)
+def test_reset_clears_coverage_state(test_runs: List[Set[int]]) -> None:
+    """Lemma: reset() empties the tracker between tests.
+
+    ReqID: COV-RESET-INV-01
+    """
+
+    tracker = _FakeCoverageTracker()
+    monkey = pytest.MonkeyPatch()
+    monkey.setenv("PYTEST_XDIST_WORKER", "gw0")
+    monkey.setattr(
+        conftest, "coverage", _fake_coverage_namespace(tracker), raising=False
+    )
+    try:
+        for executed in test_runs:
+            tracker.load(executed)
+            _invoke_reset()
+            assert (
+                tracker.lines == set()
+            ), "reset() must clear previously executed lines"
+    finally:
+        monkey.undo()
+
+
+@pytest.mark.property
+@pytest.mark.medium
+@given(
+    test_runs=st.lists(
+        st.sets(st.integers(min_value=0, max_value=20), max_size=6),
+        min_size=1,
+        max_size=10,
+    )
+)
+@settings(max_examples=50)
+def test_reset_preserves_union_of_individual_runs(test_runs: List[Set[int]]) -> None:
+    """Theorem: total coverage equals the union of isolated test runs.
+
+    ReqID: COV-RESET-INV-02
+    """
+
+    tracker = _FakeCoverageTracker()
+    monkey = pytest.MonkeyPatch()
+    monkey.setenv("PYTEST_XDIST_WORKER", "gw0")
+    monkey.setattr(
+        conftest, "coverage", _fake_coverage_namespace(tracker), raising=False
+    )
+
+    observed_union: Set[int] = set()
+    expected_union: Set[int] = set()
+
+    try:
+        for executed in test_runs:
+            assert (
+                tracker.lines == set()
+            ), "coverage state must be empty before each simulated run"
+            tracker.load(executed)
+            observed_union |= tracker.lines
+            expected_union |= set(executed)
+            _invoke_reset()
+            assert tracker.lines == set(), "coverage state must be empty after reset"
+    finally:
+        monkey.undo()
+
+    assert observed_union == expected_union

--- a/tests/property/test_synchronization_invariants.py
+++ b/tests/property/test_synchronization_invariants.py
@@ -1,0 +1,145 @@
+"""Property tests for the synchronization invariants.
+
+DocRef: docs/analysis/synchronization_algorithm_proof.md
+"""
+
+from __future__ import annotations
+
+import uuid
+from dataclasses import replace
+from typing import Dict, Tuple
+
+import pytest
+
+try:  # pragma: no cover - Hypothesis is optional
+    from hypothesis import assume, given, settings
+    from hypothesis import strategies as st
+except Exception:  # pragma: no cover - skip when Hypothesis missing
+    pytest.skip("hypothesis not available", allow_module_level=True)
+
+from devsynth.application.memory.memory_integration import MemoryIntegrationManager
+from devsynth.domain.models.memory import MemoryItem, MemoryType
+
+
+class _DummyMemoryStore:
+    """Minimal in-memory store implementing the MemoryStore protocol."""
+
+    def __init__(self) -> None:
+        self._items: Dict[str, MemoryItem] = {}
+        self._active_transactions: set[str] = set()
+
+    # MemoryStore protocol -------------------------------------------------
+    def store(self, item: MemoryItem) -> str:
+        cloned = replace(item, metadata=dict(item.metadata))
+        self._items[cloned.id] = cloned
+        return cloned.id
+
+    def retrieve(self, item_id: str) -> MemoryItem | None:
+        item = self._items.get(item_id)
+        if item is None:
+            return None
+        return replace(item, metadata=dict(item.metadata))
+
+    def search(self, query: dict[str, object] | None = None) -> list[MemoryItem]:
+        return list(self._items.values())
+
+    def delete(self, item_id: str) -> bool:
+        return self._items.pop(item_id, None) is not None
+
+    def begin_transaction(self) -> str:
+        txn_id = str(uuid.uuid4())
+        self._active_transactions.add(txn_id)
+        return txn_id
+
+    def commit_transaction(self, transaction_id: str) -> bool:
+        if transaction_id in self._active_transactions:
+            self._active_transactions.remove(transaction_id)
+            return True
+        return False
+
+    def rollback_transaction(self, transaction_id: str) -> bool:
+        if transaction_id in self._active_transactions:
+            self._active_transactions.remove(transaction_id)
+            return True
+        return False
+
+    def is_transaction_active(self, transaction_id: str) -> bool:
+        return transaction_id in self._active_transactions
+
+    # Helpers --------------------------------------------------------------
+    def snapshot(self) -> Dict[str, Tuple[object, Tuple[Tuple[str, object], ...]]]:
+        """Return deterministic state for equality checks."""
+
+        snapshot: Dict[str, Tuple[object, Tuple[Tuple[str, object], ...]]] = {}
+        for item in self._items.values():
+            metadata_items = tuple(sorted(item.metadata.items()))
+            snapshot[item.id] = (item.content, metadata_items)
+        return snapshot
+
+
+def _build_store(data: Dict[str, object]) -> _DummyMemoryStore:
+    store = _DummyMemoryStore()
+    for key, value in data.items():
+        store.store(MemoryItem(id=key, content=value, memory_type=MemoryType.SHORT_TERM))
+    return store
+
+
+def _pending_updates(
+    source: _DummyMemoryStore, target: _DummyMemoryStore
+) -> Dict[str, Tuple[object, object | None]]:
+    pending: Dict[str, Tuple[object, object | None]] = {}
+    for item in source.search({}):
+        candidate = target.retrieve(item.id)
+        if candidate is None or candidate.content != item.content:
+            pending[item.id] = (item.content, None if candidate is None else candidate.content)
+    return pending
+
+
+@st.composite
+def _store_states(draw: st.DrawFn) -> Tuple[Dict[str, int], Dict[str, int]]:
+    keys = draw(
+        st.lists(
+            st.text(min_size=1, max_size=6, alphabet=st.characters(min_codepoint=97, max_codepoint=122)),
+            min_size=1,
+            max_size=5,
+            unique=True,
+        )
+    )
+    values = draw(st.lists(st.integers(), min_size=len(keys), max_size=len(keys)))
+    source = dict(zip(keys, values))
+
+    target: Dict[str, int] = {}
+    for key in keys:
+        if draw(st.booleans()):
+            if draw(st.booleans()):
+                target[key] = source[key]
+            else:
+                alt = draw(st.integers())
+                assume(alt != source[key])
+                target[key] = alt
+    return source, target
+
+
+@pytest.mark.property
+@pytest.mark.medium
+@given(states=_store_states())
+@settings(max_examples=50)
+def test_synchronize_clears_pending_updates(states: Tuple[Dict[str, int], Dict[str, int]]) -> None:
+    """Invariant: synchronize(A, B) yields B == A and P_A = ∅.
+
+    ReqID: SYNC-INV-01
+    """
+
+    source_data, target_data = states
+    store_a = _build_store(source_data)
+    store_b = _build_store(target_data)
+
+    manager = MemoryIntegrationManager()
+    manager.register_memory_store("A", store_a)
+    manager.register_memory_store("B", store_b)
+
+    result = manager.synchronize_stores("A", "B", bidirectional=False)
+
+    assert store_a.snapshot() == store_b.snapshot()
+    assert _pending_updates(store_a, store_b) == {}
+    assert result["A_to_B"] == len(source_data)


### PR DESCRIPTION
## Summary
- add Hypothesis-driven property tests that exercise the coverage reset and synchronization proofs
- mark the coverage reset and synchronization documents as published with validation references to the new tests
- run the property invariant suite in CI so regressions surface automatically

## Testing
- DEVSYNTH_PROPERTY_TESTING=true poetry run pytest tests/property/test_coverage_reset_invariants.py tests/property/test_synchronization_invariants.py -q

------
https://chatgpt.com/codex/tasks/task_e_68d778201aa88333bbd57a0028c0c1fc