### PR TITLE
Expand run-tests regression coverage

### DIFF
--- a/tests/unit/application/cli/commands/test_run_tests_cmd_segmentation_regressions.py
+++ b/tests/unit/application/cli/commands/test_run_tests_cmd_segmentation_regressions.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import os
+from pathlib import Path
 
 import pytest
 from typer.testing import CliRunner
@@ -12,6 +13,12 @@ from tests.unit.application.cli.commands.helpers import (
     SEGMENTATION_FAILURE_TIPS,
     build_minimal_cli_app,
 )
+
+
+def _build_batch_output(label: str, error: Exception) -> str:
+    """Compose deterministic stderr for simulated failing batches."""
+
+    return f"[batch {label}] {error}\n{SEGMENTATION_FAILURE_TIPS}"
 
 
 @pytest.mark.fast
@@ -76,3 +83,90 @@ def test_segmented_cli_failure_emits_tips_and_reinjection(monkeypatch, tmp_path)
     assert len(bdd_calls) == 1
     assert "-p pytest_cov" in os.environ["PYTEST_ADDOPTS"]
     assert "pytest_bdd" in os.environ["PYTEST_ADDOPTS"]
+
+
+@pytest.mark.fast
+@pytest.mark.parametrize(
+    "failed_batches",
+    [
+        pytest.param(["one"], id="single-batch"),
+        pytest.param(["one", "two", "three"], id="multiple-batches"),
+    ],
+)
+def test_segmented_cli_failure_repeats_banner_per_batch_and_aggregate(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    failed_batches: list[str],
+) -> None:
+    """Remediation banners surface once per failed segment and aggregate."""
+
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("PYTEST_DISABLE_PLUGIN_AUTOLOAD", "1")
+    monkeypatch.setenv("PYTEST_ADDOPTS", "")
+
+    app, cli_module = build_minimal_cli_app(monkeypatch)
+
+    observed_batches: list[str] = []
+
+    def raising_segment(label: str) -> None:
+        observed_batches.append(label)
+        raise RuntimeError(f"segment {label} crashed")
+
+    monkeypatch.setattr(
+        run_tests_module,
+        "_segment_batches",
+        raising_segment,
+        raising=False,
+    )
+
+    received_kwargs: dict[str, object] = {}
+
+    def fake_run_tests(*_: object, **kwargs: object) -> tuple[bool, str]:
+        received_kwargs.update(kwargs)
+        batch_outputs: list[str] = []
+        for index, batch in enumerate(failed_batches, start=1):
+            try:
+                run_tests_module._segment_batches(batch)  # type: ignore[attr-defined]
+            except RuntimeError as exc:  # pragma: no cover - exercised via test logic
+                batch_outputs.append(_build_batch_output(str(index), exc))
+        batch_outputs.append(
+            "Aggregate segmentation failure\n" + SEGMENTATION_FAILURE_TIPS
+        )
+        return False, "\n".join(batch_outputs)
+
+    monkeypatch.setattr(cli_module, "run_tests", fake_run_tests)
+    monkeypatch.setattr(
+        cli_module, "_coverage_instrumentation_status", lambda: (True, None)
+    )
+    monkeypatch.setattr(
+        cli_module, "ensure_pytest_cov_plugin_env", lambda env: False
+    )
+    monkeypatch.setattr(
+        cli_module, "ensure_pytest_bdd_plugin_env", lambda env: False
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(
+        app,
+        [
+            "--segment",
+            "--segment-size",
+            "2",
+            "--speed",
+            "fast",
+            "--target",
+            "unit-tests",
+        ],
+        prog_name="run-tests",
+    )
+
+    assert result.exit_code == 1
+    assert isinstance(result.exception, SystemExit)
+    assert result.exception.code == 1
+    assert received_kwargs.get("segment") is True
+    assert received_kwargs.get("segment_size") == 2
+    assert observed_batches == failed_batches
+
+    remediation_count = result.stdout.count("Segment large suites to localize failures")
+    assert remediation_count == len(failed_batches) + 1
+    assert result.stdout.count("Aggregate segmentation failure") == 1

--- a/tests/unit/testing/test_run_tests_artifacts.py
+++ b/tests/unit/testing/test_run_tests_artifacts.py
@@ -13,6 +13,19 @@ import pytest
 import devsynth.testing.run_tests as run_tests_module
 
 
+@pytest.fixture
+def coverage_paths(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> tuple[Path, Path]:
+    """Point coverage artifact constants at a temporary workspace."""
+
+    coverage_json = tmp_path / "test_reports" / "coverage.json"
+    html_dir = tmp_path / "htmlcov"
+    monkeypatch.setattr(run_tests_module, "COVERAGE_JSON_PATH", coverage_json)
+    monkeypatch.setattr(run_tests_module, "COVERAGE_HTML_DIR", html_dir)
+    return coverage_json, html_dir
+
+
 @pytest.mark.fast
 def test_reset_coverage_artifacts_removes_stale_files(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     """Existing coverage outputs should be deleted prior to a new run."""
@@ -152,3 +165,97 @@ def test_run_tests_successful_single_batch(monkeypatch: pytest.MonkeyPatch) -> N
     assert success is True
     assert "pytest ok" in output
     assert "coverage ingested" in output
+
+
+@pytest.mark.fast
+def test_coverage_artifacts_status_handles_missing_json(
+    coverage_paths: tuple[Path, Path]
+) -> None:
+    """Missing JSON artifacts should surface a descriptive remediation message."""
+
+    coverage_json, html_dir = coverage_paths
+    html_dir.mkdir(parents=True, exist_ok=True)
+    (html_dir / "index.html").write_text("<html>empty</html>")
+
+    ok, reason = run_tests_module.coverage_artifacts_status()
+    assert ok is False
+    assert reason is not None and str(coverage_json) in reason
+
+
+@pytest.mark.fast
+def test_coverage_artifacts_status_rejects_invalid_json(
+    coverage_paths: tuple[Path, Path]
+) -> None:
+    """Invalid coverage JSON payloads should be rejected with context."""
+
+    coverage_json, html_dir = coverage_paths
+    coverage_json.parent.mkdir(parents=True, exist_ok=True)
+    coverage_json.write_text("not-json")
+    html_dir.mkdir(parents=True, exist_ok=True)
+    (html_dir / "index.html").write_text("<html>ok</html>")
+
+    ok, reason = run_tests_module.coverage_artifacts_status()
+    assert ok is False
+    assert reason is not None and "invalid" in reason
+
+
+@pytest.mark.fast
+def test_coverage_artifacts_status_detects_missing_html(
+    coverage_paths: tuple[Path, Path]
+) -> None:
+    """When the HTML report is absent the helper should flag the gap."""
+
+    coverage_json, _ = coverage_paths
+    coverage_json.parent.mkdir(parents=True, exist_ok=True)
+    coverage_json.write_text(json.dumps({"totals": {"percent_covered": 91.2}}))
+
+    ok, reason = run_tests_module.coverage_artifacts_status()
+    assert ok is False
+    assert reason is not None and "Coverage HTML missing" in reason
+
+
+@pytest.mark.fast
+def test_coverage_artifacts_status_detects_empty_html(
+    coverage_paths: tuple[Path, Path]
+) -> None:
+    """HTML reports that note missing data should trigger remediation."""
+
+    coverage_json, html_dir = coverage_paths
+    coverage_json.parent.mkdir(parents=True, exist_ok=True)
+    coverage_json.write_text(json.dumps({"totals": {"percent_covered": 90.0}}))
+    html_dir.mkdir(parents=True, exist_ok=True)
+    (html_dir / "index.html").write_text("No coverage data available")
+
+    ok, reason = run_tests_module.coverage_artifacts_status()
+    assert ok is False
+    assert reason is not None and "No coverage data" in reason
+
+
+@pytest.mark.fast
+def test_coverage_artifacts_status_success(coverage_paths: tuple[Path, Path]) -> None:
+    """Valid coverage artifacts should return a positive status."""
+
+    coverage_json, html_dir = coverage_paths
+    coverage_json.parent.mkdir(parents=True, exist_ok=True)
+    coverage_json.write_text(json.dumps({"totals": {"percent_covered": 93.5}}))
+    html_dir.mkdir(parents=True, exist_ok=True)
+    (html_dir / "index.html").write_text("<html>coverage ok</html>")
+
+    ok, reason = run_tests_module.coverage_artifacts_status()
+    assert ok is True
+    assert reason is None
+
+
+@pytest.mark.fast
+def test_failure_tips_includes_command_context() -> None:
+    """Failure tips prefix the command and retain segmentation guidance."""
+
+    cmd = ["python", "-m", "pytest", "tests/unit"]
+    tips = run_tests_module._failure_tips(2, cmd)
+
+    assert tips.startswith(
+        "\nPytest exited with code 2. Command: python -m pytest tests/unit"
+    )
+    assert "Troubleshooting tips:" in tips
+    assert "Segment large suites" in tips
+    assert "Re-run failing segments" in tips


### PR DESCRIPTION
## Summary
- add reusable batch output helper and parameterized segmentation regression that asserts remediation banners surface for each failing segment and the aggregate banner
- extend CLI runner invalid-input coverage to include disk write failures and maxfail propagation while strengthening invalid target exit checks
- simulate segmented plugin reinjection under disabled autoloading and broaden coverage artifact status/failure tip assertions for run_tests helpers

## Testing
- `poetry run pytest tests/unit/application/cli/commands tests/unit/testing -k "run_tests" -m fast` *(fails: import error in devsynth.application.cli.long_running_progress due to undefined _ProgressIndicatorBase)*
- `poetry run pytest tests/unit/application/cli/commands/test_run_tests_cmd_cli_runner_invalid_inputs.py tests/unit/application/cli/commands/test_run_tests_cmd_segmentation_regressions.py tests/unit/testing/test_run_tests_cli_helpers_focus.py tests/unit/testing/test_run_tests_artifacts.py tests/unit/testing/test_run_tests.py tests/unit/testing/test_run_tests_cli_invocation.py -k "run_tests" -m fast` *(fails: existing stubs lack timeout/context manager support and Typer rejects object-typed options)*
- `poetry run pytest tests/unit/application/cli/commands/test_run_tests_cmd_segmentation_regressions.py -k "repeats_banner" -m fast` *(fails: Typer cannot coerce object-typed bridge option with current version)*

------
https://chatgpt.com/codex/tasks/task_e_68e0a17e2d4c8333bfdbfb18239e395d