### PR TITLE
docs: record Autoresearch dashboard acceptance

### DIFF
--- a/docs/plan.md
+++ b/docs/plan.md
@@ -476,5 +476,7 @@ Notes and next actions
 - 2025-09-15: `poetry run devsynth run-tests --speed=fast --speed=medium --no-parallel --report --maxfail=1` completed but yielded only 13.68 % coverage; the new gate fails and artifacts persist. Reopened issues/coverage-below-threshold.md to track remediation.
 
 ## Autoresearch alignment
-- Autoresearch RFC evaluation published in [docs/analysis/autoresearch_evaluation.md](analysis/autoresearch_evaluation.md) with follow-up tickets tracking knowledge graph expansion, agent specialization, and dashboard overlays ([issues/Autoresearch-knowledge-graph-expansion.md](../issues/Autoresearch-knowledge-graph-expansion.md), [issues/Autoresearch-agent-specialization.md](../issues/Autoresearch-agent-specialization.md), [issues/Autoresearch-traceability-dashboard.md](../issues/Autoresearch-traceability-dashboard.md)).
+- Autoresearch RFC evaluation published in [docs/analysis/autoresearch_evaluation.md](analysis/autoresearch_evaluation.md).
+- Traceability dashboard overlays, signed telemetry bundles, and MVUU user-guide updates have been delivered and archived (`artifacts/mvuu_overlay_mock.html`, `artifacts/mvuu_autoresearch_overlay_snapshot.json`, and [docs/user_guides/mvuu_dashboard.md](user_guides/mvuu_dashboard.md)), closing [issues/Autoresearch-traceability-dashboard.md](../issues/Autoresearch-traceability-dashboard.md) for the 0.1.0a1 milestone.
+- Next milestone: integrate external Autoresearch connectors (MCP tool exposure → A2A orchestration → SPARQL access) so live telemetry replaces the current stubs while maintaining privacy safeguards and signed evidence flows.
 

--- a/docs/release/0.1.0-alpha.1.md
+++ b/docs/release/0.1.0-alpha.1.md
@@ -16,7 +16,7 @@ This document tracks final checklist updates and artifacts for the 0.1.0a1 pre�
 - **Quality Threshold**: ≥90 % aggregated coverage from the fast+medium profile (`poetry run devsynth run-tests --speed=fast --speed=medium --report --no-parallel`) with artifacts archived under `artifacts/releases/0.1.0a1/fast-medium/`. Capture the per-file excerpts from `term-missing:skip-covered` (see `diagnostics/devsynth_run_tests_fast_medium_20251001T150000Z_coverage.txt`) and pair them with the strict typing summary in `diagnostics/devsynth_mypy_strict_fast_medium_20251001T150000Z_compliance.txt` so the release record shows both coverage and mypy compliance percentages by module. Archive the full module inventories alongside the release evidence (`diagnostics/devsynth_coverage_per_file_20251001T152201Z.txt` and `diagnostics/devsynth_mypy_linecount_20251001T152355Z.txt`) so reviewers can audit files not visible in the excerpted summaries.【F:diagnostics/devsynth_run_tests_fast_medium_20251001T150000Z_coverage.txt†L1-L14】【F:diagnostics/devsynth_mypy_strict_fast_medium_20251001T150000Z_compliance.txt†L1-L17】【F:diagnostics/devsynth_coverage_per_file_20251001T152201Z.txt†L1-L20】【F:diagnostics/devsynth_mypy_linecount_20251001T152355Z.txt†L1-L20】
 - **CLI Behavior**: `devsynth run-tests` now forwards the repository default `--cov-fail-under=90` and reminds operators in smoke mode that the 90 % gate must be rechecked after triage, keeping coverage enforcement consistent across automation and manual runs.【F:pyproject.toml†L309-L317】【F:src/devsynth/application/cli/commands/run_tests_cmd.py†L415-L436】
 - **Configuration Safety**: Config loader now uses a standard dataclass with bounded JSON validation depth, preventing recursive schema expansion when parsing nested resources. Runtime helpers normalize JSON values and guard TOML/YAML optional dependencies.【F:src/devsynth/core/config_loader.py†L20-L107】【F:src/devsynth/core/config_loader.py†L114-L178】
-- **Autoresearch Coordination**: Integration targets the external Autoresearch service via MCP → A2A → SPARQL connectors. Current release tasks focus on stubbing interfaces without enabling local ingestion, and no Autoresearch client is included in 0.1.0a1.
+- **Autoresearch Coordination**: Integration targets the external Autoresearch service via MCP → A2A → SPARQL connectors. Current release tasks focus on stubbing interfaces without enabling local ingestion, and no Autoresearch client is included in 0.1.0a1. Autoresearch traceability overlays, telemetry exports, and the MVUU user guide updates meeting the acceptance criteria are now archived as evidence for the 0.1.0a1 cycle ahead of the connector work.【F:artifacts/mvuu_overlay_mock.html†L1-L1】【F:artifacts/mvuu_autoresearch_overlay_snapshot.json†L1-L23】【F:docs/user_guides/mvuu_dashboard.md†L1-L109】
 
 ## Dependency decisions
 - Locked FastAPI to the 0.116.x series together with Starlette 0.47.3 so smoke
@@ -77,6 +77,11 @@ This document tracks final checklist updates and artifacts for the 0.1.0a1 pre�
   so tooling is ready when the external Autoresearch connectors ship; real
   ingestion remains gated on the upcoming MCP/A2A/SPARQL milestones, and the
   release does not bundle an Autoresearch client.
+- MVUU traceability dashboard overlays, signed telemetry bundles, and user
+  guidance now satisfy the traceability dashboard acceptance criteria for
+  0.1.0a1. The next milestone is integrating the external Autoresearch
+  connectors (MCP → A2A → SPARQL) so the stubs feed live telemetry into the
+  overlays.【F:artifacts/mvuu_overlay_mock.html†L1-L1】【F:artifacts/mvuu_autoresearch_overlay_snapshot.json†L1-L23】【F:docs/user_guides/mvuu_dashboard.md†L1-L167】
 
 ## How to Verify
 1. Run local release prep: `task release:prep`

--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -189,6 +189,7 @@ Notes:
 - 2025-09-20: diagnostics/devsynth_cli_missing_20250920.log and diagnostics/poetry_install_20250920.log show the CLI still missing after codex bootstrap until `poetry install --with dev --all-extras` reruns; task 15.5 tracks automating this reinstall.
 - 2025-09-21: diagnostics/devsynth_cli_bootstrap_attempt1_20250921T021025Z.log and diagnostics/poetry_install_bootstrap_attempt1_20250921T021025Z.log confirm `scripts/install_dev.sh` now retries automatically when the CLI entry point is absent, closing task 15.5.【F:diagnostics/devsynth_cli_bootstrap_attempt1_20250921T021025Z.log†L1-L27】【F:diagnostics/poetry_install_bootstrap_attempt1_20250921T021025Z.log†L1-L63】
 - 2025-09-21: diagnostics/poetry_install_mandatory-bootstrap_attempt1_20250921T150047Z.log and diagnostics/post_install_check_20250921T150333Z.log show the new unconditional Poetry install plus post-install verification that blocks on `poetry env info --path` or CLI failures.【F:diagnostics/poetry_install_mandatory-bootstrap_attempt1_20250921T150047Z.log†L1-L40】【F:diagnostics/post_install_check_20250921T150333Z.log†L1-L2】
+- 2025-10-01: Autoresearch traceability dashboard overlays, telemetry exports, and user-guide updates accepted for 0.1.0a1; issue `issues/Autoresearch-traceability-dashboard.md` closed. Next milestone focuses on integrating external Autoresearch connectors (MCP → A2A → SPARQL) so live telemetry feeds the overlays.
 
 17. Documentation Maintenance
 17.1 [x] Deduplicate historical entries in docs/task_notes.md to keep the iteration log concise.

--- a/issues/Autoresearch-traceability-dashboard.md
+++ b/issues/Autoresearch-traceability-dashboard.md
@@ -1,5 +1,5 @@
 Milestone: 0.1.0-alpha.2
-Status: open
+Status: closed
 Owner: Observability Guild
 
 Priority: medium
@@ -32,6 +32,9 @@ translate into implementation work.
 - Autoresearch overlay mock-up: `artifacts/mvuu_overlay_mock.html`
 - Telemetry snapshot: `artifacts/mvuu_autoresearch_overlay_snapshot.json`
 - User guidance: `docs/user_guides/mvuu_dashboard.md`
+
+## Resolution (2025-10-01)
+- Acceptance criteria met with overlays, telemetry exports, and documentation updates archived for 0.1.0a1. See the overlay mock (`artifacts/mvuu_overlay_mock.html`), signed telemetry snapshot (`artifacts/mvuu_autoresearch_overlay_snapshot.json`), and MVUU user guide (`docs/user_guides/mvuu_dashboard.md`) for the implementation evidence. Next milestone tracks external connector integration so live Autoresearch telemetry can replace the current stubs.
 
 ## References
 - docs/analysis/mvuu_dashboard.md


### PR DESCRIPTION
## Summary
- note in the 0.1.0a1 release record that the Autoresearch overlays, telemetry export, and MVUU guide updates met the dashboard acceptance criteria and point to the archived evidence
- update the Autoresearch alignment section in docs/plan.md and the roadmap notes in docs/tasks.md with the completed work and the upcoming external connector integration milestone
- close issues/Autoresearch-traceability-dashboard.md with a resolution comment linking the overlay mock, telemetry snapshot, and user guide

## Testing
- not run (documentation-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68dd67fe2ee48333b1378de22ce08fa3