### PR TITLE
refactor: tighten memory adapter typing

### DIFF
--- a/src/devsynth/application/memory/__init__.py
+++ b/src/devsynth/application/memory/__init__.py
@@ -7,7 +7,7 @@ This module provides memory storage and retrieval functionality for DevSynth,
 including a Memory Manager with adapters for different storage backends.
 """
 
-from typing import TYPE_CHECKING, Any, cast
+from typing import TYPE_CHECKING, Any, ClassVar, cast
 
 from devsynth.logging_setup import DevSynthLogger
 
@@ -33,7 +33,7 @@ else:  # pragma: no cover - fallback definitions when optional adapters missing
     TinyDBMemoryAdapterType = Any  # type: ignore[assignment]
     VectorMemoryAdapterType = Any  # type: ignore[assignment]
 
-GraphMemoryAdapter: type[GraphMemoryAdapterType] | None
+GraphMemoryAdapter: ClassVar[type[GraphMemoryAdapterType] | None]
 try:  # pragma: no cover - optional dependency
     from .adapters.graph_memory_adapter import GraphMemoryAdapter as _GraphMemoryAdapter
 except ImportError as exc:  # pragma: no cover - fallback path
@@ -42,7 +42,7 @@ except ImportError as exc:  # pragma: no cover - fallback path
 else:
     GraphMemoryAdapter = cast("type[GraphMemoryAdapterType]", _GraphMemoryAdapter)
 
-VectorMemoryAdapter: type[VectorMemoryAdapterType] | None
+VectorMemoryAdapter: ClassVar[type[VectorMemoryAdapterType] | None]
 try:  # pragma: no cover - optional dependency
     from .adapters.vector_memory_adapter import (
         VectorMemoryAdapter as _VectorMemoryAdapter,
@@ -53,7 +53,7 @@ except ImportError as exc:  # pragma: no cover - fallback path
 else:
     VectorMemoryAdapter = cast("type[VectorMemoryAdapterType]", _VectorMemoryAdapter)
 
-TinyDBMemoryAdapter: type[TinyDBMemoryAdapterType] | None
+TinyDBMemoryAdapter: ClassVar[type[TinyDBMemoryAdapterType] | None]
 try:  # pragma: no cover - optional dependency
     from .adapters.tinydb_memory_adapter import (
         TinyDBMemoryAdapter as _TinyDBMemoryAdapter,
@@ -64,7 +64,7 @@ except ImportError as exc:  # pragma: no cover - fallback path
 else:
     TinyDBMemoryAdapter = cast("type[TinyDBMemoryAdapterType]", _TinyDBMemoryAdapter)
 
-__all__ = [
+__all__: list[str] = [
     "InMemoryStore",
     "SimpleContextManager",
     "JSONFileStore",

--- a/src/devsynth/application/memory/adapter_types.py
+++ b/src/devsynth/application/memory/adapter_types.py
@@ -1,0 +1,64 @@
+"""Typed adapter aliases shared across memory components."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Mapping, Sequence
+from typing import Protocol, TypeAlias, runtime_checkable
+
+from ...domain.interfaces.memory import MemoryStore
+from ...domain.models.memory import MemoryItem, MemoryType
+from .dto import (
+    MemoryMetadataValue,
+    MemoryQueryResults,
+    MemoryRecord,
+    MemorySearchQuery,
+)
+from .vector_protocol import VectorStoreProtocol
+
+
+@runtime_checkable
+class SupportsStructuredQuery(Protocol):
+    """Protocol for adapters that expose structured query helpers."""
+
+    def query_structured_data(
+        self, query: MemorySearchQuery
+    ) -> Sequence[Mapping[str, object]] | MemoryQueryResults:
+        """Return structured query results for ``query``."""
+
+
+@runtime_checkable
+class SupportsEdrrRetrieval(Protocol):
+    """Protocol for adapters providing EDRR-specific retrieval helpers."""
+
+    def retrieve_with_edrr_phase(
+        self,
+        item_type: MemoryType,
+        edrr_phase: str,
+        metadata: Mapping[str, MemoryMetadataValue],
+    ) -> MemoryItem | MemoryRecord | None:
+        """Return a memory artefact tagged with ``edrr_phase``."""
+
+
+@runtime_checkable
+class SupportsGraphQueries(Protocol):
+    """Protocol for adapters exposing graph relationship traversal."""
+
+    def query_related_items(self, item_id: str) -> Iterable[MemoryItem]:
+        """Return memory items related to ``item_id``."""
+
+
+MemoryAdapter: TypeAlias = MemoryStore | VectorStoreProtocol
+"""Union of supported adapter surfaces managed by :class:`MemoryManager`."""
+
+
+AdapterRegistry: TypeAlias = dict[str, MemoryAdapter]
+"""Concrete mapping used for adapter registries across the memory stack."""
+
+
+__all__ = [
+    "AdapterRegistry",
+    "MemoryAdapter",
+    "SupportsStructuredQuery",
+    "SupportsEdrrRetrieval",
+    "SupportsGraphQueries",
+]

--- a/src/devsynth/application/memory/fallback.py
+++ b/src/devsynth/application/memory/fallback.py
@@ -2,11 +2,15 @@
 
 from __future__ import annotations
 
+from __future__ import annotations
+
 import logging
 import time
 from dataclasses import dataclass
 from enum import Enum
-from typing import Any, Callable, Dict, List, Optional, TypeVar, Union, cast, TYPE_CHECKING
+from typing import Any, Optional, cast, TYPE_CHECKING
+
+from collections.abc import Mapping
 
 from devsynth.domain.interfaces.memory import (
     MemorySearchResponse,
@@ -24,9 +28,6 @@ if TYPE_CHECKING:  # pragma: no cover - imported for typing only
         MemoryRecord,
     )
 
-T = TypeVar("T")
-
-
 MemoryStoreProtocol = MemoryStore
 
 
@@ -42,7 +43,7 @@ class PendingOperation:
 class FallbackError(Exception):
     """Exception raised when all fallback attempts fail."""
 
-    def __init__(self, message: str, errors: Optional[Dict[str, Exception]] = None):
+    def __init__(self, message: str, errors: Optional[dict[str, Exception]] = None):
         """
         Initialize the fallback error.
 
@@ -75,7 +76,7 @@ class FallbackStore(MemoryStore, SupportsTransactions):
     def __init__(
         self,
         primary_store: MemoryStoreProtocol,
-        fallback_stores: List[MemoryStoreProtocol],
+        fallback_stores: list[MemoryStoreProtocol],
         logger: Optional[logging.Logger] = None,
     ):
         """
@@ -91,17 +92,17 @@ class FallbackStore(MemoryStore, SupportsTransactions):
         self.logger = logger or DevSynthLogger(__name__)
 
         # Store status tracking
-        self.store_status: Dict[MemoryStoreProtocol, StoreStatus] = {
+        self.store_status: dict[MemoryStoreProtocol, StoreStatus] = {
             primary_store: StoreStatus.AVAILABLE
         }
         for store in fallback_stores:
             self.store_status[store] = StoreStatus.AVAILABLE
 
         # Last error tracking
-        self.last_errors: Dict[MemoryStoreProtocol, Exception] = {}
+        self.last_errors: dict[MemoryStoreProtocol, Exception] = {}
 
         # Pending operations for reconciliation
-        self.pending_operations: List[PendingOperation] = []
+        self.pending_operations: list[PendingOperation] = []
 
     def store(self, item: MemoryItem) -> str:
         """
@@ -151,7 +152,7 @@ class FallbackStore(MemoryStore, SupportsTransactions):
                 self.store_status[self.primary_store] = StoreStatus.DEGRADED
 
         # Try fallback stores
-        errors: Dict[str, Exception] = {}
+        errors: dict[str, Exception] = {}
         for store in self.fallback_stores:
             if self.store_status[store] != StoreStatus.UNAVAILABLE:
                 try:
@@ -186,7 +187,7 @@ class FallbackStore(MemoryStore, SupportsTransactions):
         self.logger.error(error_message)
         raise FallbackError(error_message, errors)
 
-    def retrieve(self, item_id: str) -> MemoryItem | "MemoryRecord":
+    def retrieve(self, item_id: str) -> MemoryItem | MemoryRecord:
         """
         Retrieve a memory artefact with fallback.
 
@@ -218,7 +219,7 @@ class FallbackStore(MemoryStore, SupportsTransactions):
                 self.store_status[self.primary_store] = StoreStatus.DEGRADED
 
         # Try fallback stores
-        errors: Dict[str, Exception] = {}
+        errors: dict[str, Exception] = {}
         for store in self.fallback_stores:
             if self.store_status[store] != StoreStatus.UNAVAILABLE:
                 try:
@@ -243,7 +244,7 @@ class FallbackStore(MemoryStore, SupportsTransactions):
         raise KeyError(error_message)
 
     def search(
-        self, query: Dict[str, Any] | "MemoryMetadata"
+        self, query: Mapping[str, object] | MemoryMetadata
     ) -> MemorySearchResponse:
         """
         Search for memory artefacts with fallback.
@@ -272,7 +273,7 @@ class FallbackStore(MemoryStore, SupportsTransactions):
                 self.store_status[self.primary_store] = StoreStatus.DEGRADED
 
         # Try fallback stores
-        errors: Dict[str, Exception] = {}
+        errors: dict[str, Exception] = {}
         for store in self.fallback_stores:
             if self.store_status[store] != StoreStatus.UNAVAILABLE:
                 try:
@@ -321,7 +322,7 @@ class FallbackStore(MemoryStore, SupportsTransactions):
 
         # Try fallback stores
         fallback_success = False
-        errors: Dict[str, Exception] = {}
+        errors: dict[str, Exception] = {}
         for store in self.fallback_stores:
             if self.store_status[store] != StoreStatus.UNAVAILABLE:
                 try:
@@ -354,7 +355,7 @@ class FallbackStore(MemoryStore, SupportsTransactions):
         # Return success if either primary or fallback succeeded
         return primary_success or fallback_success
 
-    def get_all_items(self) -> List[MemoryItem]:
+    def get_all_items(self) -> list[MemoryItem]:
         """
         Get all memory items with fallback.
 
@@ -379,7 +380,7 @@ class FallbackStore(MemoryStore, SupportsTransactions):
                 self.store_status[self.primary_store] = StoreStatus.DEGRADED
 
         # Try fallback stores
-        errors: Dict[str, Exception] = {}
+        errors: dict[str, Exception] = {}
         for store in self.fallback_stores:
             if self.store_status[store] != StoreStatus.UNAVAILABLE:
                 try:
@@ -437,7 +438,7 @@ class FallbackStore(MemoryStore, SupportsTransactions):
                 self.store_status[self.primary_store] = StoreStatus.DEGRADED
 
         # Try fallback stores
-        errors: Dict[str, Exception] = {}
+        errors: dict[str, Exception] = {}
         for store in self.fallback_stores:
             if self.store_status[store] != StoreStatus.UNAVAILABLE:
                 try:
@@ -500,7 +501,7 @@ class FallbackStore(MemoryStore, SupportsTransactions):
 
         # Try fallback stores
         fallback_success = False
-        errors: Dict[str, Exception] = {}
+        errors: dict[str, Exception] = {}
         for store in self.fallback_stores:
             if self.store_status[store] != StoreStatus.UNAVAILABLE:
                 try:
@@ -563,7 +564,7 @@ class FallbackStore(MemoryStore, SupportsTransactions):
 
         # Try fallback stores
         fallback_success = False
-        errors: Dict[str, Exception] = {}
+        errors: dict[str, Exception] = {}
         for store in self.fallback_stores:
             if self.store_status[store] != StoreStatus.UNAVAILABLE:
                 try:
@@ -624,7 +625,7 @@ class FallbackStore(MemoryStore, SupportsTransactions):
                 self.store_status[self.primary_store] = StoreStatus.DEGRADED
 
         # Try fallback stores
-        errors: Dict[str, Exception] = {}
+        errors: dict[str, Exception] = {}
         for store in self.fallback_stores:
             if self.store_status[store] != StoreStatus.UNAVAILABLE:
                 try:
@@ -690,7 +691,7 @@ class FallbackStore(MemoryStore, SupportsTransactions):
             f"Reconciliation complete, {len(self.pending_operations)} operations remaining"
         )
 
-    def get_store_status(self) -> Dict[str, str]:
+    def get_store_status(self) -> dict[str, str]:
         """
         Get the status of all stores.
 
@@ -716,7 +717,7 @@ class FallbackStore(MemoryStore, SupportsTransactions):
 
 def with_fallback(
     primary_store: MemoryStoreProtocol,
-    fallback_stores: List[MemoryStoreProtocol],
+    fallback_stores: list[MemoryStoreProtocol],
 ) -> FallbackStore:
     """
     Create a fallback store.

--- a/src/devsynth/application/memory/memory_integration.py
+++ b/src/devsynth/application/memory/memory_integration.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from datetime import datetime
-from typing import Any, Dict, List, Optional, TYPE_CHECKING, cast
+from typing import Any, Mapping, Optional, TYPE_CHECKING, cast
 
 from devsynth.application.memory.dto import MemoryMetadata, MemoryRecord, build_memory_record
 from devsynth.exceptions import MemoryError, MemoryItemNotFoundError, MemoryStoreError
@@ -20,7 +20,7 @@ logger = DevSynthLogger(__name__)
 
 def _records_from_response(
     response: MemorySearchResponse, store_name: str
-) -> List[MemoryRecord]:
+) -> list[MemoryRecord]:
     """Normalize search responses into :class:`MemoryRecord` instances."""
 
     if isinstance(response, list):
@@ -28,7 +28,7 @@ def _records_from_response(
 
     if isinstance(response, dict):
         if "by_store" in response:
-            grouped_records: List[MemoryRecord] = []
+            grouped_records: list[MemoryRecord] = []
             by_store = cast("GroupedMemoryResults", response)["by_store"]
             for nested_store, payload in by_store.items():
                 grouped_records.extend(_records_from_response(payload, nested_store))
@@ -75,8 +75,8 @@ class MemoryIntegrationManager:
 
     def __init__(self):
         """Initialize the Memory Integration Manager."""
-        self.memory_stores = {}
-        self.vector_stores: Dict[str, VectorStore[MemoryVector]] = {}
+        self.memory_stores: dict[str, MemoryStore] = {}
+        self.vector_stores: dict[str, VectorStore[MemoryVector]] = {}
         logger.info("Memory Integration Manager initialized")
 
     def register_memory_store(self, name: str, store: MemoryStore) -> None:
@@ -153,7 +153,7 @@ class MemoryIntegrationManager:
 
     def synchronize_stores(
         self, store1: str, store2: str, bidirectional: bool = True
-    ) -> Dict[str, int]:
+    ) -> dict[str, int]:
         """
         Synchronize memory items between two stores.
 
@@ -227,9 +227,9 @@ class MemoryIntegrationManager:
 
     def query_across_stores(
         self,
-        query: Dict[str, Any] | MemoryMetadata,
-        stores: List[str] = None,
-    ) -> Dict[str, MemorySearchResponse]:
+        query: Mapping[str, object] | MemoryMetadata,
+        stores: list[str] | None = None,
+    ) -> dict[str, MemorySearchResponse]:
         """
         Query for memory items across multiple stores.
 
@@ -254,7 +254,7 @@ class MemoryIntegrationManager:
                     raise MemoryStoreError(f"Store '{store}' not registered")
 
             # Query each store
-            results: Dict[str, MemorySearchResponse] = {}
+            results: dict[str, MemorySearchResponse] = {}
             for store in stores:
                 store_results = self.memory_stores[store].search(query)
                 results[store] = store_results
@@ -267,7 +267,7 @@ class MemoryIntegrationManager:
 
     def apply_volatility_across_stores(
         self, decay_rate: float = 0.1, threshold: float = 0.5
-    ) -> Dict[str, List[str]]:
+    ) -> dict[str, list[str]]:
         """
         Apply memory volatility controls across all registered stores that support it.
 


### PR DESCRIPTION
## Summary
- add a shared adapter protocol module so memory components no longer rely on `Any`
- update `MemoryManager` and `SyncManager` to use typed adapter registries and safer async helpers
- annotate layered, integration, and fallback memory flows with explicit optional DTO handling

## Testing
- poetry run pytest tests/application/memory -k memory --maxfail=1 *(fails: path not found)*
- poetry run pytest tests/unit/application/memory --maxfail=1 *(fails: missing optional dependency `numpy`)*

------
https://chatgpt.com/codex/tasks/task_e_68deee3e4f788333a9d971f8fc9f575e