### PR TITLE
feat(memory): tighten adapter typing

### DIFF
--- a/src/devsynth/application/memory/adapters/__init__.py
+++ b/src/devsynth/application/memory/adapters/__init__.py
@@ -5,6 +5,7 @@ This package provides adapters for different memory storage backends.
 
 from devsynth.logging_setup import DevSynthLogger
 
+from ..dto import MemorySearchQuery, VectorStoreStats
 from .graph_memory_adapter import GraphMemoryAdapter
 from .storage_adapter import StorageAdapter
 from .tinydb_memory_adapter import TinyDBMemoryAdapter
@@ -35,6 +36,8 @@ __all__ = [
     "VectorMemoryAdapter",
     "TinyDBMemoryAdapter",
     "StorageAdapter",
+    "MemorySearchQuery",
+    "VectorStoreStats",
 ]
 
 if KuzuAdapter is not None:

--- a/src/devsynth/application/memory/adapters/_chromadb_protocols.py
+++ b/src/devsynth/application/memory/adapters/_chromadb_protocols.py
@@ -1,0 +1,82 @@
+"""Structural typing helpers for optional ChromaDB dependencies."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from typing import Any, Protocol, TypedDict
+
+
+class ChromaGetResult(TypedDict, total=False):
+    """Subset of fields returned by ``Collection.get``."""
+
+    ids: list[str]
+    embeddings: list[list[float]]
+    metadatas: list[Mapping[str, object]]
+    documents: list[object]
+
+
+class ChromaQueryResult(TypedDict, total=False):
+    """Subset of fields returned by ``Collection.query``."""
+
+    ids: list[list[str]]
+    embeddings: list[list[list[float]]]
+    metadatas: list[list[Mapping[str, object]]]
+    documents: list[list[object]]
+
+
+class ChromaEmbeddingFunctionProtocol(Protocol):
+    """Callable embedding function compatible with ChromaDB."""
+
+    def __call__(self, inputs: Sequence[str]) -> Sequence[Sequence[float]]:
+        ...
+
+
+class ChromaCollectionProtocol(Protocol):
+    """Structural protocol for the ChromaDB collection client."""
+
+    def get(
+        self, ids: Sequence[str] | None = ..., include: Sequence[str] | None = ...
+    ) -> ChromaGetResult | None:
+        ...
+
+    def add(
+        self,
+        *,
+        ids: Sequence[str],
+        embeddings: Sequence[Sequence[float]],
+        metadatas: Sequence[Mapping[str, object]],
+        documents: Sequence[object],
+    ) -> object:
+        ...
+
+    def delete(self, *, ids: Sequence[str]) -> None:
+        ...
+
+    def query(
+        self,
+        *,
+        query_embeddings: Sequence[Sequence[float]],
+        n_results: int,
+        include: Sequence[str],
+    ) -> ChromaQueryResult | None:
+        ...
+
+
+class ChromaClientProtocol(Protocol):
+    """Structural protocol for ChromaDB client factories."""
+
+    def get_or_create_collection(
+        self,
+        name: str,
+        embedding_function: ChromaEmbeddingFunctionProtocol | None = ...,
+    ) -> ChromaCollectionProtocol:
+        ...
+
+
+__all__ = [
+    "ChromaClientProtocol",
+    "ChromaCollectionProtocol",
+    "ChromaEmbeddingFunctionProtocol",
+    "ChromaGetResult",
+    "ChromaQueryResult",
+]

--- a/src/devsynth/application/memory/adapters/_duckdb_protocols.py
+++ b/src/devsynth/application/memory/adapters/_duckdb_protocols.py
@@ -1,0 +1,46 @@
+"""Structural typing helpers for optional DuckDB dependency."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from typing import Any, Protocol
+
+
+class DuckDBResultProtocol(Protocol):
+    """Subset of DuckDB result interface used throughout the adapters."""
+
+    def fetchall(self) -> list[tuple[Any, ...]]:
+        ...
+
+    def fetchone(self) -> tuple[Any, ...] | None:
+        ...
+
+
+class DuckDBConnectionProtocol(DuckDBResultProtocol, Protocol):
+    """Structural protocol describing the DuckDB connection object."""
+
+    def execute(
+        self, query: str, parameters: Sequence[Any] | None = ...
+    ) -> DuckDBResultProtocol:
+        ...
+
+    def close(self) -> None:
+        ...
+
+
+class DuckDBModuleProtocol(Protocol):
+    """Structural protocol for the top-level :mod:`duckdb` module."""
+
+    def connect(
+        self,
+        database: str | None = ...,
+        read_only: bool | None = ...,
+    ) -> DuckDBConnectionProtocol:
+        ...
+
+
+__all__ = [
+    "DuckDBConnectionProtocol",
+    "DuckDBModuleProtocol",
+    "DuckDBResultProtocol",
+]

--- a/src/devsynth/application/memory/adapters/_tinydb_protocols.py
+++ b/src/devsynth/application/memory/adapters/_tinydb_protocols.py
@@ -1,0 +1,77 @@
+"""Structural protocols for optional TinyDB dependencies."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, Protocol
+
+
+class TinyDBQueryLike(Protocol):
+    """Subset of TinyDB's ``Query`` API used by the adapters."""
+
+    def __getattr__(self, name: str) -> "TinyDBQueryLike":
+        ...
+
+    def __getitem__(self, item: str) -> "TinyDBQueryLike":
+        ...
+
+    def __and__(self, other: "TinyDBQueryLike") -> "TinyDBQueryLike":
+        ...
+
+
+class TinyDBQueryFactory(Protocol):
+    """Callable that produces :class:`TinyDBQueryLike` objects."""
+
+    def __call__(self) -> TinyDBQueryLike:
+        ...
+
+
+class TinyDBTableLike(Protocol):
+    """Subset of TinyDB table operations relied upon by the adapter."""
+
+    def get(self, cond: TinyDBQueryLike) -> Mapping[str, Any] | None:
+        ...
+
+    def insert(self, item: Mapping[str, Any]) -> int:
+        ...
+
+    def update(self, fields: Mapping[str, Any], cond: TinyDBQueryLike) -> list[int]:
+        ...
+
+    def remove(self, cond: TinyDBQueryLike) -> list[int]:
+        ...
+
+    def all(self) -> list[Mapping[str, Any]]:
+        ...
+
+    def search(self, cond: TinyDBQueryLike) -> list[Mapping[str, Any]]:
+        ...
+
+    def truncate(self) -> None:
+        ...
+
+
+class TinyDBFactory(Protocol):
+    """Callable returning TinyDB-like database instances."""
+
+    def __call__(self, *args: Any, **kwargs: Any) -> "TinyDBLike":
+        ...
+
+
+class TinyDBLike(Protocol):
+    """Structural protocol describing the TinyDB database object."""
+
+    def table(self, name: str) -> TinyDBTableLike:
+        ...
+
+    def close(self) -> None:
+        ...
+
+
+__all__ = [
+    "TinyDBFactory",
+    "TinyDBLike",
+    "TinyDBQueryFactory",
+    "TinyDBQueryLike",
+    "TinyDBTableLike",
+]

--- a/src/devsynth/application/memory/adapters/storage_adapter.py
+++ b/src/devsynth/application/memory/adapters/storage_adapter.py
@@ -8,25 +8,17 @@ implements the :class:`~devsynth.domain.interfaces.memory.MemoryStore` contract.
 
 from __future__ import annotations
 
-from collections.abc import Mapping
-from typing import Any, ClassVar, Protocol
+from typing import ClassVar, Protocol
 
 from ....domain.models.memory import MemoryItem, MemoryVector
 from ..dto import (
-    GroupedMemoryResults,
     MemoryMetadata,
     MemoryQueryResults,
     MemoryRecord,
+    MemorySearchQuery,
 )
 
 MemorySnapshot = dict[str, MemoryItem] | dict[str, MemoryVector]
-
-MemorySearchResponse = (
-    list[MemoryItem]
-    | list[MemoryRecord]
-    | MemoryQueryResults
-    | GroupedMemoryResults
-)
 
 
 class StorageAdapter(Protocol):
@@ -46,8 +38,8 @@ class StorageAdapter(Protocol):
         """Retrieve an item from memory by ID."""
 
     def search(
-        self, query: Mapping[str, Any] | MemoryMetadata
-    ) -> MemorySearchResponse:
+        self, query: MemorySearchQuery | MemoryMetadata
+    ) -> MemoryQueryResults | list[MemoryRecord]:
         """Search for items in memory matching the query."""
 
     def delete(self, item_id: str) -> bool:

--- a/src/devsynth/application/memory/dto.py
+++ b/src/devsynth/application/memory/dto.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from datetime import datetime
+from collections.abc import Mapping
 from typing import Iterable, MutableMapping, Sequence, TypedDict, TypeAlias, cast
 
 from typing_extensions import NotRequired
@@ -43,6 +44,10 @@ can attach precise timestamps prior to serialization.
 
 MemoryMetadata: TypeAlias = MutableMapping[str, MemoryMetadataValue]
 """Normalized metadata mapping carried alongside memory artefacts."""
+
+
+MemorySearchQuery: TypeAlias = Mapping[str, object]
+"""Normalized query mapping accepted by memory search adapters."""
 
 
 @dataclass(slots=True)
@@ -127,6 +132,16 @@ class GroupedMemoryResults(TypedDict, total=False):
     by_store: dict[str, MemoryQueryResults]
     combined: NotRequired[list[MemoryRecord]]
     query: NotRequired[str]
+    metadata: NotRequired[MemoryMetadata]
+
+
+class VectorStoreStats(TypedDict, total=False):
+    """Normalized statistics returned by vector-backed adapters."""
+
+    vector_count: int
+    embedding_dimensions: NotRequired[int]
+    collection_name: NotRequired[str]
+    persist_directory: NotRequired[str | None]
     metadata: NotRequired[MemoryMetadata]
 
 


### PR DESCRIPTION
## Summary
- add MemorySearchQuery alias and VectorStoreStats typed dict to memory DTOs and re-export them for adapter consumption
- replace numpy Any usage with a structural protocol and return typed vector stats from vector-backed adapters
- introduce ChromaDB, TinyDB, and DuckDB protocol shims so adapters avoid exposing optional dependencies as Any

## Testing
- poetry run pytest tests/unit/application/memory/test_vector_memory_adapter_extra.py *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_68db518f56d08333ac15e0530ab48533