### PR TITLE
feat(memory): add typed fallback dto handling

### DIFF
--- a/src/devsynth/application/memory/dto.py
+++ b/src/devsynth/application/memory/dto.py
@@ -159,7 +159,10 @@ if TYPE_CHECKING:  # pragma: no cover - type checking only
 from devsynth.domain.models.memory import MemoryItem, MemoryType, MemoryVector
 
 LegacyRecordMapping: TypeAlias = Mapping[str, object]
-LegacyRecordTuple: TypeAlias = tuple[MemoryRecord | MemoryItem | "MemoryVector" | LegacyRecordMapping, float | int | None]
+LegacyRecordTuple: TypeAlias = tuple[
+    MemoryRecord | MemoryItem | MemoryVector | LegacyRecordMapping,
+    float | int | None,
+]
 
 MemoryRecordInput: TypeAlias = (
     MemoryRecord

--- a/tests/unit/application/memory/test_tiered_cache_termination.py
+++ b/tests/unit/application/memory/test_tiered_cache_termination.py
@@ -11,3 +11,15 @@ def test_eviction_loop_terminates() -> None:
     for i in range(10):
         cache.put(f"k{i}", i)
     assert len(cache.get_keys()) == 3
+
+
+@pytest.mark.unit
+@pytest.mark.fast
+def test_preserves_typed_values() -> None:
+    """Generic cache returns strongly typed values."""
+
+    cache: TieredCache[int] = TieredCache(max_size=2)
+    cache.put("a", 1)
+    cache.put("b", 2)
+    assert cache.get("a") == 1
+    assert cache.get("missing") is None


### PR DESCRIPTION
## Summary
- normalize fallback memory results into typed DTOs while tracking store health and status
- update retry helpers to consume DTO unions at runtime and improve logging and callbacks
- tighten error logger context typing and extend unit tests across fallback, retry, and cache flows

## Testing
- poetry run pytest tests/unit/application/memory/test_fallback.py tests/unit/application/memory/test_retry.py tests/unit/application/memory/test_error_logger.py tests/unit/application/memory/test_tiered_cache_termination.py
- poetry run mypy --strict src/devsynth/application/memory/fallback.py src/devsynth/application/memory/retry.py

------
https://chatgpt.com/codex/tasks/task_e_68df519709a8833396d96922b10a5ee0