### PR TITLE
test: harden run-tests CLI regression coverage

### DIFF
--- a/tests/unit/application/cli/commands/helpers.py
+++ b/tests/unit/application/cli/commands/helpers.py
@@ -1,4 +1,11 @@
-"""Shared utilities and canonical stubs for CLI runner tests."""
+"""Shared utilities and canonical stubs for CLI runner tests.
+
+This module centralizes lightweight replacements for the full CLI stack so
+tests can exercise Typer integration without importing heavy dependencies.
+Notably, ``SEGMENTATION_FAILURE_TIPS`` mirrors the remediation guidance that
+``run-tests`` surfaces when segmented runs fail, keeping assertions aligned
+with the production UX.
+"""
 
 from __future__ import annotations
 

--- a/tests/unit/application/cli/commands/test_run_tests_cmd_inventory.py
+++ b/tests/unit/application/cli/commands/test_run_tests_cmd_inventory.py
@@ -62,12 +62,19 @@ def test_inventory_handles_collection_errors(monkeypatch, tmp_path):
     runner = CliRunner()
     result = runner.invoke(app, ["--inventory"], prog_name="run-tests")
 
+    assert result.exception is None
     assert result.exit_code == 0
     assert "Test inventory exported to" in result.stdout
 
     p = Path("test_reports/test_inventory.json")
+    assert p.exists()
     data = json.loads(p.read_text())
     # Ensure empty lists are used on exceptions
+    expected_targets = {"all-tests", "unit-tests", "integration-tests", "behavior-tests"}
+    expected_speeds = {"fast", "medium", "slow"}
+    assert set(data["targets"].keys()) == expected_targets
     for tgt, speeds in data["targets"].items():
+        assert set(speeds.keys()) == expected_speeds
         for spd, items in speeds.items():
             assert isinstance(items, list)
+            assert items == []

--- a/tests/unit/application/cli/commands/test_run_tests_cmd_segmentation_regressions.py
+++ b/tests/unit/application/cli/commands/test_run_tests_cmd_segmentation_regressions.py
@@ -59,7 +59,9 @@ def test_segmented_cli_failure_emits_tips_and_reinjection(monkeypatch, tmp_path)
         prog_name="run-tests",
     )
 
+    assert isinstance(result.exception, SystemExit)
     assert result.exit_code == 1
+    assert result.exception.code == 1
     assert "Tests failed" in result.stdout
     assert "Pytest exited with code 1" in result.stdout
     assert "Segment large suites to localize failures" in result.stdout


### PR DESCRIPTION
## Summary
- assert segmented run-tests failures surface remediation tips once and exit with code 1
- ensure inventory collection errors still emit a test inventory with empty lists and no Typer exit
- document shared CLI stubs used across Typer-based tests

## Testing
- `poetry run pytest tests/unit/application/cli/commands/test_run_tests_cmd_segmentation_regressions.py tests/unit/application/cli/commands/test_run_tests_cmd_inventory.py -k fast` *(fails: ModuleNotFoundError: No module named 'typer')*


------
https://chatgpt.com/codex/tasks/task_e_68d8b5965e608333a50cb311153b0998