### PR TITLE
Fix pytestmark placement and archive collection log

### DIFF
--- a/issues/test-collection-regressions-20251004.md
+++ b/issues/test-collection-regressions-20251004.md
@@ -36,8 +36,8 @@ Affected Area: tests
 - [ ] Move `pytest_plugins` declarations into the repository root `conftest.py` or convert to plugin registration helpers, then capture a clean `pytest --collect-only -q` transcript replacing the 2025-10-06 failure log.【F:logs/devsynth_run-tests_fast_medium_20251006T033632Z.log†L1-L84】
 - [ ] Recreate or relocate the missing `.feature` files referenced by behavior suites; update loaders and traceability documents accordingly.
 - [ ] Guard optional backend tests with `pytest.importorskip` plus `requires_resource` flags so they skip cleanly without extras.
-- [ ] Sweep unit/domain suites to move `pytestmark` statements outside import contexts and rerun targeted `pytest -k nothing` checks to prove SyntaxErrors are gone.【d62a9a†L12-L33】
-- [ ] Add explicit `import pytest` lines (or remove unused `pytestmark`) in integration suites to prevent import-time NameErrors.【e85f55†L1-L22】
+- [x] Sweep unit/domain suites to move `pytestmark` statements outside import contexts and rerun targeted `pytest -k nothing` checks to prove SyntaxErrors are gone.【d62a9a†L12-L33】【F:tests/integration/general/test_error_handling_at_integration_points.py†L7-L45】【F:tests/unit/application/memory/test_chromadb_store.py†L1-L58】【F:tests/behavior/steps/test_webui_integration_steps.py†L1-L58】【F:logs/pytest_collect_only_20251006T043523Z.log†L1-L113】
+- [x] Add explicit `import pytest` lines (or remove unused `pytestmark`) in integration suites to prevent import-time NameErrors; audit confirmed affected modules now import pytest alongside relocated markers.【e85f55†L1-L22】【F:tests/integration/general/test_error_handling_at_integration_points.py†L7-L43】【F:tests/behavior/steps/test_webui_integration_steps.py†L1-L18】
 - [ ] Update `pytest_bdd.scenarios(...)` paths to reference `features/general/*.feature` and capture refreshed traceability manifests.【6cd789†L12-L28】
 - [ ] Re-run smoke and `--collect-only` commands, attaching new logs when failures cease.
 
@@ -45,6 +45,7 @@ Affected Area: tests
 - 2025-10-04: Smoke command still fails pending broader regression fixes; captured output in `logs/devsynth_run-tests_smoke_fast_20251004T201351Z.log`.
 - 2025-10-04: `poetry run pytest tests/unit/application/cli/test_long_running_progress.py tests/unit/memory/test_sync_manager_protocol_runtime.py -q` passes locally after restoring `_ProgressIndicatorBase` exports and SyncManager generics.
 - 2025-10-07: `poetry run pytest --collect-only -q` completes without duplicate `pytest_bdd` registration; see `logs/pytest_collect_only_20251007.log` for the full transcript (warnings highlight legacy suites missing speed markers).
+- 2025-10-06: Relocated stray `pytestmark` assignments below import blocks and confirmed `poetry run pytest -k nothing --collect-only` collects without SyntaxError/NameError; transcript archived at `logs/pytest_collect_only_20251006T043523Z.log`.【F:tests/integration/general/test_error_handling_at_integration_points.py†L7-L45】【F:tests/unit/application/memory/test_chromadb_store.py†L1-L58】【F:tests/behavior/steps/test_webui_integration_steps.py†L1-L58】【F:logs/pytest_collect_only_20251006T043523Z.log†L1-L113】
 
 ```
 $ poetry run pytest tests/unit/application/cli/test_long_running_progress.py tests/unit/memory/test_sync_manager_protocol_runtime.py -q

--- a/logs/pytest_collect_only_20251006T043523Z.log
+++ b/logs/pytest_collect_only_20251006T043523Z.log
@@ -1,0 +1,552 @@
+===================================================== test session starts ======================================================
+platform linux -- Python 3.12.10, pytest-8.4.2, pluggy-1.6.0
+benchmark: 5.1.0 (defaults: timer=time.perf_counter disable_gc=False min_rounds=5 min_time=0.000005 max_time=1.0 calibration_precision=10 warmup=False warmup_iterations=100000)
+rootdir: /workspace/devsynth
+configfile: pytest.ini
+plugins: metadata-3.1.1, anyio-4.10.0, cov-6.3.0, mock-3.15.0, rerunfailures-16.0.1, langsmith-0.4.26, Faker-37.6.0, bdd-8.1.0, html-4.1.1, hypothesis-6.138.14, benchmark-5.1.0, xdist-3.8.0, asyncio-1.1.0
+asyncio: mode=Mode.STRICT, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
+collected 5213 items / 5213 deselected / 34 skipped / 0 selected
+
+======================================================= warnings summary =======================================================
+.venv/lib/python3.12/site-packages/pydantic_core/core_schema.py:4137
+.venv/lib/python3.12/site-packages/pydantic_core/core_schema.py:4137
+  /workspace/devsynth/.venv/lib/python3.12/site-packages/pydantic_core/core_schema.py:4137: DeprecationWarning: `FieldValidationInfo` is deprecated, use `ValidationInfo` instead.
+    warnings.warn(msg, DeprecationWarning, stacklevel=1)
+
+src/devsynth/application/edrr/wsde_specialized_agents.py:249
+  /workspace/devsynth/src/devsynth/application/edrr/wsde_specialized_agents.py:249: PytestCollectionWarning: cannot collect test class 'TestWriterAgent' because it has a __init__ constructor (from: tests/behavior/steps/test_wsde_multi_agent_steps.py)
+    class TestWriterAgent(BaseWSDESpecialist):
+
+tests/property/conftest.py:54
+  /workspace/devsynth/tests/property/conftest.py:54: PytestRemovedIn9Warning: The (path: py.path.local) argument is deprecated, please use (collection_path: pathlib.Path)
+  see https://docs.pytest.org/en/latest/deprecations.html#py-path-local-arguments-for-hooks-replaced-with-pathlib-path
+    def pytest_ignore_collect(path, config):  # type: ignore[override]
+
+scripts/analyze_test_dependencies.py:41
+  /workspace/devsynth/scripts/analyze_test_dependencies.py:41: PytestCollectionWarning: cannot collect test class 'TestDependencyAnalyzer' because it has a __init__ constructor (from: tests/unit/scripts/test_analyze_test_dependencies.py)
+    class TestDependencyAnalyzer(ast.NodeVisitor):
+
+scripts/analyze_test_dependencies.py:127
+  /workspace/devsynth/scripts/analyze_test_dependencies.py:127: PytestCollectionWarning: cannot collect test class 'TestFileAnalyzer' because it has a __init__ constructor (from: tests/unit/scripts/test_analyze_test_dependencies.py)
+    class TestFileAnalyzer:
+
+scripts/benchmark_test_execution.py:34
+  /workspace/devsynth/scripts/benchmark_test_execution.py:34: PytestCollectionWarning: cannot collect test class 'TestExecutionBenchmark' because it has a __init__ constructor (from: tests/unit/scripts/test_benchmark_test_execution.py)
+    class TestExecutionBenchmark:
+
+debug_coverage_test.py:14
+  debug_coverage_test.py:14: PytestWarning: Test 'debug_coverage_test.py::test_logging_functions' lacks exactly one speed marker; please add @pytest.mark.fast|medium|slow at function level
+    def test_logging_functions():
+
+debug_coverage_test.py:59
+  debug_coverage_test.py:59: PytestWarning: Test 'debug_coverage_test.py::test_serialization_functions' lacks exactly one speed marker; please add @pytest.mark.fast|medium|slow at function level
+    def test_serialization_functions():
+
+examples/calculator/tests/test_calculator.py:13
+  examples/calculator/tests/test_calculator.py:13: PytestWarning: Test 'examples/calculator/tests/test_calculator.py::test_add' lacks exactly one speed marker; please add @pytest.mark.fast|medium|slow at function level
+    def test_add():
+
+examples/calculator/tests/test_calculator.py:18
+  examples/calculator/tests/test_calculator.py:18: PytestWarning: Test 'examples/calculator/tests/test_calculator.py::test_subtract' lacks exactly one speed marker; please add @pytest.mark.fast|medium|slow at function level
+    def test_subtract():
+
+examples/calculator/tests/test_calculator.py:23
+  examples/calculator/tests/test_calculator.py:23: PytestWarning: Test 'examples/calculator/tests/test_calculator.py::test_multiply' lacks exactly one speed marker; please add @pytest.mark.fast|medium|slow at function level
+    def test_multiply():
+
+examples/calculator/tests/test_calculator.py:28
+  examples/calculator/tests/test_calculator.py:28: PytestWarning: Test 'examples/calculator/tests/test_calculator.py::test_divide' lacks exactly one speed marker; please add @pytest.mark.fast|medium|slow at function level
+    def test_divide():
+
+examples/calculator/tests/test_calculator.py:33
+  examples/calculator/tests/test_calculator.py:33: PytestWarning: Test 'examples/calculator/tests/test_calculator.py::test_divide_by_zero' lacks exactly one speed marker; please add @pytest.mark.fast|medium|slow at function level
+    def test_divide_by_zero():
+
+examples/full_workflow/tests/test_counter.py:11
+  examples/full_workflow/tests/test_counter.py:11: PytestWarning: Test 'examples/full_workflow/tests/test_counter.py::test_counts' lacks exactly one speed marker; please add @pytest.mark.fast|medium|slow at function level
+    def test_counts():
+
+src/devsynth/application/cli/commands/test_cmd.py:24
+  src/devsynth/application/cli/commands/test_cmd.py:24: PytestWarning: Test 'src/devsynth/application/cli/commands/test_cmd.py::test_cmd' lacks exactly one speed marker; please add @pytest.mark.fast|medium|slow at function level
+    def test_cmd(
+
+src/devsynth/application/cli/commands/test_metrics_cmd.py:24
+  src/devsynth/application/cli/commands/test_metrics_cmd.py:24: PytestWarning: Test 'src/devsynth/application/cli/commands/test_metrics_cmd.py::test_metrics_cmd' lacks exactly one speed marker; please add @pytest.mark.fast|medium|slow at function level
+    def test_metrics_cmd(
+
+templates/integration/sample_integration_test.py:14
+  templates/integration/sample_integration_test.py:14: PytestWarning: Test 'templates/integration/sample_integration_test.py::test_workflow' lacks exactly one speed marker; please add @pytest.mark.fast|medium|slow at function level
+    def test_workflow():
+
+templates/integration/test_integration_template.py:79
+  templates/integration/test_integration_template.py:79: PytestWarning: Test 'templates/integration/test_integration_template.py::TestComponentIntegration::test_end_to_end_workflow' lacks exactly one speed marker; please add @pytest.mark.fast|medium|slow at function level
+    def test_end_to_end_workflow(self, setup_components, test_environment):
+
+templates/integration/test_integration_template.py:109
+  templates/integration/test_integration_template.py:109: PytestWarning: Test 'templates/integration/test_integration_template.py::TestComponentIntegration::test_component_interaction_with_external_service' lacks exactly one speed marker; please add @pytest.mark.fast|medium|slow at function level
+    @patch("devsynth.module.path.external_service")
+
+templates/integration/test_integration_template.py:139
+  templates/integration/test_integration_template.py:139: PytestWarning: Test 'templates/integration/test_integration_template.py::TestComponentIntegration::test_error_propagation' lacks exactly one speed marker; please add @pytest.mark.fast|medium|slow at function level
+    def test_error_propagation(self, setup_components):
+
+templates/integration/test_integration_template.py:164
+  templates/integration/test_integration_template.py:164: PytestWarning: Test 'templates/integration/test_integration_template.py::TestComponentIntegration::test_state_changes' lacks exactly one speed marker; please add @pytest.mark.fast|medium|slow at function level
+    def test_state_changes(self, setup_components):
+
+templates/unit/sample_test.py:9
+  templates/unit/sample_test.py:9: PytestWarning: Test 'templates/unit/sample_test.py::test_add' lacks exactly one speed marker; please add @pytest.mark.fast|medium|slow at function level
+    def test_add():
+
+templates/unit/test_template.py:49
+  templates/unit/test_template.py:49: PytestWarning: Test 'templates/unit/test_template.py::TestComponentName::test_happy_path' lacks exactly one speed marker; please add @pytest.mark.fast|medium|slow at function level
+    def test_happy_path(self, component_fixture):
+
+templates/unit/test_template.py:73
+  templates/unit/test_template.py:73: PytestWarning: Test 'templates/unit/test_template.py::TestComponentName::test_edge_case' lacks exactly one speed marker; please add @pytest.mark.fast|medium|slow at function level
+    def test_edge_case(self, component_fixture):
+
+templates/unit/test_template.py:97
+  templates/unit/test_template.py:97: PytestWarning: Test 'templates/unit/test_template.py::TestComponentName::test_error_case' lacks exactly one speed marker; please add @pytest.mark.fast|medium|slow at function level
+    def test_error_case(self, component_fixture):
+
+templates/unit/test_template.py:121
+  templates/unit/test_template.py:121: PytestWarning: Test 'templates/unit/test_template.py::TestComponentName::test_with_mock' lacks exactly one speed marker; please add @pytest.mark.fast|medium|slow at function level
+    @patch("module.path.external_dependency")
+
+.venv/lib/python3.12/site-packages/pytest_bdd/scenario.py:296
+  .venv/lib/python3.12/site-packages/pytest_bdd/scenario.py:296: PytestWarning: Test 'tests/behavior/steps/test_alignment_metrics_steps.py::test_collect_metrics_successfully' lacks exactly one speed marker; please add @pytest.mark.fast|medium|slow at function level
+    def scenario_wrapper(request: FixtureRequest, _pytest_bdd_example: dict[str, str]) -> Any:
+
+.venv/lib/python3.12/site-packages/pytest_bdd/scenario.py:296
+  .venv/lib/python3.12/site-packages/pytest_bdd/scenario.py:296: PytestWarning: Test 'tests/behavior/steps/test_alignment_metrics_steps.py::test_handle_failure_during_metrics_collection' lacks exactly one speed marker; please add @pytest.mark.fast|medium|slow at function level
+    def scenario_wrapper(request: FixtureRequest, _pytest_bdd_example: dict[str, str]) -> Any:
+
+.venv/lib/python3.12/site-packages/pytest_bdd/scenario.py:296
+  .venv/lib/python3.12/site-packages/pytest_bdd/scenario.py:296: PytestWarning: Test 'tests/behavior/steps/test_performance_and_scalability_steps.py::test_baseline_metrics_are_captured' lacks exactly one speed marker; please add @pytest.mark.fast|medium|slow at function level
+    def scenario_wrapper(request: FixtureRequest, _pytest_bdd_example: dict[str, str]) -> Any:
+
+.venv/lib/python3.12/site-packages/pytest_bdd/scenario.py:296
+  .venv/lib/python3.12/site-packages/pytest_bdd/scenario.py:296: PytestWarning: Test 'tests/behavior/steps/test_performance_and_scalability_steps.py::test_baseline_throughput_is_calculated' lacks exactly one speed marker; please add @pytest.mark.fast|medium|slow at function level
+    def scenario_wrapper(request: FixtureRequest, _pytest_bdd_example: dict[str, str]) -> Any:
+
+.venv/lib/python3.12/site-packages/pytest_bdd/scenario.py:296
+  .venv/lib/python3.12/site-packages/pytest_bdd/scenario.py:296: PytestWarning: Test 'tests/behavior/steps/test_performance_and_scalability_steps.py::test_baseline_duration_is_recorded' lacks exactly one speed marker; please add @pytest.mark.fast|medium|slow at function level
+    def scenario_wrapper(request: FixtureRequest, _pytest_bdd_example: dict[str, str]) -> Any:
+
+.venv/lib/python3.12/site-packages/pytest_bdd/scenario.py:296
+  .venv/lib/python3.12/site-packages/pytest_bdd/scenario.py:296: PytestWarning: Test 'tests/behavior/steps/test_performance_and_scalability_steps.py::test_scalability_metrics_are_captured_for_varying_workloads[10000]' lacks exactly one speed marker; please add @pytest.mark.fast|medium|slow at function level
+    def scenario_wrapper(request: FixtureRequest, _pytest_bdd_example: dict[str, str]) -> Any:
+
+.venv/lib/python3.12/site-packages/pytest_bdd/scenario.py:296
+  .venv/lib/python3.12/site-packages/pytest_bdd/scenario.py:296: PytestWarning: Test 'tests/behavior/steps/test_performance_and_scalability_steps.py::test_scalability_metrics_are_captured_for_varying_workloads[100000]' lacks exactly one speed marker; please add @pytest.mark.fast|medium|slow at function level
+    def scenario_wrapper(request: FixtureRequest, _pytest_bdd_example: dict[str, str]) -> Any:
+
+.venv/lib/python3.12/site-packages/pytest_bdd/scenario.py:296
+  .venv/lib/python3.12/site-packages/pytest_bdd/scenario.py:296: PytestWarning: Test 'tests/behavior/steps/test_performance_and_scalability_steps.py::test_scalability_metrics_are_captured_for_varying_workloads[1000000]' lacks exactly one speed marker; please add @pytest.mark.fast|medium|slow at function level
+    def scenario_wrapper(request: FixtureRequest, _pytest_bdd_example: dict[str, str]) -> Any:
+
+.venv/lib/python3.12/site-packages/pytest_bdd/scenario.py:296
+  .venv/lib/python3.12/site-packages/pytest_bdd/scenario.py:296: PytestWarning: Test 'tests/behavior/steps/test_performance_and_scalability_steps.py::test_scalability_metrics_file_is_created' lacks exactly one speed marker; please add @pytest.mark.fast|medium|slow at function level
+    def scenario_wrapper(request: FixtureRequest, _pytest_bdd_example: dict[str, str]) -> Any:
+
+.venv/lib/python3.12/site-packages/pytest_bdd/scenario.py:296
+  .venv/lib/python3.12/site-packages/pytest_bdd/scenario.py:296: PytestWarning: Test 'tests/behavior/steps/test_performance_and_scalability_steps.py::test_scalability_throughput_is_calculated' lacks exactly one speed marker; please add @pytest.mark.fast|medium|slow at function level
+    def scenario_wrapper(request: FixtureRequest, _pytest_bdd_example: dict[str, str]) -> Any:
+
+.venv/lib/python3.12/site-packages/pytest_bdd/scenario.py:296
+  .venv/lib/python3.12/site-packages/pytest_bdd/scenario.py:296: PytestWarning: Test 'tests/behavior/test_alignment_metrics_command.py::test_collect_metrics_successfully' lacks exactly one speed marker; please add @pytest.mark.fast|medium|slow at function level
+    def scenario_wrapper(request: FixtureRequest, _pytest_bdd_example: dict[str, str]) -> Any:
+
+.venv/lib/python3.12/site-packages/pytest_bdd/scenario.py:296
+  .venv/lib/python3.12/site-packages/pytest_bdd/scenario.py:296: PytestWarning: Test 'tests/behavior/test_alignment_metrics_command.py::test_handle_failure_during_metrics_collection' lacks exactly one speed marker; please add @pytest.mark.fast|medium|slow at function level
+    def scenario_wrapper(request: FixtureRequest, _pytest_bdd_example: dict[str, str]) -> Any:
+
+tests/integration/collaboration/test_cross_store_memory_sync.py:86
+  tests/integration/collaboration/test_cross_store_memory_sync.py:86: PytestWarning: Test 'tests/integration/collaboration/test_cross_store_memory_sync.py::test_consensus_syncs_across_stores' lacks exactly one speed marker; please add @pytest.mark.fast|medium|slow at function level
+    def test_consensus_syncs_across_stores():
+
+tests/integration/collaboration/test_role_reassignment_shared_memory.py:67
+  tests/integration/collaboration/test_role_reassignment_shared_memory.py:67: PytestWarning: Test 'tests/integration/collaboration/test_role_reassignment_shared_memory.py::test_role_reassignment_shared_memory' lacks exactly one speed marker; please add @pytest.mark.fast|medium|slow at function level
+    @pytest.mark.requires_resource("lmdb")
+
+tests/integration/edrr/test_recursion_security.py:22
+  tests/integration/edrr/test_recursion_security.py:22: PytestWarning: Test 'tests/integration/edrr/test_recursion_security.py::test_recursion_threshold_sanitization' lacks exactly one speed marker; please add @pytest.mark.fast|medium|slow at function level
+    def test_recursion_threshold_sanitization():
+
+tests/integration/general/test_cli_webui_parity.py:77
+  tests/integration/general/test_cli_webui_parity.py:77: PytestWarning: Test 'tests/integration/general/test_cli_webui_parity.py::test_init_invocations_match_succeeds' lacks exactly one speed marker; please add @pytest.mark.fast|medium|slow at function level
+    def test_init_invocations_match_succeeds(parity_env):
+
+tests/integration/general/test_cli_webui_parity.py:99
+  tests/integration/general/test_cli_webui_parity.py:99: PytestWarning: Test 'tests/integration/general/test_cli_webui_parity.py::test_display_result_sanitization_succeeds' lacks exactly one speed marker; please add @pytest.mark.fast|medium|slow at function level
+    def test_display_result_sanitization_succeeds(parity_env, monkeypatch):
+
+tests/integration/general/test_cli_webui_parity.py:162
+  tests/integration/general/test_cli_webui_parity.py:162: PytestWarning: Test 'tests/integration/general/test_cli_webui_parity.py::test_progress_indicator_parity_succeeds' lacks exactly one speed marker; please add @pytest.mark.fast|medium|slow at function level
+    def test_progress_indicator_parity_succeeds(parity_env, monkeypatch):
+
+tests/integration/general/test_code_analysis_edrr_integration.py:41
+  tests/integration/general/test_code_analysis_edrr_integration.py:41: PytestWarning: Test 'tests/integration/general/test_code_analysis_edrr_integration.py::test_agent_type_expert_exists' lacks exactly one speed marker; please add @pytest.mark.fast|medium|slow at function level
+    def test_agent_type_expert_exists():
+
+tests/integration/general/test_code_analysis_edrr_integration.py:157
+  tests/integration/general/test_code_analysis_edrr_integration.py:157: PytestWarning: Test 'tests/integration/general/test_code_analysis_edrr_integration.py::test_code_analysis_in_edrr_workflow_succeeds' lacks exactly one speed marker; please add @pytest.mark.fast|medium|slow at function level
+    def test_code_analysis_in_edrr_workflow_succeeds(code_analysis_coordinator):
+
+tests/integration/general/test_code_analysis_edrr_integration.py:184
+  tests/integration/general/test_code_analysis_edrr_integration.py:184: PytestWarning: Test 'tests/integration/general/test_code_analysis_edrr_integration.py::test_code_transformation_in_edrr_workflow_succeeds' lacks exactly one speed marker; please add @pytest.mark.fast|medium|slow at function level
+    def test_code_transformation_in_edrr_workflow_succeeds(code_analysis_coordinator):
+
+tests/integration/general/test_code_analysis_edrr_integration.py:221
+  tests/integration/general/test_code_analysis_edrr_integration.py:221: PytestWarning: Test 'tests/integration/general/test_code_analysis_edrr_integration.py::test_code_refinement_in_edrr_workflow_succeeds' lacks exactly one speed marker; please add @pytest.mark.fast|medium|slow at function level
+    def test_code_refinement_in_edrr_workflow_succeeds(code_analysis_coordinator):
+
+tests/integration/general/test_code_analysis_wsde_integration.py:36
+  tests/integration/general/test_code_analysis_wsde_integration.py:36: PytestWarning: Test 'tests/integration/general/test_code_analysis_wsde_integration.py::test_agent_type_expert_exists' lacks exactly one speed marker; please add @pytest.mark.fast|medium|slow at function level
+    def test_agent_type_expert_exists():
+
+tests/integration/general/test_code_analysis_wsde_integration.py:184
+  tests/integration/general/test_code_analysis_wsde_integration.py:184: PytestWarning: Test 'tests/integration/general/test_code_analysis_wsde_integration.py::test_code_analysis_in_wsde_team_succeeds' lacks exactly one speed marker; please add @pytest.mark.fast|medium|slow at function level
+    def test_code_analysis_in_wsde_team_succeeds(wsde_team_with_code_analysis):
+
+tests/integration/general/test_code_analysis_wsde_integration.py:206
+  tests/integration/general/test_code_analysis_wsde_integration.py:206: PytestWarning: Test 'tests/integration/general/test_code_analysis_wsde_integration.py::test_code_transformation_in_wsde_team_succeeds' lacks exactly one speed marker; please add @pytest.mark.fast|medium|slow at function level
+    def test_code_transformation_in_wsde_team_succeeds(wsde_team_with_code_analysis):
+
+tests/integration/general/test_code_analysis_wsde_integration.py:238
+  tests/integration/general/test_code_analysis_wsde_integration.py:238: PytestWarning: Test 'tests/integration/general/test_code_analysis_wsde_integration.py::test_code_review_collaboration_in_wsde_team_succeeds' lacks exactly one speed marker; please add @pytest.mark.fast|medium|slow at function level
+    def test_code_review_collaboration_in_wsde_team_succeeds(wsde_team_with_code_analysis):
+
+tests/integration/general/test_code_analysis_wsde_integration.py:275
+  tests/integration/general/test_code_analysis_wsde_integration.py:275: PytestWarning: Test 'tests/integration/general/test_code_analysis_wsde_integration.py::test_code_refinement_in_wsde_team_succeeds' lacks exactly one speed marker; please add @pytest.mark.fast|medium|slow at function level
+    def test_code_refinement_in_wsde_team_succeeds(wsde_team_with_code_analysis):
+
+tests/integration/general/test_deployment_automation.py:19
+  tests/integration/general/test_deployment_automation.py:19: PytestWarning: Test 'tests/integration/general/test_deployment_automation.py::test_bootstrap_script_exists_and_builds_images' lacks exactly one speed marker; please add @pytest.mark.fast|medium|slow at function level
+    def test_bootstrap_script_exists_and_builds_images():
+
+tests/integration/general/test_deployment_automation.py:26
+  tests/integration/general/test_deployment_automation.py:26: PytestWarning: Test 'tests/integration/general/test_deployment_automation.py::test_health_check_script_exists_and_contains_curl' lacks exactly one speed marker; please add @pytest.mark.fast|medium|slow at function level
+    def test_health_check_script_exists_and_contains_curl():
+
+tests/integration/general/test_deployment_automation.py:33
+  tests/integration/general/test_deployment_automation.py:33: PytestWarning: Test 'tests/integration/general/test_deployment_automation.py::test_publish_image_script_exists_and_pushes' lacks exactly one speed marker; please add @pytest.mark.fast|medium|slow at function level
+    def test_publish_image_script_exists_and_pushes():
+
+tests/integration/general/test_deployment_automation.py:40
+  tests/integration/general/test_deployment_automation.py:40: PytestWarning: Test 'tests/integration/general/test_deployment_automation.py::test_docker_compose_defines_image_for_devsynth' lacks exactly one speed marker; please add @pytest.mark.fast|medium|slow at function level
+    def test_docker_compose_defines_image_for_devsynth():
+
+tests/integration/general/test_deployment_automation.py:47
+  tests/integration/general/test_deployment_automation.py:47: PytestWarning: Test 'tests/integration/general/test_deployment_automation.py::test_rollback_runbook_mentions_scripts' lacks exactly one speed marker; please add @pytest.mark.fast|medium|slow at function level
+    def test_rollback_runbook_mentions_scripts():
+
+tests/integration/general/test_deployment_automation.py:56
+  tests/integration/general/test_deployment_automation.py:56: PytestWarning: Test 'tests/integration/general/test_deployment_automation.py::test_rollback_script_exists_and_redeploys' lacks exactly one speed marker; please add @pytest.mark.fast|medium|slow at function level
+    def test_rollback_script_exists_and_redeploys():
+
+tests/integration/general/test_edrr_auto_phase_transition.py:132
+  tests/integration/general/test_edrr_auto_phase_transition.py:132: PytestWarning: Test 'tests/integration/general/test_edrr_auto_phase_transition.py::test_full_cycle_auto_transition_dynamic_roles_succeeds' lacks exactly one speed marker; please add @pytest.mark.fast|medium|slow at function level
+    def test_full_cycle_auto_transition_dynamic_roles_succeeds(coordinator):
+
+tests/integration/general/test_edrr_auto_phase_transition.py:153
+  tests/integration/general/test_edrr_auto_phase_transition.py:153: PytestWarning: Test 'tests/integration/general/test_edrr_auto_phase_transition.py::test_micro_cycle_results_aggregated_succeeds' lacks exactly one speed marker; please add @pytest.mark.fast|medium|slow at function level
+    def test_micro_cycle_results_aggregated_succeeds(coordinator):
+
+tests/integration/general/test_edrr_dynamic_roles.py:54
+  tests/integration/general/test_edrr_dynamic_roles.py:54: PytestWarning: Test 'tests/integration/general/test_edrr_dynamic_roles.py::test_dynamic_role_assignment_across_phases_succeeds' lacks exactly one speed marker; please add @pytest.mark.fast|medium|slow at function level
+    def test_dynamic_role_assignment_across_phases_succeeds(coordinator):
+
+tests/integration/general/test_edrr_manifest_dependencies.py:97
+  tests/integration/general/test_edrr_manifest_dependencies.py:97: PytestWarning: Test 'tests/integration/general/test_edrr_manifest_dependencies.py::test_manifest_dependencies_enforced_succeeds' lacks exactly one speed marker; please add @pytest.mark.fast|medium|slow at function level
+    def test_manifest_dependencies_enforced_succeeds(coordinator):
+
+tests/integration/general/test_edrr_micro_cycle_auto_transition.py:99
+  tests/integration/general/test_edrr_micro_cycle_auto_transition.py:99: PytestWarning: Test 'tests/integration/general/test_edrr_micro_cycle_auto_transition.py::test_micro_cycle_auto_transitions_succeeds' lacks exactly one speed marker; please add @pytest.mark.fast|medium|slow at function level
+    def test_micro_cycle_auto_transitions_succeeds(coordinator):
+
+tests/integration/general/test_edrr_micro_cycle_context.py:95
+  tests/integration/general/test_edrr_micro_cycle_context.py:95: PytestWarning: Test 'tests/integration/general/test_edrr_micro_cycle_context.py::test_micro_tasks_context_spawns_cycles_succeeds' lacks exactly one speed marker; please add @pytest.mark.fast|medium|slow at function level
+    def test_micro_tasks_context_spawns_cycles_succeeds(coordinator):
+
+tests/integration/general/test_edrr_micro_cycle_context.py:106
+  tests/integration/general/test_edrr_micro_cycle_context.py:106: PytestWarning: Test 'tests/integration/general/test_edrr_micro_cycle_context.py::test_nested_micro_tasks_create_recursive_cycles_succeeds' lacks exactly one speed marker; please add @pytest.mark.fast|medium|slow at function level
+    def test_nested_micro_tasks_create_recursive_cycles_succeeds(coordinator):
+
+tests/integration/general/test_edrr_mock_llm_integration.py:34
+  tests/integration/general/test_edrr_mock_llm_integration.py:34: PytestWarning: Test 'tests/integration/general/test_edrr_mock_llm_integration.py::test_edrr_cycle_with_mock_llm_succeeds' lacks exactly one speed marker; please add @pytest.mark.fast|medium|slow at function level
+    def test_edrr_cycle_with_mock_llm_succeeds(tmp_path):
+
+tests/integration/general/test_edrr_peer_review_voting.py:87
+  tests/integration/general/test_edrr_peer_review_voting.py:87: PytestWarning: Test 'tests/integration/general/test_edrr_peer_review_voting.py::test_voting_and_peer_review_succeeds' lacks exactly one speed marker; please add @pytest.mark.fast|medium|slow at function level
+    def test_voting_and_peer_review_succeeds(coordinator):
+
+tests/integration/general/test_edrr_phase_quality_assessment.py:99
+  tests/integration/general/test_edrr_phase_quality_assessment.py:99: PytestWarning: Test 'tests/integration/general/test_edrr_phase_quality_assessment.py::test_phase_quality_markers_are_recorded' lacks exactly one speed marker; please add @pytest.mark.fast|medium|slow at function level
+    def test_phase_quality_markers_are_recorded(coordinator):
+
+tests/integration/general/test_edrr_primus_rotation.py:83
+  tests/integration/general/test_edrr_primus_rotation.py:83: PytestWarning: Test 'tests/integration/general/test_edrr_primus_rotation.py::test_full_cycle_rotating_primus_succeeds' lacks exactly one speed marker; please add @pytest.mark.fast|medium|slow at function level
+    def test_full_cycle_rotating_primus_succeeds(coordinator, wsde_team):
+
+tests/integration/general/test_edrr_real_llm_integration.py:35
+  tests/integration/general/test_edrr_real_llm_integration.py:35: PytestWarning: Test 'tests/integration/general/test_edrr_real_llm_integration.py::test_edrr_cycle_with_real_llm_has_expected[openai]' lacks exactly one speed marker; please add @pytest.mark.fast|medium|slow at function level
+    @pytest.mark.parametrize(
+
+tests/integration/general/test_edrr_real_llm_integration.py:35
+  tests/integration/general/test_edrr_real_llm_integration.py:35: PytestWarning: Test 'tests/integration/general/test_edrr_real_llm_integration.py::test_edrr_cycle_with_real_llm_has_expected[lmstudio]' lacks exactly one speed marker; please add @pytest.mark.fast|medium|slow at function level
+    @pytest.mark.parametrize(
+
+tests/integration/general/test_edrr_real_llm_integration.py:121
+  tests/integration/general/test_edrr_real_llm_integration.py:121: PytestWarning: Test 'tests/integration/general/test_edrr_real_llm_integration.py::test_edrr_cycle_with_real_project_succeeds[openai]' lacks exactly one speed marker; please add @pytest.mark.fast|medium|slow at function level
+    @pytest.mark.parametrize(
+
+tests/integration/general/test_edrr_real_llm_integration.py:121
+  tests/integration/general/test_edrr_real_llm_integration.py:121: PytestWarning: Test 'tests/integration/general/test_edrr_real_llm_integration.py::test_edrr_cycle_with_real_project_succeeds[lmstudio]' lacks exactly one speed marker; please add @pytest.mark.fast|medium|slow at function level
+    @pytest.mark.parametrize(
+
+tests/integration/general/test_ingestion_pipeline.py:98
+  tests/integration/general/test_ingestion_pipeline.py:98: PytestWarning: Test 'tests/integration/general/test_ingestion_pipeline.py::test_ingest_cmd_non_interactive_priority_persists' lacks exactly one speed marker; please add @pytest.mark.fast|medium|slow at function level
+    @patch("devsynth.application.cli.ingest_cmd.validate_manifest")
+
+tests/integration/general/test_ingestion_pipeline.py:125
+  tests/integration/general/test_ingestion_pipeline.py:125: PytestWarning: Test 'tests/integration/general/test_ingestion_pipeline.py::test_cli_ingest_respects_env_non_interactive' lacks exactly one speed marker; please add @pytest.mark.fast|medium|slow at function level
+    @patch("devsynth.application.cli.commands.ingest_cmd._ingest_cmd")
+
+tests/integration/general/test_ingestion_pipeline.py:142
+  tests/integration/general/test_ingestion_pipeline.py:142: PytestWarning: Test 'tests/integration/general/test_ingestion_pipeline.py::TestIngestionMetrics::test_metrics_initialization_succeeds' lacks exactly one speed marker; please add @pytest.mark.fast|medium|slow at function level
+    def test_metrics_initialization_succeeds(self):
+
+tests/integration/general/test_ingestion_pipeline.py:157
+  tests/integration/general/test_ingestion_pipeline.py:157: PytestWarning: Test 'tests/integration/general/test_ingestion_pipeline.py::TestIngestionMetrics::test_phase_timing_has_expected' lacks exactly one speed marker; please add @pytest.mark.fast|medium|slow at function level
+    def test_phase_timing_has_expected(self):
+
+tests/integration/general/test_ingestion_pipeline.py:175
+  tests/integration/general/test_ingestion_pipeline.py:175: PytestWarning: Test 'tests/integration/general/test_ingestion_pipeline.py::TestIngestionMetrics::test_complete_metrics_succeeds' lacks exactly one speed marker; please add @pytest.mark.fast|medium|slow at function level
+    def test_complete_metrics_succeeds(self):
+
+tests/integration/general/test_ingestion_pipeline.py:187
+  tests/integration/general/test_ingestion_pipeline.py:187: PytestWarning: Test 'tests/integration/general/test_ingestion_pipeline.py::TestIngestionMetrics::test_get_summary_succeeds' lacks exactly one speed marker; please add @pytest.mark.fast|medium|slow at function level
+    def test_get_summary_succeeds(self):
+
+tests/integration/general/test_ingestion_pipeline.py:226
+  tests/integration/general/test_ingestion_pipeline.py:226: PytestWarning: Test 'tests/integration/general/test_ingestion_pipeline.py::TestIngestion::test_initialization_succeeds' lacks exactly one speed marker; please add @pytest.mark.fast|medium|slow at function level
+    def test_initialization_succeeds(self, temp_project_dir, create_manifest_file):
+
+tests/integration/general/test_ingestion_pipeline.py:240
+  tests/integration/general/test_ingestion_pipeline.py:240: PytestWarning: Test 'tests/integration/general/test_ingestion_pipeline.py::TestIngestion::test_initialization_with_nonexistent_project_root_succeeds' lacks exactly one speed marker; please add @pytest.mark.fast|medium|slow at function level
+    def test_initialization_with_nonexistent_project_root_succeeds(self):
+
+tests/integration/general/test_ingestion_pipeline.py:247
+  tests/integration/general/test_ingestion_pipeline.py:247: PytestWarning: Test 'tests/integration/general/test_ingestion_pipeline.py::TestIngestion::test_load_manifest_succeeds' lacks exactly one speed marker; please add @pytest.mark.fast|medium|slow at function level
+    def test_load_manifest_succeeds(
+
+tests/integration/general/test_ingestion_pipeline.py:259
+  tests/integration/general/test_ingestion_pipeline.py:259: PytestWarning: Test 'tests/integration/general/test_ingestion_pipeline.py::TestIngestion::test_load_manifest_file_not_found_succeeds' lacks exactly one speed marker; please add @pytest.mark.fast|medium|slow at function level
+    def test_load_manifest_file_not_found_succeeds(self, temp_project_dir):
+
+tests/integration/general/test_ingestion_pipeline.py:267
+  tests/integration/general/test_ingestion_pipeline.py:267: PytestWarning: Test 'tests/integration/general/test_ingestion_pipeline.py::TestIngestion::test_load_manifest_invalid_yaml_is_valid' lacks exactly one speed marker; please add @pytest.mark.fast|medium|slow at function level
+    def test_load_manifest_invalid_yaml_is_valid(self, temp_project_dir):
+
+tests/integration/general/test_ingestion_pipeline.py:278
+  tests/integration/general/test_ingestion_pipeline.py:278: PytestWarning: Test 'tests/integration/general/test_ingestion_pipeline.py::TestIngestion::test_load_manifest_missing_required_fields_succeeds' lacks exactly one speed marker; please add @pytest.mark.fast|medium|slow at function level
+    def test_load_manifest_missing_required_fields_succeeds(self, temp_project_dir):
+
+tests/integration/general/test_ingestion_pipeline.py:289
+  tests/integration/general/test_ingestion_pipeline.py:289: PytestWarning: Test 'tests/integration/general/test_ingestion_pipeline.py::TestIngestion::test_run_ingestion_succeeds' lacks exactly one speed marker; please add @pytest.mark.fast|medium|slow at function level
+    @patch("devsynth.domain.models.project.ProjectModel")
+
+tests/integration/general/test_ingestion_pipeline.py:329
+  tests/integration/general/test_ingestion_pipeline.py:329: PytestWarning: Test 'tests/integration/general/test_ingestion_pipeline.py::TestIngestion::test_run_ingestion_with_error_raises_error' lacks exactly one speed marker; please add @pytest.mark.fast|medium|slow at function level
+    @patch("devsynth.domain.models.project.ProjectModel")
+
+tests/integration/general/test_ingestion_pipeline.py:345
+  tests/integration/general/test_ingestion_pipeline.py:345: PytestWarning: Test 'tests/integration/general/test_ingestion_pipeline.py::TestIngestion::test_expand_phase_has_expected' lacks exactly one speed marker; please add @pytest.mark.fast|medium|slow at function level
+    @patch("devsynth.domain.models.project.ProjectModel")
+
+tests/integration/general/test_ingestion_pipeline.py:381
+  tests/integration/general/test_ingestion_pipeline.py:381: PytestWarning: Test 'tests/integration/general/test_ingestion_pipeline.py::TestIngestion::test_differentiate_phase_has_expected' lacks exactly one speed marker; please add @pytest.mark.fast|medium|slow at function level
+    def test_differentiate_phase_has_expected(
+
+tests/integration/general/test_ingestion_pipeline.py:401
+  tests/integration/general/test_ingestion_pipeline.py:401: PytestWarning: Test 'tests/integration/general/test_ingestion_pipeline.py::TestIngestion::test_refine_phase_has_expected' lacks exactly one speed marker; please add @pytest.mark.fast|medium|slow at function level
+    def test_refine_phase_has_expected(self, temp_project_dir, create_manifest_file):
+
+tests/integration/general/test_ingestion_pipeline.py:419
+  tests/integration/general/test_ingestion_pipeline.py:419: PytestWarning: Test 'tests/integration/general/test_ingestion_pipeline.py::TestIngestion::test_retrospect_phase_has_expected' lacks exactly one speed marker; please add @pytest.mark.fast|medium|slow at function level
+    def test_retrospect_phase_has_expected(
+
+tests/integration/general/test_ingestion_pipeline.py:439
+  tests/integration/general/test_ingestion_pipeline.py:439: PytestWarning: Test 'tests/integration/general/test_ingestion_pipeline.py::TestIngestion::test_evaluate_ingestion_process_succeeds' lacks exactly one speed marker; please add @pytest.mark.fast|medium|slow at function level
+    def test_evaluate_ingestion_process_succeeds(
+
+tests/integration/general/test_ingestion_pipeline.py:462
+  tests/integration/general/test_ingestion_pipeline.py:462: PytestWarning: Test 'tests/integration/general/test_ingestion_pipeline.py::TestIngestion::test_identify_improvement_areas_succeeds' lacks exactly one speed marker; please add @pytest.mark.fast|medium|slow at function level
+    def test_identify_improvement_areas_succeeds(
+
+tests/integration/general/test_ingestion_pipeline.py:476
+  tests/integration/general/test_ingestion_pipeline.py:476: PytestWarning: Test 'tests/integration/general/test_ingestion_pipeline.py::TestIngestion::test_generate_recommendations_succeeds' lacks exactly one speed marker; please add @pytest.mark.fast|medium|slow at function level
+    def test_generate_recommendations_succeeds(
+
+tests/integration/general/test_ingestion_pipeline.py:490
+  tests/integration/general/test_ingestion_pipeline.py:490: PytestWarning: Test 'tests/integration/general/test_ingestion_pipeline.py::TestIngestion::test_save_refined_data_succeeds' lacks exactly one speed marker; please add @pytest.mark.fast|medium|slow at function level
+    @patch("builtins.open", new_callable=MagicMock)
+
+tests/integration/general/test_ingestion_pipeline.py:510
+  tests/integration/general/test_ingestion_pipeline.py:510: PytestWarning: Test 'tests/integration/general/test_ingestion_pipeline.py::TestIngestion::test_generate_markdown_summary_succeeds' lacks exactly one speed marker; please add @pytest.mark.fast|medium|slow at function level
+    @patch("builtins.open", new_callable=MagicMock)
+
+tests/integration/general/test_ingestion_pipeline.py:539
+  tests/integration/general/test_ingestion_pipeline.py:539: PytestWarning: Test 'tests/integration/general/test_ingestion_pipeline.py::TestIngestion::test_full_pipeline_functions_has_expected' lacks exactly one speed marker; please add @pytest.mark.fast|medium|slow at function level
+    @patch("devsynth.domain.models.project.ProjectModel")
+
+tests/integration/general/test_ingestion_pipeline.py:580
+  tests/integration/general/test_ingestion_pipeline.py:580: PytestWarning: Test 'tests/integration/general/test_ingestion_pipeline.py::test_sync_manager_persistence_across_backends' lacks exactly one speed marker; please add @pytest.mark.fast|medium|slow at function level
+    @pytest.mark.requires_resource("lmdb")
+
+tests/integration/general/test_ingestion_pipeline.py:640
+  tests/integration/general/test_ingestion_pipeline.py:640: PytestWarning: Test 'tests/integration/general/test_ingestion_pipeline.py::test_kuzu_fallback_to_chromadb' lacks exactly one speed marker; please add @pytest.mark.fast|medium|slow at function level
+    def test_kuzu_fallback_to_chromadb(tmp_path, monkeypatch):
+
+tests/integration/general/test_multi_agent_roles_and_voting.py:77
+  tests/integration/general/test_multi_agent_roles_and_voting.py:77: PytestWarning: Test 'tests/integration/general/test_multi_agent_roles_and_voting.py::test_role_rotation_succeeds' lacks exactly one speed marker; please add @pytest.mark.fast|medium|slow at function level
+    def test_role_rotation_succeeds():
+
+tests/integration/general/test_multi_agent_roles_and_voting.py:91
+  tests/integration/general/test_multi_agent_roles_and_voting.py:91: PytestWarning: Test 'tests/integration/general/test_multi_agent_roles_and_voting.py::test_consensus_vote_with_non_unanimous_votes_succeeds' lacks exactly one speed marker; please add @pytest.mark.fast|medium|slow at function level
+    def test_consensus_vote_with_non_unanimous_votes_succeeds():
+
+tests/integration/general/test_multi_agent_roles_and_voting.py:110
+  tests/integration/general/test_multi_agent_roles_and_voting.py:110: PytestWarning: Test 'tests/integration/general/test_multi_agent_roles_and_voting.py::test_agent_adapter_multi_agent_workflow_succeeds' lacks exactly one speed marker; please add @pytest.mark.fast|medium|slow at function level
+    def test_agent_adapter_multi_agent_workflow_succeeds():
+
+tests/integration/general/test_sprint_edrr_integration.py:11
+  tests/integration/general/test_sprint_edrr_integration.py:11: PytestWarning: Test 'tests/integration/general/test_sprint_edrr_integration.py::test_requirements_analysis_updates_sprint_plan' lacks exactly one speed marker; please add @pytest.mark.fast|medium|slow at function level
+    def test_requirements_analysis_updates_sprint_plan():
+
+tests/integration/general/test_sprint_edrr_integration.py:37
+  tests/integration/general/test_sprint_edrr_integration.py:37: PytestWarning: Test 'tests/integration/general/test_sprint_edrr_integration.py::test_sprint_ceremonies_mapped_to_edrr_phases' lacks exactly one speed marker; please add @pytest.mark.fast|medium|slow at function level
+    def test_sprint_ceremonies_mapped_to_edrr_phases():
+
+tests/integration/general/test_sprint_edrr_integration.py:43
+  tests/integration/general/test_sprint_edrr_integration.py:43: PytestWarning: Test 'tests/integration/general/test_sprint_edrr_integration.py::test_retrospective_evaluation_logged' lacks exactly one speed marker; please add @pytest.mark.fast|medium|slow at function level
+    def test_retrospective_evaluation_logged():
+
+tests/integration/general/test_webui_e2e_workflows.py:214
+  tests/integration/general/test_webui_e2e_workflows.py:214: PytestWarning: Test 'tests/integration/general/test_webui_e2e_workflows.py::test_analysis_to_synthesis_workflow_succeeds' lacks exactly one speed marker; please add @pytest.mark.fast|medium|slow at function level
+    def test_analysis_to_synthesis_workflow_succeeds(webui_env):
+
+tests/integration/general/test_webui_e2e_workflows.py:259
+  tests/integration/general/test_webui_e2e_workflows.py:259: PytestWarning: Test 'tests/integration/general/test_webui_e2e_workflows.py::test_config_to_analysis_workflow_succeeds' lacks exactly one speed marker; please add @pytest.mark.fast|medium|slow at function level
+    def test_config_to_analysis_workflow_succeeds(webui_env):
+
+tests/integration/general/test_webui_e2e_workflows.py:298
+  tests/integration/general/test_webui_e2e_workflows.py:298: PytestWarning: Test 'tests/integration/general/test_webui_e2e_workflows.py::test_complete_e2e_workflow_succeeds' lacks exactly one speed marker; please add @pytest.mark.fast|medium|slow at function level
+    def test_complete_e2e_workflow_succeeds(webui_env):
+
+tests/integration/general/test_webui_e2e_workflows.py:385
+  tests/integration/general/test_webui_e2e_workflows.py:385: PytestWarning: Test 'tests/integration/general/test_webui_e2e_workflows.py::test_error_handling_in_workflow_succeeds' lacks exactly one speed marker; please add @pytest.mark.fast|medium|slow at function level
+    def test_error_handling_in_workflow_succeeds(webui_env):
+
+tests/integration/general/test_webui_e2e_workflows.py:451
+  tests/integration/general/test_webui_e2e_workflows.py:451: PytestWarning: Test 'tests/integration/general/test_webui_e2e_workflows.py::test_state_preservation_in_workflow_succeeds' lacks exactly one speed marker; please add @pytest.mark.fast|medium|slow at function level
+    def test_state_preservation_in_workflow_succeeds(webui_env):
+
+tests/integration/general/test_wsde_edrr_integration_advanced.py:109
+  tests/integration/general/test_wsde_edrr_integration_advanced.py:109: PytestWarning: Test 'tests/integration/general/test_wsde_edrr_integration_advanced.py::test_phase_specific_role_assignment_has_expected' lacks exactly one speed marker; please add @pytest.mark.fast|medium|slow at function level
+    def test_phase_specific_role_assignment_has_expected(enhanced_coordinator):
+
+tests/integration/general/test_wsde_edrr_integration_advanced.py:151
+  tests/integration/general/test_wsde_edrr_integration_advanced.py:151: PytestWarning: Test 'tests/integration/general/test_wsde_edrr_integration_advanced.py::test_quality_based_phase_transitions_has_expected' lacks exactly one speed marker; please add @pytest.mark.fast|medium|slow at function level
+    def test_quality_based_phase_transitions_has_expected(enhanced_coordinator):
+
+tests/integration/general/test_wsde_edrr_integration_advanced.py:177
+  tests/integration/general/test_wsde_edrr_integration_advanced.py:177: PytestWarning: Test 'tests/integration/general/test_wsde_edrr_integration_advanced.py::test_micro_cycle_implementation_succeeds' lacks exactly one speed marker; please add @pytest.mark.fast|medium|slow at function level
+    def test_micro_cycle_implementation_succeeds(enhanced_coordinator):
+
+tests/integration/general/test_wsde_edrr_integration_advanced.py:200
+  tests/integration/general/test_wsde_edrr_integration_advanced.py:200: PytestWarning: Test 'tests/integration/general/test_wsde_edrr_integration_advanced.py::test_error_handling_and_recovery_raises_error' lacks exactly one speed marker; please add @pytest.mark.fast|medium|slow at function level
+    def test_error_handling_and_recovery_raises_error(enhanced_coordinator):
+
+tests/integration/general/test_wsde_edrr_integration_advanced.py:224
+  tests/integration/general/test_wsde_edrr_integration_advanced.py:224: PytestWarning: Test 'tests/integration/general/test_wsde_edrr_integration_advanced.py::test_performance_metrics_and_traceability_succeeds' lacks exactly one speed marker; please add @pytest.mark.fast|medium|slow at function level
+    def test_performance_metrics_and_traceability_succeeds(enhanced_coordinator):
+
+tests/integration/general/test_wsde_edrr_integration_advanced.py:241
+  tests/integration/general/test_wsde_edrr_integration_advanced.py:241: PytestWarning: Test 'tests/integration/general/test_wsde_edrr_integration_advanced.py::test_memory_sync_hook_handles_wsde_events' lacks exactly one speed marker; please add @pytest.mark.fast|medium|slow at function level
+    def test_memory_sync_hook_handles_wsde_events():
+
+tests/integration/general/test_wsde_edrr_integration_end_to_end.py:104
+  tests/integration/general/test_wsde_edrr_integration_end_to_end.py:104: PytestWarning: Test 'tests/integration/general/test_wsde_edrr_integration_end_to_end.py::test_wsde_edrr_integration_end_to_end_succeeds' lacks exactly one speed marker; please add @pytest.mark.fast|medium|slow at function level
+    def test_wsde_edrr_integration_end_to_end_succeeds(coordinator):
+
+tests/integration/general/test_wsde_edrr_integration_end_to_end.py:149
+  tests/integration/general/test_wsde_edrr_integration_end_to_end.py:149: PytestWarning: Test 'tests/integration/general/test_wsde_edrr_integration_end_to_end.py::test_multi_agent_collaboration_with_memory_succeeds' lacks exactly one speed marker; please add @pytest.mark.fast|medium|slow at function level
+    def test_multi_agent_collaboration_with_memory_succeeds(coordinator):
+
+tests/integration/general/test_wsde_edrr_integration_end_to_end.py:175
+  tests/integration/general/test_wsde_edrr_integration_end_to_end.py:175: PytestWarning: Test 'tests/integration/general/test_wsde_edrr_integration_end_to_end.py::test_dialectical_reasoning_in_full_workflow_succeeds' lacks exactly one speed marker; please add @pytest.mark.fast|medium|slow at function level
+    def test_dialectical_reasoning_in_full_workflow_succeeds(coordinator):
+
+tests/integration/general/test_wsde_edrr_integration_end_to_end.py:214
+  tests/integration/general/test_wsde_edrr_integration_end_to_end.py:214: PytestWarning: Test 'tests/integration/general/test_wsde_edrr_integration_end_to_end.py::test_peer_review_integration_in_edrr_workflow_succeeds' lacks exactly one speed marker; please add @pytest.mark.fast|medium|slow at function level
+    def test_peer_review_integration_in_edrr_workflow_succeeds(coordinator):
+
+tests/integration/general/test_wsde_edrr_integration_end_to_end.py:287
+  tests/integration/general/test_wsde_edrr_integration_end_to_end.py:287: PytestWarning: Test 'tests/integration/general/test_wsde_edrr_integration_end_to_end.py::test_retrospective_phase_synchronizes_memory' lacks exactly one speed marker; please add @pytest.mark.fast|medium|slow at function level
+    def test_retrospective_phase_synchronizes_memory(coordinator):
+
+tests/integration/general/test_wsde_edrr_integration_end_to_end.py:304
+  tests/integration/general/test_wsde_edrr_integration_end_to_end.py:304: PytestWarning: Test 'tests/integration/general/test_wsde_edrr_integration_end_to_end.py::test_memory_sync_hook_captures_events_during_team_sync' lacks exactly one speed marker; please add @pytest.mark.fast|medium|slow at function level
+    def test_memory_sync_hook_captures_events_during_team_sync():
+
+tests/integration/general/test_wsde_memory_edrr_integration.py:35
+  tests/integration/general/test_wsde_memory_edrr_integration.py:35: PytestWarning: Test 'tests/integration/general/test_wsde_memory_edrr_integration.py::test_store_and_retrieve_solution_by_phase_succeeds' lacks exactly one speed marker; please add @pytest.mark.fast|medium|slow at function level
+    def test_store_and_retrieve_solution_by_phase_succeeds(tmp_path):
+
+tests/integration/general/test_wsde_memory_edrr_integration.py:54
+  tests/integration/general/test_wsde_memory_edrr_integration.py:54: PytestWarning: Test 'tests/integration/general/test_wsde_memory_edrr_integration.py::test_cross_store_sync_and_peer_review_workflow' lacks exactly one speed marker; please add @pytest.mark.fast|medium|slow at function level
+    def test_cross_store_sync_and_peer_review_workflow(tmp_path):
+
+tests/integration/general/test_wsde_memory_edrr_integration.py:123
+  tests/integration/general/test_wsde_memory_edrr_integration.py:123: PytestWarning: Test 'tests/integration/general/test_wsde_memory_edrr_integration.py::test_sync_manager_coordinated_backends' lacks exactly one speed marker; please add @pytest.mark.fast|medium|slow at function level
+    @pytest.mark.requires_resource("lmdb")
+
+tests/integration/general/test_wsde_peer_review_workflow.py:23
+  tests/integration/general/test_wsde_peer_review_workflow.py:23: PytestWarning: Test 'tests/integration/general/test_wsde_peer_review_workflow.py::test_run_peer_review_workflow' lacks exactly one speed marker; please add @pytest.mark.fast|medium|slow at function level
+    def test_run_peer_review_workflow(wsde_team):
+
+tests/integration/sprint_edrr/test_sprint_edrr_integration.py:22
+  tests/integration/sprint_edrr/test_sprint_edrr_integration.py:22: PytestWarning: Test 'tests/integration/sprint_edrr/test_sprint_edrr_integration.py::test_sprint_planning_cmd_maps_requirements' lacks exactly one speed marker; please add @pytest.mark.fast|medium|slow at function level
+    def test_sprint_planning_cmd_maps_requirements(tmp_path):
+
+tests/integration/sprint_edrr/test_sprint_edrr_integration.py:39
+  tests/integration/sprint_edrr/test_sprint_edrr_integration.py:39: PytestWarning: Test 'tests/integration/sprint_edrr/test_sprint_edrr_integration.py::test_wsde_team_coordinator_aggregates_retrospective' lacks exactly one speed marker; please add @pytest.mark.fast|medium|slow at function level
+    def test_wsde_team_coordinator_aggregates_retrospective():
+
+tests/unit/interface/test_webui_bridge_progress.py:240
+  tests/unit/interface/test_webui_bridge_progress.py:240: PytestWarning: Test 'tests/unit/interface/test_webui_bridge_progress.py::test_display_result_routes_and_message_capture' lacks exactly one speed marker; please add @pytest.mark.fast|medium|slow at function level
+    @pytest.mark.medium
+
+tests/unit/interface/test_webui_bridge_progress.py:265
+  tests/unit/interface/test_webui_bridge_progress.py:265: PytestWarning: Test 'tests/unit/interface/test_webui_bridge_progress.py::test_create_progress_thresholds_use_default_status' lacks exactly one speed marker; please add @pytest.mark.fast|medium|slow at function level
+    @pytest.mark.medium
+
+tests/unit/interface/test_webui_bridge_progress.py:282
+  tests/unit/interface/test_webui_bridge_progress.py:282: PytestWarning: Test 'tests/unit/interface/test_webui_bridge_progress.py::test_wizard_step_bounds_and_session_state_validation' lacks exactly one speed marker; please add @pytest.mark.fast|medium|slow at function level
+    @pytest.mark.medium
+
+-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
+================================================= Test Categorization Summary ==================================================
+Test Type Distribution:
+  Unit Tests: 7
+  Integration Tests: 16
+  Behavior Tests: 11
+
+Test Speed Distribution:
+  Fast Tests (< 1s): 34
+  Medium Tests (1-5s): 0
+  Slow Tests (> 5s): 0
+======================================== no tests collected (5213 deselected) in 8.39s =========================================

--- a/tests/behavior/steps/test_webui_integration_steps.py
+++ b/tests/behavior/steps/test_webui_integration_steps.py
@@ -9,11 +9,10 @@ import pytest
 pytest.importorskip("pytest_bdd")
 
 from pytest_bdd import given, parsers, scenarios, then, when
+from . import test_webui_integration_error_branches  # noqa: F401
 
 
 pytestmark = [pytest.mark.fast]
-
-from . import test_webui_integration_error_branches  # noqa: F401
 
 
 def _install_streamlit_stub() -> ModuleType:

--- a/tests/integration/general/test_error_handling_at_integration_points.py
+++ b/tests/integration/general/test_error_handling_at_integration_points.py
@@ -20,9 +20,6 @@ from devsynth.adapters.provider_system import FallbackProvider
 from devsynth.adapters.provider_system import LMStudioProvider as PS_LMStudioProvider
 from devsynth.adapters.provider_system import OpenAIProvider, ProviderError
 from devsynth.application.llm.providers import LMStudioProvider
-
-
-pytestmark = [pytest.mark.requires_resource("lmstudio")]
 from devsynth.application.agents.unified_agent import UnifiedAgent
 from devsynth.application.code_analysis.analyzer import CodeAnalyzer
 from devsynth.application.code_analysis.ast_transformer import AstTransformer
@@ -40,6 +37,9 @@ from devsynth.domain.models.agent import AgentConfig, AgentType
 from devsynth.domain.models.memory import MemoryItem, MemoryType
 from devsynth.domain.models.wsde_facade import WSDETeam
 from devsynth.methodology.base import Phase
+
+
+pytestmark = [pytest.mark.requires_resource("lmstudio")]
 
 
 class TestErrorHandlingAtIntegrationPoints:

--- a/tests/unit/application/memory/test_chromadb_store.py
+++ b/tests/unit/application/memory/test_chromadb_store.py
@@ -6,11 +6,12 @@ chromadb = pytest.importorskip(
     "chromadb", reason="ChromaDB optional backend is required for these tests"
 )
 
-pytestmark = [pytest.mark.requires_resource("chromadb"), pytest.mark.fast]
-
 from devsynth.application.memory.chromadb_store import ChromaDBStore
 from devsynth.application.memory.dto import MemoryRecord
 from devsynth.domain.models.memory import MemoryItem, MemoryType
+
+
+pytestmark = [pytest.mark.requires_resource("chromadb"), pytest.mark.fast]
 
 
 class _TestableChromaDBStore(ChromaDBStore):


### PR DESCRIPTION
## Summary
- relocate pytestmark declarations below import sections in integration, unit, and behavior suites and confirm pytest is imported where needed
- capture a fresh pytest collection log demonstrating clean SyntaxError/NameError-free imports
- update the test collection regression issue with evidence of the remediation

## Testing
- poetry run pytest -k nothing --collect-only

------
https://chatgpt.com/codex/tasks/task_e_68e3463e6ba88333999f33efa111c1f7