### PR TITLE
test: share streamlit stub across webui fixtures

### DIFF
--- a/tests/fixtures/webui_bridge_stub.py
+++ b/tests/fixtures/webui_bridge_stub.py
@@ -1,0 +1,67 @@
+"""Fixtures that coordinate Streamlit stubs across WebUI modules."""
+
+from __future__ import annotations
+
+from typing import Any, Protocol, runtime_checkable
+
+import pytest
+
+from tests.fixtures.fake_streamlit import FakeStreamlit
+
+
+@runtime_checkable
+class SupportsStreamlitLike(Protocol):
+    """Protocol capturing the small surface we rely on for Streamlit stubs."""
+
+    session_state: Any  # pragma: no cover - attribute existence only
+
+
+def _make_stub_factory(stub: SupportsStreamlitLike) -> Any:
+    """Create a callable that consistently returns ``stub``."""
+
+    def _return_stub() -> SupportsStreamlitLike:
+        return stub
+
+    return _return_stub
+
+
+def install_streamlit_stub(
+    stub: SupportsStreamlitLike, monkeypatch: pytest.MonkeyPatch
+) -> SupportsStreamlitLike:
+    """Install ``stub`` as the Streamlit implementation for WebUI modules."""
+
+    from devsynth.interface import webui_bridge
+    from devsynth.interface import webui
+    from devsynth.interface import webui_state
+
+    require_stub = _make_stub_factory(stub)
+
+    monkeypatch.setattr(webui_bridge, "st", stub, raising=False)
+    monkeypatch.setattr(webui_bridge, "_require_streamlit", require_stub, raising=False)
+
+    monkeypatch.setattr(webui, "_STREAMLIT", stub, raising=False)
+    monkeypatch.setattr(webui, "st", stub, raising=False)
+    monkeypatch.setattr(webui, "_require_streamlit", require_stub, raising=False)
+
+    monkeypatch.setattr(webui_state, "st", stub, raising=False)
+    monkeypatch.setattr(webui_state, "_require_streamlit", require_stub, raising=False)
+
+    return stub
+
+
+@pytest.fixture
+def streamlit_bridge_stub(
+    monkeypatch: pytest.MonkeyPatch,
+) -> SupportsStreamlitLike:
+    """Provide a shared :class:`FakeStreamlit` instance for WebUI tests."""
+
+    stub = FakeStreamlit()
+    install_streamlit_stub(stub, monkeypatch)
+
+    from devsynth.interface import webui_bridge
+
+    assert webui_bridge._require_streamlit() is stub
+    yield stub
+
+
+__all__ = ["install_streamlit_stub", "streamlit_bridge_stub"]

--- a/tests/fixtures/webui_test_utils.py
+++ b/tests/fixtures/webui_test_utils.py
@@ -28,6 +28,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from tests.fixtures.streamlit_mocks import StreamlitModule, StreamlitStub
+from tests.fixtures.webui_bridge_stub import install_streamlit_stub
 
 
 class DummyForm:
@@ -164,7 +165,7 @@ def create_mock_streamlit() -> StreamlitModule:
 
 
 @pytest.fixture
-def mock_streamlit():
+def mock_streamlit(monkeypatch: pytest.MonkeyPatch):
     """
     Fixture that provides a standardized mock Streamlit implementation.
 
@@ -176,13 +177,9 @@ def mock_streamlit():
     """
     # Create the mock Streamlit module
     mock_st = create_mock_streamlit()
-
-    # Patch the Streamlit module in both webui_state and webui modules
-    with (
-        patch("devsynth.interface.webui_state.st", mock_st),
-        patch("devsynth.interface.webui.st", mock_st),
-    ):
-        yield mock_st
+    install_streamlit_stub(mock_st, monkeypatch)
+    monkeypatch.setattr("devsynth.interface.webui_state.st", mock_st, raising=False)
+    yield mock_st
 
 
 @pytest.fixture

--- a/tests/unit/interface/conftest.py
+++ b/tests/unit/interface/conftest.py
@@ -5,6 +5,9 @@ import pytest
 from tests import conftest as root_conftest
 
 
+pytest_plugins = ["tests.fixtures.webui_bridge_stub"]
+
+
 @pytest.fixture
 def force_webui_available(monkeypatch: pytest.MonkeyPatch) -> None:
     """Ensure WebUI-gated tests run against the lightweight stub configuration."""


### PR DESCRIPTION
## Summary
- add a shared Streamlit stub installer so WebUI bridge and interface modules resolve the same fake instance
- expose a `streamlit_bridge_stub` fixture to interface unit tests via `pytest_plugins`
- update WebUI behavior utilities to reuse the installer when creating their mock Streamlit module

## Testing
- pytest tests/unit/interface/test_webui_behavior_checklist_fast.py::test_require_streamlit_guidance_and_cache -q *(fails: missing optional dependency `argon2`)*

------
https://chatgpt.com/codex/tasks/task_e_68dadf0eaac08333952564916b78f654