### PR TITLE
fix: harden optional backend gating

### DIFF
--- a/docs/plan.md
+++ b/docs/plan.md
@@ -387,6 +387,27 @@ Maintainer setup quickstart (resource-gated backends)
   - export DEVSYNTH_RESOURCE_CHROMADB_AVAILABLE=true
   - export DEVSYNTH_RESOURCE_FAISS_AVAILABLE=true
   - export DEVSYNTH_RESOURCE_KUZU_AVAILABLE=true
+
+### Optional Resource Toggles
+
+| Resource | Flag | Default behavior | Enablement guidance |
+| --- | --- | --- | --- |
+| Anthropic API calls | `DEVSYNTH_RESOURCE_ANTHROPIC_AVAILABLE` | Auto (skips without the `anthropic` package or `ANTHROPIC_API_KEY`) | Install the `anthropic` package and export `ANTHROPIC_API_KEY` before running Anthropics-bound suites. |
+| LLM provider fallback | `DEVSYNTH_RESOURCE_LLM_PROVIDER_AVAILABLE` | Auto (detects OpenAI or LM Studio endpoints) | Provide `OPENAI_API_KEY` or `LM_STUDIO_ENDPOINT`; the `llm` extra supplies tokenizer helpers. |
+| LM Studio bridge | `DEVSYNTH_RESOURCE_LMSTUDIO_AVAILABLE` | `false` | Opt-in once the LM Studio server is reachable and the `lmstudio` extra is installed. |
+| OpenAI client | `DEVSYNTH_RESOURCE_OPENAI_AVAILABLE` | Auto (requires `OPENAI_API_KEY`) | Export `OPENAI_API_KEY`; combine with the `llm` extra when tokenizer coverage is needed. |
+| Repository inspection | `DEVSYNTH_RESOURCE_CODEBASE_AVAILABLE` | `true` | Leave enabled for local and CI runs that mount `src/devsynth`; set `false` only when intentionally omitting the code checkout. |
+| DevSynth CLI smoke tests | `DEVSYNTH_RESOURCE_CLI_AVAILABLE` | `true` | Requires the `devsynth` entry point (`poetry install --with dev`). |
+| ChromaDB store | `DEVSYNTH_RESOURCE_CHROMADB_AVAILABLE` | Auto (skips on missing imports) | Install `poetry install --extras chromadb` or `--extras memory`. |
+| FAISS vector index | `DEVSYNTH_RESOURCE_FAISS_AVAILABLE` | Auto | Install `poetry install --extras retrieval` or `--extras memory`. |
+| Kuzu graph store | `DEVSYNTH_RESOURCE_KUZU_AVAILABLE` | Auto | Install `poetry install --extras retrieval` or `--extras memory`. |
+| LMDB key-value store | `DEVSYNTH_RESOURCE_LMDB_AVAILABLE` | Auto | Install `poetry install --extras memory` or `--extras tests`. |
+| DuckDB warehouse | `DEVSYNTH_RESOURCE_DUCKDB_AVAILABLE` | Auto | Install `poetry install --extras memory` or `--extras tests`. |
+| TinyDB document store | `DEVSYNTH_RESOURCE_TINYDB_AVAILABLE` | Auto | Install `poetry install --extras memory` or `--extras tests`. |
+| RDFLib graph utilities | `DEVSYNTH_RESOURCE_RDFLIB_AVAILABLE` | Auto | Install `poetry install --extras memory`. |
+| Memory-intensive suites | `DEVSYNTH_RESOURCE_MEMORY_AVAILABLE` | `true` | Set to `false` to skip heavy memory orchestration tests when machines are resource constrained. |
+| Sentinel test toggle | `DEVSYNTH_RESOURCE_TEST_RESOURCE_AVAILABLE` | `false` | Reserved for regression tests validating the gating helpers. |
+| WebUI integrations | `DEVSYNTH_RESOURCE_WEBUI_AVAILABLE` | Auto | Install `poetry install --extras webui` (or `--extras webui_nicegui`) for UI regression coverage. |
 - Keep runs deterministic:
   - Prefer: `poetry run devsynth run-tests --speed=fast --speed=medium --no-parallel --report`
   - For smoke/stability: `poetry run devsynth run-tests --smoke --speed=fast --no-parallel`

--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -196,6 +196,32 @@ Instructions: Check off each task when completed. Subtasks are enumerated for cl
 16.3 [x] Update issues/missing-bdd-tests.md and docs/plan.md with progress.
 16.4 [x] Populate `tests/behavior/features/memory_and_context_system.feature` with executable scenarios before promoting docs/specifications/memory-and-context-system.md beyond draft.【F:docs/specifications/memory-and-context-system.md†L1-L88】【F:tests/behavior/features/memory_and_context_system.feature†L1-L28】【F:tests/behavior/steps/test_memory_and_context_system_steps.py†L1-L137】
 
+## Optional Resource Toggles
+
+The following `DEVSYNTH_RESOURCE_*` flags gate optional integrations across the
+test suite. Leave the flag unset to use the default behavior shown below, set it
+to `true` once dependencies are available, or force `false` to skip even when
+extras are installed.
+
+| Resource | Environment flag | Default | Enablement guidance |
+| --- | --- | --- | --- |
+| Anthropic API calls | `DEVSYNTH_RESOURCE_ANTHROPIC_AVAILABLE` | Auto (requires `anthropic` import and `ANTHROPIC_API_KEY`) | Install the `anthropic` package and export `ANTHROPIC_API_KEY` when exercising Anthropic adapters. |
+| LLM provider fallback | `DEVSYNTH_RESOURCE_LLM_PROVIDER_AVAILABLE` | Auto (detects OpenAI or LM Studio endpoints) | Provide `OPENAI_API_KEY` or `LM_STUDIO_ENDPOINT`; combine with the `llm` extra for local tokenizers. |
+| LM Studio bridge | `DEVSYNTH_RESOURCE_LMSTUDIO_AVAILABLE` | `false` | Install the `lmstudio` extra (`poetry install --extras lmstudio`) and start the LM Studio server before setting the flag to `true`. |
+| OpenAI client | `DEVSYNTH_RESOURCE_OPENAI_AVAILABLE` | Auto (requires `OPENAI_API_KEY`) | Export `OPENAI_API_KEY` and, if necessary, install the `llm` extra for tokenizer helpers. |
+| Repository inspection | `DEVSYNTH_RESOURCE_CODEBASE_AVAILABLE` | `true` | Keep enabled unless intentionally running without the checked-out `src/devsynth` tree. |
+| DevSynth CLI smoke tests | `DEVSYNTH_RESOURCE_CLI_AVAILABLE` | `true` | Ensure the `devsynth` entry point is installed (via `poetry install --with dev`). |
+| ChromaDB store | `DEVSYNTH_RESOURCE_CHROMADB_AVAILABLE` | Auto (skips when imports fail) | Install `poetry install --extras chromadb` or `--extras memory` before enabling. |
+| FAISS vector index | `DEVSYNTH_RESOURCE_FAISS_AVAILABLE` | Auto | Install `poetry install --extras retrieval` or `--extras memory`. |
+| Kuzu graph store | `DEVSYNTH_RESOURCE_KUZU_AVAILABLE` | Auto | Install `poetry install --extras retrieval` or `--extras memory`. |
+| LMDB key-value store | `DEVSYNTH_RESOURCE_LMDB_AVAILABLE` | Auto | Install `poetry install --extras memory` or `--extras tests`. |
+| DuckDB warehouse | `DEVSYNTH_RESOURCE_DUCKDB_AVAILABLE` | Auto | Install `poetry install --extras memory` or `--extras tests`. |
+| TinyDB document store | `DEVSYNTH_RESOURCE_TINYDB_AVAILABLE` | Auto | Install `poetry install --extras memory` or `--extras tests`. |
+| RDFLib graph utilities | `DEVSYNTH_RESOURCE_RDFLIB_AVAILABLE` | Auto | Install `poetry install --extras memory`. |
+| Memory-intensive suites | `DEVSYNTH_RESOURCE_MEMORY_AVAILABLE` | `true` | Set to `false` to skip end-to-end memory orchestration tests when resources are constrained. |
+| Sentinel test toggle | `DEVSYNTH_RESOURCE_TEST_RESOURCE_AVAILABLE` | `false` | Reserved for unit tests validating the gating helpers. |
+| WebUI integrations | `DEVSYNTH_RESOURCE_WEBUI_AVAILABLE` | Auto | Install `poetry install --extras webui` (or `--extras webui_nicegui`) before enabling UI regressions. |
+
 Notes:
 - 2025-09-21: Smoke suite now passes with Starlette pinned `<0.47` and the sitecustomize shim; see §13.1.1 plus logs/run-tests-smoke-fast-20250921T160631Z.log for the green evidence.【F:logs/run-tests-smoke-fast-20250921T160631Z.log†L33-L40】
 - Ensure tests use resource gating and avoid accidental network calls. The run-tests command should set provider defaults when unset.

--- a/tests/behavior/steps/__init__.py
+++ b/tests/behavior/steps/__init__.py
@@ -5,17 +5,13 @@ can register every step definition.  The previous lazy-import approach caused
 ``StepDefinitionNotFound`` errors when step modules were not referenced
 explicitly in test files.  Importing everything eagerly keeps collection
 reliable without a noticeable performance impact.
+
+Pytest plugin exports now live in :mod:`tests.behavior.steps.pytest_plugins`
+and are loaded from :mod:`tests.conftest`, matching pytest 8's guidance for
+centralized plugin declarations.
 """
 
 from __future__ import annotations
-
-# Pytest inspects packages for a ``pytest_plugins`` variable when importing test
-# modules.  Without this variable defined, ``pytest`` attempts to import a
-# ``pytest_plugins`` *module* from this package which triggers our ``__getattr__``
-# loader and results in ``ModuleNotFoundError`` during test collection.  Export
-# an empty list so pytest does not try to load a missing module.
-pytest_plugins: list[str] = []
-
 
 # Provide no-op ``setUpModule`` and ``tearDownModule`` hooks so pytest does not
 # attempt to lazy-import these as modules via ``__getattr__`` on this package.

--- a/tests/behavior/steps/pytest_plugins.py
+++ b/tests/behavior/steps/pytest_plugins.py
@@ -1,0 +1,7 @@
+"""Central registry for pytest plugins used by behavior step packages."""
+
+from __future__ import annotations
+
+# Empty by default; tests/conftest.py imports this module to satisfy pytest 8's
+# requirement that plugin declarations live outside package ``__init__`` files.
+PYTEST_PLUGINS: list[str] = []

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -21,6 +21,29 @@ pytest_plugins = [
     "pytester",
 ]
 
+from importlib import import_module
+
+
+def _load_additional_pytest_plugins(module_name: str) -> None:
+    """Extend ``pytest_plugins`` with entries exported from helper modules."""
+
+    try:
+        module = import_module(module_name)
+    except Exception:
+        return
+    plugin_names = getattr(module, "PYTEST_PLUGINS", None)
+    if not plugin_names:
+        plugin_names = getattr(module, "pytest_plugins", None)
+    if not plugin_names:
+        return
+    for plugin_name in plugin_names:
+        if plugin_name not in pytest_plugins:
+            pytest_plugins.append(plugin_name)
+
+
+for _provider in ["tests.behavior.steps.pytest_plugins"]:
+    _load_additional_pytest_plugins(_provider)
+
 import logging
 import os
 import random

--- a/tests/fixtures/backends.py
+++ b/tests/fixtures/backends.py
@@ -18,6 +18,11 @@ from typing import Iterator, Optional
 import pytest
 
 from tests.conftest import is_resource_available
+from tests.fixtures.resources import (
+    OPTIONAL_BACKEND_REQUIREMENTS,
+    backend_import_reason,
+    backend_skip_reason,
+)
 
 
 # --------------------------- ChromaDB -----------------------------------------
@@ -39,6 +44,16 @@ def chromadb_client(chromadb_temp_path: Path):
     """
     if not is_resource_available("chromadb"):
         pytest.skip("Resource 'chromadb' not available")
+    extras = OPTIONAL_BACKEND_REQUIREMENTS["chromadb"]["extras"]
+    skip_reason = backend_skip_reason("chromadb", extras)
+    import_reason = backend_import_reason("chromadb", extras)
+    try:
+        pytest.importorskip("chromadb", reason=import_reason)
+    except pytest.skip.Exception:
+        raise
+    except Exception as exc:  # pragma: no cover - safety for exotic import errors
+        pytest.skip(f"{skip_reason} (import failure: {exc})")
+
     try:  # pragma: no cover - simple import check
         import chromadb
 
@@ -56,6 +71,16 @@ def faiss_index():
     """
     if not is_resource_available("faiss"):
         pytest.skip("Resource 'faiss' not available")
+    extras = OPTIONAL_BACKEND_REQUIREMENTS["faiss"]["extras"]
+    skip_reason = backend_skip_reason("faiss", extras)
+    import_reason = backend_import_reason("faiss", extras)
+    try:
+        pytest.importorskip("faiss", reason=import_reason)
+    except pytest.skip.Exception:
+        raise
+    except Exception as exc:  # pragma: no cover
+        pytest.skip(f"{skip_reason} (import failure: {exc})")
+
     try:  # pragma: no cover - import check only
         import faiss  # type: ignore
 
@@ -86,6 +111,16 @@ def duckdb_path(tmp_path: Path) -> Path:
 def duckdb_connection(duckdb_path: Path):
     if not is_resource_available("duckdb"):
         pytest.skip("Resource 'duckdb' not available")
+    extras = OPTIONAL_BACKEND_REQUIREMENTS["duckdb"]["extras"]
+    skip_reason = backend_skip_reason("duckdb", extras)
+    import_reason = backend_import_reason("duckdb", extras)
+    try:
+        pytest.importorskip("duckdb", reason=import_reason)
+    except pytest.skip.Exception:
+        raise
+    except Exception as exc:  # pragma: no cover
+        pytest.skip(f"{skip_reason} (import failure: {exc})")
+
     try:  # pragma: no cover - import check only
         import duckdb  # type: ignore
 
@@ -100,6 +135,16 @@ def lmdb_env(tmp_path: Path):
     """Return a minimal LMDB environment under a temporary directory."""
     if not is_resource_available("lmdb"):
         pytest.skip("Resource 'lmdb' not available")
+    extras = OPTIONAL_BACKEND_REQUIREMENTS["lmdb"]["extras"]
+    skip_reason = backend_skip_reason("lmdb", extras)
+    import_reason = backend_import_reason("lmdb", extras)
+    try:
+        pytest.importorskip("lmdb", reason=import_reason)
+    except pytest.skip.Exception:
+        raise
+    except Exception as exc:  # pragma: no cover
+        pytest.skip(f"{skip_reason} (import failure: {exc})")
+
     try:  # pragma: no cover - import check only
         import lmdb  # type: ignore
 
@@ -123,6 +168,16 @@ def rdflib_graph():
     """Return an empty rdflib.Graph if available, else skip."""
     if not is_resource_available("rdflib"):
         pytest.skip("Resource 'rdflib' not available")
+    extras = OPTIONAL_BACKEND_REQUIREMENTS["rdflib"]["extras"]
+    skip_reason = backend_skip_reason("rdflib", extras)
+    import_reason = backend_import_reason("rdflib", extras)
+    try:
+        pytest.importorskip("rdflib", reason=import_reason)
+    except pytest.skip.Exception:
+        raise
+    except Exception as exc:  # pragma: no cover
+        pytest.skip(f"{skip_reason} (import failure: {exc})")
+
     try:  # pragma: no cover - import check only
         import rdflib  # type: ignore
 


### PR DESCRIPTION
## Summary
- make skip_if_missing_backend resilient to partial ModuleSpec instances and route missing extras through pytest.importorskip
- guard optional backend fixtures with shared skip messaging and central plugin registration
- document the DEVSYNTH_RESOURCE_* toggles in the maintainer docs and add regression tests for skip helpers

## Testing
- poetry run pytest tests/unit/general/test_backend_resource_flags.py
- poetry run pytest tests/behavior/steps/test_memory_adapter_read_and_write_operations_steps.py -k tinydb

------
https://chatgpt.com/codex/tasks/task_e_68e29a92bcd883338f0ea9978f4f4340