### PR TITLE
feat: expose structured consensus outcomes

### DIFF
--- a/tests/property/strategies.py
+++ b/tests/property/strategies.py
@@ -15,6 +15,12 @@ from uuid import UUID, uuid4
 
 from hypothesis import strategies as st
 
+from devsynth.application.collaboration.dto import (
+    AgentOpinionRecord,
+    ConsensusOutcome,
+    ConflictRecord,
+    SynthesisArtifact,
+)
 from devsynth.domain.models.requirement import (
     Requirement,
     RequirementChange,
@@ -27,6 +33,77 @@ from devsynth.domain.models.requirement import (
 def _bounded_text(min_size: int = 1, max_size: int = 80) -> st.SearchStrategy[str]:
     return st.text(min_size=min_size, max_size=max_size).filter(
         lambda s: s.strip() != ""
+    )
+
+
+def _iso_timestamp_strategy() -> st.SearchStrategy[str]:
+    return st.datetimes(
+        min_value=datetime(2020, 1, 1),
+        max_value=datetime(2030, 12, 31),
+        timezones=[],
+    ).map(lambda dt: dt.isoformat())
+
+
+def _agent_opinion_record_strategy() -> st.SearchStrategy[AgentOpinionRecord]:
+    return st.builds(
+        AgentOpinionRecord,
+        agent_id=_bounded_text(1, 12),
+        opinion=_bounded_text(3, 60) | st.just(""),
+        rationale=_bounded_text(3, 120) | st.just(""),
+        timestamp=st.none() | _iso_timestamp_strategy(),
+        weight=st.none()
+        | st.floats(min_value=0.5, max_value=1.0, allow_nan=False, allow_infinity=False),
+    )
+
+
+def _conflict_record_strategy() -> st.SearchStrategy[ConflictRecord]:
+    return st.builds(
+        ConflictRecord,
+        conflict_id=_bounded_text(3, 24),
+        task_id=_bounded_text(3, 24),
+        agent_a=_bounded_text(1, 12),
+        agent_b=_bounded_text(1, 12),
+        opinion_a=_bounded_text(3, 80),
+        opinion_b=_bounded_text(3, 80),
+        rationale_a=_bounded_text(3, 120) | st.just(""),
+        rationale_b=_bounded_text(3, 120) | st.just(""),
+        severity_label=st.sampled_from(["high", "medium"]),
+        severity_score=st.floats(min_value=0.0, max_value=1.0, allow_nan=False, allow_infinity=False),
+    )
+
+
+def _synthesis_artifact_strategy() -> st.SearchStrategy[SynthesisArtifact]:
+    key_points = st.lists(_bounded_text(3, 80), min_size=0, max_size=3).map(tuple)
+    expertise_weights = st.dictionaries(
+        keys=_bounded_text(1, 12),
+        values=st.floats(min_value=0.0, max_value=1.0, allow_nan=False, allow_infinity=False),
+        max_size=3,
+    )
+    readability = st.fixed_dictionaries(
+        {
+            "flesch_reading_ease": st.floats(
+                min_value=0.0, max_value=100.0, allow_nan=False, allow_infinity=False
+            ),
+            "flesch_kincaid_grade": st.floats(
+                min_value=0.0, max_value=12.0, allow_nan=False, allow_infinity=False
+            ),
+            "syllables_per_word": st.floats(
+                min_value=0.0, max_value=5.0, allow_nan=False, allow_infinity=False
+            ),
+            "words_per_sentence": st.floats(
+                min_value=0.0, max_value=40.0, allow_nan=False, allow_infinity=False
+            ),
+        }
+    )
+    return st.builds(
+        SynthesisArtifact,
+        text=_bounded_text(3, 120) | st.just(""),
+        key_points=key_points,
+        expertise_weights=expertise_weights,
+        conflict_resolution_method=st.sampled_from(
+            ["weighted_expertise_synthesis", "consensus_blend"]
+        ),
+        readability_score=readability,
     )
 
 
@@ -103,54 +180,51 @@ def requirement_change_strategy() -> st.SearchStrategy[RequirementChange]:
     return st.builds(_build, change_names, req, req)
 
 
-def consensus_outcome_strategy() -> st.SearchStrategy[dict[str, Any]]:
-    """Generate a simplified consensus outcome dict matching WSDE dialectical shape.
+def consensus_outcome_strategy() -> st.SearchStrategy[ConsensusOutcome]:
+    """Generate typed consensus outcomes for property-based testing."""
 
-    Keys:
-    - id (str), task_id (str), timestamp (datetime)
-    - thesis (dict), antithesis (dict), synthesis (dict)
-    - method == "dialectical_reasoning"
-    """
-    small_text = _bounded_text(3, 60)
-    code_snip = st.one_of(
-        small_text.map(lambda s: f"print('{s}')"), st.just("x = 1\nprint(x)")
-    )
+    methods = st.sampled_from(["conflict_resolution_synthesis", "majority_opinion"])
+    agent_opinions = st.lists(
+        _agent_opinion_record_strategy(), min_size=1, max_size=3
+    ).map(tuple)
+    conflict_records = st.lists(
+        _conflict_record_strategy(), min_size=0, max_size=2
+    ).map(tuple)
+    synthesis = _synthesis_artifact_strategy()
+    majority_choice = _bounded_text(3, 80)
 
-    thesis = st.fixed_dictionaries(
-        {
-            "content": small_text,
-            "code": code_snip,
+    def _build(
+        consensus_id: str,
+        task_id: str,
+        method: str,
+        opinions: tuple[AgentOpinionRecord, ...],
+        conflicts: tuple[ConflictRecord, ...],
+        synthesis_artifact: SynthesisArtifact,
+        majority_opinion: str,
+        timestamp: str,
+    ) -> ConsensusOutcome:
+        kwargs: Dict[str, Any] = {
+            "consensus_id": consensus_id,
+            "task_id": task_id,
+            "method": method,
+            "agent_opinions": opinions,
+            "conflicts": conflicts,
+            "timestamp": timestamp,
         }
-    )
-
-    antithesis = st.fixed_dictionaries(
-        {
-            "critiques": st.lists(small_text, min_size=1, max_size=3),
-            "improvement_suggestions": st.lists(small_text, min_size=1, max_size=3),
-            "alternative_approaches": st.lists(small_text, min_size=0, max_size=2),
-        }
-    )
-
-    synthesis = st.fixed_dictionaries(
-        {
-            "integrated_critiques": st.lists(small_text, min_size=0, max_size=3),
-            "improvements": st.lists(small_text, min_size=0, max_size=3),
-            "content": small_text | st.just(""),
-            "code": code_snip | st.just(""),
-        }
-    )
+        if method == "conflict_resolution_synthesis":
+            kwargs["synthesis"] = synthesis_artifact
+        else:
+            kwargs["majority_opinion"] = majority_opinion
+        return ConsensusOutcome(**kwargs)
 
     return st.builds(
-        lambda t, a, s: {
-            "id": str(uuid4()),
-            "task_id": str(uuid4()),
-            "timestamp": datetime.now(),
-            "thesis": t,
-            "antithesis": a,
-            "synthesis": s,
-            "method": "dialectical_reasoning",
-        },
-        thesis,
-        antithesis,
+        _build,
+        st.uuids().map(str),
+        st.uuids().map(str),
+        methods,
+        agent_opinions,
+        conflict_records,
         synthesis,
+        majority_choice,
+        _iso_timestamp_strategy(),
     )

--- a/tests/property/test_requirements_consensus_properties.py
+++ b/tests/property/test_requirements_consensus_properties.py
@@ -10,6 +10,12 @@ import pytest
 from hypothesis import given, settings
 from hypothesis import strategies as st
 
+from devsynth.application.collaboration.dto import (
+    AgentOpinionRecord,
+    ConsensusOutcome,
+    ConflictRecord,
+    SynthesisArtifact,
+)
 from devsynth.domain.models.requirement import Requirement
 from devsynth.domain.models.wsde_dialectical import (
     DialecticalSequence,
@@ -88,25 +94,24 @@ def test_dialectical_reasoning_returns_expected_shape_quickly(thesis_content: st
 @pytest.mark.medium
 @settings(max_examples=5, deadline=300)
 @given(outcome=consensus_outcome_strategy())
-def test_generated_consensus_outcome_has_expected_keys(outcome: dict[str, Any]):
+def test_generated_consensus_outcome_has_expected_keys(outcome: ConsensusOutcome):
     """Generated consensus outcomes provide required keys.
 
     Issue: issues/Finalize-dialectical-reasoning.md ReqID: DRL-001
     """
-    for key in (
-        "id",
-        "task_id",
-        "timestamp",
-        "thesis",
-        "antithesis",
-        "synthesis",
-        "method",
-    ):
-        assert key in outcome
-    assert isinstance(outcome["id"], str)
-    assert isinstance(outcome["task_id"], str)
-    assert hasattr(outcome["timestamp"], "isoformat")
-    assert isinstance(outcome["thesis"], dict)
-    assert isinstance(outcome["antithesis"], dict)
-    assert isinstance(outcome["synthesis"], dict)
-    assert outcome["method"] == "dialectical_reasoning"
+    assert isinstance(outcome, ConsensusOutcome)
+    assert isinstance(outcome.consensus_id, str)
+    assert isinstance(outcome.task_id, str)
+    assert isinstance(outcome.timestamp, str)
+    assert outcome.method in {"conflict_resolution_synthesis", "majority_opinion"}
+
+    for opinion in outcome.agent_opinions:
+        assert isinstance(opinion, AgentOpinionRecord)
+
+    for conflict in outcome.conflicts:
+        assert isinstance(conflict, ConflictRecord)
+
+    if outcome.method == "conflict_resolution_synthesis":
+        assert isinstance(outcome.synthesis, SynthesisArtifact)
+    else:
+        assert isinstance(outcome.majority_opinion, str)

--- a/tests/unit/application/collaboration/test_wsde_team_consensus_conflict_detection.py
+++ b/tests/unit/application/collaboration/test_wsde_team_consensus_conflict_detection.py
@@ -2,6 +2,7 @@ from types import SimpleNamespace
 
 import pytest
 
+from devsynth.application.collaboration.dto import ConflictRecord
 from devsynth.application.collaboration.wsde_team_consensus import (
     ConsensusBuildingMixin,
 )
@@ -32,5 +33,6 @@ def test_identify_conflicts_detects_opposing_opinions() -> None:
     conflicts = team._identify_conflicts({"id": "t1"})
     assert len(conflicts) == 1
     conflict = conflicts[0]
-    assert conflict["agent1"] == "A"
-    assert conflict["agent2"] == "B"
+    assert isinstance(conflict, ConflictRecord)
+    assert conflict.agent_a == "A"
+    assert conflict.agent_b == "B"

--- a/tests/unit/application/collaboration/test_wsde_team_consensus_summary.py
+++ b/tests/unit/application/collaboration/test_wsde_team_consensus_summary.py
@@ -1,5 +1,10 @@
 import pytest
 
+from devsynth.application.collaboration.dto import (
+    AgentOpinionRecord,
+    ConsensusOutcome,
+    SynthesisArtifact,
+)
 from devsynth.application.collaboration.wsde_team_consensus import (
     ConsensusBuildingMixin,
 )
@@ -32,9 +37,22 @@ def test_summarize_voting_result_winner():
 
 def test_summarize_consensus_result_methods():
     mixin = DummyTeam()
-    consensus = {"method": "synthesis", "synthesis": {"text": "do x"}}
-    assert "synthesis consensus" in mixin.summarize_consensus_result(consensus).lower()
-    consensus = {"majority_opinion": "opt", "method": "vote"}
+    synthesis_outcome = ConsensusOutcome(
+        consensus_id="c1",
+        method="conflict_resolution_synthesis",
+        synthesis=SynthesisArtifact(text="do x"),
+        agent_opinions=(AgentOpinionRecord(agent_id="a", opinion="do x"),),
+    )
+    assert (
+        "synthesis consensus"
+        in mixin.summarize_consensus_result(synthesis_outcome).lower()
+    )
+    consensus = ConsensusOutcome(
+        consensus_id="c2",
+        method="majority_opinion",
+        majority_opinion="opt",
+        agent_opinions=(AgentOpinionRecord(agent_id="a", opinion="opt"),),
+    )
     assert (
         "majority opinion chosen" in mixin.summarize_consensus_result(consensus).lower()
     )


### PR DESCRIPTION
## Summary
- extend collaboration DTOs with typed agent opinions, conflict records, and synthesis artifacts for consensus outcomes
- refactor the WSDE consensus mixin to emit `ConsensusOutcome` instances while preserving legacy mapping access and deterministic serialization
- refresh unit and property tests to exercise the new dataclasses and Hypothesis strategies

## Testing
- poetry run pytest tests/unit/application/collaboration/test_wsde_team_consensus_conflict_detection.py tests/unit/application/collaboration/test_wsde_team_consensus_summary.py *(fails: ModuleNotFoundError: No module named 'yaml')*
- poetry run pytest tests/property -k consensus


------
https://chatgpt.com/codex/tasks/task_e_68d9be7420b4833386a780ff28c9e359