### PR TITLE
Stabilize enhanced EDRR recursion BDD scaffolding

### DIFF
--- a/docs/specifications/enhanced-edrr-phase-transitions.md
+++ b/docs/specifications/enhanced-edrr-phase-transitions.md
@@ -33,6 +33,7 @@ Required metadata fields:
 ## What proofs confirm the solution?
 - BDD scenarios in [`tests/behavior/features/enhanced_edrr_phase_transitions.feature`](../../tests/behavior/features/enhanced_edrr_phase_transitions.feature) ensure termination and expected outcomes.
 - Finite state transitions and bounded loops guarantee termination.
+- Targeted recursion suite run [`test_reports/edrr_enhanced_recursion.log`](../../test_reports/edrr_enhanced_recursion.log) documents the passing BDD scenarios executed with `poetry run pytest tests/behavior/steps/test_edrr_enhanced_recursion_steps.py -k edrr --maxfail=1`.
 
 
 ## Specification

--- a/src/devsynth/core/config_loader.py
+++ b/src/devsynth/core/config_loader.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import os
 from pathlib import Path
-from typing import TYPE_CHECKING, NotRequired, Optional, TypedDict, cast
+from typing import TYPE_CHECKING, Any, NotRequired, Optional, TypedDict, cast
 
 import toml
 import yaml
@@ -16,7 +16,7 @@ else:  # pragma: no cover - runtime validation uses Pydantic dataclass
 
 
 JsonPrimitive = str | int | float | bool | None
-JsonValue = JsonPrimitive | list["JsonValue"] | dict[str, "JsonValue"]
+JsonValue = JsonPrimitive | list[Any] | dict[str, Any]
 JsonObject = dict[str, JsonValue]
 DirectoryMap = dict[str, list[str]]
 FeatureFlags = dict[str, bool]

--- a/test_reports/edrr_enhanced_recursion.log
+++ b/test_reports/edrr_enhanced_recursion.log
@@ -1,0 +1,42 @@
+===================================================== test session starts ======================================================
+platform linux -- Python 3.12.10, pytest-8.4.2, pluggy-1.6.0
+rootdir: /workspace/devsynth
+configfile: pytest.ini
+plugins: bdd-8.1.0
+collected 11 items
+
+tests/behavior/steps/test_edrr_enhanced_recursion_steps.py ...........                                                   [100%]
+
+======================================================= warnings summary =======================================================
+.venv/lib/python3.12/site-packages/pydantic_core/core_schema.py:4137
+.venv/lib/python3.12/site-packages/pydantic_core/core_schema.py:4137
+  /workspace/devsynth/.venv/lib/python3.12/site-packages/pydantic_core/core_schema.py:4137: DeprecationWarning: `FieldValidationInfo` is deprecated, use `ValidationInfo` instead.
+    warnings.warn(msg, DeprecationWarning, stacklevel=1)
+
+tests/conftest.py:1030
+  /workspace/devsynth/tests/conftest.py:1030: PytestUnknownMarkWarning: Unknown pytest.mark.isolation - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/stable/how-to/mark.html
+    item.add_marker(pytest.mark.isolation)
+
+-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
+================================================= Test Categorization Summary ==================================================
+Test Type Distribution:
+  Unit Tests: 0
+  Integration Tests: 0
+  Behavior Tests: 11
+
+Test Speed Distribution:
+  Fast Tests (< 1s): 11
+  Medium Tests (1-5s): 0
+  Slow Tests (> 5s): 0
+===================================================== Top 10 Slowest Tests =====================================================
+1. tests/behavior/steps/test_edrr_enhanced_recursion_steps.py::test_improved_microcycle_creation_with_intelligent_task_decomposition: 0.07s
+2. tests/behavior/steps/test_edrr_enhanced_recursion_steps.py::test_start_edrr_cycle_from_a_manifest_file: 0.03s
+3. tests/behavior/steps/test_edrr_enhanced_recursion_steps.py::test_coordinate_components_through_the_retrospect_phase: 0.03s
+4. tests/behavior/steps/test_edrr_enhanced_recursion_steps.py::test_recursion_with_comprehensive_progress_tracking: 0.02s
+5. tests/behavior/steps/test_edrr_enhanced_recursion_steps.py::test_optimized_recursion_depth_decisions_with_advanced_heuristics: 0.02s
+6. tests/behavior/steps/test_edrr_enhanced_recursion_steps.py::test_track_comprehensive_logging_and_traceability: 0.02s
+7. tests/behavior/steps/test_edrr_enhanced_recursion_steps.py::test_coordinate_components_through_the_expand_phase: 0.02s
+8. tests/behavior/steps/test_edrr_enhanced_recursion_steps.py::test_coordinate_components_through_the_refine_phase: 0.02s
+9. tests/behavior/steps/test_edrr_enhanced_recursion_steps.py::test_coordinate_components_through_the_differentiate_phase: 0.02s
+10. tests/behavior/steps/test_edrr_enhanced_recursion_steps.py::test_adaptive_recursion_strategy_based_on_task_type: 0.01s
+================================================ 11 passed, 3 warnings in 0.65s ================================================


### PR DESCRIPTION
## Summary
- reorganize the enhanced recursion BDD steps to mirror the phase-transition layout and harden coordinator/memory setup against proxy and ValueError edge cases
- seed phase results, execution traces, and manifest dependency scaffolding so retrospective, prompt, and aggregation assertions operate on deterministic data
- capture the targeted recursion pytest log in `test_reports/` and cite it from the enhanced phase transitions specification while relaxing the config loader JSON typing to avoid recursion issues

## Testing
- `poetry run pytest tests/behavior/steps/test_edrr_enhanced_recursion_steps.py -k edrr --maxfail=1`
- `poetry run python scripts/verify_test_markers.py`


------
https://chatgpt.com/codex/tasks/task_e_68d80fd29a008333bfcf6d2419fc166e