### PR TITLE
fix: align memory protocol generics

### DIFF
--- a/issues/test-collection-regressions-20251004.md
+++ b/issues/test-collection-regressions-20251004.md
@@ -21,17 +21,18 @@ Affected Area: tests
 ## Observations
 - `_ProgressIndicatorBase` and related helpers are no longer exported, so CLI long-running progress tests raise `NameError` during import.【9ecea8†L1-L88】
 - `devsynth.memory.sync_manager` declares `Protocol["ValueT"]`, which is rejected at runtime, causing TypeError in every SyncManager-dependent suite.【9ecea8†L41-L84】
+- 2025-10-04: `MemoryStore` now declares `Protocol[ValueT]` with runtime-compatible generics; targeted unit tests cover typed stores and rollback flows.【F:src/devsynth/memory/sync_manager.py†L1-L73】【F:tests/unit/memory/test_sync_manager_protocol_runtime.py†L1-L76】
 - `tests/unit/interface/conftest.py` defines `pytest_plugins`, which pytest 8+ no longer supports outside the top-level conftest; collection aborts before tests run.【9ecea8†L57-L76】
 - Behavior suites reference `.feature` files that are missing from the repository (UXBridge/WebUI flow files under `tests/behavior/general/`).【9ecea8†L120-L164】
 - Optional backend smoke tests (Chromadb, Faiss, Kuzu) import drivers eagerly rather than respecting `requires_resource` markers, raising `ValueError` when extras are not installed.【9ecea8†L96-L120】
 
 ## Next Actions
 - [ ] Restore `_ProgressIndicatorBase` exports (likely `devsynth.application.cli.long_running_progress`) and ensure tests import helpers from supported modules.
-- [ ] Rework `MemoryStore` and related Protocol definitions to use proper `TypeVar` generics; add unit tests to prove runtime + mypy compatibility.
+- [x] Rework `MemoryStore` and related Protocol definitions to use proper `TypeVar` generics; add unit tests to prove runtime + mypy compatibility.
 - [ ] Move `pytest_plugins` declarations into the repository root `conftest.py` or convert to plugin registration helpers.
 - [ ] Recreate or relocate the missing `.feature` files referenced by behavior suites; update loaders and traceability documents accordingly.
 - [ ] Guard optional backend tests with `pytest.importorskip` plus `requires_resource` flags so they skip cleanly without extras.
 - [ ] Re-run smoke and `--collect-only` commands, attaching new logs when failures cease.
 
 ## Resolution Evidence
-- Pending — add passing command output, coverage manifests, and updated diagnostics after fixes land.
+- 2025-10-04: Smoke command still fails pending broader regression fixes; captured output in `logs/devsynth_run-tests_smoke_fast_20251004T201351Z.log`.

--- a/logs/devsynth_run-tests_smoke_fast_20251004T201351Z.log
+++ b/logs/devsynth_run-tests_smoke_fast_20251004T201351Z.log
@@ -1,0 +1,9 @@
+2025-10-04 20:13:55,888 - devsynth.testing.run_tests - INFO - Injected -p pytest_cov into PYTEST_ADDOPTS to preserve coverage instrumentation
+2025-10-04 20:13:55,889 - devsynth.testing.run_tests - INFO - Injected -p pytest_bdd.plugin into PYTEST_ADDOPTS to preserve pytest-bdd hooks
+2025-10-04 20:13:55,889 - devsynth.application.cli.commands.run_tests_cmd - INFO - CLI appended -p pytest_cov to PYTEST_ADDOPTS to enforce coverage instrumentation
+-p pytest_cov appended to PYTEST_ADDOPTS because plugin autoloading is disabled
+2025-10-04 20:13:55,890 - devsynth.application.cli.commands.run_tests_cmd - INFO - CLI appended -p pytest_bdd.plugin to PYTEST_ADDOPTS to preserve pytest-bdd hooks
+-p pytest_bdd.plugin appended to PYTEST_ADDOPTS because plugin autoloading is disabled
+2025-10-04 20:14:14,494 - devsynth.testing.run_tests - WARNING - Test collection failed: 
+Test collection failed:
+Tests failed

--- a/src/devsynth/memory/sync_manager.py
+++ b/src/devsynth/memory/sync_manager.py
@@ -8,8 +8,11 @@ from dataclasses import dataclass, field
 from typing import Generic, Protocol, TypeVar, runtime_checkable
 
 
+ValueT = TypeVar("ValueT")
+
+
 @runtime_checkable
-class MemoryStore(Protocol["ValueT"]):
+class MemoryStore(Protocol[ValueT]):
     """Protocol for simple key-value stores.
 
     Stores used with :class:`SyncManager` must implement read/write helpers and
@@ -17,21 +20,17 @@ class MemoryStore(Protocol["ValueT"]):
     and DuckDB satisfy this interface in the application layer.
     """
 
-    def write(self, key: str, value: "ValueT") -> None:
+    def write(self, key: str, value: ValueT) -> None:
         """Persist ``value`` under ``key``."""
 
-    def read(self, key: str) -> "ValueT":
+    def read(self, key: str) -> ValueT:
         """Return the stored value for ``key`` or raise ``KeyError``."""
 
-    def snapshot(self) -> Mapping[str, "ValueT"]:
+    def snapshot(self) -> Mapping[str, ValueT]:
         """Return a mapping representing the current store state."""
 
-    def restore(self, snapshot: Mapping[str, "ValueT"]) -> None:
+    def restore(self, snapshot: Mapping[str, ValueT]) -> None:
         """Restore the store from a previous :meth:`snapshot` output."""
-
-
-ValueT = TypeVar("ValueT")
-
 
 @dataclass(slots=True)
 class SyncManager(Generic[ValueT]):

--- a/tests/unit/memory/test_sync_manager_protocol_runtime.py
+++ b/tests/unit/memory/test_sync_manager_protocol_runtime.py
@@ -1,0 +1,76 @@
+"""Runtime protocol compatibility checks for :mod:`devsynth.memory.sync_manager`."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+import pytest
+
+from devsynth.memory.sync_manager import MemoryStore, SyncManager
+
+
+@dataclass(slots=True)
+class IntStore:
+    """Minimal ``MemoryStore`` stub storing integer payloads."""
+
+    data: dict[str, int] = field(default_factory=dict)
+    fail_on_key: str | None = None
+    restores: int = 0
+
+    def write(self, key: str, value: int) -> None:
+        if key == self.fail_on_key:
+            raise RuntimeError("boom")
+        self.data[key] = value
+
+    def read(self, key: str) -> int:
+        return self.data[key]
+
+    def snapshot(self) -> dict[str, int]:
+        return dict(self.data)
+
+    def restore(self, snapshot: dict[str, int]) -> None:
+        self.restores += 1
+        self.data = dict(snapshot)
+
+
+def build_manager(*, failing_key: str | None = None) -> SyncManager[int]:
+    stores = {
+        name: IntStore(fail_on_key=failing_key if name == "lmdb" else None)
+        for name in ("tinydb", "duckdb", "lmdb", "kuzu")
+    }
+    return SyncManager(stores)
+
+
+@pytest.mark.fast
+def test_stub_store_matches_protocol_runtime() -> None:
+    """The stub satisfies :class:`MemoryStore` at runtime and sync persists values."""
+
+    store = IntStore()
+    assert isinstance(store, MemoryStore)
+
+    manager = build_manager()
+    with manager.transaction():
+        manager.write("answer", 42)
+
+    for backend in manager.stores.values():
+        assert backend.read("answer") == 42
+        assert backend.restores == 0
+
+
+@pytest.mark.fast
+def test_transaction_rolls_back_typed_stores() -> None:
+    """A failure during the transaction restores each backend snapshot."""
+
+    manager = build_manager(failing_key="fail")
+
+    for backend in manager.stores.values():
+        backend.write("seed", 7)
+
+    with pytest.raises(RuntimeError):
+        with manager.transaction():
+            manager.write("seed", 8)
+            manager.write("fail", 9)
+
+    for backend in manager.stores.values():
+        assert backend.read("seed") == 7
+        assert backend.restores == 1


### PR DESCRIPTION
## Summary
- align `MemoryStore` with a runtime-compatible `TypeVar` and remove string annotations
- add typed SyncManager stub tests that prove protocol compatibility and rollback behaviour
- record the latest smoke run and mark the regression issue progress

## Testing
- `poetry run mypy --strict src/devsynth/memory`
- `PYTHONPATH=src poetry run pytest tests/unit/memory -k protocol_runtime -q`
- `PYTHONPATH=src poetry run python -m devsynth run-tests --smoke --speed=fast --no-parallel --maxfail=1` *(fails: known collection regressions tracked in issues/test-collection-regressions-20251004.md)*

------
https://chatgpt.com/codex/tasks/task_e_68e17eae60e08333a95974d90a33361d