### PR TITLE
feat: expand autoresearch persona overlays

### DIFF
--- a/docs/analysis/mvuu_dashboard.md
+++ b/docs/analysis/mvuu_dashboard.md
@@ -58,12 +58,16 @@ sacrificing day-to-day usability.
 
 ## Autoresearch Personas
 
-Repeatable `--research-persona` options on `devsynth mvuu-dashboard` activate the
-Research Lead, Bibliographer, and Synthesist overlays alongside
-`--research-overlays`. The command persists the selection to
-`DEVSYNTH_EXTERNAL_RESEARCH_PERSONAS` (legacy: `DEVSYNTH_AUTORESEARCH_PERSONAS`), allowing the WSDE collaboration layer to
-favour persona-aware primus selection while telemetry bundles capture persona
-assignments and fallback decisions for MVUU traceability.
+Repeatable `--research-persona` options on `devsynth mvuu-dashboard` activate
+optional overlays for any combination of Research Lead, Bibliographer,
+Synthesist, Synthesizer, Contrarian, Fact Checker, Planner, and Moderator. Each
+flag is additive, letting teams compose the facilitation mix that suits a given
+investigation. The command persists the chosen set to
+`DEVSYNTH_EXTERNAL_RESEARCH_PERSONAS` (legacy: `DEVSYNTH_AUTORESEARCH_PERSONAS`),
+so the WSDE collaboration layer and telemetry writers can respect persona-aware
+governance even when the CLI is not driving the session. Configuration files or
+environment variables may pre-populate the same comma-delimited list, ensuring
+overlays remain opt-in and reversible without code changes.
 
 ### Prompt-driven instrumentation
 

--- a/src/devsynth/domain/models/wsde_roles.py
+++ b/src/devsynth/domain/models/wsde_roles.py
@@ -150,6 +150,61 @@ def _build_research_persona_specs() -> tuple[ResearchPersonaSpec, ...]:
                 "Surface integration risks for primus coordination",
             ),
         },
+        {
+            "slug": "synthesizer",
+            "display_name": "Synthesizer",
+            "primary_role": RoleName.WORKER,
+            "supporting_roles": (RoleName.DESIGNER, RoleName.EVALUATOR),
+            "capabilities": (
+                "Convert research packets into worker-ready prototypes with designer foresight",
+                "Preserve evaluator traceability tying design choices to cited evidence",
+                "Coordinate fallback hand-offs with planner and moderator overlays",
+            ),
+        },
+        {
+            "slug": "contrarian",
+            "display_name": "Contrarian",
+            "primary_role": RoleName.EVALUATOR,
+            "supporting_roles": (RoleName.SUPERVISOR,),
+            "capabilities": (
+                "Challenge consensus through evaluator stress-tests of key assumptions",
+                "Document governance-ready dissent logs for supervisor review",
+                "Surface risk mitigations before primus decisions are finalised",
+            ),
+        },
+        {
+            "slug": "fact_checker",
+            "display_name": "Fact Checker",
+            "primary_role": RoleName.SUPERVISOR,
+            "supporting_roles": (RoleName.EVALUATOR,),
+            "capabilities": (
+                "Audit claims for supervisor-grade compliance and attribution",
+                "Reconstruct evaluator validation chains for contested evidence",
+                "Enforce corrective actions before implementation proceeds",
+            ),
+        },
+        {
+            "slug": "planner",
+            "display_name": "Planner",
+            "primary_role": RoleName.DESIGNER,
+            "supporting_roles": (RoleName.PRIMUS,),
+            "capabilities": (
+                "Sequence designer roadmaps that respect primus governance gates",
+                "Balance scope, risk, and capacity across supporting roles",
+                "Publish contingency playbooks for research-driven pivots",
+            ),
+        },
+        {
+            "slug": "moderator",
+            "display_name": "Moderator",
+            "primary_role": RoleName.PRIMUS,
+            "supporting_roles": (RoleName.SUPERVISOR,),
+            "capabilities": (
+                "Facilitate primus-level decision forums with supervisor safeguards",
+                "Resolve persona conflicts while maintaining audit trails",
+                "Escalate governance checkpoints when collaboration stalls",
+            ),
+        },
     )
 
     specs: list[ResearchPersonaSpec] = []

--- a/templates/prompts/autoresearch_personas.json
+++ b/templates/prompts/autoresearch_personas.json
@@ -41,6 +41,76 @@
         "Residual risks are quantified with next steps assigned to agents or follow-up sessions.",
         "Fallback notes document which expertise-ranked peer review resolved outstanding conflicts."
       ]
+    },
+    "synthesizer": {
+      "display_name": "Synthesizer",
+      "prompt_template": "You are the Synthesizer charged with prototyping solutions from freshly gathered evidence. Convert the Research Lead's objectives and Bibliographer packets into runnable plans or proofs of concept while preserving the citations that informed each design trade-off.",
+      "fallback_behavior": [
+        "If implementation blockers surface, publish a design gap analysis and request Planner triage before committing to a direction.",
+        "Escalate misaligned recommendations to the Moderator so the team can realign decision records before execution continues.",
+        "When evidence is insufficient, coordinate with the Fact Checker to validate assumptions and pause build-out until verification completes."
+      ],
+      "success_criteria": [
+        "Prototype notes document how each design choice maps to validated evidence packets.",
+        "Hand-off materials include reproduction steps that downstream Workers can execute without rework.",
+        "Fallback entries cite which governance checkpoint (Planner or Moderator) approved the next steps."
+      ]
+    },
+    "contrarian": {
+      "display_name": "Contrarian",
+      "prompt_template": "You are the Contrarian safeguarding the investigation against groupthink. Stress-test assumptions, propose counter-hypotheses, and require explicit evidence before consensus moves forward. Document dissenting views so the MVUU timeline captures why decisions were upheld or revised.",
+      "fallback_behavior": [
+        "If no conflicting evidence is found, request a secondary review from the Fact Checker and log the absence of challenges.",
+        "Escalate unresolved disputes to the Moderator to broker a governance-compliant decision.",
+        "When time-boxed critique expires, deliver a written risk memo detailing outstanding concerns for the Research Lead."
+      ],
+      "success_criteria": [
+        "Decision records show which hypotheses were overturned or reinforced after contrarian review.",
+        "Risk memos include recommended mitigations and clear owners for follow-up tasks.",
+        "Fallback notes capture Moderator or Research Lead directives that closed lingering disputes."
+      ]
+    },
+    "fact_checker": {
+      "display_name": "Fact Checker",
+      "prompt_template": "You are the Fact Checker verifying every critical claim before it reaches implementation. Trace citations, confirm data integrity, and enforce governance requirements for attribution. Flag unverifiable statements and demand corrections before the Synthesizer moves forward.",
+      "fallback_behavior": [
+        "If primary sources are inaccessible, request Bibliographer assistance and document the retrieval gap in telemetry.",
+        "Escalate persistent discrepancies to the Research Lead with a summary of disputed claims.",
+        "When validation tooling fails, coordinate with the Planner to reschedule verification checkpoints before launch."
+      ],
+      "success_criteria": [
+        "Every claim routed through the Synthesizer includes a verified citation chain.",
+        "Discrepancy reports log who resolved the issue and what remediation occurred.",
+        "Fallback entries list deferred validations along with the governance artifact tracking them."
+      ]
+    },
+    "planner": {
+      "display_name": "Planner",
+      "prompt_template": "You are the Planner translating investigative insights into a sequenced execution roadmap. Balance scope, risk, and available expertise while ensuring WSDE checkpoints honour governance constraints. Coordinate with the Research Lead when reprioritisation is necessary.",
+      "fallback_behavior": [
+        "If resource constraints block the roadmap, trigger a Moderator review and capture the reprioritisation rationale.",
+        "When conflicting directives arise, request a Contrarian audit to surface the competing evidence.",
+        "Escalate timeline risks to the Synthesizer and Research Lead so contingency plans are recorded before deadlines slip."
+      ],
+      "success_criteria": [
+        "Roadmaps include milestones mapped to MVUU trace entries and responsible agents.",
+        "Risk registers are updated with mitigation owners and review cadences.",
+        "Fallback documentation highlights how Moderator or Research Lead directives altered the plan."
+      ]
+    },
+    "moderator": {
+      "display_name": "Moderator",
+      "prompt_template": "You are the Moderator maintaining psychological safety and governance compliance across the Autoresearch cell. Facilitate decisions, resolve conflicts between personas, and ensure MVUU entries record rationale alongside approvals.",
+      "fallback_behavior": [
+        "If consensus cannot be reached, invoke the Research Lead for binding arbitration and log the governance clause applied.",
+        "When conflicts escalate, schedule a Contrarian and Fact Checker joint review to gather decisive evidence.",
+        "If meeting time expires, issue a decision backlog summary with follow-up actions assigned to accountable personas."
+      ],
+      "success_criteria": [
+        "MVUU entries for each major decision include Moderator sign-off and cited governance clauses.",
+        "Conflict resolution notes capture who participated and what compromise was adopted.",
+        "Fallback documentation lists pending decisions, next review windows, and accountable roles."
+      ]
     }
   }
 }

--- a/tests/unit/cli/test_mvuu_dashboard_telemetry.py
+++ b/tests/unit/cli/test_mvuu_dashboard_telemetry.py
@@ -87,6 +87,16 @@ def test_mvuu_dashboard_cli_generates_signed_telemetry(
             "Synthesist",
             "--research-persona",
             "Bibliographer",
+            "--research-persona",
+            "Synthesizer",
+            "--research-persona",
+            "Contrarian",
+            "--research-persona",
+            "Fact Checker",
+            "--research-persona",
+            "Planner",
+            "--research-persona",
+            "Moderator",
         ]
     )
 
@@ -119,14 +129,14 @@ def test_mvuu_dashboard_cli_generates_signed_telemetry(
     assert env["DEVSYNTH_EXTERNAL_RESEARCH_MODE"] == "fixture"
     assert (
         env["DEVSYNTH_EXTERNAL_RESEARCH_PERSONAS"]
-        == "Research Lead,Synthesist,Bibliographer"
+        == "Research Lead,Synthesist,Bibliographer,Synthesizer,Contrarian,Fact Checker,Planner,Moderator"
     )
     assert env["DEVSYNTH_AUTORESEARCH_OVERLAYS"] == "1"
     assert env["DEVSYNTH_AUTORESEARCH_TELEMETRY"] == str(telemetry_path)
     assert env["DEVSYNTH_AUTORESEARCH_SIGNATURE_KEY"] == secret_env
     assert (
         env["DEVSYNTH_AUTORESEARCH_PERSONAS"]
-        == "Research Lead,Synthesist,Bibliographer"
+        == "Research Lead,Synthesist,Bibliographer,Synthesizer,Contrarian,Fact Checker,Planner,Moderator"
     )
 
     personas_payload = telemetry.get("research_personas", [])
@@ -134,6 +144,11 @@ def test_mvuu_dashboard_cli_generates_signed_telemetry(
         "Research Lead",
         "Synthesist",
         "Bibliographer",
+        "Synthesizer",
+        "Contrarian",
+        "Fact Checker",
+        "Planner",
+        "Moderator",
     }
     lead_payload = next(item for item in personas_payload if item["name"] == "Research Lead")
     assert lead_payload["primary_role"] == "primus"

--- a/tests/unit/domain/models/test_wsde_roles_personas.py
+++ b/tests/unit/domain/models/test_wsde_roles_personas.py
@@ -1,0 +1,57 @@
+"""Unit tests covering research persona specifications."""
+
+from __future__ import annotations
+
+import pytest
+
+from devsynth.domain.models.wsde_roles import (
+    ResearchPersonaSpec,
+    enumerate_research_personas,
+    resolve_research_persona,
+)
+
+
+@pytest.mark.fast
+def test_enumerate_research_personas_includes_overlays() -> None:
+    """Expanded persona roster should be discoverable via enumeration."""
+
+    personas = enumerate_research_personas()
+    display_names = {spec.display_name for spec in personas}
+
+    expected = {
+        "Research Lead",
+        "Bibliographer",
+        "Synthesist",
+        "Synthesizer",
+        "Contrarian",
+        "Fact Checker",
+        "Planner",
+        "Moderator",
+    }
+
+    assert display_names == expected
+
+
+@pytest.mark.fast
+@pytest.mark.parametrize(
+    "persona_name",
+    [
+        "Synthesizer",
+        "Contrarian",
+        "Fact Checker",
+        "Planner",
+        "Moderator",
+    ],
+)
+def test_persona_payload_exposes_overlay_metadata(persona_name: str) -> None:
+    """Overlay personas must provide telemetry metadata when enabled."""
+
+    spec = resolve_research_persona(persona_name)
+    assert isinstance(spec, ResearchPersonaSpec)
+
+    payload = spec.as_payload()
+    assert payload["name"] == persona_name
+    assert payload["capabilities"], "Capabilities should not be empty"
+    assert payload.get("prompt_template"), "Prompt template must be recorded"
+    assert payload.get("fallback_behavior"), "Fallback behavior must be recorded"
+    assert payload.get("success_criteria"), "Success criteria must be recorded"


### PR DESCRIPTION
## Summary
- add Synthesizer, Contrarian, Fact Checker, Planner, and Moderator personas to the autoresearch prompt dataset with governance guidance
- map the new personas to WSDE role capabilities and expose their metadata for telemetry
- extend unit coverage for persona resolution, CLI overlays, and document how optional overlays are toggled via CLI or configuration

## Testing
- `poetry run pytest tests/unit/domain/models/test_wsde_roles_personas.py tests/unit/cli/test_mvuu_dashboard_telemetry.py::test_mvuu_dashboard_cli_generates_signed_telemetry`


------
https://chatgpt.com/codex/tasks/task_e_68de01ccb04c833391ccff710ab91d25