### PR TITLE
build: migrate extras to project optional deps

### DIFF
--- a/diagnostics/poetry_build_20251008T032328Z.log
+++ b/diagnostics/poetry_build_20251008T032328Z.log
@@ -1,0 +1,7 @@
+Building devsynth (0.1.0a1)
+Building sdist
+  - Building sdist
+  - Built devsynth-0.1.0a1.tar.gz
+Building wheel
+  - Building wheel
+  - Built devsynth-0.1.0a1-py3-none-any.whl

--- a/diagnostics/poetry_check_20251008T032324Z.log
+++ b/diagnostics/poetry_check_20251008T032324Z.log
@@ -1,0 +1,1 @@
+Warning: Defining console scripts in [tool.poetry.scripts] is deprecated. Use [project.scripts] instead. ([tool.poetry.scripts] should only be used for scripts of type 'file').

--- a/diagnostics/release_prep_verify_markers.txt
+++ b/diagnostics/release_prep_verify_markers.txt
@@ -1,1 +1,5 @@
-[info] verify_test_markers: files=1264, cache_hits=1264, cache_misses=0, issues=0, speed_violations=0, property_violations=0
+2025-10-08 03:24:01,485 - devsynth.application.utils.token_tracker - INFO - Tiktoken is available for accurate token counting
+[info] property marker advisories (informational) in tests/property:
+ - /workspace/devsynth/tests/property/test_enhanced_graph_memory_adapter.py::test_traverse_graph_depth_bound: missing @pytest.mark.property
+ - /workspace/devsynth/tests/property/test_enhanced_graph_memory_adapter.py::test_research_provenance_persists: missing @pytest.mark.property
+[info] verify_test_markers: files=1265, cache_hits=0, cache_misses=1265, issues=0, speed_violations=0, property_violations=2

--- a/diagnostics/task_release_prep_20251008T032333Z.log
+++ b/diagnostics/task_release_prep_20251008T032333Z.log
@@ -1,0 +1,2193 @@
+task: [release:prep] poetry env info --path
+/workspace/devsynth/.venv
+task: [release:prep] poetry run python scripts/verify_python_version.py
+[info] Python 3.12.10 detected
+task: [release:prep] poetry install --with dev --extras "tests retrieval chromadb api"
+Installing dependencies from lock file
+
+Package operations: 46 installs, 0 updates, 0 removals
+
+  - Installing zipp (3.23.0)
+  - Installing importlib-metadata (8.7.0)
+  - Installing opentelemetry-api (1.36.0)
+  - Installing protobuf (6.32.0)
+  - Installing pyasn1 (0.6.1)
+  - Installing fsspec (2025.9.0)
+  - Installing hf-xet (1.1.9)
+  - Installing humanfriendly (10.0)
+  - Installing mpmath (1.3.0)
+  - Installing oauthlib (3.3.1)
+  - Installing opentelemetry-proto (1.36.0)
+  - Installing opentelemetry-semantic-conventions (0.57b0)
+  - Installing pyasn1-modules (0.4.2)
+  - Installing rsa (4.9.1)
+  - Installing backoff (2.2.1)
+  - Installing coloredlogs (15.0.1)
+  - Installing durationpy (0.10)
+  - Installing flatbuffers (25.2.10)
+  - Installing google-auth (2.40.3)
+  - Installing googleapis-common-protos (1.70.0)
+  - Installing grpcio (1.74.0)
+  - Installing huggingface-hub (0.34.4)
+  - Installing opentelemetry-exporter-otlp-proto-common (1.36.0)
+  - Installing opentelemetry-sdk (1.36.0)
+  - Installing pyproject-hooks (1.2.0)
+  - Installing requests-oauthlib (2.0.0)
+  - Installing sympy (1.14.0)
+  - Installing websocket-client (1.8.0)
+  - Installing bcrypt (4.3.0)
+  - Installing build (1.3.0)
+  - Installing importlib-resources (6.5.2)
+  - Installing mmh3 (5.2.0)
+  - Installing opentelemetry-exporter-otlp-proto-grpc (1.36.0)
+  - Installing onnxruntime (1.22.1)
+  - Installing kubernetes (33.1.0)
+  - Installing overrides (7.7.0)
+  - Installing posthog (5.4.0)
+  - Installing pybase64 (1.4.2)
+  - Installing pypika (0.48.9)
+  - Installing tokenizers (0.22.0)
+  - Installing astor (0.8.1)
+  - Installing chromadb (1.0.20)
+  - Installing duckdb (1.3.2)
+  - Installing faiss-cpu (1.12.0)
+  - Installing kuzu (0.11.2)
+  - Installing lmdb (1.7.3)
+
+Installing the current project: devsynth (0.1.0a1)
+task: [release:prep] bash -lc 'mkdir -p diagnostics; poetry run python scripts/verify_test_markers.py | tee diagnostics/release_prep_verify_markers.txt; EXIT=${PIPESTATUS[0]}; exit $EXIT'
+2025-10-08 03:24:01,485 - devsynth.application.utils.token_tracker - INFO - Tiktoken is available for accurate token counting
+[info] property marker advisories (informational) in tests/property:
+ - /workspace/devsynth/tests/property/test_enhanced_graph_memory_adapter.py::test_traverse_graph_depth_bound: missing @pytest.mark.property
+ - /workspace/devsynth/tests/property/test_enhanced_graph_memory_adapter.py::test_research_provenance_persists: missing @pytest.mark.property
+[info] verify_test_markers: files=1265, cache_hits=0, cache_misses=1265, issues=0, speed_violations=0, property_violations=2
+task: [clean] rm -rf dist
+task: [clean] rm -rf .pytest_cache
+task: [clean] rm -rf .coverage
+task: [clean] rm -rf coverage.xml
+task: [clean] rm -rf site
+task: [clean] find . -type d -name __pycache__ -exec rm -rf {} +
+task: [clean] find . -name '*\,cover' -delete
+task: [build:wheel] poetry build --format wheel
+Building devsynth (0.1.0a1)
+Building wheel
+  - Building wheel
+  - Built devsynth-0.1.0a1-py3-none-any.whl
+task: [build:sdist] poetry build --format sdist
+Building devsynth (0.1.0a1)
+Building sdist
+  - Building sdist
+  - Built devsynth-0.1.0a1.tar.gz
+task: [test:smoke] PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 poetry run pytest -p no:cov -p no:xdist --maxfail=1 -q
+ssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssss [  2%]
+ssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssss [  4%]
+ssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssss [  6%]
+ssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssss [  9%]
+ssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssss [ 11%]
+ssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssss [ 13%]
+ssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssss [ 16%]
+ssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssss [ 18%]
+ssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssss [ 20%]
+ssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssss [ 22%]
+ssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssss [ 25%]
+ssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssss [ 27%]
+ssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssss [ 29%]
+ssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssss [ 32%]
+ssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssss [ 34%]
+ssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssss [ 36%]
+ssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssss [ 38%]
+ssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssss [ 41%]
+ssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssss [ 43%]
+ssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssss [ 45%]
+ssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssss [ 48%]
+ssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssss [ 50%]
+ssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssss [ 52%]
+ssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssss [ 54%]
+ssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssss [ 57%]
+ssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssss [ 59%]
+ssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssss [ 61%]
+ssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssss [ 64%]
+ssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssss [ 66%]
+ssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssss [ 68%]
+ssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssss [ 70%]
+ssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssss [ 73%]
+ssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssss [ 75%]
+ssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssss [ 77%]
+ssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssss [ 80%]
+ssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssss [ 82%]
+ssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssss [ 84%]
+ssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssss [ 86%]
+ssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssss [ 89%]
+ssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssss [ 91%]
+ssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssss [ 93%]
+ssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssss [ 96%]
+ssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssss [ 98%]
+ssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssss                               [100%]
+======================================================= warnings summary =======================================================
+.venv/lib/python3.12/site-packages/pydantic_core/core_schema.py:4137
+.venv/lib/python3.12/site-packages/pydantic_core/core_schema.py:4137
+  /workspace/devsynth/.venv/lib/python3.12/site-packages/pydantic_core/core_schema.py:4137: DeprecationWarning: `FieldValidationInfo` is deprecated, use `ValidationInfo` instead.
+    warnings.warn(msg, DeprecationWarning, stacklevel=1)
+
+.venv/lib/python3.12/site-packages/astor/op_util.py:92
+  /workspace/devsynth/.venv/lib/python3.12/site-packages/astor/op_util.py:92: DeprecationWarning: ast.Num is deprecated and will be removed in Python 3.14; use ast.Constant instead
+    precedence_data = dict((getattr(ast, x, None), z) for x, y, z in op_data)
+
+<frozen importlib._bootstrap>:488
+  <frozen importlib._bootstrap>:488: DeprecationWarning: builtin type SwigPyPacked has no __module__ attribute
+
+<frozen importlib._bootstrap>:488
+  <frozen importlib._bootstrap>:488: DeprecationWarning: builtin type SwigPyObject has no __module__ attribute
+
+<frozen importlib._bootstrap>:488
+  <frozen importlib._bootstrap>:488: DeprecationWarning: builtin type swigvarlink has no __module__ attribute
+
+src/devsynth/application/edrr/wsde_specialized_agents.py:249
+  /workspace/devsynth/src/devsynth/application/edrr/wsde_specialized_agents.py:249: PytestCollectionWarning: cannot collect test class 'TestWriterAgent' because it has a __init__ constructor (from: tests/behavior/steps/test_wsde_multi_agent_steps.py)
+    class TestWriterAgent(BaseWSDESpecialist):
+
+tests/property/conftest.py:54
+  /workspace/devsynth/tests/property/conftest.py:54: PytestRemovedIn9Warning: The (path: py.path.local) argument is deprecated, please use (collection_path: pathlib.Path)
+  see https://docs.pytest.org/en/latest/deprecations.html#py-path-local-arguments-for-hooks-replaced-with-pathlib-path
+    def pytest_ignore_collect(path, config):  # type: ignore[override]
+
+scripts/analyze_test_dependencies.py:41
+  /workspace/devsynth/scripts/analyze_test_dependencies.py:41: PytestCollectionWarning: cannot collect test class 'TestDependencyAnalyzer' because it has a __init__ constructor (from: tests/unit/scripts/test_analyze_test_dependencies.py)
+    class TestDependencyAnalyzer(ast.NodeVisitor):
+
+scripts/analyze_test_dependencies.py:127
+  /workspace/devsynth/scripts/analyze_test_dependencies.py:127: PytestCollectionWarning: cannot collect test class 'TestFileAnalyzer' because it has a __init__ constructor (from: tests/unit/scripts/test_analyze_test_dependencies.py)
+    class TestFileAnalyzer:
+
+scripts/benchmark_test_execution.py:34
+  /workspace/devsynth/scripts/benchmark_test_execution.py:34: PytestCollectionWarning: cannot collect test class 'TestExecutionBenchmark' because it has a __init__ constructor (from: tests/unit/scripts/test_benchmark_test_execution.py)
+    class TestExecutionBenchmark:
+
+tests/integration/memory/test_kuzu_embedded_fast.py:41
+  tests/integration/memory/test_kuzu_embedded_fast.py:41: PytestWarning: Test 'tests/integration/memory/test_kuzu_embedded_fast.py::test_kuzu_store_round_trip' lacks exactly one speed marker; please add @pytest.mark.fast|medium|slow at function level
+    def test_kuzu_store_round_trip(tmp_path, monkeypatch):
+
+tests/integration/memory/test_kuzu_embedded_fast.py:70
+  tests/integration/memory/test_kuzu_embedded_fast.py:70: PytestWarning: Test 'tests/integration/memory/test_kuzu_embedded_fast.py::test_kuzu_memory_store_search_round_trip' lacks exactly one speed marker; please add @pytest.mark.fast|medium|slow at function level
+    def test_kuzu_memory_store_search_round_trip(tmp_path, monkeypatch):
+
+-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
+================================================= Test Categorization Summary ==================================================
+Test Type Distribution:
+  Unit Tests: 3821
+  Integration Tests: 443
+  Behavior Tests: 961
+
+Test Speed Distribution:
+  Fast Tests (< 1s): 5274
+  Medium Tests (1-5s): 0
+  Slow Tests (> 5s): 0
+===================================================== Top 10 Slowest Tests =====================================================
+1. tests/behavior/test_webui_commands.py::test_analyze_test_metrics: 0.20s
+2. tests/unit/application/requirements/test_dialectical_reasoner.py::test_assess_impact_stores_with_phase: 0.04s
+3. tests/unit/security/test_validation.py::TestValidateNonEmpty::test_invalid_string_is_valid[]: 0.00s
+4. tests/behavior/steps/test_webui_navigation_prompts_steps.py::test_submit_onboarding_information_when_prompted: 0.00s
+5. debug_coverage_test.py::test_logging_functions: 0.00s
+6. tests/unit/application/requirements/test_dialectical_reasoner_parsing_payloads.py::test_argument_parsing_consensus_failure_payload_preserved: 0.00s
+7. tests/unit/application/llm/test_offline_provider.py::TestOfflineProvider::test_get_embedding_is_deterministic: 0.00s
+8. tests/behavior/steps/test_edrr_enhanced_recursion_steps.py::test_start_edrr_cycle_from_a_manifest_file: 0.00s
+9. tests/unit/methodology/test_edrr_coordinator.py::test_record_consensus_failure_logs: 0.00s
+10. tests/unit/domain/models/test_wsde_dialectical_reasoning.py::TestWSDEDialecticalReasoning::test_balance_security_and_performance_succeeds: 0.00s
+5274 skipped, 13 warnings in 547.42s (0:09:07)
+task: [security:bandit] poetry run bandit -q -r src
+[manager]	WARNING	Test in comment: shell is not a test name or id, ignoring
+[manager]	WARNING	Test in comment: arg is not a test name or id, ignoring
+[manager]	WARNING	Test in comment: specifies is not a test name or id, ignoring
+[manager]	WARNING	Test in comment: completion is not a test name or id, ignoring
+[manager]	WARNING	Test in comment: target is not a test name or id, ignoring
+[manager]	WARNING	Test in comment: shell is not a test name or id, ignoring
+[manager]	WARNING	Test in comment: arg is not a test name or id, ignoring
+[manager]	WARNING	Test in comment: specifies is not a test name or id, ignoring
+[manager]	WARNING	Test in comment: completion is not a test name or id, ignoring
+[manager]	WARNING	Test in comment: target is not a test name or id, ignoring
+[manager]	WARNING	Test in comment: shell is not a test name or id, ignoring
+[manager]	WARNING	Test in comment: arg is not a test name or id, ignoring
+[manager]	WARNING	Test in comment: selects is not a test name or id, ignoring
+[manager]	WARNING	Test in comment: completion is not a test name or id, ignoring
+[manager]	WARNING	Test in comment: target is not a test name or id, ignoring
+[manager]	WARNING	Test in comment: internal is not a test name or id, ignoring
+[manager]	WARNING	Test in comment: checkpoints is not a test name or id, ignoring
+[manager]	WARNING	Test in comment: from is not a test name or id, ignoring
+[manager]	WARNING	Test in comment: trusted is not a test name or id, ignoring
+[manager]	WARNING	Test in comment: source is not a test name or id, ignoring
+[manager]	WARNING	Test in comment: workflows is not a test name or id, ignoring
+[manager]	WARNING	Test in comment: stored is not a test name or id, ignoring
+[manager]	WARNING	Test in comment: and is not a test name or id, ignoring
+[manager]	WARNING	Test in comment: loaded is not a test name or id, ignoring
+[manager]	WARNING	Test in comment: locally is not a test name or id, ignoring
+[manager]	WARNING	Test in comment: only is not a test name or id, ignoring
+[manager]	WARNING	Test in comment: default is not a test name or id, ignoring
+[manager]	WARNING	Test in comment: open is not a test name or id, ignoring
+[manager]	WARNING	Test in comment: binding is not a test name or id, ignoring
+[manager]	WARNING	Test in comment: for is not a test name or id, ignoring
+[manager]	WARNING	Test in comment: developer is not a test name or id, ignoring
+[manager]	WARNING	Test in comment: convenience is not a test name or id, ignoring
+[manager]	WARNING	Test in comment: intentionally is not a test name or id, ignoring
+[manager]	WARNING	Test in comment: exposed is not a test name or id, ignoring
+[manager]	WARNING	Test in comment: for is not a test name or id, ignoring
+[manager]	WARNING	Test in comment: remote is not a test name or id, ignoring
+[manager]	WARNING	Test in comment: access is not a test name or id, ignoring
+[tester]	WARNING	nosec encountered (B104), but no failed test on line 1516
+Run started:2025-10-08 03:33:46.983858
+
+Test results:
+>> Issue: [B110:try_except_pass] Try, Except, Pass detected.
+   Severity: Low   Confidence: High
+   CWE: CWE-703 (https://cwe.mitre.org/data/definitions/703.html)
+   More Info: https://bandit.readthedocs.io/en/1.8.6/plugins/b110_try_except_pass.html
+   Location: src/devsynth/adapters/chromadb_memory_store.py:257:8
+256	            self.close()
+257	        except Exception:  # pragma: no cover - defensive
+258	            pass
+259	
+
+--------------------------------------------------
+>> Issue: [B110:try_except_pass] Try, Except, Pass detected.
+   Severity: Low   Confidence: High
+   CWE: CWE-703 (https://cwe.mitre.org/data/definitions/703.html)
+   More Info: https://bandit.readthedocs.io/en/1.8.6/plugins/b110_try_except_pass.html
+   Location: src/devsynth/adapters/cli/typer_adapter.py:424:12
+423	                )
+424	            except Exception:
+425	                # Do not crash CLI due to logging issues
+426	                pass
+427	
+
+--------------------------------------------------
+>> Issue: [B110:try_except_pass] Try, Except, Pass detected.
+   Severity: Low   Confidence: High
+   CWE: CWE-703 (https://cwe.mitre.org/data/definitions/703.html)
+   More Info: https://bandit.readthedocs.io/en/1.8.6/plugins/b110_try_except_pass.html
+   Location: src/devsynth/adapters/cli/typer_adapter.py:458:12
+457	                method()
+458	            except Exception:
+459	                pass
+460	    return app
+
+--------------------------------------------------
+>> Issue: [B403:blacklist] Consider possible security implications associated with pickle module.
+   Severity: Low   Confidence: High
+   CWE: CWE-502 (https://cwe.mitre.org/data/definitions/502.html)
+   More Info: https://bandit.readthedocs.io/en/1.8.6/blacklists/blacklist_imports.html#b403-import-pickle
+   Location: src/devsynth/adapters/orchestration/langgraph_adapter.py:9:0
+8	import os
+9	import pickle
+10	from collections.abc import Callable
+
+--------------------------------------------------
+>> Issue: [B403:blacklist] Consider possible security implications associated with pickle module.
+   Severity: Low   Confidence: High
+   CWE: CWE-502 (https://cwe.mitre.org/data/definitions/502.html)
+   More Info: https://bandit.readthedocs.io/en/1.8.6/blacklists/blacklist_imports.html#b403-import-pickle
+   Location: src/devsynth/adapters/orchestration/langgraph_adapter.py:498:12
+497	        if "pytest" in sys.modules:
+498	            import pickle
+499	
+
+--------------------------------------------------
+>> Issue: [B311:blacklist] Standard pseudo-random generators are not suitable for security/cryptographic purposes.
+   Severity: Low   Confidence: High
+   CWE: CWE-330 (https://cwe.mitre.org/data/definitions/330.html)
+   More Info: https://bandit.readthedocs.io/en/1.8.6/blacklists/blacklist_calls.html#b311-random
+   Location: src/devsynth/adapters/provider_system.py:832:47
+831	
+832	                        delay = delay * (0.5 + random.random())
+833	
+
+--------------------------------------------------
+>> Issue: [B311:blacklist] Standard pseudo-random generators are not suitable for security/cryptographic purposes.
+   Severity: Low   Confidence: High
+   CWE: CWE-330 (https://cwe.mitre.org/data/definitions/330.html)
+   More Info: https://bandit.readthedocs.io/en/1.8.6/blacklists/blacklist_calls.html#b311-random
+   Location: src/devsynth/adapters/provider_system.py:1004:47
+1003	
+1004	                        delay = delay * (0.5 + random.random())
+1005	
+
+--------------------------------------------------
+>> Issue: [B311:blacklist] Standard pseudo-random generators are not suitable for security/cryptographic purposes.
+   Severity: Low   Confidence: High
+   CWE: CWE-330 (https://cwe.mitre.org/data/definitions/330.html)
+   More Info: https://bandit.readthedocs.io/en/1.8.6/blacklists/blacklist_calls.html#b311-random
+   Location: src/devsynth/adapters/provider_system.py:1309:47
+1308	
+1309	                        delay = delay * (0.5 + random.random())
+1310	
+
+--------------------------------------------------
+>> Issue: [B311:blacklist] Standard pseudo-random generators are not suitable for security/cryptographic purposes.
+   Severity: Low   Confidence: High
+   CWE: CWE-330 (https://cwe.mitre.org/data/definitions/330.html)
+   More Info: https://bandit.readthedocs.io/en/1.8.6/blacklists/blacklist_calls.html#b311-random
+   Location: src/devsynth/adapters/provider_system.py:1477:47
+1476	
+1477	                        delay = delay * (0.5 + random.random())
+1478	
+
+--------------------------------------------------
+>> Issue: [B404:blacklist] Consider possible security implications associated with the subprocess module.
+   Severity: Low   Confidence: High
+   CWE: CWE-78 (https://cwe.mitre.org/data/definitions/78.html)
+   More Info: https://bandit.readthedocs.io/en/1.8.6/blacklists/blacklist_imports.html#b404-import-subprocess
+   Location: src/devsynth/agents/sandbox.py:6:0
+5	import builtins
+6	import subprocess
+7	from collections.abc import Callable
+
+--------------------------------------------------
+>> Issue: [B404:blacklist] Consider possible security implications associated with the subprocess module.
+   Severity: Low   Confidence: High
+   CWE: CWE-78 (https://cwe.mitre.org/data/definitions/78.html)
+   More Info: https://bandit.readthedocs.io/en/1.8.6/blacklists/blacklist_imports.html#b404-import-subprocess
+   Location: src/devsynth/application/agents/test.py:5:0
+4	import re
+5	import subprocess
+6	import sys
+
+--------------------------------------------------
+>> Issue: [B603:subprocess_without_shell_equals_true] subprocess call - check for execution of untrusted input.
+   Severity: Low   Confidence: High
+   CWE: CWE-78 (https://cwe.mitre.org/data/definitions/78.html)
+   More Info: https://bandit.readthedocs.io/en/1.8.6/plugins/b603_subprocess_without_shell_equals_true.html
+   Location: src/devsynth/application/agents/test.py:127:17
+126	
+127	        result = subprocess.run(
+128	            [sys.executable, "-m", "pytest", "-q"],
+129	            cwd=str(directory),
+130	            env=env,
+131	            capture_output=True,
+132	            text=True,
+133	        )
+134	        output = result.stdout + result.stderr
+
+--------------------------------------------------
+>> Issue: [B112:try_except_continue] Try, Except, Continue detected.
+   Severity: Low   Confidence: High
+   CWE: CWE-703 (https://cwe.mitre.org/data/definitions/703.html)
+   More Info: https://bandit.readthedocs.io/en/1.8.6/plugins/b112_try_except_continue.html
+   Location: src/devsynth/application/agents/wsde_memory_integration.py:189:24
+188	                                break
+189	                        except Exception:
+190	                            continue
+191	                for item in items:
+
+--------------------------------------------------
+>> Issue: [B404:blacklist] Consider possible security implications associated with the subprocess module.
+   Severity: Low   Confidence: High
+   CWE: CWE-78 (https://cwe.mitre.org/data/definitions/78.html)
+   More Info: https://bandit.readthedocs.io/en/1.8.6/blacklists/blacklist_imports.html#b404-import-subprocess
+   Location: src/devsynth/application/cli/commands/completion_cmd.py:9:0
+8	import shutil
+9	import subprocess
+10	import sys
+
+--------------------------------------------------
+>> Issue: [B607:start_process_with_partial_path] Starting a process with a partial executable path
+   Severity: Low   Confidence: High
+   CWE: CWE-78 (https://cwe.mitre.org/data/definitions/78.html)
+   More Info: https://bandit.readthedocs.io/en/1.8.6/plugins/b607_start_process_with_partial_path.html
+   Location: src/devsynth/application/cli/commands/completion_cmd.py:90:25
+89	            try:
+90	                result = subprocess.run(
+91	                    ["brew", "--prefix"], capture_output=True, text=True, check=False
+92	                )
+93	                if result.returncode == 0:
+
+--------------------------------------------------
+>> Issue: [B603:subprocess_without_shell_equals_true] subprocess call - check for execution of untrusted input.
+   Severity: Low   Confidence: High
+   CWE: CWE-78 (https://cwe.mitre.org/data/definitions/78.html)
+   More Info: https://bandit.readthedocs.io/en/1.8.6/plugins/b603_subprocess_without_shell_equals_true.html
+   Location: src/devsynth/application/cli/commands/completion_cmd.py:90:25
+89	            try:
+90	                result = subprocess.run(
+91	                    ["brew", "--prefix"], capture_output=True, text=True, check=False
+92	                )
+93	                if result.returncode == 0:
+
+--------------------------------------------------
+>> Issue: [B101:assert_used] Use of assert detected. The enclosed code will be removed when compiling to optimised byte code.
+   Severity: Low   Confidence: High
+   CWE: CWE-703 (https://cwe.mitre.org/data/definitions/703.html)
+   More Info: https://bandit.readthedocs.io/en/1.8.6/plugins/b101_assert_used.html
+   Location: src/devsynth/application/cli/commands/doctor_cmd.py:177:8
+176	        spec = importlib.util.spec_from_file_location("validate_config", script_path)
+177	        assert spec and spec.loader
+178	        module = importlib.util.module_from_spec(spec)
+
+--------------------------------------------------
+>> Issue: [B404:blacklist] Consider possible security implications associated with the subprocess module.
+   Severity: Low   Confidence: High
+   CWE: CWE-78 (https://cwe.mitre.org/data/definitions/78.html)
+   More Info: https://bandit.readthedocs.io/en/1.8.6/blacklists/blacklist_imports.html#b404-import-subprocess
+   Location: src/devsynth/application/cli/commands/mvu_exec_cmd.py:7:0
+6	
+7	import subprocess
+8	from typing import List, Optional
+
+--------------------------------------------------
+>> Issue: [B603:subprocess_without_shell_equals_true] subprocess call - check for execution of untrusted input.
+   Severity: Low   Confidence: High
+   CWE: CWE-78 (https://cwe.mitre.org/data/definitions/78.html)
+   More Info: https://bandit.readthedocs.io/en/1.8.6/plugins/b603_subprocess_without_shell_equals_true.html
+   Location: src/devsynth/application/cli/commands/mvu_exec_cmd.py:30:16
+29	    logger.debug("Executing MVU command: %s", command)
+30	    completed = subprocess.run(command, capture_output=True, text=True)
+31	    output = (completed.stdout or "") + (completed.stderr or "")
+
+--------------------------------------------------
+>> Issue: [B404:blacklist] Consider possible security implications associated with the subprocess module.
+   Severity: Low   Confidence: High
+   CWE: CWE-78 (https://cwe.mitre.org/data/definitions/78.html)
+   More Info: https://bandit.readthedocs.io/en/1.8.6/blacklists/blacklist_imports.html#b404-import-subprocess
+   Location: src/devsynth/application/cli/commands/mvuu_dashboard_cmd.py:13:0
+12	import os
+13	import subprocess
+14	import sys
+
+--------------------------------------------------
+>> Issue: [B607:start_process_with_partial_path] Starting a process with a partial executable path
+   Severity: Low   Confidence: High
+   CWE: CWE-78 (https://cwe.mitre.org/data/definitions/78.html)
+   More Info: https://bandit.readthedocs.io/en/1.8.6/plugins/b607_start_process_with_partial_path.html
+   Location: src/devsynth/application/cli/commands/mvuu_dashboard_cmd.py:247:4
+246	    trace_path = repo_root / "traceability.json"
+247	    subprocess.run(
+248	        ["devsynth", "mvu", "report", "--output", str(trace_path)],
+249	        check=False,
+250	    )
+251	    env = os.environ.copy()
+
+--------------------------------------------------
+>> Issue: [B603:subprocess_without_shell_equals_true] subprocess call - check for execution of untrusted input.
+   Severity: Low   Confidence: High
+   CWE: CWE-78 (https://cwe.mitre.org/data/definitions/78.html)
+   More Info: https://bandit.readthedocs.io/en/1.8.6/plugins/b603_subprocess_without_shell_equals_true.html
+   Location: src/devsynth/application/cli/commands/mvuu_dashboard_cmd.py:247:4
+246	    trace_path = repo_root / "traceability.json"
+247	    subprocess.run(
+248	        ["devsynth", "mvu", "report", "--output", str(trace_path)],
+249	        check=False,
+250	    )
+251	    env = os.environ.copy()
+
+--------------------------------------------------
+>> Issue: [B607:start_process_with_partial_path] Starting a process with a partial executable path
+   Severity: Low   Confidence: High
+   CWE: CWE-78 (https://cwe.mitre.org/data/definitions/78.html)
+   More Info: https://bandit.readthedocs.io/en/1.8.6/plugins/b607_start_process_with_partial_path.html
+   Location: src/devsynth/application/cli/commands/mvuu_dashboard_cmd.py:315:4
+314	
+315	    subprocess.run(["streamlit", "run", str(script_path)], check=False, env=env)
+316	    return 0
+
+--------------------------------------------------
+>> Issue: [B603:subprocess_without_shell_equals_true] subprocess call - check for execution of untrusted input.
+   Severity: Low   Confidence: High
+   CWE: CWE-78 (https://cwe.mitre.org/data/definitions/78.html)
+   More Info: https://bandit.readthedocs.io/en/1.8.6/plugins/b603_subprocess_without_shell_equals_true.html
+   Location: src/devsynth/application/cli/commands/mvuu_dashboard_cmd.py:315:4
+314	
+315	    subprocess.run(["streamlit", "run", str(script_path)], check=False, env=env)
+316	    return 0
+
+--------------------------------------------------
+>> Issue: [B105:hardcoded_password_string] Possible hardcoded password: '-p'
+   Severity: Low   Confidence: Medium
+   CWE: CWE-259 (https://cwe.mitre.org/data/definitions/259.html)
+   More Info: https://bandit.readthedocs.io/en/1.8.6/plugins/b105_hardcoded_password_string.html
+   Location: src/devsynth/application/cli/commands/run_tests_cmd.py:128:20
+127	    for index, token in enumerate(tokens):
+128	        if token == "-p" and index + 1 < len(tokens) and tokens[index + 1] == plugin:
+129	            return True
+
+--------------------------------------------------
+>> Issue: [B110:try_except_pass] Try, Except, Pass detected.
+   Severity: Low   Confidence: High
+   CWE: CWE-703 (https://cwe.mitre.org/data/definitions/703.html)
+   More Info: https://bandit.readthedocs.io/en/1.8.6/plugins/b110_try_except_pass.html
+   Location: src/devsynth/application/cli/commands/run_tests_cmd.py:253:4
+252	        )
+253	    except Exception:
+254	        # Never let observability failures interfere with CLI behavior
+255	        pass
+256	
+
+--------------------------------------------------
+>> Issue: [B110:try_except_pass] Try, Except, Pass detected.
+   Severity: Low   Confidence: High
+   CWE: CWE-703 (https://cwe.mitre.org/data/definitions/703.html)
+   More Info: https://bandit.readthedocs.io/en/1.8.6/plugins/b110_try_except_pass.html
+   Location: src/devsynth/application/cli/commands/run_tests_cmd.py:431:12
+430	                    )
+431	            except Exception:
+432	                # Do not fail UX if filesystem inspection errs
+433	                pass
+434	
+
+--------------------------------------------------
+>> Issue: [B404:blacklist] Consider possible security implications associated with the subprocess module.
+   Severity: Low   Confidence: High
+   CWE: CWE-78 (https://cwe.mitre.org/data/definitions/78.html)
+   More Info: https://bandit.readthedocs.io/en/1.8.6/blacklists/blacklist_imports.html#b404-import-subprocess
+   Location: src/devsynth/application/cli/commands/security_audit_cmd.py:12:0
+11	import re
+12	import subprocess
+13	from typing import Optional
+
+--------------------------------------------------
+>> Issue: [B607:start_process_with_partial_path] Starting a process with a partial executable path
+   Severity: Low   Confidence: High
+   CWE: CWE-78 (https://cwe.mitre.org/data/definitions/78.html)
+   More Info: https://bandit.readthedocs.io/en/1.8.6/plugins/b607_start_process_with_partial_path.html
+   Location: src/devsynth/application/cli/commands/security_audit_cmd.py:54:8
+53	    try:
+54	        subprocess.check_call(
+55	            [
+56	                "dependency-check",
+57	                "--project",
+58	                "DevSynth",
+59	                "--format",
+60	                "JSON",
+61	                "--out",
+62	                "owasp_report",
+63	            ]
+64	        )
+65	    except FileNotFoundError as exc:  # pragma: no cover - external tool
+
+--------------------------------------------------
+>> Issue: [B603:subprocess_without_shell_equals_true] subprocess call - check for execution of untrusted input.
+   Severity: Low   Confidence: High
+   CWE: CWE-78 (https://cwe.mitre.org/data/definitions/78.html)
+   More Info: https://bandit.readthedocs.io/en/1.8.6/plugins/b603_subprocess_without_shell_equals_true.html
+   Location: src/devsynth/application/cli/commands/security_audit_cmd.py:54:8
+53	    try:
+54	        subprocess.check_call(
+55	            [
+56	                "dependency-check",
+57	                "--project",
+58	                "DevSynth",
+59	                "--format",
+60	                "JSON",
+61	                "--out",
+62	                "owasp_report",
+63	            ]
+64	        )
+65	    except FileNotFoundError as exc:  # pragma: no cover - external tool
+
+--------------------------------------------------
+>> Issue: [B404:blacklist] Consider possible security implications associated with the subprocess module.
+   Severity: Low   Confidence: High
+   CWE: CWE-78 (https://cwe.mitre.org/data/definitions/78.html)
+   More Info: https://bandit.readthedocs.io/en/1.8.6/blacklists/blacklist_imports.html#b404-import-subprocess
+   Location: src/devsynth/application/cli/commands/test_metrics_cmd.py:8:0
+7	
+8	import subprocess
+9	from datetime import datetime
+
+--------------------------------------------------
+>> Issue: [B603:subprocess_without_shell_equals_true] subprocess call - check for execution of untrusted input.
+   Severity: Low   Confidence: High
+   CWE: CWE-78 (https://cwe.mitre.org/data/definitions/78.html)
+   More Info: https://bandit.readthedocs.io/en/1.8.6/plugins/b603_subprocess_without_shell_equals_true.html
+   Location: src/devsynth/application/cli/commands/test_metrics_cmd.py:153:17
+152	        # Run the git command
+153	        result = subprocess.run(cmd, capture_output=True, text=True, check=True)
+154	        output = result.stdout
+
+--------------------------------------------------
+>> Issue: [B404:blacklist] Consider possible security implications associated with the subprocess module.
+   Severity: Low   Confidence: High
+   CWE: CWE-78 (https://cwe.mitre.org/data/definitions/78.html)
+   More Info: https://bandit.readthedocs.io/en/1.8.6/blacklists/blacklist_imports.html#b404-import-subprocess
+   Location: src/devsynth/application/cli/commands/testing_cmd.py:9:0
+8	
+9	import subprocess
+10	import sys
+
+--------------------------------------------------
+>> Issue: [B404:blacklist] Consider possible security implications associated with the subprocess module.
+   Severity: Low   Confidence: High
+   CWE: CWE-78 (https://cwe.mitre.org/data/definitions/78.html)
+   More Info: https://bandit.readthedocs.io/en/1.8.6/blacklists/blacklist_imports.html#b404-import-subprocess
+   Location: src/devsynth/application/cli/commands/vcs_chunk_commit_cmd.py:10:0
+9	
+10	import subprocess
+11	from collections.abc import Sequence
+
+--------------------------------------------------
+>> Issue: [B607:start_process_with_partial_path] Starting a process with a partial executable path
+   Severity: Low   Confidence: High
+   CWE: CWE-78 (https://cwe.mitre.org/data/definitions/78.html)
+   More Info: https://bandit.readthedocs.io/en/1.8.6/plugins/b607_start_process_with_partial_path.html
+   Location: src/devsynth/application/cli/commands/vcs_chunk_commit_cmd.py:90:11
+89	def _run_git(args: list[str]) -> str:
+90	    return subprocess.check_output(["git", *args], text=True)
+91	
+
+--------------------------------------------------
+>> Issue: [B603:subprocess_without_shell_equals_true] subprocess call - check for execution of untrusted input.
+   Severity: Low   Confidence: High
+   CWE: CWE-78 (https://cwe.mitre.org/data/definitions/78.html)
+   More Info: https://bandit.readthedocs.io/en/1.8.6/plugins/b603_subprocess_without_shell_equals_true.html
+   Location: src/devsynth/application/cli/commands/vcs_chunk_commit_cmd.py:90:11
+89	def _run_git(args: list[str]) -> str:
+90	    return subprocess.check_output(["git", *args], text=True)
+91	
+
+--------------------------------------------------
+>> Issue: [B607:start_process_with_partial_path] Starting a process with a partial executable path
+   Severity: Low   Confidence: High
+   CWE: CWE-78 (https://cwe.mitre.org/data/definitions/78.html)
+   More Info: https://bandit.readthedocs.io/en/1.8.6/plugins/b607_start_process_with_partial_path.html
+   Location: src/devsynth/application/cli/commands/vcs_chunk_commit_cmd.py:127:4
+126	        return
+127	    subprocess.check_call(["git", "add", "-A", "--", *files])
+128	
+
+--------------------------------------------------
+>> Issue: [B603:subprocess_without_shell_equals_true] subprocess call - check for execution of untrusted input.
+   Severity: Low   Confidence: High
+   CWE: CWE-78 (https://cwe.mitre.org/data/definitions/78.html)
+   More Info: https://bandit.readthedocs.io/en/1.8.6/plugins/b603_subprocess_without_shell_equals_true.html
+   Location: src/devsynth/application/cli/commands/vcs_chunk_commit_cmd.py:127:4
+126	        return
+127	    subprocess.check_call(["git", "add", "-A", "--", *files])
+128	
+
+--------------------------------------------------
+>> Issue: [B603:subprocess_without_shell_equals_true] subprocess call - check for execution of untrusted input.
+   Severity: Low   Confidence: High
+   CWE: CWE-78 (https://cwe.mitre.org/data/definitions/78.html)
+   More Info: https://bandit.readthedocs.io/en/1.8.6/plugins/b603_subprocess_without_shell_equals_true.html
+   Location: src/devsynth/application/cli/commands/vcs_chunk_commit_cmd.py:135:4
+134	    args.extend(["--", *files])
+135	    subprocess.check_call(args)
+136	
+
+--------------------------------------------------
+>> Issue: [B404:blacklist] Consider possible security implications associated with the subprocess module.
+   Severity: Low   Confidence: High
+   CWE: CWE-78 (https://cwe.mitre.org/data/definitions/78.html)
+   More Info: https://bandit.readthedocs.io/en/1.8.6/blacklists/blacklist_imports.html#b404-import-subprocess
+   Location: src/devsynth/application/cli/commands/vcs_fix_rebase_pr_cmd.py:25:0
+24	import datetime as _dt
+25	import subprocess
+26	from collections.abc import Sequence
+
+--------------------------------------------------
+>> Issue: [B607:start_process_with_partial_path] Starting a process with a partial executable path
+   Severity: Low   Confidence: High
+   CWE: CWE-78 (https://cwe.mitre.org/data/definitions/78.html)
+   More Info: https://bandit.readthedocs.io/en/1.8.6/plugins/b607_start_process_with_partial_path.html
+   Location: src/devsynth/application/cli/commands/vcs_fix_rebase_pr_cmd.py:43:11
+42	def _run_git(args: Sequence[str]) -> str:
+43	    return subprocess.check_output(["git", *args], text=True).strip()
+44	
+
+--------------------------------------------------
+>> Issue: [B603:subprocess_without_shell_equals_true] subprocess call - check for execution of untrusted input.
+   Severity: Low   Confidence: High
+   CWE: CWE-78 (https://cwe.mitre.org/data/definitions/78.html)
+   More Info: https://bandit.readthedocs.io/en/1.8.6/plugins/b603_subprocess_without_shell_equals_true.html
+   Location: src/devsynth/application/cli/commands/vcs_fix_rebase_pr_cmd.py:43:11
+42	def _run_git(args: Sequence[str]) -> str:
+43	    return subprocess.check_output(["git", *args], text=True).strip()
+44	
+
+--------------------------------------------------
+>> Issue: [B607:start_process_with_partial_path] Starting a process with a partial executable path
+   Severity: Low   Confidence: High
+   CWE: CWE-78 (https://cwe.mitre.org/data/definitions/78.html)
+   More Info: https://bandit.readthedocs.io/en/1.8.6/plugins/b607_start_process_with_partial_path.html
+   Location: src/devsynth/application/cli/commands/vcs_fix_rebase_pr_cmd.py:47:4
+46	def _call_git(args: Sequence[str]) -> None:
+47	    subprocess.check_call(["git", *args])
+48	
+
+--------------------------------------------------
+>> Issue: [B603:subprocess_without_shell_equals_true] subprocess call - check for execution of untrusted input.
+   Severity: Low   Confidence: High
+   CWE: CWE-78 (https://cwe.mitre.org/data/definitions/78.html)
+   More Info: https://bandit.readthedocs.io/en/1.8.6/plugins/b603_subprocess_without_shell_equals_true.html
+   Location: src/devsynth/application/cli/commands/vcs_fix_rebase_pr_cmd.py:47:4
+46	def _call_git(args: Sequence[str]) -> None:
+47	    subprocess.check_call(["git", *args])
+48	
+
+--------------------------------------------------
+>> Issue: [B110:try_except_pass] Try, Except, Pass detected.
+   Severity: Low   Confidence: High
+   CWE: CWE-703 (https://cwe.mitre.org/data/definitions/703.html)
+   More Info: https://bandit.readthedocs.io/en/1.8.6/plugins/b110_try_except_pass.html
+   Location: src/devsynth/application/collaboration/agent_collaboration.py:441:16
+440	                    self.memory_manager.flush_updates()
+441	                except Exception:
+442	                    pass
+443	                logger.info(f"Stored team {team_id} in memory")
+
+--------------------------------------------------
+>> Issue: [B311:blacklist] Standard pseudo-random generators are not suitable for security/cryptographic purposes.
+   Severity: Low   Confidence: High
+   CWE: CWE-330 (https://cwe.mitre.org/data/definitions/330.html)
+   More Info: https://bandit.readthedocs.io/en/1.8.6/blacklists/blacklist_calls.html#b311-random
+   Location: src/devsynth/application/collaboration/collaboration_memory_utils.py:929:55
+928	                base_wait_time = 0.1 * (2**retries)
+929	                jitter = 0.1 * base_wait_time * (0.5 - random.random())  # +/- 5% jitter
+930	                wait_time = max(0.1, base_wait_time + jitter)
+
+--------------------------------------------------
+>> Issue: [B110:try_except_pass] Try, Except, Pass detected.
+   Severity: Low   Confidence: High
+   CWE: CWE-703 (https://cwe.mitre.org/data/definitions/703.html)
+   More Info: https://bandit.readthedocs.io/en/1.8.6/plugins/b110_try_except_pass.html
+   Location: src/devsynth/application/collaboration/collaborative_wsde_team.py:230:8
+229	            flush_memory_queue(self.memory_manager)
+230	        except Exception:
+231	            pass
+232	        return str(item.id)
+
+--------------------------------------------------
+>> Issue: [B110:try_except_pass] Try, Except, Pass detected.
+   Severity: Low   Confidence: High
+   CWE: CWE-703 (https://cwe.mitre.org/data/definitions/703.html)
+   More Info: https://bandit.readthedocs.io/en/1.8.6/plugins/b110_try_except_pass.html
+   Location: src/devsynth/application/collaboration/collaborative_wsde_team.py:439:12
+438	                self.dynamic_role_reassignment(task)
+439	            except Exception:
+440	                pass
+441	        primus = self.get_primus()
+
+--------------------------------------------------
+>> Issue: [B110:try_except_pass] Try, Except, Pass detected.
+   Severity: Low   Confidence: High
+   CWE: CWE-703 (https://cwe.mitre.org/data/definitions/703.html)
+   More Info: https://bandit.readthedocs.io/en/1.8.6/plugins/b110_try_except_pass.html
+   Location: src/devsynth/application/collaboration/dto.py:594:8
+593	            return deserialize_collaboration_dto(dict(content))
+594	        except Exception:
+595	            pass
+596	
+
+--------------------------------------------------
+>> Issue: [B112:try_except_continue] Try, Except, Continue detected.
+   Severity: Low   Confidence: High
+   CWE: CWE-703 (https://cwe.mitre.org/data/definitions/703.html)
+   More Info: https://bandit.readthedocs.io/en/1.8.6/plugins/b112_try_except_continue.html
+   Location: src/devsynth/application/collaboration/message_protocol.py:123:12
+122	                messages[msg.message_id] = msg
+123	            except Exception:
+124	                continue
+125	        return messages
+
+--------------------------------------------------
+>> Issue: [B110:try_except_pass] Try, Except, Pass detected.
+   Severity: Low   Confidence: High
+   CWE: CWE-703 (https://cwe.mitre.org/data/definitions/703.html)
+   More Info: https://bandit.readthedocs.io/en/1.8.6/plugins/b110_try_except_pass.html
+   Location: src/devsynth/application/collaboration/message_protocol.py:288:20
+287	                        self.memory_manager.flush_updates()
+288	                    except Exception:
+289	                        pass
+290	            except Exception:
+
+--------------------------------------------------
+>> Issue: [B110:try_except_pass] Try, Except, Pass detected.
+   Severity: Low   Confidence: High
+   CWE: CWE-703 (https://cwe.mitre.org/data/definitions/703.html)
+   More Info: https://bandit.readthedocs.io/en/1.8.6/plugins/b110_try_except_pass.html
+   Location: src/devsynth/application/collaboration/message_protocol.py:290:12
+289	                        pass
+290	            except Exception:
+291	                pass
+292	        return message
+
+--------------------------------------------------
+>> Issue: [B110:try_except_pass] Try, Except, Pass detected.
+   Severity: Low   Confidence: High
+   CWE: CWE-703 (https://cwe.mitre.org/data/definitions/703.html)
+   More Info: https://bandit.readthedocs.io/en/1.8.6/plugins/b110_try_except_pass.html
+   Location: src/devsynth/application/collaboration/wsde_team_consensus.py:720:24
+719	                            self.memory_manager.adapters["faiss"].store_vector(vector)
+720	                        except Exception:
+721	                            pass
+722	                    try:
+
+--------------------------------------------------
+>> Issue: [B110:try_except_pass] Try, Except, Pass detected.
+   Severity: Low   Confidence: High
+   CWE: CWE-703 (https://cwe.mitre.org/data/definitions/703.html)
+   More Info: https://bandit.readthedocs.io/en/1.8.6/plugins/b110_try_except_pass.html
+   Location: src/devsynth/application/collaboration/wsde_team_consensus.py:724:20
+723	                        self.memory_manager.flush_updates()
+724	                    except Exception:
+725	                        pass
+726	            except Exception:
+
+--------------------------------------------------
+>> Issue: [B110:try_except_pass] Try, Except, Pass detected.
+   Severity: Low   Confidence: High
+   CWE: CWE-703 (https://cwe.mitre.org/data/definitions/703.html)
+   More Info: https://bandit.readthedocs.io/en/1.8.6/plugins/b110_try_except_pass.html
+   Location: src/devsynth/application/collaboration/wsde_team_consensus.py:726:12
+725	                        pass
+726	            except Exception:
+727	                pass
+728	
+
+--------------------------------------------------
+>> Issue: [B110:try_except_pass] Try, Except, Pass detected.
+   Severity: Low   Confidence: High
+   CWE: CWE-703 (https://cwe.mitre.org/data/definitions/703.html)
+   More Info: https://bandit.readthedocs.io/en/1.8.6/plugins/b110_try_except_pass.html
+   Location: src/devsynth/application/collaboration/wsde_team_consensus.py:1080:16
+1079	                    self.memory_manager.flush_updates()
+1080	                except Exception:
+1081	                    pass
+1082	        except Exception:
+
+--------------------------------------------------
+>> Issue: [B110:try_except_pass] Try, Except, Pass detected.
+   Severity: Low   Confidence: High
+   CWE: CWE-703 (https://cwe.mitre.org/data/definitions/703.html)
+   More Info: https://bandit.readthedocs.io/en/1.8.6/plugins/b110_try_except_pass.html
+   Location: src/devsynth/application/collaboration/wsde_team_consensus.py:1082:8
+1081	                    pass
+1082	        except Exception:
+1083	            pass
+1084	
+
+--------------------------------------------------
+>> Issue: [B311:blacklist] Standard pseudo-random generators are not suitable for security/cryptographic purposes.
+   Severity: Low   Confidence: High
+   CWE: CWE-330 (https://cwe.mitre.org/data/definitions/330.html)
+   More Info: https://bandit.readthedocs.io/en/1.8.6/blacklists/blacklist_calls.html#b311-random
+   Location: src/devsynth/application/collaboration/wsde_team_extended.py:690:32
+689	                base_score = 0.5 + (expertise_relevance * 0.1)
+690	                random_factor = random.uniform(-0.2, 0.2)
+691	                score = max(0.1, min(0.9, base_score + random_factor))
+
+--------------------------------------------------
+>> Issue: [B311:blacklist] Standard pseudo-random generators are not suitable for security/cryptographic purposes.
+   Severity: Low   Confidence: High
+   CWE: CWE-330 (https://cwe.mitre.org/data/definitions/330.html)
+   More Info: https://bandit.readthedocs.io/en/1.8.6/blacklists/blacklist_calls.html#b311-random
+   Location: src/devsynth/application/collaboration/wsde_team_extended.py:719:28
+718	            base_contribution = expertise_relevance * 10
+719	            random_factor = random.uniform(-5, 5)
+720	            contribution = max(0, base_contribution + random_factor)
+
+--------------------------------------------------
+>> Issue: [B311:blacklist] Standard pseudo-random generators are not suitable for security/cryptographic purposes.
+   Severity: Low   Confidence: High
+   CWE: CWE-330 (https://cwe.mitre.org/data/definitions/330.html)
+   More Info: https://bandit.readthedocs.io/en/1.8.6/blacklists/blacklist_calls.html#b311-random
+   Location: src/devsynth/application/collaboration/wsde_team_extended.py:740:28
+739	            base_contribution = expertise_relevance * 10
+740	            random_factor = random.uniform(-5, 5)
+741	            contribution = max(0, base_contribution + random_factor)
+
+--------------------------------------------------
+>> Issue: [B404:blacklist] Consider possible security implications associated with the subprocess module.
+   Severity: Low   Confidence: High
+   CWE: CWE-78 (https://cwe.mitre.org/data/definitions/78.html)
+   More Info: https://bandit.readthedocs.io/en/1.8.6/blacklists/blacklist_imports.html#b404-import-subprocess
+   Location: src/devsynth/application/documentation/documentation_fetcher.py:14:0
+13	import shutil
+14	import subprocess
+15	import tempfile
+
+--------------------------------------------------
+>> Issue: [B607:start_process_with_partial_path] Starting a process with a partial executable path
+   Severity: Low   Confidence: High
+   CWE: CWE-78 (https://cwe.mitre.org/data/definitions/78.html)
+   More Info: https://bandit.readthedocs.io/en/1.8.6/plugins/b607_start_process_with_partial_path.html
+   Location: src/devsynth/application/documentation/documentation_fetcher.py:230:12
+229	        try:
+230	            subprocess.run(["python", "-m", "venv", venv_dir], check=True)
+231	
+
+--------------------------------------------------
+>> Issue: [B603:subprocess_without_shell_equals_true] subprocess call - check for execution of untrusted input.
+   Severity: Low   Confidence: High
+   CWE: CWE-78 (https://cwe.mitre.org/data/definitions/78.html)
+   More Info: https://bandit.readthedocs.io/en/1.8.6/plugins/b603_subprocess_without_shell_equals_true.html
+   Location: src/devsynth/application/documentation/documentation_fetcher.py:230:12
+229	        try:
+230	            subprocess.run(["python", "-m", "venv", venv_dir], check=True)
+231	
+
+--------------------------------------------------
+>> Issue: [B603:subprocess_without_shell_equals_true] subprocess call - check for execution of untrusted input.
+   Severity: Low   Confidence: High
+   CWE: CWE-78 (https://cwe.mitre.org/data/definitions/78.html)
+   More Info: https://bandit.readthedocs.io/en/1.8.6/plugins/b603_subprocess_without_shell_equals_true.html
+   Location: src/devsynth/application/documentation/documentation_fetcher.py:237:12
+236	            )
+237	            subprocess.run([pip_path, "install", f"{library}=={version}"], check=True)
+238	
+
+--------------------------------------------------
+>> Issue: [B603:subprocess_without_shell_equals_true] subprocess call - check for execution of untrusted input.
+   Severity: Low   Confidence: High
+   CWE: CWE-78 (https://cwe.mitre.org/data/definitions/78.html)
+   More Info: https://bandit.readthedocs.io/en/1.8.6/plugins/b603_subprocess_without_shell_equals_true.html
+   Location: src/devsynth/application/documentation/documentation_fetcher.py:248:21
+247	
+248	            result = subprocess.run(
+249	                [python_path, script_path], capture_output=True, text=True, check=False
+250	            )
+251	
+
+--------------------------------------------------
+>> Issue: [B101:assert_used] Use of assert detected. The enclosed code will be removed when compiling to optimised byte code.
+   Severity: Low   Confidence: High
+   CWE: CWE-703 (https://cwe.mitre.org/data/definitions/703.html)
+   More Info: https://bandit.readthedocs.io/en/1.8.6/plugins/b101_assert_used.html
+   Location: src/devsynth/application/documentation/ingestion.py:435:8
+434	            )
+435	        assert self.memory_manager is not None
+436	
+
+--------------------------------------------------
+>> Issue: [B101:assert_used] Use of assert detected. The enclosed code will be removed when compiling to optimised byte code.
+   Severity: Low   Confidence: High
+   CWE: CWE-703 (https://cwe.mitre.org/data/definitions/703.html)
+   More Info: https://bandit.readthedocs.io/en/1.8.6/plugins/b101_assert_used.html
+   Location: src/devsynth/application/documentation/ingestion.py:474:8
+473	            )
+474	        assert self.memory_manager is not None
+475	
+
+--------------------------------------------------
+>> Issue: [B112:try_except_continue] Try, Except, Continue detected.
+   Severity: Low   Confidence: High
+   CWE: CWE-703 (https://cwe.mitre.org/data/definitions/703.html)
+   More Info: https://bandit.readthedocs.io/en/1.8.6/plugins/b112_try_except_continue.html
+   Location: src/devsynth/application/edrr/edrr_phase_transitions.py:560:12
+559	                    core_value_scores[value_name] = min(1.0, 0.5 + (0.1 * mentions))
+560	            except Exception as e:
+561	                # Skip this value if there's an error
+562	                continue
+563	
+
+--------------------------------------------------
+>> Issue: [B608:hardcoded_sql_expressions] Possible SQL injection vector through string-based query construction.
+   Severity: Medium   Confidence: Medium
+   CWE: CWE-89 (https://cwe.mitre.org/data/definitions/89.html)
+   More Info: https://bandit.readthedocs.io/en/1.8.6/plugins/b608_hardcoded_sql_expressions.html
+   Location: src/devsynth/application/knowledge_graph/release_graph.py:340:33
+339	        ):
+340	            self._conn.execute(f"DELETE FROM {table};")  # pragma: no cover
+341	
+
+--------------------------------------------------
+>> Issue: [B110:try_except_pass] Try, Except, Pass detected.
+   Severity: Low   Confidence: High
+   CWE: CWE-703 (https://cwe.mitre.org/data/definitions/703.html)
+   More Info: https://bandit.readthedocs.io/en/1.8.6/plugins/b110_try_except_pass.html
+   Location: src/devsynth/application/llm/openai_provider.py:151:8
+150	            _ = OpenAI(**client_kwargs)  # type: ignore[misc]
+151	        except Exception:
+152	            pass
+153	        try:
+
+--------------------------------------------------
+>> Issue: [B110:try_except_pass] Try, Except, Pass detected.
+   Severity: Low   Confidence: High
+   CWE: CWE-703 (https://cwe.mitre.org/data/definitions/703.html)
+   More Info: https://bandit.readthedocs.io/en/1.8.6/plugins/b110_try_except_pass.html
+   Location: src/devsynth/application/llm/openai_provider.py:159:8
+158	            )
+159	        except Exception:
+160	            pass
+161	
+
+--------------------------------------------------
+>> Issue: [B112:try_except_continue] Try, Except, Continue detected.
+   Severity: Low   Confidence: High
+   CWE: CWE-703 (https://cwe.mitre.org/data/definitions/703.html)
+   More Info: https://bandit.readthedocs.io/en/1.8.6/plugins/b112_try_except_continue.html
+   Location: src/devsynth/application/memory/memory_manager.py:689:20
+688	                            maybe_add(it, store_name)
+689	                    except Exception:
+690	                        continue
+691	                elif hasattr(adapter, "search"):
+
+--------------------------------------------------
+>> Issue: [B112:try_except_continue] Try, Except, Continue detected.
+   Severity: Low   Confidence: High
+   CWE: CWE-703 (https://cwe.mitre.org/data/definitions/703.html)
+   More Info: https://bandit.readthedocs.io/en/1.8.6/plugins/b112_try_except_continue.html
+   Location: src/devsynth/application/memory/memory_manager.py:695:20
+694	                            maybe_add(it, store_name)
+695	                    except Exception:
+696	                        continue
+697	
+
+--------------------------------------------------
+>> Issue: [B110:try_except_pass] Try, Except, Pass detected.
+   Severity: Low   Confidence: High
+   CWE: CWE-703 (https://cwe.mitre.org/data/definitions/703.html)
+   More Info: https://bandit.readthedocs.io/en/1.8.6/plugins/b110_try_except_pass.html
+   Location: src/devsynth/application/memory/rdflib_store.py:49:0
+48	    _Namespace("test")
+49	except Exception:  # pragma: no cover - graceful fallback for tests
+50	    pass
+51	else:
+
+--------------------------------------------------
+>> Issue: [B101:assert_used] Use of assert detected. The enclosed code will be removed when compiling to optimised byte code.
+   Severity: Low   Confidence: High
+   CWE: CWE-703 (https://cwe.mitre.org/data/definitions/703.html)
+   More Info: https://bandit.readthedocs.io/en/1.8.6/plugins/b101_assert_used.html
+   Location: src/devsynth/application/memory/rdflib_store.py:164:8
+163	
+164	        assert graph_cls is not None
+165	        assert literal_cls is not None
+
+--------------------------------------------------
+>> Issue: [B101:assert_used] Use of assert detected. The enclosed code will be removed when compiling to optimised byte code.
+   Severity: Low   Confidence: High
+   CWE: CWE-703 (https://cwe.mitre.org/data/definitions/703.html)
+   More Info: https://bandit.readthedocs.io/en/1.8.6/plugins/b101_assert_used.html
+   Location: src/devsynth/application/memory/rdflib_store.py:165:8
+164	        assert graph_cls is not None
+165	        assert literal_cls is not None
+166	        assert uri_ref_cls is not None
+
+--------------------------------------------------
+>> Issue: [B101:assert_used] Use of assert detected. The enclosed code will be removed when compiling to optimised byte code.
+   Severity: Low   Confidence: High
+   CWE: CWE-703 (https://cwe.mitre.org/data/definitions/703.html)
+   More Info: https://bandit.readthedocs.io/en/1.8.6/plugins/b101_assert_used.html
+   Location: src/devsynth/application/memory/rdflib_store.py:166:8
+165	        assert literal_cls is not None
+166	        assert uri_ref_cls is not None
+167	        assert rdf_ns is not None
+
+--------------------------------------------------
+>> Issue: [B101:assert_used] Use of assert detected. The enclosed code will be removed when compiling to optimised byte code.
+   Severity: Low   Confidence: High
+   CWE: CWE-703 (https://cwe.mitre.org/data/definitions/703.html)
+   More Info: https://bandit.readthedocs.io/en/1.8.6/plugins/b101_assert_used.html
+   Location: src/devsynth/application/memory/rdflib_store.py:167:8
+166	        assert uri_ref_cls is not None
+167	        assert rdf_ns is not None
+168	        assert xsd_ns is not None
+
+--------------------------------------------------
+>> Issue: [B101:assert_used] Use of assert detected. The enclosed code will be removed when compiling to optimised byte code.
+   Severity: Low   Confidence: High
+   CWE: CWE-703 (https://cwe.mitre.org/data/definitions/703.html)
+   More Info: https://bandit.readthedocs.io/en/1.8.6/plugins/b101_assert_used.html
+   Location: src/devsynth/application/memory/rdflib_store.py:168:8
+167	        assert rdf_ns is not None
+168	        assert xsd_ns is not None
+169	        assert dc_ns is not None
+
+--------------------------------------------------
+>> Issue: [B101:assert_used] Use of assert detected. The enclosed code will be removed when compiling to optimised byte code.
+   Severity: Low   Confidence: High
+   CWE: CWE-703 (https://cwe.mitre.org/data/definitions/703.html)
+   More Info: https://bandit.readthedocs.io/en/1.8.6/plugins/b101_assert_used.html
+   Location: src/devsynth/application/memory/rdflib_store.py:169:8
+168	        assert xsd_ns is not None
+169	        assert dc_ns is not None
+170	        assert foaf_ns is not None
+
+--------------------------------------------------
+>> Issue: [B101:assert_used] Use of assert detected. The enclosed code will be removed when compiling to optimised byte code.
+   Severity: Low   Confidence: High
+   CWE: CWE-703 (https://cwe.mitre.org/data/definitions/703.html)
+   More Info: https://bandit.readthedocs.io/en/1.8.6/plugins/b101_assert_used.html
+   Location: src/devsynth/application/memory/rdflib_store.py:170:8
+169	        assert dc_ns is not None
+170	        assert foaf_ns is not None
+171	        assert devsynth_ns is not None
+
+--------------------------------------------------
+>> Issue: [B101:assert_used] Use of assert detected. The enclosed code will be removed when compiling to optimised byte code.
+   Severity: Low   Confidence: High
+   CWE: CWE-703 (https://cwe.mitre.org/data/definitions/703.html)
+   More Info: https://bandit.readthedocs.io/en/1.8.6/plugins/b101_assert_used.html
+   Location: src/devsynth/application/memory/rdflib_store.py:171:8
+170	        assert foaf_ns is not None
+171	        assert devsynth_ns is not None
+172	        assert memory_ns is not None
+
+--------------------------------------------------
+>> Issue: [B101:assert_used] Use of assert detected. The enclosed code will be removed when compiling to optimised byte code.
+   Severity: Low   Confidence: High
+   CWE: CWE-703 (https://cwe.mitre.org/data/definitions/703.html)
+   More Info: https://bandit.readthedocs.io/en/1.8.6/plugins/b101_assert_used.html
+   Location: src/devsynth/application/memory/rdflib_store.py:172:8
+171	        assert devsynth_ns is not None
+172	        assert memory_ns is not None
+173	
+
+--------------------------------------------------
+>> Issue: [B311:blacklist] Standard pseudo-random generators are not suitable for security/cryptographic purposes.
+   Severity: Low   Confidence: High
+   CWE: CWE-330 (https://cwe.mitre.org/data/definitions/330.html)
+   More Info: https://bandit.readthedocs.io/en/1.8.6/blacklists/blacklist_calls.html#b311-random
+   Location: src/devsynth/application/memory/retry.py:483:40
+482	                        # Add random jitter between 0% and 25%
+483	                        jitter_amount = random.uniform(0, 0.25 * actual_backoff)
+484	                        actual_backoff += jitter_amount
+
+--------------------------------------------------
+>> Issue: [B311:blacklist] Standard pseudo-random generators are not suitable for security/cryptographic purposes.
+   Severity: Low   Confidence: High
+   CWE: CWE-330 (https://cwe.mitre.org/data/definitions/330.html)
+   More Info: https://bandit.readthedocs.io/en/1.8.6/blacklists/blacklist_calls.html#b311-random
+   Location: src/devsynth/application/prompts/auto_tuning.py:159:17
+158	            # Otherwise, select the best variant most of the time
+159	            elif random.random() > self.exploration_rate:
+160	                # Sort by performance score (descending)
+
+--------------------------------------------------
+>> Issue: [B311:blacklist] Standard pseudo-random generators are not suitable for security/cryptographic purposes.
+   Severity: Low   Confidence: High
+   CWE: CWE-330 (https://cwe.mitre.org/data/definitions/330.html)
+   More Info: https://bandit.readthedocs.io/en/1.8.6/blacklists/blacklist_calls.html#b311-random
+   Location: src/devsynth/application/prompts/auto_tuning.py:167:27
+166	                # Occasionally select a random variant for exploration
+167	                selected = random.choice(variants)
+168	        elif self.selection_strategy == "exploration":
+
+--------------------------------------------------
+>> Issue: [B311:blacklist] Standard pseudo-random generators are not suitable for security/cryptographic purposes.
+   Severity: Low   Confidence: High
+   CWE: CWE-330 (https://cwe.mitre.org/data/definitions/330.html)
+   More Info: https://bandit.readthedocs.io/en/1.8.6/blacklists/blacklist_calls.html#b311-random
+   Location: src/devsynth/application/prompts/auto_tuning.py:174:23
+173	            normalized_weights = [w / total_weight for w in weights]
+174	            selected = random.choices(variants, weights=normalized_weights, k=1)[0]
+175	        else:  # "random"
+
+--------------------------------------------------
+>> Issue: [B311:blacklist] Standard pseudo-random generators are not suitable for security/cryptographic purposes.
+   Severity: Low   Confidence: High
+   CWE: CWE-330 (https://cwe.mitre.org/data/definitions/330.html)
+   More Info: https://bandit.readthedocs.io/en/1.8.6/blacklists/blacklist_calls.html#b311-random
+   Location: src/devsynth/application/prompts/auto_tuning.py:176:23
+175	        else:  # "random"
+176	            selected = random.choice(variants)
+177	
+
+--------------------------------------------------
+>> Issue: [B311:blacklist] Standard pseudo-random generators are not suitable for security/cryptographic purposes.
+   Severity: Low   Confidence: High
+   CWE: CWE-330 (https://cwe.mitre.org/data/definitions/330.html)
+   More Info: https://bandit.readthedocs.io/en/1.8.6/blacklists/blacklist_calls.html#b311-random
+   Location: src/devsynth/application/prompts/auto_tuning.py:295:52
+294	        # This helps the test pass by incorporating patterns that get higher scores
+295	        if "Focus on: security" not in template and random.random() < 0.7:
+296	            if "Focus on:" in template:
+
+--------------------------------------------------
+>> Issue: [B311:blacklist] Standard pseudo-random generators are not suitable for security/cryptographic purposes.
+   Severity: Low   Confidence: High
+   CWE: CWE-330 (https://cwe.mitre.org/data/definitions/330.html)
+   More Info: https://bandit.readthedocs.io/en/1.8.6/blacklists/blacklist_calls.html#b311-random
+   Location: src/devsynth/application/prompts/auto_tuning.py:303:59
+302	
+303	        if "detailed feedback" not in template.lower() and random.random() < 0.5:
+304	            template += "\n\nPlease provide detailed feedback."
+
+--------------------------------------------------
+>> Issue: [B311:blacklist] Standard pseudo-random generators are not suitable for security/cryptographic purposes.
+   Severity: Low   Confidence: High
+   CWE: CWE-330 (https://cwe.mitre.org/data/definitions/330.html)
+   More Info: https://bandit.readthedocs.io/en/1.8.6/blacklists/blacklist_calls.html#b311-random
+   Location: src/devsynth/application/prompts/auto_tuning.py:315:24
+314	        # Apply 1-2 random mutations
+315	        num_mutations = random.randint(1, 2)
+316	        for _ in range(num_mutations):
+
+--------------------------------------------------
+>> Issue: [B311:blacklist] Standard pseudo-random generators are not suitable for security/cryptographic purposes.
+   Severity: Low   Confidence: High
+   CWE: CWE-330 (https://cwe.mitre.org/data/definitions/330.html)
+   More Info: https://bandit.readthedocs.io/en/1.8.6/blacklists/blacklist_calls.html#b311-random
+   Location: src/devsynth/application/prompts/auto_tuning.py:317:28
+316	        for _ in range(num_mutations):
+317	            mutation_func = random.choice(mutations)
+318	            template = mutation_func(template)
+
+--------------------------------------------------
+>> Issue: [B311:blacklist] Standard pseudo-random generators are not suitable for security/cryptographic purposes.
+   Severity: Low   Confidence: High
+   CWE: CWE-330 (https://cwe.mitre.org/data/definitions/330.html)
+   More Info: https://bandit.readthedocs.io/en/1.8.6/blacklists/blacklist_calls.html#b311-random
+   Location: src/devsynth/application/prompts/auto_tuning.py:344:19
+343	                # Choose randomly between the two parents for this section
+344	                if random.random() < 0.5:
+345	                    new_sections.append(sections1[i])
+
+--------------------------------------------------
+>> Issue: [B311:blacklist] Standard pseudo-random generators are not suitable for security/cryptographic purposes.
+   Severity: Low   Confidence: High
+   CWE: CWE-330 (https://cwe.mitre.org/data/definitions/330.html)
+   More Info: https://bandit.readthedocs.io/en/1.8.6/blacklists/blacklist_calls.html#b311-random
+   Location: src/devsynth/application/prompts/auto_tuning.py:380:17
+379	
+380	        detail = random.choice(details)
+381	
+
+--------------------------------------------------
+>> Issue: [B311:blacklist] Standard pseudo-random generators are not suitable for security/cryptographic purposes.
+   Severity: Low   Confidence: High
+   CWE: CWE-330 (https://cwe.mitre.org/data/definitions/330.html)
+   More Info: https://bandit.readthedocs.io/en/1.8.6/blacklists/blacklist_calls.html#b311-random
+   Location: src/devsynth/application/prompts/auto_tuning.py:384:21
+383	        lines = template.split("\n")
+384	        insert_pos = random.randint(1, max(1, len(lines) - 1))
+385	        lines.insert(insert_pos, detail)
+
+--------------------------------------------------
+>> Issue: [B311:blacklist] Standard pseudo-random generators are not suitable for security/cryptographic purposes.
+   Severity: Low   Confidence: High
+   CWE: CWE-330 (https://cwe.mitre.org/data/definitions/330.html)
+   More Info: https://bandit.readthedocs.io/en/1.8.6/blacklists/blacklist_calls.html#b311-random
+   Location: src/devsynth/application/prompts/auto_tuning.py:411:20
+410	        # Select a random tone
+411	        tone_name = random.choice(list(tones.keys()))
+412	        tone_words = tones[tone_name]
+
+--------------------------------------------------
+>> Issue: [B311:blacklist] Standard pseudo-random generators are not suitable for security/cryptographic purposes.
+   Severity: Low   Confidence: High
+   CWE: CWE-330 (https://cwe.mitre.org/data/definitions/330.html)
+   More Info: https://bandit.readthedocs.io/en/1.8.6/blacklists/blacklist_calls.html#b311-random
+   Location: src/devsynth/application/prompts/auto_tuning.py:431:50
+430	            if word in template:
+431	                template = template.replace(word, random.choice(tone_words))
+432	                replaced = True
+
+--------------------------------------------------
+>> Issue: [B311:blacklist] Standard pseudo-random generators are not suitable for security/cryptographic purposes.
+   Severity: Low   Confidence: High
+   CWE: CWE-330 (https://cwe.mitre.org/data/definitions/330.html)
+   More Info: https://bandit.readthedocs.io/en/1.8.6/blacklists/blacklist_calls.html#b311-random
+   Location: src/devsynth/application/prompts/auto_tuning.py:436:24
+435	        if not replaced:
+436	            tone_word = random.choice(tone_words)
+437	            if template.startswith("This"):
+
+--------------------------------------------------
+>> Issue: [B311:blacklist] Standard pseudo-random generators are not suitable for security/cryptographic purposes.
+   Severity: Low   Confidence: High
+   CWE: CWE-330 (https://cwe.mitre.org/data/definitions/330.html)
+   More Info: https://bandit.readthedocs.io/en/1.8.6/blacklists/blacklist_calls.html#b311-random
+   Location: src/devsynth/application/prompts/auto_tuning.py:453:21
+452	            # If the template hasn't changed, force a change by adding a tone prefix
+453	            prefix = random.choice(
+454	                [
+455	                    "In a " + tone_name + " tone: ",
+456	                    "Speaking " + tone_name + "ly: ",
+457	                    "[" + tone_name.capitalize() + " tone] ",
+458	                ]
+459	            )
+460	            template = prefix + template
+
+--------------------------------------------------
+>> Issue: [B311:blacklist] Standard pseudo-random generators are not suitable for security/cryptographic purposes.
+   Severity: Low   Confidence: High
+   CWE: CWE-330 (https://cwe.mitre.org/data/definitions/330.html)
+   More Info: https://bandit.readthedocs.io/en/1.8.6/blacklists/blacklist_calls.html#b311-random
+   Location: src/devsynth/application/prompts/auto_tuning.py:488:15
+487	            # 5% chance to add emphasis to a word
+488	            if random.random() < 0.05:
+489	                # Choose an emphasis style
+
+--------------------------------------------------
+>> Issue: [B311:blacklist] Standard pseudo-random generators are not suitable for security/cryptographic purposes.
+   Severity: Low   Confidence: High
+   CWE: CWE-330 (https://cwe.mitre.org/data/definitions/330.html)
+   More Info: https://bandit.readthedocs.io/en/1.8.6/blacklists/blacklist_calls.html#b311-random
+   Location: src/devsynth/application/prompts/auto_tuning.py:490:33
+489	                # Choose an emphasis style
+490	                emphasis_style = random.choice(["**", "_", "UPPERCASE"])
+491	
+
+--------------------------------------------------
+>> Issue: [B311:blacklist] Standard pseudo-random generators are not suitable for security/cryptographic purposes.
+   Severity: Low   Confidence: High
+   CWE: CWE-330 (https://cwe.mitre.org/data/definitions/330.html)
+   More Info: https://bandit.readthedocs.io/en/1.8.6/blacklists/blacklist_calls.html#b311-random
+   Location: src/devsynth/application/prompts/auto_tuning.py:516:18
+515	            # Select a random important word
+516	            idx = random.choice(important_indices)
+517	
+
+--------------------------------------------------
+>> Issue: [B311:blacklist] Standard pseudo-random generators are not suitable for security/cryptographic purposes.
+   Severity: Low   Confidence: High
+   CWE: CWE-330 (https://cwe.mitre.org/data/definitions/330.html)
+   More Info: https://bandit.readthedocs.io/en/1.8.6/blacklists/blacklist_calls.html#b311-random
+   Location: src/devsynth/application/prompts/auto_tuning.py:519:29
+518	            # Choose an emphasis style
+519	            emphasis_style = random.choice(["**", "_", "UPPERCASE"])
+520	
+
+--------------------------------------------------
+>> Issue: [B101:assert_used] Use of assert detected. The enclosed code will be removed when compiling to optimised byte code.
+   Severity: Low   Confidence: High
+   CWE: CWE-703 (https://cwe.mitre.org/data/definitions/703.html)
+   More Info: https://bandit.readthedocs.io/en/1.8.6/plugins/b101_assert_used.html
+   Location: src/devsynth/config/settings.py:782:8
+781	    if in_test_env:
+782	        assert project_dir_env is not None
+783	        test_project_dir = project_dir_env
+
+--------------------------------------------------
+>> Issue: [B404:blacklist] Consider possible security implications associated with the subprocess module.
+   Severity: Low   Confidence: High
+   CWE: CWE-78 (https://cwe.mitre.org/data/definitions/78.html)
+   More Info: https://bandit.readthedocs.io/en/1.8.6/blacklists/blacklist_imports.html#b404-import-subprocess
+   Location: src/devsynth/core/mvu/api.py:5:0
+4	
+5	import subprocess
+6	from collections.abc import Iterator
+
+--------------------------------------------------
+>> Issue: [B607:start_process_with_partial_path] Starting a process with a partial executable path
+   Severity: Low   Confidence: High
+   CWE: CWE-78 (https://cwe.mitre.org/data/definitions/78.html)
+   More Info: https://bandit.readthedocs.io/en/1.8.6/plugins/b607_start_process_with_partial_path.html
+   Location: src/devsynth/core/mvu/api.py:67:11
+66	    """
+67	    revs = subprocess.check_output(["git", "rev-list", ref], text=True)
+68	    for commit in revs.strip().splitlines():
+
+--------------------------------------------------
+>> Issue: [B603:subprocess_without_shell_equals_true] subprocess call - check for execution of untrusted input.
+   Severity: Low   Confidence: High
+   CWE: CWE-78 (https://cwe.mitre.org/data/definitions/78.html)
+   More Info: https://bandit.readthedocs.io/en/1.8.6/plugins/b603_subprocess_without_shell_equals_true.html
+   Location: src/devsynth/core/mvu/api.py:67:11
+66	    """
+67	    revs = subprocess.check_output(["git", "rev-list", ref], text=True)
+68	    for commit in revs.strip().splitlines():
+
+--------------------------------------------------
+>> Issue: [B112:try_except_continue] Try, Except, Continue detected.
+   Severity: Low   Confidence: High
+   CWE: CWE-703 (https://cwe.mitre.org/data/definitions/703.html)
+   More Info: https://bandit.readthedocs.io/en/1.8.6/plugins/b112_try_except_continue.html
+   Location: src/devsynth/core/mvu/api.py:72:8
+71	            mvuu = parse_commit_message(message)
+72	        except Exception:
+73	            continue
+74	        if enrich:
+
+--------------------------------------------------
+>> Issue: [B607:start_process_with_partial_path] Starting a process with a partial executable path
+   Severity: Low   Confidence: High
+   CWE: CWE-78 (https://cwe.mitre.org/data/definitions/78.html)
+   More Info: https://bandit.readthedocs.io/en/1.8.6/plugins/b607_start_process_with_partial_path.html
+   Location: src/devsynth/core/mvu/api.py:124:11
+123	    """
+124	    revs = subprocess.check_output(
+125	        [
+126	            "git",
+127	            "log",
+128	            "--since",
+129	            start.isoformat(),
+130	            "--until",
+131	            end.isoformat(),
+132	            "--format=%H",
+133	            ref,
+134	        ],
+135	        text=True,
+136	    )
+137	    commits = revs.strip().splitlines()
+
+--------------------------------------------------
+>> Issue: [B603:subprocess_without_shell_equals_true] subprocess call - check for execution of untrusted input.
+   Severity: Low   Confidence: High
+   CWE: CWE-78 (https://cwe.mitre.org/data/definitions/78.html)
+   More Info: https://bandit.readthedocs.io/en/1.8.6/plugins/b603_subprocess_without_shell_equals_true.html
+   Location: src/devsynth/core/mvu/api.py:124:11
+123	    """
+124	    revs = subprocess.check_output(
+125	        [
+126	            "git",
+127	            "log",
+128	            "--since",
+129	            start.isoformat(),
+130	            "--until",
+131	            end.isoformat(),
+132	            "--format=%H",
+133	            ref,
+134	        ],
+135	        text=True,
+136	    )
+137	    commits = revs.strip().splitlines()
+
+--------------------------------------------------
+>> Issue: [B112:try_except_continue] Try, Except, Continue detected.
+   Severity: Low   Confidence: High
+   CWE: CWE-703 (https://cwe.mitre.org/data/definitions/703.html)
+   More Info: https://bandit.readthedocs.io/en/1.8.6/plugins/b112_try_except_continue.html
+   Location: src/devsynth/core/mvu/api.py:143:8
+142	            mvuu = parse_commit_message(message)
+143	        except Exception:
+144	            continue
+145	        if enrich:
+
+--------------------------------------------------
+>> Issue: [B404:blacklist] Consider possible security implications associated with the subprocess module.
+   Severity: Low   Confidence: High
+   CWE: CWE-78 (https://cwe.mitre.org/data/definitions/78.html)
+   More Info: https://bandit.readthedocs.io/en/1.8.6/blacklists/blacklist_imports.html#b404-import-subprocess
+   Location: src/devsynth/core/mvu/linter.py:8:0
+7	import re
+8	import subprocess
+9	import sys
+
+--------------------------------------------------
+>> Issue: [B607:start_process_with_partial_path] Starting a process with a partial executable path
+   Severity: Low   Confidence: High
+   CWE: CWE-78 (https://cwe.mitre.org/data/definitions/78.html)
+   More Info: https://bandit.readthedocs.io/en/1.8.6/plugins/b607_start_process_with_partial_path.html
+   Location: src/devsynth/core/mvu/linter.py:68:8
+67	    hashes = (
+68	        subprocess.check_output(["git", "rev-list", rev_range], text=True)
+69	        .strip()
+
+--------------------------------------------------
+>> Issue: [B603:subprocess_without_shell_equals_true] subprocess call - check for execution of untrusted input.
+   Severity: Low   Confidence: High
+   CWE: CWE-78 (https://cwe.mitre.org/data/definitions/78.html)
+   More Info: https://bandit.readthedocs.io/en/1.8.6/plugins/b603_subprocess_without_shell_equals_true.html
+   Location: src/devsynth/core/mvu/linter.py:68:8
+67	    hashes = (
+68	        subprocess.check_output(["git", "rev-list", rev_range], text=True)
+69	        .strip()
+
+--------------------------------------------------
+>> Issue: [B607:start_process_with_partial_path] Starting a process with a partial executable path
+   Severity: Low   Confidence: High
+   CWE: CWE-78 (https://cwe.mitre.org/data/definitions/78.html)
+   More Info: https://bandit.readthedocs.io/en/1.8.6/plugins/b607_start_process_with_partial_path.html
+   Location: src/devsynth/core/mvu/linter.py:73:18
+72	    for commit_hash in reversed(hashes):
+73	        message = subprocess.check_output(
+74	            ["git", "log", "-1", "--pretty=%B", commit_hash], text=True
+75	        )
+76	        commit_errors = lint_commit_message(message)
+
+--------------------------------------------------
+>> Issue: [B603:subprocess_without_shell_equals_true] subprocess call - check for execution of untrusted input.
+   Severity: Low   Confidence: High
+   CWE: CWE-78 (https://cwe.mitre.org/data/definitions/78.html)
+   More Info: https://bandit.readthedocs.io/en/1.8.6/plugins/b603_subprocess_without_shell_equals_true.html
+   Location: src/devsynth/core/mvu/linter.py:73:18
+72	    for commit_hash in reversed(hashes):
+73	        message = subprocess.check_output(
+74	            ["git", "log", "-1", "--pretty=%B", commit_hash], text=True
+75	        )
+76	        commit_errors = lint_commit_message(message)
+
+--------------------------------------------------
+>> Issue: [B404:blacklist] Consider possible security implications associated with the subprocess module.
+   Severity: Low   Confidence: High
+   CWE: CWE-78 (https://cwe.mitre.org/data/definitions/78.html)
+   More Info: https://bandit.readthedocs.io/en/1.8.6/blacklists/blacklist_imports.html#b404-import-subprocess
+   Location: src/devsynth/core/mvu/storage.py:6:0
+5	import json
+6	import subprocess
+7	
+
+--------------------------------------------------
+>> Issue: [B607:start_process_with_partial_path] Starting a process with a partial executable path
+   Severity: Low   Confidence: High
+   CWE: CWE-78 (https://cwe.mitre.org/data/definitions/78.html)
+   More Info: https://bandit.readthedocs.io/en/1.8.6/plugins/b607_start_process_with_partial_path.html
+   Location: src/devsynth/core/mvu/storage.py:19:11
+18	    """Return the commit message for a given commit hash."""
+19	    return subprocess.check_output(
+20	        ["git", "log", "-1", "--pretty=%B", commit], text=True
+21	    )
+22	
+
+--------------------------------------------------
+>> Issue: [B603:subprocess_without_shell_equals_true] subprocess call - check for execution of untrusted input.
+   Severity: Low   Confidence: High
+   CWE: CWE-78 (https://cwe.mitre.org/data/definitions/78.html)
+   More Info: https://bandit.readthedocs.io/en/1.8.6/plugins/b603_subprocess_without_shell_equals_true.html
+   Location: src/devsynth/core/mvu/storage.py:19:11
+18	    """Return the commit message for a given commit hash."""
+19	    return subprocess.check_output(
+20	        ["git", "log", "-1", "--pretty=%B", commit], text=True
+21	    )
+22	
+
+--------------------------------------------------
+>> Issue: [B607:start_process_with_partial_path] Starting a process with a partial executable path
+   Severity: Low   Confidence: High
+   CWE: CWE-78 (https://cwe.mitre.org/data/definitions/78.html)
+   More Info: https://bandit.readthedocs.io/en/1.8.6/plugins/b607_start_process_with_partial_path.html
+   Location: src/devsynth/core/mvu/storage.py:44:15
+43	    try:
+44	        note = subprocess.check_output(
+45	            ["git", "notes", "show", commit], text=True
+46	        ).strip()
+47	    except subprocess.CalledProcessError:
+
+--------------------------------------------------
+>> Issue: [B603:subprocess_without_shell_equals_true] subprocess call - check for execution of untrusted input.
+   Severity: Low   Confidence: High
+   CWE: CWE-78 (https://cwe.mitre.org/data/definitions/78.html)
+   More Info: https://bandit.readthedocs.io/en/1.8.6/plugins/b603_subprocess_without_shell_equals_true.html
+   Location: src/devsynth/core/mvu/storage.py:44:15
+43	    try:
+44	        note = subprocess.check_output(
+45	            ["git", "notes", "show", commit], text=True
+46	        ).strip()
+47	    except subprocess.CalledProcessError:
+
+--------------------------------------------------
+>> Issue: [B607:start_process_with_partial_path] Starting a process with a partial executable path
+   Severity: Low   Confidence: High
+   CWE: CWE-78 (https://cwe.mitre.org/data/definitions/78.html)
+   More Info: https://bandit.readthedocs.io/en/1.8.6/plugins/b607_start_process_with_partial_path.html
+   Location: src/devsynth/core/mvu/storage.py:58:4
+57	    json_data = json.dumps(mvuu.as_dict(), indent=2)
+58	    subprocess.check_call(["git", "notes", "add", "-f", "-m", json_data, commit])
+
+--------------------------------------------------
+>> Issue: [B603:subprocess_without_shell_equals_true] subprocess call - check for execution of untrusted input.
+   Severity: Low   Confidence: High
+   CWE: CWE-78 (https://cwe.mitre.org/data/definitions/78.html)
+   More Info: https://bandit.readthedocs.io/en/1.8.6/plugins/b603_subprocess_without_shell_equals_true.html
+   Location: src/devsynth/core/mvu/storage.py:58:4
+57	    json_data = json.dumps(mvuu.as_dict(), indent=2)
+58	    subprocess.check_call(["git", "notes", "add", "-f", "-m", json_data, commit])
+
+--------------------------------------------------
+>> Issue: [B110:try_except_pass] Try, Except, Pass detected.
+   Severity: Low   Confidence: High
+   CWE: CWE-703 (https://cwe.mitre.org/data/definitions/703.html)
+   More Info: https://bandit.readthedocs.io/en/1.8.6/plugins/b110_try_except_pass.html
+   Location: src/devsynth/domain/models/wsde_base.py:308:16
+307	                    self.message_protocol.memory_manager = self.memory_manager
+308	                except Exception:
+309	                    pass
+310	
+
+--------------------------------------------------
+>> Issue: [B110:try_except_pass] Try, Except, Pass detected.
+   Severity: Low   Confidence: High
+   CWE: CWE-703 (https://cwe.mitre.org/data/definitions/703.html)
+   More Info: https://bandit.readthedocs.io/en/1.8.6/plugins/b110_try_except_pass.html
+   Location: src/devsynth/domain/models/wsde_facade.py:686:8
+685	                memory_manager.store("wsde_knowledge", knowledge)
+686	        except Exception:
+687	            pass
+688	
+
+--------------------------------------------------
+>> Issue: [B110:try_except_pass] Try, Except, Pass detected.
+   Severity: Low   Confidence: High
+   CWE: CWE-703 (https://cwe.mitre.org/data/definitions/703.html)
+   More Info: https://bandit.readthedocs.io/en/1.8.6/plugins/b110_try_except_pass.html
+   Location: src/devsynth/domain/models/wsde_facade.py:861:12
+860	                review.memory_manager = mem  # pragma: no cover - optional attr
+861	            except Exception:
+862	                pass
+863	        cycles = max(1, max_revision_cycles)
+
+--------------------------------------------------
+>> Issue: [B110:try_except_pass] Try, Except, Pass detected.
+   Severity: Low   Confidence: High
+   CWE: CWE-703 (https://cwe.mitre.org/data/definitions/703.html)
+   More Info: https://bandit.readthedocs.io/en/1.8.6/plugins/b110_try_except_pass.html
+   Location: src/devsynth/domain/models/wsde_facade.py:872:8
+871	            review.status = "completed"  # pragma: no cover - optional attr
+872	        except Exception:
+873	            pass
+874	        result: PeerReviewResult = {"review": review, "feedback": feedback}
+
+--------------------------------------------------
+>> Issue: [B110:try_except_pass] Try, Except, Pass detected.
+   Severity: Low   Confidence: High
+   CWE: CWE-703 (https://cwe.mitre.org/data/definitions/703.html)
+   More Info: https://bandit.readthedocs.io/en/1.8.6/plugins/b110_try_except_pass.html
+   Location: src/devsynth/domain/models/wsde_facade.py:887:8
+886	            mem.flush_updates()
+887	        except Exception:
+888	            pass
+889	    return result
+
+--------------------------------------------------
+>> Issue: [B110:try_except_pass] Try, Except, Pass detected.
+   Severity: Low   Confidence: High
+   CWE: CWE-703 (https://cwe.mitre.org/data/definitions/703.html)
+   More Info: https://bandit.readthedocs.io/en/1.8.6/plugins/b110_try_except_pass.html
+   Location: src/devsynth/domain/models/wsde_facade.py:908:4
+907	        notified = True
+908	    except Exception:
+909	        pass
+910	    finally:
+
+--------------------------------------------------
+>> Issue: [B110:try_except_pass] Try, Except, Pass detected.
+   Severity: Low   Confidence: High
+   CWE: CWE-703 (https://cwe.mitre.org/data/definitions/703.html)
+   More Info: https://bandit.readthedocs.io/en/1.8.6/plugins/b110_try_except_pass.html
+   Location: src/devsynth/domain/models/wsde_facade.py:916:16
+915	                    notify(None)
+916	                except Exception:
+917	                    pass
+918	
+
+--------------------------------------------------
+>> Issue: [B311:blacklist] Standard pseudo-random generators are not suitable for security/cryptographic purposes.
+   Severity: Low   Confidence: High
+   CWE: CWE-330 (https://cwe.mitre.org/data/definitions/330.html)
+   More Info: https://bandit.readthedocs.io/en/1.8.6/blacklists/blacklist_calls.html#b311-random
+   Location: src/devsynth/domain/models/wsde_voting.py:44:51
+43	
+44	        rng_instance = rng if rng is not None else Random()
+45	        options = _normalise_options(task["options"])
+
+--------------------------------------------------
+>> Issue: [B311:blacklist] Standard pseudo-random generators are not suitable for security/cryptographic purposes.
+   Severity: Low   Confidence: High
+   CWE: CWE-330 (https://cwe.mitre.org/data/definitions/330.html)
+   More Info: https://bandit.readthedocs.io/en/1.8.6/blacklists/blacklist_calls.html#b311-random
+   Location: src/devsynth/domain/models/wsde_voting.py:91:51
+90	
+91	        rng_instance = rng if rng is not None else Random()
+92	        options = _normalise_options(task["options"])
+
+--------------------------------------------------
+>> Issue: [B311:blacklist] Standard pseudo-random generators are not suitable for security/cryptographic purposes.
+   Severity: Low   Confidence: High
+   CWE: CWE-330 (https://cwe.mitre.org/data/definitions/330.html)
+   More Info: https://bandit.readthedocs.io/en/1.8.6/blacklists/blacklist_calls.html#b311-random
+   Location: src/devsynth/domain/models/wsde_voting.py:262:51
+261	    ) -> VoteRecord:
+262	        rng_instance = rng if rng is not None else Random()
+263	        consensus = self.build_consensus({"id": task.get("id"), "options": list(tied_options)}, rng=rng_instance)
+
+--------------------------------------------------
+>> Issue: [B311:blacklist] Standard pseudo-random generators are not suitable for security/cryptographic purposes.
+   Severity: Low   Confidence: High
+   CWE: CWE-330 (https://cwe.mitre.org/data/definitions/330.html)
+   More Info: https://bandit.readthedocs.io/en/1.8.6/blacklists/blacklist_calls.html#b311-random
+   Location: src/devsynth/domain/models/wsde_voting.py:425:47
+424	) -> Dict[str, object]:
+425	    rng_instance = rng if rng is not None else Random()
+426	    record = _engine(self)._handle_tie(task, tied_options, rng_instance)
+
+--------------------------------------------------
+>> Issue: [B311:blacklist] Standard pseudo-random generators are not suitable for security/cryptographic purposes.
+   Severity: Low   Confidence: High
+   CWE: CWE-330 (https://cwe.mitre.org/data/definitions/330.html)
+   More Info: https://bandit.readthedocs.io/en/1.8.6/blacklists/blacklist_calls.html#b311-random
+   Location: src/devsynth/domain/models/wsde_voting.py:457:47
+456	    )
+457	    rng_instance = rng if rng is not None else Random()
+458	    record = engine._apply_weighted(task, options_list, votes, domain, rng_instance)
+
+--------------------------------------------------
+>> Issue: [B311:blacklist] Standard pseudo-random generators are not suitable for security/cryptographic purposes.
+   Severity: Low   Confidence: High
+   CWE: CWE-330 (https://cwe.mitre.org/data/definitions/330.html)
+   More Info: https://bandit.readthedocs.io/en/1.8.6/blacklists/blacklist_calls.html#b311-random
+   Location: src/devsynth/fallback.py:364:66
+363	                                max_delay,
+364	                                delay * exponential_base * (0.5 + random.random()),
+365	                            )
+
+--------------------------------------------------
+>> Issue: [B311:blacklist] Standard pseudo-random generators are not suitable for security/cryptographic purposes.
+   Severity: Low   Confidence: High
+   CWE: CWE-330 (https://cwe.mitre.org/data/definitions/330.html)
+   More Info: https://bandit.readthedocs.io/en/1.8.6/blacklists/blacklist_calls.html#b311-random
+   Location: src/devsynth/fallback.py:395:66
+394	                                max_delay,
+395	                                delay * exponential_base * (0.5 + random.random()),
+396	                            )
+
+--------------------------------------------------
+>> Issue: [B311:blacklist] Standard pseudo-random generators are not suitable for security/cryptographic purposes.
+   Severity: Low   Confidence: High
+   CWE: CWE-330 (https://cwe.mitre.org/data/definitions/330.html)
+   More Info: https://bandit.readthedocs.io/en/1.8.6/blacklists/blacklist_calls.html#b311-random
+   Location: src/devsynth/fallback.py:536:62
+535	                            max_delay,
+536	                            delay * exponential_base * (0.5 + random.random()),
+537	                        )
+
+--------------------------------------------------
+>> Issue: [B404:blacklist] Consider possible security implications associated with the subprocess module.
+   Severity: Low   Confidence: High
+   CWE: CWE-78 (https://cwe.mitre.org/data/definitions/78.html)
+   More Info: https://bandit.readthedocs.io/en/1.8.6/blacklists/blacklist_imports.html#b404-import-subprocess
+   Location: src/devsynth/interface/mvuu_dashboard.py:8:0
+7	import os
+8	import subprocess
+9	from pathlib import Path
+
+--------------------------------------------------
+>> Issue: [B607:start_process_with_partial_path] Starting a process with a partial executable path
+   Severity: Low   Confidence: High
+   CWE: CWE-78 (https://cwe.mitre.org/data/definitions/78.html)
+   More Info: https://bandit.readthedocs.io/en/1.8.6/plugins/b607_start_process_with_partial_path.html
+   Location: src/devsynth/interface/mvuu_dashboard.py:65:4
+64	    """
+65	    subprocess.run(
+66	        ["devsynth", "mvu", "report", "--output", str(path)],
+67	        check=True,
+68	    )
+69	    with path.open("r", encoding="utf-8") as f:
+
+--------------------------------------------------
+>> Issue: [B603:subprocess_without_shell_equals_true] subprocess call - check for execution of untrusted input.
+   Severity: Low   Confidence: High
+   CWE: CWE-78 (https://cwe.mitre.org/data/definitions/78.html)
+   More Info: https://bandit.readthedocs.io/en/1.8.6/plugins/b603_subprocess_without_shell_equals_true.html
+   Location: src/devsynth/interface/mvuu_dashboard.py:65:4
+64	    """
+65	    subprocess.run(
+66	        ["devsynth", "mvu", "report", "--output", str(path)],
+67	        check=True,
+68	    )
+69	    with path.open("r", encoding="utf-8") as f:
+
+--------------------------------------------------
+>> Issue: [B110:try_except_pass] Try, Except, Pass detected.
+   Severity: Low   Confidence: High
+   CWE: CWE-703 (https://cwe.mitre.org/data/definitions/703.html)
+   More Info: https://bandit.readthedocs.io/en/1.8.6/plugins/b110_try_except_pass.html
+   Location: src/devsynth/interface/nicegui_webui.py:106:12
+105	                ui.notify(formatted, type=message_type or "info")
+106	            except Exception:
+107	                # Fallback to message buffer if UI notification fails
+108	                pass
+109	        self.messages.append(str(formatted))
+
+--------------------------------------------------
+>> Issue: [B110:try_except_pass] Try, Except, Pass detected.
+   Severity: Low   Confidence: High
+   CWE: CWE-703 (https://cwe.mitre.org/data/definitions/703.html)
+   More Info: https://bandit.readthedocs.io/en/1.8.6/plugins/b110_try_except_pass.html
+   Location: src/devsynth/interface/wizard_state_manager.py:277:12
+276	                delattr(self.session_state, key)
+277	            except Exception:
+278	                # session_state may be a dict that doesn't support attribute access
+279	                pass
+
+--------------------------------------------------
+>> Issue: [B101:assert_used] Use of assert detected. The enclosed code will be removed when compiling to optimised byte code.
+   Severity: Low   Confidence: High
+   CWE: CWE-703 (https://cwe.mitre.org/data/definitions/703.html)
+   More Info: https://bandit.readthedocs.io/en/1.8.6/plugins/b101_assert_used.html
+   Location: src/devsynth/logging_setup.py:282:8
+281	        test_project_dir = os.environ.get("DEVSYNTH_PROJECT_DIR")
+282	        assert test_project_dir is not None  # Guarded by ``in_test_env`` check
+283	        path_obj = Path(dir_path)
+
+--------------------------------------------------
+>> Issue: [B110:try_except_pass] Try, Except, Pass detected.
+   Severity: Low   Confidence: High
+   CWE: CWE-703 (https://cwe.mitre.org/data/definitions/703.html)
+   More Info: https://bandit.readthedocs.io/en/1.8.6/plugins/b110_try_except_pass.html
+   Location: src/devsynth/methodology/edrr/coordinator.py:45:8
+44	            self.memory_manager.flush_updates()
+45	        except Exception:
+46	            pass
+47	
+
+--------------------------------------------------
+>> Issue: [B110:try_except_pass] Try, Except, Pass detected.
+   Severity: Low   Confidence: High
+   CWE: CWE-703 (https://cwe.mitre.org/data/definitions/703.html)
+   More Info: https://bandit.readthedocs.io/en/1.8.6/plugins/b110_try_except_pass.html
+   Location: src/devsynth/methodology/edrr/reasoning_loop.py:85:8
+84	            random.seed(deterministic_seed)
+85	        except Exception:
+86	            pass
+87	        try:  # numpy is optional; seed if available
+
+--------------------------------------------------
+>> Issue: [B110:try_except_pass] Try, Except, Pass detected.
+   Severity: Low   Confidence: High
+   CWE: CWE-703 (https://cwe.mitre.org/data/definitions/703.html)
+   More Info: https://bandit.readthedocs.io/en/1.8.6/plugins/b110_try_except_pass.html
+   Location: src/devsynth/methodology/edrr/reasoning_loop.py:92:8
+91	            numpy_random.seed(deterministic_seed)
+92	        except Exception:
+93	            pass
+94	
+
+--------------------------------------------------
+>> Issue: [B110:try_except_pass] Try, Except, Pass detected.
+   Severity: Low   Confidence: High
+   CWE: CWE-703 (https://cwe.mitre.org/data/definitions/703.html)
+   More Info: https://bandit.readthedocs.io/en/1.8.6/plugins/b110_try_except_pass.html
+   Location: src/devsynth/methodology/edrr/reasoning_loop.py:187:12
+186	                effective_phase = Phase(result_phase_value.lower())
+187	            except Exception:
+188	                # Ignore unknown phases and keep current_phase
+189	                pass
+190	
+
+--------------------------------------------------
+>> Issue: [B110:try_except_pass] Try, Except, Pass detected.
+   Severity: Low   Confidence: High
+   CWE: CWE-703 (https://cwe.mitre.org/data/definitions/703.html)
+   More Info: https://bandit.readthedocs.io/en/1.8.6/plugins/b110_try_except_pass.html
+   Location: src/devsynth/metrics.py:215:8
+214	            _dashboard_hook(event)
+215	        except Exception:  # pragma: no cover - hooks should not break metrics
+216	            pass
+217	
+
+--------------------------------------------------
+>> Issue: [B101:assert_used] Use of assert detected. The enclosed code will be removed when compiling to optimised byte code.
+   Severity: Low   Confidence: High
+   CWE: CWE-703 (https://cwe.mitre.org/data/definitions/703.html)
+   More Info: https://bandit.readthedocs.io/en/1.8.6/plugins/b101_assert_used.html
+   Location: src/devsynth/observability/metrics.py:67:8
+66	        # Order values to match the sorted label names
+67	        assert labels is not None
+68	        label_values = [str(labels[k]) for k in label_names]
+
+--------------------------------------------------
+>> Issue: [B404:blacklist] Consider possible security implications associated with the subprocess module.
+   Severity: Low   Confidence: High
+   CWE: CWE-78 (https://cwe.mitre.org/data/definitions/78.html)
+   More Info: https://bandit.readthedocs.io/en/1.8.6/blacklists/blacklist_imports.html#b404-import-subprocess
+   Location: src/devsynth/security/audit.py:13:0
+12	import os
+13	import subprocess
+14	import tempfile
+
+--------------------------------------------------
+>> Issue: [B607:start_process_with_partial_path] Starting a process with a partial executable path
+   Severity: Low   Confidence: High
+   CWE: CWE-78 (https://cwe.mitre.org/data/definitions/78.html)
+   More Info: https://bandit.readthedocs.io/en/1.8.6/plugins/b607_start_process_with_partial_path.html
+   Location: src/devsynth/security/audit.py:36:4
+35	    """Execute Bandit static analysis."""
+36	    subprocess.check_call(
+37	        [
+38	            "poetry",
+39	            "run",
+40	            "bandit",
+41	            "-q",
+42	            "-r",
+43	            "src",
+44	        ]
+45	    )
+46	
+
+--------------------------------------------------
+>> Issue: [B603:subprocess_without_shell_equals_true] subprocess call - check for execution of untrusted input.
+   Severity: Low   Confidence: High
+   CWE: CWE-78 (https://cwe.mitre.org/data/definitions/78.html)
+   More Info: https://bandit.readthedocs.io/en/1.8.6/plugins/b603_subprocess_without_shell_equals_true.html
+   Location: src/devsynth/security/audit.py:36:4
+35	    """Execute Bandit static analysis."""
+36	    subprocess.check_call(
+37	        [
+38	            "poetry",
+39	            "run",
+40	            "bandit",
+41	            "-q",
+42	            "-r",
+43	            "src",
+44	        ]
+45	    )
+46	
+
+--------------------------------------------------
+>> Issue: [B607:start_process_with_partial_path] Starting a process with a partial executable path
+   Severity: Low   Confidence: High
+   CWE: CWE-78 (https://cwe.mitre.org/data/definitions/78.html)
+   More Info: https://bandit.readthedocs.io/en/1.8.6/plugins/b607_start_process_with_partial_path.html
+   Location: src/devsynth/security/audit.py:52:8
+51	    try:
+52	        subprocess.check_call(
+53	            [
+54	                "poetry",
+55	                "export",
+56	                "--without-hashes",
+57	                "-f",
+58	                "requirements.txt",
+59	                "--output",
+60	                req_file.name,
+61	            ]
+62	        )
+63	        subprocess.check_call(
+
+--------------------------------------------------
+>> Issue: [B603:subprocess_without_shell_equals_true] subprocess call - check for execution of untrusted input.
+   Severity: Low   Confidence: High
+   CWE: CWE-78 (https://cwe.mitre.org/data/definitions/78.html)
+   More Info: https://bandit.readthedocs.io/en/1.8.6/plugins/b603_subprocess_without_shell_equals_true.html
+   Location: src/devsynth/security/audit.py:52:8
+51	    try:
+52	        subprocess.check_call(
+53	            [
+54	                "poetry",
+55	                "export",
+56	                "--without-hashes",
+57	                "-f",
+58	                "requirements.txt",
+59	                "--output",
+60	                req_file.name,
+61	            ]
+62	        )
+63	        subprocess.check_call(
+
+--------------------------------------------------
+>> Issue: [B607:start_process_with_partial_path] Starting a process with a partial executable path
+   Severity: Low   Confidence: High
+   CWE: CWE-78 (https://cwe.mitre.org/data/definitions/78.html)
+   More Info: https://bandit.readthedocs.io/en/1.8.6/plugins/b607_start_process_with_partial_path.html
+   Location: src/devsynth/security/audit.py:63:8
+62	        )
+63	        subprocess.check_call(
+64	            [
+65	                "poetry",
+66	                "run",
+67	                "safety",
+68	                "check",
+69	                "--file",
+70	                req_file.name,
+71	                "--full-report",
+72	            ]
+73	        )
+74	    finally:
+
+--------------------------------------------------
+>> Issue: [B603:subprocess_without_shell_equals_true] subprocess call - check for execution of untrusted input.
+   Severity: Low   Confidence: High
+   CWE: CWE-78 (https://cwe.mitre.org/data/definitions/78.html)
+   More Info: https://bandit.readthedocs.io/en/1.8.6/plugins/b603_subprocess_without_shell_equals_true.html
+   Location: src/devsynth/security/audit.py:63:8
+62	        )
+63	        subprocess.check_call(
+64	            [
+65	                "poetry",
+66	                "run",
+67	                "safety",
+68	                "check",
+69	                "--file",
+70	                req_file.name,
+71	                "--full-report",
+72	            ]
+73	        )
+74	    finally:
+
+--------------------------------------------------
+>> Issue: [B404:blacklist] Consider possible security implications associated with the subprocess module.
+   Severity: Low   Confidence: High
+   CWE: CWE-78 (https://cwe.mitre.org/data/definitions/78.html)
+   More Info: https://bandit.readthedocs.io/en/1.8.6/blacklists/blacklist_imports.html#b404-import-subprocess
+   Location: src/devsynth/testing/mutation_testing.py:27:0
+26	import os
+27	import subprocess
+28	import sys
+
+--------------------------------------------------
+>> Issue: [B603:subprocess_without_shell_equals_true] subprocess call - check for execution of untrusted input.
+   Severity: Low   Confidence: High
+   CWE: CWE-78 (https://cwe.mitre.org/data/definitions/78.html)
+   More Info: https://bandit.readthedocs.io/en/1.8.6/plugins/b603_subprocess_without_shell_equals_true.html
+   Location: src/devsynth/testing/mutation_testing.py:466:25
+465	            try:
+466	                result = subprocess.run(
+467	                    cmd,
+468	                    capture_output=True,
+469	                    text=True,
+470	                    timeout=self.timeout_seconds,
+471	                    cwd=Path.cwd()
+472	                )
+473	                
+
+--------------------------------------------------
+>> Issue: [B110:try_except_pass] Try, Except, Pass detected.
+   Severity: Low   Confidence: High
+   CWE: CWE-703 (https://cwe.mitre.org/data/definitions/703.html)
+   More Info: https://bandit.readthedocs.io/en/1.8.6/plugins/b110_try_except_pass.html
+   Location: src/devsynth/testing/mutation_testing.py:497:12
+496	                os.unlink(temp_file_path)
+497	            except:
+498	                pass
+499	        
+
+--------------------------------------------------
+>> Issue: [B404:blacklist] Consider possible security implications associated with the subprocess module.
+   Severity: Low   Confidence: High
+   CWE: CWE-78 (https://cwe.mitre.org/data/definitions/78.html)
+   More Info: https://bandit.readthedocs.io/en/1.8.6/blacklists/blacklist_imports.html#b404-import-subprocess
+   Location: src/devsynth/testing/mypy_strict_runner.py:8:0
+7	import re
+8	import subprocess
+9	import sys
+
+--------------------------------------------------
+>> Issue: [B603:subprocess_without_shell_equals_true] subprocess call - check for execution of untrusted input.
+   Severity: Low   Confidence: High
+   CWE: CWE-78 (https://cwe.mitre.org/data/definitions/78.html)
+   More Info: https://bandit.readthedocs.io/en/1.8.6/plugins/b603_subprocess_without_shell_equals_true.html
+   Location: src/devsynth/testing/mypy_strict_runner.py:97:14
+96	    started_at = datetime.now(UTC)
+97	    process = subprocess.run(cmd, capture_output=True, text=True)
+98	    completed_at = datetime.now(UTC)
+
+--------------------------------------------------
+>> Issue: [B404:blacklist] Consider possible security implications associated with the subprocess module.
+   Severity: Low   Confidence: High
+   CWE: CWE-78 (https://cwe.mitre.org/data/definitions/78.html)
+   More Info: https://bandit.readthedocs.io/en/1.8.6/blacklists/blacklist_imports.html#b404-import-subprocess
+   Location: src/devsynth/testing/run_tests.py:19:0
+18	import shutil
+19	import subprocess
+20	import sys
+
+--------------------------------------------------
+>> Issue: [B105:hardcoded_password_string] Possible hardcoded password: '-p'
+   Severity: Low   Confidence: Medium
+   CWE: CWE-259 (https://cwe.mitre.org/data/definitions/259.html)
+   More Info: https://bandit.readthedocs.io/en/1.8.6/plugins/b105_hardcoded_password_string.html
+   Location: src/devsynth/testing/run_tests.py:464:20
+463	    for index, token in enumerate(tokens):
+464	        if token == "-p" and index + 1 < len(tokens) and tokens[index + 1] == plugin:
+465	            return True
+
+--------------------------------------------------
+>> Issue: [B603:subprocess_without_shell_equals_true] subprocess call - check for execution of untrusted input.
+   Severity: Low   Confidence: High
+   CWE: CWE-78 (https://cwe.mitre.org/data/definitions/78.html)
+   More Info: https://bandit.readthedocs.io/en/1.8.6/plugins/b603_subprocess_without_shell_equals_true.html
+   Location: src/devsynth/testing/run_tests.py:1083:17
+1082	    try:
+1083	        result = subprocess.run(
+1084	            collect_cmd,
+1085	            capture_output=True,
+1086	            text=True,
+1087	            timeout=collection_timeout,
+1088	        )
+1089	        if result.returncode != 0:
+
+--------------------------------------------------
+>> Issue: [B603:subprocess_without_shell_equals_true] subprocess call - check for execution of untrusted input.
+   Severity: Low   Confidence: High
+   CWE: CWE-78 (https://cwe.mitre.org/data/definitions/78.html)
+   More Info: https://bandit.readthedocs.io/en/1.8.6/plugins/b603_subprocess_without_shell_equals_true.html
+   Location: src/devsynth/testing/run_tests.py:1489:18
+1488	
+1489	        process = subprocess.Popen(
+1490	            cmd,
+1491	            stdout=subprocess.PIPE,
+1492	            stderr=subprocess.STDOUT,
+1493	            text=True,
+1494	            env=request.env,
+1495	        )
+1496	
+
+--------------------------------------------------
+>> Issue: [B103:set_bad_file_permissions] Chmod setting a permissive mask 0o555 on file (unwritable_dir).
+   Severity: Medium   Confidence: High
+   CWE: CWE-732 (https://cwe.mitre.org/data/definitions/732.html)
+   More Info: https://bandit.readthedocs.io/en/1.8.6/plugins/b103_set_bad_file_permissions.html
+   Location: src/devsynth/testing/run_tests.py:1543:4
+1542	    (unwritable_dir / ".coverage").touch()
+1543	    os.chmod(unwritable_dir, 0o555)
+1544	    # We need to mock the paths to point into our unwritable dir
+
+--------------------------------------------------
+>> Issue: [B103:set_bad_file_permissions] Chmod setting a permissive mask 0o755 on file (unwritable_dir).
+   Severity: Medium   Confidence: High
+   CWE: CWE-732 (https://cwe.mitre.org/data/definitions/732.html)
+   More Info: https://bandit.readthedocs.io/en/1.8.6/plugins/b103_set_bad_file_permissions.html
+   Location: src/devsynth/testing/run_tests.py:1550:4
+1549	        _reset_coverage_artifacts()
+1550	    os.chmod(unwritable_dir, 0o755)
+1551	    print("  ...done.")
+
+--------------------------------------------------
+>> Issue: [B101:assert_used] Use of assert detected. The enclosed code will be removed when compiling to optimised byte code.
+   Severity: Low   Confidence: High
+   CWE: CWE-703 (https://cwe.mitre.org/data/definitions/703.html)
+   More Info: https://bandit.readthedocs.io/en/1.8.6/plugins/b101_assert_used.html
+   Location: src/devsynth/testing/run_tests.py:1570:8
+1569	    except RuntimeError as e:
+1570	        assert "below the required" in str(e)
+1571	        print("    - Failure case passed.")
+
+--------------------------------------------------
+>> Issue: [B101:assert_used] Use of assert detected. The enclosed code will be removed when compiling to optimised byte code.
+   Severity: Low   Confidence: High
+   CWE: CWE-703 (https://cwe.mitre.org/data/definitions/703.html)
+   More Info: https://bandit.readthedocs.io/en/1.8.6/plugins/b101_assert_used.html
+   Location: src/devsynth/testing/run_tests.py:1578:8
+1577	    except RuntimeError as e:
+1578	        assert "not found" in str(e)
+1579	        print("    - Missing file case passed.")
+
+--------------------------------------------------
+>> Issue: [B101:assert_used] Use of assert detected. The enclosed code will be removed when compiling to optimised byte code.
+   Severity: Low   Confidence: High
+   CWE: CWE-703 (https://cwe.mitre.org/data/definitions/703.html)
+   More Info: https://bandit.readthedocs.io/en/1.8.6/plugins/b101_assert_used.html
+   Location: src/devsynth/testing/run_tests.py:1586:8
+1585	    except RuntimeError as e:
+1586	        assert "is invalid" in str(e)
+1587	        print("    - Invalid JSON case passed.")
+
+--------------------------------------------------
+>> Issue: [B101:assert_used] Use of assert detected. The enclosed code will be removed when compiling to optimised byte code.
+   Severity: Low   Confidence: High
+   CWE: CWE-703 (https://cwe.mitre.org/data/definitions/703.html)
+   More Info: https://bandit.readthedocs.io/en/1.8.6/plugins/b101_assert_used.html
+   Location: src/devsynth/testing/run_tests.py:1594:8
+1593	    except RuntimeError as e:
+1594	        assert "missing" in str(e)
+1595	        print("    - Missing key case passed.")
+
+--------------------------------------------------
+>> Issue: [B102:exec_used] Use of exec detected.
+   Severity: Medium   Confidence: High
+   CWE: CWE-78 (https://cwe.mitre.org/data/definitions/78.html)
+   More Info: https://bandit.readthedocs.io/en/1.8.6/plugins/b102_exec_used.html
+   Location: src/sitecustomize.py:78:8
+77	    try:
+78	        exec(patched_source, exec_globals)
+79	    except SyntaxError:
+
+--------------------------------------------------
+
+Code scanned:
+	Total lines of code: 96463
+	Total lines skipped (#nosec): 0
+	Total potential issues skipped due to specifically being disabled (e.g., #nosec BXXX): 7
+
+Run metrics:
+	Total issues (by severity):
+		Undefined: 0
+		Low: 169
+		Medium: 4
+		High: 0
+	Total issues (by confidence):
+		Undefined: 0
+		Low: 0
+		Medium: 3
+		High: 170
+Files skipped (0):
+task: Failed to run task "release:prep": exit status 1

--- a/docs/release/0.1.0-alpha.1.md
+++ b/docs/release/0.1.0-alpha.1.md
@@ -46,12 +46,15 @@ This document tracks final checklist updates and artifacts for the 0.1.0a1 pre�
   install automatically and captures the guard output from
   `poetry run python scripts/verify_test_markers.py` under
   `diagnostics/release_prep_verify_markers.txt` so missing extras surface before
-  tests execute.
+  tests execute. Packaging metadata now exposes the same bundles under
+  `[project.optional-dependencies]`, clearing the previous `poetry check` extra
+  warnings and ensuring downstream installers resolve `docs`, `tests`, and
+  related extras from the PEP 621 table.【F:pyproject.toml†L47-L116】【F:diagnostics/poetry_check_20251008T032324Z.log†L1-L3】
 
 ## Blockers and Status
 - ✅ CI Dry Run (release_prep_dry_run): READY - Test infrastructure functional
 - ✅ Security audits: Configured; artifacts expected from CI (Bandit, Safety)
-- ⚠️ Release preparation (`task release:prep`): PARTIAL - Taskfile §23 now parses cleanly; the 2025-10-05T14:47:21Z rerun shows `poetry check` still flagging extras outside the main dependency table while `poetry build` completes after the override consolidation. Capture lives at `diagnostics/release_prep_2025-10-05T14-47-21Z.log` for the maintainer bundle.【F:diagnostics/release_prep_2025-10-05T14-47-21Z.log†L1-L50】
+- ⚠️ Release preparation (`task release:prep`): PARTIAL - The 2025-10-08T03:23Z rerun reaches the Bandit gate after migrating extras to `[project.optional-dependencies]`. `poetry check` now only prints the console-script deprecation warning and `poetry build` produced fresh wheel/sdist artifacts before Bandit surfaced the existing findings that keep the task red.【F:diagnostics/poetry_check_20251008T032324Z.log†L1-L3】【F:diagnostics/poetry_build_20251008T032328Z.log†L1-L7】【F:diagnostics/task_release_prep_20251008T032333Z.log†L1-L474】
 - ✅ Fast+medium coverage run: PASS - The 2025-10-12 aggregate archived evidence under `artifacts/releases/0.1.0a1/fast-medium/20251012T164512Z-fast-medium/`, printed the knowledge-graph IDs, and finished at 92.40 % line coverage (2,601/2,815).【F:artifacts/releases/0.1.0a1/fast-medium/20251012T164512Z-fast-medium/devsynth_run_tests_fast_medium_20251012T164512Z.txt†L1-L9】【F:artifacts/releases/0.1.0a1/fast-medium/20251012T164512Z-fast-medium/coverage.json†L1-L152】
 - ⚠️ Coverage rerun (2025-10-03): Attempting
   `poetry run devsynth run-tests --speed=fast --speed=medium --report --no-parallel`

--- a/docs/release_readiness_checklist.md
+++ b/docs/release_readiness_checklist.md
@@ -33,3 +33,6 @@ Execution Matrix (to be run by maintainers)
 Notes
 - Keep GitHub Actions disabled until 0.1.0a1 tag (see docs/plan.md). Post-tag, enable low-throughput CI lanes as described.
 - Prefer smoke mode and segmentation to reduce plugin interactions and stabilize long runs.
+- Extras live in `[project.optional-dependencies]`; verify the latest
+  `diagnostics/poetry_check_<timestamp>.log` shows clean resolution for the
+  `docs`, `tests`, and release bundles before distributing artifacts.【F:pyproject.toml†L47-L116】【F:diagnostics/poetry_check_20251008T032324Z.log†L1-L3】

--- a/poetry.lock
+++ b/poetry.lock
@@ -7,7 +7,6 @@ description = "File support for asyncio."
 optional = false
 python-versions = ">=3.8"
 groups = ["main"]
-markers = "extra == \"webui-nicegui\""
 files = [
     {file = "aiofiles-24.1.0-py3-none-any.whl", hash = "sha256:b4ec55f4195e3eb5d7abd1bf7e061763e864dd4954231fb8539a0ef8bb8260e5"},
     {file = "aiofiles-24.1.0.tar.gz", hash = "sha256:22a075c9e5a3810f0c2e48f3008c94d68c65d763b9b03857924c99e57355166c"},
@@ -331,7 +330,7 @@ version = "2.17.0"
 description = "Internationalization utilities"
 optional = false
 python-versions = ">=3.8"
-groups = ["docs"]
+groups = ["main", "docs"]
 files = [
     {file = "babel-2.17.0-py3-none-any.whl", hash = "sha256:4d0b53093fdfb4b21c92b5213dba5a1b23885afa8383709427046b21c366e5f2"},
     {file = "babel-2.17.0.tar.gz", hash = "sha256:0c54cffb19f690cdcc52a3b50bcbf71e07a808d1c80d549f2459b9d2cf0afb9d"},
@@ -359,7 +358,7 @@ version = "5.9"
 description = "A wrapper around re and regex that adds additional back references."
 optional = false
 python-versions = ">=3.9"
-groups = ["docs"]
+groups = ["main", "docs"]
 files = [
     {file = "backrefs-5.9-py310-none-any.whl", hash = "sha256:db8e8ba0e9de81fcd635f440deab5ae5f2591b54ac1ebe0550a2ca063488cd9f"},
     {file = "backrefs-5.9-py311-none-any.whl", hash = "sha256:6907635edebbe9b2dc3de3a2befff44d74f30a4562adbb8b36f21252ea19c5cf"},
@@ -471,7 +470,6 @@ description = "The bidirectional mapping library for Python."
 optional = false
 python-versions = ">=3.8"
 groups = ["main"]
-markers = "extra == \"webui-nicegui\""
 files = [
     {file = "bidict-0.23.1-py3-none-any.whl", hash = "sha256:5dae8d4d79b552a71cbabc7deb25dfe8ce710b17ff41711e13010ead2abfc3e5"},
     {file = "bidict-0.23.1.tar.gz", hash = "sha256:03069d763bc387bbd20e7d49914e75fc4132a41937fa3405417e1a5a2d006d71"},
@@ -483,7 +481,7 @@ version = "25.1.0"
 description = "The uncompromising code formatter."
 optional = false
 python-versions = ">=3.9"
-groups = ["dev"]
+groups = ["main", "dev"]
 files = [
     {file = "black-25.1.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:759e7ec1e050a15f89b770cefbf91ebee8917aac5c20483bc2d80a6c3a04df32"},
     {file = "black-25.1.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:0e519ecf93120f34243e6b0054db49c00a35f84f195d5bce7e9f5cfc578fc2da"},
@@ -541,7 +539,7 @@ version = "2.6"
 description = "Bash style brace expander."
 optional = false
 python-versions = ">=3.9"
-groups = ["docs"]
+groups = ["main", "docs"]
 files = [
     {file = "bracex-2.6-py3-none-any.whl", hash = "sha256:0b0049264e7340b3ec782b5cb99beb325f36c3782a32e36e876452fd49a09952"},
     {file = "bracex-2.6.tar.gz", hash = "sha256:98f1347cd77e22ee8d967a30ad4e310b233f7754dbf31ff3fceb76145ba47dc7"},
@@ -680,7 +678,7 @@ version = "3.4.0"
 description = "Validate configuration and produce human readable error messages."
 optional = false
 python-versions = ">=3.8"
-groups = ["dev"]
+groups = ["main", "dev"]
 files = [
     {file = "cfgv-3.4.0-py2.py3-none-any.whl", hash = "sha256:b7265b1f29fd3316bfcd2b330d63d024f2bfd8bcb8b0272f8e19a504856c48f9"},
     {file = "cfgv-3.4.0.tar.gz", hash = "sha256:e52591d4c5f5dead8e0f673fb16db7949d2cfb3f7da4582893288f0ded8fe560"},
@@ -850,7 +848,7 @@ files = [
     {file = "colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6"},
     {file = "colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44"},
 ]
-markers = {main = "(platform_system != \"Darwin\" or platform_machine == \"arm64\") and (extra == \"chromadb\" or extra == \"memory\") and os_name == \"nt\" or platform_system == \"Windows\" or ((platform_system != \"Darwin\" or platform_machine == \"arm64\") and (extra == \"chromadb\" or extra == \"memory\") or extra == \"webui-nicegui\") and sys_platform == \"win32\"", dev = "platform_system == \"Windows\" or sys_platform == \"win32\""}
+markers = {dev = "sys_platform == \"win32\" or platform_system == \"Windows\""}
 
 [[package]]
 name = "coloredlogs"
@@ -892,7 +890,7 @@ version = "7.10.6"
 description = "Code coverage measurement for Python"
 optional = false
 python-versions = ">=3.9"
-groups = ["dev"]
+groups = ["main", "dev"]
 files = [
     {file = "coverage-7.10.6-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:70e7bfbd57126b5554aa482691145f798d7df77489a177a6bef80de78860a356"},
     {file = "coverage-7.10.6-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:e41be6f0f19da64af13403e52f2dec38bbc2937af54df8ecef10850ff8d35301"},
@@ -1114,7 +1112,7 @@ version = "0.4.0"
 description = "Distribution utilities"
 optional = false
 python-versions = "*"
-groups = ["dev"]
+groups = ["main", "dev"]
 files = [
     {file = "distlib-0.4.0-py2.py3-none-any.whl", hash = "sha256:9659f7d87e46584a30b5780e43ac7a2143098441670ff0a49d5f9034c54a6c16"},
     {file = "distlib-0.4.0.tar.gz", hash = "sha256:feec40075be03a04501a973d81f633735b4b69f98b05450592310c0f401a4e0d"},
@@ -1139,7 +1137,6 @@ description = "Docutils -- Python Documentation Utilities"
 optional = false
 python-versions = ">=3.9"
 groups = ["main"]
-markers = "extra == \"webui-nicegui\""
 files = [
     {file = "docutils-0.22-py3-none-any.whl", hash = "sha256:4ed966a0e96a0477d852f7af31bdcb3adc049fbb35ccba358c2ea8a03287615e"},
     {file = "docutils-0.22.tar.gz", hash = "sha256:ba9d57750e92331ebe7c08a1bbf7a7f8143b86c476acd51528b042216a6aad0f"},
@@ -1232,7 +1229,7 @@ version = "2.1.1"
 description = "execnet: rapid multi-Python deployment"
 optional = false
 python-versions = ">=3.8"
-groups = ["dev"]
+groups = ["main", "dev"]
 files = [
     {file = "execnet-2.1.1-py3-none-any.whl", hash = "sha256:26dee51f1b80cebd6d0ca8e74dd8745419761d3bef34163928cbebbdc4749fdc"},
     {file = "execnet-2.1.1.tar.gz", hash = "sha256:5189b52c6121c24feae288166ab41b32549c7e2348652736540b9e6e7d4e72e3"},
@@ -1348,7 +1345,6 @@ description = "FastAPI framework, high performance, easy to learn, fast to code,
 optional = false
 python-versions = ">=3.8"
 groups = ["main"]
-markers = "extra == \"api\" or extra == \"tests\" or extra == \"webui-nicegui\""
 files = [
     {file = "fastapi-0.116.2-py3-none-any.whl", hash = "sha256:c3a7a8fb830b05f7e087d920e0d786ca1fc9892eb4e9a84b227be4c1bc7569db"},
     {file = "fastapi-0.116.2.tar.gz", hash = "sha256:231a6af2fe21cfa2c32730170ad8514985fc250bec16c9b242d3b94c835ef529"},
@@ -1582,7 +1578,7 @@ version = "29.0.0"
 description = "Gherkin parser (official, by Cucumber team)"
 optional = false
 python-versions = "*"
-groups = ["dev"]
+groups = ["main", "dev"]
 files = [
     {file = "gherkin_official-29.0.0-py3-none-any.whl", hash = "sha256:26967b0d537a302119066742669e0e8b663e632769330be675457ae993e1d1bc"},
     {file = "gherkin_official-29.0.0.tar.gz", hash = "sha256:dbea32561158f02280d7579d179b019160d072ce083197625e2f80a6776bb9eb"},
@@ -1594,7 +1590,7 @@ version = "2.1.0"
 description = "Copy your docs directly to the gh-pages branch."
 optional = false
 python-versions = "*"
-groups = ["docs"]
+groups = ["main", "docs"]
 files = [
     {file = "ghp-import-2.1.0.tar.gz", hash = "sha256:9c535c4c61193c2df8871222567d7fd7e5014d835f97dc7b7439069e2413d343"},
     {file = "ghp_import-2.1.0-py3-none-any.whl", hash = "sha256:8337dd7b50877f163d4c0289bc1f1c7f127550241988d568c1db512c4324a619"},
@@ -1694,7 +1690,7 @@ description = "Lightweight in-process concurrent programming"
 optional = false
 python-versions = ">=3.9"
 groups = ["main"]
-markers = "platform_machine == \"aarch64\" or platform_machine == \"ppc64le\" or platform_machine == \"x86_64\" or platform_machine == \"amd64\" or platform_machine == \"AMD64\" or platform_machine == \"win32\" or platform_machine == \"WIN32\""
+markers = "(platform_system != \"Darwin\" or platform_machine == \"aarch64\" or platform_machine == \"ppc64le\" or platform_machine == \"amd64\" or platform_machine == \"AMD64\" or platform_machine == \"win32\" or platform_machine == \"WIN32\" or platform_machine == \"x86_64\") and (platform_system == \"Linux\" or platform_machine == \"aarch64\" or platform_machine == \"ppc64le\" or platform_machine == \"x86_64\" or platform_machine == \"amd64\" or platform_machine == \"AMD64\" or platform_machine == \"win32\" or platform_machine == \"WIN32\") and (platform_machine == \"x86_64\" or platform_machine == \"aarch64\" or platform_machine == \"ppc64le\" or platform_machine == \"amd64\" or platform_machine == \"AMD64\" or platform_machine == \"win32\" or platform_machine == \"WIN32\")"
 files = [
     {file = "greenlet-3.2.4-cp310-cp310-macosx_11_0_universal2.whl", hash = "sha256:8c68325b0d0acf8d91dde4e6f930967dd52a5302cd4062932a6b2e7c2969f47c"},
     {file = "greenlet-3.2.4-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:94385f101946790ae13da500603491f04a76b6e4c059dab271b3ce2e283b2590"},
@@ -1762,7 +1758,7 @@ version = "1.14.0"
 description = "Signatures for entire Python programs. Extract the structure, the frame, the skeleton of your project, to generate API documentation or find breaking changes in your API."
 optional = false
 python-versions = ">=3.9"
-groups = ["docs"]
+groups = ["main", "docs"]
 files = [
     {file = "griffe-1.14.0-py3-none-any.whl", hash = "sha256:0e9d52832cccf0f7188cfe585ba962d2674b241c01916d780925df34873bceb0"},
     {file = "griffe-1.14.0.tar.gz", hash = "sha256:9d2a15c1eca966d68e00517de5d69dd1bc5c9f2335ef6c1775362ba5b8651a13"},
@@ -1855,7 +1851,7 @@ description = "Fast transfer of large files with the Hugging Face Hub."
 optional = true
 python-versions = ">=3.8"
 groups = ["main"]
-markers = "(platform_system != \"Darwin\" or platform_machine == \"arm64\" or extra == \"offline\") and (extra == \"chromadb\" or extra == \"memory\" or extra == \"offline\") and (platform_machine == \"x86_64\" or platform_machine == \"amd64\" or platform_machine == \"arm64\" or platform_machine == \"aarch64\")"
+markers = "(platform_system != \"Darwin\" or platform_machine == \"arm64\" or platform_machine == \"amd64\" or platform_machine == \"aarch64\" or platform_machine == \"x86_64\") and (platform_system != \"Darwin\" or platform_machine == \"arm64\" or extra == \"offline\") and (extra == \"chromadb\" or extra == \"memory\" or extra == \"offline\") and (platform_machine == \"x86_64\" or platform_machine == \"amd64\" or platform_machine == \"arm64\" or platform_machine == \"aarch64\") and (platform_system != \"Linux\" and platform_system != \"Darwin\" or platform_machine == \"x86_64\" or platform_machine == \"arm64\" or platform_machine == \"amd64\" or platform_machine == \"aarch64\")"
 files = [
     {file = "hf_xet-1.1.9-cp37-abi3-macosx_10_12_x86_64.whl", hash = "sha256:a3b6215f88638dd7a6ff82cb4e738dcbf3d863bf667997c093a3c990337d1160"},
     {file = "hf_xet-1.1.9-cp37-abi3-macosx_11_0_arm64.whl", hash = "sha256:9b486de7a64a66f9a172f4b3e0dfe79c9f0a93257c501296a2521a13495a698a"},
@@ -1899,7 +1895,6 @@ description = "A collection of framework independent HTTP protocol utils."
 optional = false
 python-versions = ">=3.8.0"
 groups = ["main"]
-markers = "(platform_system != \"Darwin\" or platform_machine == \"arm64\" or extra == \"webui-nicegui\") and (extra == \"chromadb\" or extra == \"memory\" or extra == \"webui-nicegui\")"
 files = [
     {file = "httptools-0.6.4-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:3c73ce323711a6ffb0d247dcd5a550b8babf0f757e86a52558fe5b86d6fefcc0"},
     {file = "httptools-0.6.4-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:345c288418f0944a6fe67be8e6afa9262b18c7626c3ef3c28adc5eabc06a68da"},
@@ -2068,7 +2063,6 @@ description = "A library for property-based testing"
 optional = false
 python-versions = ">=3.9"
 groups = ["main"]
-markers = "extra == \"docs\""
 files = [
     {file = "hypothesis-6.138.14-py3-none-any.whl", hash = "sha256:1a702ecfff7034b3252d7a83328093388641cdba863197169559839e841c2154"},
     {file = "hypothesis-6.138.14.tar.gz", hash = "sha256:5c1aa1ce3f1094b5c04ea03476017695bda408a174330e5275e40ddd06d3307a"},
@@ -2102,7 +2096,7 @@ version = "2.6.14"
 description = "File identification library for Python"
 optional = false
 python-versions = ">=3.9"
-groups = ["dev"]
+groups = ["main", "dev"]
 files = [
     {file = "identify-2.6.14-py2.py3-none-any.whl", hash = "sha256:11a073da82212c6646b1f39bb20d4483bfb9543bd5566fec60053c4bb309bf2e"},
     {file = "identify-2.6.14.tar.gz", hash = "sha256:663494103b4f717cb26921c52f8751363dc89db64364cd836a9bf1535f53cd6a"},
@@ -2133,7 +2127,6 @@ description = "Cross-platform network interface and IP address enumeration libra
 optional = false
 python-versions = "*"
 groups = ["main"]
-markers = "extra == \"webui-nicegui\""
 files = [
     {file = "ifaddr-0.2.0-py3-none-any.whl", hash = "sha256:085e0305cfe6f16ab12d72e2024030f5d52674afad6911bb1eee207177b8a748"},
     {file = "ifaddr-0.2.0.tar.gz", hash = "sha256:cc0cbfcaabf765d44595825fb96a99bb12c79716b73b44330ea38ee2b0c4aed4"},
@@ -2191,7 +2184,7 @@ version = "2.1.0"
 description = "brain-dead simple config-ini parsing"
 optional = false
 python-versions = ">=3.8"
-groups = ["dev"]
+groups = ["main", "dev"]
 files = [
     {file = "iniconfig-2.1.0-py3-none-any.whl", hash = "sha256:9deba5723312380e77435581c6bf4935c94cbfab9b1ed33ef8d238ea168eb760"},
     {file = "iniconfig-2.1.0.tar.gz", hash = "sha256:3abbd2e30b36733fee78f9c7f7308f2d0050e88f0087fd25c2645f63c773e1c7"},
@@ -2272,7 +2265,7 @@ version = "6.0.1"
 description = "A Python utility / library to sort Python imports."
 optional = false
 python-versions = ">=3.9.0"
-groups = ["dev"]
+groups = ["main", "dev"]
 files = [
     {file = "isort-6.0.1-py3-none-any.whl", hash = "sha256:2dc5d7f65c9678d94c88dfc29161a320eec67328bc97aad576874cb4be1e9615"},
     {file = "isort-6.0.1.tar.gz", hash = "sha256:1cb5df28dfbc742e490c5e41bad6da41b805b0a8be7bc93cd0fb2a8a890ac450"},
@@ -2289,7 +2282,6 @@ description = "Safely pass data to untrusted environments and back."
 optional = false
 python-versions = ">=3.8"
 groups = ["main"]
-markers = "extra == \"webui-nicegui\""
 files = [
     {file = "itsdangerous-2.2.0-py3-none-any.whl", hash = "sha256:c6242fc49e35958c8b15141343aa660db5fc54d4f13a1db01a3f5891b98700ef"},
     {file = "itsdangerous-2.2.0.tar.gz", hash = "sha256:e0050c0b7da1eea53ffaf149c0cfbb5c6e2e2b69c4bef22c81fa6eb73e5f6173"},
@@ -2326,7 +2318,6 @@ files = [
     {file = "jinja2-3.1.6-py3-none-any.whl", hash = "sha256:85ece4451f492d0c13c5dd7c13a64681a86afae63a5f347908daf103ce6d2f67"},
     {file = "jinja2-3.1.6.tar.gz", hash = "sha256:0137fb05990d35f1275a587e9aee6d56da821fc83491a0fb838183be43f66d6d"},
 ]
-markers = {main = "extra == \"webui\" or extra == \"webui-nicegui\""}
 
 [package.dependencies]
 MarkupSafe = ">=2.0"
@@ -2713,7 +2704,6 @@ description = "Building stateful, multi-actor applications with LLMs"
 optional = false
 python-versions = ">=3.9"
 groups = ["main"]
-markers = "extra == \"minimal\""
 files = [
     {file = "langgraph-0.6.7-py3-none-any.whl", hash = "sha256:c724dd8c24806b70faf4903e8e20c0234f8c0a356e0e96a88035cbecca9df2cf"},
     {file = "langgraph-0.6.7.tar.gz", hash = "sha256:ba7fd17b8220142d6a4269b6038f2b3dcbcef42cd5ecf4a4c8d9b60b010830a6"},
@@ -2734,7 +2724,6 @@ description = "Library with base interfaces for LangGraph checkpoint savers."
 optional = false
 python-versions = ">=3.9"
 groups = ["main"]
-markers = "extra == \"minimal\""
 files = [
     {file = "langgraph_checkpoint-2.1.1-py3-none-any.whl", hash = "sha256:5a779134fd28134a9a83d078be4450bbf0e0c79fdf5e992549658899e6fc5ea7"},
     {file = "langgraph_checkpoint-2.1.1.tar.gz", hash = "sha256:72038c0f9e22260cb9bff1f3ebe5eb06d940b7ee5c1e4765019269d4f21cf92d"},
@@ -2751,7 +2740,6 @@ description = "Library with high-level APIs for creating and executing LangGraph
 optional = false
 python-versions = ">=3.9"
 groups = ["main"]
-markers = "extra == \"minimal\""
 files = [
     {file = "langgraph_prebuilt-0.6.4-py3-none-any.whl", hash = "sha256:819f31d88b84cb2729ff1b79db2d51e9506b8fb7aaacfc0d359d4fe16e717344"},
     {file = "langgraph_prebuilt-0.6.4.tar.gz", hash = "sha256:e9e53b906ee5df46541d1dc5303239e815d3ec551e52bb03dd6463acc79ec28f"},
@@ -2768,7 +2756,6 @@ description = "SDK for interacting with LangGraph API"
 optional = false
 python-versions = ">=3.9"
 groups = ["main"]
-markers = "extra == \"minimal\""
 files = [
     {file = "langgraph_sdk-0.2.6-py3-none-any.whl", hash = "sha256:477216b573b8177bbd849f4c754782a81279fbbd88bfadfeda44422d14b18b08"},
     {file = "langgraph_sdk-0.2.6.tar.gz", hash = "sha256:7db27cd86d1231fa614823ff416fcd2541b5565ad78ae950f31ae96d7af7c519"},
@@ -2891,7 +2878,7 @@ version = "1.3.10"
 description = "A super-fast templating language that borrows the best ideas from the existing templating languages."
 optional = false
 python-versions = ">=3.8"
-groups = ["dev"]
+groups = ["main", "dev"]
 files = [
     {file = "mako-1.3.10-py3-none-any.whl", hash = "sha256:baef24a52fc4fc514a0887ac600f9f1cff3d82c61d4d700a1fa84d597b88db59"},
     {file = "mako-1.3.10.tar.gz", hash = "sha256:99579a6f39583fa7e5630a28c3c1f440e4e97a414b80372649c0ce338da2ea28"},
@@ -2911,7 +2898,7 @@ version = "3.9"
 description = "Python implementation of John Gruber's Markdown."
 optional = false
 python-versions = ">=3.9"
-groups = ["docs"]
+groups = ["main", "docs"]
 files = [
     {file = "markdown-3.9-py3-none-any.whl", hash = "sha256:9f4d91ed810864ea88a6f32c07ba8bee1346c0cc1f6b1f9f6c822f2a9667d280"},
     {file = "markdown-3.9.tar.gz", hash = "sha256:d2900fe1782bd33bdbbd56859defef70c2e78fc46668f8eb9df3128138f2cb6a"},
@@ -2932,7 +2919,6 @@ files = [
     {file = "markdown_it_py-4.0.0-py3-none-any.whl", hash = "sha256:87327c59b172c5011896038353a81343b6754500a08cd7a4973bb48c6d578147"},
     {file = "markdown_it_py-4.0.0.tar.gz", hash = "sha256:cb0a2b4aa34f932c007117b194e945bd74e0ec24133ceb5bac59009cda1cb9f3"},
 ]
-markers = {main = "(platform_system != \"Darwin\" or platform_machine == \"arm64\" or extra == \"minimal\") and (extra == \"chromadb\" or extra == \"memory\" or extra == \"minimal\")"}
 
 [package.dependencies]
 mdurl = ">=0.1,<1.0"
@@ -2953,7 +2939,6 @@ description = "A fast and complete Python implementation of Markdown"
 optional = false
 python-versions = "<4,>=3.9"
 groups = ["main"]
-markers = "extra == \"webui-nicegui\""
 files = [
     {file = "markdown2-2.5.4-py3-none-any.whl", hash = "sha256:3c4b2934e677be7fec0e6f2de4410e116681f4ad50ec8e5ba7557be506d3f439"},
     {file = "markdown2-2.5.4.tar.gz", hash = "sha256:a09873f0b3c23dbfae589b0080587df52ad75bb09a5fa6559147554736676889"},
@@ -3035,7 +3020,6 @@ files = [
     {file = "MarkupSafe-3.0.2-cp39-cp39-win_amd64.whl", hash = "sha256:6e296a513ca3d94054c2c881cc913116e90fd030ad1c656b3869762b754f5f8a"},
     {file = "markupsafe-3.0.2.tar.gz", hash = "sha256:ee55d3edf80167e48ea11a923c7386f4669df67d7994554387f84e7d8b0a2bf0"},
 ]
-markers = {main = "extra == \"webui\" or extra == \"webui-nicegui\""}
 
 [[package]]
 name = "marshmallow"
@@ -3095,7 +3079,6 @@ files = [
     {file = "mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8"},
     {file = "mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba"},
 ]
-markers = {main = "(platform_system != \"Darwin\" or platform_machine == \"arm64\" or extra == \"minimal\") and (extra == \"chromadb\" or extra == \"memory\" or extra == \"minimal\")"}
 
 [[package]]
 name = "mergedeep"
@@ -3103,7 +3086,7 @@ version = "1.3.4"
 description = "A deep merge function for 🐍."
 optional = false
 python-versions = ">=3.6"
-groups = ["docs"]
+groups = ["main", "docs"]
 files = [
     {file = "mergedeep-1.3.4-py3-none-any.whl", hash = "sha256:70775750742b25c0d8f36c55aed03d24c3384d17c951b3175d898bd778ef0307"},
     {file = "mergedeep-1.3.4.tar.gz", hash = "sha256:0096d52e9dad9939c3d975a774666af186eda617e6ca84df4c94dec30004f2a8"},
@@ -3115,7 +3098,7 @@ version = "1.6.1"
 description = "Project documentation with Markdown."
 optional = false
 python-versions = ">=3.8"
-groups = ["docs"]
+groups = ["main", "docs"]
 files = [
     {file = "mkdocs-1.6.1-py3-none-any.whl", hash = "sha256:db91759624d1647f3f34aa0c3f327dd2601beae39a366d6e064c03468d35c20e"},
     {file = "mkdocs-1.6.1.tar.gz", hash = "sha256:7b432f01d928c084353ab39c57282f29f92136665bdd6abf7c1ec8d822ef86f2"},
@@ -3146,7 +3129,7 @@ version = "1.4.3"
 description = "Automatically link across pages in MkDocs."
 optional = false
 python-versions = ">=3.9"
-groups = ["docs"]
+groups = ["main", "docs"]
 files = [
     {file = "mkdocs_autorefs-1.4.3-py3-none-any.whl", hash = "sha256:469d85eb3114801d08e9cc55d102b3ba65917a869b893403b8987b601cf55dc9"},
     {file = "mkdocs_autorefs-1.4.3.tar.gz", hash = "sha256:beee715b254455c4aa93b6ef3c67579c399ca092259cc41b7d9342573ff1fc75"},
@@ -3163,7 +3146,7 @@ version = "0.5.0"
 description = "MkDocs plugin to programmatically generate documentation pages during the build"
 optional = false
 python-versions = ">=3.7"
-groups = ["docs"]
+groups = ["main", "docs"]
 files = [
     {file = "mkdocs_gen_files-0.5.0-py3-none-any.whl", hash = "sha256:7ac060096f3f40bd19039e7277dd3050be9a453c8ac578645844d4d91d7978ea"},
     {file = "mkdocs_gen_files-0.5.0.tar.gz", hash = "sha256:4c7cf256b5d67062a788f6b1d035e157fc1a9498c2399be9af5257d4ff4d19bc"},
@@ -3178,7 +3161,7 @@ version = "0.2.0"
 description = "MkDocs extension that lists all dependencies according to a mkdocs.yml file"
 optional = false
 python-versions = ">=3.8"
-groups = ["docs"]
+groups = ["main", "docs"]
 files = [
     {file = "mkdocs_get_deps-0.2.0-py3-none-any.whl", hash = "sha256:2bf11d0b133e77a0dd036abeeb06dec8775e46efa526dc70667d8863eefc6134"},
     {file = "mkdocs_get_deps-0.2.0.tar.gz", hash = "sha256:162b3d129c7fad9b19abfdcb9c1458a651628e4b1dea628ac68790fb3061c60c"},
@@ -3195,7 +3178,7 @@ version = "7.1.7"
 description = "Mkdocs Markdown includer plugin."
 optional = false
 python-versions = ">=3.9"
-groups = ["docs"]
+groups = ["main", "docs"]
 files = [
     {file = "mkdocs_include_markdown_plugin-7.1.7-py3-none-any.whl", hash = "sha256:a0c13efe4f6b05a419c022e201055bf43145eed90de65f2353c33fb4005b6aa5"},
     {file = "mkdocs_include_markdown_plugin-7.1.7.tar.gz", hash = "sha256:677637e04c2d3497c50340be522e2a7f614124f592c7982d88b859f88d527a4c"},
@@ -3214,7 +3197,7 @@ version = "0.6.2"
 description = "MkDocs plugin to specify the navigation in Markdown instead of YAML"
 optional = false
 python-versions = ">=3.9"
-groups = ["docs"]
+groups = ["main", "docs"]
 files = [
     {file = "mkdocs_literate_nav-0.6.2-py3-none-any.whl", hash = "sha256:0a6489a26ec7598477b56fa112056a5e3a6c15729f0214bea8a4dbc55bd5f630"},
     {file = "mkdocs_literate_nav-0.6.2.tar.gz", hash = "sha256:760e1708aa4be86af81a2b56e82c739d5a8388a0eab1517ecfd8e5aa40810a75"},
@@ -3229,7 +3212,7 @@ version = "9.6.19"
 description = "Documentation that simply works"
 optional = false
 python-versions = ">=3.8"
-groups = ["docs"]
+groups = ["main", "docs"]
 files = [
     {file = "mkdocs_material-9.6.19-py3-none-any.whl", hash = "sha256:7492d2ac81952a467ca8a10cac915d6ea5c22876932f44b5a0f4f8e7d68ac06f"},
     {file = "mkdocs_material-9.6.19.tar.gz", hash = "sha256:80e7b3f9acabfee9b1f68bd12c26e59c865b3d5bbfb505fd1344e970db02c4aa"},
@@ -3260,7 +3243,7 @@ version = "1.3.1"
 description = "Extension pack for Python Markdown and MkDocs Material."
 optional = false
 python-versions = ">=3.8"
-groups = ["docs"]
+groups = ["main", "docs"]
 files = [
     {file = "mkdocs_material_extensions-1.3.1-py3-none-any.whl", hash = "sha256:adff8b62700b25cb77b53358dad940f3ef973dd6db797907c49e3c2ef3ab4e31"},
     {file = "mkdocs_material_extensions-1.3.1.tar.gz", hash = "sha256:10c9511cea88f568257f960358a467d12b970e1f7b2c0e5fb2bb48cab1928443"},
@@ -3272,7 +3255,7 @@ version = "0.3.10"
 description = "MkDocs plugin to allow clickable sections that lead to an index page"
 optional = false
 python-versions = ">=3.9"
-groups = ["docs"]
+groups = ["main", "docs"]
 files = [
     {file = "mkdocs_section_index-0.3.10-py3-none-any.whl", hash = "sha256:bc27c0d0dc497c0ebaee1fc72839362aed77be7318b5ec0c30628f65918e4776"},
     {file = "mkdocs_section_index-0.3.10.tar.gz", hash = "sha256:a82afbda633c82c5568f0e3b008176b9b365bf4bd8b6f919d6eff09ee146b9f8"},
@@ -3287,7 +3270,7 @@ version = "0.1.6"
 description = "Mkdocs plugin for generating Typer CLI docs"
 optional = false
 python-versions = ">=3.10"
-groups = ["docs"]
+groups = ["main", "docs"]
 files = [
     {file = "mkdocs_typer2-0.1.6-py3-none-any.whl", hash = "sha256:1642d0bd3efc3b2efe1efe3ee0231dcbc69602d592613264b621636e9169151f"},
     {file = "mkdocs_typer2-0.1.6.tar.gz", hash = "sha256:0d83e01ddd108ebb2f61229d73317bc3ee9d94e98c68efeb4a5ef8492d163a75"},
@@ -3304,7 +3287,7 @@ version = "0.30.0"
 description = "Automatic documentation from sources, for MkDocs."
 optional = false
 python-versions = ">=3.9"
-groups = ["docs"]
+groups = ["main", "docs"]
 files = [
     {file = "mkdocstrings-0.30.0-py3-none-any.whl", hash = "sha256:ae9e4a0d8c1789697ac776f2e034e2ddd71054ae1cf2c2bb1433ccfd07c226f2"},
     {file = "mkdocstrings-0.30.0.tar.gz", hash = "sha256:5d8019b9c31ddacd780b6784ffcdd6f21c408f34c0bd1103b5351d609d5b4444"},
@@ -3329,7 +3312,7 @@ version = "1.18.2"
 description = "A Python handler for mkdocstrings."
 optional = false
 python-versions = ">=3.9"
-groups = ["docs"]
+groups = ["main", "docs"]
 files = [
     {file = "mkdocstrings_python-1.18.2-py3-none-any.whl", hash = "sha256:944fe6deb8f08f33fa936d538233c4036e9f53e840994f6146e8e94eb71b600d"},
     {file = "mkdocstrings_python-1.18.2.tar.gz", hash = "sha256:4ad536920a07b6336f50d4c6d5603316fafb1172c5c882370cbbc954770ad323"},
@@ -3679,7 +3662,7 @@ version = "1.17.1"
 description = "Optional static typing for Python"
 optional = false
 python-versions = ">=3.9"
-groups = ["dev"]
+groups = ["main", "dev"]
 files = [
     {file = "mypy-1.17.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:3fbe6d5555bf608c47203baa3e72dbc6ec9965b3d7c318aa9a4ca76f465bd972"},
     {file = "mypy-1.17.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:80ef5c058b7bce08c83cac668158cb7edea692e458d21098c7d3bce35a5d43e7"},
@@ -3778,7 +3761,6 @@ description = "Python package for creating and manipulating graphs and networks"
 optional = false
 python-versions = ">=3.11"
 groups = ["main"]
-markers = "extra == \"minimal\""
 files = [
     {file = "networkx-3.5-py3-none-any.whl", hash = "sha256:0030d386a9a06dee3565298b4a734b68589749a544acbb6c412dc9e2489ec6ec"},
     {file = "networkx-3.5.tar.gz", hash = "sha256:d4c6f9cf81f52d69230866796b82afbccdec3db7ae4fbd1b65ea750feed50037"},
@@ -3800,7 +3782,6 @@ description = "Create web-based user interfaces with Python. The nice way."
 optional = false
 python-versions = "<4.0,>=3.8"
 groups = ["main"]
-markers = "extra == \"webui-nicegui\""
 files = [
     {file = "nicegui-2.24.0-py3-none-any.whl", hash = "sha256:76cd72f87b2775537fbc96d97925a8b41a09c166bf67ba9f1999c16f73e0698e"},
     {file = "nicegui-2.24.0.tar.gz", hash = "sha256:139314d786344965ec2b24691f74055292f5dc458b575d12c4607b7c3ebda8cf"},
@@ -3869,7 +3850,7 @@ version = "1.9.1"
 description = "Node.js virtual environment builder"
 optional = false
 python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,!=3.6.*,>=2.7"
-groups = ["dev"]
+groups = ["main", "dev"]
 files = [
     {file = "nodeenv-1.9.1-py2.py3-none-any.whl", hash = "sha256:ba11c9782d29c27c70ffbdda2d7415098754709be8a7056d79a737cd901155c9"},
     {file = "nodeenv-1.9.1.tar.gz", hash = "sha256:6ec12890a2dab7946721edbfbcd91f3319c6ccc9aec47be7c7e6b7011ee6645f"},
@@ -4155,7 +4136,6 @@ description = "Fast, correct Python JSON library supporting dataclasses, datetim
 optional = false
 python-versions = ">=3.9"
 groups = ["main"]
-markers = "platform_python_implementation != \"PyPy\" or extra == \"minimal\" or (platform_system != \"Darwin\" or platform_machine == \"arm64\") and (extra == \"chromadb\" or extra == \"memory\") or extra == \"webui-nicegui\" and platform_machine != \"i386\" and platform_machine != \"i686\""
 files = [
     {file = "orjson-3.11.3-cp310-cp310-macosx_10_15_x86_64.macosx_11_0_arm64.macosx_10_15_universal2.whl", hash = "sha256:29cb1f1b008d936803e2da3d7cba726fc47232c45df531b29edf0b232dd737e7"},
     {file = "orjson-3.11.3-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:97dceed87ed9139884a55db8722428e27bd8452817fbf1869c58b49fecab1120"},
@@ -4249,7 +4229,6 @@ description = "Fast, correct Python msgpack library supporting dataclasses, date
 optional = false
 python-versions = ">=3.9"
 groups = ["main"]
-markers = "extra == \"minimal\""
 files = [
     {file = "ormsgpack-1.10.0-cp310-cp310-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:8a52c7ce7659459f3dc8dec9fd6a6c76f855a0a7e2b61f26090982ac10b95216"},
     {file = "ormsgpack-1.10.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:060f67fe927582f4f63a1260726d019204b72f460cf20930e6c925a1d129f373"},
@@ -4340,7 +4319,7 @@ version = "0.5.7"
 description = "Divides large result sets into pages for easier browsing"
 optional = false
 python-versions = "*"
-groups = ["docs"]
+groups = ["main", "docs"]
 files = [
     {file = "paginate-0.5.7-py2.py3-none-any.whl", hash = "sha256:b885e2af73abcf01d9559fd5216b57ef722f8c42affbb63942377668e35c7591"},
     {file = "paginate-0.5.7.tar.gz", hash = "sha256:22bd083ab41e1a8b4f3690544afb2c60c25e5c9a63a30fa2f483f6c60c8e5945"},
@@ -4440,7 +4419,7 @@ version = "1.20.2"
 description = "parse() is the opposite of format()"
 optional = false
 python-versions = "*"
-groups = ["dev"]
+groups = ["main", "dev"]
 files = [
     {file = "parse-1.20.2-py2.py3-none-any.whl", hash = "sha256:967095588cb802add9177d0c0b6133b5ba33b1ea9007ca800e526f42a85af558"},
     {file = "parse-1.20.2.tar.gz", hash = "sha256:b41d604d16503c79d81af5165155c0b20f6c8d6c559efa66b4b695c3e5a0a0ce"},
@@ -4452,7 +4431,7 @@ version = "0.6.6"
 description = "Simplifies to build parse types based on the parse module"
 optional = false
 python-versions = "!=3.0.*,!=3.1.*,>=2.7"
-groups = ["dev"]
+groups = ["main", "dev"]
 files = [
     {file = "parse_type-0.6.6-py2.py3-none-any.whl", hash = "sha256:3ca79bbe71e170dfccc8ec6c341edfd1c2a0fc1e5cfd18330f93af938de2348c"},
     {file = "parse_type-0.6.6.tar.gz", hash = "sha256:513a3784104839770d690e04339a8b4d33439fcd5dd99f2e4580f9fc1097bfb2"},
@@ -4489,7 +4468,7 @@ version = "0.12.1"
 description = "Utility library for gitignore style pattern matching of file paths."
 optional = false
 python-versions = ">=3.8"
-groups = ["dev", "docs"]
+groups = ["main", "dev", "docs"]
 files = [
     {file = "pathspec-0.12.1-py3-none-any.whl", hash = "sha256:a0d503e138a4c123b27490a4f7beda6a01c6f288df0e4a8b79c7eb0dc7b4cc08"},
     {file = "pathspec-0.12.1.tar.gz", hash = "sha256:a482d51503a1ab33b1c67a6c3813a26953dbdc71c31dacaef9a838c4e29f5712"},
@@ -4643,7 +4622,7 @@ version = "4.4.0"
 description = "A small Python package for determining appropriate platform-specific dirs, e.g. a `user data dir`."
 optional = false
 python-versions = ">=3.9"
-groups = ["dev", "docs"]
+groups = ["main", "dev", "docs"]
 files = [
     {file = "platformdirs-4.4.0-py3-none-any.whl", hash = "sha256:abd01743f24e5287cd7a5db3752faf1a2d65353f38ec26d98e25a6db65958c85"},
     {file = "platformdirs-4.4.0.tar.gz", hash = "sha256:ca753cf4d81dc309bc67b0ea38fd15dc97bc30ce419a7f58d13eb3bf14c4febf"},
@@ -4660,7 +4639,7 @@ version = "1.6.0"
 description = "plugin and hook calling mechanisms for python"
 optional = false
 python-versions = ">=3.9"
-groups = ["dev"]
+groups = ["main", "dev"]
 files = [
     {file = "pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746"},
     {file = "pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3"},
@@ -4701,7 +4680,7 @@ version = "4.3.0"
 description = "A framework for managing and maintaining multi-language pre-commit hooks."
 optional = false
 python-versions = ">=3.9"
-groups = ["dev"]
+groups = ["main", "dev"]
 files = [
     {file = "pre_commit-4.3.0-py2.py3-none-any.whl", hash = "sha256:2b0747ad7e6e967169136edffee14c16e148a778a54e4f967921aa1ebf2308d8"},
     {file = "pre_commit-4.3.0.tar.gz", hash = "sha256:499fe450cc9d42e9d58e606262795ecb64dd05438943c62b66f6a8673da30b16"},
@@ -4859,7 +4838,7 @@ description = ""
 optional = true
 python-versions = ">=3.9"
 groups = ["main"]
-markers = "(platform_system != \"Darwin\" or platform_machine == \"arm64\") and (extra == \"chromadb\" or extra == \"memory\") or extra == \"webui\""
+markers = "(platform_system != \"Darwin\" or platform_machine == \"arm64\" or extra == \"webui\") and (extra == \"chromadb\" or extra == \"memory\" or extra == \"webui\")"
 files = [
     {file = "protobuf-6.32.0-cp310-abi3-win32.whl", hash = "sha256:84f9e3c1ff6fb0308dbacb0950d8aa90694b0d0ee68e75719cb044b7078fe741"},
     {file = "protobuf-6.32.0-cp310-abi3-win_amd64.whl", hash = "sha256:a8bdbb2f009cfc22a36d031f22a625a38b615b5e19e558a7b756b3279723e68e"},
@@ -4879,7 +4858,6 @@ description = "Python to JavaScript compiler."
 optional = false
 python-versions = "*"
 groups = ["main"]
-markers = "extra == \"webui-nicegui\""
 files = [
     {file = "pscript-0.7.7-py3-none-any.whl", hash = "sha256:b0fdac0df0393a4d7497153fea6a82e6429f32327c4c0a4817f1cd68adc08083"},
     {file = "pscript-0.7.7.tar.gz", hash = "sha256:8632f7a4483f235514aadee110edee82eb6d67336bf68744a7b18d76e50442f8"},
@@ -4891,7 +4869,7 @@ version = "7.0.0"
 description = "Cross-platform lib for process and system monitoring in Python.  NOTE: the syntax of this script MUST be kept compatible with Python 2.7."
 optional = false
 python-versions = ">=3.6"
-groups = ["dev"]
+groups = ["main", "dev"]
 files = [
     {file = "psutil-7.0.0-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:101d71dc322e3cffd7cea0650b09b3d08b8e7c4109dd6809fe452dfd00e58b25"},
     {file = "psutil-7.0.0-cp36-abi3-macosx_11_0_arm64.whl", hash = "sha256:39db632f6bb862eeccf56660871433e111b6ea58f2caea825571951d4b6aa3da"},
@@ -5470,7 +5448,6 @@ files = [
     {file = "pygments-2.19.2-py3-none-any.whl", hash = "sha256:86540386c03d588bb81d44bc3928634ff26449851e99741617ecb9037ee5ec0b"},
     {file = "pygments-2.19.2.tar.gz", hash = "sha256:636cb2477cec7f8952536970bc533bc43743542f70392ae026374600add5b887"},
 ]
-markers = {main = "(platform_system != \"Darwin\" or platform_machine == \"arm64\" or extra == \"minimal\") and (extra == \"chromadb\" or extra == \"memory\" or extra == \"minimal\") or extra == \"webui-nicegui\""}
 
 [package.extras]
 windows-terminal = ["colorama (>=0.4.6)"]
@@ -5481,7 +5458,7 @@ version = "10.16.1"
 description = "Extension pack for Python Markdown."
 optional = false
 python-versions = ">=3.9"
-groups = ["docs"]
+groups = ["main", "docs"]
 files = [
     {file = "pymdown_extensions-10.16.1-py3-none-any.whl", hash = "sha256:d6ba157a6c03146a7fb122b2b9a121300056384eafeec9c9f9e584adfdb2a32d"},
     {file = "pymdown_extensions-10.16.1.tar.gz", hash = "sha256:aace82bcccba3efc03e25d584e6a22d27a8e17caa3f4dd9f207e49b787aa9a91"},
@@ -5556,7 +5533,7 @@ version = "8.4.2"
 description = "pytest: simple powerful testing with Python"
 optional = false
 python-versions = ">=3.9"
-groups = ["dev"]
+groups = ["main", "dev"]
 files = [
     {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
     {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
@@ -5597,7 +5574,7 @@ version = "8.1.0"
 description = "BDD for pytest"
 optional = false
 python-versions = ">=3.9"
-groups = ["dev"]
+groups = ["main", "dev"]
 files = [
     {file = "pytest_bdd-8.1.0-py3-none-any.whl", hash = "sha256:2124051e71a05ad7db15296e39013593f72ebf96796e1b023a40e5453c47e5fb"},
     {file = "pytest_bdd-8.1.0.tar.gz", hash = "sha256:ef0896c5cd58816dc49810e8ff1d632f4a12019fb3e49959b2d349ffc1c9bfb5"},
@@ -5639,7 +5616,7 @@ version = "6.3.0"
 description = "Pytest plugin for measuring coverage."
 optional = false
 python-versions = ">=3.9"
-groups = ["dev"]
+groups = ["main", "dev"]
 files = [
     {file = "pytest_cov-6.3.0-py3-none-any.whl", hash = "sha256:440db28156d2468cafc0415b4f8e50856a0d11faefa38f30906048fe490f1749"},
     {file = "pytest_cov-6.3.0.tar.gz", hash = "sha256:35c580e7800f87ce892e687461166e1ac2bcb8fb9e13aea79032518d6e503ff2"},
@@ -5698,7 +5675,7 @@ version = "3.15.0"
 description = "Thin-wrapper around the mock package for easier use with pytest"
 optional = false
 python-versions = ">=3.9"
-groups = ["dev"]
+groups = ["main", "dev"]
 files = [
     {file = "pytest_mock-3.15.0-py3-none-any.whl", hash = "sha256:ef2219485fb1bd256b00e7ad7466ce26729b30eadfc7cbcdb4fa9a92ca68db6f"},
     {file = "pytest_mock-3.15.0.tar.gz", hash = "sha256:ab896bd190316b9d5d87b277569dfcdf718b2d049a2ccff5f7aca279c002a1cf"},
@@ -5716,7 +5693,7 @@ version = "16.0.1"
 description = "pytest plugin to re-run tests to eliminate flaky failures"
 optional = false
 python-versions = ">=3.9"
-groups = ["dev"]
+groups = ["main", "dev"]
 files = [
     {file = "pytest_rerunfailures-16.0.1-py3-none-any.whl", hash = "sha256:0bccc0e3b0e3388275c25a100f7077081318196569a121217688ed05e58984b9"},
     {file = "pytest_rerunfailures-16.0.1.tar.gz", hash = "sha256:ed4b3a6e7badb0a720ddd93f9de1e124ba99a0cb13bc88561b3c168c16062559"},
@@ -5732,7 +5709,7 @@ version = "3.8.0"
 description = "pytest xdist plugin for distributed testing, most importantly across multiple CPUs"
 optional = false
 python-versions = ">=3.9"
-groups = ["dev"]
+groups = ["main", "dev"]
 files = [
     {file = "pytest_xdist-3.8.0-py3-none-any.whl", hash = "sha256:202ca578cfeb7370784a8c33d6d05bc6e13b4f25b5053c30a152269fd10f0b88"},
     {file = "pytest_xdist-3.8.0.tar.gz", hash = "sha256:7e578125ec9bc6050861aa93f2d59f1d8d085595d6551c2c90b6f4fad8d3a9f1"},
@@ -5758,7 +5735,6 @@ files = [
     {file = "python-dateutil-2.9.0.post0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3"},
     {file = "python_dateutil-2.9.0.post0-py2.py3-none-any.whl", hash = "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427"},
 ]
-markers = {main = "(platform_system != \"Darwin\" or platform_machine == \"arm64\") and (extra == \"chromadb\" or extra == \"memory\") or extra == \"webui\""}
 
 [package.dependencies]
 six = ">=1.5"
@@ -5785,7 +5761,6 @@ description = "Engine.IO server and client for Python"
 optional = false
 python-versions = ">=3.6"
 groups = ["main"]
-markers = "extra == \"webui-nicegui\""
 files = [
     {file = "python_engineio-4.12.2-py3-none-any.whl", hash = "sha256:8218ab66950e179dfec4b4bbb30aecf3f5d86f5e58e6fc1aa7fde2c698b2804f"},
     {file = "python_engineio-4.12.2.tar.gz", hash = "sha256:e7e712ffe1be1f6a05ee5f951e72d434854a32fcfc7f6e4d9d3cae24ec70defa"},
@@ -5806,7 +5781,6 @@ description = "A streaming multipart parser for Python"
 optional = false
 python-versions = ">=3.8"
 groups = ["main"]
-markers = "extra == \"webui-nicegui\""
 files = [
     {file = "python_multipart-0.0.20-py3-none-any.whl", hash = "sha256:8a62d3a8335e06589fe01f2a3e178cdcc632f3fbe0d492ad9ee0ec35aab1f104"},
     {file = "python_multipart-0.0.20.tar.gz", hash = "sha256:8dd0cab45b8e23064ae09147625994d090fa46f5b0d1e13af944c331a7fa9d13"},
@@ -5819,7 +5793,6 @@ description = "Socket.IO server and client for Python"
 optional = false
 python-versions = ">=3.8"
 groups = ["main"]
-markers = "extra == \"webui-nicegui\""
 files = [
     {file = "python_socketio-5.13.0-py3-none-any.whl", hash = "sha256:51f68d6499f2df8524668c24bcec13ba1414117cfb3a90115c559b601ab10caf"},
     {file = "python_socketio-5.13.0.tar.gz", hash = "sha256:ac4e19a0302ae812e23b712ec8b6427ca0521f7c582d6abb096e36e24a263029"},
@@ -5917,7 +5890,7 @@ version = "1.1"
 description = "A custom YAML tag for referencing environment variables in YAML files."
 optional = false
 python-versions = ">=3.9"
-groups = ["docs"]
+groups = ["main", "docs"]
 files = [
     {file = "pyyaml_env_tag-1.1-py3-none-any.whl", hash = "sha256:17109e1a528561e32f026364712fee1264bc2ea6715120891174ed1b980d2e04"},
     {file = "pyyaml_env_tag-1.1.tar.gz", hash = "sha256:2eb38b75a2d21ee0475d6d97ec19c63287a7e140231e4214969d0eac923cd7ff"},
@@ -6125,7 +6098,7 @@ version = "0.25.8"
 description = "A utility library for mocking out the `requests` Python library."
 optional = false
 python-versions = ">=3.8"
-groups = ["dev"]
+groups = ["main", "dev"]
 files = [
     {file = "responses-0.25.8-py3-none-any.whl", hash = "sha256:0c710af92def29c8352ceadff0c3fe340ace27cf5af1bbe46fb71275bcd2831c"},
     {file = "responses-0.25.8.tar.gz", hash = "sha256:9374d047a575c8f781b94454db5cab590b6029505f488d12899ddb10a4af1cf4"},
@@ -6150,7 +6123,6 @@ files = [
     {file = "rich-14.1.0-py3-none-any.whl", hash = "sha256:536f5f1785986d6dbdea3c75205c473f970777b4a0d6c6dd1b696aa05a3fa04f"},
     {file = "rich-14.1.0.tar.gz", hash = "sha256:e497a48b844b0320d45007cdebfeaeed8db2a4f4bcf49f15e455cfc4af11eaa8"},
 ]
-markers = {main = "(platform_system != \"Darwin\" or platform_machine == \"arm64\" or extra == \"minimal\") and (extra == \"chromadb\" or extra == \"memory\" or extra == \"minimal\")"}
 
 [package.dependencies]
 markdown-it-py = ">=2.2.0"
@@ -6545,7 +6517,6 @@ files = [
     {file = "shellingham-1.5.4-py2.py3-none-any.whl", hash = "sha256:7ecfff8f2fd72616f7481040475a65b2bf8af90a56c89140852d1120324e8686"},
     {file = "shellingham-1.5.4.tar.gz", hash = "sha256:8dbca0739d487e5bd35ab3ca4b36e11c4078f3a234bfce294b0a0291363404de"},
 ]
-markers = {main = "(platform_system != \"Darwin\" or platform_machine == \"arm64\" or extra == \"minimal\") and (extra == \"chromadb\" or extra == \"memory\" or extra == \"minimal\")"}
 
 [[package]]
 name = "simple-websocket"
@@ -6554,7 +6525,6 @@ description = "Simple WebSocket server and client for Python"
 optional = false
 python-versions = ">=3.6"
 groups = ["main"]
-markers = "extra == \"webui-nicegui\""
 files = [
     {file = "simple_websocket-1.1.0-py3-none-any.whl", hash = "sha256:4af6069630a38ed6c561010f0e11a5bc0d4ca569b36306eb257cd9a192497c8c"},
     {file = "simple_websocket-1.1.0.tar.gz", hash = "sha256:7939234e7aa067c534abdab3a9ed933ec9ce4691b0713c78acb195560aa52ae4"},
@@ -6578,7 +6548,6 @@ files = [
     {file = "six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274"},
     {file = "six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81"},
 ]
-markers = {main = "(platform_system != \"Darwin\" or platform_machine == \"arm64\" or extra == \"webui\") and (extra == \"chromadb\" or extra == \"memory\" or extra == \"webui\")"}
 
 [[package]]
 name = "smmap"
@@ -6615,7 +6584,6 @@ files = [
     {file = "sortedcontainers-2.4.0-py2.py3-none-any.whl", hash = "sha256:a163dcaede0f1c021485e957a39245190e74249897e2ae4b2aa38595db237ee0"},
     {file = "sortedcontainers-2.4.0.tar.gz", hash = "sha256:25caa5a06cc30b6b83d11423433f65d1f9d76c4c6a0c90e3379eaa43b9bfdb88"},
 ]
-markers = {main = "extra == \"docs\""}
 
 [[package]]
 name = "sqlalchemy"
@@ -6906,7 +6874,7 @@ description = ""
 optional = true
 python-versions = ">=3.9"
 groups = ["main"]
-markers = "(platform_system != \"Darwin\" or platform_machine == \"arm64\") and (extra == \"chromadb\" or extra == \"memory\") or extra == \"offline\""
+markers = "(platform_system != \"Darwin\" or platform_machine == \"arm64\" or extra == \"offline\") and (extra == \"chromadb\" or extra == \"memory\" or extra == \"offline\")"
 files = [
     {file = "tokenizers-0.22.0-cp39-abi3-macosx_10_12_x86_64.whl", hash = "sha256:eaa9620122a3fb99b943f864af95ed14c8dfc0f47afa3b404ac8c16b3f2bb484"},
     {file = "tokenizers-0.22.0-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:71784b9ab5bf0ff3075bceeb198149d2c5e068549c0d18fe32d06ba0deb63f79"},
@@ -6940,7 +6908,6 @@ description = "Python Library for Tom's Obvious, Minimal Language"
 optional = false
 python-versions = ">=2.6, !=3.0.*, !=3.1.*, !=3.2.*"
 groups = ["main"]
-markers = "extra == \"minimal\" or extra == \"dev\" or extra == \"webui\""
 files = [
     {file = "toml-0.10.2-py2.py3-none-any.whl", hash = "sha256:806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b"},
     {file = "toml-0.10.2.tar.gz", hash = "sha256:b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f"},
@@ -7126,7 +7093,6 @@ files = [
     {file = "typer-0.17.4-py3-none-any.whl", hash = "sha256:015534a6edaa450e7007eba705d5c18c3349dcea50a6ad79a5ed530967575824"},
     {file = "typer-0.17.4.tar.gz", hash = "sha256:b77dc07d849312fd2bb5e7f20a7af8985c7ec360c45b051ed5412f64d8dc1580"},
 ]
-markers = {main = "(platform_system != \"Darwin\" or platform_machine == \"arm64\") and (extra == \"chromadb\" or extra == \"memory\") or extra == \"minimal\""}
 
 [package.dependencies]
 click = ">=8.0.0"
@@ -7367,7 +7333,7 @@ description = "Fast implementation of asyncio event loop on top of libuv"
 optional = false
 python-versions = ">=3.8.0"
 groups = ["main"]
-markers = "((platform_system != \"Darwin\" or platform_machine == \"arm64\") and (extra == \"chromadb\" or extra == \"memory\") or extra == \"webui-nicegui\") and sys_platform != \"win32\" and sys_platform != \"cygwin\" and platform_python_implementation != \"PyPy\""
+markers = "sys_platform != \"win32\" and sys_platform != \"cygwin\" and platform_python_implementation != \"PyPy\""
 files = [
     {file = "uvloop-0.21.0-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:ec7e6b09a6fdded42403182ab6b832b71f4edaf7f37a9a0e371a01db5f0cb45f"},
     {file = "uvloop-0.21.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:196274f2adb9689a289ad7d65700d37df0c0930fd8e4e743fa4834e850d7719d"},
@@ -7420,7 +7386,6 @@ description = "A simple module to extract html/script/style from a vuejs '.vue' 
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*"
 groups = ["main"]
-markers = "extra == \"webui-nicegui\""
 files = [
     {file = "vbuild-0.8.2-py2.py3-none-any.whl", hash = "sha256:d76bcc976a1c53b6a5776ac947606f9e7786c25df33a587ebe33ed09dd8a1076"},
     {file = "vbuild-0.8.2.tar.gz", hash = "sha256:270cd9078349d907dfae6c0e6364a5a5e74cb86183bb5093613f12a18b435fa9"},
@@ -7435,7 +7400,7 @@ version = "20.34.0"
 description = "Virtual Python Environment builder"
 optional = false
 python-versions = ">=3.8"
-groups = ["dev"]
+groups = ["main", "dev"]
 files = [
     {file = "virtualenv-20.34.0-py3-none-any.whl", hash = "sha256:341f5afa7eee943e4984a9207c025feedd768baff6753cd660c857ceb3e36026"},
     {file = "virtualenv-20.34.0.tar.gz", hash = "sha256:44815b2c9dee7ed86e387b842a84f20b93f7f417f95886ca1996a72a4138eb1a"},
@@ -7489,7 +7454,6 @@ files = [
     {file = "watchdog-6.0.0-py3-none-win_ia64.whl", hash = "sha256:a1914259fa9e1454315171103c6a30961236f508b9b623eae470268bbcc6a22f"},
     {file = "watchdog-6.0.0.tar.gz", hash = "sha256:9ddf7c82fda3ae8e24decda1338ede66e1c99883db93711d8fb941eaa2d8c282"},
 ]
-markers = {main = "extra == \"webui\" and platform_system != \"Darwin\""}
 
 [package.extras]
 watchmedo = ["PyYAML (>=3.10)"]
@@ -7501,7 +7465,6 @@ description = "Simple, modern and high performance file watching and code reload
 optional = false
 python-versions = ">=3.9"
 groups = ["main"]
-markers = "(platform_system != \"Darwin\" or platform_machine == \"arm64\" or extra == \"webui-nicegui\") and (extra == \"chromadb\" or extra == \"memory\" or extra == \"webui-nicegui\")"
 files = [
     {file = "watchfiles-1.1.0-cp310-cp310-macosx_10_12_x86_64.whl", hash = "sha256:27f30e14aa1c1e91cb653f03a63445739919aef84c8d2517997a83155e7a2fcc"},
     {file = "watchfiles-1.1.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:3366f56c272232860ab45c77c3ca7b74ee819c8e1f6f35a7125556b198bbc6df"},
@@ -7620,7 +7583,7 @@ version = "10.1"
 description = "Wildcard/glob file name matcher."
 optional = false
 python-versions = ">=3.9"
-groups = ["docs"]
+groups = ["main", "docs"]
 files = [
     {file = "wcmatch-10.1-py3-none-any.whl", hash = "sha256:5848ace7dbb0476e5e55ab63c6bbd529745089343427caa5537f230cc01beb8a"},
     {file = "wcmatch-10.1.tar.gz", hash = "sha256:f11f94208c8c8484a16f4f48638a85d771d9513f4ab3f37595978801cb9465af"},
@@ -7666,7 +7629,6 @@ description = "An implementation of the WebSocket Protocol (RFC 6455 & 7692)"
 optional = false
 python-versions = ">=3.9"
 groups = ["main"]
-markers = "(platform_system != \"Darwin\" or platform_machine == \"arm64\" or extra == \"webui-nicegui\") and (extra == \"chromadb\" or extra == \"memory\" or extra == \"webui-nicegui\")"
 files = [
     {file = "websockets-15.0.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:d63efaa0cd96cf0c5fe4d581521d9fa87744540d4bc999ae6e08595a1014b45b"},
     {file = "websockets-15.0.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:ac60e3b188ec7574cb761b08d50fcedf9d77f1530352db4eef1707fe9dee7205"},
@@ -7758,7 +7720,6 @@ description = "WebSockets state-machine based protocol implementation"
 optional = false
 python-versions = ">=3.7.0"
 groups = ["main"]
-markers = "extra == \"lmstudio\" or extra == \"webui-nicegui\""
 files = [
     {file = "wsproto-1.2.0-py3-none-any.whl", hash = "sha256:b9acddd652b585d75b20477888c56642fdade28bdfd3579aa24a4d2c037dd736"},
     {file = "wsproto-1.2.0.tar.gz", hash = "sha256:ad565f26ecb92588a3e43bc3d96164de84cd9902482b130d0ddbaa9664a85065"},
@@ -7774,7 +7735,6 @@ description = "Python binding for xxHash"
 optional = false
 python-versions = ">=3.7"
 groups = ["main"]
-markers = "extra == \"minimal\""
 files = [
     {file = "xxhash-3.5.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:ece616532c499ee9afbb83078b1b952beffef121d989841f7f4b3dc5ac0fd212"},
     {file = "xxhash-3.5.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:3171f693dbc2cef6477054a665dc255d996646b4023fe56cb4db80e26f4cc520"},
@@ -8156,8 +8116,8 @@ cffi = ["cffi (>=1.17) ; python_version >= \"3.13\" and platform_python_implemen
 [extras]
 api = ["fastapi", "prometheus-client"]
 chromadb = ["chromadb", "tiktoken"]
-dev = ["pydantic-settings", "pyyaml", "toml"]
-docs = ["hypothesis"]
+dev = ["black", "isort", "mkdocs", "mkdocs-gen-files", "mkdocs-include-markdown-plugin", "mkdocs-literate-nav", "mkdocs-material", "mkdocs-section-index", "mkdocs-typer2", "mkdocstrings-python", "mypy", "pre-commit", "psutil", "pydantic-settings", "pytest", "pytest-bdd", "pytest-cov", "pytest-mock", "pytest-xdist", "pyyaml", "responses", "toml"]
+docs = ["hypothesis", "mkdocs", "mkdocs-gen-files", "mkdocs-include-markdown-plugin", "mkdocs-literate-nav", "mkdocs-material", "mkdocs-section-index", "mkdocs-typer2", "mkdocstrings-python"]
 gui = ["dearpygui"]
 llm = ["httpx", "tiktoken"]
 lmstudio = ["lmstudio"]
@@ -8165,11 +8125,11 @@ memory = ["chromadb", "duckdb", "faiss-cpu", "kuzu", "lmdb", "numpy", "tinydb"]
 minimal = ["langgraph", "networkx", "pydantic", "pydantic-settings", "pyyaml", "requests", "rich", "toml", "typer"]
 offline = ["transformers"]
 retrieval = ["faiss-cpu", "kuzu"]
-tests = ["astor", "duckdb", "fastapi", "httpx", "lmdb", "tinydb"]
+tests = ["astor", "duckdb", "fastapi", "httpx", "lmdb", "pytest-rerunfailures", "tinydb"]
 webui = ["streamlit"]
 webui-nicegui = ["nicegui"]
 
 [metadata]
 lock-version = "2.1"
 python-versions = "<3.13,>=3.12"
-content-hash = "dd81f85a6ca91ddb8fc7ac417eaca35d1e6de7739e3d4121c947e7cbd82bdc15"
+content-hash = "f466cae0b5ffced136f6ceeb582e90d4d334fe05baf9f158b00ce96a423c16ba"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,10 +1,4 @@
 [tool.poetry]
-name = "devsynth"
-version = "0.1.0a1"
-description = "DevSynth project"
-authors = ["DevSynth Team"]
-license = "MIT"
-readme = "README.md"
 packages = [{include = "devsynth", from = "src"}]
 # Explicitly control packaged files for sdist/wheel hygiene
 include = [
@@ -20,14 +14,25 @@ exclude = [
     "test_reports/**",
     "docs/archived/**",
 ]
+
+[project]
+name = "devsynth"
+version = "0.1.0a1"
+description = "DevSynth project"
+readme = "README.md"
+license = "MIT"
+authors = [{name = "DevSynth Team"}]
+requires-python = ">=3.12,<3.13"
 classifiers = [
     "Development Status :: 3 - Alpha",
     "Intended Audience :: Developers",
-    "License :: OSI Approved :: MIT License",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3 :: Only",
     "Programming Language :: Python :: 3.12",
-    "Operating System :: OS Independent"
+    "Operating System :: OS Independent",
+]
+dynamic = [
+    "dependencies",
 ]
 
 [tool.poetry.dependencies]
@@ -134,7 +139,7 @@ mkdocs-typer2 = "*"
 mkdocs-literate-nav = "*"
 mkdocs-section-index = "*"
 
-[tool.poetry.extras]
+[project.optional-dependencies]
 # docs: build the project documentation
 # minimal: baseline runtime requirements without heavy optional dependencies
 # retrieval: enables vector retrieval support via kuzu and faiss
@@ -162,18 +167,42 @@ minimal = [
     "pyyaml",
     "requests",
 ]
-
-retrieval = ["kuzu", "faiss-cpu"]
-chromadb = ["chromadb", "tiktoken"]
+retrieval = [
+    'kuzu; platform_system == "Linux" and platform_machine == "x86_64"',
+    'faiss-cpu; platform_system != "Darwin" or platform_machine == "arm64"',
+]
+chromadb = [
+    'chromadb; platform_system != "Darwin" or platform_machine == "arm64"',
+    "tiktoken",
+]
 lmstudio = ["lmstudio"]
-memory = ["tinydb", "duckdb", "lmdb", "kuzu", "faiss-cpu", "chromadb", "numpy"]
+memory = [
+    "tinydb",
+    "duckdb",
+    "lmdb",
+    'kuzu; platform_system == "Linux" and platform_machine == "x86_64"',
+    'faiss-cpu; platform_system != "Darwin" or platform_machine == "arm64"',
+    'chromadb; platform_system != "Darwin" or platform_machine == "arm64"',
+    "numpy",
+]
 llm = ["tiktoken", "httpx"]
 offline = ["transformers"]
-api = ["fastapi", "prometheus-client"]
+api = [
+    "fastapi>=0.116.2,<0.117",
+    "prometheus-client",
+]
 webui = ["streamlit"]
 webui_nicegui = ["nicegui"]
 gui = ["dearpygui"]
-tests = ["fastapi", "httpx", "tinydb", "duckdb", "lmdb", "astor", "pytest-rerunfailures"]
+tests = [
+    "fastapi>=0.116.2,<0.117",
+    "httpx",
+    "tinydb",
+    "duckdb",
+    "lmdb",
+    "astor",
+    "pytest-rerunfailures",
+]
 dev = [
     "responses",
     "pytest",

--- a/test_reports/test_markers_report.json
+++ b/test_reports/test_markers_report.json
@@ -1,6 +1,6 @@
 {
   "markers": {
-    "fast": 1809,
+    "fast": 1814,
     "no_network": 15,
     "medium": 1579,
     "parametrize": 71,
@@ -15,14 +15,14 @@
     "integtest": 1,
     "asyncio": 25,
     "skipif": 3,
-    "property": 31,
+    "property": 32,
     "anyio": 3,
-    "unit": 7,
+    "unit": 11,
     "smoke": 4,
     "skip": 2,
     "allow_real_coverage_artifacts": 2
   },
-  "files_scanned": 1264,
+  "files_scanned": 1265,
   "files_with_issues": 0,
   "undocumented_markers": []
 }


### PR DESCRIPTION
## Summary
- migrate packaging metadata to the `[project]` table and re-home extras under `[project.optional-dependencies]`, refreshing the lock file to keep doc bundles installable
- document the optional-dependency change in the 0.1.0a1 release notes and maintainer checklist, and record the updated marker evidence from the latest release-prep run
- capture fresh `poetry check`, `poetry build`, and `task release:prep` transcripts under `diagnostics/` for the release evidence bundle

## Testing
- `poetry check`
- `poetry build`
- `task release:prep` *(fails: existing Bandit findings remain open, log captured)*


------
https://chatgpt.com/codex/tasks/task_e_68e5d81bb4bc83339c59f39c946d975d