### PR TITLE
test: add deterministic stubs for memory backends

### DIFF
--- a/docs/testing/integration_extras.md
+++ b/docs/testing/integration_extras.md
@@ -10,6 +10,12 @@ Audience: developers running integration tests locally or in targeted CI jobs.
 - Run via the CLI wrapper to ensure consistent plugins and env defaults:
   poetry run devsynth run-tests --target integration-tests --speed=medium
 
+### Deterministic unit coverage for optional memory backends
+- The memory unit suite now provides in-repo stubs for ChromaDB, DuckDB, FAISS, and Kuzu.
+- Stubs live under `tests/unit/application/memory/conftest.py` and set resource flags automatically.
+- CRUD tests exercise the production adapters without needing the optional wheels installed.
+- Install the real extras only when validating live integrations or performance tuning.
+
 ## Extras to Resource Flags Mapping
 These extras are defined in pyproject [tool.poetry.extras] and map to test resource flags as follows:
 

--- a/tests/unit/application/memory/test_chromadb_store.py
+++ b/tests/unit/application/memory/test_chromadb_store.py
@@ -1,13 +1,10 @@
-import os
-import os
 import uuid
 
+import chromadb
 import pytest
 
 from devsynth.application.memory.chromadb_store import ChromaDBStore
 from devsynth.domain.models.memory import MemoryItem, MemoryType
-
-chromadb = pytest.importorskip("chromadb")
 
 
 class _TestableChromaDBStore(ChromaDBStore):
@@ -28,9 +25,6 @@ class _TestableChromaDBStore(ChromaDBStore):
 @pytest.mark.fast
 def test_store_and_retrieve_with_fallback(monkeypatch, tmp_path):
     """Store and retrieve items using fallback storage. ReqID: N/A"""
-    if os.environ.get("DEVSYNTH_RESOURCE_CHROMADB_AVAILABLE") != "1":
-        pytest.skip("ChromaDB resource not available")
-
     class FailingClient:
         def get_collection(self, name):  # pragma: no cover - forced failure
             raise RuntimeError("fail")
@@ -39,7 +33,6 @@ def test_store_and_retrieve_with_fallback(monkeypatch, tmp_path):
             raise RuntimeError("fail")
 
     monkeypatch.setattr(chromadb, "EphemeralClient", lambda: FailingClient())
-    monkeypatch.setenv("DEVSYNTH_NO_FILE_LOGGING", "1")
 
     store = _TestableChromaDBStore(str(tmp_path))
     item = MemoryItem(

--- a/tests/unit/application/memory/test_chromadb_store_delete_versions.py
+++ b/tests/unit/application/memory/test_chromadb_store_delete_versions.py
@@ -10,9 +10,6 @@ from unittest.mock import MagicMock
 
 import pytest
 
-pytest.importorskip("chromadb")
-pytest.importorskip("tiktoken")
-
 from devsynth.application.memory.chromadb_store import ChromaDBStore
 from devsynth.domain.models.memory import MemoryItem
 

--- a/tests/unit/application/memory/test_duckdb_store.py
+++ b/tests/unit/application/memory/test_duckdb_store.py
@@ -1,6 +1,5 @@
 import json
 import os
-import os
 import uuid
 from datetime import datetime, timedelta
 from typing import Any, Dict, List, Optional
@@ -8,9 +7,6 @@ from typing import Any, Dict, List, Optional
 import numpy as np
 import pytest
 
-pytest.importorskip("duckdb")
-if os.environ.get("DEVSYNTH_RESOURCE_DUCKDB_AVAILABLE", "true").lower() == "false":
-    pytest.skip("DuckDB resource not available", allow_module_level=True)
 from devsynth.application.memory.duckdb_store import DuckDBStore
 from devsynth.application.memory.dto import build_memory_record
 from devsynth.domain.models.memory import MemoryItem, MemoryType, MemoryVector

--- a/tests/unit/application/memory/test_faiss_store.py
+++ b/tests/unit/application/memory/test_faiss_store.py
@@ -10,14 +10,8 @@ from datetime import datetime
 import numpy as np
 import pytest
 
-faiss = pytest.importorskip("faiss")
-
 from devsynth.application.memory.faiss_store import FAISSStore  # noqa: E402
 from devsynth.domain.models.memory import MemoryVector  # noqa: E402
-from tests.conftest import is_resource_available  # noqa: E402
-
-if not is_resource_available("faiss"):
-    pytest.skip("Resource 'faiss' not available", allow_module_level=True)
 
 
 def _build_vector(


### PR DESCRIPTION
## Summary
- provide deterministic stub modules for ChromaDB, DuckDB, FAISS, and Kuzu so the memory unit suite covers CRUD paths without optional wheels
- update memory adapter tests to rely on the new fixtures and keep resource markers while avoiding module-level skips
- document the new stubbed coverage flow in `docs/testing/integration_extras.md`

## Testing
- ⚠️ `poetry run devsynth run-tests --speed=fast --speed=medium --no-parallel` *(fails: ModuleNotFoundError: No module named 'devsynth' in this environment)*
- ✅ `poetry run python scripts/verify_test_markers.py`


------
https://chatgpt.com/codex/tasks/task_e_68dab5cf1a488333978367d68fe913c2