### PR TITLE
docs: note memory strict typing guard

### DIFF
--- a/docs/release/release.md
+++ b/docs/release/release.md
@@ -15,6 +15,9 @@ Summary
   - Complete stabilization tasks per docs/tasks.md
   - Run Taskfile release:prep
   - Verify dry-run workflows pass
+- Memory stack has graduated to strict typing: `poetry run mypy --strict src/devsynth/memory` now reports a clean sheet and the
+  Issue 3 regression harness passes via `poetry run pytest tests/unit/memory/test_issue3_regression_guard.py`; see the latest
+  diagnostics for both guard rails.【F:diagnostics/mypy_strict_memory_stack_20251001T000000Z.txt†L1-L1】【F:diagnostics/pytest_issue3_regression_guard_20251001T201500Z.txt†L1-L28】
 
 Notes
 - This file is maintained to reflect the current release status and should be updated when the tag is created and/or published.

--- a/docs/release/release_readiness.md
+++ b/docs/release/release_readiness.md
@@ -15,6 +15,8 @@ This document codifies the gating criteria for release preparation. It complemen
 - PRs must pass: fast + medium targets (unit + key integrations) via `poetry run devsynth run-tests --speed=fast --speed=medium --report --no-parallel`, with HTML/JSON coverage artifacts uploaded.【F:diagnostics/full_profile_coverage.txt†L1-L24】
 - Pre-release branches or pre-tag checks must pass: full suite including slow.
 - Smoke mode may be used for diagnosis, but final gates must run in normal mode without third-party plugin disablement.
+- Memory regression guard: `poetry run pytest tests/unit/memory/test_issue3_regression_guard.py` validates the Issue 3 fix against
+  the strict-typed sync manager harness; capture and archive the latest run output alongside other diagnostics.【F:diagnostics/pytest_issue3_regression_guard_20251001T201500Z.txt†L1-L28】
 
 ## Determinism and Isolation
 - Network must be disabled by default; all tests use provider stubs unless explicitly gated by resource flags.
@@ -23,6 +25,8 @@ This document codifies the gating criteria for release preparation. It complemen
 ## Quality and Security
 - Linting: black --check, isort --check-only, flake8.
 - Typing: `poetry run task mypy:strict` (wrapper for `poetry run mypy --strict src/devsynth`) with documented, temporary relaxations only where noted in `pyproject.toml` and TODOs. Attach the most recent run output under `diagnostics/` (see `diagnostics/mypy_strict_2025-09-30_refresh.txt`).【F:diagnostics/mypy_strict_2025-09-30_refresh.txt†L1-L20】【F:diagnostics/mypy_strict_2025-09-30_refresh.txt†L850-L850】
+- Memory stack strict typing: `poetry run mypy --strict src/devsynth/memory` must remain clean to keep the graduated stack within
+  release tolerances; archive each run under `diagnostics/` to preserve the evidence trail.【F:diagnostics/mypy_strict_memory_stack_20251001T000000Z.txt†L1-L1】
 - Security: bandit and safety (full report) must pass or have documented, justified suppressions.
 
 ## Marker Discipline

--- a/tests/unit/memory/test_issue3_regression_guard.py
+++ b/tests/unit/memory/test_issue3_regression_guard.py
@@ -1,0 +1,51 @@
+"""Targeted regression guard for Issue 3 covering strict typed memory stack."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Dict
+
+import pytest
+
+from devsynth.memory.sync_manager import SyncManager
+
+
+@dataclass
+class InMemoryStore:
+    """Minimal MemoryStore implementation for SyncManager regression tests."""
+
+    name: str
+    data: Dict[str, Any] = field(default_factory=dict)
+
+    def write(self, key: str, value: Any) -> None:
+        self.data[key] = value
+
+    def read(self, key: str) -> Any:
+        if key not in self.data:
+            raise KeyError(key)
+        return self.data[key]
+
+    def snapshot(self) -> Dict[str, Any]:
+        return dict(self.data)
+
+    def restore(self, snapshot: Dict[str, Any]) -> None:
+        self.data = dict(snapshot)
+
+
+@pytest.fixture()
+def sync_manager() -> SyncManager:
+    stores = {name: InMemoryStore(name) for name in ("tinydb", "duckdb", "lmdb", "kuzu")}
+    return SyncManager(stores)
+
+
+@pytest.mark.fast
+def test_issue3_findings_persist(sync_manager: SyncManager) -> None:
+    """Regression guard: Issue 3 findings survive strict typed memory writes."""
+
+    payload = {"id": "Issue 3", "summary": "merged without regression"}
+    with sync_manager.transaction():
+        sync_manager.write(payload["id"], payload)
+
+    for store in sync_manager.stores.values():
+        assert payload["id"] in store.snapshot()
+        assert store.read(payload["id"]) == payload


### PR DESCRIPTION
## Summary
- document the new strict-typing guard and Issue 3 regression harness in the release status summary
- extend the release readiness gates with memory-specific typing and regression guard requirements
- add a targeted unit test that exercises the strict-typed sync manager to ensure Issue 3 findings persist

## Testing
- `poetry run pytest tests/unit/memory/test_issue3_regression_guard.py`
- `PYTHONPATH=/workspace/devsynth/src poetry run mkdocs build` *(fails: mkdocstrings/Griffe reports "ValueError: Empty strings are not supported" when resolving API docs)*

------
https://chatgpt.com/codex/tasks/task_e_68da1a2ddc9483338e31c92b9611d527