### PR TITLE
feat: add collaboration DTOs with deterministic persistence

### DIFF
--- a/src/devsynth/application/collaboration/dto.py
+++ b/src/devsynth/application/collaboration/dto.py
@@ -1,0 +1,396 @@
+"""Typed data-transfer objects for collaboration workflows."""
+
+from __future__ import annotations
+
+from collections import OrderedDict
+from collections.abc import Mapping as MappingABC, Sequence as SequenceABC
+from dataclasses import MISSING, dataclass, field, fields
+from typing import (
+    Any,
+    ClassVar,
+    Dict,
+    Iterable,
+    Mapping,
+    Optional,
+    Sequence,
+    Tuple,
+    Type,
+    TypeVar,
+    Union,
+    get_args,
+    get_origin,
+)
+
+
+__all__ = [
+    "AgentPayload",
+    "TaskDescriptor",
+    "ConsensusOutcome",
+    "ReviewDecision",
+    "PeerReviewRecord",
+    "MemorySyncPort",
+    "CollaborationDTO",
+    "MessagePayload",
+    "deserialize_collaboration_dto",
+    "serialize_collaboration_dto",
+    "serialize_message_payload",
+    "deserialize_message_payload",
+    "ensure_collaboration_payload",
+    "ensure_memory_sync_port",
+    "serialize_memory_sync_port",
+]
+
+
+T = TypeVar("T", bound="BaseDTO")
+
+
+def _ordered_mapping(items: Iterable[Tuple[str, Any]]) -> Dict[str, Any]:
+    return dict(OrderedDict(sorted(items, key=lambda item: item[0])))
+
+
+def _serialize_value(value: Any) -> Any:
+    if isinstance(value, BaseDTO):
+        return value.to_dict()
+    if isinstance(value, MappingABC):
+        return _ordered_mapping((str(k), _serialize_value(v)) for k, v in value.items())
+    if isinstance(value, SequenceABC) and not isinstance(value, (str, bytes, bytearray)):
+        return [_serialize_value(v) for v in value]
+    return value
+
+
+def _normalize_mapping(value: MappingABC[str, Any]) -> Dict[str, Any]:
+    return _ordered_mapping((str(k), _deserialize_arbitrary(v)) for k, v in value.items())
+
+
+def _deserialize_arbitrary(value: Any) -> Any:
+    if isinstance(value, MappingABC):
+        return _normalize_mapping(value)
+    if isinstance(value, SequenceABC) and not isinstance(value, (str, bytes, bytearray)):
+        return [_deserialize_arbitrary(v) for v in value]
+    return value
+
+
+def _is_optional(annotation: Any) -> bool:
+    origin = get_origin(annotation)
+    if origin is Union:
+        args = get_args(annotation)
+        return any(arg is type(None) for arg in args)
+    return False
+
+
+def _unwrap_optional(annotation: Any) -> Any:
+    args = [arg for arg in get_args(annotation) if arg is not type(None)]
+    return args[0] if args else Any
+
+
+def _coerce_value(annotation: Any, value: Any) -> Any:
+    if value is None:
+        return None
+
+    origin = get_origin(annotation)
+
+    if origin is Union and _is_optional(annotation):
+        return _coerce_value(_unwrap_optional(annotation), value)
+
+    if isinstance(value, BaseDTO):
+        return value
+
+    if isinstance(annotation, type) and issubclass_safe(annotation, BaseDTO):
+        return annotation.from_dict(value)
+
+    if origin in {list, tuple}:
+        item_type = get_args(annotation)[0] if get_args(annotation) else Any
+        coerced = [_coerce_value(item_type, v) for v in value]
+        return tuple(coerced) if origin is tuple else coerced
+
+    if origin in {dict, Mapping} and isinstance(value, MappingABC):
+        return _normalize_mapping(value)
+
+    return _deserialize_arbitrary(value)
+
+
+def issubclass_safe(candidate: Any, parent: Type[Any]) -> bool:
+    try:
+        return isinstance(candidate, type) and issubclass(candidate, parent)
+    except TypeError:
+        return False
+
+
+class BaseDTO:
+    """Base helpers for DTO serialization."""
+
+    dto_type: ClassVar[str]
+    extra_field_name: ClassVar[Optional[str]] = None
+
+    def to_dict(self) -> Dict[str, Any]:
+        result_items = [("dto_type", self.dto_type)]
+        for field_info in fields(self):
+            value = getattr(self, field_info.name)
+            result_items.append((field_info.name, _serialize_value(value)))
+        return dict(OrderedDict(result_items))
+
+    @classmethod
+    def from_dict(cls: Type[T], data: Mapping[str, Any]) -> T:
+        if not isinstance(data, MappingABC):
+            raise TypeError(f"Expected mapping for {cls.__name__}, received {type(data)!r}")
+
+        prepared: Dict[str, Any] = {}
+        for key, value in data.items():
+            if key == "dto_type":
+                continue
+            prepared[str(key)] = value
+
+        field_map = {f.name: f for f in fields(cls)}
+        kwargs: Dict[str, Any] = {}
+        extras: Dict[str, Any] = {}
+
+        for name, value in prepared.items():
+            field_info = field_map.get(name)
+            if field_info is None:
+                extras[name] = _deserialize_arbitrary(value)
+                continue
+            kwargs[name] = _coerce_value(field_info.type, value)
+
+        extra_field = cls.extra_field_name
+        if extras:
+            if extra_field and extra_field in field_map:
+                current = kwargs.get(extra_field)
+                if current is None:
+                    current_map: Dict[str, Any] = {}
+                elif isinstance(current, MappingABC):
+                    current_map = dict(current)
+                else:
+                    current_map = {}
+                current_map.update(extras)
+                kwargs[extra_field] = _normalize_mapping(current_map)
+            else:
+                raise ValueError(
+                    f"Unexpected extra fields for {cls.__name__}: {sorted(extras.keys())}"
+                )
+
+        for field_info in field_map.values():
+            if field_info.init and field_info.name not in kwargs:
+                if field_info.default is not MISSING:
+                    kwargs[field_info.name] = field_info.default
+                elif field_info.default_factory is not MISSING:  # type: ignore[attr-defined]
+                    kwargs[field_info.name] = field_info.default_factory()  # type: ignore[misc]
+
+        return cls(**kwargs)  # type: ignore[arg-type]
+
+
+def _dto_type_name(cls: Type[BaseDTO]) -> str:
+    return getattr(cls, "dto_type", cls.__name__)
+
+
+def _register_dto(cls: Type[T]) -> Type[T]:
+    dto_registry[_dto_type_name(cls)] = cls
+    return cls
+
+
+@dataclass(frozen=True, slots=True)
+class AgentPayload(BaseDTO):
+    dto_type: ClassVar[str] = "AgentPayload"
+    extra_field_name: ClassVar[str] = "attributes"
+
+    agent_id: Optional[str] = None
+    display_name: Optional[str] = None
+    role: Optional[str] = None
+    status: Optional[str] = None
+    summary: Optional[str] = None
+    attributes: Mapping[str, Any] = field(default_factory=dict)
+    payload: Optional[Any] = None
+
+
+@dataclass(frozen=True, slots=True)
+class TaskDescriptor(BaseDTO):
+    dto_type: ClassVar[str] = "TaskDescriptor"
+    extra_field_name: ClassVar[str] = "metadata"
+
+    task_id: Optional[str] = None
+    summary: Optional[str] = None
+    description: Optional[str] = None
+    status: Optional[str] = None
+    assignee: Optional[str] = None
+    tags: Tuple[str, ...] = ()
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True, slots=True)
+class ConsensusOutcome(BaseDTO):
+    dto_type: ClassVar[str] = "ConsensusOutcome"
+    extra_field_name: ClassVar[str] = "metadata"
+
+    consensus_id: Optional[str] = None
+    achieved: Optional[bool] = None
+    confidence: Optional[float] = None
+    rationale: Optional[str] = None
+    participants: Tuple[str, ...] = ()
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True, slots=True)
+class ReviewDecision(BaseDTO):
+    dto_type: ClassVar[str] = "ReviewDecision"
+    extra_field_name: ClassVar[str] = "metadata"
+
+    decision_id: Optional[str] = None
+    reviewer: Optional[str] = None
+    approved: Optional[bool] = None
+    notes: Optional[str] = None
+    score: Optional[float] = None
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True, slots=True)
+class PeerReviewRecord(BaseDTO):
+    dto_type: ClassVar[str] = "PeerReviewRecord"
+    extra_field_name: ClassVar[str] = "metadata"
+
+    task: Optional[TaskDescriptor] = None
+    decision: Optional[ReviewDecision] = None
+    consensus: Optional[ConsensusOutcome] = None
+    reviewers: Tuple[str, ...] = ()
+    notes: Optional[str] = None
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True, slots=True)
+class MemorySyncPort(BaseDTO):
+    dto_type: ClassVar[str] = "MemorySyncPort"
+    extra_field_name: ClassVar[str] = "options"
+
+    adapter: str = "conversation"
+    channel: str = "default"
+    priority: Optional[str] = None
+    options: Mapping[str, Any] = field(default_factory=dict)
+
+
+dto_registry: Dict[str, Type[BaseDTO]] = {}
+
+for cls in (
+    AgentPayload,
+    TaskDescriptor,
+    ConsensusOutcome,
+    ReviewDecision,
+    PeerReviewRecord,
+    MemorySyncPort,
+):
+    _register_dto(cls)
+
+
+CollaborationDTO = Union[
+    AgentPayload,
+    TaskDescriptor,
+    ConsensusOutcome,
+    ReviewDecision,
+    PeerReviewRecord,
+]
+
+LegacyPayload = Union[str, int, float, bool, None, Sequence[Any], Mapping[str, Any]]
+
+MessagePayload = Union[CollaborationDTO, LegacyPayload]
+
+
+def serialize_collaboration_dto(dto: CollaborationDTO) -> Dict[str, Any]:
+    return dto.to_dict()
+
+
+def deserialize_collaboration_dto(data: Mapping[str, Any]) -> CollaborationDTO:
+    if not isinstance(data, MappingABC):
+        raise TypeError("Collaborative payload must be provided as a mapping")
+
+    dto_type = data.get("dto_type")
+    if dto_type:
+        dto_cls = dto_registry.get(str(dto_type))
+        if dto_cls is None:
+            raise ValueError(f"Unknown dto_type '{dto_type}'")
+        instance = dto_cls.from_dict(data)
+        if isinstance(instance, MemorySyncPort):
+            raise TypeError("Expected collaboration DTO, received MemorySyncPort")
+        return instance  # type: ignore[return-value]
+
+    # Fallback to AgentPayload to avoid data loss for legacy entries.
+    return AgentPayload.from_dict(data)  # type: ignore[return-value]
+
+
+def serialize_message_payload(payload: MessagePayload) -> Any:
+    if isinstance(payload, BaseDTO):
+        return payload.to_dict()
+    if isinstance(payload, MappingABC):
+        return _normalize_mapping(payload)
+    if isinstance(payload, SequenceABC) and not isinstance(payload, (str, bytes, bytearray)):
+        return [_serialize_value(item) for item in payload]
+    return payload
+
+
+def deserialize_message_payload(data: Any) -> MessagePayload:
+    if isinstance(data, MappingABC):
+        dto_type = data.get("dto_type")
+        if dto_type:
+            dto_cls = dto_registry.get(str(dto_type))
+            if dto_cls is not None:
+                instance = dto_cls.from_dict(data)
+                if isinstance(instance, MemorySyncPort):
+                    return instance.to_dict()
+                return instance  # type: ignore[return-value]
+        return _normalize_mapping(data)
+    if isinstance(data, SequenceABC) and not isinstance(data, (str, bytes, bytearray)):
+        return [_deserialize_arbitrary(item) for item in data]
+    return data
+
+
+def ensure_collaboration_payload(
+    content: Any, *, default: Type[CollaborationDTO] = AgentPayload
+) -> CollaborationDTO:
+    if isinstance(content, BaseDTO):
+        if isinstance(content, MemorySyncPort):
+            raise TypeError("MemorySyncPort cannot be used as message content")
+        return content  # type: ignore[return-value]
+
+    if isinstance(content, MappingABC):
+        try:
+            return deserialize_collaboration_dto(dict(content))
+        except Exception:
+            pass
+
+    if isinstance(content, str):
+        return default.from_dict({"summary": content})
+
+    if isinstance(content, (int, float, bool)):
+        return default.from_dict({"payload": content})  # type: ignore[arg-type]
+
+    if isinstance(content, SequenceABC) and not isinstance(content, (str, bytes, bytearray)):
+        return default.from_dict({"payload": list(content)})  # type: ignore[arg-type]
+
+    raise TypeError("Unsupported message content type for collaboration payload")
+
+
+def ensure_memory_sync_port(
+    metadata: Optional[Union[MemorySyncPort, Mapping[str, Any]]]
+) -> Optional[MemorySyncPort]:
+    if metadata is None:
+        return None
+    if isinstance(metadata, MemorySyncPort):
+        return metadata
+    if isinstance(metadata, MappingABC):
+        base = dict(metadata)
+        adapter = str(base.pop("adapter", "conversation"))
+        channel = str(base.pop("channel", "default"))
+        priority_value = base.pop("priority", None)
+        priority = str(priority_value) if priority_value is not None else None
+        nested_options = base.pop("options", {})
+        base.pop("dto_type", None)
+        if isinstance(nested_options, MappingABC):
+            for key, value in nested_options.items():
+                base.setdefault(key, value)
+        options = _normalize_mapping(base) if base else {}
+        return MemorySyncPort(adapter=adapter, channel=channel, priority=priority, options=options)
+    raise TypeError("Metadata must be MemorySyncPort or mapping type")
+
+
+def serialize_memory_sync_port(metadata: Optional[MemorySyncPort]) -> Optional[Dict[str, Any]]:
+    if metadata is None:
+        return None
+    return metadata.to_dict()
+
+

--- a/tests/unit/application/collaboration/test_message_protocol.py
+++ b/tests/unit/application/collaboration/test_message_protocol.py
@@ -1,24 +1,216 @@
+import json
+import os
+import sys
+import types
+from pathlib import Path
+
 import pytest
 
+if "argon2" not in sys.modules:
+    argon2_stub = types.ModuleType("argon2")
+    exceptions_stub = types.ModuleType("argon2.exceptions")
+
+    class _VerifyMismatchError(Exception):
+        """Placeholder mismatch error."""
+
+    exceptions_stub.VerifyMismatchError = _VerifyMismatchError
+    sys.modules["argon2.exceptions"] = exceptions_stub
+
+    class _PasswordHasher:  # pragma: no cover - test shim
+        def __init__(self, *args: object, **kwargs: object) -> None:  # noqa: D401 - minimal stub
+            """Stub password hasher for tests without argon2 dependency."""
+
+        def hash(self, password: str) -> str:
+            return password
+
+        def verify(self, hashed: str, password: str) -> bool:
+            return hashed == password
+
+    argon2_stub.PasswordHasher = _PasswordHasher
+    argon2_stub.exceptions = exceptions_stub
+    sys.modules["argon2"] = argon2_stub
+
+
+if "jsonschema" not in sys.modules:
+    jsonschema_stub = types.ModuleType("jsonschema")
+
+    def _validate(instance: object, schema: object, *args: object, **kwargs: object) -> bool:
+        return True
+
+    class _DraftValidator:  # pragma: no cover - shim
+        def __init__(self, *args: object, **kwargs: object) -> None:  # noqa: D401 - stub
+            """Minimal validator stub."""
+
+        def validate(self, instance: object, schema: object) -> bool:
+            return True
+
+    jsonschema_stub.validate = _validate
+    jsonschema_stub.Draft7Validator = _DraftValidator
+    sys.modules["jsonschema"] = jsonschema_stub
+
+
+if "toml" not in sys.modules:
+    toml_stub = types.ModuleType("toml")
+
+    def _loads(content: str, *args: object, **kwargs: object) -> dict[str, object]:
+        return {}
+
+    def _load(fp: object, *args: object, **kwargs: object) -> dict[str, object]:
+        return {}
+
+    class _TomlDecodeError(Exception):
+        """Placeholder TOML decode error."""
+
+    toml_stub.loads = _loads
+    toml_stub.load = _load
+    toml_stub.TomlDecodeError = _TomlDecodeError
+    sys.modules["toml"] = toml_stub
+
+
+if "yaml" not in sys.modules:
+    yaml_stub = types.ModuleType("yaml")
+
+    def _safe_load(stream: object) -> dict[str, object]:
+        return {}
+
+    yaml_stub.safe_load = _safe_load
+    sys.modules["yaml"] = yaml_stub
+
+
+if "pydantic" not in sys.modules:
+    pydantic_stub = types.ModuleType("pydantic")
+
+    class _BaseModel:  # pragma: no cover - shim
+        def __init__(self, *args: object, **kwargs: object) -> None:  # noqa: D401 - stub
+            """Minimal pydantic-like base model."""
+
+            if args:
+                raise TypeError("Positional arguments are not supported in stub")
+            for key, value in kwargs.items():
+                setattr(self, key, value)
+
+    class _ValidationError(Exception):
+        """Placeholder validation error."""
+
+    pydantic_stub.BaseModel = _BaseModel
+    pydantic_stub.ValidationError = _ValidationError
+    pydantic_stub.Field = lambda default=None, **kwargs: default  # type: ignore[assignment]
+
+    class _FieldValidationInfo:  # pragma: no cover - shim
+        """Placeholder field validation info."""
+
+    pydantic_stub.FieldValidationInfo = _FieldValidationInfo
+
+    def _field_validator(*fields: str, **kwargs: object):  # pragma: no cover - shim
+        def decorator(func):
+            return func
+
+        return decorator
+
+    pydantic_stub.field_validator = _field_validator
+    dataclasses_stub = types.ModuleType("pydantic.dataclasses")
+
+    def _dataclass(cls: type | None = None, **kwargs: object):  # pragma: no cover - shim
+        def decorator(target: type) -> type:
+            return target
+
+        if cls is None:
+            return decorator
+        return cls
+
+    dataclasses_stub.dataclass = _dataclass
+    sys.modules["pydantic.dataclasses"] = dataclasses_stub
+    pydantic_stub.dataclasses = dataclasses_stub
+    sys.modules["pydantic"] = pydantic_stub
+
+
+if "pydantic_settings" not in sys.modules:
+    settings_stub = types.ModuleType("pydantic_settings")
+
+    class _BaseSettings:  # pragma: no cover - shim
+        model_config: dict[str, object] = {}
+
+        def __init__(self, *args: object, **kwargs: object) -> None:  # noqa: D401 - stub
+            """Minimal settings base class."""
+
+    class _SettingsConfigDict(dict):
+        """Dictionary subclass placeholder."""
+
+    settings_stub.BaseSettings = _BaseSettings
+    settings_stub.SettingsConfigDict = _SettingsConfigDict
+    sys.modules["pydantic_settings"] = settings_stub
+
+
+if "devsynth.application.memory.memory_manager" not in sys.modules:
+    memory_manager_stub = types.ModuleType("devsynth.application.memory.memory_manager")
+
+    class _MemoryManager:  # pragma: no cover - shim
+        def __init__(self, *args: object, **kwargs: object) -> None:  # noqa: D401 - stub
+            self.adapters: dict[str, object] = {}
+
+        def update_item(self, *args: object, **kwargs: object) -> None:
+            return None
+
+        def flush_updates(self) -> None:
+            return None
+
+    memory_manager_stub.MemoryManager = _MemoryManager
+    sys.modules["devsynth.application.memory.memory_manager"] = memory_manager_stub
+    application_memory_stub = types.ModuleType("devsynth.application.memory")
+    application_memory_stub.__path__ = []  # type: ignore[attr-defined]
+    application_memory_stub.MemoryManager = _MemoryManager
+    sys.modules["devsynth.application.memory"] = application_memory_stub
+
+
+if "devsynth.config.settings" not in sys.modules:
+    config_settings_stub = types.ModuleType("devsynth.config.settings")
+
+    def _ensure_path_exists(path: object) -> None:  # pragma: no cover - shim
+        return None
+
+    def _get_settings() -> types.SimpleNamespace:
+        return types.SimpleNamespace(wsde_settings={}, memory_store_type="memory")
+
+    config_settings_stub.ensure_path_exists = _ensure_path_exists
+    config_settings_stub.get_settings = _get_settings
+    sys.modules["devsynth.config.settings"] = config_settings_stub
+
+
+if "devsynth.config" not in sys.modules:
+    config_stub = types.ModuleType("devsynth.config")
+    config_stub.get_settings = lambda: types.SimpleNamespace(wsde_settings={}, memory_store_type="memory")
+    config_stub.get_llm_settings = lambda: {}
+    config_stub.load_dotenv = lambda *args, **kwargs: None
+    config_stub._settings = types.SimpleNamespace(wsde_settings={}, memory_store_type="memory")
+    sys.modules["devsynth.config"] = config_stub
+
+
+from devsynth.application.collaboration.dto import (
+    AgentPayload,
+    MemorySyncPort,
+    TaskDescriptor,
+)
 from devsynth.application.collaboration.message_protocol import (
     MessageProtocol,
+    MessageStore,
     MessageType,
 )
 
 
 @pytest.mark.medium
-def test_send_message_priority_succeeds():
-    """Test that send message priority succeeds.
+def test_send_message_priority_succeeds(tmp_path: Path) -> None:
+    """High priority metadata remains prioritized after DTO conversion."""
 
-    ReqID: N/A"""
-    proto = MessageProtocol()
+    storage = tmp_path / "messages.json"
+    proto = MessageProtocol(store=MessageStore(storage_file=str(storage)))
+
     proto.send_message(
         sender="a",
         recipients=["b"],
         message_type=MessageType.STATUS_UPDATE,
         subject="s",
         content="c",
-        metadata={"priority": "high"},
+        metadata={"priority": "high", "channel": "inbox"},
     )
     proto.send_message(
         sender="a",
@@ -26,24 +218,85 @@ def test_send_message_priority_succeeds():
         message_type=MessageType.STATUS_UPDATE,
         subject="s2",
         content="c2",
-        metadata={},
     )
-    assert proto.history[0].metadata.get("priority") == "high"
+
+    assert proto.history[0].metadata is not None
+    assert isinstance(proto.history[0].metadata, MemorySyncPort)
+    assert proto.history[0].metadata.priority == "high"
+    assert proto.history[0].metadata.channel == "inbox"
 
 
 @pytest.mark.medium
-def test_get_messages_filtered_succeeds():
-    """Test that get messages filtered succeeds.
+def test_get_messages_filtered_succeeds(tmp_path: Path) -> None:
+    """Messages retrieved via filters preserve DTO content."""
 
-    ReqID: N/A"""
-    proto = MessageProtocol()
+    storage = tmp_path / "messages.json"
+    proto = MessageProtocol(store=MessageStore(storage_file=str(storage)))
+    payload = TaskDescriptor(task_id="task-1", summary="demo", tags=("alpha", "beta"))
     msg = proto.send_message(
         sender="a",
         recipients=["b"],
         message_type=MessageType.DECISION_REQUEST,
         subject="x",
-        content="y",
-        metadata={},
+        content=payload,
     )
+
     result = proto.get_messages("b", {"message_type": MessageType.DECISION_REQUEST})
+
     assert result == [msg]
+    assert isinstance(result[0].content, TaskDescriptor)
+    assert result[0].content == payload
+
+
+@pytest.mark.medium
+def test_dto_round_trip_and_deterministic_serialization(tmp_path: Path) -> None:
+    """DTO helpers yield deterministic dictionaries suitable for persistence."""
+
+    os.environ["DEVSYNTH_NO_FILE_LOGGING"] = "0"
+    storage = tmp_path / "messages.json"
+    store = MessageStore(storage_file=str(storage))
+    proto = MessageProtocol(store=store)
+
+    payload = AgentPayload(
+        agent_id="agent-123",
+        display_name="Analyst",
+        role="reviewer",
+        attributes={"b": 2, "a": 1},
+        payload=["checkpoint", "complete"],
+    )
+    metadata = MemorySyncPort(adapter="tinydb", channel="primary", priority="medium", options={"retention": "long"})
+
+    proto.send_message(
+        sender="analyst",
+        recipients=["lead"],
+        message_type=MessageType.STATUS_UPDATE,
+        subject="Report",
+        content=payload,
+        metadata=metadata,
+    )
+
+    serialized_payload = payload.to_dict()
+    assert list(serialized_payload.keys()) == [
+        "dto_type",
+        "agent_id",
+        "display_name",
+        "role",
+        "status",
+        "summary",
+        "attributes",
+        "payload",
+    ]
+    assert list(serialized_payload["attributes"].keys()) == ["a", "b"]
+    assert AgentPayload.from_dict(serialized_payload) == payload
+
+    reloaded_store = MessageStore(storage_file=str(storage))
+    reloaded_messages = reloaded_store.get_all_messages()
+    assert len(reloaded_messages) == 1
+    reloaded = reloaded_messages[0]
+    assert isinstance(reloaded.content, AgentPayload)
+    assert reloaded.content == payload
+    assert reloaded.metadata == metadata
+
+    with storage.open("r", encoding="utf-8") as handle:
+        file_data = json.load(handle)
+    assert file_data["messages"][0]["content"]["attributes"] == {"a": 1, "b": 2}


### PR DESCRIPTION
## Summary
- add typed collaboration DTOs with deterministic to_dict/from_dict helpers for agent payloads and memory sync metadata
- refactor the message protocol to serialize message content and metadata through the new DTO layer while preserving legacy data
- extend message protocol unit tests to cover DTO round-tripping and deterministic storage with lightweight dependency stubs

## Testing
- poetry run pytest tests/unit/application/collaboration/test_message_protocol.py


------
https://chatgpt.com/codex/tasks/task_e_68d99e4848948333b03c39fe9a4cab35