### PR TITLE
feat: align collaboration DTO serialization with dataclasses

### DIFF
--- a/tests/unit/application/collaboration/test_agent_collaboration_system.py
+++ b/tests/unit/application/collaboration/test_agent_collaboration_system.py
@@ -1,22 +1,28 @@
 import pytest
 
+import pytest
+
 from devsynth.application.collaboration.agent_collaboration import (
     AgentCollaborationSystem,
     AgentMessage,
     MessageType,
 )
+from devsynth.application.collaboration.dto import AgentPayload
 
 
 @pytest.mark.fast
 def test_agent_message_to_dict() -> None:
     """ReqID: N/A"""
 
-    msg = AgentMessage("a", "b", MessageType.TASK_ASSIGNMENT, {"x": 1})
+    payload = AgentPayload(attributes={"x": 1})
+    msg = AgentMessage("a", "b", MessageType.TASK_ASSIGNMENT, payload)
     data = msg.to_dict()
     assert data["sender_id"] == "a"
     assert data["recipient_id"] == "b"
     assert data["message_type"] == "TASK_ASSIGNMENT"
-    assert data["content"] == {"x": 1}
+    assert data["content"]["dto_type"] == "AgentPayload"
+    assert data["content"]["attributes"] == {"x": 1}
+    assert msg.content == {"x": 1}
 
 
 class DummyMemoryManager:

--- a/tests/unit/application/collaboration/test_memory_utils_conversion.py
+++ b/tests/unit/application/collaboration/test_memory_utils_conversion.py
@@ -17,3 +17,6 @@ def test_task_round_trip_to_memory_item() -> None:
     restored = from_memory_item(item)
     assert isinstance(restored, CollaborationTask)
     assert restored.id == task.id
+    assert item.content["descriptor"]["dto_type"] == "TaskDescriptor"
+    assert restored.descriptor.task_id == task.id
+    assert restored.inputs == {"x": 1}


### PR DESCRIPTION
## Summary
- convert AgentMessage and CollaborationTask into dataclasses backed by AgentPayload and TaskDescriptor DTOs, keeping descriptors in sync with assignments and status updates
- normalize collaboration memory serialization to use DTO to_dict/from_dict helpers and propagate MemorySyncPort metadata when flushing or restoring queues
- refresh unit tests to assert DTO-aware serialization for messages and tasks

## Testing
- poetry run pytest tests/unit/application/collaboration/test_agent_collaboration_system.py tests/unit/application/collaboration/test_memory_utils_conversion.py

------
https://chatgpt.com/codex/tasks/task_e_68d9ab87a5f48333a7e32dd8f8d0b673