### PR TITLE
Add streamlit-free WebUI coverage and logging invariants tests

### DIFF
--- a/docs/specifications/webui-dashboard-progress-sanitization.md
+++ b/docs/specifications/webui-dashboard-progress-sanitization.md
@@ -1,0 +1,51 @@
+---
+author: DevSynth Team
+date: 2025-10-03
+last_reviewed: 2025-10-03
+status: draft
+tags:
+  - specification
+  - webui
+  - telemetry
+  - logging
+  - sanitization
+  - routing
+
+title: WebUI Dashboard Progress and Sanitization Guarantees
+version: 0.1.0-alpha.1
+---
+
+# Summary
+
+## Socratic Checklist
+- What is the problem?
+- What proofs confirm the solution?
+
+## Motivation
+Dashboards that operate without a live Streamlit runtime must still honor layout
+toggles, deterministic routing, and telemetry hooks. Progress indicators should
+produce sanitized status updates while emitting structured debug traces. These
+expectations ensure the WebUI remains observable in fast test suites that rely
+on stubs instead of the interactive framework.
+
+## Specification
+- **Layout Toggles**: The WebUI shall compute layout breakpoints from cached
+  `session_state.screen_width` values and apply the resulting CSS (padding,
+  sidebar width) before invoking the navigation router.
+- **Router Invocation**: The router must be constructed exactly once per run
+  with the active navigation map and execute immediately after layout styles are
+  applied.
+- **Progress Telemetry**: Progress indicators and subtasks shall sanitize all
+  descriptive text, emit deterministic status markdown, and log each update via
+  the module logger.
+- **Bridge Sanitization**: `display_result` must sanitize payloads prior to
+  delegating to Streamlit rendering helpers so that test doubles can assert on
+  clean output.
+
+## Acceptance Criteria
+- Fast unit tests can run the WebUI without importing Streamlit and still verify
+  CSS payloads, router invocations, and sanitized telemetry.
+- Progress checkpoints produce sanitized status text, exercise subtask helpers,
+  and capture debug messages for each update.
+- Sanitization hooks execute before messages reach rendering APIs, preserving
+  traceable evidence for security-critical outputs.

--- a/tests/unit/interface/test_webui_streamlit_free_progress_fast.py
+++ b/tests/unit/interface/test_webui_streamlit_free_progress_fast.py
@@ -1,0 +1,178 @@
+"""Streamlit-free WebUI regression coverage for routing, progress, and sanitization."""
+
+from __future__ import annotations
+
+"""Streamlit-free WebUI regression coverage for routing and progress telemetry."""
+
+import importlib
+import sys
+from types import ModuleType
+from typing import Iterator, Tuple
+from unittest.mock import MagicMock
+
+import pytest
+
+from tests.unit.interface.test_webui_enhanced import _mock_streamlit
+
+
+@pytest.fixture
+def streamlit_free_webui(
+    monkeypatch: pytest.MonkeyPatch,
+) -> Iterator[Tuple[ModuleType, ModuleType, dict[str, MagicMock]]]:
+    """Reload :mod:`devsynth.interface.webui` with a deterministic Streamlit stub."""
+
+    st = _mock_streamlit()
+    st.sidebar.radio = MagicMock(return_value="Summary")
+    st.session_state.screen_width = 860
+    st.session_state.screen_height = 600
+
+    monkeypatch.setitem(sys.modules, "streamlit", st)
+
+    import devsynth.interface.webui as webui
+
+    importlib.reload(webui)
+
+    navigation = {"Summary": MagicMock(name="summary_page")}
+
+    monkeypatch.setattr(webui.PageRenderer, "navigation_items", lambda self: navigation)
+
+    try:
+        yield webui, st, navigation
+    finally:
+        sys.modules.pop("streamlit", None)
+        importlib.reload(webui)
+
+
+@pytest.fixture
+def progress_webui(
+    monkeypatch: pytest.MonkeyPatch,
+) -> Iterator[Tuple[ModuleType, ModuleType, MagicMock, MagicMock, MagicMock]]:
+    """Provide a reloaded WebUI module with deterministic progress containers."""
+
+    st = _mock_streamlit()
+    status_container = MagicMock(name="status_container")
+    time_container = MagicMock(name="time_container")
+    bar_container = MagicMock(name="bar_container")
+
+    st.empty = MagicMock(side_effect=[status_container, time_container])
+    st.progress = MagicMock(return_value=bar_container)
+
+    monkeypatch.setitem(sys.modules, "streamlit", st)
+
+    import devsynth.interface.webui as webui
+
+    importlib.reload(webui)
+
+    try:
+        yield webui, st, status_container, time_container, bar_container
+    finally:
+        sys.modules.pop("streamlit", None)
+        importlib.reload(webui)
+
+
+@pytest.fixture
+def sanitized_webui(
+    monkeypatch: pytest.MonkeyPatch,
+) -> Iterator[Tuple[ModuleType, ModuleType]]:
+    """Yield a reloaded WebUI module for sanitization assertions."""
+
+    st = _mock_streamlit()
+    monkeypatch.setitem(sys.modules, "streamlit", st)
+
+    import devsynth.interface.webui as webui
+
+    importlib.reload(webui)
+
+    try:
+        yield webui, st
+    finally:
+        sys.modules.pop("streamlit", None)
+        importlib.reload(webui)
+
+
+@pytest.mark.fast
+def test_webui_run_configures_dashboard_and_invokes_router(
+    streamlit_free_webui: Tuple[ModuleType, ModuleType, dict[str, MagicMock]]
+) -> None:
+    """ReqID: WEBUI-DASH-TOGGLE-01 — Layout toggles wire routing without Streamlit."""
+
+    webui, st, navigation = streamlit_free_webui
+    ui = webui.WebUI()
+
+    ui.run()
+
+    assert isinstance(ui._router, webui.Router)
+    assert ui._router.pages == navigation
+    assert st.set_page_config.call_count == 1
+    sidebar_css_calls = [call.args[0] for call in st.markdown.call_args_list]
+    assert any("sidebar-content" in payload and "30%" in payload for payload in sidebar_css_calls)
+    st.sidebar.radio.assert_called_once_with("Navigation", list(navigation), index=0)
+
+
+@pytest.mark.fast
+def test_progress_updates_emit_telemetry_and_sanitize_checkpoints(
+    progress_webui: Tuple[ModuleType, ModuleType, MagicMock, MagicMock, MagicMock],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """ReqID: WEBUI-PROGRESS-TRACE-02 — Progress checkpoints sanitize and log telemetry."""
+
+    webui, st, status_container, time_container, bar_container = progress_webui
+
+    sanitized_inputs: list[str] = []
+
+    def capture_sanitize(text: str) -> str:
+        sanitized_inputs.append(text)
+        return f"safe::{text}"
+
+    logger_spy = MagicMock()
+
+    monkeypatch.setattr(webui, "sanitize_output", capture_sanitize)
+    monkeypatch.setattr(webui, "logger", logger_spy)
+
+    ui = webui.WebUI()
+    progress = ui.create_progress("Download <file>", total=4)
+
+    step_id = progress.add_subtask("Subtask <A>", total=4, status="In <progress>")
+    progress.update(advance=1, description="Chunk <1>")
+    progress.update_subtask(step_id, advance=2, description="Stage <2>")
+    progress.complete_subtask(step_id)
+    progress.complete()
+
+    assert sanitized_inputs == [
+        "Download <file>",
+        "Subtask <A>",
+        "In <progress>",
+        "Chunk <1>",
+        "Stage <2>",
+    ]
+
+    status_payloads = [call.args[0] for call in status_container.markdown.call_args_list]
+    assert any(payload.startswith("**safe::Download <file>") for payload in status_payloads)
+    bar_updates = [call.args[0] for call in bar_container.progress.call_args_list]
+    assert bar_updates[0] == 0.0
+    assert pytest.approx(bar_updates[-1]) == 1.0
+    assert logger_spy.debug.call_count >= 3
+
+
+@pytest.mark.fast
+def test_display_result_sanitizes_message_before_render(
+    sanitized_webui: Tuple[ModuleType, ModuleType],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """ReqID: WEBUI-SAN-03 — Bridge output sanitization precedes rendering hooks."""
+
+    webui, st = sanitized_webui
+
+    sanitized_inputs: list[str] = []
+
+    def capture_sanitize(message: str) -> str:
+        sanitized_inputs.append(message)
+        return f"clean::{message}"
+
+    monkeypatch.setattr(webui, "sanitize_output", capture_sanitize)
+
+    ui = webui.WebUI()
+    ui.display_result("<script>alert('x')</script>", message_type="info")
+
+    assert sanitized_inputs == ["<script>alert('x')</script>"]
+    st.info.assert_called_once_with("clean::<script>alert('x')</script>")

--- a/tests/unit/logging/test_logging_setup_invariants.py
+++ b/tests/unit/logging/test_logging_setup_invariants.py
@@ -1,0 +1,153 @@
+"""Logging invariants for handler wiring, redaction, and context switching."""
+
+from __future__ import annotations
+
+import importlib
+import logging
+from collections.abc import Iterator
+from pathlib import Path
+from types import ModuleType
+from typing import Sequence
+
+import pytest
+
+
+@pytest.fixture()
+def reloaded_logging_setup() -> Iterator[ModuleType]:
+    """Reload :mod:`devsynth.logging_setup` with a pristine root logger."""
+
+    import devsynth.logging_setup as logging_setup
+
+    root_logger = logging.getLogger()
+    original_handlers = list(root_logger.handlers)
+    original_filters = list(root_logger.filters)
+    original_level = root_logger.level
+
+    for handler in root_logger.handlers[:]:
+        root_logger.removeHandler(handler)
+        try:
+            handler.close()
+        except Exception:  # pragma: no cover - defensive guard
+            pass
+    for filt in root_logger.filters[:]:
+        root_logger.removeFilter(filt)
+
+    reloaded = importlib.reload(logging_setup)
+
+    try:
+        yield reloaded
+    finally:
+        for handler in root_logger.handlers[:]:
+            root_logger.removeHandler(handler)
+            try:
+                handler.close()
+            except Exception:  # pragma: no cover - defensive guard
+                pass
+        for handler in original_handlers:
+            root_logger.addHandler(handler)
+        for filt in original_filters:
+            root_logger.addFilter(filt)
+        root_logger.setLevel(original_level)
+        importlib.reload(logging_setup)
+
+
+def _file_handlers() -> Sequence[logging.FileHandler]:
+    root_logger = logging.getLogger()
+    return [
+        handler
+        for handler in root_logger.handlers
+        if isinstance(handler, logging.FileHandler)
+    ]
+
+
+@pytest.mark.fast
+def test_configure_logging_is_idempotent_for_handlers(
+    reloaded_logging_setup: ModuleType,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """ReqID: LOG-INV-01 — Handler wiring remains stable across repeated config."""
+
+    logging_setup = reloaded_logging_setup
+
+    monkeypatch.setenv("DEVSYNTH_LOG_DIR", str(tmp_path / "logs"))
+    monkeypatch.setenv("DEVSYNTH_LOG_FILENAME", "cli.jsonl")
+    monkeypatch.delenv("DEVSYNTH_NO_FILE_LOGGING", raising=False)
+    monkeypatch.delenv("DEVSYNTH_PROJECT_DIR", raising=False)
+
+    logging_setup.configure_logging()
+    initial_handlers = tuple(_file_handlers())
+    assert len(initial_handlers) == 1
+    initial_path = Path(initial_handlers[0].baseFilename)
+    assert initial_path.name == "cli.jsonl"
+
+    logging_setup.configure_logging()
+    repeated_handlers = tuple(_file_handlers())
+    assert repeated_handlers == initial_handlers
+    assert Path(logging_setup.get_log_file()) == initial_path
+
+
+@pytest.mark.fast
+def test_redact_secrets_filter_masks_known_tokens(
+    reloaded_logging_setup: ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """ReqID: LOG-INV-02 — Redaction filter masks secrets in messages and extras."""
+
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-example1234567890")
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "anthropic-secret-abcdef")
+
+    logging_setup = reloaded_logging_setup
+    filt = logging_setup.RedactSecretsFilter()
+
+    record = logging.LogRecord(
+        name="devsynth.tests.redaction",
+        level=logging.INFO,
+        pathname=__file__,
+        lineno=0,
+        msg="Token sk-example1234567890 should be redacted",
+        args=(),
+        exc_info=None,
+    )
+    record.extra = {"api_key": "anthropic-secret-abcdef"}
+
+    assert filt.filter(record)
+    assert "sk-example1234567890" not in record.msg
+    assert "***REDACTED***7890" in record.msg
+    assert record.extra["api_key"].startswith("***REDACTED***")
+    assert record.extra["api_key"].endswith("cdef")
+
+
+@pytest.mark.fast
+def test_cli_to_test_context_switch_updates_log_destination(
+    reloaded_logging_setup: ModuleType,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """ReqID: LOG-INV-03 — Switching contexts rewires file handlers deterministically."""
+
+    logging_setup = reloaded_logging_setup
+
+    cli_dir = tmp_path / "cli"
+    monkeypatch.setenv("DEVSYNTH_LOG_DIR", str(cli_dir))
+    monkeypatch.delenv("DEVSYNTH_PROJECT_DIR", raising=False)
+    monkeypatch.delenv("DEVSYNTH_NO_FILE_LOGGING", raising=False)
+
+    logging_setup.configure_logging()
+    cli_handlers = tuple(_file_handlers())
+    assert len(cli_handlers) == 1
+    cli_path = Path(cli_handlers[0].baseFilename)
+    assert cli_path.is_relative_to(cli_dir)
+
+    project_dir = tmp_path / "project"
+    project_dir.mkdir(exist_ok=True)
+    monkeypatch.delenv("DEVSYNTH_LOG_DIR", raising=False)
+    monkeypatch.setenv("DEVSYNTH_PROJECT_DIR", str(project_dir))
+
+    logging_setup.configure_logging()
+    test_handlers = tuple(_file_handlers())
+    assert len(test_handlers) == 1
+    test_path = Path(test_handlers[0].baseFilename)
+    assert test_path.is_relative_to(project_dir)
+    assert test_path != cli_path
+    assert Path(logging_setup.get_log_file()) == test_path

--- a/tests/unit/methodology/edrr/test_reasoning_loop_timeouts_fast.py
+++ b/tests/unit/methodology/edrr/test_reasoning_loop_timeouts_fast.py
@@ -1,0 +1,205 @@
+"""Strengthened EDRR reasoning loop scenarios for budgets and error propagation."""
+
+# Strengthened EDRR reasoning loop scenarios for budgets and fallbacks.
+
+from __future__ import annotations
+
+import importlib
+from types import ModuleType
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from devsynth.methodology.edrr.contracts import CoordinatorRecorder, NullWSDETeam
+from devsynth.methodology.edrr.reasoning_loop import Phase
+
+rl = importlib.import_module("devsynth.methodology.edrr.reasoning_loop")
+
+
+@pytest.mark.fast
+def test_import_helper_exposes_typed_apply() -> None:
+    """ReqID: EDRR-LOOP-Import-00 — Internal accessor returns the typed callable."""
+
+    assert rl._import_apply_dialectical_reasoning() is rl.typed_apply
+
+
+@pytest.mark.fast
+def test_reasoning_loop_respects_total_budget_and_emits_debug(monkeypatch: pytest.MonkeyPatch) -> None:
+    """ReqID: EDRR-LOOP-Timeout-01 — Total budget stops iterations with telemetry."""
+
+    clock = {"value": 0.0}
+
+    def fake_monotonic() -> float:
+        return clock["value"]
+
+    def fake_apply(*_args: Any, **_kwargs: Any) -> dict[str, Any]:
+        clock["value"] += 0.25
+        return {"status": "in_progress", "phase": "refine"}
+
+    logger_spy = MagicMock()
+
+    monkeypatch.setattr(rl.time, "monotonic", fake_monotonic)
+    monkeypatch.setattr(rl, "_import_apply_dialectical_reasoning", lambda: fake_apply)
+    monkeypatch.setattr(rl, "logger", logger_spy)
+
+    results = rl.reasoning_loop(
+        wsde_team=NullWSDETeam(),
+        task={},
+        critic_agent=None,
+        max_iterations=4,
+        max_total_seconds=0.2,
+    )
+
+    assert results == [{"status": "in_progress", "phase": "refine"}]
+    assert any(
+        "max_total_seconds budget" in call.args[0]
+        for call in logger_spy.debug.call_args_list
+    )
+
+
+@pytest.mark.fast
+def test_reasoning_loop_uses_fallback_after_invalid_phase(monkeypatch: pytest.MonkeyPatch) -> None:
+    """ReqID: EDRR-LOOP-Phase-02 — Invalid phases fall back to deterministic transitions."""
+
+    payloads = [
+        {"status": "in_progress", "phase": "mystery", "next_phase": "differentiate"},
+        {"status": "completed"},
+    ]
+    calls = {"index": 0}
+
+    def fake_apply(*_args: Any, **_kwargs: Any) -> dict[str, Any]:
+        value = payloads[calls["index"]]
+        calls["index"] += 1
+        return value
+
+    coordinator = CoordinatorRecorder()
+
+    monkeypatch.setattr(rl, "_import_apply_dialectical_reasoning", lambda: fake_apply)
+
+    results = rl.reasoning_loop(
+        wsde_team=NullWSDETeam(),
+        task={},
+        critic_agent=None,
+        coordinator=coordinator,
+        phase=Phase.EXPAND,
+        max_iterations=3,
+    )
+
+    assert len(results) == 2
+    assert [phase for phase, _ in coordinator.records] == ["expand", "differentiate"]
+
+
+@pytest.mark.fast
+def test_reasoning_loop_stops_after_retry_exhaustion(monkeypatch: pytest.MonkeyPatch) -> None:
+    """ReqID: EDRR-LOOP-Error-03 — Exhausted retries propagate stop conditions."""
+
+    calls = {"count": 0}
+
+    def flaky_apply(*_args: Any, **_kwargs: Any) -> dict[str, Any]:
+        calls["count"] += 1
+        if calls["count"] == 1:
+            return {"status": "in_progress", "phase": "refine"}
+        raise RuntimeError("boom")
+
+    logger_spy = MagicMock()
+
+    monkeypatch.setattr(rl, "_import_apply_dialectical_reasoning", lambda: flaky_apply)
+    monkeypatch.setattr(rl.time, "sleep", lambda _seconds: None)
+    monkeypatch.setattr(rl, "logger", logger_spy)
+
+    results = rl.reasoning_loop(
+        wsde_team=NullWSDETeam(),
+        task={},
+        critic_agent=None,
+        max_iterations=3,
+        retry_attempts=1,
+        retry_backoff=0.05,
+    )
+
+    assert results == [{"status": "in_progress", "phase": "refine"}]
+    assert calls["count"] == 3
+    messages = [call.args[0] for call in logger_spy.debug.call_args_list]
+    assert any("Transient error" in message for message in messages)
+    assert any("Giving up after retries" in message for message in messages)
+
+
+@pytest.mark.fast
+def test_reasoning_loop_seeds_random_and_numpy(monkeypatch: pytest.MonkeyPatch) -> None:
+    """ReqID: EDRR-LOOP-Seed-04 — Deterministic seeding configures random providers."""
+
+    import random as real_random
+
+    seed_spy = MagicMock()
+    monkeypatch.setattr(real_random, "seed", seed_spy)
+
+    original_import_module = importlib.import_module
+    fake_numpy_random = MagicMock()
+
+    def fake_import_module(name: str, package: str | None = None):
+        if name == "numpy.random":
+            return fake_numpy_random
+        return original_import_module(name, package)
+
+    monkeypatch.setattr(importlib, "import_module", fake_import_module)
+
+    def single_run(*_args: Any, **_kwargs: Any) -> dict[str, Any]:
+        return {"status": "completed", "phase": "refine"}
+
+    monkeypatch.setattr(rl, "_import_apply_dialectical_reasoning", lambda: single_run)
+
+    results = rl.reasoning_loop(
+        wsde_team=NullWSDETeam(),
+        task={"prompt": "seeded"},
+        critic_agent=None,
+        deterministic_seed=123,
+    )
+
+    assert results == [{"status": "completed", "phase": "refine"}]
+    seed_spy.assert_called_once_with(123)
+    fake_numpy_random.seed.assert_called_once_with(123)
+
+
+@pytest.mark.fast
+def test_reasoning_loop_applies_synthesis_to_task(monkeypatch: pytest.MonkeyPatch) -> None:
+    """ReqID: EDRR-LOOP-Synthesis-05 — Synthesis payload updates the working task."""
+
+    class TaskRecorder:
+        def __init__(self) -> None:
+            self.syntheses: list[dict[str, Any]] = []
+
+        def with_solution(self, synthesis: dict[str, Any]) -> "TaskRecorder":
+            self.syntheses.append(synthesis)
+            return self
+
+    task_stub = TaskRecorder()
+
+    payloads = [
+        {
+            "status": "in_progress",
+            "phase": "expand",
+            "synthesis": {"value": 1},
+            "next_phase": "differentiate",
+        },
+        {"status": "completed"},
+    ]
+    calls = {"index": 0}
+
+    def fake_apply(*_args: Any, **_kwargs: Any) -> dict[str, Any]:
+        value = payloads[calls["index"]]
+        calls["index"] += 1
+        return value
+
+    monkeypatch.setattr(rl, "ensure_dialectical_task", lambda _task: task_stub)
+    monkeypatch.setattr(rl, "_import_apply_dialectical_reasoning", lambda: fake_apply)
+
+    results = rl.reasoning_loop(
+        wsde_team=NullWSDETeam(),
+        task={"prompt": "update"},
+        critic_agent=None,
+        phase=Phase.EXPAND,
+        max_iterations=3,
+    )
+
+    assert len(results) == 2
+    assert task_stub.syntheses == [{"value": 1}]


### PR DESCRIPTION
## Summary
- add fast Streamlit-free WebUI tests that exercise routing toggles, progress telemetry, and bridge sanitization
- add logging setup invariants for handler idempotency, redaction filters, and CLI/test context switching
- extend EDRR reasoning loop timeout and fallback scenarios and document the new dashboard progress specification

## Testing
- `poetry run pytest tests/unit/interface/test_webui_streamlit_free_progress_fast.py tests/unit/logging/test_logging_setup_invariants.py tests/unit/methodology/edrr/test_reasoning_loop_timeouts_fast.py`


------
https://chatgpt.com/codex/tasks/task_e_68e05b160b7883339f21edb857cac087