### PR TITLE
Add fast tests for run_tests plugin failure handling

### DIFF
--- a/tests/unit/testing/test_run_tests_coverage_short_circuit.py
+++ b/tests/unit/testing/test_run_tests_coverage_short_circuit.py
@@ -42,3 +42,5 @@ def test_ensure_coverage_artifacts_short_circuits_without_measured_files(
     assert not legacy_dir.exists()
     assert stub.html_calls == []
     assert stub.json_calls == []
+    assert len(stub.instances) == 1
+    assert Path(stub.instances[0].data_file).resolve() == data_file.resolve()

--- a/tests/unit/testing/test_run_tests_plugin_env.py
+++ b/tests/unit/testing/test_run_tests_plugin_env.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+from collections.abc import MutableMapping
+from typing import Callable
+
+import pytest
+
+pytest_plugins = ["tests.unit.testing"]
+
+import devsynth.testing.run_tests as rt
+
+
+pytestmark = pytest.mark.fast
+
+
+@pytest.mark.parametrize(
+    ("ensure", "initial_env", "expected_changed", "expected_addopts"),
+    (
+        (
+            rt.ensure_pytest_cov_plugin_env,
+            {"PYTEST_DISABLE_PLUGIN_AUTOLOAD": "1", "PYTEST_ADDOPTS": "--no-cov -s"},
+            False,
+            "--no-cov -s",
+        ),
+        (
+            rt.ensure_pytest_cov_plugin_env,
+            {"PYTEST_DISABLE_PLUGIN_AUTOLOAD": "1", "PYTEST_ADDOPTS": "-k smoke"},
+            True,
+            "-k smoke -p pytest_cov",
+        ),
+        (
+            rt.ensure_pytest_bdd_plugin_env,
+            {"PYTEST_DISABLE_PLUGIN_AUTOLOAD": "1", "PYTEST_ADDOPTS": "-p no:pytest_bdd -s"},
+            False,
+            "-p no:pytest_bdd -s",
+        ),
+        (
+            rt.ensure_pytest_bdd_plugin_env,
+            {"PYTEST_DISABLE_PLUGIN_AUTOLOAD": "1", "PYTEST_ADDOPTS": "-k feature"},
+            True,
+            "-k feature -p pytest_bdd.plugin",
+        ),
+    ),
+)
+def test_ensure_pytest_plugin_env_addopts_overrides(
+    ensure: Callable[[MutableMapping[str, str]], bool],
+    initial_env: dict[str, str],
+    expected_changed: bool,
+    expected_addopts: str,
+) -> None:
+    """Ensure pytest plugin helpers respect opt-outs and reinject when needed."""
+
+    env: dict[str, str] = dict(initial_env)
+
+    changed = ensure(env)
+
+    assert changed is expected_changed
+    assert env["PYTEST_ADDOPTS"] == expected_addopts
+
+    if not expected_changed:
+        assert env == initial_env
+    else:
+        assert env != initial_env
+        assert env["PYTEST_DISABLE_PLUGIN_AUTOLOAD"] == "1"

--- a/tests/unit/testing/test_run_tests_plugin_timeouts.py
+++ b/tests/unit/testing/test_run_tests_plugin_timeouts.py
@@ -6,6 +6,8 @@ from pathlib import Path
 
 import pytest
 
+pytest_plugins = ["tests.unit.testing"]
+
 import devsynth.testing.run_tests as rt
 
 


### PR DESCRIPTION
## Summary
- extend the coverage stub factory so tests can reuse fake coverage instances when asserting behavior
- verify coverage artifact generation short-circuits without writing output when no files are measured
- add fast regression tests for subprocess collection timeouts and pytest plugin opt-out and reinjection flows

## Testing
- `poetry run pytest tests/unit/testing/test_run_tests_plugin_timeouts.py tests/unit/testing/test_run_tests_coverage_short_circuit.py tests/unit/testing/test_run_tests_plugin_env.py`


------
https://chatgpt.com/codex/tasks/task_e_68d8b6a3d794833380bab134bfb65a54