### PR TITLE
refactor: type-safe sync manager transactions

### DIFF
--- a/tests/unit/application/memory/test_mixed_backend_transactions.py
+++ b/tests/unit/application/memory/test_mixed_backend_transactions.py
@@ -2,6 +2,7 @@ from datetime import datetime
 
 import pytest
 
+from devsynth.application.memory.dto import MemoryRecord
 from devsynth.application.memory.transaction_context import TransactionContext
 from devsynth.domain.models.memory import MemoryItem, MemoryType
 
@@ -39,6 +40,28 @@ class DummyStore:
         return True
 
 
+class SnapshotOnlyStore:
+    """Store without native transactions to test snapshot restoration."""
+
+    def __init__(self) -> None:
+        self.items: dict[str, MemoryItem] = {}
+        self.stored_payloads: list[MemoryItem] = []
+
+    def store(self, item: MemoryItem) -> str:
+        self.stored_payloads.append(item)
+        self.items[item.id] = item
+        return item.id
+
+    def retrieve(self, item_id: str) -> MemoryItem | None:
+        return self.items.get(item_id)
+
+    def get_all_items(self) -> list[MemoryItem]:
+        return list(self.items.values())
+
+    def delete(self, item_id: str) -> None:
+        self.items.pop(item_id, None)
+
+
 class TestMixedBackendTransactions:
     """Tests cross-store transactions across different backends."""
 
@@ -68,3 +91,43 @@ class TestMixedBackendTransactions:
         assert store_b.retrieve("2").content == "Store B"
         assert store_a.flushed > 0
         assert store_b.flushed > 0
+
+    @pytest.mark.medium
+    def test_snapshot_rollback_restores_memory_records(self):
+        store = SnapshotOnlyStore()
+        original = MemoryItem(
+            id="snap-1",
+            content="baseline",
+            memory_type=MemoryType.SHORT_TERM,
+            metadata={"version": "initial"},
+            created_at=datetime.now(),
+        )
+        store.store(original)
+        context = TransactionContext([store])
+        with pytest.raises(RuntimeError):
+            with context:
+                updated = MemoryItem(
+                    id="snap-1",
+                    content="mutated",
+                    memory_type=MemoryType.SHORT_TERM,
+                    metadata={"version": "updated"},
+                    created_at=datetime.now(),
+                )
+                store.store(updated)
+                raise RuntimeError("force rollback")
+
+        restored = store.retrieve("snap-1")
+        assert restored is not None
+        assert restored.content == "baseline"
+        assert restored.metadata["version"] == "initial"
+        assert store.stored_payloads[-1].metadata["version"] == "initial"
+
+        rollback_entries = [
+            entry
+            for entry in context.operations
+            if entry["phase"] == "rollback"
+        ]
+        assert rollback_entries
+        for entry in rollback_entries:
+            assert all(isinstance(record, MemoryRecord) for record in entry["records"])
+            assert all(record.source == entry["store"] for record in entry["records"])

--- a/tests/unit/application/memory/test_sync_manager_transactions.py
+++ b/tests/unit/application/memory/test_sync_manager_transactions.py
@@ -1,0 +1,104 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import cast
+
+import pytest
+
+from devsynth.application.memory.memory_manager import MemoryManager
+from devsynth.application.memory.sync_manager import SyncManager
+from devsynth.application.memory.dto import MemoryRecord
+from devsynth.domain.models.memory import MemoryItem, MemoryType
+
+
+class RecordingStore:
+    """Store that records stored payloads for verification."""
+
+    def __init__(self) -> None:
+        self.items: dict[str, MemoryItem] = {}
+        self.stored_payloads: list[MemoryItem] = []
+
+    def store(self, item: MemoryItem) -> str:
+        self.stored_payloads.append(item)
+        self.items[item.id] = item
+        return item.id
+
+    def retrieve(self, item_id: str) -> MemoryItem | None:
+        return self.items.get(item_id)
+
+    def get_all_items(self) -> list[MemoryItem]:
+        return list(self.items.values())
+
+    def delete(self, item_id: str) -> None:
+        self.items.pop(item_id, None)
+
+    def flush(self) -> None:
+        # SyncManager expects adapters to expose flush hooks during commits.
+        return None
+
+
+def _manager() -> MemoryManager:
+    adapters = {"alpha": RecordingStore(), "beta": RecordingStore()}
+    manager = MemoryManager(adapters=adapters)
+    return manager
+
+
+@pytest.mark.fast
+def test_queue_update_enqueues_memory_record() -> None:
+    manager = _manager()
+    sync_manager: SyncManager = manager.sync_manager
+    item = MemoryItem(
+        id="queued-1",
+        content="queue-test",
+        memory_type=MemoryType.SHORT_TERM,
+        metadata={"origin": "alpha"},
+        created_at=datetime.now(),
+    )
+
+    sync_manager.queue_update("alpha", item)
+
+    with sync_manager._queue_lock:  # noqa: SLF001 - internal verification for test
+        queued_store, record = sync_manager._queue[-1]
+
+    assert queued_store == "alpha"
+    assert isinstance(record, MemoryRecord)
+    assert record.item.metadata["origin"] == "alpha"
+
+    sync_manager.flush_queue()
+    beta_store = manager.adapters["beta"]
+    assert beta_store.retrieve("queued-1") is not None
+
+
+@pytest.mark.fast
+def test_transaction_rollback_uses_normalized_snapshots() -> None:
+    manager = _manager()
+    sync_manager: SyncManager = manager.sync_manager
+    alpha_store = cast(RecordingStore, manager.adapters["alpha"])
+
+    original = MemoryItem(
+        id="alpha-1",
+        content="baseline",
+        memory_type=MemoryType.SHORT_TERM,
+        metadata={"revision": 1},
+        created_at=datetime.now(),
+    )
+    alpha_store.store(original)
+
+    with pytest.raises(RuntimeError):
+        with sync_manager.transaction(["alpha"]):
+            mutated = MemoryItem(
+                id="alpha-1",
+                content="mutated",
+                memory_type=MemoryType.SHORT_TERM,
+                metadata={"revision": 2},
+                created_at=datetime.now(),
+            )
+            alpha_store.store(mutated)
+            raise RuntimeError("fail transaction")
+
+    restored = alpha_store.retrieve("alpha-1")
+    assert restored is not None
+    assert restored.content == "baseline"
+    assert restored.metadata == {"revision": 1}
+    assert alpha_store.stored_payloads[-1].metadata == {"revision": 1}
+    assert manager.sync_manager.get_cache_size() == 0


### PR DESCRIPTION
## Summary
- refactor the sync manager to persist typed transaction metadata and normalized MemoryRecord caches
- tighten TransactionContext typing so snapshots and operation logs operate on DTOs
- add targeted unit tests exercising snapshot rollbacks and queue normalization

## Testing
- poetry run mypy --strict src/devsynth/application/memory/sync_manager.py src/devsynth/application/memory/transaction_context.py *(fails: strict run reports pre-existing typing issues across memory package)*
- poetry run pytest tests/unit/application/memory/test_mixed_backend_transactions.py tests/unit/application/memory/test_sync_manager_transactions.py *(fails: optional memory subpackage import raises TypeError from dto legacy unions)*

------
https://chatgpt.com/codex/tasks/task_e_68df464d701483339588d5e4979a6f03