### PR TITLE
feat: add Autoresearch telemetry connector fallbacks

### DIFF
--- a/tests/unit/cli/test_mvuu_dashboard_telemetry.py
+++ b/tests/unit/cli/test_mvuu_dashboard_telemetry.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import json
-from datetime import datetime
 from pathlib import Path
 
 import pytest
@@ -25,17 +24,16 @@ mvuu_dashboard_cmd = importlib.util.module_from_spec(spec)
 sys.modules.setdefault("mvuu_dashboard_cmd", mvuu_dashboard_cmd)
 assert spec.loader is not None
 spec.loader.exec_module(mvuu_dashboard_cmd)
-from devsynth.interface.research_telemetry import (
-    build_research_telemetry_payload,
-    sign_payload,
-)
+from devsynth.interface.research_telemetry import sign_payload
 
 
-@pytest.mark.fast
-def test_mvuu_dashboard_cli_generates_signed_telemetry(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    """CLI should emit telemetry and pass overlay flags to Streamlit."""
+def _prepare_cli_environment(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    trace_payload: dict[str, object],
+) -> tuple[Path, Path, list[tuple[list[str], dict[str, str] | None]]]:
+    """Create a temporary repo layout and patch subprocess invocation."""
 
     repo_root = tmp_path
     (repo_root / "src" / "devsynth" / "interface").mkdir(parents=True)
@@ -43,17 +41,12 @@ def test_mvuu_dashboard_cli_generates_signed_telemetry(
     script_path.write_text("print('stub streamlit app')\n", encoding="utf-8")
 
     trace_path = repo_root / "traceability.json"
-    trace_payload = {
-        "DSY-0001": {"utility_statement": "Investigate", "agent_persona": "Analyst"}
-    }
     trace_path.write_text(json.dumps(trace_payload), encoding="utf-8")
 
     telemetry_path = repo_root / "telemetry.json"
-    secret_env = "CLI_EXTERNAL_RESEARCH_SECRET"
-    monkeypatch.setenv(secret_env, "secret-value")
     monkeypatch.setenv("DEVSYNTH_REPO_ROOT", str(repo_root))
 
-    captured = []
+    captured: list[tuple[list[str], dict[str, str] | None]] = []
 
     def fake_run(cmd, check=False, env=None, **kwargs):
         captured.append((cmd, env))
@@ -62,6 +55,24 @@ def test_mvuu_dashboard_cli_generates_signed_telemetry(
         return type("Proc", (), {"returncode": 0})()
 
     monkeypatch.setattr(mvuu_dashboard_cmd.subprocess, "run", fake_run)
+
+    return telemetry_path, trace_path, captured
+
+
+@pytest.mark.fast
+def test_mvuu_dashboard_cli_generates_signed_telemetry(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """CLI should emit telemetry and pass overlay flags to Streamlit."""
+
+    trace_payload = {
+        "DSY-0001": {"utility_statement": "Investigate", "agent_persona": "Analyst"}
+    }
+    telemetry_path, trace_path, captured = _prepare_cli_environment(
+        tmp_path, monkeypatch, trace_payload=trace_payload
+    )
+    secret_env = "CLI_EXTERNAL_RESEARCH_SECRET"
+    monkeypatch.setenv(secret_env, "secret-value")
 
     exit_code = mvuu_dashboard_cmd.mvuu_dashboard_cmd(
         [
@@ -89,14 +100,13 @@ def test_mvuu_dashboard_cli_generates_signed_telemetry(
     assert signature["algorithm"] == "HMAC-SHA256"
     assert signature["key_id"] == f"env:{secret_env}"
 
-    payload_obj = build_research_telemetry_payload(
-        trace_payload,
-        session_id=payload["session_id"],
-        generated_at=datetime.fromisoformat(payload["generated_at"]),
-    )
-    if "research_personas" in payload:
-        payload_obj["research_personas"] = payload["research_personas"]
-    expected = sign_payload(payload_obj, secret="secret-value", key_id=f"env:{secret_env}")
+    connector_status = payload["connector_status"]
+    assert connector_status["mode"] == "fixture"
+    assert connector_status["provider"] == "local"
+    assert connector_status["forced_local"] is False
+    assert "reasons" in connector_status and "not-configured" in connector_status["reasons"]
+
+    expected = sign_payload(payload, secret="secret-value", key_id=f"env:{secret_env}")
     assert expected.digest == signature["digest"]
 
     streamlit_call = next(
@@ -106,6 +116,7 @@ def test_mvuu_dashboard_cli_generates_signed_telemetry(
     assert env["DEVSYNTH_EXTERNAL_RESEARCH_OVERLAYS"] == "1"
     assert env["DEVSYNTH_EXTERNAL_RESEARCH_TELEMETRY"] == str(telemetry_path)
     assert env["DEVSYNTH_EXTERNAL_RESEARCH_SIGNATURE_KEY"] == secret_env
+    assert env["DEVSYNTH_EXTERNAL_RESEARCH_MODE"] == "fixture"
     assert (
         env["DEVSYNTH_EXTERNAL_RESEARCH_PERSONAS"]
         == "Research Lead,Synthesist,Bibliographer"
@@ -138,3 +149,192 @@ def test_mvuu_dashboard_cli_generates_signed_telemetry(
 
     monkeypatch.delenv("DEVSYNTH_REPO_ROOT", raising=False)
     monkeypatch.delenv(secret_env, raising=False)
+
+
+@pytest.mark.fast
+def test_mvuu_dashboard_cli_uses_live_connectors(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """When connectors are available the CLI records live mode metadata."""
+
+    trace_payload = {
+        "DSY-1001": {"utility_statement": "Correlate signals", "agent_persona": "Lead"}
+    }
+    telemetry_path, _trace_path, captured = _prepare_cli_environment(
+        tmp_path, monkeypatch, trace_payload=trace_payload
+    )
+    secret_env = "CLI_EXTERNAL_RESEARCH_SECRET"
+    monkeypatch.setenv(secret_env, "secret-value")
+    monkeypatch.setenv("DEVSYNTH_EXTERNAL_RESEARCH_CONNECTORS", "1")
+
+    class StubClient:
+        def __init__(self) -> None:
+            self.handshake_calls: list[str] = []
+            self.fetch_calls: list[tuple[str, str | None]] = []
+
+        def handshake(self, session_id: str) -> dict[str, object]:
+            self.handshake_calls.append(session_id)
+            return {
+                "health": {"status": "ok"},
+                "session": {"session_id": session_id},
+                "capabilities": {"tools": ["sparql"]},
+            }
+
+        def fetch_trace_updates(
+            self, sparql_query: str, session_id: str | None = None
+        ) -> dict[str, object]:
+            self.fetch_calls.append((sparql_query, session_id))
+            return {
+                "results": {"records": [{"trace_id": "remote-1"}], "session_id": session_id},
+                "metrics": {"pending": 0},
+            }
+
+    stub_client = StubClient()
+
+    def fake_builder(*, enabled: bool) -> StubClient:
+        assert enabled is True
+        return stub_client
+
+    monkeypatch.setattr(mvuu_dashboard_cmd, "_build_autoresearch_client", fake_builder)
+
+    exit_code = mvuu_dashboard_cmd.mvuu_dashboard_cmd(
+        [
+            "--research-overlays",
+            "--telemetry-path",
+            str(telemetry_path),
+            "--signature-env",
+            secret_env,
+        ]
+    )
+
+    assert exit_code == 0
+    assert telemetry_path.exists()
+
+    telemetry = json.loads(telemetry_path.read_text(encoding="utf-8"))
+    connector_status = telemetry["connector_status"]
+    assert connector_status["mode"] == "live"
+    assert connector_status["forced_local"] is False
+    assert connector_status.get("reasons") in (None, [])
+    assert connector_status["handshake"]["session"]["session_id"] == telemetry["session_id"]
+    assert connector_status["query"]["results"]["records"] == [{"trace_id": "remote-1"}]
+
+    assert stub_client.handshake_calls
+    assert stub_client.fetch_calls
+
+    streamlit_call = next((cmd, env) for cmd, env in captured if cmd[:2] == ["streamlit", "run"])
+    _, env = streamlit_call
+    assert env["DEVSYNTH_EXTERNAL_RESEARCH_MODE"] == "live"
+
+    monkeypatch.delenv("DEVSYNTH_REPO_ROOT", raising=False)
+    monkeypatch.delenv(secret_env, raising=False)
+    monkeypatch.delenv("DEVSYNTH_EXTERNAL_RESEARCH_CONNECTORS", raising=False)
+
+
+@pytest.mark.fast
+def test_mvuu_dashboard_cli_falls_back_on_connector_error(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Connector failures should not abort the CLI and retain fixture mode."""
+
+    trace_payload = {"DSY-2002": {"utility_statement": "Index references"}}
+    telemetry_path, _trace_path, captured = _prepare_cli_environment(
+        tmp_path, monkeypatch, trace_payload=trace_payload
+    )
+    secret_env = "CLI_EXTERNAL_RESEARCH_SECRET"
+    monkeypatch.setenv(secret_env, "secret-value")
+    monkeypatch.setenv("DEVSYNTH_EXTERNAL_RESEARCH_CONNECTORS", "1")
+
+    class RaisingClient:
+        def __init__(self) -> None:
+            self.handshake_calls = 0
+            self.fetch_calls = 0
+
+        def handshake(self, session_id: str) -> dict[str, object]:
+            self.handshake_calls += 1
+            raise RuntimeError("handshake failure")
+
+        def fetch_trace_updates(self, sparql_query: str, session_id: str | None = None) -> dict[str, object]:
+            self.fetch_calls += 1
+            return {}
+
+    stub_client = RaisingClient()
+
+    def fake_builder(*, enabled: bool) -> RaisingClient:
+        assert enabled is True
+        return stub_client
+
+    monkeypatch.setattr(mvuu_dashboard_cmd, "_build_autoresearch_client", fake_builder)
+
+    exit_code = mvuu_dashboard_cmd.mvuu_dashboard_cmd(
+        [
+            "--research-overlays",
+            "--telemetry-path",
+            str(telemetry_path),
+            "--signature-env",
+            secret_env,
+        ]
+    )
+
+    assert exit_code == 0
+    telemetry = json.loads(telemetry_path.read_text(encoding="utf-8"))
+    connector_status = telemetry["connector_status"]
+    assert connector_status["mode"] == "fixture"
+    assert "handshake-error" in connector_status["reasons"]
+    assert "query" not in connector_status
+
+    assert stub_client.handshake_calls == 1
+    assert stub_client.fetch_calls == 0
+
+    streamlit_call = next((cmd, env) for cmd, env in captured if cmd[:2] == ["streamlit", "run"])
+    _, env = streamlit_call
+    assert env["DEVSYNTH_EXTERNAL_RESEARCH_MODE"] == "fixture"
+
+    monkeypatch.delenv("DEVSYNTH_REPO_ROOT", raising=False)
+    monkeypatch.delenv(secret_env, raising=False)
+    monkeypatch.delenv("DEVSYNTH_EXTERNAL_RESEARCH_CONNECTORS", raising=False)
+
+
+@pytest.mark.fast
+def test_mvuu_dashboard_cli_force_local_mode(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Force-local flag should bypass connector construction entirely."""
+
+    trace_payload = {"DSY-3003": {"utility_statement": "Summarise"}}
+    telemetry_path, _trace_path, captured = _prepare_cli_environment(
+        tmp_path, monkeypatch, trace_payload=trace_payload
+    )
+    secret_env = "CLI_EXTERNAL_RESEARCH_SECRET"
+    monkeypatch.setenv(secret_env, "secret-value")
+    monkeypatch.setenv("DEVSYNTH_EXTERNAL_RESEARCH_CONNECTORS", "1")
+
+    def failing_builder(*, enabled: bool):  # type: ignore[no-untyped-def]
+        raise AssertionError("builder should not be called when forced local")
+
+    monkeypatch.setattr(mvuu_dashboard_cmd, "_build_autoresearch_client", failing_builder)
+
+    exit_code = mvuu_dashboard_cmd.mvuu_dashboard_cmd(
+        [
+            "--research-overlays",
+            "--telemetry-path",
+            str(telemetry_path),
+            "--signature-env",
+            secret_env,
+            "--force-local-research",
+        ]
+    )
+
+    assert exit_code == 0
+    telemetry = json.loads(telemetry_path.read_text(encoding="utf-8"))
+    connector_status = telemetry["connector_status"]
+    assert connector_status["mode"] == "fixture"
+    assert connector_status["forced_local"] is True
+    assert "forced-local" in connector_status["reasons"]
+
+    streamlit_call = next((cmd, env) for cmd, env in captured if cmd[:2] == ["streamlit", "run"])
+    _, env = streamlit_call
+    assert env["DEVSYNTH_EXTERNAL_RESEARCH_MODE"] == "fixture"
+
+    monkeypatch.delenv("DEVSYNTH_REPO_ROOT", raising=False)
+    monkeypatch.delenv(secret_env, raising=False)
+    monkeypatch.delenv("DEVSYNTH_EXTERNAL_RESEARCH_CONNECTORS", raising=False)


### PR DESCRIPTION
## Summary
- integrate the Autoresearch client into the MVUU dashboard CLI to attempt live connector handshakes and SPARQL queries with graceful fixture fallbacks
- add a force-local overlays flag/environment, persist connector mode metadata, and log when fixture mode is used
- extend CLI telemetry unit tests to cover live, fallback, and forced-local scenarios

## Testing
- poetry run pytest tests/unit/cli/test_mvuu_dashboard_telemetry.py

------
https://chatgpt.com/codex/tasks/task_e_68ddfb5292f083339fd80178e0f47de0