### PR TITLE
feat: introduce typed collaboration payload DTOs

### DIFF
--- a/tests/unit/application/collaboration/test_agent_collaboration_system.py
+++ b/tests/unit/application/collaboration/test_agent_collaboration_system.py
@@ -12,7 +12,7 @@ from devsynth.application.collaboration.dto import AgentPayload
 def test_agent_message_to_dict() -> None:
     """ReqID: N/A"""
 
-    payload = AgentPayload(attributes={"x": 1})
+    payload = AgentPayload(attributes={"b": 2, "a": 1})
     msg = AgentMessage("a", "b", MessageType.TASK_ASSIGNMENT, payload)
     data = msg.to_dict()
     assert data["sender_id"] == "a"
@@ -20,7 +20,18 @@ def test_agent_message_to_dict() -> None:
     assert data["message_type"] == "TASK_ASSIGNMENT"
     assert data["content"] == payload.to_dict()
     assert msg.payload == payload
-    assert msg.content == {"x": 1}
+    assert msg.content == {"a": 1, "b": 2}
+
+
+@pytest.mark.fast
+def test_agent_message_accepts_string_payload() -> None:
+    """String payloads are wrapped into AgentPayload summaries."""
+
+    msg = AgentMessage("sender", "recipient", MessageType.STATUS_UPDATE, "hello world")
+
+    assert isinstance(msg.payload, AgentPayload)
+    assert msg.payload.summary == "hello world"
+    assert msg.content == {"summary": "hello world"}
 
 
 class DummyMemoryManager:


### PR DESCRIPTION
## Summary
- replace legacy payload handling with typed JSON-compatible DTO utilities and protocols for agent payloads, task descriptors, and message filters
- adapt agent collaboration and message protocol layers to use structured payloads and filter objects end-to-end
- expand collaboration unit tests to cover DTO round-trips and validation failures

## Testing
- poetry run mypy --strict src/devsynth/application/collaboration/dto.py src/devsynth/application/collaboration/message_protocol.py
- poetry run pytest tests/unit/application/collaboration/test_message_protocol.py tests/unit/application/collaboration/test_agent_collaboration_system.py

------
https://chatgpt.com/codex/tasks/task_e_68db282d0c308333a0feeaf469352a21