### PR TITLE
feat(memory): add metadata row serialization helpers

### DIFF
--- a/src/devsynth/application/memory/metadata_serialization.py
+++ b/src/devsynth/application/memory/metadata_serialization.py
@@ -1,15 +1,74 @@
-"""Typed helpers for serializing and deserializing memory metadata payloads."""
+"""Typed helpers for serializing memory metadata and query row payloads."""
 
 from __future__ import annotations
 
 import json
+from collections.abc import Iterable, Mapping, Sequence
 from datetime import datetime
-from typing import Mapping, Sequence, cast
+from typing import cast
 
-from .dto import MemoryMetadata, MemoryMetadataValue
+from .dto import (
+    MemoryMetadata,
+    MemoryMetadataValue,
+    MemoryQueryResults,
+    MemoryRecord,
+    build_memory_record,
+)
 
 JSONPrimitive = str | int | float | bool | None
 JSONValue = JSONPrimitive | list["JSONValue"] | dict[str, "JSONValue"]
+
+__all__ = [
+    "JSONPrimitive",
+    "JSONValue",
+    "dumps",
+    "from_serializable",
+    "loads",
+    "query_results_from_rows",
+    "record_from_row",
+    "row_from_record",
+    "to_serializable",
+]
+
+
+def _coerce_serialized_mapping(payload: object) -> Mapping[str, object] | None:
+    if payload is None:
+        return None
+    if isinstance(payload, Mapping):
+        return cast(Mapping[str, object], payload)
+    if isinstance(payload, (bytes, bytearray)):
+        try:
+            payload = payload.decode("utf-8")
+        except UnicodeDecodeError:  # pragma: no cover - defensive guard
+            return None
+    if isinstance(payload, str):
+        try:
+            decoded = json.loads(payload)
+        except json.JSONDecodeError:
+            return None
+        if isinstance(decoded, Mapping):
+            return cast(Mapping[str, object], decoded)
+        return None
+    return None
+
+
+def _coerce_similarity(value: object) -> float | None:
+    if value is None:
+        return None
+    if isinstance(value, (int, float)):
+        return float(value)
+    try:
+        return float(value)  # type: ignore[arg-type]
+    except (TypeError, ValueError):
+        return None
+
+
+def _coerce_source(value: object, default: str | None = None) -> str | None:
+    if value is None:
+        return default
+    if isinstance(value, str):
+        return value
+    return str(value)
 
 
 def _encode_value(value: MemoryMetadataValue) -> JSONValue:
@@ -66,3 +125,121 @@ def loads(serialized: str | bytes | bytearray | None) -> MemoryMetadata:
     if not isinstance(payload, dict):  # pragma: no cover - defensive guard
         raise TypeError("Metadata payload must deserialize into a mapping")
     return from_serializable(payload)
+
+
+def record_from_row(
+    row: Mapping[str, object] | MemoryRecord,
+    *,
+    metadata_field: str = "metadata",
+    similarity_field: str = "similarity",
+    source_field: str = "source",
+    default_source: str | None = None,
+) -> MemoryRecord:
+    """Build a :class:`MemoryRecord` from a serialized row payload.
+
+    Parameters
+    ----------
+    row:
+        Raw row payload returned from a persistence layer.  The helper accepts
+        mappings (for example ``sqlite3.Row`` instances) or already constructed
+        :class:`MemoryRecord` objects.
+    metadata_field:
+        Mapping key that stores serialized metadata values.  When present the
+        payload is decoded via :func:`from_serializable` before being delegated
+        to :func:`build_memory_record`.
+    similarity_field:
+        Mapping key containing similarity or score information.  The value is
+        coerced into a ``float`` when possible.
+    source_field:
+        Mapping key that identifies the originating store.  When absent the
+        ``default_source`` is used instead.
+    default_source:
+        Fallback store identifier applied when the row omits ``source_field``.
+    """
+
+    if isinstance(row, MemoryRecord):
+        resolved_source = row.source if row.source is not None else default_source
+        return build_memory_record(row, source=resolved_source)
+
+    payload = dict(row)
+
+    metadata_payload = payload.get(metadata_field)
+    decoded_metadata = _coerce_serialized_mapping(metadata_payload)
+    if decoded_metadata is not None:
+        payload[metadata_field] = from_serializable(decoded_metadata)
+
+    similarity_value = payload.pop(similarity_field, None)
+    similarity = _coerce_similarity(similarity_value)
+
+    source_value = payload.pop(source_field, None)
+    source = _coerce_source(source_value, default_source)
+
+    return build_memory_record(payload, source=source, similarity=similarity)
+
+
+def row_from_record(
+    record: MemoryRecord,
+    *,
+    metadata_field: str = "metadata",
+    similarity_field: str = "similarity",
+    source_field: str = "source",
+    include_similarity: bool = True,
+    include_source: bool = True,
+) -> dict[str, object]:
+    """Serialize a :class:`MemoryRecord` into a persistence-friendly mapping."""
+
+    row = record.item.to_dict()
+    row[metadata_field] = to_serializable(record.item.metadata)
+
+    if include_similarity and record.similarity is not None:
+        row[similarity_field] = record.similarity
+
+    if include_source and record.source:
+        row[source_field] = record.source
+
+    return row
+
+
+def query_results_from_rows(
+    store: str,
+    rows: Iterable[Mapping[str, object] | MemoryRecord] | None,
+    *,
+    total: int | None = None,
+    latency_ms: float | int | str | None = None,
+    metadata: Mapping[str, object] | str | bytes | bytearray | None = None,
+    metadata_field: str = "metadata",
+    similarity_field: str = "similarity",
+    source_field: str = "source",
+) -> MemoryQueryResults:
+    """Shape raw row payloads into :class:`MemoryQueryResults` mappings."""
+
+    record_payloads: Iterable[Mapping[str, object] | MemoryRecord] = rows or ()
+    records = [
+        record_from_row(
+            payload,
+            metadata_field=metadata_field,
+            similarity_field=similarity_field,
+            source_field=source_field,
+            default_source=store,
+        )
+        for payload in record_payloads
+    ]
+
+    result: MemoryQueryResults = {"store": store, "records": records}
+
+    if total is not None:
+        result["total"] = int(total)
+
+    if latency_ms is not None:
+        result["latency_ms"] = float(latency_ms)
+
+    if metadata is not None:
+        decoded = _coerce_serialized_mapping(metadata)
+        if decoded is None and isinstance(metadata, Mapping):
+            decoded = metadata
+        if decoded is not None:
+            normalized = from_serializable(decoded)
+            if normalized:
+                result["metadata"] = normalized
+
+    return result

--- a/tests/unit/application/memory/test_metadata_serialization_helpers.py
+++ b/tests/unit/application/memory/test_metadata_serialization_helpers.py
@@ -1,0 +1,123 @@
+"""Unit coverage for metadata serialization row helpers."""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime
+
+import pytest
+
+from devsynth.application.memory.dto import build_memory_record
+from devsynth.application.memory.metadata_serialization import (
+    query_results_from_rows,
+    record_from_row,
+    row_from_record,
+    to_serializable,
+)
+
+
+@pytest.mark.fast
+def test_record_round_trip_preserves_metadata() -> None:
+    """`record_from_row` should reverse `row_from_record` outputs."""
+
+    nested_metadata = {
+        "timestamp": datetime(2024, 1, 2, 3, 4, 5),
+        "nested": {
+            "count": 2,
+            "entries": [
+                {"seen_at": datetime(2024, 1, 2, 3, 4, 5)},
+                {"seen_at": datetime(2024, 1, 2, 6, 7, 8)},
+            ],
+        },
+    }
+    record = build_memory_record(
+        {
+            "id": "rec-1",
+            "content": {"message": "hello"},
+            "memory_type": "context",
+            "metadata": nested_metadata,
+        },
+        source="vector-store",
+        similarity=0.91,
+    )
+
+    row_payload = row_from_record(record)
+    restored = record_from_row(row_payload, default_source="fallback-store")
+
+    assert restored.source == "vector-store"
+    assert restored.similarity == pytest.approx(0.91)
+    assert restored.item.id == "rec-1"
+    assert restored.item.metadata["timestamp"] == nested_metadata["timestamp"]
+    assert restored.item.metadata["nested"]["entries"][0]["seen_at"] == nested_metadata["nested"]["entries"][0]["seen_at"]
+
+
+@pytest.mark.fast
+def test_record_from_row_handles_stringified_metadata() -> None:
+    """Metadata stored as JSON strings should be decoded automatically."""
+
+    serialized_metadata = json.dumps(
+        to_serializable(
+            {
+                "level": 3,
+                "expires_at": datetime(2024, 5, 6, 7, 8, 9),
+            }
+        )
+    )
+
+    restored = record_from_row(
+        {
+            "id": "row-1",
+            "content": "payload",
+            "memory_type": "context",
+            "metadata": serialized_metadata,
+            "similarity": "0.42",
+        },
+        default_source="duckdb",
+    )
+
+    assert restored.source == "duckdb"
+    assert restored.similarity == pytest.approx(0.42)
+    assert restored.item.metadata["level"] == 3
+    assert restored.item.metadata["expires_at"] == datetime(2024, 5, 6, 7, 8, 9)
+
+
+@pytest.mark.fast
+def test_query_results_from_rows_shapes_records() -> None:
+    """Row helpers should produce query results with normalized metadata."""
+
+    rows = [
+        {
+            "id": "a",
+            "content": "alpha",
+            "memory_type": "context",
+            "metadata": to_serializable({"score": 1}),
+        },
+        {
+            "id": "b",
+            "content": "beta",
+            "memory_type": "knowledge",
+            "metadata": to_serializable({"score": 2}),
+            "source": "secondary",
+            "similarity": 0.33,
+        },
+    ]
+
+    results = query_results_from_rows(
+        "primary",
+        rows,
+        total="2",
+        latency_ms="3.5",
+        metadata=to_serializable({"batch": 1, "started_at": datetime(2024, 4, 5, 6, 7)}),
+    )
+
+    assert results["store"] == "primary"
+    assert results["total"] == 2
+    assert results["latency_ms"] == pytest.approx(3.5)
+    assert results["metadata"]["batch"] == 1
+    assert results["metadata"]["started_at"] == datetime(2024, 4, 5, 6, 7)
+
+    primary_record, secondary_record = results["records"]
+    assert primary_record.source == "primary"
+    assert secondary_record.source == "secondary"
+    assert secondary_record.similarity == pytest.approx(0.33)
+


### PR DESCRIPTION
## Summary
- add helpers to rebuild `MemoryRecord` and `MemoryQueryResults` instances from serialized rows while decoding metadata
- provide row serialization helpers that reuse existing metadata encoding utilities and refresh module exports
- add targeted unit tests covering round trips, nested metadata, and grouped query shaping

## Testing
- PYTHONPATH=src poetry run pytest tests/unit/application/memory/test_metadata_serialization_helpers.py *(fails: ModuleNotFoundError: No module named 'numpy')*


------
https://chatgpt.com/codex/tasks/task_e_68db5d3fad208333a6f0f7a7f66d9f01