### PR TITLE
feat: add research personas and telemetry toggles

### DIFF
--- a/docs/analysis/autoresearch_evaluation.md
+++ b/docs/analysis/autoresearch_evaluation.md
@@ -71,6 +71,19 @@ implementation guidance. Update the role assignment matrix and BDD coverage so
 primus rotation still honours expertise and collaboration checkpoints remain
 automated.
 
+### Implementation Snapshot
+- **Research Lead** now inherits Primus leadership alongside supervisor
+  oversight, coordinating research queues and ensuring critique cycles remain
+  accountable to the existing WSDE rotation contract.
+- **Bibliographer** pairs evaluator analysis with worker execution so citation
+  vetting feeds the same review loops already exercised by WSDE evaluators and
+  supervisors.
+- **Synthesist** extends designer planning with evaluator validation, closing
+  the loop between ideation and assessment before work reaches implementation.
+- Persona toggles in the CLI surface these configurations for Autoresearch
+  sessions while emitting MVUU telemetry that records assignments, transitions,
+  and any expertise-based fallbacks.
+
 ### Socratic Q&A
 - **Q:** How do research personas coexist with the core WSDE roles?
   **A:** Map each new persona to a supporting responsibility (e.g., Synthesist →

--- a/docs/analysis/mvuu_dashboard.md
+++ b/docs/analysis/mvuu_dashboard.md
@@ -55,3 +55,12 @@ These overlays are disabled by default; teams enable them via the `--research-me
 knowledge graph to fetch supporting artefacts and annotates TraceIDs with
 bibliographic context, ensuring Autoresearch remains auditable without
 sacrificing day-to-day usability.
+
+## Autoresearch Personas
+
+Repeatable `--research-persona` options on `devsynth mvuu-dashboard` activate the
+Research Lead, Bibliographer, and Synthesist overlays alongside
+`--research-overlays`. The command persists the selection to
+`DEVSYNTH_AUTORESEARCH_PERSONAS`, allowing the WSDE collaboration layer to
+favour persona-aware primus selection while telemetry bundles capture persona
+assignments and fallback decisions for MVUU traceability.

--- a/issues/Autoresearch-agent-specialization.md
+++ b/issues/Autoresearch-agent-specialization.md
@@ -12,23 +12,23 @@ roles. Without dedicated responsibilities and telemetry, research initiatives ar
 hard to audit and optimise.
 
 ## Action Plan
-- [ ] Implement Research Lead, Bibliographer, and Synthesist personas mapped to
+- [x] Implement Research Lead, Bibliographer, and Synthesist personas mapped to
       WSDE core roles and controlled by CLI flags.
-- [ ] Update primus selection heuristics to respect Autoresearch expertise
+- [x] Update primus selection heuristics to respect Autoresearch expertise
       signals without regressing default task allocation.
-- [ ] Emit MVUU trace checkpoints and documentation that clarify research
+- [x] Emit MVUU trace checkpoints and documentation that clarify research
       hand-offs and expected deliverables.
 - [ ] Extend prompts and training data with persona expectations and fallback
       behaviours.
 
 ## Acceptance Criteria
-- [ ] Behaviour tests demonstrate persona assignment, collaboration checkpoints,
+- [x] Behaviour tests demonstrate persona assignment, collaboration checkpoints,
       and knowledge graph integration across the Autoresearch workflow.
-- [ ] Unit tests cover CLI toggles, telemetry payloads, and primus selection
+- [x] Unit tests cover CLI toggles, telemetry payloads, and primus selection
       adjustments.
-- [ ] MVUU dashboards surface Autoresearch overlays with trace IDs linked to
+- [x] MVUU dashboards surface Autoresearch overlays with trace IDs linked to
       research summaries.
-- [ ] Documentation highlights research responsibilities and failure modes for
+- [x] Documentation highlights research responsibilities and failure modes for
       each persona.
 
 ## References

--- a/tests/behavior/features/wsde_agent_model_refinement.feature
+++ b/tests/behavior/features/wsde_agent_model_refinement.feature
@@ -42,3 +42,10 @@ Feature: WSDE Agent Model Refinement
     And the Critic should identify thesis and antithesis
     And the team should work toward a synthesis
     And the final solution should reflect the dialectical process
+
+  Scenario: Research personas coordinate evidence logging
+    Given research personas Research Lead, Bibliographer, and Synthesist are enabled
+    When a research-intensive task enters the workflow
+    Then the Research Lead persona should become the temporary Primus
+    And persona transitions should be recorded for MVUU telemetry
+    And expertise-based primus selection should be used if no persona matches


### PR DESCRIPTION
## Summary
- add research persona specifications, scoring, and telemetry helpers to the WSDE role manager
- enable persona-aware primus selection, MVUU payload annotations, and coordinator fallbacks with updated documentation and issue tracking
- extend BDD and unit coverage for persona transitions, CLI toggles, and MVUU evidence capture

## Testing
- `poetry run pytest tests/unit/cli/test_mvuu_dashboard_telemetry.py`
- `poetry run pytest tests/unit/application/collaboration/test_collaborative_wsde_team.py::TestCollaborativeWSDETeam::test_research_persona_assignments_emit_telemetry`
- `poetry run pytest tests/unit/agents/test_wsde_team_coordinator_strict.py`


------
https://chatgpt.com/codex/tasks/task_e_68dc0f94af4883339e52e52dbf8be9d1