### PR TITLE
test: align agent api tests with typed schemas

### DIFF
--- a/tests/unit/application/requirements/test_requirement_service_dtos.py
+++ b/tests/unit/application/requirements/test_requirement_service_dtos.py
@@ -1,0 +1,189 @@
+import uuid
+import sys
+from importlib.util import module_from_spec, spec_from_file_location
+from pathlib import Path
+from types import ModuleType
+from unittest.mock import MagicMock
+
+import pytest
+
+if "devsynth.ports.requirement_port" not in sys.modules:
+    requirement_port_stub = ModuleType("devsynth.ports.requirement_port")
+
+    class RequirementRepositoryPort:  # pragma: no cover - test stub
+        ...
+
+    class ChangeRepositoryPort:  # pragma: no cover - test stub
+        ...
+
+    class DialecticalReasonerPort:  # pragma: no cover - test stub
+        ...
+
+    class NotificationPort:  # pragma: no cover - test stub
+        ...
+
+    requirement_port_stub.RequirementRepositoryPort = RequirementRepositoryPort
+    requirement_port_stub.ChangeRepositoryPort = ChangeRepositoryPort
+    requirement_port_stub.DialecticalReasonerPort = DialecticalReasonerPort
+    requirement_port_stub.NotificationPort = NotificationPort
+    sys.modules["devsynth.ports.requirement_port"] = requirement_port_stub
+
+ROOT = Path(__file__).resolve().parents[4]
+
+models_spec = spec_from_file_location(
+    "devsynth.application.requirements.models", ROOT / "src/devsynth/application/requirements/models.py"
+)
+requirement_models = module_from_spec(models_spec)
+assert models_spec.loader is not None
+sys.modules[models_spec.name] = requirement_models
+models_spec.loader.exec_module(requirement_models)
+
+ChangeNotificationPayload = requirement_models.ChangeNotificationPayload
+ChangeNotificationEvent = requirement_models.ChangeNotificationEvent
+EDRRPhase = requirement_models.EDRRPhase
+RequirementUpdateDTO = requirement_models.RequirementUpdateDTO
+
+service_spec = spec_from_file_location(
+    "devsynth.application.requirements.requirement_service",
+    ROOT / "src/devsynth/application/requirements/requirement_service.py",
+)
+requirement_service_module = module_from_spec(service_spec)
+assert service_spec.loader is not None
+sys.modules[service_spec.name] = requirement_service_module
+service_spec.loader.exec_module(requirement_service_module)
+RequirementService = requirement_service_module.RequirementService
+from devsynth.domain.models.requirement import (
+    ChangeType,
+    Requirement,
+    RequirementPriority,
+    RequirementStatus,
+    RequirementType,
+    RequirementChange,
+)
+
+
+@pytest.fixture
+def requirement() -> Requirement:
+    """Build a canonical requirement for update/delete scenarios."""
+
+    return Requirement(
+        id=uuid.uuid4(),
+        title="Original",
+        description="Initial description",
+        status=RequirementStatus.DRAFT,
+        priority=RequirementPriority.MEDIUM,
+        type=RequirementType.FUNCTIONAL,
+        created_by="author",
+        dependencies=[],
+        tags=["initial"],
+        metadata={"key": "value"},
+    )
+
+
+@pytest.fixture
+def service(requirement: Requirement) -> RequirementService:
+    """Construct a requirement service with mocked ports."""
+
+    requirement_repo = MagicMock()
+    requirement_repo.get_requirement.return_value = requirement
+    requirement_repo.save_requirement.side_effect = lambda req: req
+    requirement_repo.delete_requirement.return_value = True
+
+    change_repo = MagicMock()
+    change_repo.save_change.side_effect = lambda change: change
+
+    dialectical = MagicMock()
+    notifier = MagicMock()
+
+    return RequirementService(
+        requirement_repository=requirement_repo,
+        change_repository=change_repo,
+        dialectical_reasoner=dialectical,
+        notification_service=notifier,
+    )
+
+
+@pytest.mark.fast
+def test_update_requirement_uses_typed_dto_and_dialectical_hooks(
+    service: RequirementService,
+    requirement: Requirement,
+):
+    """Requirement updates emit typed payloads and dialectical metadata."""
+
+    updates = RequirementUpdateDTO(
+        title="Updated",
+        description="Refined description",
+        priority=RequirementPriority.HIGH,
+        tags=("initial", "refined"),
+    )
+
+    updated = service.update_requirement(
+        requirement_id=requirement.id,
+        updates=updates,
+        user_id="reviewer",
+        reason="Refinement",
+    )
+
+    assert isinstance(updated, Requirement)
+    assert updated.title == "Updated"
+    assert updated.description == "Refined description"
+    assert updated.priority is RequirementPriority.HIGH
+    assert updated.tags == ["initial", "refined"]
+
+    service.dialectical_reasoner.evaluate_change.assert_called_once()
+    service.dialectical_reasoner.assess_impact.assert_called_once()
+
+    eval_args, eval_kwargs = service.dialectical_reasoner.evaluate_change.call_args
+    change_arg: RequirementChange = eval_args[0]
+    assert isinstance(change_arg, RequirementChange)
+    assert change_arg.change_type is ChangeType.MODIFY
+    assert change_arg.previous_state.title == "Original"
+    assert change_arg.new_state.title == "Updated"
+    assert eval_kwargs["edrr_phase"] is EDRRPhase.REFINE
+
+    assess_kwargs = service.dialectical_reasoner.assess_impact.call_args.kwargs
+    assert assess_kwargs["edrr_phase"] is EDRRPhase.REFINE
+
+    service.notification_service.notify_change_proposed.assert_called_once()
+    payload_arg: ChangeNotificationPayload = (
+        service.notification_service.notify_change_proposed.call_args.args[0]
+    )
+    assert isinstance(payload_arg, ChangeNotificationPayload)
+    assert payload_arg.event is ChangeNotificationEvent.PROPOSED
+    assert payload_arg.audit.edrr_phase is EDRRPhase.REFINE
+    assert payload_arg.audit.actor_id == "reviewer"
+
+
+@pytest.mark.fast
+def test_delete_requirement_emits_retrospect_phase(service: RequirementService, requirement: Requirement):
+    """Deleting a requirement notifies dialectical consumers with RETROSPECT phase."""
+
+    deleted = service.delete_requirement(
+        requirement_id=requirement.id,
+        user_id="reviewer",
+        reason="Obsolete",
+    )
+
+    assert deleted is True
+
+    service.change_repository.save_change.assert_called_once()
+    saved_change: RequirementChange = service.change_repository.save_change.call_args.args[0]
+    assert saved_change.change_type is ChangeType.REMOVE
+    assert saved_change.previous_state is requirement
+
+    service.dialectical_reasoner.evaluate_change.assert_called_once()
+    eval_kwargs = service.dialectical_reasoner.evaluate_change.call_args.kwargs
+    assert eval_kwargs["edrr_phase"] is EDRRPhase.RETROSPECT
+
+    service.dialectical_reasoner.assess_impact.assert_called_once()
+    assess_kwargs = service.dialectical_reasoner.assess_impact.call_args.kwargs
+    assert assess_kwargs["edrr_phase"] is EDRRPhase.RETROSPECT
+
+    service.notification_service.notify_change_proposed.assert_called_once()
+    payload_arg: ChangeNotificationPayload = (
+        service.notification_service.notify_change_proposed.call_args.args[0]
+    )
+    assert isinstance(payload_arg, ChangeNotificationPayload)
+    assert payload_arg.event is ChangeNotificationEvent.PROPOSED
+    assert payload_arg.audit.edrr_phase is EDRRPhase.RETROSPECT
+    assert payload_arg.audit.change.change_type is ChangeType.REMOVE

--- a/tests/unit/interface/test_api_endpoints.py
+++ b/tests/unit/interface/test_api_endpoints.py
@@ -2,25 +2,15 @@ import pytest
 
 pytest.importorskip("fastapi")
 pytest.importorskip("fastapi.testclient")
-pytest.skip("requires FastAPI test client", allow_module_level=True)
-from unittest.mock import MagicMock, patch
+
+from unittest.mock import patch
 
 from fastapi import HTTPException
 from fastapi.testclient import TestClient
 
 from devsynth.application.cli._command_exports import COMMAND_ATTRIBUTE_NAMES
 from devsynth.api import app
-from devsynth.interface.agentapi import (
-    LATEST_MESSAGES,
-    CodeRequest,
-    DoctorRequest,
-    EDRRCycleRequest,
-    GatherRequest,
-    InitRequest,
-    SpecRequest,
-    SynthesizeRequest,
-)
-from devsynth.interface.agentapi import TestSpecRequest as APITestSpecRequest
+from devsynth.interface import agentapi as agentapi_module
 from devsynth.interface.agentapi import (
     code_endpoint,
     doctor_endpoint,
@@ -32,24 +22,32 @@ from devsynth.interface.agentapi import (
     synthesize_endpoint,
 )
 from devsynth.interface.agentapi import test_endpoint as api_test_endpoint
+from devsynth.interface.agentapi_models import (
+    CodeRequest,
+    DoctorRequest,
+    EDRRCycleRequest,
+    GatherRequest,
+    HealthResponse,
+    InitRequest,
+    MetricsResponse,
+    PriorityLevel,
+    SpecRequest,
+    SynthesisTarget,
+    SynthesizeRequest,
+    TestSpecRequest,
+    WorkflowResponse,
+)
 
 
 @pytest.fixture
 def clean_state():
     """Set up clean state for tests."""
-    # Store original state of LATEST_MESSAGES
-    original_messages = LATEST_MESSAGES.copy()
-
-    # Clear any existing messages before test
-    LATEST_MESSAGES.clear()
+    original_messages = agentapi_module.LATEST_MESSAGES
+    agentapi_module.LATEST_MESSAGES = tuple()
 
     yield
 
-    # Clean up state after test
-    LATEST_MESSAGES.clear()
-
-    # Restore original messages
-    LATEST_MESSAGES.extend(original_messages)
+    agentapi_module.LATEST_MESSAGES = original_messages
 
 
 @pytest.fixture
@@ -138,7 +136,7 @@ def mock_cli_commands():
         }
 
 
-@pytest.mark.slow
+@pytest.mark.medium
 def test_health_endpoint_requires_authentication_succeeds(client, clean_state):
     """Test that the health endpoint requires authentication.
 
@@ -149,12 +147,15 @@ def test_health_endpoint_requires_authentication_succeeds(client, clean_state):
     response = client.get("/health", headers={"Authorization": "Bearer invalid_token"})
     assert response.status_code == 401
 
-    response = client.get("/health", headers={"Authorization": "Bearer test_token"})
-    assert response.status_code == 200
-    assert response.json() == {"status": "ok"}
+    success = client.get("/health", headers={"Authorization": "Bearer test_token"})
+    assert success.status_code == 200
+    payload = HealthResponse.model_validate(success.json())
+    assert payload.status == "ok"
+    assert payload.uptime >= 0
+    assert payload.additional_info is None
 
 
-@pytest.mark.slow
+@pytest.mark.medium
 def test_metrics_endpoint_requires_authentication_succeeds(client, clean_state):
     """Test that the metrics endpoint requires authentication.
 
@@ -165,60 +166,77 @@ def test_metrics_endpoint_requires_authentication_succeeds(client, clean_state):
     response = client.get("/metrics", headers={"Authorization": "Bearer invalid_token"})
     assert response.status_code == 401
 
-    response = client.get("/metrics", headers={"Authorization": "Bearer test_token"})
-    assert response.status_code == 200
+    success = client.get("/metrics", headers={"Authorization": "Bearer test_token"})
+    assert success.status_code == 200
+    metrics_lines = tuple(filter(None, success.text.splitlines()))
+    metrics_payload = MetricsResponse(metrics=metrics_lines)
+    assert any(line.startswith("api_uptime_seconds") for line in metrics_payload.metrics)
+    assert any(
+        line.startswith('endpoint_requests{endpoint="health"}')
+        for line in metrics_payload.metrics
+    )
+    assert any(
+        line.startswith('endpoint_requests{endpoint="metrics"}')
+        for line in metrics_payload.metrics
+    )
 
 
-@pytest.mark.slow
+@pytest.mark.medium
 def test_init_endpoint_initializes_project_succeeds(mock_cli_commands, clean_state):
     """Test that the init endpoint initializes a project.
 
     ReqID: N/A"""
-    request = InitRequest(path=".", project_root=None, language=None, goals=None)
+    request = InitRequest(path=".")
     response = init_endpoint(request, token=None)
-    assert response.messages == ["Init successful"]
+    assert isinstance(response, WorkflowResponse)
+    assert response.messages == ("Init successful",)
+    assert response.metadata is None
+    assert agentapi_module.LATEST_MESSAGES == ("Init successful",)
 
-    mock_cli_commands["init_cmd"].assert_called_once_with(
-        path=".",
-        project_root=None,
-        language=None,
-        goals=None,
-        bridge=mock_cli_commands["init_cmd"].call_args[1]["bridge"],
-    )
+    call_kwargs = mock_cli_commands["init_cmd"].call_args.kwargs
+    assert call_kwargs["path"] == "."
+    assert call_kwargs["project_root"] is None
+    assert call_kwargs["language"] is None
+    assert call_kwargs["goals"] is None
+    assert "bridge" in call_kwargs
 
 
-@pytest.mark.slow
-def test_gather_endpoint_collects_requirements_succeeds(mock_cli_commands, clean_state):
+@pytest.mark.medium
+def test_gather_endpoint_collects_requirements_succeeds(
+    mock_cli_commands, clean_state
+):
     """Test that the gather endpoint collects requirements.
 
     ReqID: N/A"""
     request = GatherRequest(
-        goals="test goals", constraints="test constraints", priority="high"
+        goals="test goals", constraints="test constraints", priority=PriorityLevel.HIGH
     )
     response = gather_endpoint(request, token=None)
-    assert response.messages == ["Gather successful"]
+    assert isinstance(response, WorkflowResponse)
+    assert response.messages == ("Gather successful",)
+    assert agentapi_module.LATEST_MESSAGES == ("Gather successful",)
 
-    mock_cli_commands["gather_cmd"].assert_called_once_with(
-        bridge=mock_cli_commands["gather_cmd"].call_args[1]["bridge"]
-    )
+    mock_cli_commands["gather_cmd"].assert_called_once()
+    assert "bridge" in mock_cli_commands["gather_cmd"].call_args.kwargs
 
 
-@pytest.mark.slow
+@pytest.mark.medium
 def test_synthesize_endpoint_runs_pipeline_succeeds(mock_cli_commands, clean_state):
     """Test that the synthesize endpoint runs the pipeline.
 
     ReqID: N/A"""
-    request = SynthesizeRequest(target="unit")
+    request = SynthesizeRequest(target=SynthesisTarget.UNIT)
     response = synthesize_endpoint(request, token=None)
-    assert response.messages == ["Synthesize successful"]
+    assert isinstance(response, WorkflowResponse)
+    assert response.messages == ("Synthesize successful",)
+    assert agentapi_module.LATEST_MESSAGES == ("Synthesize successful",)
 
-    mock_cli_commands["run_pipeline_cmd"].assert_called_once_with(
-        target="unit",
-        bridge=mock_cli_commands["run_pipeline_cmd"].call_args[1]["bridge"],
-    )
+    call_kwargs = mock_cli_commands["run_pipeline_cmd"].call_args.kwargs
+    assert call_kwargs["target"] == SynthesisTarget.UNIT
+    assert "bridge" in call_kwargs
 
 
-@pytest.mark.slow
+@pytest.mark.medium
 def test_spec_endpoint_generates_specifications_succeeds(
     mock_cli_commands, clean_state
 ):
@@ -227,117 +245,113 @@ def test_spec_endpoint_generates_specifications_succeeds(
     ReqID: N/A"""
     request = SpecRequest(requirements_file="requirements.md")
     response = spec_endpoint(request, token=None)
-    assert response.messages == ["Spec successful"]
+    assert isinstance(response, WorkflowResponse)
+    assert response.messages == ("Spec successful",)
+    assert agentapi_module.LATEST_MESSAGES == ("Spec successful",)
 
-    mock_cli_commands["spec_cmd"].assert_called_once_with(
-        requirements_file="requirements.md",
-        bridge=mock_cli_commands["spec_cmd"].call_args[1]["bridge"],
-    )
+    call_kwargs = mock_cli_commands["spec_cmd"].call_args.kwargs
+    assert call_kwargs["requirements_file"] == "requirements.md"
+    assert "bridge" in call_kwargs
 
 
-@pytest.mark.slow
+@pytest.mark.medium
 def test_test_endpoint_generates_tests_succeeds(mock_cli_commands, clean_state):
     """Test that the test endpoint generates tests from specifications.
 
     ReqID: N/A"""
+    request = TestSpecRequest(spec_file="specs.md")
+    response = api_test_endpoint(request, token=None)
+    assert isinstance(response, WorkflowResponse)
+    assert response.messages == ("Test successful",)
+    assert agentapi_module.LATEST_MESSAGES == ("Test successful",)
 
-    def update_bridge(bridge, **kwargs):
-        bridge.display_result("Test successful")
-        return True
-
-    mock_cli_commands["test_cmd"].side_effect = update_bridge
-
-    from devsynth.interface.agentapi import AgentAPI, APIBridge
-
-    bridge = APIBridge()
-    agent_api = AgentAPI(bridge)
-    messages = agent_api.test(spec_file="specs.md", output_dir=None)
-
-    assert messages == ["Test successful"]
-    mock_cli_commands["test_cmd"].assert_called_once()
-    call_kwargs = mock_cli_commands["test_cmd"].call_args[1]
+    call_kwargs = mock_cli_commands["test_cmd"].call_args.kwargs
     assert call_kwargs["spec_file"] == "specs.md"
     assert call_kwargs["output_dir"] is None
     assert "bridge" in call_kwargs
 
 
-@pytest.mark.slow
+@pytest.mark.medium
 def test_code_endpoint_generates_code_succeeds(mock_cli_commands, clean_state):
     """Test that the code endpoint generates code from tests.
 
     ReqID: N/A"""
     request = CodeRequest(output_dir=None)
     response = code_endpoint(request, token=None)
-    assert response.messages == ["Code successful"]
+    assert isinstance(response, WorkflowResponse)
+    assert response.messages == ("Code successful",)
+    assert agentapi_module.LATEST_MESSAGES == ("Code successful",)
 
-    mock_cli_commands["code_cmd"].assert_called_once_with(
-        output_dir=None, bridge=mock_cli_commands["code_cmd"].call_args[1]["bridge"]
-    )
+    call_kwargs = mock_cli_commands["code_cmd"].call_args.kwargs
+    assert call_kwargs["output_dir"] is None
+    assert "bridge" in call_kwargs
 
 
-@pytest.mark.slow
+@pytest.mark.medium
 def test_doctor_endpoint_runs_diagnostics_succeeds(mock_cli_commands, clean_state):
     """Test that the doctor endpoint runs diagnostics.
 
     ReqID: N/A"""
     request = DoctorRequest(path=".", fix=False)
     response = doctor_endpoint(request, token=None)
-    assert response.messages == ["Doctor successful"]
+    assert isinstance(response, WorkflowResponse)
+    assert response.messages == ("Doctor successful",)
+    assert agentapi_module.LATEST_MESSAGES == ("Doctor successful",)
 
-    mock_cli_commands["doctor_cmd"].assert_called_once_with(
-        path=".",
-        fix=False,
-        bridge=mock_cli_commands["doctor_cmd"].call_args[1]["bridge"],
-    )
+    call_kwargs = mock_cli_commands["doctor_cmd"].call_args.kwargs
+    assert call_kwargs["path"] == "."
+    assert call_kwargs["fix"] is False
+    assert "bridge" in call_kwargs
 
 
-@pytest.mark.slow
+@pytest.mark.medium
 def test_edrr_cycle_endpoint_runs_cycle_succeeds(mock_cli_commands, clean_state):
     """Test that the edrr_cycle endpoint runs an EDRR cycle.
 
     ReqID: N/A"""
     request = EDRRCycleRequest(prompt="test prompt", context=None, max_iterations=3)
     response = edrr_cycle_endpoint(request, token=None)
-    assert response.messages == ["EDRR cycle successful"]
+    assert isinstance(response, WorkflowResponse)
+    assert response.messages == ("EDRR cycle successful",)
+    assert agentapi_module.LATEST_MESSAGES == ("EDRR cycle successful",)
 
-    mock_cli_commands["edrr_cycle_cmd"].assert_called_once_with(
-        prompt="test prompt",
-        context=None,
-        max_iterations=3,
-        bridge=mock_cli_commands["edrr_cycle_cmd"].call_args[1]["bridge"],
-    )
+    call_kwargs = mock_cli_commands["edrr_cycle_cmd"].call_args.kwargs
+    assert call_kwargs["prompt"] == "test prompt"
+    assert call_kwargs["context"] is None
+    assert call_kwargs["max_iterations"] == 3
+    assert "bridge" in call_kwargs
 
 
-@pytest.mark.slow
+@pytest.mark.medium
 def test_status_endpoint_returns_messages_returns_expected_result(clean_state):
     """Test that the status endpoint returns the latest messages.
 
     ReqID: N/A"""
-    LATEST_MESSAGES.clear()
-    LATEST_MESSAGES.append("Status: running")
+    agentapi_module.LATEST_MESSAGES = ("Status: running",)
     response = status_endpoint(token=None)
-    assert response.messages == ["Status: running"]
+    assert isinstance(response, WorkflowResponse)
+    assert response.messages == ("Status: running",)
 
 
-@pytest.mark.slow
+@pytest.mark.medium
 def test_test_endpoint_generates_tests_from_spec_succeeds(
     mock_cli_commands, clean_state
 ):
     """Test that the test endpoint generates tests from a specification file.
 
     ReqID: FR-17"""
-    request = APITestSpecRequest(spec_file="specs.md", output_dir=None)
+    request = TestSpecRequest(spec_file="specs.md", output_dir="out")
     response = api_test_endpoint(request, token=None)
-    assert response.messages == ["Test successful"]
+    assert isinstance(response, WorkflowResponse)
+    assert response.messages == ("Test successful",)
 
-    mock_cli_commands["test_cmd"].assert_called_once_with(
-        spec_file="specs.md",
-        output_dir=None,
-        bridge=mock_cli_commands["test_cmd"].call_args[1]["bridge"],
-    )
+    call_kwargs = mock_cli_commands["test_cmd"].call_args.kwargs
+    assert call_kwargs["spec_file"] == "specs.md"
+    assert call_kwargs["output_dir"] == "out"
+    assert "bridge" in call_kwargs
 
 
-@pytest.mark.slow
+@pytest.mark.medium
 def test_endpoints_handle_errors_properly_raises_error(mock_cli_commands, clean_state):
     """Test that the endpoints handle errors properly by returning appropriate HTTP exceptions.
 


### PR DESCRIPTION
## Summary
- refresh Agent API endpoint tests to build requests from the shared schema module and assert WorkflowResponse payloads
- extend AgentAPI class unit coverage to assert typed responses and schema validation failures
- add requirement service DTO tests and document OpenAPI schema exposure via integration coverage

## Testing
- PYTHONPATH=src poetry run devsynth run-tests --speed=fast *(fails: ModuleNotFoundError: click)*
- PYTHONPATH=src poetry run devsynth run-tests --speed=medium --tests tests/unit/interface/test_api_endpoints.py *(fails: ModuleNotFoundError: click)*
- poetry run pytest tests/unit/interface/test_api_endpoints.py -m medium *(skipped: fastapi not installed)*
- poetry run pytest tests/unit/application/requirements/test_requirement_service_dtos.py -m fast

------
https://chatgpt.com/codex/tasks/task_e_68daa7924218833395495e814a0ede5f