### PR TITLE
Add CLI runner coverage threshold unit tests

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -207,6 +207,7 @@ tasks:
     cmds:
       - bash -lc 'poetry run pytest -o addopts="" \
           tests/unit/application/cli/commands/test_run_tests_cmd_cli_runner_paths.py \
+          tests/unit/application/cli/commands/test_run_tests_cmd_cli_runner_thresholds.py \
           tests/unit/application/cli/commands/test_run_tests_cmd.py \
           --cov=devsynth.application.cli.commands.run_tests_cmd \
           --cov=devsynth.testing.run_tests \

--- a/tests/unit/application/cli/commands/helpers.py
+++ b/tests/unit/application/cli/commands/helpers.py
@@ -1,0 +1,84 @@
+"""Shared utilities for CLI runner tests."""
+
+from __future__ import annotations
+
+import importlib
+import sys
+from types import ModuleType
+from typing import Any
+
+import pytest
+from typer import Typer
+
+
+def load_run_tests_cli_module(monkeypatch: pytest.MonkeyPatch) -> ModuleType:
+    """Load ``run_tests_cmd`` with minimal registry stubs to avoid heavy deps."""
+
+    alignment_module = ModuleType("alignment_metrics_cmd")
+
+    def _noop_alignment(*args: Any, **kwargs: Any) -> bool:
+        return True
+
+    alignment_module.alignment_metrics_cmd = _noop_alignment  # type: ignore[attr-defined]
+    monkeypatch.setitem(
+        sys.modules,
+        "devsynth.application.cli.commands.alignment_metrics_cmd",
+        alignment_module,
+    )
+
+    test_metrics_module = ModuleType("test_metrics_cmd")
+    test_metrics_module.test_metrics_cmd = _noop_alignment  # type: ignore[attr-defined]
+    monkeypatch.setitem(
+        sys.modules,
+        "devsynth.application.cli.commands.test_metrics_cmd",
+        test_metrics_module,
+    )
+
+    registry_module = ModuleType("registry")
+
+    class _Registry(dict):
+        def __getitem__(self, key: str) -> Any:  # type: ignore[override]
+            if key not in self:
+                super().__setitem__(key, _noop_alignment)
+            return super().__getitem__(key)
+
+    registry_module.COMMAND_REGISTRY = _Registry(
+        {
+            "alignment-metrics": alignment_module.alignment_metrics_cmd,
+            "test-metrics": test_metrics_module.test_metrics_cmd,
+        }
+    )
+
+    def _register(name: str, fn: Any) -> None:
+        registry_module.COMMAND_REGISTRY[name] = fn
+
+    registry_module.register = _register  # type: ignore[attr-defined]
+    monkeypatch.setitem(
+        sys.modules,
+        "devsynth.application.cli.registry",
+        registry_module,
+    )
+
+    for module_name in [
+        "devsynth.application.cli",
+        "devsynth.application.cli.cli_commands",
+        "devsynth.application.cli.commands.metrics_cmds",
+        "devsynth.application.cli.commands.run_tests_cmd",
+    ]:
+        sys.modules.pop(module_name, None)
+
+    return importlib.import_module("devsynth.application.cli.commands.run_tests_cmd")
+
+
+def build_minimal_cli_app(
+    monkeypatch: pytest.MonkeyPatch,
+) -> tuple[Typer, ModuleType]:
+    """Construct a Typer app exposing only the ``run-tests`` command."""
+
+    cli_module = load_run_tests_cli_module(monkeypatch)
+    app = Typer()
+    app.command(name="run-tests")(cli_module.run_tests_cmd)
+    return app, cli_module
+
+
+__all__ = ["build_minimal_cli_app", "load_run_tests_cli_module"]

--- a/tests/unit/application/cli/commands/test_run_tests_cmd_cli_runner_paths.py
+++ b/tests/unit/application/cli/commands/test_run_tests_cmd_cli_runner_paths.py
@@ -2,85 +2,14 @@
 
 from __future__ import annotations
 
-import importlib
 import json
-import sys
-from types import ModuleType
 from typing import Any
 
 import pytest
-from typer import Typer
 from typer.testing import CliRunner
 
 from devsynth.testing import run_tests as run_tests_module
-
-
-def _load_cli_module(monkeypatch: pytest.MonkeyPatch) -> ModuleType:
-    """Load run_tests_cmd with minimal registry stubs to avoid optional deps."""
-
-    alignment_module = ModuleType("alignment_metrics_cmd")
-
-    def _noop_alignment(*args: Any, **kwargs: Any) -> bool:
-        return True
-
-    alignment_module.alignment_metrics_cmd = _noop_alignment  # type: ignore[attr-defined]
-    monkeypatch.setitem(
-        sys.modules,
-        "devsynth.application.cli.commands.alignment_metrics_cmd",
-        alignment_module,
-    )
-
-    test_metrics_module = ModuleType("test_metrics_cmd")
-    test_metrics_module.test_metrics_cmd = _noop_alignment  # type: ignore[attr-defined]
-    monkeypatch.setitem(
-        sys.modules,
-        "devsynth.application.cli.commands.test_metrics_cmd",
-        test_metrics_module,
-    )
-
-    registry_module = ModuleType("registry")
-
-    class _Registry(dict):
-        def __getitem__(self, key: str) -> Any:  # type: ignore[override]
-            if key not in self:
-                super().__setitem__(key, _noop_alignment)
-            return super().__getitem__(key)
-
-    registry_module.COMMAND_REGISTRY = _Registry(
-        {
-            "alignment-metrics": alignment_module.alignment_metrics_cmd,
-            "test-metrics": test_metrics_module.test_metrics_cmd,
-        }
-    )
-
-    def _register(name: str, fn: Any) -> None:
-        registry_module.COMMAND_REGISTRY[name] = fn
-
-    registry_module.register = _register  # type: ignore[attr-defined]
-    monkeypatch.setitem(
-        sys.modules,
-        "devsynth.application.cli.registry",
-        registry_module,
-    )
-
-    for module_name in [
-        "devsynth.application.cli",
-        "devsynth.application.cli.cli_commands",
-        "devsynth.application.cli.commands.metrics_cmds",
-        "devsynth.application.cli.commands.run_tests_cmd",
-    ]:
-        sys.modules.pop(module_name, None)
-
-    return importlib.import_module("devsynth.application.cli.commands.run_tests_cmd")
-
-
-def _build_minimal_app(monkeypatch: pytest.MonkeyPatch) -> tuple[Typer, ModuleType]:
-    """Construct a Typer app exposing only the run-tests command."""
-
-    cli_module = _load_cli_module(monkeypatch)
-    app = Typer()
-    app.command(name="run-tests")(cli_module.run_tests_cmd)
-    return app, cli_module
+from tests.unit.application.cli.commands.helpers import build_minimal_cli_app
 
 
 @pytest.mark.fast
@@ -131,7 +60,7 @@ def test_cli_segmented_run_injects_plugins_and_emits_failure_tips(
     monkeypatch.setattr(run_tests_module.subprocess, "Popen", DummyProcess)
 
     runner = CliRunner()
-    app, _ = _build_minimal_app(monkeypatch)
+    app, _ = build_minimal_cli_app(monkeypatch)
     result = runner.invoke(
         app,
         [
@@ -176,7 +105,7 @@ def test_cli_inventory_mode_exports_json_via_typer(
         suffix = speed or "all"
         return [f"{target}::{suffix}::test_case"]
 
-    app, cli_module = _build_minimal_app(monkeypatch)
+    app, cli_module = build_minimal_cli_app(monkeypatch)
     monkeypatch.setattr(cli_module, "collect_tests_with_cache", fake_collect)
 
     runner = CliRunner()
@@ -208,7 +137,7 @@ def test_cli_enforces_coverage_threshold_via_cli_runner(
 
     monkeypatch.chdir(tmp_path)
 
-    app, cli_module = _build_minimal_app(monkeypatch)
+    app, cli_module = build_minimal_cli_app(monkeypatch)
 
     runner = CliRunner()
 
@@ -275,7 +204,7 @@ def test_cli_enforces_coverage_threshold_via_cli_runner(
 def test_cli_exits_when_pytest_cov_disabled_via_autoload(monkeypatch: pytest.MonkeyPatch) -> None:
     """Typer run surfaces remediation tips when pytest-cov is disabled."""
 
-    app, cli_module = _build_minimal_app(monkeypatch)
+    app, cli_module = build_minimal_cli_app(monkeypatch)
 
     runner = CliRunner()
 

--- a/tests/unit/application/cli/commands/test_run_tests_cmd_cli_runner_thresholds.py
+++ b/tests/unit/application/cli/commands/test_run_tests_cmd_cli_runner_thresholds.py
@@ -1,0 +1,155 @@
+"""Typer CLI coverage enforcement tests for ``devsynth run-tests``."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from typer.testing import CliRunner
+
+from tests.unit.application.cli.commands.helpers import build_minimal_cli_app
+
+
+@pytest.mark.fast
+def test_cli_reports_coverage_artifacts_success(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Successful CLI run emits artifact locations after enforcing thresholds."""
+
+    monkeypatch.chdir(tmp_path)
+
+    app, cli_module = build_minimal_cli_app(monkeypatch)
+
+    html_dir = tmp_path / "htmlcov"
+    html_dir.mkdir()
+    html_index = html_dir / "index.html"
+    html_index.write_text("<html>coverage</html>")
+
+    json_path = tmp_path / "test_reports" / "coverage.json"
+    json_path.parent.mkdir()
+    json_path.write_text("{}")
+
+    monkeypatch.setattr(cli_module, "COVERAGE_HTML_DIR", html_dir)
+    monkeypatch.setattr(cli_module, "COVERAGE_JSON_PATH", json_path)
+
+    monkeypatch.setattr(cli_module, "run_tests", lambda *_, **__: (True, "pytest ok"))
+    monkeypatch.setattr(
+        cli_module, "_coverage_instrumentation_status", lambda: (True, None)
+    )
+
+    artifact_calls: list[None] = []
+
+    def _coverage_artifact_status_stub() -> tuple[bool, str | None]:
+        artifact_calls.append(None)
+        return True, None
+
+    monkeypatch.setattr(
+        cli_module, "coverage_artifacts_status", _coverage_artifact_status_stub
+    )
+
+    monkeypatch.setattr(
+        cli_module,
+        "enforce_coverage_threshold",
+        lambda exit_on_failure=False: 91.2,
+    )
+    monkeypatch.setattr(cli_module, "ensure_pytest_cov_plugin_env", lambda env: False)
+    monkeypatch.setattr(cli_module, "ensure_pytest_bdd_plugin_env", lambda env: False)
+
+    runner = CliRunner()
+    result = runner.invoke(
+        app,
+        ["--target", "unit-tests", "--speed", "fast", "--report"],
+        prog_name="run-tests",
+    )
+
+    assert result.exit_code == 0
+    assert "Coverage 91.20% meets the 70% threshold" in result.stdout
+    assert str(html_index.resolve()) in result.stdout
+    assert str(json_path.resolve()) in result.stdout
+    assert artifact_calls, "coverage_artifacts_status should be evaluated"
+
+
+@pytest.mark.fast
+def test_cli_exits_when_coverage_artifacts_missing(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Missing coverage artifacts trigger an exit with remediation guidance."""
+
+    monkeypatch.chdir(tmp_path)
+
+    app, cli_module = build_minimal_cli_app(monkeypatch)
+
+    monkeypatch.setattr(cli_module, "run_tests", lambda *_, **__: (True, ""))
+    monkeypatch.setattr(
+        cli_module, "_coverage_instrumentation_status", lambda: (True, None)
+    )
+    monkeypatch.setattr(cli_module, "enforce_coverage_threshold", lambda **_: 80.0)
+    monkeypatch.setattr(
+        cli_module,
+        "coverage_artifacts_status",
+        lambda: (False, "coverage.json missing"),
+    )
+    monkeypatch.setattr(
+        cli_module,
+        "_emit_coverage_artifact_messages",
+        lambda _: (_ for _ in ()).throw(
+            AssertionError("Coverage messaging should not run when artifacts fail")
+        ),
+    )
+    monkeypatch.setattr(cli_module, "ensure_pytest_cov_plugin_env", lambda env: False)
+    monkeypatch.setattr(cli_module, "ensure_pytest_bdd_plugin_env", lambda env: False)
+
+    runner = CliRunner()
+    result = runner.invoke(
+        app,
+        ["--target", "unit-tests", "--speed", "fast"],
+        prog_name="run-tests",
+    )
+
+    assert result.exit_code == 1
+    assert "Coverage artifacts missing or empty" in result.stdout
+    assert "coverage.json missing" in result.stdout
+    assert "Ensure pytest-cov is active for this session" in result.stdout
+
+
+@pytest.mark.fast
+def test_cli_surfaces_threshold_runtime_errors(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Runtime errors from threshold enforcement bubble up through the CLI."""
+
+    monkeypatch.chdir(tmp_path)
+
+    app, cli_module = build_minimal_cli_app(monkeypatch)
+
+    monkeypatch.setattr(cli_module, "run_tests", lambda *_, **__: (True, ""))
+    monkeypatch.setattr(
+        cli_module, "_coverage_instrumentation_status", lambda: (True, None)
+    )
+    monkeypatch.setattr(cli_module, "coverage_artifacts_status", lambda: (True, None))
+    monkeypatch.setattr(
+        cli_module,
+        "enforce_coverage_threshold",
+        lambda exit_on_failure=False: (_ for _ in ()).throw(
+            RuntimeError("Coverage 62.5% below threshold")
+        ),
+    )
+    monkeypatch.setattr(
+        cli_module,
+        "_emit_coverage_artifact_messages",
+        lambda _: (_ for _ in ()).throw(
+            AssertionError("Coverage messaging should not run on failure")
+        ),
+    )
+    monkeypatch.setattr(cli_module, "ensure_pytest_cov_plugin_env", lambda env: False)
+    monkeypatch.setattr(cli_module, "ensure_pytest_bdd_plugin_env", lambda env: False)
+
+    runner = CliRunner()
+    result = runner.invoke(
+        app,
+        ["--target", "unit-tests", "--speed", "fast"],
+        prog_name="run-tests",
+    )
+
+    assert result.exit_code == 1
+    assert "Coverage 62.5% below threshold" in result.stdout


### PR DESCRIPTION
## Summary
- extract shared helpers for building the isolated run-tests Typer app used in CLI unit tests
- add CliRunner-based coverage enforcement tests that simulate artifact success, artifact failures, and threshold exceptions
- include the new CLI threshold tests in the focused coverage Taskfile pipeline

## Testing
- poetry run pytest tests/unit/application/cli/commands/test_run_tests_cmd_cli_runner_thresholds.py
- poetry run pytest tests/unit/application/cli/commands/test_run_tests_cmd.py --cov --cov-fail-under=0

------
https://chatgpt.com/codex/tasks/task_e_68d77aa47a7c8333a66d9ec5452ed95f