### PR TITLE
Align WSDE specifications with general behaviour suites

### DIFF
--- a/docs/specifications/consensus-building.md
+++ b/docs/specifications/consensus-building.md
@@ -1,51 +1,81 @@
 ---
 author: DevSynth Team
 date: 2025-08-19
-last_reviewed: 2025-09-22
+last_reviewed: 2025-09-29
 status: review
 tags:
-
-- specification
+  - specification
+  - wsde
+  - consensus
 
 title: Consensus Building
 version: 0.1.0-alpha.1
 ---
 
-<!--
-Required metadata fields:
-- author: document author
-- date: creation date
-- last_reviewed: last review date
-- status: draft | review | published
-- tags: search keywords
-- title: short descriptive name
-- version: specification version
--->
-
 # Summary
 
-## Socratic Checklist
-- What is the problem?
-- What proofs confirm the solution?
+Consensus building ensures WSDE teams surface expertise-weighted perspectives,
+resolve conflicts, and document final decisions with rationale. The executable
+stories in
+[`tests/behavior/features/general/consensus_building.feature`](../../tests/behavior/features/general/consensus_building.feature)
+set the baseline behaviour for voting, conflict mediation, and decision history.
+Companion scenarios in
+[`tests/behavior/features/general/delegate_task_consensus.feature`](../../tests/behavior/features/general/delegate_task_consensus.feature)
+and
+[`tests/behavior/features/general/wsde_voting_mechanisms.feature`](../../tests/behavior/features/general/wsde_voting_mechanisms.feature)
+extend those flows into delegation and voting tie-breakers.
 
 ## Motivation
 
-## What proofs confirm the solution?
-- BDD scenarios in [`tests/behavior/features/consensus_building.feature`](../../tests/behavior/features/consensus_building.feature) and [`tests/behavior/features/general/consensus_building.feature`](../../tests/behavior/features/general/consensus_building.feature) run through [`tests/behavior/steps/test_basic_consensus_steps.py`](../../tests/behavior/steps/test_basic_consensus_steps.py) and [`tests/behavior/steps/test_consensus_building_steps.py`](../../tests/behavior/steps/test_consensus_building_steps.py), covering majority vote, threshold handling, conflict resolution, and decision tracking.
-- Delegation and fallback scenarios in [`tests/behavior/features/general/delegate_task_consensus.feature`](../../tests/behavior/features/general/delegate_task_consensus.feature) and [`tests/behavior/features/general/wsde_voting_mechanisms.feature`](../../tests/behavior/features/general/wsde_voting_mechanisms.feature) ensure consensus is integrated into voting flows when ties or failures occur.
-- Unit suites such as [`tests/unit/application/collaboration/test_wsde_team_consensus_utils.py`](../../tests/unit/application/collaboration/test_wsde_team_consensus_utils.py), [`tests/unit/application/collaboration/test_wsde_team_consensus_summary.py`](../../tests/unit/application/collaboration/test_wsde_team_consensus_summary.py), and [`tests/unit/application/collaboration/test_wsde_team_consensus_conflict_detection.py`](../../tests/unit/application/collaboration/test_wsde_team_consensus_conflict_detection.py) verify weighted voting, logging, and conflict detection utilities.
-- Property-based coverage in [`tests/property/test_reasoning_loop_properties.py`](../../tests/property/test_reasoning_loop_properties.py) ensures consensus hooks interact safely with the dialectical reasoning loop.
-
+WSDE collaboration depends on transparent decision paths. Weighted voting and
+conflict resolution must align with the domain models in
+[`src/devsynth/domain/models/wsde_voting.py`](../../src/devsynth/domain/models/wsde_voting.py)
+and
+[`src/devsynth/domain/models/wsde_decision_making.py`](../../src/devsynth/domain/models/wsde_decision_making.py).
+The team coordinator integrates these models via
+[`src/devsynth/application/collaboration/wsde_team_consensus.py`](../../src/devsynth/application/collaboration/wsde_team_consensus.py),
+so the specification keeps the documentation synchronized with the behaviour the
+unit suites assert.
 
 ## Specification
 
-- `build_consensus` aggregates votes and reasoning metadata, supporting configurable thresholds, weighted expertise, and tie-breaking strategies.
-- WSDE teams fallback to consensus when voting deadlocks and document the fallback path, including contributing agents and rationales.
-- Consensus summaries record contributors, method, reasoning, and comparative analyses for auditability and downstream persistence.
-- Decision histories store vote tallies, explanations, and consensus metadata for later review.
+- **Weighted voting**: Each decision captures agent votes along with expertise
+  weights. Weighted tallies determine the preferred option, and rationale is
+  stored alongside the vote to justify the weighting.
+- **Conflict resolution**: When conflicts arise the team records dissenting
+  positions, triggers facilitated dialogue, and documents the steps taken to
+  address the concerns before recording the consensus result.
+- **Tie-breaking**: Predefined strategies (e.g., primus adjudication,
+  escalation, or expertise comparison) apply deterministically when weighted
+  voting ends in a tie, with the chosen method captured in the decision history.
+- **Decision tracking**: Decision records include contributors, weighted scores,
+  conflict notes, applied tie-breaking strategy, and a narrative explanation
+  suitable for stakeholder review.
 
 ## Acceptance Criteria
 
-- Majority, weighted, and tie-breaking paths are all exercised by behavior suites and produce structured consensus objects.
-- Consensus fallbacks surface when dialectical reasoning or voting fails, ensuring decisions remain traceable.
-- Decision histories expose contributors, rationale, and method for each consensus result.
+- Behaviour suites for consensus building, delegation, and voting mechanisms run
+  with consistent role statements and scenario names across the general and
+  mirrored features, demonstrating parity in how teams record votes, resolve
+  conflicts, and document history.
+- Consensus services serialize decision outcomes, participant metadata, and
+  conflict indicators as validated by unit tests including
+  [`tests/unit/application/collaboration/test_wsde_team_consensus_utils.py`](../../tests/unit/application/collaboration/test_wsde_team_consensus_utils.py),
+  [`tests/unit/application/collaboration/test_wsde_team_consensus_conflict_detection.py`](../../tests/unit/application/collaboration/test_wsde_team_consensus_conflict_detection.py),
+  and
+  [`tests/unit/application/collaboration/test_wsde_memory_sync_hooks.py`](../../tests/unit/application/collaboration/test_wsde_memory_sync_hooks.py).
+- Decision histories propagate through orchestration layers without data loss,
+  satisfying the integration points in
+  [`src/devsynth/consensus.py`](../../src/devsynth/consensus.py) and the
+  collaboration coordinator tests that verify consensus payloads.
+
+## Traceability
+
+- **Behaviour**: `consensus_building.feature`, `delegate_task_consensus.feature`,
+  `wsde_voting_mechanisms.feature`
+- **Domain models**: `domain/models/wsde_voting.py`,
+  `domain/models/wsde_decision_making.py`,
+  `application/collaboration/wsde_team_consensus.py`, `consensus.py`
+- **Unit suites**: `tests/unit/application/collaboration/test_wsde_team_consensus_utils.py`,
+  `tests/unit/application/collaboration/test_wsde_team_consensus_conflict_detection.py`,
+  `tests/unit/application/collaboration/test_wsde_memory_sync_hooks.py`

--- a/docs/specifications/wsde-agent-model-refinement.md
+++ b/docs/specifications/wsde-agent-model-refinement.md
@@ -1,91 +1,76 @@
 ---
 author: DevSynth Team
 date: 2025-08-19
-last_reviewed: 2025-10-20
+last_reviewed: 2025-09-29
 status: review
 tags:
-
-- specification
-- autoresearch
+  - specification
+  - wsde
+  - collaboration
 
 title: WSDE Agent Model Refinement
 version: 0.1.0-alpha.1
 ---
 
-<!--
-Required metadata fields:
-- author: document author
-- date: creation date
-- last_reviewed: last review date
-- status: draft | review | published
-- tags: search keywords
-- title: short descriptive name
-- version: specification version
--->
-
 # Summary
 
-## Socratic Checklist
-- What is the problem?
-  WSDE teams provide flexible collaboration but lack specialised research roles
-  that can drive Autoresearch tasks without overloading Designer or Evaluator
-  personas.
-- What proofs confirm the solution?
-  Behaviour-driven tests cover role assignment, primus rotation, and research
-  persona workflows while MVUU traces demonstrate improved critique quality and
-  reduced iteration counts when Autoresearch roles are active.
+The refined WSDE agent model codifies peer-based collaboration, context-driven
+leadership, autonomous contribution, consensus alignment, and dialectical review.
+Executable stories in
+[`tests/behavior/features/general/wsde_agent_model.feature`](../../tests/behavior/features/general/wsde_agent_model.feature)
+articulate these behaviours, with
+[`tests/behavior/features/wsde_agent_model_refinement.feature`](../../tests/behavior/features/wsde_agent_model_refinement.feature)
+mirroring them for targeted regression coverage.
 
 ## Motivation
 
-DevSynth's WSDE organisation already supports dynamic role assignment, dialectical
-reasoning, and knowledge graph integration. The Autoresearch RFC introduces new
-workstreams—scoping research questions, evaluating sources, and synthesising
-findings—that benefit from explicitly trained personas. Formalising these roles
-keeps the collaboration model intelligible, preserves accountability, and allows
-agents to record research provenance consistently.
+WSDE teams adapt roles based on expertise and task context. Aligning the
+specification with the domain models in
+[`src/devsynth/domain/models/wsde_base.py`](../../src/devsynth/domain/models/wsde_base.py),
+[`src/devsynth/domain/models/wsde_context_driven_leadership.py`](../../src/devsynth/domain/models/wsde_context_driven_leadership.py),
+[`src/devsynth/domain/models/wsde_roles.py`](../../src/devsynth/domain/models/wsde_roles.py),
+and
+[`src/devsynth/domain/models/wsde_multidisciplinary.py`](../../src/devsynth/domain/models/wsde_multidisciplinary.py)
+keeps the documentation synchronized with how the runtime handles primus
+selection, role blending, and dialectical critique coordination.
 
 ## Specification
 
-- Extend the WSDE role taxonomy with three research personas:
-  - **Research Lead**: orchestrates research objectives, defines knowledge graph
-    queries, and manages Autoresearch task queues.
-  - **Bibliographer**: validates sources, tracks citation provenance, and
-    maintains links between research artefacts and requirements.
-  - **Synthesist**: converts vetted findings into actionable implementation
-    guidance, ensuring critiques and solutions incorporate research insights.
-- Update the `WSDETeam` role assignment matrix:
-  - `assign_roles` maps each persona to an underlying WSDE core role (Lead →
-    Supervisor, Bibliographer → Designer, Synthesist → Evaluator) while allowing
-    agents to hold both a core and research role.
-  - `select_primus_by_expertise` considers research proficiency scores when tasks
-    include an `autoresearch` flag.
-- Add Autoresearch collaboration checkpoints:
-  - After the Expand phase, the Research Lead records the active hypothesis set
-    and outstanding research questions in memory.
-  - Before Retrospect, the Synthesist publishes a `research_summary` artefact and
-    links it to MVUU trace entries.
-- Implement CLI flags (`--research-personas` and `--research-metrics`) that toggle
-  persona activation and emit MVUU-compatible telemetry.
-- Document research role responsibilities and failure modes so training data and
-  runtime prompts reinforce expectations.
+- **Peer-based collaboration**: Teams instantiate with agents operating as peers
+  without fixed hierarchies. Any agent can initiate work, and authority rotates
+  according to situational expertise.
+- **Context-driven leadership**: Primus selection responds to task metadata and
+  expertise scores, promoting the agent best suited for the active work item and
+  reverting leadership when the context changes.
+- **Autonomous contribution**: Agents may propose solutions or critiques at any
+  phase, with the system aggregating contributions without ordering constraints.
+- **Consensus alignment**: When multiple solutions emerge the team invokes the
+  consensus pipeline, ensuring the final decision captures inputs from all
+  relevant agents.
+- **Dialectical review**: Critic roles apply thesis, antithesis, and synthesis
+  analysis to proposed solutions, and the resulting synthesis informs the team
+  outcome and stored artefacts.
 
 ## Acceptance Criteria
 
-- Behaviour scenarios demonstrate that Autoresearch tasks assign Research Lead,
-  Bibliographer, and Synthesist roles without displacing the existing Worker and
-  Supervisor duties.
-- Primus rotation prioritises agents with Autoresearch expertise when the task
-  includes a research flag, while default behaviour remains unchanged for other
-  tasks.
-- MVUU traces include research checkpoints that reference knowledge graph
-  artefacts and agent decisions.
-- Unit tests verify that CLI toggles activate persona instrumentation and emit
-  the expected telemetry payloads.
+- Behaviour suites demonstrate parity between the general and mirrored features
+  for each scenario (peer collaboration, context-driven leadership, autonomous
+  collaboration, consensus decisions, and dialectical review).
+- Domain logic for primus rotation, peer review, and dialectical analysis is
+  exercised by unit suites such as
+  [`tests/unit/general/test_wsde_team_extended.py`](../../tests/unit/general/test_wsde_team_extended.py),
+  [`tests/unit/general/test_wsde_team_coordinator.py`](../../tests/unit/general/test_wsde_team_coordinator.py),
+  and
+  [`tests/unit/domain/models/test_wsde_base_methods.py`](../../tests/unit/domain/models/test_wsde_base_methods.py).
+- Role metadata and multidisciplinary overlays remain consistent with the
+  responsibilities outlined in the domain models listed above.
 
-## Proofs
+## Traceability
 
-- `wsde_agent_model_refinement.feature` scenarios validate persona assignment and
-  MVUU trace generation.
-- Unit tests cover the updated primus selection heuristics and telemetry writers.
-- Integration tests run Autoresearch tasks end-to-end, confirming that knowledge
-  graph insights feed into critiques and synthesis outputs.
+- **Behaviour**: `wsde_agent_model.feature`, `wsde_agent_model_refinement.feature`
+- **Domain models**: `domain/models/wsde_base.py`,
+  `domain/models/wsde_context_driven_leadership.py`, `domain/models/wsde_roles.py`,
+  `domain/models/wsde_multidisciplinary.py`
+- **Unit suites**: `tests/unit/general/test_wsde_team_extended.py`,
+  `tests/unit/general/test_wsde_team_coordinator.py`,
+  `tests/unit/domain/models/test_wsde_base_methods.py`

--- a/docs/specifications/wsde-message-passing-and-peer-review.md
+++ b/docs/specifications/wsde-message-passing-and-peer-review.md
@@ -1,40 +1,75 @@
 ---
 author: DevSynth Team
 date: 2025-08-19
-last_reviewed: 2025-08-19
-status: draft
+last_reviewed: 2025-09-29
+status: review
 tags:
-
-- specification
+  - specification
+  - wsde
+  - peer-review
 
 title: WSDE Message Passing and Peer Review
 version: 0.1.0-alpha.1
 ---
 
-<!--
-Required metadata fields:
-- author: document author
-- date: creation date
-- last_reviewed: last review date
-- status: draft | review | published
-- tags: search keywords
-- title: short descriptive name
-- version: specification version
--->
-
 # Summary
 
-## Socratic Checklist
-- What is the problem?
-- What proofs confirm the solution?
+WSDE message passing and peer review provide the communication backbone for
+collaborative quality control. Executable scenarios in
+[`tests/behavior/features/general/wsde_message_passing_peer_review.feature`](../../tests/behavior/features/general/wsde_message_passing_peer_review.feature)
+outline broadcast, priority, structured payload, and review cycles that the
+platform must support. The mirrored workflow feature at
+[`tests/behavior/features/wsde_message_passing_and_peer_review.feature`](../../tests/behavior/features/wsde_message_passing_and_peer_review.feature)
+keeps targeted regression checks in sync.
 
 ## Motivation
 
-## What proofs confirm the solution?
-- BDD scenarios in [`tests/behavior/features/wsde_message_passing_and_peer_review.feature`](../../tests/behavior/features/wsde_message_passing_and_peer_review.feature) ensure termination and expected outcomes.
-- Finite state transitions and bounded loops guarantee termination.
-
+Reliable peer review depends on predictable messaging semantics and persistent
+history. The domain implementation across
+[`src/devsynth/domain/models/wsde_base.py`](../../src/devsynth/domain/models/wsde_base.py),
+[`src/devsynth/domain/models/wsde_utils.py`](../../src/devsynth/domain/models/wsde_utils.py),
+and
+[`src/devsynth/application/collaboration/peer_review.py`](../../src/devsynth/application/collaboration/peer_review.py)
+relies on these guarantees to route requests, evaluate feedback, and store
+results. Updating the specification ensures documentation matches the behaviours
+covered by the feature files and unit suites.
 
 ## Specification
 
+- **Direct and broadcast messaging**: Agents can send directed messages and
+  broadcasts with sender, recipient, type, and timestamp fields captured for each
+  event. Broadcasts record a single event with derived recipient metadata.
+- **Priority handling**: Message queues respect explicit priority markers,
+  ensuring high-priority updates are processed ahead of lower priorities.
+- **Structured content**: Messages accept structured payloads (e.g., tabular
+  data) that remain queryable by key to support dashboards and audit requests.
+- **Peer review execution**: Review submissions trigger reviewer assignment,
+  criteria-aware evaluation, dialectical analysis, revision cycles, and history
+  tracking as detailed in the feature scenarios.
+- **History persistence**: Communication and peer review records remain
+  filterable by agent, type, and timeframe for reporting and governance.
+
 ## Acceptance Criteria
+
+- Behaviour suites demonstrate parity for message passing, broadcast, priority,
+  structured content, reviewer assignment, acceptance criteria, revision cycles,
+  dialectical analysis, and history tracking between the general and mirrored
+  feature files.
+- Domain classes append message metadata and peer review outcomes as validated by
+  unit suites such as
+  [`tests/unit/domain/models/test_wsde_base_methods.py`](../../tests/unit/domain/models/test_wsde_base_methods.py),
+  [`tests/unit/application/collaboration/test_peer_review_store.py`](../../tests/unit/application/collaboration/test_peer_review_store.py),
+  and
+  [`tests/unit/general/test_wsde_team_extended.py`](../../tests/unit/general/test_wsde_team_extended.py).
+- Collaboration services expose retrieval APIs consistent with the message and
+  peer review history requirements asserted in the domain and application layers.
+
+## Traceability
+
+- **Behaviour**: `wsde_message_passing_peer_review.feature`,
+  `wsde_message_passing_and_peer_review.feature`
+- **Domain models**: `domain/models/wsde_base.py`, `domain/models/wsde_utils.py`,
+  `application/collaboration/peer_review.py`
+- **Unit suites**: `tests/unit/domain/models/test_wsde_base_methods.py`,
+  `tests/unit/application/collaboration/test_peer_review_store.py`,
+  `tests/unit/general/test_wsde_team_extended.py`

--- a/docs/specifications/wsde-peer-review-workflow.md
+++ b/docs/specifications/wsde-peer-review-workflow.md
@@ -1,40 +1,80 @@
 ---
 author: DevSynth Team
 date: 2025-08-19
-last_reviewed: 2025-08-19
-status: draft
+last_reviewed: 2025-09-29
+status: review
 tags:
-
-- specification
+  - specification
+  - wsde
+  - peer-review
 
 title: WSDE Peer Review Workflow
 version: 0.1.0-alpha.1
 ---
 
-<!--
-Required metadata fields:
-- author: document author
-- date: creation date
-- last_reviewed: last review date
-- status: draft | review | published
-- tags: search keywords
-- title: short descriptive name
-- version: specification version
--->
-
 # Summary
 
-## Socratic Checklist
-- What is the problem?
-- What proofs confirm the solution?
+The WSDE peer review workflow coordinates structured message passing, reviewer
+assignment, and revision tracking so teams can iterate on work products with
+audit-ready evidence. Behaviour scenarios in
+[`tests/behavior/features/general/wsde_message_passing_peer_review.feature`](../../tests/behavior/features/general/wsde_message_passing_peer_review.feature)
+and its mirrored suite
+[`tests/behavior/features/wsde_peer_review_workflow.feature`](../../tests/behavior/features/wsde_peer_review_workflow.feature)
+define the communication and review checkpoints that the workflow must support.
 
 ## Motivation
 
-## What proofs confirm the solution?
-- BDD scenarios in [`tests/behavior/features/wsde_peer_review_workflow.feature`](../../tests/behavior/features/wsde_peer_review_workflow.feature) ensure termination and expected outcomes.
-- Finite state transitions and bounded loops guarantee termination.
-
+Peer review is a critical control point for the WSDE collaboration model. The
+workflow needs to channel role-aware communication, ensure reviewers apply
+acceptance criteria, and surface dialectical critiques so that downstream EDRR
+phases and compliance reporting can rely on consistent records. Aligning the
+specification with the executable stories keeps the workflow behaviour in sync
+with the domain models in
+[`src/devsynth/domain/wsde/workflow.py`](../../src/devsynth/domain/wsde/workflow.py)
+and the peer review utilities in
+[`src/devsynth/domain/models/wsde_utils.py`](../../src/devsynth/domain/models/wsde_utils.py).
 
 ## Specification
 
+- **Structured message routing**: All peer review requests and updates travel
+  through WSDE message queues with sender, recipient, type, and priority fields
+  captured as described in the "Message passing" scenarios. Message payloads
+  support structured content that can be queried by key for audit and tooling
+  integrations.
+- **Reviewer assignment and execution**: When a work product is submitted the
+  workflow invokes reviewer selection based on expertise metadata. Reviewers
+  receive targeted requests, deliver independent evaluations, and the author
+  receives the full feedback set.
+- **Acceptance criteria and revision cycles**: Review messages embed acceptance
+  criteria where provided, record pass/fail outcomes, and capture dialectical
+  analysis (thesis, antithesis, synthesis). Revisions loop until reviewers
+  approve, with the workflow maintaining version and history metadata.
+- **History and persistence**: Communication and review events are appended to
+  the peer review history, exposing timestamps, participants, and decision
+  rationale for retrieval by orchestration services.
+
 ## Acceptance Criteria
+
+- Behaviour scenarios covering message routing, broadcast messaging, structured
+  payloads, reviewer assignment, acceptance criteria, revision loops, dialectical
+  analysis, and history tracking all execute without divergence between the
+  general and workflow-specific feature suites.
+- Domain utilities persist peer review records, consensus fallbacks, and message
+  metadata as validated by unit suites such as
+  [`tests/unit/domain/test_wsde_peer_review_workflow.py`](../../tests/unit/domain/test_wsde_peer_review_workflow.py),
+  [`tests/unit/application/collaboration/test_peer_review_store.py`](../../tests/unit/application/collaboration/test_peer_review_store.py),
+  and
+  [`tests/unit/general/test_wsde_team_extended.py`](../../tests/unit/general/test_wsde_team_extended.py).
+- The workflow exposes revision history and dialectical critique artefacts for
+  downstream consumers, satisfying the persistence expectations asserted in
+  [`src/devsynth/application/collaboration/peer_review.py`](../../src/devsynth/application/collaboration/peer_review.py).
+
+## Traceability
+
+- **Behaviour**: `wsde_message_passing_peer_review.feature`,
+  `wsde_peer_review_workflow.feature`
+- **Domain models**: `domain/wsde/workflow.py`, `domain/models/wsde_utils.py`,
+  `application/collaboration/peer_review.py`
+- **Unit suites**: `tests/unit/domain/test_wsde_peer_review_workflow.py`,
+  `tests/unit/application/collaboration/test_peer_review_store.py`,
+  `tests/unit/general/test_wsde_team_extended.py`

--- a/tests/behavior/features/wsde_agent_model_refinement.feature
+++ b/tests/behavior/features/wsde_agent_model_refinement.feature
@@ -1,30 +1,44 @@
 Feature: WSDE Agent Model Refinement
-  As a [role]
-  I want to [capability]
-  So that [benefit]
+  As a developer using DevSynth
+  I want to use the refined WSDE agent model
+  So that I can benefit from non-hierarchical, context-driven agent collaboration
 
   Background:
-    Given [common setup step 1]
-    And [common setup step 2]
+    Given the DevSynth system is initialized
+    And a team of agents is configured
+    And the WSDE model is enabled
 
-  Scenario: [Scenario 1 Name]
-    Given [precondition 1]
-    When [action 1]
-    Then [expected outcome 1]
-    And [expected outcome 2]
+  Scenario: Peer-based collaboration
+    When I create a team with multiple agents
+    Then all agents should be treated as peers
+    And no agent should have permanent hierarchical authority
+    And agents should be able to collaborate without rigid role sequences
 
-  Scenario: [Scenario 2 Name]
-    Given [precondition 1]
-    When [action 1]
-    Then [expected outcome 1]
+  Scenario: Context-driven leadership
+    Given a team with multiple agents with different expertise
+    When a task requiring specific expertise is assigned
+    Then the agent with the most relevant expertise should become the temporary Primus
+    And the Primus role should change based on the task context
+    And the previous Primus should return to peer status
 
-  Scenario Outline: [Parameterized Scenario Name]
-    Given [precondition with <parameter>]
-    When [action with <parameter>]
-    Then [expected outcome with <parameter>]
+  Scenario: Autonomous collaboration
+    Given a team with multiple agents
+    When a complex task is assigned
+    Then any agent should be able to propose solutions at any stage
+    And any agent should be able to provide critiques at any stage
+    And the system should consider input from all agents
 
-    Examples:
-      | parameter | other_value |
-      | value1    | result1     |
-      | value2    | result2     |
-      | value3    | result3     |
+  Scenario: Consensus-based decision making
+    Given a team with multiple agents
+    When multiple solutions are proposed for a task
+    Then the system should facilitate consensus building
+    And the final decision should reflect input from all relevant agents
+    And no single agent should have dictatorial authority
+
+  Scenario: Dialectical review process
+    Given a team with a Critic agent
+    When a solution is proposed
+    Then the Critic agent should apply dialectical reasoning
+    And the Critic should identify thesis and antithesis
+    And the team should work toward a synthesis
+    And the final solution should reflect the dialectical process

--- a/tests/behavior/features/wsde_message_passing_and_peer_review.feature
+++ b/tests/behavior/features/wsde_message_passing_and_peer_review.feature
@@ -1,30 +1,87 @@
 Feature: WSDE Message Passing and Peer Review
-  As a [role]
-  I want to [capability]
-  So that [benefit]
+  As a developer using DevSynth
+  I want to use structured message passing and peer review in the WSDE model
+  So that agents can communicate effectively and improve output quality through systematic review
 
   Background:
-    Given [common setup step 1]
-    And [common setup step 2]
+    Given the DevSynth system is initialized
+    And a team of agents is configured
+    And the WSDE model is enabled
 
-  Scenario: [Scenario 1 Name]
-    Given [precondition 1]
-    When [action 1]
-    Then [expected outcome 1]
-    And [expected outcome 2]
+  Scenario: Message passing between agents
+    Given a team with multiple agents
+    When agent "worker-1" sends a message to agent "supervisor-1" with type "status_update"
+    Then agent "supervisor-1" should receive the message
+    And the message should have the correct sender, recipient, and type
+    And the message should be stored in the communication history
 
-  Scenario: [Scenario 2 Name]
-    Given [precondition 1]
-    When [action 1]
-    Then [expected outcome 1]
+  Scenario: Broadcast message to multiple agents
+    Given a team with multiple agents
+    When agent "primus-1" sends a broadcast message to all agents with type "task_assignment"
+    Then all agents should receive the message
+    And each message should have the correct sender and type
+    And the broadcast should be recorded as a single communication event
 
-  Scenario Outline: [Parameterized Scenario Name]
-    Given [precondition with <parameter>]
-    When [action with <parameter>]
-    Then [expected outcome with <parameter>]
+  Scenario: Message passing with priority levels
+    Given a team with multiple agents
+    When agent "worker-1" sends a message with priority "high" to agent "primus-1"
+    Then agent "primus-1" should receive the message with priority "high"
+    And high priority messages should be processed before lower priority messages
+    And the message priority should be recorded in the communication history
 
-    Examples:
-      | parameter | other_value |
-      | value1    | result1     |
-      | value2    | result2     |
-      | value3    | result3     |
+  Scenario: Message passing with structured content
+    Given a team with multiple agents
+    When agent "worker-1" sends a message with structured content:
+      | key        | value        |
+      | task_id    | task-123     |
+      | status     | in_progress  |
+      | completion | 75           |
+      | blockers   | none         |
+    Then agent "supervisor-1" should receive the message with the structured content
+    And the structured content should be accessible as a parsed object
+    And the message should be queryable by content fields
+
+  Scenario: Peer review request and execution
+    Given a team with multiple agents
+    When agent "worker-1" submits a work product for peer review
+    Then the system should assign reviewers based on expertise
+    And each reviewer should receive a review request message
+    And each reviewer should evaluate the work product independently
+    And each reviewer should submit feedback
+    And the original agent should receive all feedback
+
+  Scenario: Peer review with acceptance criteria
+    Given a team with multiple agents
+    When agent "worker-1" submits a work product with specific acceptance criteria
+    Then the peer review request should include the acceptance criteria
+    And reviewers should evaluate the work against the criteria
+    And the review results should indicate pass/fail for each criterion
+    And the overall review should include a final acceptance decision
+
+  Scenario: Peer review with revision cycle
+    Given a team with multiple agents
+    When agent "worker-1" submits a work product that requires revisions
+    And reviewers provide feedback requiring changes
+    Then agent "worker-1" should receive the consolidated feedback
+    And agent "worker-1" should create a revised version
+    And the revised version should be submitted for another review cycle
+    And the system should track the revision history
+    And the final accepted version should be marked as approved
+
+  Scenario: Peer review with dialectical analysis
+    Given a team with a Critic agent
+    When a work product is submitted for peer review
+    Then the Critic agent should apply dialectical analysis
+    And the analysis should identify strengths (thesis)
+    And the analysis should identify weaknesses (antithesis)
+    And the analysis should propose improvements (synthesis)
+    And the dialectical analysis should be included in the review feedback
+
+  Scenario: Message and review history tracking
+    Given a team with multiple agents that have exchanged messages
+    And multiple peer reviews have been conducted
+    When I request the communication history for the team
+    Then I should receive a chronological record of all messages
+    And I should receive a record of all peer reviews
+    And the history should include metadata about senders, recipients, and timestamps
+    And the history should be filterable by message type, agent, and time period

--- a/tests/behavior/features/wsde_peer_review_workflow.feature
+++ b/tests/behavior/features/wsde_peer_review_workflow.feature
@@ -1,30 +1,87 @@
 Feature: WSDE Peer Review Workflow
-  As a [role]
-  I want to [capability]
-  So that [benefit]
+  As a developer using DevSynth
+  I want to use structured message passing and peer review in the WSDE model
+  So that agents can communicate effectively and improve output quality through systematic review
 
   Background:
-    Given [common setup step 1]
-    And [common setup step 2]
+    Given the DevSynth system is initialized
+    And a team of agents is configured
+    And the WSDE model is enabled
 
-  Scenario: [Scenario 1 Name]
-    Given [precondition 1]
-    When [action 1]
-    Then [expected outcome 1]
-    And [expected outcome 2]
+  Scenario: Message passing between agents
+    Given a team with multiple agents
+    When agent "worker-1" sends a message to agent "supervisor-1" with type "status_update"
+    Then agent "supervisor-1" should receive the message
+    And the message should have the correct sender, recipient, and type
+    And the message should be stored in the communication history
 
-  Scenario: [Scenario 2 Name]
-    Given [precondition 1]
-    When [action 1]
-    Then [expected outcome 1]
+  Scenario: Broadcast message to multiple agents
+    Given a team with multiple agents
+    When agent "primus-1" sends a broadcast message to all agents with type "task_assignment"
+    Then all agents should receive the message
+    And each message should have the correct sender and type
+    And the broadcast should be recorded as a single communication event
 
-  Scenario Outline: [Parameterized Scenario Name]
-    Given [precondition with <parameter>]
-    When [action with <parameter>]
-    Then [expected outcome with <parameter>]
+  Scenario: Message passing with priority levels
+    Given a team with multiple agents
+    When agent "worker-1" sends a message with priority "high" to agent "primus-1"
+    Then agent "primus-1" should receive the message with priority "high"
+    And high priority messages should be processed before lower priority messages
+    And the message priority should be recorded in the communication history
 
-    Examples:
-      | parameter | other_value |
-      | value1    | result1     |
-      | value2    | result2     |
-      | value3    | result3     |
+  Scenario: Message passing with structured content
+    Given a team with multiple agents
+    When agent "worker-1" sends a message with structured content:
+      | key        | value        |
+      | task_id    | task-123     |
+      | status     | in_progress  |
+      | completion | 75           |
+      | blockers   | none         |
+    Then agent "supervisor-1" should receive the message with the structured content
+    And the structured content should be accessible as a parsed object
+    And the message should be queryable by content fields
+
+  Scenario: Peer review request and execution
+    Given a team with multiple agents
+    When agent "worker-1" submits a work product for peer review
+    Then the system should assign reviewers based on expertise
+    And each reviewer should receive a review request message
+    And each reviewer should evaluate the work product independently
+    And each reviewer should submit feedback
+    And the original agent should receive all feedback
+
+  Scenario: Peer review with acceptance criteria
+    Given a team with multiple agents
+    When agent "worker-1" submits a work product with specific acceptance criteria
+    Then the peer review request should include the acceptance criteria
+    And reviewers should evaluate the work against the criteria
+    And the review results should indicate pass/fail for each criterion
+    And the overall review should include a final acceptance decision
+
+  Scenario: Peer review with revision cycle
+    Given a team with multiple agents
+    When agent "worker-1" submits a work product that requires revisions
+    And reviewers provide feedback requiring changes
+    Then agent "worker-1" should receive the consolidated feedback
+    And agent "worker-1" should create a revised version
+    And the revised version should be submitted for another review cycle
+    And the system should track the revision history
+    And the final accepted version should be marked as approved
+
+  Scenario: Peer review with dialectical analysis
+    Given a team with a Critic agent
+    When a work product is submitted for peer review
+    Then the Critic agent should apply dialectical analysis
+    And the analysis should identify strengths (thesis)
+    And the analysis should identify weaknesses (antithesis)
+    And the analysis should propose improvements (synthesis)
+    And the dialectical analysis should be included in the review feedback
+
+  Scenario: Message and review history tracking
+    Given a team with multiple agents that have exchanged messages
+    And multiple peer reviews have been conducted
+    When I request the communication history for the team
+    Then I should receive a chronological record of all messages
+    And I should receive a record of all peer reviews
+    And the history should include metadata about senders, recipients, and timestamps
+    And the history should be filterable by message type, agent, and time period


### PR DESCRIPTION
## Summary
- refresh the WSDE consensus, peer review workflow, agent model, and message passing specifications to mirror the general behaviour suites and reference supporting domain models and unit tests
- replace the placeholder WSDE behaviour feature files with the executable scenarios from the general suite to keep wording and traceability aligned

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dad098f77c8333a0d9e93b7af0ba18