### PR TITLE
test: mark alignment metrics command scenarios as fast

### DIFF
--- a/tests/behavior/test_alignment_metrics_command.py
+++ b/tests/behavior/test_alignment_metrics_command.py
@@ -9,6 +9,7 @@ from .steps.test_alignment_metrics_steps import *  # noqa: F401,F403
 
 pytestmark = [
     pytest.mark.requires_resource("cli"),
+    pytest.mark.fast,
 ]
 
 # Get the absolute path to the feature file


### PR DESCRIPTION
## Summary
- mark the alignment metrics command behavior tests with the `fast` speed marker alongside the existing CLI resource requirement

## Testing
- poetry run python scripts/verify_test_markers.py
- poetry run devsynth run-tests --speed=fast --collect-only *(fails: ModuleNotFoundError: No module named 'devsynth')*

------
https://chatgpt.com/codex/tasks/task_e_68de8d22659c83339a5b954784326272