### PR TITLE
refactor: tighten memory store typing and transactions

### DIFF
--- a/src/devsynth/application/memory/context_manager.py
+++ b/src/devsynth/application/memory/context_manager.py
@@ -15,6 +15,8 @@ from devsynth.exceptions import DevSynthError
 class InMemoryStore(MemoryStore):
     """In-memory implementation of MemoryStore."""
 
+    supports_transactions: bool = True
+
     def __init__(self):
         self.items = {}
         # Simple transaction support: map tx_id -> snapshot of items

--- a/src/devsynth/application/memory/faiss_store.py
+++ b/src/devsynth/application/memory/faiss_store.py
@@ -21,7 +21,7 @@ except ImportError as e:  # pragma: no cover - optional dependency
     ) from e
 from datetime import datetime
 from pathlib import Path
-from typing import Any, Dict, List, Mapping, Optional, Tuple, Union
+from typing import Any, Dict, List, Mapping, Optional, Tuple, Union, ContextManager
 
 from devsynth.exceptions import (
     DevSynthError,
@@ -31,7 +31,7 @@ from devsynth.exceptions import (
 )
 from devsynth.logging_setup import DevSynthLogger
 
-from ...domain.interfaces.memory import VectorStore
+from ...domain.interfaces.memory import SupportsTransactions, VectorStore
 from ...domain.models.memory import MemoryVector
 from .dto import MemoryMetadata, VectorStoreStats
 from .metadata_serialization import from_serializable, to_serializable
@@ -40,7 +40,7 @@ from .metadata_serialization import from_serializable, to_serializable
 logger = DevSynthLogger(__name__)
 
 
-class FAISSStore(VectorStore[MemoryVector]):
+class FAISSStore(VectorStore[MemoryVector], SupportsTransactions):
     """
     FAISS implementation of the VectorStore interface.
 
@@ -205,7 +205,9 @@ class FAISSStore(VectorStore[MemoryVector]):
         return True
 
     @contextmanager
-    def transaction(self, transaction_id: str | None = None):
+    def transaction(
+        self, transaction_id: str | None = None
+    ) -> ContextManager[str]:
         """Context manager providing transactional semantics."""
 
         tx_id = self.begin_transaction(transaction_id)
@@ -529,3 +531,5 @@ class FAISSStore(VectorStore[MemoryVector]):
             if vec:
                 vectors.append(vec)
         return vectors
+    supports_transactions: bool = True
+

--- a/tests/unit/application/memory/conftest.py
+++ b/tests/unit/application/memory/conftest.py
@@ -809,6 +809,8 @@ else:
 class ProtocolCompliantMemoryStore(MemoryStore):
     """In-memory ``MemoryStore`` implementation satisfying the protocol."""
 
+    supports_transactions: bool = True
+
     def __init__(self, *args: object, **kwargs: object) -> None:
         self._records: dict[str, MemoryRecord] = {}
         self._active_transactions: set[str] = set()

--- a/tests/unit/application/memory/test_fallback.py
+++ b/tests/unit/application/memory/test_fallback.py
@@ -133,8 +133,8 @@ class TestFallbackStore:
         assert store.store_status[primary_store] == StoreStatus.DEGRADED
         assert store.store_status[fallback_store] == StoreStatus.AVAILABLE
         assert len(store.pending_operations) == 1
-        assert store.pending_operations[0]["type"] == "store"
-        assert store.pending_operations[0]["item"] == memory_item
+        assert store.pending_operations[0].operation == "store"
+        assert store.pending_operations[0].item == memory_item
 
     @pytest.mark.medium
     def test_store_all_failures(self, primary_store, fallback_store, memory_item):
@@ -280,8 +280,8 @@ class TestFallbackStore:
         assert store.store_status[primary_store] == StoreStatus.DEGRADED
         assert store.store_status[fallback_store] == StoreStatus.AVAILABLE
         assert len(store.pending_operations) == 1
-        assert store.pending_operations[0]["type"] == "delete"
-        assert store.pending_operations[0]["item_id"] == "test-item-1"
+        assert store.pending_operations[0].operation == "delete"
+        assert store.pending_operations[0].item_id == "test-item-1"
 
     @pytest.mark.medium
     def test_delete_all_failures(self, primary_store, fallback_store):
@@ -368,8 +368,8 @@ class TestFallbackStore:
         assert store.store_status[primary_store] == StoreStatus.DEGRADED
         assert store.store_status[fallback_store] == StoreStatus.AVAILABLE
         assert len(store.pending_operations) == 1
-        assert store.pending_operations[0]["type"] == "begin_transaction"
-        assert store.pending_operations[0]["transaction_id"] == "tx-1"
+        assert store.pending_operations[0].operation == "begin_transaction"
+        assert store.pending_operations[0].transaction_id == "tx-1"
 
     @pytest.mark.medium
     def test_begin_transaction_all_failures(self, primary_store, fallback_store):
@@ -416,8 +416,8 @@ class TestFallbackStore:
         assert store.store_status[primary_store] == StoreStatus.DEGRADED
         assert store.store_status[fallback_store] == StoreStatus.AVAILABLE
         assert len(store.pending_operations) == 1
-        assert store.pending_operations[0]["type"] == "commit_transaction"
-        assert store.pending_operations[0]["transaction_id"] == "tx-1"
+        assert store.pending_operations[0].operation == "commit_transaction"
+        assert store.pending_operations[0].transaction_id == "tx-1"
 
     @pytest.mark.medium
     def test_commit_transaction_all_failures(self, primary_store, fallback_store):


### PR DESCRIPTION
## Summary
- add metadata coercion helpers to TinyDB and LMDB stores and advertise transaction support flags across memory adapters
- rework JSON file store search/transaction plumbing around typed records and dataclasses
- replace fallback store registries and pending payloads with typed structures and update tests for the new API

## Testing
- `pytest tests/unit/application/memory/test_fallback.py` *(fails: ModuleNotFoundError: No module named 'numpy')*
- `pytest tests/unit/general/test_memory_system.py -k JSONFileStore`

------
https://chatgpt.com/codex/tasks/task_e_68de985883048333b587330e98eebe3f