### PR TITLE
feat: tighten UX progress and autoresearch typing

### DIFF
--- a/src/devsynth/interface/agentapi.py
+++ b/src/devsynth/interface/agentapi.py
@@ -35,7 +35,12 @@ from devsynth.interface.agentapi_models import (
     WorkflowResponse,
     SynthesisTarget,
 )
-from devsynth.interface.ux_bridge import ProgressIndicator, UXBridge, sanitize_output
+from devsynth.interface.ux_bridge import (
+    ProgressIndicator,
+    SubtaskProgressSnapshot,
+    UXBridge,
+    sanitize_output,
+)
 from devsynth.logging_setup import DevSynthLogger
 
 logger = DevSynthLogger(__name__)
@@ -123,8 +128,8 @@ class APIBridge(UXBridge):
             self._total = float(total)
             self._current = 0.0
             self._status = ProgressStatus.STARTING
-            self._subtasks: dict[str, dict[str, float | str]] = {}
-            self._nested_subtasks: dict[str, dict[str, dict[str, float | str]]] = {}
+            self._subtasks: dict[str, SubtaskProgressSnapshot] = {}
+            self._nested_subtasks: dict[str, dict[str, SubtaskProgressSnapshot]] = {}
             self._messages.append(self._description)
             self._record_snapshot()
 

--- a/src/devsynth/interface/webui_bridge.py
+++ b/src/devsynth/interface/webui_bridge.py
@@ -129,7 +129,12 @@ class WebUIProgressIndicator(ProgressIndicator):
         """Mark the progress indicator as complete."""
         self._current = self._total
 
-    def add_subtask(self, description: str, total: int = 100) -> str:
+    def add_subtask(
+        self,
+        description: str,
+        total: int = 100,
+        status: str = "Starting...",
+    ) -> str:
         """Add a subtask to the progress indicator.
 
         Args:
@@ -141,15 +146,20 @@ class WebUIProgressIndicator(ProgressIndicator):
         """
         desc = _safe_text(description, fallback="<subtask>")
         task_id = f"subtask_{len(self._subtasks)}"
+        initial_status = _safe_text(status, fallback=_default_status(0.0, total))
         self._subtasks[task_id] = SubtaskState(
             description=desc,
             total=total,
-            status=_default_status(0.0, total),
+            status=initial_status,
         )
         return task_id
 
     def update_subtask(
-        self, task_id: str, advance: float = 1, description: str | None = None
+        self,
+        task_id: str,
+        advance: float = 1,
+        description: str | None = None,
+        status: str | None = None,
     ) -> None:
         """Update a subtask's progress.
 
@@ -168,7 +178,10 @@ class WebUIProgressIndicator(ProgressIndicator):
             )
 
         subtask.current += advance
-        subtask.status = _default_status(subtask.current, subtask.total)
+        if status is not None:
+            subtask.status = _safe_text(status, fallback=subtask.status)
+        else:
+            subtask.status = _default_status(subtask.current, subtask.total)
 
     def complete_subtask(self, task_id: str) -> None:
         """Mark a subtask as complete.

--- a/tests/unit/interface/test_autoresearch_telemetry.py
+++ b/tests/unit/interface/test_autoresearch_telemetry.py
@@ -5,11 +5,23 @@ from __future__ import annotations
 import pytest
 
 from devsynth.interface.autoresearch import (
+    AutoresearchPayload,
     SignatureEnvelope,
     build_autoresearch_payload,
     sign_payload,
     verify_signature,
 )
+
+
+def _minimal_payload() -> AutoresearchPayload:
+    return {
+        "version": "1.0",
+        "generated_at": "2025-01-01T00:00:00+00:00",
+        "session_id": "session",
+        "timeline": [],
+        "provenance_filters": [],
+        "integrity_badges": [],
+    }
 
 
 @pytest.mark.fast
@@ -42,7 +54,16 @@ def test_build_autoresearch_payload_produces_timeline_snapshot() -> None:
 def test_signature_roundtrip_validates() -> None:
     """Signatures should verify against canonical payloads."""
 
-    payload = {"timeline": [{"trace_id": "DSY-0001"}]}
+    payload = _minimal_payload()
+    payload["timeline"].append(
+        {
+            "trace_id": "DSY-0001",
+            "summary": "",
+            "timestamp": "2025-01-01T00:00:00+00:00",
+            "agent_persona": "Analyst",
+            "knowledge_refs": [],
+        }
+    )
     secret = "topsecret"
 
     envelope = sign_payload(payload, secret=secret, key_id="env:TEST")
@@ -55,7 +76,7 @@ def test_signature_roundtrip_validates() -> None:
 def test_signature_failure_with_wrong_secret() -> None:
     """Changing the secret should invalidate the signature."""
 
-    payload = {"timeline": []}
+    payload = _minimal_payload()
     secret = "alpha"
     envelope = sign_payload(payload, secret=secret, key_id="env:TEST")
 

--- a/tests/unit/interface/test_progress_helpers.py
+++ b/tests/unit/interface/test_progress_helpers.py
@@ -1,0 +1,95 @@
+"""Tests covering progress helper types exposed by UX bridge."""
+
+from __future__ import annotations
+
+import pytest
+
+import sys
+from types import SimpleNamespace
+
+
+class _FakePasswordHasher:
+    def __init__(self, *args: object, **kwargs: object) -> None:  # pragma: no cover - simple stub
+        pass
+
+    def hash(self, password: str) -> str:  # pragma: no cover - simple stub
+        return password
+
+    def verify(self, stored_hash: str, password: str) -> bool:  # pragma: no cover - simple stub
+        return stored_hash == password
+
+
+sys.modules.setdefault("argon2", SimpleNamespace(PasswordHasher=_FakePasswordHasher))
+sys.modules.setdefault(
+    "argon2.exceptions", SimpleNamespace(VerifyMismatchError=Exception)
+)
+
+
+from devsynth.interface.ux_bridge import (
+    PROGRESS_STATUS_VALUES,
+    ProgressIndicator,
+    SubtaskProgressSnapshot,
+    SupportsNestedSubtasks,
+    UXBridge,
+)
+
+
+class _TestBridge(UXBridge):
+    """Minimal bridge to access the internal dummy progress indicator."""
+
+    def __init__(self) -> None:
+        self.messages: list[str] = []
+
+    def ask_question(
+        self,
+        message: str,
+        *,
+        choices: tuple[str, ...] | None = None,
+        default: str | None = None,
+        show_default: bool = True,
+    ) -> str:
+        return default or (choices[0] if choices else "")
+
+    def confirm_choice(self, message: str, *, default: bool = False) -> bool:
+        return default
+
+    def display_result(
+        self,
+        message: str,
+        *,
+        highlight: bool = False,
+        message_type: str | None = None,
+    ) -> None:
+        self.messages.append(message)
+
+
+@pytest.mark.fast
+def test_dummy_progress_supports_nested_protocol() -> None:
+    """The built-in dummy progress indicator exposes nested operations."""
+
+    indicator = _TestBridge().create_progress("task")
+    assert isinstance(indicator, ProgressIndicator)
+    assert isinstance(indicator, SupportsNestedSubtasks)
+
+    subtask_id = indicator.add_subtask("child", status=PROGRESS_STATUS_VALUES[0])
+    nested_id = indicator.add_nested_subtask(subtask_id, "nested")
+    indicator.update_subtask(subtask_id, status=PROGRESS_STATUS_VALUES[1])
+    indicator.update_nested_subtask(subtask_id, nested_id, status=PROGRESS_STATUS_VALUES[2])
+    indicator.complete_nested_subtask(subtask_id, nested_id)
+    indicator.complete_subtask(subtask_id)
+    indicator.complete()
+
+
+@pytest.mark.fast
+def test_subtask_snapshot_typed_structure() -> None:
+    """Subtask snapshots allow the expected progress fields."""
+
+    snapshot: SubtaskProgressSnapshot = {
+        "description": "Example",
+        "total": 100.0,
+        "current": 10.0,
+        "status": PROGRESS_STATUS_VALUES[0],
+        "nested_subtasks": {},
+    }
+
+    assert snapshot["status"] == PROGRESS_STATUS_VALUES[0]


### PR DESCRIPTION
## Summary
- add progress status constants, snapshot typing, and subtask protocols to the UX bridge
- align progress implementations and API bridge bookkeeping with the richer progress types
- introduce typed autoresearch payload containers and update signing/tests to exercise them

## Testing
- poetry run pytest tests/unit/interface/test_progress_helpers.py tests/unit/interface/test_autoresearch_telemetry.py

------
https://chatgpt.com/codex/tasks/task_e_68dc6a27ff588333b834f6c88bb2813f