### PR TITLE
refactor: type CLI DTO layer and stabilize imports

### DIFF
--- a/src/devsynth/application/cli/__init__.py
+++ b/src/devsynth/application/cli/__init__.py
@@ -1,32 +1,24 @@
-"""Application-level CLI facades that delegate into orchestration layer."""
+from __future__ import annotations
+
+"""Package initialisation for the DevSynth CLI."""
 
 from typing import Callable
 
 from devsynth.logging_setup import DevSynthLogger
 
-logger = DevSynthLogger(__name__)
-
-# Import modules so they register their commands
-from .commands import (
-    config_cmds,
-    diagnostics_cmds,
-    documentation_cmds,
-    extra_cmds,
-    generation_cmds,
-    interface_cmds,
-    metrics_cmds,
-    pipeline_cmds,
-    validation_cmds,
-)
-from .commands.config_cmds import config_app
-from .commands.inspect_code_cmd import inspect_code_cmd
-from .ingest_cmd import ingest_cmd
+from ._command_exports import COMMAND_ATTRIBUTE_NAMES, COMMAND_ATTRIBUTE_TO_SLUG
 from .registry import COMMAND_REGISTRY
 
-from ._command_exports import COMMAND_ATTRIBUTE_TO_SLUG, COMMAND_ATTRIBUTE_NAMES
-
+logger = DevSynthLogger(__name__)
 
 CommandCallable = Callable[..., object]
+
+_COMMANDS_LOADED = False
+
+# Placeholders populated when command modules import successfully.
+config_app: CommandCallable | None = None
+inspect_code_cmd: CommandCallable | None = None
+ingest_cmd: CommandCallable | None = None
 
 
 def _registered_command(slug: str) -> CommandCallable:
@@ -38,102 +30,64 @@ def _registered_command(slug: str) -> CommandCallable:
         raise RuntimeError(f"CLI command '{slug}' is not registered") from exc
 
 
-align_cmd: CommandCallable = _registered_command(
-    COMMAND_ATTRIBUTE_TO_SLUG["align_cmd"]
-)
-completion_cmd: CommandCallable = _registered_command(
-    COMMAND_ATTRIBUTE_TO_SLUG["completion_cmd"]
-)
-init_cmd: CommandCallable = _registered_command(
-    COMMAND_ATTRIBUTE_TO_SLUG["init_cmd"]
-)
-run_tests_cmd: CommandCallable = _registered_command(
-    COMMAND_ATTRIBUTE_TO_SLUG["run_tests_cmd"]
-)
-edrr_cycle_cmd: CommandCallable = _registered_command(
-    COMMAND_ATTRIBUTE_TO_SLUG["edrr_cycle_cmd"]
-)
-security_audit_cmd: CommandCallable = _registered_command(
-    COMMAND_ATTRIBUTE_TO_SLUG["security_audit_cmd"]
-)
-reprioritize_issues_cmd: CommandCallable = _registered_command(
-    COMMAND_ATTRIBUTE_TO_SLUG["reprioritize_issues_cmd"]
-)
-atomic_rewrite_cmd: CommandCallable = _registered_command(
-    COMMAND_ATTRIBUTE_TO_SLUG["atomic_rewrite_cmd"]
-)
-mvuu_dashboard_cmd: CommandCallable = _registered_command(
-    COMMAND_ATTRIBUTE_TO_SLUG["mvuu_dashboard_cmd"]
-)
-spec_cmd: CommandCallable = _registered_command(
-    COMMAND_ATTRIBUTE_TO_SLUG["spec_cmd"]
-)
-test_cmd: CommandCallable = _registered_command(
-    COMMAND_ATTRIBUTE_TO_SLUG["test_cmd"]
-)
-code_cmd: CommandCallable = _registered_command(
-    COMMAND_ATTRIBUTE_TO_SLUG["code_cmd"]
-)
-webapp_cmd: CommandCallable = _registered_command(
-    COMMAND_ATTRIBUTE_TO_SLUG["webapp_cmd"]
-)
-serve_cmd: CommandCallable = _registered_command(
-    COMMAND_ATTRIBUTE_TO_SLUG["serve_cmd"]
-)
-dbschema_cmd: CommandCallable = _registered_command(
-    COMMAND_ATTRIBUTE_TO_SLUG["dbschema_cmd"]
-)
-webui_cmd: CommandCallable = _registered_command(
-    COMMAND_ATTRIBUTE_TO_SLUG["webui_cmd"]
-)
-dpg_cmd: CommandCallable = _registered_command(
-    COMMAND_ATTRIBUTE_TO_SLUG["dpg_cmd"]
-)
-alignment_metrics_cmd: CommandCallable = _registered_command(
-    COMMAND_ATTRIBUTE_TO_SLUG["alignment_metrics_cmd"]
-)
-test_metrics_cmd: CommandCallable = _registered_command(
-    COMMAND_ATTRIBUTE_TO_SLUG["test_metrics_cmd"]
-)
-run_pipeline_cmd: CommandCallable = _registered_command(
-    COMMAND_ATTRIBUTE_TO_SLUG["run_pipeline_cmd"]
-)
-run_cmd: CommandCallable = _registered_command(
-    COMMAND_ATTRIBUTE_TO_SLUG["run_cmd"]
-)
-gather_cmd: CommandCallable = _registered_command(
-    COMMAND_ATTRIBUTE_TO_SLUG["gather_cmd"]
-)
-refactor_cmd: CommandCallable = _registered_command(
-    COMMAND_ATTRIBUTE_TO_SLUG["refactor_cmd"]
-)
-inspect_cmd: CommandCallable = _registered_command(
-    COMMAND_ATTRIBUTE_TO_SLUG["inspect_cmd"]
-)
-inspect_config_cmd: CommandCallable = _registered_command(
-    COMMAND_ATTRIBUTE_TO_SLUG["inspect_config_cmd"]
-)
-config_cmd: CommandCallable = _registered_command(
-    COMMAND_ATTRIBUTE_TO_SLUG["config_cmd"]
-)
-enable_feature_cmd: CommandCallable = _registered_command(
-    COMMAND_ATTRIBUTE_TO_SLUG["enable_feature_cmd"]
-)
-doctor_cmd: CommandCallable = _registered_command(
-    COMMAND_ATTRIBUTE_TO_SLUG["doctor_cmd"]
-)
-check_cmd: CommandCallable = _registered_command(
-    COMMAND_ATTRIBUTE_TO_SLUG["check_cmd"]
-)
-generate_docs_cmd: CommandCallable = _registered_command(
-    COMMAND_ATTRIBUTE_TO_SLUG["generate_docs_cmd"]
-)
-validate_manifest_cmd: CommandCallable = _registered_command(
-    COMMAND_ATTRIBUTE_TO_SLUG["validate_manifest_cmd"]
-)
-validate_metadata_cmd: CommandCallable = _registered_command(
-    COMMAND_ATTRIBUTE_TO_SLUG["validate_metadata_cmd"]
-)
+def _register_commands() -> None:
+    """Ensure CLI command modules are imported and registered."""
+
+    global _COMMANDS_LOADED, config_app, inspect_code_cmd, ingest_cmd
+
+    if _COMMANDS_LOADED:
+        return
+
+    try:  # pragma: no cover - exercised indirectly via attribute access
+        from .commands import (  # type: ignore import-not-found
+            config_cmds,
+            diagnostics_cmds,
+            documentation_cmds,
+            extra_cmds,
+            generation_cmds,
+            interface_cmds,
+            metrics_cmds,
+            pipeline_cmds,
+            validation_cmds,
+        )
+        from .commands.config_cmds import config_app as loaded_config_app
+        from .commands.inspect_code_cmd import inspect_code_cmd as loaded_inspect
+        from .ingest_cmd import ingest_cmd as loaded_ingest
+    except ModuleNotFoundError as exc:
+        logger.debug(
+            "Skipping CLI command registration due to missing optional dependency: %s",
+            exc,
+        )
+        _COMMANDS_LOADED = True
+        return
+
+    config_app = loaded_config_app
+    inspect_code_cmd = loaded_inspect
+    ingest_cmd = loaded_ingest
+
+    for attr_name in COMMAND_ATTRIBUTE_NAMES:
+        slug = COMMAND_ATTRIBUTE_TO_SLUG.get(attr_name)
+        if slug is None:
+            continue
+        globals()[attr_name] = _registered_command(slug)
+
+    _COMMANDS_LOADED = True
+
+
+def __getattr__(name: str) -> object:
+    """Lazily expose CLI command callables when requested."""
+
+    if name in {
+        "config_app",
+        "inspect_code_cmd",
+        "ingest_cmd",
+    } or name in COMMAND_ATTRIBUTE_NAMES:
+        _register_commands()
+        if name in globals() and globals()[name] is not None:
+            return globals()[name]
+        raise AttributeError(f"CLI command '{name}' is unavailable")
+    raise AttributeError(f"module '{__name__}' has no attribute '{name}'")
+
 
 __all__ = [
     "config_app",
@@ -141,3 +95,6 @@ __all__ = [
     "ingest_cmd",
     "COMMAND_REGISTRY",
 ] + list(COMMAND_ATTRIBUTE_NAMES)
+
+
+_register_commands()

--- a/src/devsynth/application/cli/autocomplete.py
+++ b/src/devsynth/application/cli/autocomplete.py
@@ -5,10 +5,13 @@ and their arguments. It uses Typer's autocompletion mechanism to provide
 suggestions as the user types.
 """
 
+from __future__ import annotations
+
 from pathlib import Path
-from typing import Any, List, Optional
 
 import typer
+
+from devsynth.application.cli.models import TyperAutocomplete
 
 # List of all available commands
 COMMANDS = [
@@ -124,7 +127,7 @@ COMMAND_EXAMPLES = {
 }
 
 
-def get_completions(incomplete: str) -> List[str]:
+def get_completions(incomplete: str) -> list[str]:
     """Get command completion suggestions based on the incomplete input.
 
     Args:
@@ -151,7 +154,7 @@ def complete_command(incomplete: str) -> str:
     return incomplete
 
 
-def command_autocomplete(ctx: typer.Context, incomplete: str) -> List[str]:
+def command_autocomplete(ctx: typer.Context, incomplete: str) -> list[str]:
     """Provide autocompletion for DevSynth commands.
 
     This function is used by Typer to provide command autocompletion.
@@ -166,7 +169,7 @@ def command_autocomplete(ctx: typer.Context, incomplete: str) -> List[str]:
     return get_completions(incomplete)
 
 
-def file_path_autocomplete(ctx: typer.Context, incomplete: str) -> List[str]:
+def file_path_autocomplete(ctx: typer.Context, incomplete: str) -> list[str]:
     """Provide autocompletion for file paths.
 
     Args:
@@ -244,7 +247,7 @@ def get_all_commands_help() -> str:
 
 
 def generate_completion_script(
-    shell: str = "bash", install: bool = False, path: Optional[Path] = None
+    shell: str = "bash", install: bool = False, path: Path | None = None
 ) -> str:
     """Generate a shell completion script for the DevSynth CLI.
 
@@ -273,6 +276,10 @@ def generate_completion_script(
         return str(target)
 
     return script
+
+
+_COMMAND_AUTOCOMPLETE: TyperAutocomplete = command_autocomplete
+_FILE_PATH_AUTOCOMPLETE: TyperAutocomplete = file_path_autocomplete
 
 
 __all__ = [

--- a/src/devsynth/application/cli/models.py
+++ b/src/devsynth/application/cli/models.py
@@ -1,0 +1,103 @@
+from __future__ import annotations
+
+"""Data transfer objects and protocols for CLI infrastructure."""
+
+from collections.abc import Callable, Mapping, Sequence
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, TypeAlias
+
+from rich.console import RenderableType
+
+if TYPE_CHECKING:  # pragma: no cover - import for typing only
+    from typer import Context
+
+    from devsynth.application.cli.command_output_formatter import (
+        CommandOutputStyle,
+        CommandOutputType,
+    )
+
+
+BridgeErrorPayload: TypeAlias = Exception | Mapping[str, object] | str
+"""Payload accepted by UX bridge error handlers."""
+
+
+CommandTableRow: TypeAlias = Mapping[str, object]
+CommandTableData: TypeAlias = Sequence[CommandTableRow]
+CommandListData: TypeAlias = Sequence[object]
+
+
+@dataclass(frozen=True, slots=True)
+class CommandDisplay:
+    """Representation of formatted CLI content ready for rendering."""
+
+    renderable: RenderableType
+    output_type: "CommandOutputType"
+    output_style: "CommandOutputStyle"
+    title: str | None = None
+    subtitle: str | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class ProgressHistoryEntry:
+    """Capture of a status transition for a long running task."""
+
+    time: float
+    status: str
+    completed: float
+
+
+@dataclass(frozen=True, slots=True)
+class ProgressCheckpoint:
+    """Checkpoint recorded during long running progress updates."""
+
+    time: float
+    progress: float
+    eta: float
+
+
+@dataclass(frozen=True, slots=True)
+class ProgressSnapshot:
+    """Immutable snapshot of current progress state."""
+
+    description: str
+    progress: float
+    elapsed: float
+    elapsed_str: str
+    subtasks: int
+    history: Sequence[ProgressHistoryEntry] = field(default_factory=tuple)
+    checkpoints: Sequence[ProgressCheckpoint] = field(default_factory=tuple)
+    eta: float | None = None
+    eta_str: str | None = None
+    remaining: float | None = None
+    remaining_str: str | None = None
+
+
+@dataclass(slots=True)
+class SubtaskState:
+    """Runtime information tracked for each subtask."""
+
+    task_id: int
+    total: float
+
+
+@dataclass(frozen=True, slots=True)
+class ProgressSubtaskSpec:
+    """Configuration for a subtask provided when starting progress."""
+
+    name: str
+    total: int = 100
+    status: str = "Starting..."
+
+
+ProgressSubtaskLike: TypeAlias = ProgressSubtaskSpec | Mapping[str, object]
+ProgressUpdate: TypeAlias = Callable[[float, str | None, str | None, str | None], None]
+TyperAutocomplete: TypeAlias = Callable[["Context", str], list[str]]
+CommandResultData: TypeAlias = (
+    str
+    | CommandTableRow
+    | CommandTableData
+    | CommandListData
+    | CommandDisplay
+)
+"""Supported input values for standardized command formatting."""
+

--- a/tests/unit/application/cli/test_command_output_formatter.py
+++ b/tests/unit/application/cli/test_command_output_formatter.py
@@ -10,6 +10,7 @@ from devsynth.application.cli.command_output_formatter import (
     CommandOutputType,
     StandardizedOutputFormatter,
 )
+from devsynth.application.cli.models import CommandDisplay
 
 
 @pytest.fixture()
@@ -21,8 +22,9 @@ def formatter():
 @pytest.mark.fast
 def test_format_message_minimal_returns_text(formatter):
     out = formatter.format_message("hello", output_style=CommandOutputStyle.MINIMAL)
-    assert isinstance(out, Text)
-    assert "hello" in out.plain
+    assert isinstance(out, CommandDisplay)
+    assert isinstance(out.renderable, Text)
+    assert "hello" in out.renderable.plain
 
 
 @pytest.mark.fast
@@ -30,8 +32,9 @@ def test_format_message_simple_highlight_false_returns_str(formatter):
     out = formatter.format_message(
         "hello", output_style=CommandOutputStyle.SIMPLE, highlight=False
     )
-    assert isinstance(out, str)
-    assert out == "hello"
+    assert isinstance(out, CommandDisplay)
+    assert isinstance(out.renderable, str)
+    assert out.renderable == "hello"
 
 
 @pytest.mark.fast
@@ -40,21 +43,24 @@ def test_format_message_standard_with_markup_returns_panel_passthrough(formatter
     out = formatter.format_message(
         "[bold]hi[/bold]", output_style=CommandOutputStyle.STANDARD
     )
-    assert isinstance(out, Panel)
+    assert isinstance(out, CommandDisplay)
+    assert isinstance(out.renderable, Panel)
 
 
 @pytest.mark.fast
 def test_format_table_with_dict_and_list(formatter):
     tbl1 = formatter.format_table({"a": 1, "b": {"x": 2}})
     tbl2 = formatter.format_table([{"a": 1, "b": 2}, {"a": 3, "b": 4}])
-    assert hasattr(tbl1, "add_row") and hasattr(tbl2, "add_row")
+    assert isinstance(tbl1, CommandDisplay)
+    assert isinstance(tbl2, CommandDisplay)
+    assert hasattr(tbl1.renderable, "add_row") and hasattr(tbl2.renderable, "add_row")
 
 
 @pytest.mark.fast
 def test_format_table_with_unsupported_type_falls_back(formatter):
     tbl = formatter.format_table(42)
-    # The table should have a single column named "Data"
-    assert any(col.header == "Data" for col in tbl.columns)
+    assert isinstance(tbl, CommandDisplay)
+    assert any(col.header == "Data" for col in tbl.renderable.columns)
 
 
 @pytest.mark.fast
@@ -63,9 +69,12 @@ def test_format_list_variants(formatter):
     minimal = formatter.format_list(items, output_style=CommandOutputStyle.MINIMAL)
     simple = formatter.format_list(items, output_style=CommandOutputStyle.SIMPLE)
     standard = formatter.format_list(items, output_style=CommandOutputStyle.STANDARD)
-    assert isinstance(minimal, str)
-    assert isinstance(simple, Text)
-    assert isinstance(standard, Panel)
+    assert isinstance(minimal, CommandDisplay)
+    assert isinstance(simple, CommandDisplay)
+    assert isinstance(standard, CommandDisplay)
+    assert isinstance(minimal.renderable, str)
+    assert isinstance(simple.renderable, Text)
+    assert isinstance(standard.renderable, Panel)
 
 
 @pytest.mark.fast
@@ -74,12 +83,15 @@ def test_format_code_variants(formatter):
     minimal = formatter.format_code(code, output_style=CommandOutputStyle.MINIMAL)
     simple = formatter.format_code(code, output_style=CommandOutputStyle.SIMPLE)
     standard = formatter.format_code(code, output_style=CommandOutputStyle.STANDARD)
-    assert isinstance(minimal, str)
+    assert isinstance(minimal, CommandDisplay)
     # SIMPLE returns a Syntax object rendered via Rich
     from rich.syntax import Syntax
 
-    assert isinstance(simple, Syntax)
-    assert isinstance(standard, Panel)
+    assert isinstance(simple, CommandDisplay)
+    assert isinstance(standard, CommandDisplay)
+    assert isinstance(minimal.renderable, str)
+    assert isinstance(simple.renderable, Syntax)
+    assert isinstance(standard.renderable, Panel)
 
 
 @pytest.mark.fast
@@ -111,9 +123,12 @@ def test_format_help_variants(formatter):
         output_style=CommandOutputStyle.STANDARD,
     )
 
-    assert isinstance(minimal, str)
-    assert isinstance(simple, Text)
-    assert isinstance(standard, Panel)
+    assert isinstance(minimal, CommandDisplay)
+    assert isinstance(simple, CommandDisplay)
+    assert isinstance(standard, CommandDisplay)
+    assert isinstance(minimal.renderable, str)
+    assert isinstance(simple.renderable, Text)
+    assert isinstance(standard.renderable, Panel)
 
 
 @pytest.mark.fast


### PR DESCRIPTION
## Summary
- add typed CLI data models for command formatting, progress snapshots, and Typer callbacks and refactor helpers to return them
- lazily register CLI command callables and provide a lightweight devsynth.config stub so optional dependencies no longer break imports
- update CLI unit tests to validate the new dataclasses and typed progress history/checkpoints

## Testing
- poetry run mypy --strict src/devsynth/application/cli/autocomplete.py src/devsynth/application/cli/command_output_formatter.py src/devsynth/application/cli/long_running_progress.py src/devsynth/application/cli/utils.py
- PYTHONPATH=src poetry run python -m pytest tests/unit/application/cli/test_command_output_formatter.py tests/unit/application/cli/test_long_running_progress.py tests/unit/application/cli/test_autocomplete.py

------
https://chatgpt.com/codex/tasks/task_e_68d98ad9f7e4833395b71b5f4136e597