### PR TITLE
docs: realign v0.1.0a1 readiness plan

### DIFF
--- a/dialectical_audit.log
+++ b/dialectical_audit.log
@@ -28,7 +28,8 @@
     "Feature 'Finalize dialectical reasoning' reference discrepancy resolved (2025-09-09).",
     "Feature 'Logging Setup Utilities' reference discrepancy resolved (2025-09-09).",
     "Feature 'Performance and scalability testing' reference discrepancy resolved (2025-09-09).",
-    "Restoring strict typing for devsynth.application.edrr.* deferred after mypy reported 430 errors (2025-09-13)."
-    "External research telemetry naming policy adopted; integration stubs documented for Autoresearch MCP/A2A flows (2025-10-02)."
+    "Restoring strict typing for devsynth.application.edrr.* deferred after mypy reported 430 errors (2025-09-13).",
+    "External research telemetry naming policy adopted; integration stubs documented for Autoresearch MCP/A2A flows (2025-10-02).",
+    "Dialectical + Socratic review reopened v0.1.0a1 readiness; execution plan established with staged PR roadmap (2025-10-02)."
   ]
 }

--- a/docs/release/v0.1.0a1_execution_plan.md
+++ b/docs/release/v0.1.0a1_execution_plan.md
@@ -1,0 +1,62 @@
+# DevSynth v0.1.0a1 Execution Plan (Updated 2025-10-02)
+
+## Purpose
+This document synthesizes the RFC proposal, current diagnostics, and dialectical + Socratic analysis to determine the highest-impact work required before tagging v0.1.0a1. It identifies which RFC initiatives are in-scope for the alpha tag, organizes them into actionable pull requests, and clarifies sequencing and parallelization constraints. The plan assumes no TestPyPI activity per maintainer directive.
+
+## Evidence Baseline (2025-10-02 UTC)
+- `poetry run mypy --strict src/devsynth` reports 794 errors across 82 files (see `diagnostics/mypy_strict_2025-09-30_refresh.txt`).
+- Fast + medium coverage sweep fails the ≥90% threshold with 20.92 % measured coverage (see `diagnostics/full_profile_coverage.txt`).
+- Behavior/Bdd suites exist but lack executable coverage gates for the newest features (per `docs/plan.md` diagnostics log and `test_markers_report.json`).
+- RFC focus areas extend beyond alpha scope; not all should be attempted pre-tag.
+
+## Dialectical Evaluation of RFC Scope
+- **Thesis (Ambitious Adoption):** Implement the full RFC (knowledge graph expansion, multi-agent rotation, UI, compliance engine) now to align alpha with long-term vision.
+- **Antithesis (Pragmatic Release):** Attempting the full RFC now would prolong the alpha indefinitely; strict typing and coverage already block the release.
+- **Synthesis (Targeted Execution):** For v0.1.0a1 prioritize infrastructure that directly affects reliability metrics (typing, coverage, tests, traceability) and leave heavyweight platform upgrades for post-alpha follow-up. RFC elements that provide immediate validation, traceability, or gating remain in-scope; exploratory UX and large-scale backends are deferred.
+
+## Socratic Cross-Examination
+1. **What is the release-blocking problem?** Mypy strict failure, sub-90 % coverage, and missing behavior coverage audit trails undermine confidence in the alpha tag.
+2. **What proofs confirm remediation?** Passing `poetry run mypy --strict src/devsynth`, ≥90 % aggregate coverage with reproducible artifacts, and updated traceability + behavior reports captured in `test_reports/` and docs.
+3. **What resources do we control?** Existing modular tests, diagnostics logs, in-repo issue tracker, and ability to add focused specs/tests without TestPyPI.
+4. **Which RFC items produce measurable release impact?** Strengthening typing, coverage instrumentation, WSDE coordination scripts, and traceability dashboards deliver direct release metrics; Web UI explorers or new backends do not.
+5. **What stops us from executing now?** Lack of prioritized ownership, absence of dependency graph for fixes, and outdated issue status implying readiness.
+
+## High-Impact Objectives (Pre-Tag)
+1. **Restore strict typing compliance** for `src/devsynth` with sustainable stubs and targeted refactors.
+2. **Raise combined fast+medium coverage to ≥90 %** via targeted tests for low-coverage modules and verifying instrumentation.
+3. **Guarantee behavior and property coverage** with executable specs that mirror new requirements.
+4. **Stabilize WSDE multi-agent workflows** that feed coverage/typing status into planning (automation scripts + documentation updates).
+5. **Refresh traceability + documentation** so issues, specs, and diagnostics reflect current blockers and planned remedies.
+
+## Pull Request Work Breakdown
+| PR | Goal | Key Tasks | Dependencies | Parallelizable? |
+|----|------|-----------|--------------|-----------------|
+| **PR-1:** Diagnostics Realignment & Issue Corrections | Update release readiness docs/issues to reflect actual blockers; add dashboards for typing/coverage debt. | - Update `issues/v0-1-0a1-highest-impact-changes-summary.md` with current status and metrics.<br>- Publish strict typing & coverage debt snapshots (link existing diagnostics).<br>- Document RFC evaluation + prioritized scope (this file). | None | Can start immediately; unblock planning conversations. |
+| **PR-2:** Strict Typing Remediation Sprint (Wave 1) | Reduce mypy strict errors by focusing on top-offenders modules (e.g., `application/cli`, `testing/run_tests`, `core/config_loader`). | - Establish per-module TODO in `docs/typing/`.<br>- Apply targeted type annotations, generics fixes, stub updates.<br>- Ensure `poetry run mypy --strict src/devsynth/application src/devsynth/testing` passes.<br>- Add regression tests where signatures change. | PR-1 (ensures authoritative plan + ownership). | Parallelizable with PR-3 once module ownership assigned; dependent teams can work on disjoint modules. |
+| **PR-3:** Coverage Uplift Sprint (Wave 1) | Increase line coverage for modules below 50 % (CLI commands, logging setup, provider adapters). | - Add focused unit/integration tests guided by diagnostics.<br>- Validate `poetry run devsynth run-tests --target all-tests --speed=fast --speed=medium --no-parallel --report` reaches ≥60 % interim target.<br>- Ensure new tests follow marker discipline and property/behavior gating. | PR-1 (shared plan + metrics). | Parallelizable with PR-2; coordinate to avoid touching same modules simultaneously. |
+| **PR-4:** Behavior & Property Spec Hardening | Ensure BDD scenarios and property tests trace to requirements and contribute to coverage. | - Draft/update specs under `docs/specifications/` for prioritized behavior gaps.<br>- Add/repair `tests/behavior/...` and `tests/property/...` to align with new specs.<br>- Update `scripts/verify_requirements_traceability.py` data sources if needed.<br>- Confirm behavior tests counted in coverage by CLI runs. | PR-1, plus partial outputs from PR-2/3 when specs refer to newly typed modules. | Partially parallel: spec drafting can begin after PR-1; final behavior tests may depend on refactors landing in PR-2/3. |
+| **PR-5:** Final Compliance Gate | Achieve release criteria across repo. | - Ensure `poetry run mypy --strict src/devsynth` passes.<br>- Achieve ≥90 % coverage in fast+medium aggregate.<br>- Regenerate release notes + readiness checklist.<br>- Capture CLI + diagnostics evidence in docs.<br>- Update `docs/release/0.1.0-alpha.1.md` with final steps. | PR-2, PR-3, PR-4 completion. | Not parallel; final integration step. |
+
+## Parallelization Notes
+- PR-2 and PR-3 can proceed concurrently after PR-1 since they target different layers (typing vs. testing). Use coordination doc to avoid merge conflicts on shared files.
+- PR-4 spec drafting can occur during PR-2/3, but final merges wait until code/test changes stabilize.
+- PR-5 is inherently sequential, performing the final gate once other sprints succeed.
+
+## Task Board Snapshot
+- `docs/typing/strict_typing_wave1.md` (to be created) — enumerates targeted modules, owners, error counts, and fix approaches.
+- `docs/testing/coverage_wave1.md` (to be created) — maps low-coverage modules to planned tests and responsible engineers.
+- Update `docs/tasks.md` §21 with new subtasks referencing PR numbers and diagnostics.
+
+## Acceptance Criteria
+1. **Typing:** `poetry run mypy --strict src/devsynth` returns exit code 0 with updated suppressions documented.
+2. **Testing:** Fast+medium aggregate via CLI meets ≥90 % coverage, leaving artifacts in `htmlcov/` and `test_reports/`.
+3. **Behavior Specs:** All new/updated specs link to BDD features, each test includes one speed marker, and property tests run under `DEVSYNTH_PROPERTY_TESTING=true`.
+4. **Documentation:** Issues, release docs, and traceability matrices accurately reflect remaining work and completed items.
+5. **Dialectical Audit:** `dialectical_audit.log` receives an entry summarizing the synthesis reached in this plan.
+
+## Immediate Next Steps (Action Items)
+1. Merge PR-1 updates (this plan + issue corrections) to establish authoritative baseline.
+2. Kick off typing and coverage sprints with dedicated owners per module/test file.
+3. Schedule daily sync to review diagnostics outputs and adjust focus areas.
+4. Prepare release readiness dashboard updates for PR-5 validation.
+

--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -9,7 +9,7 @@ tags:
   - "release-preparation"
 status: "active"
 author: "DevSynth Team"
-last_reviewed: "2025-09-30"
+last_reviewed: "2025-10-02"
 source: "Derived from docs/plan.md (Test Readiness and Coverage Improvement Plan)"
 ---
 
@@ -20,6 +20,13 @@ source: "Derived from docs/plan.md (Test Readiness and Coverage Improvement Plan
 # DevSynth 0.1.0a1 — Actionable Improvement Tasks Checklist
 
 Instructions: Check off each task when completed. Subtasks are enumerated for clarity and traceability. Follow the order for optimal flow. All commands should be run via Poetry.
+
+0. Execution Plan Realignment (Phase preflight)
+0.1 [ ] Review `docs/release/v0.1.0a1_execution_plan.md` and confirm staged PR ownership in planning meeting notes.
+0.2 [ ] Update release readiness issues (`coverage-below-threshold.md`, `critical-mypy-errors-v0-1-0a1.md`, `release-readiness-assessment-v0-1-0a1.md`) to match 2025-10-02 status.
+0.3 [ ] Draft `docs/typing/strict_typing_wave1.md` with module owners, baseline error counts, and remediation hypotheses.
+0.4 [ ] Draft `docs/testing/coverage_wave1.md` mapping low-coverage modules to targeted tests and responsible engineers.
+0.5 [ ] Circulate plan via WSDE standup; log acknowledgment in meeting notes and dialectical audit follow-up.
 
 1. Environment and Tooling Baseline (Phase 0)
 1.1 [x] Provision environment and install go-task: `bash scripts/install_dev.sh`.

--- a/issues/v0-1-0a1-highest-impact-changes-summary.md
+++ b/issues/v0-1-0a1-highest-impact-changes-summary.md
@@ -1,144 +1,88 @@
 # v0.1.0a1 Highest Impact Changes Summary
 
-**Date**: 2025-09-24  
-**Status**: completed  
-**Priority**: critical  
-**Affected Area**: release  
+**Date**: 2025-10-02
+**Status**: in progress
+**Priority**: critical
+**Affected Area**: release
 
 ## Executive Summary
 
-**DevSynth is READY for v0.1.0a1 alpha release.** Through multi-disciplinary analysis using dialectical and Socratic reasoning, we have identified and implemented the highest impact changes needed to move toward the v0.1.0a1 release.
+**DevSynth is not yet ready for the v0.1.0a1 alpha tag.** Dialectical and Socratic review shows that strict typing and coverage gates are still red, behavior/traceability evidence is incomplete, and documentation has drifted to imply readiness that the diagnostics do not support.
 
 ## Key Findings
 
-### ✅ FUNCTIONAL READINESS ACHIEVED
-- **CLI Operations**: `devsynth --help`, `devsynth doctor`, `devsynth run-tests` all work
-- **Test Infrastructure**: 1,024+ tests collected and executed successfully  
-- **Coverage System**: Working and measuring (7.38% baseline established)
-- **Core Architecture**: Modular design implemented and functional
-- **Dependencies**: Resolved critical issues (FastAPI/Starlette MRO addressed)
+### 🔄 Current Readiness Gaps
+- **Strict Typing**: `poetry run mypy --strict src/devsynth` reports 794 errors across 82 files (`diagnostics/mypy_strict_2025-09-30_refresh.txt`).
+- **Coverage**: Fast+medium aggregate remains at 20.92 % vs. the enforced ≥90 % threshold (`diagnostics/full_profile_coverage.txt`).
+- **Behavior & Property Coverage**: Recent features lack executable behavior specs contributing to coverage; property suite health still depends on manual toggles.
+- **Documentation Drift**: Several issues and release notes still claim completion, masking remaining work.
 
-### ✅ CRITICAL FIXES IMPLEMENTED
-1. **Fixed corrupted coverage database** - Removed `.coverage` file blocking measurement
-2. **Fixed critical indentation errors** in `src/devsynth/testing/run_tests.py`
-3. **Restored test infrastructure** - Only 1 failing test out of 1,024+ collected
-4. **Established working baseline** - 7.38% coverage with clean measurement
+### 🔧 Critical Fixes Outstanding
+1. **Strict typing remediation wave** – prioritize `application/cli`, `testing/run_tests`, and `core/config_loader` modules.
+2. **Coverage uplift** – add targeted unit/integration tests for low-coverage modules (CLI commands, logging setup, provider adapters).
+3. **Behavior/property spec alignment** – refresh specs and ensure coverage instrumentation captures them.
+4. **Documentation reset** – align readiness assessments and dashboards with 2025-10-02 evidence.
 
-### ✅ QUALITY METRICS ALIGNED
-- **Coverage Threshold**: Adjusted to 70% for alpha (industry standard)
-- **Test Success Rate**: >99% (1 failure out of 1,024+ tests)
-- **CLI Functionality**: All core commands operational
-- **Architecture Integrity**: Sound modular design validated
+### 🎯 Quality Targets (Alpha)
+- **Coverage Threshold**: Maintain the ≥90 % fail-under and meet it prior to tagging.
+- **Test Success Rate**: 100 % across unit, integration, behavior, and property suites.
+- **CLI Functionality**: Continue running smoke, fast, and medium profiles during every sprint to catch regressions.
+- **Architecture Integrity**: Preserve modular design while applying type and test fixes.
 
-## Dialectical Analysis Results
+## Dialectical + Socratic Analysis
 
-### Thesis: High Coverage Required
-- 90% test coverage ensures reliability
-- Comprehensive testing prevents regressions
+- **Thesis**: Declare readiness once coverage instrumentation works.
+  - *Pros*: Demonstrates visible progress and builds morale.
+  - *Cons*: Ignores strict typing debt and low coverage; risks reputational damage if tagged prematurely.
+- **Antithesis**: Block release until every RFC initiative lands.
+  - *Pros*: Guarantees feature completeness against long-term roadmap.
+  - *Cons*: Unrealistic for alpha timeline; delays core reliability work.
+- **Synthesis**: Prioritize reliability gates (typing, coverage, behavior specs) while staging remaining RFC items after the tag.
 
-### Antithesis: Coverage Blocking Progress  
-- 90% coverage unrealistic for alpha release
-- Focus on metrics vs. user value preventing delivery
+**Socratic Check**
+1. *What is the release-blocking problem?* – Failing strict typing and coverage gates, plus incomplete behavior evidence.
+2. *What proofs confirm remediation?* – Passing `poetry run mypy --strict src/devsynth`, ≥90 % fast+medium coverage artifacts, updated traceability reports, and synchronized documentation.
+3. *What resources do we control?* – Diagnostics logs, existing tests/specs, in-repo issue tracker, and automation scripts.
+4. *What stands in the way?* – Lack of an up-to-date plan and dependency mapping, plus outdated issues implying completion.
 
-### Synthesis: Pragmatic Alpha Approach ✅ IMPLEMENTED
-- **70% coverage threshold** for alpha (industry standard)
-- **Focus on core functionality** testing
-- **Plan to reach 90%** for stable release
-- **Functional validation** over metric optimization
-
-## Socratic Analysis Results
-
-**Q: What is the real problem we're solving?**  
-A: Deliver a functional alpha release for user feedback and validation ✅
-
-**Q: What evidence do we need that the system works?**  
-A: Core CLI commands work, basic agent functionality operates, memory systems function ✅
-
-**Q: What's preventing the release?**  
-A: Previously unrealistic coverage targets and broken test infrastructure, now RESOLVED ✅
-
-**Q: What's the minimum viable quality bar?**  
-A: Core user journeys tested and working, basic stability demonstrated ✅
-
-## Impact Assessment
-
-### HIGH IMPACT CHANGES ✅ COMPLETED
-1. **Test Infrastructure Repair** - Critical blocker removed
-2. **Coverage System Restoration** - Measurement now functional  
-3. **CLI Functionality Validation** - Core workflows operational
-4. **Quality Threshold Adjustment** - Realistic alpha standards
-
-### MEDIUM IMPACT CHANGES (Optional)
-1. Fix remaining 1 test failure (non-blocking for alpha)
-2. Improve coverage from 7.38% toward 70% target
-3. Address FastAPI/Starlette MRO completely (workaround in place)
-
-### LOW IMPACT CHANGES (Post-Alpha)
-1. Comprehensive coverage uplift to 90%
-2. Additional test scenarios
-3. Performance optimizations
-
-## Release Readiness Status
-
-| Criteria | Status | Evidence |
-|----------|--------|----------|
-| CLI Functional | ✅ PASS | `devsynth --help`, `devsynth doctor` work |
-| Test Infrastructure | ✅ PASS | 1,024+ tests collected, >99% success rate |
-| Coverage Measurement | ✅ PASS | 7.38% measured, system functional |
-| Core Architecture | ✅ PASS | Modular design validated |
-| Quality Threshold | ✅ PASS | 70% alpha target established |
-| Dependencies | ✅ PASS | Critical issues resolved |
+## Action Plan Alignment
+- Adopt the staged PR roadmap in `docs/release/v0.1.0a1_execution_plan.md` (PR-1 through PR-5).
+- Produce supporting worklogs: `docs/typing/strict_typing_wave1.md` and `docs/testing/coverage_wave1.md`.
+- Reopen affected release readiness issues and sync their status with this summary.
 
 ## Recommendations
 
-### IMMEDIATE (Ready Now)
-1. **Proceed with alpha release** - All critical blockers resolved
-2. **Update release documentation** with pragmatic quality criteria
-3. **Execute final UAT** with realistic alpha expectations
-4. **Tag v0.1.0a1** once UAT completed
+### Immediate (Reopened)
+1. Merge the diagnostics realignment updates (PR-1) so the plan and issues match reality.
+2. Launch the strict typing wave targeting the highest-error modules.
+3. Initiate the coverage uplift sprint with targeted tests and instrumentation verification.
+4. Refresh release documentation and dashboards with 2025-10-02 status.
 
-### SHORT-TERM (Next 1-2 weeks)
-1. **Improve coverage** from 7.38% toward 70% target
-2. **Fix remaining test failure** (non-blocking)
-3. **Enhance documentation** for maintainers
+### Short-Term (Next 1–2 Weeks)
+1. Reduce strict typing error count below 200.
+2. Raise fast+medium aggregate coverage to ≥60 % as an interim milestone.
+3. Align behavior/property specs with refreshed requirements traceability reports and ensure they run in coverage sweeps.
 
-### LONG-TERM (Post-Alpha)
-1. **Achieve 90% coverage** for stable release
-2. **Comprehensive test scenarios** 
-3. **Performance optimization**
+### Long-Term (Pre-Tag Completion)
+1. Achieve 0 strict typing errors (`poetry run mypy --strict src/devsynth` passes).
+2. Sustain ≥90 % coverage across fast+medium suites with reproducible artifacts.
+3. Automate dashboards linking diagnostics to WSDE planning and release readiness reviews.
 
 ## Risk Assessment
+- **Reliability perception** – Claiming readiness before gates pass undermines trust.
+- **Technical debt** – Large mypy backlog complicates future refactors and increases bug risk.
+- **Process alignment** – Without synchronized documentation, WSDE agents cannot collaborate effectively.
 
-### LOW RISK ✅
-- Core functionality implemented and working
-- Architecture is sound and validated
-- Dependencies stable with workarounds
-
-### MINIMAL RISK
-- Single test failure (internal functionality, not user-facing)
-- Coverage below eventual target (but above alpha threshold)
-
-## Related Issues Updated
-
-- ✅ [coverage-below-threshold.md](coverage-below-threshold.md) - Updated with breakthrough
-- ✅ [release-finalization-uat.md](release-finalization-uat.md) - Ready for UAT
-- ✅ [alpha-release-readiness-assessment.md](alpha-release-readiness-assessment.md) - Confirmed ready
-- ✅ [critical-run-tests-function-restored.md](critical-run-tests-function-restored.md) - Function working
+## Related Issues to Review
+- 🔄 [coverage-below-threshold.md](coverage-below-threshold.md) – update milestones to track coverage wave.
+- 🔄 [critical-mypy-errors-v0-1-0a1.md](critical-mypy-errors-v0-1-0a1.md) – align strict typing wave tasks.
+- 🔄 [release-readiness-assessment-v0-1-0a1.md](release-readiness-assessment-v0-1-0a1.md) – update status and dependencies.
 
 ## Conclusion
 
-**DevSynth has achieved functional readiness for v0.1.0a1 alpha release.** The highest impact changes have been successfully implemented:
+**DevSynth must complete the reliability workstreams above before claiming alpha readiness.** Track progress through the staged PR plan in `docs/release/v0.1.0a1_execution_plan.md` and do not tag v0.1.0a1 until:
 
-1. **Critical infrastructure repaired** 
-2. **Quality standards aligned** with alpha expectations
-3. **Core functionality validated**
-4. **Test infrastructure operational**
-
-The system is ready to deliver value to users and gather feedback for continued development toward stable release.
-
-## Next Steps
-
-1. **Execute UAT** with alpha-appropriate criteria
-2. **Update release notes** with functional readiness evidence
-3. **Tag v0.1.0a1** release
-4. **Continue coverage improvement** in parallel development
+1. Strict typing passes in strict mode.
+2. Coverage meets ≥90 % across fast+medium suites.
+3. Behavior and property specs demonstrate end-to-end traceability.
+4. Documentation and issues reflect an accurate, up-to-date status.


### PR DESCRIPTION
## Summary
- add a refreshed v0.1.0a1 execution plan detailing prioritized PR waves, dependencies, and acceptance criteria
- rewrite the highest-impact changes issue to reflect current diagnostics and highlight strict typing and coverage blockers
- update the release task checklist and dialectical audit log to incorporate the new plan and follow-up actions

## Testing
- not run (documentation-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68defaa756f88333a933b61c6e79c0c4