### PR TITLE
feat: align memory adapters with typed protocols

### DIFF
--- a/src/devsynth/application/memory/adapter_types.py
+++ b/src/devsynth/application/memory/adapter_types.py
@@ -12,6 +12,7 @@ from .dto import (
     MemoryMetadataValue,
     MemoryQueryResults,
     MemoryRecord,
+    MemoryRecordInput,
     MemorySearchQuery,
 )
 from .vector_protocol import VectorStoreProtocol
@@ -53,6 +54,24 @@ class SupportsGraphQueries(Protocol):
         """Return memory items related to ``item_id``."""
 
 
+@runtime_checkable
+class SupportsRetrieve(Protocol):
+    """Protocol for adapters exposing ``retrieve`` operations."""
+
+    def retrieve(self, item_id: str) -> MemoryItem | MemoryRecord | None:
+        """Return a memory artefact identified by ``item_id``."""
+
+
+@runtime_checkable
+class SupportsSearch(Protocol):
+    """Protocol for adapters exposing ``search`` helpers."""
+
+    def search(
+        self, query: MemorySearchQuery | MemoryMetadata
+    ) -> Sequence[MemoryRecordInput] | MemoryRecordInput | MemoryQueryResults:
+        """Return search results for ``query``."""
+
+
 MemoryAdapter: TypeAlias = MemoryStore | VectorStoreProtocol
 """Union of supported adapter surfaces managed by :class:`MemoryManager`."""
 
@@ -68,4 +87,6 @@ __all__ = [
     "SupportsStructuredQuery",
     "SupportsEdrrRetrieval",
     "SupportsGraphQueries",
+    "SupportsRetrieve",
+    "SupportsSearch",
 ]

--- a/src/devsynth/application/memory/vector_protocol.py
+++ b/src/devsynth/application/memory/vector_protocol.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from collections.abc import Sequence
-from typing import TYPE_CHECKING, Any, Protocol, TypeAlias
+from typing import TYPE_CHECKING, Any, Protocol, TypeAlias, runtime_checkable
 
 from ...domain.models.memory import MemoryVector
 from .dto import MemoryRecord, VectorStoreStats
@@ -19,6 +19,7 @@ else:  # pragma: no cover - runtime fallback
 EmbeddingVector: TypeAlias = Sequence[float] | NumpyEmbedding
 
 
+@runtime_checkable
 class VectorStoreProtocol(Protocol):
     """Structural protocol implemented by vector store adapters."""
 

--- a/tests/unit/application/memory/test_lmdb_store.py
+++ b/tests/unit/application/memory/test_lmdb_store.py
@@ -219,7 +219,7 @@ class TestLMDBStore:
         """Test that transactions are isolated.
 
         ReqID: N/A"""
-        with store.begin_transaction() as txn:
+        with store.transaction() as txn:
             item = MemoryItem(
                 id="",
                 content="Transaction test",
@@ -249,7 +249,7 @@ class TestLMDBStore:
         )
         item1_id = store.store(item1)
         try:
-            with store.begin_transaction() as txn:
+            with store.transaction() as txn:
                 item2 = MemoryItem(
                     id="",
                     content="Inside transaction",
@@ -280,7 +280,7 @@ class TestLMDBStore:
         transaction_id = str(uuid.uuid4())
 
         with pytest.raises(RuntimeError):
-            with store.begin_transaction(transaction_id=transaction_id):
+            with store.transaction(transaction_id=transaction_id):
                 assert store.is_transaction_active(transaction_id)
                 raise RuntimeError("abort for cleanup check")
 


### PR DESCRIPTION
## Summary
- add runtime-checkable search and retrieve protocols so memory manager, query routing, and sync manager avoid casts while returning normalized DTOs
- refactor the LMDB adapter to return typed transaction identifiers and expose a dedicated context manager, updating unit and behavior fixtures accordingly
- streamline S3 adapter bootstrap and vector helper usage so cross-store flows operate on concrete types

## Testing
- poetry run mypy --strict src/devsynth *(fails: numerous pre-existing strict typing errors across the memory package)*
- poetry run pytest --collect-only tests/integration/memory/test_sync_manager_core_transactions.py


------
https://chatgpt.com/codex/tasks/task_e_68dff6fb67848333aaba1c3fc4e2eeea