### PR TITLE
feat: tighten agent API typing and validation

### DIFF
--- a/stubs/fastapi/fastapi/__init__.pyi
+++ b/stubs/fastapi/fastapi/__init__.pyi
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
-from collections.abc import Awaitable, Callable, Mapping, MutableMapping
-from typing import Any, Optional, TypeVar
+from typing import Any, Awaitable, Callable, Mapping, MutableMapping, Optional, Sequence, TypeVar
 
+from typing_extensions import ParamSpec
 
+_P = ParamSpec("_P")
+_R = TypeVar("_R")
 _T = TypeVar("_T")
 
 
@@ -14,13 +16,14 @@ class _URL:
 class Request:
     headers: Mapping[str, str]
     url: _URL
+    client: Any
 
 
 class HTTPException(Exception):
     status_code: int
-    detail: str | None
+    detail: Any
 
-    def __init__(self, *, status_code: int, detail: str | None = ...) -> None: ...
+    def __init__(self, *, status_code: int, detail: Any = ...) -> None: ...
 
 
 def Depends(dependency: Callable[..., _T] | None = ...) -> _T: ...
@@ -36,35 +39,75 @@ def Header(
 
 class _StatusModule:
     HTTP_401_UNAUTHORIZED: int
+    HTTP_429_TOO_MANY_REQUESTS: int
+    HTTP_500_INTERNAL_SERVER_ERROR: int
 
 
 status: _StatusModule
-
-
-class FastAPI:
-    def __init__(self, *, title: str | None = ...) -> None: ...
-
-    def include_router(self, router: Any, *, prefix: str = ...) -> None: ...
-
-    def middleware(
-        self, middleware_type: str
-    ) -> Callable[[Callable[..., Awaitable[Any]]], Callable[..., Awaitable[Any]]]: ...
-
-    def get(
-        self, path: str
-    ) -> Callable[[Callable[..., Awaitable[Any]]], Callable[..., Awaitable[Any]]]: ...
-
-
-class APIRouter:
-    def __init__(self, *args: Any, **kwargs: Any) -> None: ...
-
-    def add_api_route(self, path: str, endpoint: Callable[..., Awaitable[Any]], *, methods: Optional[list[str]] = ...) -> None: ...
 
 
 class Response:
     def __init__(self, content: Any = ..., *, media_type: str | None = ...) -> None: ...
 
     headers: MutableMapping[str, str]
+
+
+class FastAPI:
+    def __init__(
+        self,
+        *,
+        title: str | None = ...,
+        description: str | None = ...,
+        version: str | None = ...,
+        docs_url: str | None = ...,
+        redoc_url: str | None = ...,
+    ) -> None: ...
+
+    def include_router(self, router: APIRouter, *, prefix: str = ...) -> None: ...
+
+    def middleware(
+        self, middleware_type: str
+    ) -> Callable[[Callable[..., Awaitable[Any]]], Callable[..., Awaitable[Any]]]: ...
+
+    def get(self, path: str) -> Callable[[Callable[_P, _R]], Callable[_P, _R]]: ...
+
+    def exception_handler(
+        self, exc_class: type[Exception]
+    ) -> Callable[[Callable[[Request, Exception], Awaitable[Any]]], Callable[[Request, Exception], Awaitable[Any]]]: ...
+
+
+class APIRouter:
+    def __init__(self, *args: Any, **kwargs: Any) -> None: ...
+
+    def add_api_route(
+        self,
+        path: str,
+        endpoint: Callable[..., Awaitable[Any]],
+        *,
+        methods: Optional[Sequence[str]] = ...,
+    ) -> None: ...
+
+    def get(
+        self,
+        path: str,
+        *,
+        response_model: type[Any] | None = ...,
+        responses: Mapping[int, Any] | None = ...,
+        tags: Sequence[str] | None = ...,
+        summary: str | None = ...,
+        description: str | None = ...,
+    ) -> Callable[[Callable[_P, _R]], Callable[_P, _R]]: ...
+
+    def post(
+        self,
+        path: str,
+        *,
+        response_model: type[Any] | None = ...,
+        responses: Mapping[int, Any] | None = ...,
+        tags: Sequence[str] | None = ...,
+        summary: str | None = ...,
+        description: str | None = ...,
+    ) -> Callable[[Callable[_P, _R]], Callable[_P, _R]]: ...
 
 
 class TestClient:

--- a/stubs/fastapi/fastapi/responses/__init__.pyi
+++ b/stubs/fastapi/fastapi/responses/__init__.pyi
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Any, MutableMapping
+from typing import Any, Mapping, MutableMapping
 
 
 class Response:
@@ -10,11 +10,25 @@ class Response:
 
 
 class JSONResponse(Response):
-    ...
+    def __init__(
+        self,
+        content: Any = ...,
+        *,
+        status_code: int = ...,
+        headers: Mapping[str, str] | None = ...,
+        media_type: str | None = ...,
+    ) -> None: ...
 
 
 class PlainTextResponse(Response):
-    ...
+    def __init__(
+        self,
+        content: str = ...,
+        *,
+        status_code: int = ...,
+        headers: Mapping[str, str] | None = ...,
+        media_type: str | None = ...,
+    ) -> None: ...
 
 
 class StreamingResponse(Response):


### PR DESCRIPTION
## Summary
- add typed FastAPI decorator helpers plus dataclass envelopes so agent API endpoints retain concrete types and response builders
- normalize progress tracking with SubtaskState records and strict float coercion while propagating the helpers across the router
- extend FastAPI stubs and regression coverage for string-based progress updates

## Testing
- `poetry run pytest tests/unit/interface/test_agentapi_rate_limit_progress.py`
- `poetry run mypy src/devsynth/interface` *(fails: existing missing stubs/annotations across interface package)*

------
https://chatgpt.com/codex/tasks/task_e_68dc73a90784833388b779ab25fefcde