### PR TITLE
feat: add autoresearch personas CLI and telemetry

### DIFF
--- a/docs/analysis/autoresearch_evaluation.md
+++ b/docs/analysis/autoresearch_evaluation.md
@@ -65,11 +65,14 @@ specializations lack clear acceptance criteria.
 
 ### Synthesis
 - Extend the WSDE role roster with research-focused capabilities but bind each
-persona to measurable outcomes: Research Leads manage query strategies,
-Bibliographers vet sources, and Synthesists translate insights into actionable
-implementation guidance. Update the role assignment matrix and BDD coverage so
-primus rotation still honours expertise and collaboration checkpoints remain
-automated.
+  persona to measurable outcomes: Research Leads manage query strategies,
+  Bibliographers vet sources, and Synthesists translate insights into actionable
+  implementation guidance. Update the role assignment matrix and BDD coverage so
+  primus rotation still honours expertise and collaboration checkpoints remain
+  automated. Persona toggles now live in `devsynth autoresearch`, mapping CLI
+  preferences to `ResearchPersonaDefinition` entries in
+  `src/devsynth/domain/models/wsde_roles.py` and propagating telemetry through
+  the WSDE coordinator mixins for MVUU capture.
 
 ### Socratic Q&A
 - **Q:** How do research personas coexist with the core WSDE roles?

--- a/docs/analysis/mvuu_dashboard.md
+++ b/docs/analysis/mvuu_dashboard.md
@@ -51,6 +51,13 @@ Autoresearch workflows extend the dashboard with optional overlays:
   CLI so reviewers can verify that research artefacts rendered in the dashboard
   match the underlying knowledge graph data.
 
+Persona telemetry emitted by `devsynth autoresearch` supplies the dashboard with
+primus transition evidence (`persona_selected` and `persona_task_completed`
+events). When overlays are enabled the dashboard highlights which agent assumed
+Research Lead, Bibliographer, or Synthesist duties for each TraceID, pulling the
+structured payload recorded by `ResearchPersonaCoordinator` and exposing it in
+the sidebar alongside MVUU metadata.
+
 These overlays are disabled by default; teams enable them via the `--research-metrics` CLI flag or a dashboard toggle. When active, the dashboard queries the
 knowledge graph to fetch supporting artefacts and annotates TraceIDs with
 bibliographic context, ensuring Autoresearch remains auditable without

--- a/issues/Autoresearch-agent-specialization.md
+++ b/issues/Autoresearch-agent-specialization.md
@@ -12,23 +12,23 @@ roles. Without dedicated responsibilities and telemetry, research initiatives ar
 hard to audit and optimise.
 
 ## Action Plan
-- [ ] Implement Research Lead, Bibliographer, and Synthesist personas mapped to
+- [x] Implement Research Lead, Bibliographer, and Synthesist personas mapped to
       WSDE core roles and controlled by CLI flags.
-- [ ] Update primus selection heuristics to respect Autoresearch expertise
+- [x] Update primus selection heuristics to respect Autoresearch expertise
       signals without regressing default task allocation.
-- [ ] Emit MVUU trace checkpoints and documentation that clarify research
+- [x] Emit MVUU trace checkpoints and documentation that clarify research
       hand-offs and expected deliverables.
 - [ ] Extend prompts and training data with persona expectations and fallback
       behaviours.
 
 ## Acceptance Criteria
-- [ ] Behaviour tests demonstrate persona assignment, collaboration checkpoints,
+- [x] Behaviour tests demonstrate persona assignment, collaboration checkpoints,
       and knowledge graph integration across the Autoresearch workflow.
-- [ ] Unit tests cover CLI toggles, telemetry payloads, and primus selection
+- [x] Unit tests cover CLI toggles, telemetry payloads, and primus selection
       adjustments.
 - [ ] MVUU dashboards surface Autoresearch overlays with trace IDs linked to
       research summaries.
-- [ ] Documentation highlights research responsibilities and failure modes for
+- [x] Documentation highlights research responsibilities and failure modes for
       each persona.
 
 ## References

--- a/src/devsynth/application/cli/commands/__init__.py
+++ b/src/devsynth/application/cli/commands/__init__.py
@@ -5,6 +5,7 @@ Command modules for the CLI application.
 from .align_cmd import align_cmd
 from .alignment_metrics_cmd import alignment_metrics_cmd
 from .analyze_manifest_cmd import analyze_manifest_cmd
+from .autoresearch_cmd import autoresearch_cmd
 from .doctor_cmd import doctor_cmd
 from .edrr_cycle_cmd import edrr_cycle_cmd
 from .generate_docs_cmd import generate_docs_cmd
@@ -29,5 +30,6 @@ __all__ = [
     "test_metrics_cmd",
     "generate_docs_cmd",
     "analyze_manifest_cmd",
+    "autoresearch_cmd",
     "ingest_cmd",
 ]

--- a/src/devsynth/application/cli/commands/autoresearch_cmd.py
+++ b/src/devsynth/application/cli/commands/autoresearch_cmd.py
@@ -1,0 +1,94 @@
+"""CLI command for enabling Autoresearch personas."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from datetime import datetime
+
+from devsynth.adapters.agents.agent_adapter import WSDETeamCoordinator
+from devsynth.core.mvu.models import MVUU
+from devsynth.domain.models.wsde_roles import iter_research_personas
+
+
+def _persona_choices() -> list[str]:  # pragma: no cover - trivial helper
+    return [persona.identifier for persona in iter_research_personas()]
+
+
+def autoresearch_cmd(argv: list[str] | None = None) -> int:
+    """Configure research personas and emit MVUU telemetry."""
+
+    parser = argparse.ArgumentParser(
+        prog="autoresearch",
+        description="Configure Autoresearch personas for WSDE collaboration",
+    )
+    parser.add_argument(
+        "--enable-personas",
+        action="store_true",
+        help="Activate persona-aware primus selection",
+    )
+    parser.add_argument(
+        "--persona",
+        action="append",
+        choices=_persona_choices(),
+        help="Specify one or more personas to activate",
+    )
+    parser.add_argument(
+        "--trace-id",
+        help="Optional TraceID to reuse for MVUU emission",
+    )
+    parser.add_argument(
+        "--no-trace",
+        action="store_true",
+        help="Skip MVUU trace emission",
+    )
+    args = parser.parse_args(argv)
+
+    coordinator = WSDETeamCoordinator()
+    personas = list(args.persona or [])
+    if args.enable_personas and not personas:
+        personas = _persona_choices()
+    active_personas = coordinator.configure_personas(args.enable_personas, personas)
+
+    telemetry_snapshot = list(coordinator.research_persona_telemetry)
+    if args.enable_personas:
+        team = coordinator.create_team("autoresearch_cli")
+        coordinator._record_persona_event(
+            "cli_team_initialized",
+            {
+                "team": team.name,
+                "personas": active_personas,
+            },
+        )
+        telemetry_snapshot = list(coordinator.research_persona_telemetry)
+
+    payload: dict[str, object] = {
+        "personas": active_personas,
+        "telemetry": telemetry_snapshot,
+    }
+
+    if not args.no_trace:
+        trace_id = args.trace_id or f"AR-{datetime.utcnow().strftime('%Y%m%d%H%M%S')}"
+        mvuu = MVUU(
+            utility_statement="Autoresearch persona toggles applied",
+            affected_files=[
+                "src/devsynth/domain/models/wsde_roles.py",
+                "src/devsynth/application/collaboration/wsde_team_extended.py",
+                "src/devsynth/adapters/agents/agent_adapter.py",
+            ],
+            tests=[
+                "tests/unit/cli/test_autoresearch_persona_cli.py",
+                "tests/unit/general/test_wsde_team_coordinator.py",
+            ],
+            TraceID=trace_id,
+            mvuu=True,
+            issue="Autoresearch-agent-specialization",
+            notes="Research personas activated via CLI",
+        )
+        payload["mvuu"] = mvuu.as_dict()
+
+    print(json.dumps(payload))
+    return 0
+
+
+__all__ = ["autoresearch_cmd"]

--- a/src/devsynth/application/collaboration/wsde_team_coordinator.py
+++ b/src/devsynth/application/collaboration/wsde_team_coordinator.py
@@ -1,0 +1,93 @@
+"""Persona-aware coordination helpers for WSDE teams."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Mapping, MutableMapping, Sequence
+
+from devsynth.domain.models.wsde_facade import WSDETeam
+from devsynth.domain.models.wsde_roles import get_research_persona, iter_research_personas
+from devsynth.logging_setup import DevSynthLogger
+
+logger = DevSynthLogger(__name__)
+
+
+@dataclass(slots=True)
+class ResearchPersonaCoordinator:
+    """Mixin providing research persona configuration and telemetry."""
+
+    research_personas_enabled: bool = False
+    research_persona_preferences: list[str] = field(default_factory=list)
+    research_persona_telemetry: list[dict[str, Any]] = field(default_factory=list)
+
+    def configure_personas(
+        self, enabled: bool, personas: Sequence[str] | None = None
+    ) -> list[str]:
+        """Toggle persona-aware behaviours and record the requested set."""
+
+        self.research_personas_enabled = enabled
+        self.research_persona_preferences.clear()
+        if not enabled:
+            self._record_persona_event("personas_disabled", {})
+            return []
+
+        selected = personas or [definition.identifier for definition in iter_research_personas()]
+        for candidate in selected:
+            try:
+                definition = get_research_persona(candidate)
+            except KeyError:
+                logger.debug("Ignoring unknown persona toggle: %s", candidate)
+                continue
+            self.research_persona_preferences.append(definition.identifier)
+        payload = {"personas": list(self.research_persona_preferences)}
+        self._record_persona_event("personas_enabled", payload)
+        return list(self.research_persona_preferences)
+
+    # ------------------------------------------------------------------
+    # Integration helpers used by WSDETeamCoordinator
+    # ------------------------------------------------------------------
+
+    def _configure_team_personas(self, team: WSDETeam) -> None:
+        if not self.research_personas_enabled:
+            return
+        if hasattr(team, "enable_research_personas"):
+            team.enable_research_personas(self.research_persona_preferences)
+
+    def _apply_persona_strategy(
+        self, team: WSDETeam, task: MutableMapping[str, Any]
+    ) -> None:
+        if not self.research_personas_enabled:
+            return
+        if not hasattr(team, "_apply_research_persona_selection"):
+            return
+        selection = team._apply_research_persona_selection(task)
+        if selection is not None:
+            self._record_persona_event(
+                "persona_selected",
+                {
+                    "team": getattr(team, "name", "team"),
+                    "persona": getattr(selection, "active_persona", None),
+                    "agent": getattr(selection, "name", "agent"),
+                    "task_id": str(task.get("id", "unknown")),
+                },
+            )
+        else:
+            self._record_persona_event(
+                "persona_selection_fallback",
+                {
+                    "team": getattr(team, "name", "team"),
+                    "task_id": str(task.get("id", "unknown")),
+                    "personas": list(self.research_persona_preferences),
+                },
+            )
+
+    def _record_persona_event(self, event: str, payload: Mapping[str, Any]) -> None:
+        self.research_persona_telemetry.append(
+            {
+                "event": event,
+                "payload": dict(payload),
+            }
+        )
+
+
+__all__ = ["ResearchPersonaCoordinator"]

--- a/tests/behavior/features/wsde_agent_model_refinement.feature
+++ b/tests/behavior/features/wsde_agent_model_refinement.feature
@@ -42,3 +42,11 @@ Feature: WSDE Agent Model Refinement
     And the Critic should identify thesis and antithesis
     And the team should work toward a synthesis
     And the final solution should reflect the dialectical process
+
+  Scenario: Research personas capture telemetry
+    Given the DevSynth system is initialized
+    And a team of agents is configured
+    And the WSDE model is enabled
+    When research personas are activated for a research task
+    Then persona telemetry should capture primus transitions
+    And MVUU evidence should record the persona activation

--- a/tests/unit/cli/test_autoresearch_persona_cli.py
+++ b/tests/unit/cli/test_autoresearch_persona_cli.py
@@ -1,0 +1,214 @@
+"""Tests for the autoresearch CLI command."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+
+def _load_command():
+    """Import the CLI command with a lightweight rich stub."""
+
+    if "rich.console" not in sys.modules:
+        rich_module = types.ModuleType("rich")
+        console_module = types.ModuleType("rich.console")
+        table_module = types.ModuleType("rich.table")
+        markdown_module = types.ModuleType("rich.markdown")
+        panel_module = types.ModuleType("rich.panel")
+        progress_module = types.ModuleType("rich.progress")
+        prompt_module = types.ModuleType("rich.prompt")
+        style_module = types.ModuleType("rich.style")
+        text_module = types.ModuleType("rich.text")
+        theme_module = types.ModuleType("rich.theme")
+
+        class _Console:  # pragma: no cover - trivial stub
+            def __init__(self, *_, **__):
+                pass
+
+            def print(self, *_, **__):
+                pass
+
+        console_module.Console = _Console
+        table_module.Table = object
+        markdown_module.Markdown = object
+        panel_module.Panel = object
+        progress_module.Progress = object
+        progress_module.BarColumn = object
+        progress_module.MofNCompleteColumn = object
+        progress_module.SpinnerColumn = object
+        progress_module.TextColumn = object
+        progress_module.TimeElapsedColumn = object
+        progress_module.TimeRemainingColumn = object
+        prompt_module.Confirm = object
+        prompt_module.Prompt = object
+        style_module.Style = object
+        text_module.Text = object
+        theme_module.Theme = object
+        rich_module.console = console_module
+        sys.modules["rich"] = rich_module
+        sys.modules["rich.console"] = console_module
+        sys.modules["rich.table"] = table_module
+        sys.modules["rich.markdown"] = markdown_module
+        sys.modules["rich.panel"] = panel_module
+        sys.modules["rich.progress"] = progress_module
+        sys.modules["rich.prompt"] = prompt_module
+        sys.modules["rich.style"] = style_module
+        sys.modules["rich.text"] = text_module
+        sys.modules["rich.theme"] = theme_module
+
+    if "toml" not in sys.modules:
+        toml_module = types.ModuleType("toml")
+
+        def _loads(_: str) -> dict[str, object]:  # pragma: no cover - simple stub
+            return {}
+
+        toml_module.loads = _loads
+        toml_module.load = lambda *_args, **_kwargs: {}
+        sys.modules["toml"] = toml_module
+
+    if "yaml" not in sys.modules:
+        yaml_module = types.ModuleType("yaml")
+
+        def _safe_load(_: object) -> dict[str, object]:  # pragma: no cover - simple stub
+            return {}
+
+        yaml_module.safe_load = _safe_load
+        sys.modules["yaml"] = yaml_module
+
+    if "devsynth.config" not in sys.modules:
+        config_module = types.ModuleType("devsynth.config")
+
+        class _DummyConfig:
+            pass
+
+        def _get_project_config(*_args, **_kwargs):  # pragma: no cover - stub
+            return _DummyConfig()
+
+        def _save_config(*_args, **_kwargs) -> None:  # pragma: no cover - stub
+            return None
+
+        config_module.get_project_config = _get_project_config
+        config_module.save_config = _save_config
+        sys.modules["devsynth.config"] = config_module
+
+    if "devsynth" not in sys.modules:
+        sys.modules["devsynth"] = types.ModuleType("devsynth")
+
+    if "devsynth.core" not in sys.modules:
+        sys.modules["devsynth.core"] = types.ModuleType("devsynth.core")
+
+    if "devsynth.core.mvu" not in sys.modules:
+        sys.modules["devsynth.core.mvu"] = types.ModuleType("devsynth.core.mvu")
+
+    if "devsynth.core.mvu.models" not in sys.modules:
+        mvu_module = types.ModuleType("devsynth.core.mvu.models")
+
+        class _StubMVUU:
+            def __init__(self, **kwargs):
+                self._data = kwargs
+
+            def as_dict(self) -> dict[str, object]:  # pragma: no cover - simple stub
+                return dict(self._data)
+
+        mvu_module.MVUU = _StubMVUU
+        sys.modules["devsynth.core.mvu.models"] = mvu_module
+        sys.modules["devsynth.core"].mvu = types.SimpleNamespace(models=mvu_module)
+
+    module_name = "__autoresearch_cli_cmd__"
+    if module_name in sys.modules and hasattr(sys.modules[module_name], "autoresearch_cmd"):
+        return sys.modules[module_name].autoresearch_cmd
+
+    sys.modules.pop(module_name, None)
+    base_path = Path(__file__).resolve().parents[3]
+    module_path = base_path / "src" / "devsynth" / "application" / "cli" / "commands" / "autoresearch_cmd.py"
+    spec = importlib.util.spec_from_file_location(module_name, module_path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec and spec.loader
+    sys.modules[module_name] = module
+    spec.loader.exec_module(module)
+    return module.autoresearch_cmd
+
+
+@pytest.mark.fast
+def test_autoresearch_cli_emits_trace(capfd, monkeypatch):
+    """The command should emit MVUU trace metadata when enabled."""
+
+    autoresearch_cmd = _load_command()
+    module = sys.modules["__autoresearch_cli_cmd__"]
+
+    class _StubCoordinator:
+        def __init__(self):
+            self.research_persona_preferences: list[str] = []
+            self.research_persona_telemetry: list[dict[str, object]] = []
+
+        def configure_personas(self, enabled: bool, personas: list[str]) -> list[str]:
+            self.research_persona_preferences = personas if enabled else []
+            self.research_persona_telemetry.append({"event": "configured"})
+            return self.research_persona_preferences
+
+        def create_team(self, _team_id: str):
+            class _Team:
+                name = "stub"
+
+                def enable_research_personas(self, *_args, **_kwargs):
+                    return []
+
+            return _Team()
+
+        def _record_persona_event(self, event: str, payload: dict[str, object]) -> None:
+            self.research_persona_telemetry.append({"event": event, "payload": payload})
+
+    monkeypatch.setattr(module, "WSDETeamCoordinator", _StubCoordinator)
+
+    exit_code = autoresearch_cmd(
+        ["--enable-personas", "--persona", "research_lead", "--trace-id", "TRACE-123"]
+    )
+    assert exit_code == 0
+    captured = capfd.readouterr()
+    payload = json.loads(captured.out)
+    assert payload["personas"] == ["research_lead"]
+    assert payload["mvuu"]["TraceID"] == "TRACE-123"
+    assert payload["mvuu"]["mvuu"] is True
+
+
+@pytest.mark.fast
+def test_autoresearch_cli_handles_no_trace(capfd, monkeypatch):
+    """The --no-trace flag suppresses MVUU emission."""
+
+    autoresearch_cmd = _load_command()
+    module = sys.modules["__autoresearch_cli_cmd__"]
+
+    class _StubCoordinator:
+        def __init__(self):
+            self.research_persona_preferences: list[str] = []
+            self.research_persona_telemetry: list[dict[str, object]] = []
+
+        def configure_personas(self, enabled: bool, personas: list[str]) -> list[str]:
+            self.research_persona_preferences = personas if enabled else []
+            return self.research_persona_preferences
+
+        def create_team(self, _team_id: str):
+            class _Team:
+                name = "stub"
+
+                def enable_research_personas(self, *_args, **_kwargs):
+                    return []
+
+            return _Team()
+
+        def _record_persona_event(self, event: str, payload: dict[str, object]) -> None:
+            self.research_persona_telemetry.append({"event": event, "payload": payload})
+
+    monkeypatch.setattr(module, "WSDETeamCoordinator", _StubCoordinator)
+
+    exit_code = autoresearch_cmd(["--no-trace"])
+    assert exit_code == 0
+    captured = capfd.readouterr()
+    payload = json.loads(captured.out)
+    assert payload["personas"] == []
+    assert "mvuu" not in payload


### PR DESCRIPTION
## Summary
- define research personas with telemetry-aware primus selection and role fallbacks
- add coordinator mixin, CLI command, and docs/issue updates to toggle personas and emit MVUU traces
- expand unit and behavior coverage for persona workflows and logged evidence

## Testing
- poetry run pytest tests/unit/cli/test_autoresearch_persona_cli.py tests/unit/general/test_wsde_team_coordinator.py -k persona -m "fast or medium"

------
https://chatgpt.com/codex/tasks/task_e_68dc0851219c83339d52f472c5a4bb9f