### PR TITLE
Fix CLI imports and adjust test fixtures

### DIFF
--- a/diagnostics/pytest_collect_20251005T153355Z.log
+++ b/diagnostics/pytest_collect_20251005T153355Z.log
@@ -1,0 +1,242 @@
+===================================================== test session starts ======================================================
+platform linux -- Python 3.12.10, pytest-8.4.2, pluggy-1.6.0
+benchmark: 5.1.0 (defaults: timer=time.perf_counter disable_gc=False min_rounds=5 min_time=0.000005 max_time=1.0 calibration_precision=10 warmup=False warmup_iterations=100000)
+rootdir: /workspace/devsynth
+configfile: pytest.ini
+plugins: metadata-3.1.1, html-4.1.1, cov-6.3.0, mock-3.15.0, langsmith-0.4.26, xdist-3.8.0, rerunfailures-16.0.1, anyio-4.10.0, hypothesis-6.138.14, bdd-8.1.0, asyncio-1.1.0, benchmark-5.1.0, Faker-37.6.0
+asyncio: mode=Mode.STRICT, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
+collected 630 items / 1 error / 10 skipped
+
+============================================================ ERRORS ============================================================
+________________________ ERROR collecting tests/behavior/steps/test_webui_integration_error_branches.py ________________________
+.venv/lib/python3.12/site-packages/_pytest/python.py:498: in importtestmodule
+    mod = import_path(
+.venv/lib/python3.12/site-packages/_pytest/pathlib.py:587: in import_path
+    importlib.import_module(module_name)
+/root/.pyenv/versions/3.12.10/lib/python3.12/importlib/__init__.py:90: in import_module
+    return _bootstrap._gcd_import(name[level:], package, level)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+<frozen importlib._bootstrap>:1387: in _gcd_import
+    ???
+<frozen importlib._bootstrap>:1360: in _find_and_load
+    ???
+<frozen importlib._bootstrap>:1331: in _find_and_load_unlocked
+    ???
+<frozen importlib._bootstrap>:935: in _load_unlocked
+    ???
+.venv/lib/python3.12/site-packages/_pytest/assertion/rewrite.py:177: in exec_module
+    source_stat, co = _rewrite_test(fn, self.config)
+                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+.venv/lib/python3.12/site-packages/_pytest/assertion/rewrite.py:359: in _rewrite_test
+    co = compile(tree, strfn, "exec", dont_inherit=True)
+         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+E     File "/workspace/devsynth/tests/behavior/steps/test_webui_integration_error_branches.py", line 12
+E       from __future__ import annotations
+E       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+E   SyntaxError: from __future__ imports must occur at the beginning of the file
+======================================================= warnings summary =======================================================
+.venv/lib/python3.12/site-packages/pydantic_core/core_schema.py:4137
+.venv/lib/python3.12/site-packages/pydantic_core/core_schema.py:4137
+  /workspace/devsynth/.venv/lib/python3.12/site-packages/pydantic_core/core_schema.py:4137: DeprecationWarning: `FieldValidationInfo` is deprecated, use `ValidationInfo` instead.
+    warnings.warn(msg, DeprecationWarning, stacklevel=1)
+
+.venv/lib/python3.12/site-packages/pytest_bdd/plugin.py:137
+  /workspace/devsynth/.venv/lib/python3.12/site-packages/pytest_bdd/plugin.py:137: PytestUnknownMarkWarning: Unknown pytest.mark.reqid-cli-overhaul-pseudocode - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/stable/how-to/mark.html
+    mark = getattr(pytest.mark, tag)
+
+.venv/lib/python3.12/site-packages/pytest_bdd/plugin.py:137
+  /workspace/devsynth/.venv/lib/python3.12/site-packages/pytest_bdd/plugin.py:137: PytestUnknownMarkWarning: Unknown pytest.mark.reqid-cli-ui-improvements - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/stable/how-to/mark.html
+    mark = getattr(pytest.mark, tag)
+
+.venv/lib/python3.12/site-packages/pytest_bdd/plugin.py:137
+  /workspace/devsynth/.venv/lib/python3.12/site-packages/pytest_bdd/plugin.py:137: PytestUnknownMarkWarning: Unknown pytest.mark.reqid-delimiting-recursion-algorithms - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/stable/how-to/mark.html
+    mark = getattr(pytest.mark, tag)
+
+.venv/lib/python3.12/site-packages/pytest_bdd/plugin.py:137
+  /workspace/devsynth/.venv/lib/python3.12/site-packages/pytest_bdd/plugin.py:137: PytestUnknownMarkWarning: Unknown pytest.mark.reqid-dialectical-reasoning-impact-memory-persistence - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/stable/how-to/mark.html
+    mark = getattr(pytest.mark, tag)
+
+.venv/lib/python3.12/site-packages/pytest_bdd/plugin.py:137
+  /workspace/devsynth/.venv/lib/python3.12/site-packages/pytest_bdd/plugin.py:137: PytestUnknownMarkWarning: Unknown pytest.mark.reqid-document-generator-enhancement-requirements - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/stable/how-to/mark.html
+    mark = getattr(pytest.mark, tag)
+
+.venv/lib/python3.12/site-packages/pytest_bdd/plugin.py:137
+  /workspace/devsynth/.venv/lib/python3.12/site-packages/pytest_bdd/plugin.py:137: PytestUnknownMarkWarning: Unknown pytest.mark.reqid-documentation-plan - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/stable/how-to/mark.html
+    mark = getattr(pytest.mark, tag)
+
+.venv/lib/python3.12/site-packages/pytest_bdd/plugin.py:137
+  /workspace/devsynth/.venv/lib/python3.12/site-packages/pytest_bdd/plugin.py:137: PytestUnknownMarkWarning: Unknown pytest.mark.reqid-edrr-recursion-termination - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/stable/how-to/mark.html
+    mark = getattr(pytest.mark, tag)
+
+.venv/lib/python3.12/site-packages/pytest_bdd/plugin.py:137
+  /workspace/devsynth/.venv/lib/python3.12/site-packages/pytest_bdd/plugin.py:137: PytestUnknownMarkWarning: Unknown pytest.mark.reqid-edrr-cycle-specification - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/stable/how-to/mark.html
+    mark = getattr(pytest.mark, tag)
+
+.venv/lib/python3.12/site-packages/pytest_bdd/plugin.py:137
+  /workspace/devsynth/.venv/lib/python3.12/site-packages/pytest_bdd/plugin.py:137: PytestUnknownMarkWarning: Unknown pytest.mark.reqid-edrr-framework-integration-summary - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/stable/how-to/mark.html
+    mark = getattr(pytest.mark, tag)
+
+.venv/lib/python3.12/site-packages/pytest_bdd/plugin.py:137
+  /workspace/devsynth/.venv/lib/python3.12/site-packages/pytest_bdd/plugin.py:137: PytestUnknownMarkWarning: Unknown pytest.mark.reqid-edrr-phase-recovery-threshold-helpers - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/stable/how-to/mark.html
+    mark = getattr(pytest.mark, tag)
+
+.venv/lib/python3.12/site-packages/pytest_bdd/plugin.py:137
+  /workspace/devsynth/.venv/lib/python3.12/site-packages/pytest_bdd/plugin.py:137: PytestUnknownMarkWarning: Unknown pytest.mark.reqid-edrr-reasoning-loop-integration - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/stable/how-to/mark.html
+    mark = getattr(pytest.mark, tag)
+
+.venv/lib/python3.12/site-packages/pytest_bdd/plugin.py:137
+  /workspace/devsynth/.venv/lib/python3.12/site-packages/pytest_bdd/plugin.py:137: PytestUnknownMarkWarning: Unknown pytest.mark.reqid-end-to-end-deployment - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/stable/how-to/mark.html
+    mark = getattr(pytest.mark, tag)
+
+.venv/lib/python3.12/site-packages/pytest_bdd/plugin.py:137
+  /workspace/devsynth/.venv/lib/python3.12/site-packages/pytest_bdd/plugin.py:137: PytestUnknownMarkWarning: Unknown pytest.mark.reqid-generated-test-execution-failure - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/stable/how-to/mark.html
+    mark = getattr(pytest.mark, tag)
+
+.venv/lib/python3.12/site-packages/pytest_bdd/plugin.py:137
+  /workspace/devsynth/.venv/lib/python3.12/site-packages/pytest_bdd/plugin.py:137: PytestUnknownMarkWarning: Unknown pytest.mark.reqid-hybrid-memory-architecture - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/stable/how-to/mark.html
+    mark = getattr(pytest.mark, tag)
+
+.venv/lib/python3.12/site-packages/pytest_bdd/plugin.py:137
+  /workspace/devsynth/.venv/lib/python3.12/site-packages/pytest_bdd/plugin.py:137: PytestUnknownMarkWarning: Unknown pytest.mark.reqid-index - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/stable/how-to/mark.html
+    mark = getattr(pytest.mark, tag)
+
+.venv/lib/python3.12/site-packages/pytest_bdd/plugin.py:137
+  /workspace/devsynth/.venv/lib/python3.12/site-packages/pytest_bdd/plugin.py:137: PytestUnknownMarkWarning: Unknown pytest.mark.reqid-integration-test-generation - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/stable/how-to/mark.html
+    mark = getattr(pytest.mark, tag)
+
+.venv/lib/python3.12/site-packages/pytest_bdd/plugin.py:137
+  /workspace/devsynth/.venv/lib/python3.12/site-packages/pytest_bdd/plugin.py:137: PytestUnknownMarkWarning: Unknown pytest.mark.reqid-lmstudio-integration - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/stable/how-to/mark.html
+    mark = getattr(pytest.mark, tag)
+
+.venv/lib/python3.12/site-packages/pytest_bdd/plugin.py:137
+  /workspace/devsynth/.venv/lib/python3.12/site-packages/pytest_bdd/plugin.py:137: PytestUnknownMarkWarning: Unknown pytest.mark.reqid-memory-optional-tinydb-dependency - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/stable/how-to/mark.html
+    mark = getattr(pytest.mark, tag)
+
+.venv/lib/python3.12/site-packages/pytest_bdd/plugin.py:137
+  /workspace/devsynth/.venv/lib/python3.12/site-packages/pytest_bdd/plugin.py:137: PytestUnknownMarkWarning: Unknown pytest.mark.reqid-metrics-system - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/stable/how-to/mark.html
+    mark = getattr(pytest.mark, tag)
+
+.venv/lib/python3.12/site-packages/pytest_bdd/plugin.py:137
+  /workspace/devsynth/.venv/lib/python3.12/site-packages/pytest_bdd/plugin.py:137: PytestUnknownMarkWarning: Unknown pytest.mark.reqid-mvuu-config - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/stable/how-to/mark.html
+    mark = getattr(pytest.mark, tag)
+
+.venv/lib/python3.12/site-packages/pytest_bdd/plugin.py:137
+  /workspace/devsynth/.venv/lib/python3.12/site-packages/pytest_bdd/plugin.py:137: PytestUnknownMarkWarning: Unknown pytest.mark.reqid-nicegui-interface - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/stable/how-to/mark.html
+    mark = getattr(pytest.mark, tag)
+
+.venv/lib/python3.12/site-packages/pytest_bdd/plugin.py:137
+  /workspace/devsynth/.venv/lib/python3.12/site-packages/pytest_bdd/plugin.py:137: PytestUnknownMarkWarning: Unknown pytest.mark.reqid-recursive-edrr-pseudocode - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/stable/how-to/mark.html
+    mark = getattr(pytest.mark, tag)
+
+.venv/lib/python3.12/site-packages/pytest_bdd/plugin.py:137
+  /workspace/devsynth/.venv/lib/python3.12/site-packages/pytest_bdd/plugin.py:137: PytestUnknownMarkWarning: Unknown pytest.mark.reqid-run-tests-maxfail-option - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/stable/how-to/mark.html
+    mark = getattr(pytest.mark, tag)
+
+.venv/lib/python3.12/site-packages/pytest_bdd/plugin.py:137
+  /workspace/devsynth/.venv/lib/python3.12/site-packages/pytest_bdd/plugin.py:137: PytestUnknownMarkWarning: Unknown pytest.mark.reqid-spec-template - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/stable/how-to/mark.html
+    mark = getattr(pytest.mark, tag)
+
+.venv/lib/python3.12/site-packages/pytest_bdd/plugin.py:137
+  /workspace/devsynth/.venv/lib/python3.12/site-packages/pytest_bdd/plugin.py:137: PytestUnknownMarkWarning: Unknown pytest.mark.reqid-test-generation-multi-module - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/stable/how-to/mark.html
+    mark = getattr(pytest.mark, tag)
+
+.venv/lib/python3.12/site-packages/pytest_bdd/plugin.py:137
+  /workspace/devsynth/.venv/lib/python3.12/site-packages/pytest_bdd/plugin.py:137: PytestUnknownMarkWarning: Unknown pytest.mark.reqid-tiered-cache-validation - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/stable/how-to/mark.html
+    mark = getattr(pytest.mark, tag)
+
+.venv/lib/python3.12/site-packages/pytest_bdd/plugin.py:137
+  /workspace/devsynth/.venv/lib/python3.12/site-packages/pytest_bdd/plugin.py:137: PytestUnknownMarkWarning: Unknown pytest.mark.reqid-unified-configuration-loader - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/stable/how-to/mark.html
+    mark = getattr(pytest.mark, tag)
+
+.venv/lib/python3.12/site-packages/pytest_bdd/plugin.py:137
+  /workspace/devsynth/.venv/lib/python3.12/site-packages/pytest_bdd/plugin.py:137: PytestUnknownMarkWarning: Unknown pytest.mark.reqid-uxbridge-extension - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/stable/how-to/mark.html
+    mark = getattr(pytest.mark, tag)
+
+.venv/lib/python3.12/site-packages/pytest_bdd/plugin.py:137
+  /workspace/devsynth/.venv/lib/python3.12/site-packages/pytest_bdd/plugin.py:137: PytestUnknownMarkWarning: Unknown pytest.mark.reqid-verify-test-markers-performance - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/stable/how-to/mark.html
+    mark = getattr(pytest.mark, tag)
+
+.venv/lib/python3.12/site-packages/pytest_bdd/plugin.py:137
+  /workspace/devsynth/.venv/lib/python3.12/site-packages/pytest_bdd/plugin.py:137: PytestUnknownMarkWarning: Unknown pytest.mark.reqid-webui-core - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/stable/how-to/mark.html
+    mark = getattr(pytest.mark, tag)
+
+.venv/lib/python3.12/site-packages/pytest_bdd/plugin.py:137
+  /workspace/devsynth/.venv/lib/python3.12/site-packages/pytest_bdd/plugin.py:137: PytestUnknownMarkWarning: Unknown pytest.mark.reqid-webui-detailed-spec - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/stable/how-to/mark.html
+    mark = getattr(pytest.mark, tag)
+
+.venv/lib/python3.12/site-packages/pytest_bdd/plugin.py:137
+  /workspace/devsynth/.venv/lib/python3.12/site-packages/pytest_bdd/plugin.py:137: PytestUnknownMarkWarning: Unknown pytest.mark.reqid-webui-diagnostics-audit-logs - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/stable/how-to/mark.html
+    mark = getattr(pytest.mark, tag)
+
+.venv/lib/python3.12/site-packages/pytest_bdd/plugin.py:137
+  /workspace/devsynth/.venv/lib/python3.12/site-packages/pytest_bdd/plugin.py:137: PytestUnknownMarkWarning: Unknown pytest.mark.reqid-webui-pseudocode - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/stable/how-to/mark.html
+    mark = getattr(pytest.mark, tag)
+
+.venv/lib/python3.12/site-packages/pytest_bdd/plugin.py:137
+  /workspace/devsynth/.venv/lib/python3.12/site-packages/pytest_bdd/plugin.py:137: PytestUnknownMarkWarning: Unknown pytest.mark.reqid-webui-spec - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/stable/how-to/mark.html
+    mark = getattr(pytest.mark, tag)
+
+.venv/lib/python3.12/site-packages/pytest_bdd/plugin.py:137
+  /workspace/devsynth/.venv/lib/python3.12/site-packages/pytest_bdd/plugin.py:137: PytestUnknownMarkWarning: Unknown pytest.mark.reqid-wsde-interaction-specification - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/stable/how-to/mark.html
+    mark = getattr(pytest.mark, tag)
+
+.venv/lib/python3.12/site-packages/pytest_bdd/plugin.py:137
+  /workspace/devsynth/.venv/lib/python3.12/site-packages/pytest_bdd/plugin.py:137: PytestUnknownMarkWarning: Unknown pytest.mark.reqid-wsde-role-progression-memory - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/stable/how-to/mark.html
+    mark = getattr(pytest.mark, tag)
+
+-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
+================================================= Test Categorization Summary ==================================================
+Test Type Distribution:
+  Unit Tests: 0
+  Integration Tests: 2
+  Behavior Tests: 8
+
+Test Speed Distribution:
+  Fast Tests (< 1s): 10
+  Medium Tests (1-5s): 0
+  Slow Tests (> 5s): 0
+=================================================== short test summary info ====================================================
+ERROR tests/behavior/steps/test_webui_integration_error_branches.py
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! stopping after 1 failures !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+========================================== 10 skipped, 38 warnings, 1 error in 2.24s ===========================================
+===================================================== test session starts ======================================================
+platform linux -- Python 3.12.10, pytest-8.4.2, pluggy-1.6.0
+benchmark: 5.1.0 (defaults: timer=time.perf_counter disable_gc=False min_rounds=5 min_time=0.000005 max_time=1.0 calibration_precision=10 warmup=False warmup_iterations=100000)
+rootdir: /workspace/devsynth
+configfile: pytest.ini
+plugins: metadata-3.1.1, html-4.1.1, cov-6.3.0, mock-3.15.0, langsmith-0.4.26, xdist-3.8.0, rerunfailures-16.0.1, anyio-4.10.0, hypothesis-6.138.14, bdd-8.1.0, asyncio-1.1.0, benchmark-5.1.0, Faker-37.6.0
+asyncio: mode=Mode.STRICT, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
+collected 15 items
+
+tests/unit/application/cli/test_autocomplete.py ...........                                                              [ 73%]
+tests/unit/application/cli/test_ingest_cmd.py ....                                                                       [100%]
+
+======================================================= warnings summary =======================================================
+.venv/lib/python3.12/site-packages/pydantic_core/core_schema.py:4137
+.venv/lib/python3.12/site-packages/pydantic_core/core_schema.py:4137
+  /workspace/devsynth/.venv/lib/python3.12/site-packages/pydantic_core/core_schema.py:4137: DeprecationWarning: `FieldValidationInfo` is deprecated, use `ValidationInfo` instead.
+    warnings.warn(msg, DeprecationWarning, stacklevel=1)
+
+-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
+================================================= Test Categorization Summary ==================================================
+Test Type Distribution:
+  Unit Tests: 15
+  Integration Tests: 0
+  Behavior Tests: 0
+
+Test Speed Distribution:
+  Fast Tests (< 1s): 15
+  Medium Tests (1-5s): 0
+  Slow Tests (> 5s): 0
+===================================================== Top 10 Slowest Tests =====================================================
+1. tests/unit/application/cli/test_autocomplete.py::test_get_completions_returns_expected_result: 0.05s
+2. tests/unit/application/cli/test_ingest_cmd.py::test_load_manifest_defaults: 0.01s
+3. tests/unit/application/cli/test_autocomplete.py::test_file_path_autocomplete_returns_expected_result: 0.01s
+4. tests/unit/application/cli/test_ingest_cmd.py::test_ingest_cmd_non_interactive_skips_prompts: 0.01s
+5. tests/unit/application/cli/test_ingest_cmd.py::test_ingest_cmd_defaults_enable_non_interactive: 0.01s
+6. tests/unit/application/cli/test_ingest_cmd.py::test_load_manifest_reads_yaml: 0.01s
+7. tests/unit/application/cli/test_autocomplete.py::test_file_path_autocomplete_handles_nested_prefixes: 0.00s
+8. tests/unit/application/cli/test_autocomplete.py::test_get_all_commands_help_returns_expected_result: 0.00s
+9. tests/unit/application/cli/test_autocomplete.py::test_complete_command_returns_expected_result: 0.00s
+10. tests/unit/application/cli/test_autocomplete.py::test_command_autocomplete_returns_expected_result: 0.00s
+================================================ 15 passed, 2 warnings in 0.73s ================================================

--- a/src/devsynth/application/cli/commands/ingest_cmd.py
+++ b/src/devsynth/application/cli/commands/ingest_cmd.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from typing import Dict, List, Optional
 
 import typer
+from typer.models import OptionInfo
 
 from devsynth.interface.ux_bridge import UXBridge
 from devsynth.logging_setup import DevSynthLogger
@@ -152,6 +153,12 @@ def ingest_cmd(
                 base_path=str(base_dir), use_rdflib_store=True
             )
         return adapter
+
+    if isinstance(research_artifact, OptionInfo):
+        research_artifact = None
+
+    if isinstance(verify_research_hash, OptionInfo):
+        verify_research_hash = None
 
     if research_artifact:
         graph_adapter = _ensure_adapter()

--- a/src/devsynth/application/cli/ingest_cmd.py
+++ b/src/devsynth/application/cli/ingest_cmd.py
@@ -32,7 +32,7 @@ from devsynth.interface.cli import CLIUXBridge
 from devsynth.interface.ux_bridge import UXBridge
 from devsynth.logging_setup import DevSynthLogger
 from devsynth.methodology.base import Phase
-from .ingest_models import (
+from devsynth.application.cli.ingest_models import (
     DifferentiationPhaseResult,
     ExpandPhaseResult,
     ManifestModel,

--- a/tests/unit/application/cli/test_autocomplete.py
+++ b/tests/unit/application/cli/test_autocomplete.py
@@ -3,18 +3,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from devsynth.application.cli.autocomplete import (
-    COMMAND_DESCRIPTIONS,
-    COMMAND_EXAMPLES,
-    COMMANDS,
-    command_autocomplete,
-    complete_command,
-    file_path_autocomplete,
-    generate_completion_script,
-    get_all_commands_help,
-    get_command_help,
-    get_completions,
-)
+from devsynth.application.cli import autocomplete as module
 
 
 @pytest.mark.medium
@@ -22,10 +11,12 @@ def test_get_completions_returns_expected_result():
     """Test that get_completions returns commands that start with the incomplete string.
 
     ReqID: FR-66a"""
-    assert set(get_completions("")) == set(COMMANDS)
-    assert set(get_completions("i")) == {cmd for cmd in COMMANDS if cmd.startswith("i")}
-    assert get_completions("init") == ["init"]
-    assert get_completions("xyz") == []
+    assert set(module.get_completions("")) == set(module.COMMANDS)
+    assert set(module.get_completions("i")) == {
+        cmd for cmd in module.COMMANDS if cmd.startswith("i")
+    }
+    assert module.get_completions("init") == ["init"]
+    assert module.get_completions("xyz") == []
 
 
 @pytest.mark.medium
@@ -33,14 +24,14 @@ def test_complete_command_returns_expected_result():
     """Test that complete_command returns the completed command if there's a unique match.
 
     ReqID: FR-66a"""
-    assert complete_command("init") == "init"
+    assert module.complete_command("init") == "init"
     incomplete = "i"
-    matches = [cmd for cmd in COMMANDS if cmd.startswith(incomplete)]
+    matches = [cmd for cmd in module.COMMANDS if cmd.startswith(incomplete)]
     if len(matches) > 1:
-        assert complete_command(incomplete) == incomplete
+        assert module.complete_command(incomplete) == incomplete
     else:
-        assert complete_command(incomplete) == matches[0]
-    assert complete_command("xyz") == "xyz"
+        assert module.complete_command(incomplete) == matches[0]
+    assert module.complete_command("xyz") == "xyz"
 
 
 @pytest.mark.medium
@@ -49,12 +40,12 @@ def test_command_autocomplete_returns_expected_result():
 
     ReqID: FR-66a"""
     ctx = MagicMock()
-    assert set(command_autocomplete(ctx, "")) == set(COMMANDS)
-    assert set(command_autocomplete(ctx, "i")) == {
-        cmd for cmd in COMMANDS if cmd.startswith("i")
+    assert set(module.command_autocomplete(ctx, "")) == set(module.COMMANDS)
+    assert set(module.command_autocomplete(ctx, "i")) == {
+        cmd for cmd in module.COMMANDS if cmd.startswith("i")
     }
-    assert command_autocomplete(ctx, "init") == ["init"]
-    assert command_autocomplete(ctx, "xyz") == []
+    assert module.command_autocomplete(ctx, "init") == ["init"]
+    assert module.command_autocomplete(ctx, "xyz") == []
 
 
 @pytest.mark.medium
@@ -63,18 +54,18 @@ def test_command_autocomplete_matches_metadata() -> None:
 
     ctx = MagicMock()
     # Empty input should expose the full command roster described in COMMANDS.
-    suggestions = command_autocomplete(ctx, "")
-    assert suggestions == get_completions("")
-    assert set(suggestions) == set(COMMANDS)
+    suggestions = module.command_autocomplete(ctx, "")
+    assert suggestions == module.get_completions("")
+    assert set(suggestions) == set(module.COMMANDS)
 
     # Ambiguous prefixes should return every matching command with metadata entries.
-    ambiguous = command_autocomplete(ctx, "co")
-    expected_matches = {cmd for cmd in COMMANDS if cmd.startswith("co")}
+    ambiguous = module.command_autocomplete(ctx, "co")
+    expected_matches = {cmd for cmd in module.COMMANDS if cmd.startswith("co")}
     assert set(ambiguous) == expected_matches
     for cmd in ambiguous:
-        assert COMMAND_DESCRIPTIONS[cmd]
+        assert module.COMMAND_DESCRIPTIONS[cmd]
         # Examples are optional but should exist for all current commands.
-        assert cmd in COMMAND_EXAMPLES
+        assert cmd in module.COMMAND_EXAMPLES
 
 
 @pytest.mark.medium
@@ -96,13 +87,13 @@ def test_file_path_autocomplete_returns_expected_result():
         mock_dir1.name = "dir1"
         mock_dir1.__str__.return_value = "dir1"
         mock_cwd.iterdir.return_value = [mock_file1, mock_file2, mock_dir1]
-        result = file_path_autocomplete(ctx, "")
+        result = module.file_path_autocomplete(ctx, "")
         assert set(result) == {"file1.txt", "file2.txt", "dir1"}
-        result = file_path_autocomplete(ctx, "file")
+        result = module.file_path_autocomplete(ctx, "file")
         assert set(result) == {"file1.txt", "file2.txt"}
-        result = file_path_autocomplete(ctx, "dir")
+        result = module.file_path_autocomplete(ctx, "dir")
         assert set(result) == {"dir1"}
-        result = file_path_autocomplete(ctx, "xyz")
+        result = module.file_path_autocomplete(ctx, "xyz")
         assert result == []
         mock_path.side_effect = None
         mock_path.reset_mock()
@@ -120,7 +111,7 @@ def test_file_path_autocomplete_returns_expected_result():
         mock_file2.name = "file2.txt"
         mock_file2.__str__.return_value = "dir1/file2.txt"
         parent_dir.iterdir.return_value = [mock_file1, mock_file2]
-        result = file_path_autocomplete(ctx, "dir1/file")
+        result = module.file_path_autocomplete(ctx, "dir1/file")
         assert set(result) == {"dir1/file1.txt", "dir1/file2.txt"}
 
 
@@ -128,11 +119,13 @@ def test_file_path_autocomplete_returns_expected_result():
 def test_file_path_autocomplete_handles_nested_prefixes(monkeypatch, tmp_path):
     """Ensure nested path autocompletion mirrors Path logic (autocomplete.py::file_path_autocomplete)."""
 
-    monkeypatch.chdir(tmp_path)
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    monkeypatch.chdir(workspace)
     # Build a directory tree with overlapping prefixes to validate ambiguity handling.
-    file_alpha = tmp_path / "alpha.txt"
-    file_beta = tmp_path / "alphabet.txt"
-    nested = tmp_path / "archive"
+    file_alpha = workspace / "alpha.txt"
+    file_beta = workspace / "alphabet.txt"
+    nested = workspace / "archive"
     nested.mkdir()
     nested_file = nested / "alpha-report.md"
     nested_other = nested / "beta-report.md"
@@ -143,17 +136,17 @@ def test_file_path_autocomplete_handles_nested_prefixes(monkeypatch, tmp_path):
 
     ctx = MagicMock()
 
-    empty = file_path_autocomplete(ctx, "")
+    empty = module.file_path_autocomplete(ctx, "")
     assert {Path(p).name for p in empty} == {
         file_alpha.name,
         file_beta.name,
         nested.name,
     }
 
-    ambiguous_local = file_path_autocomplete(ctx, "alp")
+    ambiguous_local = module.file_path_autocomplete(ctx, "alp")
     assert {Path(p).name for p in ambiguous_local} == {file_alpha.name, file_beta.name}
 
-    nested_matches = file_path_autocomplete(ctx, f"{nested.name}/a")
+    nested_matches = module.file_path_autocomplete(ctx, f"{nested.name}/a")
     assert {Path(p).name for p in nested_matches} == {nested_file.name}
 
 
@@ -162,21 +155,22 @@ def test_get_command_help_returns_expected_result():
     """Test that get_command_help returns detailed help text for a command.
 
     ReqID: FR-66a"""
-    command = next(iter(COMMAND_EXAMPLES.keys()))
-    help_text = get_command_help(command)
+    command = next(iter(module.COMMAND_EXAMPLES.keys()))
+    help_text = module.get_command_help(command)
     assert f"Command: {command}" in help_text
-    assert COMMAND_DESCRIPTIONS.get(command, "") in help_text
-    for example in COMMAND_EXAMPLES.get(command, []):
+    assert module.COMMAND_DESCRIPTIONS.get(command, "") in help_text
+    for example in module.COMMAND_EXAMPLES.get(command, []):
         assert example in help_text
     command_with_desc = next(
-        (cmd for cmd in COMMAND_DESCRIPTIONS if cmd not in COMMAND_EXAMPLES), None
+        (cmd for cmd in module.COMMAND_DESCRIPTIONS if cmd not in module.COMMAND_EXAMPLES),
+        None,
     )
     if command_with_desc:
-        help_text = get_command_help(command_with_desc)
+        help_text = module.get_command_help(command_with_desc)
         assert f"Command: {command_with_desc}" in help_text
-        assert COMMAND_DESCRIPTIONS.get(command_with_desc, "") in help_text
+        assert module.COMMAND_DESCRIPTIONS.get(command_with_desc, "") in help_text
         assert "Examples:" not in help_text
-    help_text = get_command_help("nonexistent")
+    help_text = module.get_command_help("nonexistent")
     assert "Command: nonexistent" in help_text
     assert "No description available" in help_text
 
@@ -187,12 +181,13 @@ def test_get_all_commands_help_returns_expected_result():
 
     ReqID: FR-66a"""
 
-    help_text = get_all_commands_help()
+    help_text = module.get_all_commands_help()
     assert "Available Commands:" in help_text
-    for command in COMMANDS:
+    for command in module.COMMANDS:
         assert command in help_text
         assert (
-            COMMAND_DESCRIPTIONS.get(command, "No description available") in help_text
+            module.COMMAND_DESCRIPTIONS.get(command, "No description available")
+            in help_text
         )
 
 
@@ -210,8 +205,6 @@ class _StubCompletion:
 def test_generate_completion_script_installs_to_target(monkeypatch, tmp_path):
     """Ensure installation writes the generated script to the provided path."""
 
-    import devsynth.application.cli import autocomplete as module
-
     expected = "# completion script"
     monkeypatch.setattr(module, "_load_click_command", lambda: object())
     monkeypatch.setattr(
@@ -219,7 +212,7 @@ def test_generate_completion_script_installs_to_target(monkeypatch, tmp_path):
     )
 
     target = tmp_path / "devsynth.zsh"
-    result = generate_completion_script("zsh", install=True, path=target)
+    result = module.generate_completion_script("zsh", install=True, path=target)
 
     assert result == str(target)
     assert target.read_text() == expected
@@ -228,8 +221,6 @@ def test_generate_completion_script_installs_to_target(monkeypatch, tmp_path):
 @pytest.mark.medium
 def test_generate_completion_script_uses_home_directory(monkeypatch, tmp_path):
     """Validate the default install path leverages ``Path.home()``."""
-
-    import devsynth.application.cli import autocomplete as module
 
     expected = "# bash completion"
     monkeypatch.setattr(module, "_load_click_command", lambda: object())
@@ -242,7 +233,7 @@ def test_generate_completion_script_uses_home_directory(monkeypatch, tmp_path):
         classmethod(lambda cls: tmp_path),
     )
 
-    result = generate_completion_script("bash", install=True)
+    result = module.generate_completion_script("bash", install=True)
 
     destination = tmp_path / ".devsynth-completion.bash"
     assert result == str(destination)
@@ -253,13 +244,11 @@ def test_generate_completion_script_uses_home_directory(monkeypatch, tmp_path):
 def test_generate_completion_script_returns_source(monkeypatch):
     """The helper should return the script text when not installing."""
 
-    import devsynth.application.cli import autocomplete as module
-
     expected = "# fish completion"
     monkeypatch.setattr(module, "_load_click_command", lambda: object())
     monkeypatch.setattr(
         module, "_build_shell_complete", lambda shell, command: _StubCompletion(expected)
     )
 
-    script = generate_completion_script("fish", install=False, path=None)
+    script = module.generate_completion_script("fish", install=False, path=None)
     assert script == expected

--- a/tests/unit/application/collaboration/test_wsde_memory_sync_hooks.py
+++ b/tests/unit/application/collaboration/test_wsde_memory_sync_hooks.py
@@ -6,12 +6,13 @@ import pytest
 
 from devsynth.application.collaboration.dto import AgentOpinionRecord
 from devsynth.application.collaboration.wsde_team_consensus import (
-
-pytestmark = [pytest.mark.fast]
     ConsensusBuildingMixin,
 )
 from devsynth.application.memory.memory_manager import MemoryManager
 from devsynth.domain.interfaces.memory import MemoryStore
+
+
+pytestmark = [pytest.mark.fast]
 
 
 class DummyAgent:

--- a/tests/unit/application/collaboration/test_wsde_team_consensus_summary.py
+++ b/tests/unit/application/collaboration/test_wsde_team_consensus_summary.py
@@ -1,8 +1,6 @@
 import pytest
 
 from devsynth.application.collaboration.dto import (
-
-pytestmark = [pytest.mark.fast]
     AgentOpinionRecord,
     ConsensusOutcome,
     SynthesisArtifact,
@@ -10,6 +8,9 @@ pytestmark = [pytest.mark.fast]
 from devsynth.application.collaboration.wsde_team_consensus import (
     ConsensusBuildingMixin,
 )
+
+
+pytestmark = [pytest.mark.fast]
 
 
 class DummyTeam(ConsensusBuildingMixin):

--- a/tests/unit/application/collaboration/test_wsde_team_consensus_utils.py
+++ b/tests/unit/application/collaboration/test_wsde_team_consensus_utils.py
@@ -1,11 +1,13 @@
 from unittest.mock import MagicMock
+
 import pytest
 
 from devsynth.application.collaboration.wsde_team_consensus import (
-
-pytestmark = [pytest.mark.fast]
     ConsensusBuildingMixin,
 )
+
+
+pytestmark = [pytest.mark.fast]
 
 
 class DummyConsensus(ConsensusBuildingMixin):


### PR DESCRIPTION
## Summary
- move the pytest speed markers below the import blocks in the WSDE collaboration unit tests
- update the CLI autocomplete unit tests to import the module alias, adjust path assertions, and rely on a dedicated workspace directory
- switch the ingest command to explicit package imports, guard Typer OptionInfo defaults, and archive the latest pytest collection transcript

## Testing
- `poetry run pytest -k nothing --maxfail=1` *(fails: known SyntaxError in tests/behavior/steps/test_webui_integration_error_branches.py)*
- `poetry run pytest tests/unit/application/cli/test_autocomplete.py tests/unit/application/cli/test_ingest_cmd.py --maxfail=1`


------
https://chatgpt.com/codex/tasks/task_e_68e28f60bab08333baeb97bf6e158261