### PR TITLE
chore: capture smoke test run diagnostics

### DIFF
--- a/diagnostics/testing/devsynth_run_tests_smoke_fast_20251007T174914Z_summary.txt
+++ b/diagnostics/testing/devsynth_run_tests_smoke_fast_20251007T174914Z_summary.txt
@@ -1,0 +1,4 @@
+Summary for `poetry run devsynth run-tests --smoke --speed=fast --no-parallel --maxfail=1` executed 2025-10-07T17:49Z (UTC):
+- Outcome: ❌ Test collection aborted; pytest never advanced past the collector and the CLI exited with the "Test collection failed" banner.
+- Evidence: Raw console transcript stored at logs/devsynth_run-tests_smoke_fast_20251007T174914Z.log.
+- Notes: Knowledge-graph publication and coverage hints were not emitted because the run terminated during collection, so no tests executed and no artifacts were produced.

--- a/logs/devsynth_run-tests_smoke_fast_20251007T174914Z.log
+++ b/logs/devsynth_run-tests_smoke_fast_20251007T174914Z.log
@@ -1,0 +1,9 @@
+2025-10-07 17:49:21,537 - devsynth.testing.run_tests - INFO - Injected -p pytest_cov into PYTEST_ADDOPTS to preserve coverage instrumentation
+2025-10-07 17:49:21,538 - devsynth.testing.run_tests - INFO - Injected -p pytest_bdd.plugin into PYTEST_ADDOPTS to preserve pytest-bdd hooks
+2025-10-07 17:49:21,538 - devsynth.application.cli.commands.run_tests_cmd - INFO - CLI appended -p pytest_cov to PYTEST_ADDOPTS to enforce coverage instrumentation
+-p pytest_cov appended to PYTEST_ADDOPTS because plugin autoloading is disabled
+2025-10-07 17:49:21,538 - devsynth.application.cli.commands.run_tests_cmd - INFO - CLI appended -p pytest_bdd.plugin to PYTEST_ADDOPTS to preserve pytest-bdd hooks
+-p pytest_bdd.plugin appended to PYTEST_ADDOPTS because plugin autoloading is disabled
+2025-10-07 17:54:00,346 - devsynth.testing.run_tests - WARNING - Test collection failed: 
+Test collection failed:
+Tests failed


### PR DESCRIPTION
## Summary
- capture the 2025-10-07 smoke test run transcript under logs/
- add a diagnostics summary describing the collection failure and lack of knowledge-graph output

## Testing
- `poetry run devsynth run-tests --smoke --speed=fast --no-parallel --maxfail=1` *(fails: Test collection failed)*

------
https://chatgpt.com/codex/tasks/task_e_68e551054f008333887a1e316ed6d169