### PR TITLE
fix(cli): export long running progress base alias

### DIFF
--- a/src/devsynth/application/cli/long_running_progress.py
+++ b/src/devsynth/application/cli/long_running_progress.py
@@ -72,6 +72,9 @@ else:
     _ProgressIndicatorBase = ProgressIndicator
 
 
+__all__ = ["LongRunningProgressIndicator", "_ProgressIndicatorBase"]
+
+
 logger = DevSynthLogger(__name__)
 
 T = TypeVar("T")

--- a/tests/unit/application/cli/test_long_running_progress.py
+++ b/tests/unit/application/cli/test_long_running_progress.py
@@ -38,6 +38,18 @@ def test_progress_indicator_base_alias_is_exported() -> None:
     assert issubclass(long_running_progress.LongRunningProgressIndicator, base)
 
 
+@pytest.mark.fast
+def test_progress_indicator_base_alias_import_statement_works() -> None:
+    """Direct ``from module import`` access to the alias succeeds."""
+
+    from devsynth.application.cli.long_running_progress import (
+        _ProgressIndicatorBase as imported_base,
+    )
+
+    assert imported_base is long_running_progress.ProgressIndicator
+    assert issubclass(long_running_progress.LongRunningProgressIndicator, imported_base)
+
+
 class FakeClock:
     """Deterministic clock returning monotonically increasing floats."""
 

--- a/tests/unit/application/cli/test_long_running_progress_deterministic.py
+++ b/tests/unit/application/cli/test_long_running_progress_deterministic.py
@@ -191,6 +191,18 @@ def test_progress_indicator_base_alias_stays_exported() -> None:
     assert issubclass(long_running_progress.LongRunningProgressIndicator, base)
 
 
+@pytest.mark.fast
+def test_progress_indicator_base_alias_direct_import_succeeds() -> None:
+    """Importing the alias via ``from module import`` succeeds under stubs."""
+
+    from devsynth.application.cli.long_running_progress import (
+        _ProgressIndicatorBase as imported_base,
+    )
+
+    assert imported_base is long_running_progress.ProgressIndicator
+    assert issubclass(long_running_progress.LongRunningProgressIndicator, imported_base)
+
+
 class CountingClock:
     """Generator-backed clock based on ``itertools.count``."""
 


### PR DESCRIPTION
## Summary
- export `_ProgressIndicatorBase` from the long running progress module so runtime imports stay stable
- extend deterministic and standard CLI progress tests to cover direct `from module import` usage of the alias

## Testing
- poetry run pytest tests/unit/application/cli/test_long_running_progress.py tests/unit/memory/test_sync_manager_protocol_runtime.py -q

------
https://chatgpt.com/codex/tasks/task_e_68e3d02f868083339165971dfb503be1