### PR TITLE
Align recursion step imports for EDRR recursion tests

### DIFF
--- a/tests/behavior/steps/test_edrr_enhanced_recursion_steps.py
+++ b/tests/behavior/steps/test_edrr_enhanced_recursion_steps.py
@@ -2,28 +2,20 @@
 
 from __future__ import annotations
 
-from pytest_bdd import given, parsers, scenarios, then, when
-
-# Import the feature file for this test
-
-pytestmark = [pytest.mark.fast]
-
-scenarios("../features/general/edrr_enhanced_recursion.feature")
-
-# Content from test_edrr_coordinator_steps.py inlined here
-"""Step definitions for the EDRR Coordinator feature."""
-
-import pytest
-
-# Removed duplicate __future__ import
-from pytest_bdd import given, parsers, scenarios, then, when
-
-scenarios("../features/general/edrr_coordinator.feature")
 import json
 import os
 import tempfile
 from pathlib import Path
 from typing import Dict, Tuple
+
+import pytest
+from pytest_bdd import given, parsers, scenarios, then, when
+
+# Register feature scenarios.
+pytestmark = [pytest.mark.fast]
+
+scenarios("../features/general/edrr_enhanced_recursion.feature")
+scenarios("../features/general/edrr_coordinator.feature")
 
 from devsynth.application.code_analysis.analyzer import CodeAnalyzer
 from devsynth.application.code_analysis.ast_transformer import AstTransformer


### PR DESCRIPTION
## Summary
- move the pytest import in the enhanced recursion step definitions above the pytestmark declaration
- align the module header with the working phase transition steps file

## Testing
- `poetry run pytest tests/behavior/steps/test_edrr_enhanced_recursion_steps.py -k edrr --maxfail=1` *(fails: RecursionError in devsynth.core.config_loader during import)*

------
https://chatgpt.com/codex/tasks/task_e_68d81a141b2083338839ee699df87b39