### PR TITLE
feat: refine memory dto typing for search records

### DIFF
--- a/src/devsynth/application/memory/adapter_types.py
+++ b/src/devsynth/application/memory/adapter_types.py
@@ -8,12 +8,18 @@ from typing import Protocol, TypeAlias, runtime_checkable
 from ...domain.interfaces.memory import MemoryStore
 from ...domain.models.memory import MemoryItem, MemoryType
 from .dto import (
+    MemoryMetadata,
     MemoryMetadataValue,
     MemoryQueryResults,
     MemoryRecord,
     MemorySearchQuery,
 )
 from .vector_protocol import VectorStoreProtocol
+
+StructuredQueryRow: TypeAlias = Mapping[
+    str,
+    MemoryMetadataValue | Sequence[MemoryMetadataValue] | MemoryItem | MemoryMetadata,
+]
 
 
 @runtime_checkable
@@ -22,7 +28,7 @@ class SupportsStructuredQuery(Protocol):
 
     def query_structured_data(
         self, query: MemorySearchQuery
-    ) -> Sequence[Mapping[str, object]] | MemoryQueryResults:
+    ) -> Sequence[StructuredQueryRow] | MemoryQueryResults:
         """Return structured query results for ``query``."""
 
 
@@ -34,7 +40,7 @@ class SupportsEdrrRetrieval(Protocol):
         self,
         item_type: MemoryType,
         edrr_phase: str,
-        metadata: Mapping[str, MemoryMetadataValue],
+        metadata: MemoryMetadata,
     ) -> MemoryItem | MemoryRecord | None:
         """Return a memory artefact tagged with ``edrr_phase``."""
 
@@ -58,6 +64,7 @@ AdapterRegistry: TypeAlias = dict[str, MemoryAdapter]
 __all__ = [
     "AdapterRegistry",
     "MemoryAdapter",
+    "StructuredQueryRow",
     "SupportsStructuredQuery",
     "SupportsEdrrRetrieval",
     "SupportsGraphQueries",

--- a/src/devsynth/application/memory/context_manager.py
+++ b/src/devsynth/application/memory/context_manager.py
@@ -11,7 +11,7 @@ from devsynth.logging_setup import DevSynthLogger
 
 from ...domain.interfaces.memory import ContextManager, MemoryStore
 from ...domain.models.memory import MemoryItem, MemoryType
-from .dto import MemoryMetadata, MemoryMetadataValue
+from .dto import MemoryMetadata, MemoryMetadataValue, MemorySearchQuery
 
 logger = DevSynthLogger(__name__)
 
@@ -39,7 +39,9 @@ class InMemoryStore(MemoryStore):
         """Retrieve an item from memory by ID."""
         return self.items.get(item_id)
 
-    def search(self, query: MemoryMetadata) -> list[MemoryItem]:
+    def search(
+        self, query: MemorySearchQuery | MemoryMetadata
+    ) -> list[MemoryItem]:
         """Search for items in memory matching the query."""
         result = []
         for item in self.items.values():
@@ -127,7 +129,7 @@ class InMemoryStore(MemoryStore):
         return True
 
 
-ContextValue = (
+ContextValue: TypeAlias = (
     MemoryMetadataValue
     | MemoryItem
     | list[MemoryItem]

--- a/src/devsynth/application/memory/vector_protocol.py
+++ b/src/devsynth/application/memory/vector_protocol.py
@@ -3,10 +3,20 @@
 from __future__ import annotations
 
 from collections.abc import Sequence
-from typing import Any, Protocol
+from typing import TYPE_CHECKING, Any, Protocol, TypeAlias
 
 from ...domain.models.memory import MemoryVector
-from .dto import MemoryRecord
+from .dto import MemoryRecord, VectorStoreStats
+
+if TYPE_CHECKING:  # pragma: no cover - typing-only imports
+    from numpy.typing import NDArray
+    import numpy as np
+
+    NumpyEmbedding: TypeAlias = NDArray[np.floating[Any]]
+else:  # pragma: no cover - runtime fallback
+    NumpyEmbedding: TypeAlias = Sequence[float]
+
+EmbeddingVector: TypeAlias = Sequence[float] | NumpyEmbedding
 
 
 class VectorStoreProtocol(Protocol):
@@ -19,12 +29,12 @@ class VectorStoreProtocol(Protocol):
         ...
 
     def similarity_search(
-        self, query_embedding: Sequence[float], top_k: int = 5
-    ) -> list[MemoryRecord] | list[MemoryVector]:
+        self, query_embedding: EmbeddingVector, top_k: int = 5
+    ) -> list[MemoryRecord]:
         ...
 
     def delete_vector(self, vector_id: str) -> bool:
         ...
 
-    def get_collection_stats(self) -> dict[str, Any]:
+    def get_collection_stats(self) -> VectorStoreStats:
         ...


### PR DESCRIPTION
## Summary
- update memory DTOs to normalize legacy mapping and tuple payloads into typed MemoryRecord instances
- tighten vector store and adapter protocols around embedding inputs, stats payloads, and structured query rows
- align context manager helpers and unit fixtures/tests with the new typing guarantees

## Testing
- `poetry run mypy --strict src/devsynth/application/memory/dto.py src/devsynth/application/memory/vector_protocol.py` *(fails: existing strict typing violations and missing third-party stubs outside the touched modules)*

------
https://chatgpt.com/codex/tasks/task_e_68df403ecac483339cb8feee49af515e