### PR TITLE
Annotate feature docs with implementation status callouts

### DIFF
--- a/docs/features/chromadb_memory_store.md
+++ b/docs/features/chromadb_memory_store.md
@@ -7,6 +7,7 @@ tags:
   - "documentation"
   - "feature"
 status: "draft"
+implementation_status: "partial"
 author: "DevSynth Team"
 last_reviewed: "2025-08-19"
 ---
@@ -19,3 +20,8 @@ last_reviewed: "2025-08-19"
 Feature: ChromaDB memory store
 
 Provides a persistent vector store for embeddings using ChromaDB.
+
+!!! warning "Implementation status: Partial"
+    - The adapter imports the `chromadb` client at module import time and raises if the optional dependency is missing, so the feature currently requires the extra package to be installed before the CLI can even load the module.【F:src/devsynth/adapters/chromadb_memory_store.py†L1-L118】
+    - The broader memory subsystem remains unstable—ChromaDB hardening and cross-store synchronization work are still tracked in the "Complete memory system integration" issue.【F:issues/Complete-memory-system-integration.md†L1-L37】
+    - Remediation is planned under PR-3 "Optional Backend & pytest Plugin Guardrails" in the v0.1.0a1 execution plan, which schedules fixture and resource-gating fixes for optional services like ChromaDB.【F:docs/release/v0.1.0a1_execution_plan.md†L40-L72】

--- a/docs/features/kuzu_memory_integration.md
+++ b/docs/features/kuzu_memory_integration.md
@@ -6,6 +6,7 @@ tags:
   - "documentation"
   - "feature"
 status: "draft"
+implementation_status: "partial"
 author: "DevSynth Team"
 last_reviewed: "2025-08-13"
 ---
@@ -23,3 +24,8 @@ Integrates the Kuzu graph database as a memory store, providing persistent graph
 
 - [Kuzu Memory Integration specification](../specifications/kuzu_memory_integration.md)
 - [Memory Integration Guide](../developer_guides/memory_integration_guide.md)
+
+!!! warning "Implementation status: Partial"
+    - The current adapter emulates Kùzu behaviour with a JSON-backed in-memory store and NumPy-based similarity search, so it does not yet talk to a live Kùzu database.【F:src/devsynth/adapters/memory/kuzu_adapter.py†L1-L160】
+    - Full cross-store synchronization and transactional durability remain open in the "Complete memory system integration" remediation issue.【F:issues/Complete-memory-system-integration.md†L1-L37】
+    - The v0.1.0a1 execution plan schedules optional-backend guardrails (PR-3) to stabilize adapters like the Kùzu fallback alongside ChromaDB fixes.【F:docs/release/v0.1.0a1_execution_plan.md†L40-L72】

--- a/docs/features/multi_disciplinary_dialectical_reasoning.md
+++ b/docs/features/multi_disciplinary_dialectical_reasoning.md
@@ -7,6 +7,7 @@ tags:
   - "documentation"
   - "feature"
 status: "draft"
+implementation_status: "partial"
 author: "DevSynth Team"
 last_reviewed: "2025-08-19"
 ---
@@ -19,3 +20,8 @@ last_reviewed: "2025-08-19"
 Feature: Multi-disciplinary Dialectical Reasoning
 
 WSDE teams merge perspectives across disciplines to refine solutions.
+
+!!! warning "Implementation status: Partial"
+    - The "Finalize dialectical reasoning" issue remains in progress and still calls out missing workflow integration, consensus failure handling, and broader test coverage for this reasoning loop.【F:issues/Finalize-dialectical-reasoning.md†L1-L40】
+    - The feature status matrix lists WSDE agent collaboration—including the multi-disciplinary reasoning utilities—as partial, with remaining validation tracked through the open WSDE collaboration issues.【F:docs/implementation/feature_status_matrix.md†L51-L107】
+    - The release plan’s dependency matrix treats the WSDE collaboration stack as a release-blocking remediation stream, ensuring the outstanding dialectical proofs land before the 0.1.0 hardening phase.【F:docs/plan.md†L305-L309】

--- a/docs/features/mvu_command_execution.md
+++ b/docs/features/mvu_command_execution.md
@@ -7,6 +7,7 @@ tags:
   - "documentation"
   - "feature"
 status: "draft"
+implementation_status: "in-progress"
 author: "DevSynth Team"
 last_reviewed: "2025-08-19"
 ---
@@ -19,3 +20,7 @@ last_reviewed: "2025-08-19"
 Feature: MVU Command Execution
 
 MVU CLI commands manage metadata and project setup.
+
+!!! warning "Implementation status: In progress"
+    - The "MVU Command Execution" issue remains open, documenting that the CLI workflow still needs to be implemented and validated against its BDD scenarios.【F:issues/mvu-command-execution.md†L1-L23】
+    - The release roadmap schedules MVUU engine and command tooling for the 0.1.0 milestone, so remediation is planned alongside the wider MVU deliverables.【F:docs/roadmap/release_plan.md†L70-L75】

--- a/docs/features/mvu_shell_command_execution.md
+++ b/docs/features/mvu_shell_command_execution.md
@@ -7,6 +7,7 @@ tags:
   - "documentation"
   - "feature"
 status: "draft"
+implementation_status: "in-progress"
 author: "DevSynth Team"
 last_reviewed: "2025-08-19"
 ---
@@ -19,3 +20,7 @@ last_reviewed: "2025-08-19"
 Feature: MVU shell command execution
 
 The MVU CLI runs shell commands within a traceable session.
+
+!!! warning "Implementation status: In progress"
+    - The outstanding "MVU Command Execution" issue covers the shell execution workflow as well, noting that the behaviour described here still needs implementation and executable coverage.【F:issues/mvu-command-execution.md†L1-L23】
+    - The 0.1.0 release roadmap keeps MVUU engine and command tooling on the milestone plan, so this shell workflow remains part of the tracked remediation scope.【F:docs/roadmap/release_plan.md†L70-L75】

--- a/docs/features/webui_diagnostics_page.md
+++ b/docs/features/webui_diagnostics_page.md
@@ -7,6 +7,7 @@ tags:
   - "documentation"
   - "feature"
 status: "draft"
+implementation_status: "in-progress"
 author: "DevSynth Team"
 last_reviewed: "2025-07-21"
 ---
@@ -20,3 +21,7 @@ Feature: WebUI Diagnostics Page
 
 The diagnostics page in the WebUI runs environment checks using the doctor
 command to help users verify project health.
+
+!!! warning "Implementation status: In progress"
+    - The dedicated "WebUI Diagnostics Page" issue is still marked in progress, confirming that the Streamlit page has not yet shipped despite the documentation describing its behaviour.【F:issues/webui-diagnostics-page.md†L1-L20】
+    - The v0.1.0a1 execution plan keeps documentation alignment with the critical recommendations on the remediation roadmap, so this page’s callouts will be revisited once the scheduled evidence refresh lands.【F:docs/release/v0.1.0a1_execution_plan.md†L31-L72】

--- a/docs/features/wsde_role_progression.md
+++ b/docs/features/wsde_role_progression.md
@@ -3,6 +3,7 @@ author: DevSynth Team
 date: '2025-07-20'
 last_reviewed: '2025-07-20'
 status: draft
+implementation_status: blocked
 tags:
   - feature
   - wsde
@@ -20,3 +21,8 @@ EDRR phase transition occurs, `progress_roles` reassigns roles and uses
 consistent state.
 
 This feature is exercised in `tests/behavior/features/wsde/collaboration_flow.feature`.
+
+!!! warning "Implementation status: Blocked"
+    - The "Finalize WSDE/EDRR workflow logic" issue remains blocked because integration suites still hang inside the collaboration memory utilities, so the end-to-end role progression workflow is incomplete.【F:issues/Finalize-WSDE-EDRR-workflow-logic.md†L1-L40】
+    - The feature status matrix continues to classify WSDE agent collaboration as partial, with remediation linked to the same blocked issues and archived failure reports.【F:docs/implementation/feature_status_matrix.md†L51-L107】
+    - The release plan’s dependency matrix highlights the WSDE collaboration backlog as a release-blocking remediation stream, keeping these fixes on the critical path to 0.1.0.【F:docs/plan.md†L305-L309】


### PR DESCRIPTION
## Summary
- add implementation_status metadata to critical feature docs and flag truthful readiness callouts
- document partial memory backend coverage and link remediation plan for ChromaDB and Kùzu adapters
- note outstanding WSDE, MVU, and WebUI diagnostics gaps with references to the active remediation plan

## Testing
- not run (documentation-only change)


------
https://chatgpt.com/codex/tasks/task_e_68e31e6261748333a5a90c44783150ca