### PR TITLE
refactor: normalize memory search DTO responses

### DIFF
--- a/src/devsynth/application/memory/dto.py
+++ b/src/devsynth/application/memory/dto.py
@@ -1,4 +1,4 @@
-"""Typed data transfer objects for exchanging memory records across adapters.
+"""DTO helpers for normalizing memory search responses.
 
 The DTOs in this module bridge domain-level memory models with infrastructure
 layers.  They should be used when memory content leaves a store boundary (for
@@ -19,7 +19,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from datetime import datetime
-from typing import MutableMapping, Sequence, TypedDict, TypeAlias
+from typing import Iterable, MutableMapping, Sequence, TypedDict, TypeAlias
 
 from typing_extensions import NotRequired
 
@@ -69,6 +69,36 @@ class MemoryRecord:
             # update the metadata payload without mutating shared structures.
             self.metadata = dict(self.metadata)
 
+    @property
+    def id(self) -> str:
+        """Expose the underlying item's identifier for backward compatibility."""
+
+        return self.item.id
+
+    @property
+    def content(self) -> object:
+        """Return the wrapped item's content."""
+
+        return self.item.content
+
+    @property
+    def memory_type(self) -> object:
+        """Return the wrapped item's memory type."""
+
+        return self.item.memory_type
+
+    @property
+    def created_at(self) -> datetime | None:
+        """Mirror the wrapped item's ``created_at`` timestamp."""
+
+        return self.item.created_at
+
+    @property
+    def score(self) -> float | None:
+        """Alias ``similarity`` for legacy callers."""
+
+        return self.similarity
+
 
 class MemoryQueryResults(TypedDict, total=False):
     """Results returned by querying a single memory store.
@@ -104,5 +134,155 @@ class GroupedMemoryResults(TypedDict, total=False):
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:  # pragma: no cover - type checking only
-    from devsynth.domain.models.memory import MemoryItem
+    from devsynth.domain.models.memory import MemoryItem, MemoryVector
+
+from devsynth.domain.models.memory import MemoryItem, MemoryType, MemoryVector
+
+
+def _normalize_metadata(*payloads: MemoryMetadata | None) -> MemoryMetadata | None:
+    merged: MemoryMetadata = {}
+    for payload in payloads:
+        if not payload:
+            continue
+        merged.update(payload)
+    return merged or None
+
+
+def build_memory_record(
+    payload: MemoryRecord | MemoryItem | MemoryVector | tuple[object, float] | None,
+    *,
+    source: str | None = None,
+    similarity: float | None = None,
+    metadata: MemoryMetadata | None = None,
+) -> MemoryRecord:
+    """Coerce adapter payloads into :class:`MemoryRecord` instances."""
+
+    if payload is None:
+        item = MemoryItem(id="", content="", memory_type=MemoryType.CONTEXT)
+        base_similarity = None
+        base_metadata: MemoryMetadata | None = None
+    elif isinstance(payload, MemoryRecord):
+        base_similarity = payload.similarity
+        base_metadata = payload.metadata
+        item = payload.item
+    else:
+        tuple_similarity: float | None = None
+        underlying = payload
+        if isinstance(payload, tuple) and len(payload) == 2:
+            possible_item, possible_score = payload
+            if isinstance(possible_score, (int, float)):
+                underlying = possible_item
+                tuple_similarity = float(possible_score)
+        if isinstance(underlying, MemoryItem):
+            item = underlying
+        elif isinstance(underlying, MemoryVector):
+            vector_metadata = dict(underlying.metadata or {})
+            raw_type = vector_metadata.get("memory_type")
+            try:
+                memory_type = (
+                    MemoryType.from_raw(raw_type)
+                    if raw_type is not None
+                    else MemoryType.CONTEXT
+                )
+            except ValueError:
+                memory_type = MemoryType.CONTEXT
+            vector_metadata["memory_type"] = memory_type.value
+            vector_metadata.setdefault("embedding", list(underlying.embedding))
+            item = MemoryItem(
+                id=underlying.id,
+                content=underlying.content,
+                memory_type=memory_type,
+                metadata=vector_metadata,
+                created_at=underlying.created_at,
+            )
+        else:
+            if hasattr(underlying, "get"):
+                mapping = dict(underlying)  # type: ignore[arg-type]
+                raw_type = mapping.get("memory_type", MemoryType.CONTEXT)
+                try:
+                    memory_type = MemoryType.from_raw(raw_type)
+                except ValueError:
+                    memory_type = MemoryType.CONTEXT
+                item = MemoryItem(
+                    id=mapping.get("id", ""),
+                    content=mapping.get("content"),
+                    memory_type=memory_type,
+                    metadata=mapping.get("metadata"),
+                )
+                base_metadata = mapping.get("metadata")
+            else:  # pragma: no cover - defensive fallback for unexpected payloads
+                item = MemoryItem(id="", content=underlying, memory_type=MemoryType.CONTEXT)
+        base_similarity = tuple_similarity
+        base_metadata = getattr(item, "metadata", None)
+
+    merged_similarity = similarity if similarity is not None else base_similarity
+    merged_metadata = _normalize_metadata(base_metadata, metadata)
+
+    record_source = source
+    if record_source is None and isinstance(payload, MemoryRecord):
+        record_source = payload.source
+
+    return MemoryRecord(
+        item=item,
+        similarity=merged_similarity,
+        source=record_source,
+        metadata=merged_metadata,
+    )
+
+
+def build_query_results(
+    store: str,
+    payload: MemoryQueryResults | Sequence[object] | object | None,
+    *,
+    metadata: MemoryMetadata | None = None,
+) -> MemoryQueryResults:
+    """Normalize adapter responses into a :class:`MemoryQueryResults` mapping."""
+
+    if isinstance(payload, dict) and "records" in payload:
+        store_name = payload.get("store", store)
+        records_iter = payload.get("records", [])
+        records = [
+            build_memory_record(record, source=store_name)
+            for record in records_iter
+        ]
+        combined_metadata = _normalize_metadata(payload.get("metadata"), metadata)
+        normalized: MemoryQueryResults = {"store": store_name, "records": records}
+        if "total" in payload and payload["total"] is not None:
+            normalized["total"] = int(payload["total"])
+        if "latency_ms" in payload and payload["latency_ms"] is not None:
+            normalized["latency_ms"] = float(payload["latency_ms"])
+        if combined_metadata:
+            normalized["metadata"] = combined_metadata
+        return normalized
+
+    records: list[MemoryRecord]
+    if payload is None:
+        records = []
+    elif isinstance(payload, Sequence) and not isinstance(payload, (str, bytes)):
+        records = [build_memory_record(item, source=store) for item in payload]
+    else:
+        records = [build_memory_record(payload, source=store)]
+
+    combined_metadata = _normalize_metadata(metadata)
+    result: MemoryQueryResults = {"store": store, "records": records}
+    if combined_metadata:
+        result["metadata"] = combined_metadata
+    return result
+
+
+def deduplicate_records(records: Iterable[MemoryRecord]) -> list[MemoryRecord]:
+    """Collapse duplicate records by ``MemoryItem`` identifier."""
+
+    best_by_id: dict[str, MemoryRecord] = {}
+    for record in records:
+        identifier = record.item.id or f"{record.source}:{id(record.item)}"
+        current = best_by_id.get(identifier)
+        if current is None:
+            best_by_id[identifier] = record
+            continue
+        current_score = current.similarity if current.similarity is not None else float("-inf")
+        new_score = record.similarity if record.similarity is not None else float("-inf")
+        if new_score > current_score:
+            best_by_id[identifier] = record
+    return list(best_by_id.values())
 

--- a/src/devsynth/application/memory/search_patterns.py
+++ b/src/devsynth/application/memory/search_patterns.py
@@ -2,27 +2,31 @@
 
 from __future__ import annotations
 
-from typing import Any, Dict, List
+from typing import List
 
+from .dto import GroupedMemoryResults, MemoryQueryResults, MemoryRecord
 from .memory_manager import MemoryManager
 from .query_router import QueryRouter
 
 
 class SearchPatterns:
-    """Provide convenience methods for common search patterns."""
+    """Provide convenience methods for common search patterns returning DTOs."""
 
     def __init__(self, manager: MemoryManager) -> None:
         self.manager = manager
         self.router = QueryRouter(manager)
 
-    def direct_search(self, query: str, store: str) -> List[Any]:
-        """Search a single store directly."""
+    def direct_search(self, query: str, store: str) -> MemoryQueryResults:
+        """Search a single store directly and return normalized results."""
+
         return self.router.direct_query(query, store)
 
-    def cross_store_search(self, query: str) -> Dict[str, List[Any]]:
-        """Search all configured stores and return grouped results."""
+    def cross_store_search(self, query: str) -> GroupedMemoryResults:
+        """Search all configured stores and return grouped DTO responses."""
+
         return self.router.cross_store_query(query)
 
-    def federated_search(self, query: str) -> List[Any]:
-        """Search all stores and return a ranked, aggregated list."""
+    def federated_search(self, query: str) -> List[MemoryRecord]:
+        """Search all stores and return a ranked, aggregated list of records."""
+
         return self.router.federated_query(query)


### PR DESCRIPTION
## Summary
- add DTO helper utilities to convert adapter payloads into `MemoryRecord` and query result structures
- update `MemoryManager` search and query flows to return typed records while reusing the shared helpers
- refactor the query router and search patterns to operate on `MemoryRecord` DTOs with deduplicated, ranked responses

## Testing
- `poetry run mypy --strict src/devsynth/application/memory/memory_manager.py src/devsynth/application/memory/query_router.py src/devsynth/application/memory/search_patterns.py`


------
https://chatgpt.com/codex/tasks/task_e_68d9ecee63a083338db7cfd8ee16f233