### PR TITLE
fix: preserve memory store protocol runtime metadata

### DIFF
--- a/src/devsynth/memory/__init__.py
+++ b/src/devsynth/memory/__init__.py
@@ -1,6 +1,13 @@
 """Memory subsystem with tiered caching."""
 
 from .layered_cache import DictCacheLayer, MultiLayeredMemory
-from .sync_manager import SyncManager
+from .sync_manager import MemoryStore, Snapshot, SyncManager, ValueT
 
-__all__ = ["DictCacheLayer", "MultiLayeredMemory", "SyncManager"]
+__all__ = [
+    "DictCacheLayer",
+    "MemoryStore",
+    "MultiLayeredMemory",
+    "Snapshot",
+    "SyncManager",
+    "ValueT",
+]

--- a/src/devsynth/memory/sync_manager.py
+++ b/src/devsynth/memory/sync_manager.py
@@ -3,15 +3,15 @@
 from collections.abc import Mapping
 from contextlib import contextmanager
 from dataclasses import dataclass, field
-from typing import Generic, Protocol, TypeAlias, TypeVar, runtime_checkable
+from typing import Generic, Protocol, TypeVar, runtime_checkable
 
 
 ValueT = TypeVar("ValueT")
-Snapshot: TypeAlias = Mapping[str, ValueT]
+Snapshot = Mapping[str, ValueT]
 
 
 @runtime_checkable
-class MemoryStore(Protocol[ValueT]):
+class MemoryStore(Protocol, Generic[ValueT]):
     """Protocol for simple key-value stores.
 
     Stores used with :class:`SyncManager` must implement read/write helpers and


### PR DESCRIPTION
## Summary
- update `MemoryStore` to remain `runtime_checkable` while keeping explicit generic parameters and snapshot typing metadata
- re-export the memory protocol helpers from the memory package for consistent imports

## Testing
- poetry run pytest tests/unit/memory/test_sync_manager_protocol_runtime.py

------
https://chatgpt.com/codex/tasks/task_e_68e54a893e8c83338601817cbfd298d9