### PR TITLE
chore: document devsynth cli gap blocking coverage refresh

### DIFF
--- a/artifacts/run-tests/unit-fast-20250928T145807Z/coverage-term-missing.txt
+++ b/artifacts/run-tests/unit-fast-20250928T145807Z/coverage-term-missing.txt
@@ -1,0 +1,27 @@
+Warning: 'devsynth' is an entry point defined in pyproject.toml, but it's not installed as a script. You may get improper `sys.argv[0]`.
+
+The support to run uninstalled scripts will be removed in a future release.
+
+Run `poetry install` to resolve and get rid of this message.
+
+Traceback (most recent call last):
+  File "<string>", line 1, in <module>
+  File "/root/.pyenv/versions/3.12.10/lib/python3.12/importlib/__init__.py", line 90, in import_module
+    return _bootstrap._gcd_import(name[level:], package, level)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "<frozen importlib._bootstrap>", line 1387, in _gcd_import
+  File "<frozen importlib._bootstrap>", line 1360, in _find_and_load
+  File "<frozen importlib._bootstrap>", line 1310, in _find_and_load_unlocked
+  File "<frozen importlib._bootstrap>", line 488, in _call_with_frames_removed
+  File "<frozen importlib._bootstrap>", line 1387, in _gcd_import
+  File "<frozen importlib._bootstrap>", line 1360, in _find_and_load
+  File "<frozen importlib._bootstrap>", line 1310, in _find_and_load_unlocked
+  File "<frozen importlib._bootstrap>", line 488, in _call_with_frames_removed
+  File "<frozen importlib._bootstrap>", line 1387, in _gcd_import
+  File "<frozen importlib._bootstrap>", line 1360, in _find_and_load
+  File "<frozen importlib._bootstrap>", line 1310, in _find_and_load_unlocked
+  File "<frozen importlib._bootstrap>", line 488, in _call_with_frames_removed
+  File "<frozen importlib._bootstrap>", line 1387, in _gcd_import
+  File "<frozen importlib._bootstrap>", line 1360, in _find_and_load
+  File "<frozen importlib._bootstrap>", line 1324, in _find_and_load_unlocked
+ModuleNotFoundError: No module named 'devsynth'

--- a/issues/devsynth-cli-missing.md
+++ b/issues/devsynth-cli-missing.md
@@ -1,6 +1,6 @@
 # devsynth CLI missing after setup
 Milestone: 0.1.0a1
-Status: closed
+Status: open
 Priority: medium
 Dependencies: scripts/install_dev.sh, poetry install --with dev --all-extras
 
@@ -23,6 +23,7 @@ The `scripts/verify_post_install.py` script has been enhanced to explicitly chec
 - 2025-09-20: New container session still reports `ModuleNotFoundError: No module named 'devsynth'` until `poetry install --with dev --all-extras` runs; captured in diagnostics/devsynth_cli_missing_20250920.log and diagnostics/poetry_install_20250920.log for follow-up.
 - 2025-09-21: `poetry run devsynth --help` again failed with `ModuleNotFoundError` before reinstall; running `poetry install --with dev --all-extras` restored the CLI and extras, and a follow-up `bash scripts/install_dev.sh` captured a clean bootstrap in diagnostics/install_dev_20250921T054430Z.log.
 - 2025-09-24: Modified `scripts/verify_post_install.py` to explicitly check for the `devsynth` executable, improving diagnostic and retry reliability.
+- 2025-09-28: Fresh session attempting `poetry run devsynth run-tests --target unit-tests --speed=fast --no-parallel --cov-report=term-missing` exited with code 1 because the `devsynth` package is not installed. Evidence captured in `artifacts/run-tests/unit-fast-20250928T145807Z/coverage-term-missing.txt`. Follow-up requires reinstalling via `poetry install --with dev --extras "tests retrieval chromadb api"` before rerunning the coverage workflow.
 
 ## Next Actions
 - [ ] Monitor for further occurrences of the `devsynth` CLI missing in fresh environments.


### PR DESCRIPTION
## Summary
- capture the failed fast unit coverage attempt that exits with ModuleNotFoundError due to the missing devsynth entry point
- reopen the devsynth CLI gap issue and document the 2025-09-28 incident plus remediation path

## Testing
- `poetry run devsynth run-tests --target unit-tests --speed=fast --no-parallel --cov-report=term-missing` *(fails: ModuleNotFoundError because the devsynth package is not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68d947fe61b083338695f0f08a857877